### PR TITLE
Revert move @types/react in devDependencies of apputils

### DIFF
--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -63,6 +63,7 @@
     "@lumino/signaling": "^1.4.3",
     "@lumino/virtualdom": "^1.8.0",
     "@lumino/widgets": "^1.19.0",
+    "@types/react": "^17.0.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "sanitize-html": "~2.3.3",
@@ -71,7 +72,6 @@
   "devDependencies": {
     "@jupyterlab/testutils": "^3.3.0-alpha.0",
     "@types/jest": "^26.0.10",
-    "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@types/sanitize-html": "^2.3.1",
     "jest": "^26.4.2",


### PR DESCRIPTION
## References and Code changes

Reverts the main change of #10717 (keeping the typo correction)

## User-facing and backwards-incompatible changes

Avoids breaking everything :sweat: 

