### PR TITLE
Responsive document toolbar

### DIFF
--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -381,17 +381,19 @@ export class Toolbar<T extends Widget = Widget> extends Widget {
 
   protected onResize(msg: Widget.ResizeMessage) {
     super.onResize(msg);
-    if (this.resizeTimer) {
-      clearTimeout(this.resizeTimer);
-    }
+    if (msg.width > 0) {
+      if (this.resizeTimer) {
+        clearTimeout(this.resizeTimer);
+      }
 
-    this.resizeTimer = setTimeout(() => {
-      this._onResize(msg);
-    }, 250);
+      this.resizeTimer = setTimeout(() => {
+        this._onResize(msg);
+      }, 250);
+    }
   }
 
   private _onResize(msg: Widget.ResizeMessage) {
-    if (this.parent!.isAttached) {
+    if (this.parent && this.parent.isAttached) {
       const toolbarWidth = this.node.clientWidth;
       const opener = this.popupOpener;
       const openerWidth = 30;

--- a/packages/apputils/test/toolbar.spec.ts
+++ b/packages/apputils/test/toolbar.spec.ts
@@ -58,7 +58,12 @@ describe('@jupyterlab/apputils', () => {
         widget.addItem('foo', new Widget());
         widget.addItem('bar', new Widget());
         widget.addItem('baz', new Widget());
-        expect(toArray(widget.names())).toEqual(['foo', 'bar', 'baz']);
+        expect(toArray(widget.names())).toEqual([
+          'foo',
+          'bar',
+          'baz',
+          'toolbar-popup-opener'
+        ]);
       });
     });
 
@@ -86,14 +91,24 @@ describe('@jupyterlab/apputils', () => {
         widget.addItem('a', new Widget());
         widget.addItem('b', new Widget());
         widget.insertItem(1, 'c', new Widget());
-        expect(toArray(widget.names())).toEqual(['a', 'c', 'b']);
+        expect(toArray(widget.names())).toEqual([
+          'a',
+          'c',
+          'b',
+          'toolbar-popup-opener'
+        ]);
       });
 
       it('should clamp the bounds', () => {
         widget.addItem('a', new Widget());
         widget.addItem('b', new Widget());
         widget.insertItem(10, 'c', new Widget());
-        expect(toArray(widget.names())).toEqual(['a', 'b', 'c']);
+        expect(toArray(widget.names())).toEqual([
+          'a',
+          'b',
+          'c',
+          'toolbar-popup-opener'
+        ]);
       });
     });
 
