### PR TITLE
Add alt attirbutes for test docs sprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2326,7 +2326,7 @@ extensible for other widgets who wish to support it.
 
 ### Status Bar
 
-<img alt=" " src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/statusbar.png" class="jp-screenshot">
+<img alt= "A screenshot of the updated JupyterLab status bar." src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/statusbar.png" class="jp-screenshot">
 
 We have integrated the [JupyterLab Status Bar
 package](https://github.com/jupyterlab/jupyterlab-statusbar) package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1488,7 +1488,7 @@ We are very excited to add Eric Charles to the core team this month!
   the file browser window
   ([#8393](https://github.com/jupyterlab/jupyterlab/pull/8393))
 
-<img alt=" " src="https://user-images.githubusercontent.com/13181907/81358007-3b77d700-90a3-11ea-885c-31628c55744b.png" class="jp-screenshot">
+<img alt="A screenshot of the JupyterLab file browser." src="https://user-images.githubusercontent.com/13181907/81358007-3b77d700-90a3-11ea-885c-31628c55744b.png" class="jp-screenshot">
 
 - Enable horizontal scrolling for toolbars to improve mobile
   experience

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1482,36 +1482,36 @@ We are very excited to add Eric Charles to the core team this month!
   ([#8562](https://github.com/jupyterlab/jupyterlab/pull/8562),
   [#8477](https://github.com/jupyterlab/jupyterlab/issues/8477))
 
-<img src="https://user-images.githubusercontent.com/226720/84566070-966daf80-ad6e-11ea-815b-5f48136b524b.gif" class="jp-screenshot">
+<img alt=" " src="https://user-images.githubusercontent.com/226720/84566070-966daf80-ad6e-11ea-815b-5f48136b524b.gif" class="jp-screenshot">
 
 - Adds a visual clue for distinguishing hidden files and folders in
   the file browser window
   ([#8393](https://github.com/jupyterlab/jupyterlab/pull/8393))
 
-<img src="https://user-images.githubusercontent.com/13181907/81358007-3b77d700-90a3-11ea-885c-31628c55744b.png" class="jp-screenshot">
+<img alt=" " src="https://user-images.githubusercontent.com/13181907/81358007-3b77d700-90a3-11ea-885c-31628c55744b.png" class="jp-screenshot">
 
 - Enable horizontal scrolling for toolbars to improve mobile
   experience
   ([#8417](https://github.com/jupyterlab/jupyterlab/pull/8417))
 
-<img src="https://user-images.githubusercontent.com/591645/81733090-bb31e700-9491-11ea-96ab-a4b1695b8e3c.gif" class="jp-screenshot">
+<img alt=" " src="https://user-images.githubusercontent.com/591645/81733090-bb31e700-9491-11ea-96ab-a4b1695b8e3c.gif" class="jp-screenshot">
 
 - Improves the right-click context menu for the file editor
   ([#8425](https://github.com/jupyterlab/jupyterlab/pull/8425))
 
-<img src="https://user-images.githubusercontent.com/25207344/84947222-d8bd2680-b0b7-11ea-98da-e4907f9131ba.png" class="jp-screenshot">
+<img alt=" " src="https://user-images.githubusercontent.com/25207344/84947222-d8bd2680-b0b7-11ea-98da-e4907f9131ba.png" class="jp-screenshot">
 
 - Merge cell attachments when merging cells
   ([#8427](https://github.com/jupyterlab/jupyterlab/pull/8427),
   [#8414](https://github.com/jupyterlab/jupyterlab/issues/8414))
 
-<img src="https://user-images.githubusercontent.com/591645/82072833-97acad80-96d8-11ea-957c-ce006731219b.gif" class="jp-screenshot">
+<img alt=" " src="https://user-images.githubusercontent.com/591645/82072833-97acad80-96d8-11ea-957c-ce006731219b.gif" class="jp-screenshot">
 
 - Add styling for high memory usage warning in status bar with
   nbresuse
   ([#8437](https://github.com/jupyterlab/jupyterlab/pull/8437))
 
-<img src="https://user-images.githubusercontent.com/7725109/82213619-1b150b80-9932-11ea-9a53-570bd82d3d2a.png" class="jp-screenshot">
+<img alt=" " src="https://user-images.githubusercontent.com/7725109/82213619-1b150b80-9932-11ea-9a53-570bd82d3d2a.png" class="jp-screenshot">
 
 - Adds support for Python version 3.10
   ([#8445](https://github.com/jupyterlab/jupyterlab/pull/8445))
@@ -1519,7 +1519,7 @@ We are very excited to add Eric Charles to the core team this month!
   ([#8495](https://github.com/jupyterlab/jupyterlab/pull/8495),
   [#8494](https://github.com/jupyterlab/jupyterlab/issues/8494))
 
-<img src="https://user-images.githubusercontent.com/45380/83218329-c8123400-a13b-11ea-9137-6b91a29dbc08.png" class="jp-screenshot">
+<img alt=" " src="https://user-images.githubusercontent.com/45380/83218329-c8123400-a13b-11ea-9137-6b91a29dbc08.png" class="jp-screenshot">
 
 ### For developers
 
@@ -1634,7 +1634,7 @@ closed.
   notebook toolbar
   ([#8024](https://github.com/jupyterlab/jupyterlab/pull/8024))
 
-<img src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_restartrunallbutton.png" class="jp-screenshot">
+<img alt=" " src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_restartrunallbutton.png" class="jp-screenshot">
 
 - Added a context menu item for opening a Markdown editor from the
   Markdown preview
@@ -1758,18 +1758,18 @@ closed.
   ([#7407](https://github.com/jupyterlab/jupyterlab/pull/7407),
   [#7786](https://github.com/jupyterlab/jupyterlab/pull/7786))
 
-<img src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_celltags.png" class="jp-screenshot">
+<img alt=" " src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_celltags.png" class="jp-screenshot">
 
 - File info display when hovering on a file in the file browser
   ([#7485](https://github.com/jupyterlab/jupyterlab/pull/7485),
   [#7352](https://github.com/jupyterlab/jupyterlab/issues/7352))
 
-<img src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_fileinfo.png" class="jp-screenshot">
+<img alt=" " src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_fileinfo.png" class="jp-screenshot">
 
 - Support for searching outputs in notebooks
   ([#7258](https://github.com/jupyterlab/jupyterlab/pull/7258))
 
-<img src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_searchoutput.png" class="jp-screenshot">
+<img alt=" " src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_searchoutput.png" class="jp-screenshot">
 
 - `Ctrl Shift .` and `Ctrl Shift ,` shortcuts move focus to the next
   and previous tab bar in the main area, respectively
@@ -2303,7 +2303,7 @@ in 1.0.0, and other 1.0.x milestones for bugs fixed in patch releases.
 
 ### Find and Replace
 
-<img src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/find.png" class="jp-screenshot">
+<img alt=" " src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/find.png" class="jp-screenshot">
 
 We have added first class support for find and replace across
 JupyterLab. It is currently supported in notebooks and text files and is
@@ -2326,7 +2326,7 @@ extensible for other widgets who wish to support it.
 
 ### Status Bar
 
-<img src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/statusbar.png" class="jp-screenshot">
+<img alt=" " src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/statusbar.png" class="jp-screenshot">
 
 We have integrated the [JupyterLab Status Bar
 package](https://github.com/jupyterlab/jupyterlab-statusbar) package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1494,7 +1494,7 @@ We are very excited to add Eric Charles to the core team this month!
   experience
   ([#8417](https://github.com/jupyterlab/jupyterlab/pull/8417))
 
-<img alt=" " src="https://user-images.githubusercontent.com/591645/81733090-bb31e700-9491-11ea-96ab-a4b1695b8e3c.gif" class="jp-screenshot">
+<img alt="An animation demonstrating improved scrolling and navigation on mobile." src="https://user-images.githubusercontent.com/591645/81733090-bb31e700-9491-11ea-96ab-a4b1695b8e3c.gif" class="jp-screenshot">
 
 - Improves the right-click context menu for the file editor
   ([#8425](https://github.com/jupyterlab/jupyterlab/pull/8425))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2303,7 +2303,7 @@ in 1.0.0, and other 1.0.x milestones for bugs fixed in patch releases.
 
 ### Find and Replace
 
-<img alt="A notebook with multiple cells and the find and replace interface in the upper right" src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/find.png" class="jp-screenshot">
+<img alt="A notebook with multiple cells and the find and replace interface in the upper right." src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/find.png" class="jp-screenshot">
 
 We have added first class support for find and replace across
 JupyterLab. It is currently supported in notebooks and text files and is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1499,19 +1499,19 @@ We are very excited to add Eric Charles to the core team this month!
 - Improves the right-click context menu for the file editor
   ([#8425](https://github.com/jupyterlab/jupyterlab/pull/8425))
 
-<img alt=" " src="https://user-images.githubusercontent.com/25207344/84947222-d8bd2680-b0b7-11ea-98da-e4907f9131ba.png" class="jp-screenshot">
+<img alt="A context menu in a text file with options like undo and redo" src="https://user-images.githubusercontent.com/25207344/84947222-d8bd2680-b0b7-11ea-98da-e4907f9131ba.png" class="jp-screenshot">
 
 - Merge cell attachments when merging cells
   ([#8427](https://github.com/jupyterlab/jupyterlab/pull/8427),
   [#8414](https://github.com/jupyterlab/jupyterlab/issues/8414))
 
-<img alt=" " src="https://user-images.githubusercontent.com/591645/82072833-97acad80-96d8-11ea-957c-ce006731219b.gif" class="jp-screenshot">
+<img alt="An animation demonstrating merging two cells with image outputs into one cell with both outputs" src="https://user-images.githubusercontent.com/591645/82072833-97acad80-96d8-11ea-957c-ce006731219b.gif" class="jp-screenshot">
 
 - Add styling for high memory usage warning in status bar with
   nbresuse
   ([#8437](https://github.com/jupyterlab/jupyterlab/pull/8437))
 
-<img alt=" " src="https://user-images.githubusercontent.com/7725109/82213619-1b150b80-9932-11ea-9a53-570bd82d3d2a.png" class="jp-screenshot">
+<img alt="A status bar message that says memory 110.51 MB used out of 117.25 MB available" src="https://user-images.githubusercontent.com/7725109/82213619-1b150b80-9932-11ea-9a53-570bd82d3d2a.png" class="jp-screenshot">
 
 - Adds support for Python version 3.10
   ([#8445](https://github.com/jupyterlab/jupyterlab/pull/8445))
@@ -1519,7 +1519,7 @@ We are very excited to add Eric Charles to the core team this month!
   ([#8495](https://github.com/jupyterlab/jupyterlab/pull/8495),
   [#8494](https://github.com/jupyterlab/jupyterlab/issues/8494))
 
-<img alt=" " src="https://user-images.githubusercontent.com/45380/83218329-c8123400-a13b-11ea-9137-6b91a29dbc08.png" class="jp-screenshot">
+<img alt="Demonstrating editing an SVG in one tab and while it is previewed live in another tab" src="https://user-images.githubusercontent.com/45380/83218329-c8123400-a13b-11ea-9137-6b91a29dbc08.png" class="jp-screenshot">
 
 ### For developers
 
@@ -1634,7 +1634,7 @@ closed.
   notebook toolbar
   ([#8024](https://github.com/jupyterlab/jupyterlab/pull/8024))
 
-<img alt=" " src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_restartrunallbutton.png" class="jp-screenshot">
+<img alt="The main JupyterLab toolbar with focus on the Restart Kernel and Run All Cells button" src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_restartrunallbutton.png" class="jp-screenshot">
 
 - Added a context menu item for opening a Markdown editor from the
   Markdown preview
@@ -1758,18 +1758,18 @@ closed.
   ([#7407](https://github.com/jupyterlab/jupyterlab/pull/7407),
   [#7786](https://github.com/jupyterlab/jupyterlab/pull/7786))
 
-<img alt=" " src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_celltags.png" class="jp-screenshot">
+<img alt="Notebook cell tags in the left sidebar next to an open notebook" src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_celltags.png" class="jp-screenshot">
 
 - File info display when hovering on a file in the file browser
   ([#7485](https://github.com/jupyterlab/jupyterlab/pull/7485),
   [#7352](https://github.com/jupyterlab/jupyterlab/issues/7352))
 
-<img alt=" " src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_fileinfo.png" class="jp-screenshot">
+<img alt="The file browser with a tooltip describing a notebook's info like the the name, size, and kernel" src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_fileinfo.png" class="jp-screenshot">
 
 - Support for searching outputs in notebooks
   ([#7258](https://github.com/jupyterlab/jupyterlab/pull/7258))
 
-<img alt=" " src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_searchoutput.png" class="jp-screenshot">
+<img alt="A notebook with multiple cells and the cell output searching in the upper right" src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_searchoutput.png" class="jp-screenshot">
 
 - `Ctrl Shift .` and `Ctrl Shift ,` shortcuts move focus to the next
   and previous tab bar in the main area, respectively
@@ -2303,7 +2303,7 @@ in 1.0.0, and other 1.0.x milestones for bugs fixed in patch releases.
 
 ### Find and Replace
 
-<img alt=" " src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/find.png" class="jp-screenshot">
+<img alt="A notebook with multiple cells and the find and replace interface in the upper right" src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/find.png" class="jp-screenshot">
 
 We have added first class support for find and replace across
 JupyterLab. It is currently supported in notebooks and text files and is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1499,19 +1499,19 @@ We are very excited to add Eric Charles to the core team this month!
 - Improves the right-click context menu for the file editor
   ([#8425](https://github.com/jupyterlab/jupyterlab/pull/8425))
 
-<img alt="A context menu in a text file with options like undo and redo" src="https://user-images.githubusercontent.com/25207344/84947222-d8bd2680-b0b7-11ea-98da-e4907f9131ba.png" class="jp-screenshot">
+<img alt="A context menu in a text file with options like undo and redo." src="https://user-images.githubusercontent.com/25207344/84947222-d8bd2680-b0b7-11ea-98da-e4907f9131ba.png" class="jp-screenshot">
 
 - Merge cell attachments when merging cells
   ([#8427](https://github.com/jupyterlab/jupyterlab/pull/8427),
   [#8414](https://github.com/jupyterlab/jupyterlab/issues/8414))
 
-<img alt="An animation demonstrating merging two cells with image outputs into one cell with both outputs" src="https://user-images.githubusercontent.com/591645/82072833-97acad80-96d8-11ea-957c-ce006731219b.gif" class="jp-screenshot">
+<img alt="An animation demonstrating merging two cells with image outputs into one cell with both outputs." src="https://user-images.githubusercontent.com/591645/82072833-97acad80-96d8-11ea-957c-ce006731219b.gif" class="jp-screenshot">
 
 - Add styling for high memory usage warning in status bar with
   nbresuse
   ([#8437](https://github.com/jupyterlab/jupyterlab/pull/8437))
 
-<img alt="A status bar message that says memory 110.51 MB used out of 117.25 MB available" src="https://user-images.githubusercontent.com/7725109/82213619-1b150b80-9932-11ea-9a53-570bd82d3d2a.png" class="jp-screenshot">
+<img alt="A status bar message that says memory 110.51 MB used out of 117.25 MB available." src="https://user-images.githubusercontent.com/7725109/82213619-1b150b80-9932-11ea-9a53-570bd82d3d2a.png" class="jp-screenshot">
 
 - Adds support for Python version 3.10
   ([#8445](https://github.com/jupyterlab/jupyterlab/pull/8445))
@@ -1519,7 +1519,7 @@ We are very excited to add Eric Charles to the core team this month!
   ([#8495](https://github.com/jupyterlab/jupyterlab/pull/8495),
   [#8494](https://github.com/jupyterlab/jupyterlab/issues/8494))
 
-<img alt="Demonstrating editing an SVG in one tab and while it is previewed live in another tab" src="https://user-images.githubusercontent.com/45380/83218329-c8123400-a13b-11ea-9137-6b91a29dbc08.png" class="jp-screenshot">
+<img alt="Demonstrating editing an SVG in one tab and while it is previewed live in another tab." src="https://user-images.githubusercontent.com/45380/83218329-c8123400-a13b-11ea-9137-6b91a29dbc08.png" class="jp-screenshot">
 
 ### For developers
 
@@ -1634,7 +1634,7 @@ closed.
   notebook toolbar
   ([#8024](https://github.com/jupyterlab/jupyterlab/pull/8024))
 
-<img alt="The main JupyterLab toolbar with focus on the Restart Kernel and Run All Cells button" src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_restartrunallbutton.png" class="jp-screenshot">
+<img alt="The main JupyterLab toolbar with focus on the Restart Kernel and Run All Cells button." src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_restartrunallbutton.png" class="jp-screenshot">
 
 - Added a context menu item for opening a Markdown editor from the
   Markdown preview
@@ -1758,18 +1758,18 @@ closed.
   ([#7407](https://github.com/jupyterlab/jupyterlab/pull/7407),
   [#7786](https://github.com/jupyterlab/jupyterlab/pull/7786))
 
-<img alt="Notebook cell tags in the left sidebar next to an open notebook" src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_celltags.png" class="jp-screenshot">
+<img alt="Notebook cell tags in the left sidebar next to an open notebook." src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_celltags.png" class="jp-screenshot">
 
 - File info display when hovering on a file in the file browser
   ([#7485](https://github.com/jupyterlab/jupyterlab/pull/7485),
   [#7352](https://github.com/jupyterlab/jupyterlab/issues/7352))
 
-<img alt="The file browser with a tooltip describing a notebook's info like the the name, size, and kernel" src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_fileinfo.png" class="jp-screenshot">
+<img alt="The file browser with a tooltip describing a notebook's info like the the name, size, and kernel." src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_fileinfo.png" class="jp-screenshot">
 
 - Support for searching outputs in notebooks
   ([#7258](https://github.com/jupyterlab/jupyterlab/pull/7258))
 
-<img alt="A notebook with multiple cells and the cell output searching in the upper right" src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_searchoutput.png" class="jp-screenshot">
+<img alt="A notebook with multiple cells and the cell output searching in the upper right." src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_searchoutput.png" class="jp-screenshot">
 
 - `Ctrl Shift .` and `Ctrl Shift ,` shortcuts move focus to the next
   and previous tab bar in the main area, respectively

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1482,7 +1482,7 @@ We are very excited to add Eric Charles to the core team this month!
   ([#8562](https://github.com/jupyterlab/jupyterlab/pull/8562),
   [#8477](https://github.com/jupyterlab/jupyterlab/issues/8477))
 
-<img alt=" " src="https://user-images.githubusercontent.com/226720/84566070-966daf80-ad6e-11ea-815b-5f48136b524b.gif" class="jp-screenshot">
+<img alt="An animation of the Jupyterlab interface that demonstrates restarting a kernel and running code cells." src="https://user-images.githubusercontent.com/226720/84566070-966daf80-ad6e-11ea-815b-5f48136b524b.gif" class="jp-screenshot">
 
 - Adds a visual clue for distinguishing hidden files and folders in
   the file browser window

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1764,7 +1764,7 @@ closed.
   ([#7485](https://github.com/jupyterlab/jupyterlab/pull/7485),
   [#7352](https://github.com/jupyterlab/jupyterlab/issues/7352))
 
-<img alt="The file browser with a tooltip describing a notebook's info like the the name, size, and kernel." src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_fileinfo.png" class="jp-screenshot">
+<img alt="The file browser with a tooltip describing a notebook's info like the name, size, and kernel." src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_fileinfo.png" class="jp-screenshot">
 
 - Support for searching outputs in notebooks
   ([#7258](https://github.com/jupyterlab/jupyterlab/pull/7258))

--- a/docs/source/user/files.rst
+++ b/docs/source/user/files.rst
@@ -22,7 +22,7 @@ Many actions on files can also be carried out in the File menu:
 .. image:: images/file_menu_top.png
    :align: center
    :class: jp-screenshot
-   :alt: Alt text here
+   :alt: A screenshot showing the File menu open including options like "New", "Save All"
 
 .. _open-file:
 
@@ -89,7 +89,7 @@ directory open.
 .. image:: images/shareable_link.png
    :align: center
    :class: jp-screenshot
-   :alt: Alt text here
+   :alt: A screenshot showing the Copy Shareable Link option in the context menu opened over a file, which is the last entry on the list
 
 .. _file-copy-path:
 
@@ -119,7 +119,7 @@ You can also create new documents or activities using the File menu:
 .. image:: images/file_create_text_file.png
    :align: center
    :class: jp-screenshot
-   :alt: Alt text here
+   :alt: A screenshot showing the context menu entry for creating a new file
 
 .. _current-directory:
 

--- a/docs/source/user/files.rst
+++ b/docs/source/user/files.rst
@@ -15,7 +15,7 @@ The file browser is in the left sidebar Files tab:
 .. image:: images/file_menu_left.png
    :align: center
    :class: jp-screenshot
-   :alt: Alt text here
+   :alt: Arrow pointing to the file browser in the upper left sidebar 
 
 Many actions on files can also be carried out in the File menu:
 

--- a/docs/source/user/files.rst
+++ b/docs/source/user/files.rst
@@ -22,7 +22,7 @@ Many actions on files can also be carried out in the File menu:
 .. image:: images/file_menu_top.png
    :align: center
    :class: jp-screenshot
-   :alt: A screenshot showing the File menu open including options like "New", "Save All"
+   :alt: A screen shot showing the File menu open including options like "New", "Save All"
 
 .. _open-file:
 
@@ -89,7 +89,7 @@ directory open.
 .. image:: images/shareable_link.png
    :align: center
    :class: jp-screenshot
-   :alt: A screenshot showing the Copy Shareable Link option in the context menu opened over a file, which is the last entry on the list
+   :alt: A screen shot showing the Copy Shareable Link option in the context menu opened over a file, which is the last entry on the list
 
 .. _file-copy-path:
 

--- a/docs/source/user/files.rst
+++ b/docs/source/user/files.rst
@@ -15,14 +15,14 @@ The file browser is in the left sidebar Files tab:
 .. image:: images/file_menu_left.png
    :align: center
    :class: jp-screenshot
-   :alt: Arrow pointing to the file browser in the upper left sidebar 
+   :alt: Arrow pointing to the file browser in the upper left sidebar.
 
 Many actions on files can also be carried out in the File menu:
 
 .. image:: images/file_menu_top.png
    :align: center
    :class: jp-screenshot
-   :alt: A screen shot showing the File menu open including options like "New", "Save All"
+   :alt: A screen shot showing the File menu open including options like "New", "Save All."
 
 .. _open-file:
 
@@ -89,7 +89,7 @@ directory open.
 .. image:: images/shareable_link.png
    :align: center
    :class: jp-screenshot
-   :alt: A screen shot showing the Copy Shareable Link option in the context menu opened over a file, which is the last entry on the list
+   :alt: A screen shot showing the Copy Shareable Link option in the context menu opened over a file, which is the last entry on the list.
 
 .. _file-copy-path:
 
@@ -119,7 +119,7 @@ You can also create new documents or activities using the File menu:
 .. image:: images/file_create_text_file.png
    :align: center
    :class: jp-screenshot
-   :alt: A screenshot showing the context menu entry for creating a new file
+   :alt: A screenshot showing the context menu entry for creating a new file.
 
 .. _current-directory:
 

--- a/docs/source/user/files.rst
+++ b/docs/source/user/files.rst
@@ -15,12 +15,14 @@ The file browser is in the left sidebar Files tab:
 .. image:: images/file_menu_left.png
    :align: center
    :class: jp-screenshot
+   :alt: Alt text here
 
 Many actions on files can also be carried out in the File menu:
 
 .. image:: images/file_menu_top.png
    :align: center
    :class: jp-screenshot
+   :alt: Alt text here
 
 .. _open-file:
 
@@ -87,6 +89,7 @@ directory open.
 .. image:: images/shareable_link.png
    :align: center
    :class: jp-screenshot
+   :alt: Alt text here
 
 .. _file-copy-path:
 
@@ -116,6 +119,7 @@ You can also create new documents or activities using the File menu:
 .. image:: images/file_create_text_file.png
    :align: center
    :class: jp-screenshot
+   :alt: Alt text here
 
 .. _current-directory:
 

--- a/docs/source/user/files.rst
+++ b/docs/source/user/files.rst
@@ -89,7 +89,7 @@ directory open.
 .. image:: images/shareable_link.png
    :align: center
    :class: jp-screenshot
-   :alt: A screen shot showing the Copy Shareable Link option in the context menu opened over a file, which is the last entry on the list.
+   :alt: A screenshot showing the Copy Shareable Link option in the context menu opened over a file, which is the last entry on the list.
 
 .. _file-copy-path:
 

--- a/docs/source/user/files.rst
+++ b/docs/source/user/files.rst
@@ -22,7 +22,7 @@ Many actions on files can also be carried out in the File menu:
 .. image:: images/file_menu_top.png
    :align: center
    :class: jp-screenshot
-   :alt: A screen shot showing the File menu open including options like "New", "Save All."
+   :alt: A screenshot showing the File menu open including options like "New", "Save All."
 
 .. _open-file:
 

--- a/docs/source/user/interface.rst
+++ b/docs/source/user/interface.rst
@@ -112,7 +112,7 @@ activities in the main work area:
 .. image:: images/interface_tabs.png
    :align: center
    :class: jp-screenshot
-   :alt: A screen shot of the tabs panel in JupyterLab that lists some sample documents.
+   :alt: A screenshot of the tabs panel in JupyterLab that lists some sample documents.
 
 The same information is also available in the Tabs menu:
 

--- a/docs/source/user/interface.rst
+++ b/docs/source/user/interface.rst
@@ -18,7 +18,7 @@ cell tools inspector <notebook>`, and the :ref:`tabs list <tabs>`.
 .. image:: images/interface_jupyterlab.png
    :align: center
    :class: jp-screenshot
-   :alt: Alt text here
+   :alt: A screenshot of the JupyterLab interface. The main work area is in the middle section of the interface. There is also a left sidebar and a top menu bar.
 
 JupyterLab sessions always reside in a :ref:`workspace <url-workspaces-ui>`.
 Workspaces contain the state of JupyterLab: the files that are currently open,
@@ -63,7 +63,7 @@ and a list of tabs in the main work area:
 .. image:: images/interface_left.png
    :align: center
    :class: jp-screenshot
-   :alt: Alt text here
+   :alt: A screenshot of the primary JupyterLab sidebar a variety of files in the file browser
 
 .. _left-sidebar-toggle:
 
@@ -112,7 +112,7 @@ activities in the main work area:
 .. image:: images/interface_tabs.png
    :align: center
    :class: jp-screenshot
-   :alt: Alt text here
+   :alt: A screen shot of the tabs panel in JupyterLab that lists some sample documents.
 
 The same information is also available in the Tabs menu:
 

--- a/docs/source/user/interface.rst
+++ b/docs/source/user/interface.rst
@@ -63,7 +63,7 @@ and a list of tabs in the main work area:
 .. image:: images/interface_left.png
    :align: center
    :class: jp-screenshot
-   :alt: A screen shot of the primary JupyterLab sidebar a variety of files in the file browser.
+   :alt: A screenshot of the primary JupyterLab sidebar showing a variety of files in the file browser.
 
 .. _left-sidebar-toggle:
 

--- a/docs/source/user/interface.rst
+++ b/docs/source/user/interface.rst
@@ -18,7 +18,7 @@ cell tools inspector <notebook>`, and the :ref:`tabs list <tabs>`.
 .. image:: images/interface_jupyterlab.png
    :align: center
    :class: jp-screenshot
-   :alt: A screen shot of the JupyterLab interface. The main work area is in the middle section of the interface. There is also a left sidebar and a top menu bar.
+   :alt: A screenshot of the JupyterLab interface. The main work area is in the middle section of the interface. There is also a left sidebar and a top menu bar.
 
 JupyterLab sessions always reside in a :ref:`workspace <url-workspaces-ui>`.
 Workspaces contain the state of JupyterLab: the files that are currently open,

--- a/docs/source/user/interface.rst
+++ b/docs/source/user/interface.rst
@@ -18,6 +18,7 @@ cell tools inspector <notebook>`, and the :ref:`tabs list <tabs>`.
 .. image:: images/interface_jupyterlab.png
    :align: center
    :class: jp-screenshot
+   :alt: Alt text here
 
 JupyterLab sessions always reside in a :ref:`workspace <url-workspaces-ui>`.
 Workspaces contain the state of JupyterLab: the files that are currently open,
@@ -62,6 +63,7 @@ and a list of tabs in the main work area:
 .. image:: images/interface_left.png
    :align: center
    :class: jp-screenshot
+   :alt: Alt text here
 
 .. _left-sidebar-toggle:
 
@@ -110,12 +112,14 @@ activities in the main work area:
 .. image:: images/interface_tabs.png
    :align: center
    :class: jp-screenshot
+   :alt: Alt text here
 
 The same information is also available in the Tabs menu:
 
 .. image:: images/interface_tabs_menu.png
    :align: center
    :class: jp-screenshot
+   :alt: Alt text here
 
 .. _tabs-singledocument:
 

--- a/docs/source/user/interface.rst
+++ b/docs/source/user/interface.rst
@@ -18,7 +18,7 @@ cell tools inspector <notebook>`, and the :ref:`tabs list <tabs>`.
 .. image:: images/interface_jupyterlab.png
    :align: center
    :class: jp-screenshot
-   :alt: A screenshot of the JupyterLab interface. The main work area is in the middle section of the interface. There is also a left sidebar and a top menu bar.
+   :alt: A screen shot of the JupyterLab interface. The main work area is in the middle section of the interface. There is also a left sidebar and a top menu bar.
 
 JupyterLab sessions always reside in a :ref:`workspace <url-workspaces-ui>`.
 Workspaces contain the state of JupyterLab: the files that are currently open,
@@ -63,7 +63,7 @@ and a list of tabs in the main work area:
 .. image:: images/interface_left.png
    :align: center
    :class: jp-screenshot
-   :alt: A screenshot of the primary JupyterLab sidebar a variety of files in the file browser
+   :alt: A screen shot of the primary JupyterLab sidebar a variety of files in the file browser
 
 .. _left-sidebar-toggle:
 
@@ -119,7 +119,7 @@ The same information is also available in the Tabs menu:
 .. image:: images/interface_tabs_menu.png
    :align: center
    :class: jp-screenshot
-   :alt: Alt text here
+   :alt: A screen shot of the tabs menu in JupyterLab with a list of sample documents.
 
 .. _tabs-singledocument:
 

--- a/docs/source/user/interface.rst
+++ b/docs/source/user/interface.rst
@@ -119,7 +119,7 @@ The same information is also available in the Tabs menu:
 .. image:: images/interface_tabs_menu.png
    :align: center
    :class: jp-screenshot
-   :alt: A screen shot of the tabs menu in JupyterLab with a list of sample documents.
+   :alt: A screenshot of the tabs menu in JupyterLab with a list of sample documents.
 
 .. _tabs-singledocument:
 

--- a/docs/source/user/interface.rst
+++ b/docs/source/user/interface.rst
@@ -63,7 +63,7 @@ and a list of tabs in the main work area:
 .. image:: images/interface_left.png
    :align: center
    :class: jp-screenshot
-   :alt: A screen shot of the primary JupyterLab sidebar a variety of files in the file browser
+   :alt: A screen shot of the primary JupyterLab sidebar a variety of files in the file browser.
 
 .. _left-sidebar-toggle:
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

This is does not address any existing issues that I am aware of. Sprinting to add alt text to documentation has been mentioned in the [weekly team meetings](https://github.com/jupyterlab/team-compass/issues/117#issuecomment-880060794) and [jupyter/accessibility](https://github.com/jupyter/accessibility/issues/43#issuecomment-845365269).

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Adds alt attributes to images under `CHANGELOG.md`, `interface.rst`, and `files.rst`.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->
Images in the docs under `CHANGELOG.md`, `interface.rst`, and `files.rst`will have descriptions. Alt text supports users who use screen readers as well as those that do not.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

None! ✨ 
