### PR TITLE
Set anonymous username bug

### DIFF
--- a/packages/docprovider/src/yprovider.ts
+++ b/packages/docprovider/src/yprovider.ts
@@ -47,7 +47,7 @@ export class WebSocketProviderWithLocks
     const awareness = options.ymodel.awareness;
     const currState = awareness.getLocalState();
     // only set if this was not already set by another plugin
-    if (currState && currState.name == null) {
+    if (currState && currState.user?.name == null) {
       options.ymodel.awareness.setLocalStateField('user', {
         name,
         color


### PR DESCRIPTION
If no other plugin sets the name for RTC, the document provider sets an anonymous name.
The problem is that the state object contains a `user` object with name and color, not the name and color directly.

## References
https://github.com/jupyterlab/jupyterlab/blob/b119f08b50072f469fefacea465d99cbaab68ee3/packages/docprovider/src/yprovider.ts#L51-L54

## Code changes
Check if there is a user, and this has the name `user`.

## User-facing changes
N/A

## Backwards-incompatible changes
N/A
