### PR TITLE
Automated Changelog Entry for 3.1.0rc2 on 3.1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,12 +32,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 
 - Add some upgrade notes to JupyterLab 3.1 [#10654](https://github.com/jupyterlab/jupyterlab/pull/10654) ([@fcollonval](https://github.com/fcollonval))
 
-### Contributors to this release
-
-([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-07-13&to=2021-07-21&type=c))
-
-[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-07-13..2021-07-21&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2021-07-13..2021-07-21&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-07-13..2021-07-21&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-07-13..2021-07-21&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-07-13..2021-07-21&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-07-13..2021-07-21&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-07-13..2021-07-21&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-07-13..2021-07-21&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-07-13..2021-07-21&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-07-13..2021-07-21&type=Issues)
-
 <!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.1.0rc0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.1.0rc2
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.1.0rc1...d5379411b1a19f19bb94465e93cb0714f224b08f))
+
+### Enhancements made
+
+- fixes doc string for toc syncCollapseState setting [#10639](https://github.com/jupyterlab/jupyterlab/pull/10639) ([@andrewfulton9](https://github.com/andrewfulton9))
+
+### Bugs fixed
+
+- Restore the focus target check removed in #10517 [#10664](https://github.com/jupyterlab/jupyterlab/pull/10664) ([@krassowski](https://github.com/krassowski))
+- Fixed event handler in debugger session test [#10651](https://github.com/jupyterlab/jupyterlab/pull/10651) ([@JohanMabille](https://github.com/JohanMabille))
+- Fix error messages when creating new dirs/files in a read only dir [#10641](https://github.com/jupyterlab/jupyterlab/pull/10641) ([@vkaidalov-rft](https://github.com/vkaidalov-rft))
+- More automated release fixes [#10621](https://github.com/jupyterlab/jupyterlab/pull/10621) ([@blink1073](https://github.com/blink1073))
+
+### Maintenance and upkeep improvements
+
+- Fix typo in the `dirty` plugin id [#10623](https://github.com/jupyterlab/jupyterlab/pull/10623) ([@jtpio](https://github.com/jtpio))
+- Move the context menu building logic to a separate plugin [#10624](https://github.com/jupyterlab/jupyterlab/pull/10624) ([@jtpio](https://github.com/jtpio))
+
+### Documentation improvements
+
+- Add some upgrade notes to JupyterLab 3.1 [#10654](https://github.com/jupyterlab/jupyterlab/pull/10654) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-07-13&to=2021-07-21&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-07-13..2021-07-21&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2021-07-13..2021-07-21&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-07-13..2021-07-21&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-07-13..2021-07-21&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-07-13..2021-07-21&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-07-13..2021-07-21&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-07-13..2021-07-21&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-07-13..2021-07-21&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-07-13..2021-07-21&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-07-13..2021-07-21&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.1.0rc0
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.1.0b3...a8d22506a60cd879105276b1624affb57c49cb6c))
@@ -15,8 +47,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 ### Bugs fixed
 
 - Disable autoclosing brackets by default in console [#10612](https://github.com/jupyterlab/jupyterlab/pull/10612) ([@jasongrout](https://github.com/jasongrout))
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.1.0b3
 


### PR DESCRIPTION
Automated Changelog Entry for 3.1.0rc2 on 3.1.x
Python version: 3.1.0rc2
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/application-top: 3.1.0-rc.2
@jupyterlab/example-federated: 2.2.0-rc.2
@jupyterlab/example-filebrowser: 3.1.0-rc.2
@jupyterlab/example-console: 3.1.0-rc.2
@jupyterlab/example-cell: 3.1.0-rc.2
@jupyterlab/example-app: 3.1.0-rc.2
@jupyterlab/example-notebook: 3.1.0-rc.2
@jupyterlab/example-terminal: 3.1.0-rc.2
@jupyterlab/example-federated-core: 2.2.0-rc.2
@jupyterlab/example-federated-phosphor: 2.2.0-rc.2
@jupyterlab/example-federated-middle: 2.2.0-rc.2
@jupyterlab/example-federated-md: 2.2.0-rc.2
@jupyterlab/inspector: 3.1.0-rc.2
@jupyterlab/hub-extension: 3.1.0-rc.2
@jupyterlab/tooltip-extension: 3.1.0-rc.2
@jupyterlab/observables: 4.1.0-rc.2
@jupyterlab/help-extension: 3.1.0-rc.2
@jupyterlab/console-extension: 3.1.0-rc.2
@jupyterlab/apputils: 3.1.0-rc.2
@jupyterlab/launcher-extension: 3.1.0-rc.2
@jupyterlab/property-inspector: 3.1.0-rc.2
@jupyterlab/shortcuts-extension: 3.1.0-rc.2
@jupyterlab/application-extension: 3.1.0-rc.2
@jupyterlab/running-extension: 3.1.0-rc.2
@jupyterlab/launcher: 3.1.0-rc.2
@jupyterlab/mainmenu-extension: 3.1.0-rc.2
@jupyterlab/debugger-extension: 3.1.0-rc.2
@jupyterlab/terminal-extension: 3.1.0-rc.2
@jupyterlab/rendermime-interfaces: 3.1.0-rc.2
@jupyterlab/vdom-extension: 3.1.0-rc.2
@jupyterlab/coreutils: 5.1.0-rc.2
@jupyterlab/outputarea: 3.1.0-rc.2
@jupyterlab/services: 6.1.0-rc.2
@jupyterlab/theme-light-extension: 3.1.0-rc.2
@jupyterlab/running: 3.1.0-rc.2
@jupyterlab/extensionmanager-extension: 3.1.0-rc.2
@jupyterlab/documentsearch-extension: 3.1.0-rc.2
@jupyterlab/settingeditor: 3.1.0-rc.2
@jupyterlab/inspector-extension: 3.1.0-rc.2
@jupyterlab/debugger: 3.1.0-rc.2
@jupyterlab/statedb: 3.1.0-rc.2
@jupyterlab/json-extension: 3.1.0-rc.2
@jupyterlab/docprovider: 3.1.0-rc.2
@jupyterlab/cells: 3.1.0-rc.2
@jupyterlab/markdownviewer-extension: 3.1.0-rc.2
@jupyterlab/documentsearch: 3.1.0-rc.2
@jupyterlab/csvviewer-extension: 3.1.0-rc.2
@jupyterlab/filebrowser: 3.1.0-rc.2
@jupyterlab/codemirror: 3.1.0-rc.2
@jupyterlab/docregistry: 3.1.0-rc.2
@jupyterlab/fileeditor-extension: 3.1.0-rc.2
@jupyterlab/nbformat: 3.1.0-rc.2
@jupyterlab/pdf-extension: 3.1.0-rc.2
@jupyterlab/statusbar-extension: 3.1.0-rc.2
@jupyterlab/extensionmanager: 3.1.0-rc.2
@jupyterlab/codemirror-extension: 3.1.0-rc.2
@jupyterlab/docprovider-extension: 3.1.0-rc.2
@jupyterlab/theme-dark-extension: 3.1.0-rc.2
@jupyterlab/tooltip: 3.1.0-rc.2
@jupyterlab/rendermime-extension: 3.1.0-rc.2
@jupyterlab/toc: 5.1.0-rc.2
@jupyterlab/settingeditor-extension: 3.1.0-rc.2
@jupyterlab/vdom: 3.1.0-rc.2
@jupyterlab/javascript-extension: 3.1.0-rc.2
@jupyterlab/metapackage: 3.1.0-rc.2
@jupyterlab/logconsole: 3.1.0-rc.2
@jupyterlab/docmanager: 3.1.0-rc.2
@jupyterlab/ui-components-extension: 3.1.0-rc.2
@jupyterlab/htmlviewer: 3.1.0-rc.2
@jupyterlab/nbconvert-css: 3.1.0-rc.2
@jupyterlab/markdownviewer: 3.1.0-rc.2
@jupyterlab/docmanager-extension: 3.1.0-rc.2
@jupyterlab/rendermime: 3.1.0-rc.2
@jupyterlab/shared-models: 3.1.0-rc.2
@jupyterlab/apputils-extension: 3.1.0-rc.2
@jupyterlab/celltags: 3.1.0-rc.2
@jupyterlab/imageviewer-extension: 3.1.0-rc.2
@jupyterlab/translation: 3.1.0-rc.2
@jupyterlab/console: 3.1.0-rc.2
@jupyterlab/imageviewer: 3.1.0-rc.2
@jupyterlab/mainmenu: 3.1.0-rc.2
@jupyterlab/toc-extension: 5.1.0-rc.2
@jupyterlab/mathjax2: 3.1.0-rc.2
@jupyterlab/attachments: 3.1.0-rc.2
@jupyterlab/translation-extension: 3.1.0-rc.2
@jupyterlab/celltags-extension: 3.1.0-rc.2
@jupyterlab/completer: 3.1.0-rc.2
@jupyterlab/notebook-extension: 3.1.0-rc.2
@jupyterlab/logconsole-extension: 3.1.0-rc.2
@jupyterlab/fileeditor: 3.1.0-rc.2
@jupyterlab/statusbar: 3.1.0-rc.2
@jupyterlab/completer-extension: 3.1.0-rc.2
@jupyterlab/vega5-extension: 3.1.0-rc.2
@jupyterlab/codeeditor: 3.1.0-rc.2
@jupyterlab/notebook: 3.1.0-rc.2
@jupyterlab/htmlviewer-extension: 3.1.0-rc.2
@jupyterlab/application: 3.1.0-rc.2
@jupyterlab/mathjax2-extension: 3.1.0-rc.2
@jupyterlab/terminal: 3.1.0-rc.2
@jupyterlab/settingregistry: 3.1.0-rc.2
@jupyterlab/ui-components: 3.1.0-rc.2
@jupyterlab/filebrowser-extension: 3.1.0-rc.2
@jupyterlab/csvviewer: 3.1.0-rc.2
node-example: 3.1.0-rc.2
@jupyterlab/example-services-browser: 3.1.0-rc.2
@jupyterlab/example-services-outputarea: 3.1.0-rc.2
@jupyterlab/builder: 3.1.0-rc.2
@jupyterlab/buildutils: 3.1.0-rc.2
@jupyterlab/template: 3.1.0-rc.2
@jupyterlab/testutils: 3.1.0-rc.2
@jupyterlab/mock-extension: 3.1.0-rc.2
@jupyterlab/mock-token: 3.1.0-rc.2
@jupyterlab/mock-consumer: 3.1.0-rc.2
@jupyterlab/mock-provider: 3.1.0-rc.2

After merging this PR run the "Draft Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.1.x  |
| Version Spec | build |
