### PR TITLE
Add icon and mnemonic menu attributes in settings

### DIFF
--- a/packages/application-extension/schema/main.json
+++ b/packages/application-extension/schema/main.json
@@ -80,6 +80,10 @@
           "type": "boolean",
           "default": false
         },
+        "icon": {
+          "description": "Menu icon id",
+          "type": "string"
+        },
         "id": {
           "description": "Menu unique id",
           "type": "string",
@@ -95,6 +99,12 @@
         "label": {
           "description": "Menu label",
           "type": "string"
+        },
+        "mnemonic": {
+          "description": "Mnemonic index for the label",
+          "type": "number",
+          "minimum": -1,
+          "default": -1
         },
         "rank": {
           "description": "Menu rank",

--- a/packages/apputils/src/menufactory.ts
+++ b/packages/apputils/src/menufactory.ts
@@ -1,4 +1,5 @@
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import { LabIcon } from '@jupyterlab/ui-components';
 import { JSONExt } from '@lumino/coreutils';
 import { ContextMenu, Menu } from '@lumino/widgets';
 
@@ -58,6 +59,12 @@ export namespace MenuFactory {
     const menu = menuFactory(item);
     menu.id = item.id;
     menu.title.label = item.label ?? capitalize(menu.id);
+    if (item.icon) {
+      menu.title.icon = LabIcon.resolve({ icon: item.icon });
+    }
+    if (item.mnemonic !== undefined) {
+      menu.title.mnemonic = item.mnemonic;
+    }
 
     item.items
       ?.filter(item => !item.disabled)

--- a/packages/mainmenu-extension/schema/plugin.json
+++ b/packages/mainmenu-extension/schema/plugin.json
@@ -329,6 +329,10 @@
           "type": "boolean",
           "default": false
         },
+        "icon": {
+          "description": "Menu icon id",
+          "type": "string"
+        },
         "id": {
           "description": "Menu unique id",
           "type": "string",
@@ -344,6 +348,12 @@
         "label": {
           "description": "Menu label",
           "type": "string"
+        },
+        "mnemonic": {
+          "description": "Mnemonic index for the label",
+          "type": "number",
+          "minimum": -1,
+          "default": -1
         },
         "rank": {
           "description": "Menu rank",

--- a/packages/settingregistry/src/plugin-schema.json
+++ b/packages/settingregistry/src/plugin-schema.json
@@ -76,6 +76,10 @@
           "type": "boolean",
           "default": false
         },
+        "icon": {
+          "description": "Menu icon id",
+          "type": "string"
+        },
         "id": {
           "description": "Menu unique id",
           "oneOf": [
@@ -106,6 +110,12 @@
         "label": {
           "description": "Menu label",
           "type": "string"
+        },
+        "mnemonic": {
+          "description": "Mnemonic index for the label",
+          "type": "number",
+          "minimum": -1,
+          "default": -1
         },
         "rank": {
           "description": "Menu rank",

--- a/packages/settingregistry/src/tokens.ts
+++ b/packages/settingregistry/src/tokens.ts
@@ -211,6 +211,22 @@ export namespace ISettingRegistry {
     label?: string;
 
     /**
+     * Menu icon id
+     *
+     * #### Note
+     * The icon id will looked for in registered LabIcon.
+     */
+    icon?: string;
+
+    /**
+     * Get the mnemonic index for the title.
+     *
+     * #### Notes
+     * The default value is `-1`.
+     */
+    mnemonic?: number;
+
+    /**
      * Whether a menu is disabled. `False` by default.
      *
      * #### Notes


### PR DESCRIPTION
Follow-up of #10373

When using the new menu definition from settings, I saw that those menu attributes were not available from the data description.