### PR TITLE
Clean up link checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ ignore="tests examples"
 [tool.check-manifest]
 ignore = ["binder/**", "builder/**", "buildutils/**", "design/**", "dev_mode/**", "examples/**", "packages/**", "scripts/**", "testutils/**", "*.json", "yarn.lock", "readthedocs.yml", ".bumpversion.cfg", ".*", "clean.py", "lint-staged.config.js", "release/*", "typedoc-theme/**", "typedoc.js", "jupyterlab/schemas/**", "jupyterlab/static/**", "jupyterlab/themes/**", "jupyterlab/style.js"]
 
+[tool.jupyter-releaser]
+skip = ["check-links"]
+
 [tool.jupyter-releaser.options]
 ignore-glob = ["packages/ui-components/docs/source/ui_components.rst"]
 ignore-links = ["../api/*.*"]


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
More progress toward https://github.com/jupyterlab/jupyterlab/issues/10340
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Use the new skip config available in Jupyter Releaser to skip the long Check Links phase, and use the Jupyter Releaser logic in our existing `linkcheck` job.   This saves about 10 minutes in the Check Release job and makes our link checking more robust.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->