### PR TITLE
Use appName in page title when restoring workspaces (vs 3.1.x)

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -335,7 +335,7 @@ async function updateTabTitle(workspace: string, db: IStateDB, name: string) {
   const data: any = await db.toJSON();
   let current: string = data['layout-restorer:data']?.main?.current;
   if (current === undefined) {
-    document.title = `JupyterLab${
+    document.title = `${PageConfig.getOption('appName') || 'JupyterLab'}${
       workspace.startsWith('auto-') ? ` (${workspace})` : ``
     }`;
   } else {


### PR DESCRIPTION
## References

- fixes #10722

## Code changes

- uses `PageConfig`'s `appName` instead of hard-coded JupyterLab

## User-facing changes

- Users of customized lab applications will see their custom app name after the page restarts

## Backwards-incompatible changes

- n/a