@@ -103,7 +118,13 @@ describe('@jupyterlab/apputils', () => {
         widget.addItem('b', new Widget());
         widget.insertItem(1, 'c', new Widget());
         widget.insertAfter('c', 'd', new Widget());
-        expect(toArray(widget.names())).toEqual(['a', 'c', 'd', 'b']);
+        expect(toArray(widget.names())).toEqual([
+          'a',
+          'c',
+          'd',
+          'b',
+          'toolbar-popup-opener'
+        ]);
       });
 
       it('should return false if the target item does not exist', () => {
@@ -120,7 +141,13 @@ describe('@jupyterlab/apputils', () => {
         widget.addItem('b', new Widget());
         widget.insertItem(1, 'c', new Widget());
         widget.insertBefore('c', 'd', new Widget());
-        expect(toArray(widget.names())).toEqual(['a', 'd', 'c', 'b']);
+        expect(toArray(widget.names())).toEqual([
+          'a',
+          'd',
+          'c',
+          'b',
+          'toolbar-popup-opener'
+        ]);
       });
 
       it('should return false if the target item does not exist', () => {

--- a/packages/debugger/test/debugger.spec.ts
+++ b/packages/debugger/test/debugger.spec.ts
@@ -168,7 +168,7 @@ describe('Debugger', () => {
       const node = sidebar.callstack.node;
       const items = node.querySelectorAll('button');
 
-      expect(items.length).toEqual(6);
+      expect(items.length).toEqual(7);
       items.forEach(item => {
         expect(Array.from(items[0].classList)).toEqual(
           expect.arrayContaining(['jp-ToolbarButtonComponent'])

--- a/packages/docregistry/test/default.spec.ts
+++ b/packages/docregistry/test/default.spec.ts
@@ -189,10 +189,18 @@ describe('docregistry/default', () => {
         const context = await Mock.createFileContext();
         const widget = factory.createNew(context);
         const widget2 = factory.createNew(context);
-        expect(toArray(widget.toolbar.names())).toEqual(['foo', 'bar']);
-        expect(toArray(widget2.toolbar.names())).toEqual(['foo', 'bar']);
-        expect(toArray(widget.toolbar.children()).length).toBe(2);
-        expect(toArray(widget2.toolbar.children()).length).toBe(2);
+        expect(toArray(widget.toolbar.names())).toEqual([
+          'foo',
+          'bar',
+          'toolbar-popup-opener'
+        ]);
+        expect(toArray(widget2.toolbar.names())).toEqual([
+          'foo',
+          'bar',
+          'toolbar-popup-opener'
+        ]);
+        expect(toArray(widget.toolbar.children()).length).toBe(3);
+        expect(toArray(widget2.toolbar.children()).length).toBe(3);
       });
     });
 

--- a/packages/notebook/style/toolbar.css
+++ b/packages/notebook/style/toolbar.css
@@ -33,3 +33,16 @@
 .jp-Notebook-toolbarCellTypeDropdown span {
   top: 5px !important;
 }
+
+.jp-Toolbar-responsive-popup {
+  position: absolute;
+  height: 29px;
+  width: 300px;
+  scroll: auto;
+  z-index: 100;
+  border: solid gray 1px;
+  background: var(--jp-toolbar-background);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}

--- a/packages/notebook/style/toolbar.css
+++ b/packages/notebook/style/toolbar.css
@@ -36,13 +36,20 @@
 
 .jp-Toolbar-responsive-popup {
   position: absolute;
-  height: 29px;
-  width: 300px;
-  scroll: auto;
-  z-index: 100;
-  border: solid gray 1px;
-  background: var(--jp-toolbar-background);
+  height: var(--jp-private-toolbar-height);
   display: flex;
-  align-items: center;
+  flex-direction: row;
   justify-content: flex-end;
+  border-bottom: var(--jp-border-width) solid var(--jp-toolbar-border-color);
+  box-shadow: var(--jp-toolbar-box-shadow);
+  background: var(--jp-toolbar-background);
+  min-height: var(--jp-toolbar-micro-height);
+  padding: 2px;
+  z-index: 1;
+  right: 0px;
+  top: 0px;
+}
+
+.jp-toolbar > .jp-Toolbar-responsive-opener {
+  margin-left: auto;
 }

--- a/packages/notebook/test/widgetfactory.spec.ts
+++ b/packages/notebook/test/widgetfactory.spec.ts
@@ -130,10 +130,18 @@ describe('@jupyterlab/notebook', () => {
         const factory = createFactory(toolbarFactory);
         const panel = factory.createNew(context);
         const panel2 = factory.createNew(context);
-        expect(toArray(panel.toolbar.names())).toEqual(['foo', 'bar']);
-        expect(toArray(panel2.toolbar.names())).toEqual(['foo', 'bar']);
-        expect(toArray(panel.toolbar.children()).length).toBe(2);
-        expect(toArray(panel2.toolbar.children()).length).toBe(2);
+        expect(toArray(panel.toolbar.names())).toEqual([
+          'foo',
+          'bar',
+          'toolbar-popup-opener'
+        ]);
+        expect(toArray(panel2.toolbar.names())).toEqual([
+          'foo',
+          'bar',
+          'toolbar-popup-opener'
+        ]);
+        expect(toArray(panel.toolbar.children()).length).toBe(3);
+        expect(toArray(panel2.toolbar.children()).length).toBe(3);
       });
 
       it('should clone from the optional source widget', () => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
This PR fixes the issue [#10595](https://github.com/jupyterlab/jupyterlab/issues/10595)

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Toolbar class has a new default button and a popup. The resize handler is added which keeps track of widths of items and  moves them to the popup if the cumulative width increases toolbar width. Alternatively, if toolbar width is big enough to accommodate any widgets in the popup, they are moved back to the toolbar.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Toolbar has a new default button and a popup that stores items that don't fit in the toolbar when the toolbar is resized. 

<!-- For visual changes, include before and after screenshots here. -->
![responsive-toolbar](https://user-images.githubusercontent.com/289369/127290665-aef5f6fc-8a4e-4f0c-a6df-2637afb599ab.gif)



## Backwards-incompatible changes
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None
