### PR TITLE
Workaround disappearing palette issue by using blur

### DIFF
--- a/packages/apputils/src/commandpalette.ts
+++ b/packages/apputils/src/commandpalette.ts
@@ -66,6 +66,9 @@ export class ModalCommandPalette extends Panel {
         this.hideAndReset();
       }
     });
+    // required to properly receive blur and focus events;
+    // selection of items with mouse may not work without this.
+    this.node.tabIndex = 0;
   }
 
   get palette(): CommandPalette {
@@ -109,10 +112,16 @@ export class ModalCommandPalette extends Panel {
       case 'keydown':
         this._evtKeydown(event as KeyboardEvent);
         break;
-      case 'focus': {
+      case 'blur': {
         // if the focus shifted outside of this DOM element, hide and reset.
-        const target = event.target as HTMLElement;
-        if (!this.node.contains(target as HTMLElement)) {
+        if (
+          // focus went away from child element
+          this.node.contains(event.target as HTMLElement) &&
+          // and it did NOT go to another child element but someplace else
+          !this.node.contains(
+            (event as MouseEvent).relatedTarget as HTMLElement
+          )
+        ) {
           event.stopPropagation();
           this.hideAndReset();
         }
@@ -163,11 +172,11 @@ export class ModalCommandPalette extends Panel {
   }
 
   protected onBeforeHide(msg: Message): void {
-    document.removeEventListener('focus', this, true);
+    document.removeEventListener('blur', this, true);
   }
 
   protected onAfterShow(msg: Message): void {
-    document.addEventListener('focus', this, true);
+    document.addEventListener('blur', this, true);
   }
 
   /**

--- a/packages/apputils/test/commandpalette.spec.ts
+++ b/packages/apputils/test/commandpalette.spec.ts
@@ -66,11 +66,13 @@ describe('@jupyterlab/apputils', () => {
       });
     });
 
-    describe('#focus()', () => {
+    describe('#blur()', () => {
       it('should hide and reset when focus is shifted', () => {
         MessageLoop.sendMessage(modalPalette, Widget.Msg.ActivateRequest);
         palette.inputNode.value = 'Search string…';
-        simulate(document.body, 'focus');
+        simulate(modalPalette.node, 'blur', {
+          relatedTarget: document.body
+        });
         expect(modalPalette.isVisible).toBe(false);
         expect(palette.inputNode.value).toEqual('');
       });


### PR DESCRIPTION
## References

Closes #10638.

I think that the problem steams from the notebook re-focusing on cells after each command. As modal command palette does not get focus in the first place, using `blur` event instead of `focus` event skips the event emitted by notebook that would close the command palette.

## Code changes

Listen to `blur` instead of `focus`, check [`relatedTarget`](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/relatedTarget) of the `blur` event.

## User-facing changes

Command palette can be invoked from a cell when editor is active and does not disappear immediately after flashing for half a second.

## Backwards-incompatible changes

None