### PR TITLE
Normalize translation domain

### DIFF
--- a/packages/translation/src/gettext.ts
+++ b/packages/translation/src/gettext.ts
@@ -13,6 +13,8 @@
 | See: https://github.com/DefinitelyTyped/DefinitelyTyped
 |----------------------------------------------------------------------------*/
 
+import { normalizeDomain } from './utils';
+
 /**
  * A plural form function.
  */
@@ -30,6 +32,9 @@ interface IJsonDataHeader {
   /**
    * The domain of the translation, usually the normalized package name.
    * Example: "jupyterlab", "jupyterlab_git"
+   *
+   * #### Note
+   * Normalization replaces `-` by `_` in package name.
    */
   domain: string;
 
@@ -72,6 +77,9 @@ interface IOptions {
   /**
    * The domain of the translation, usually the normalized package name.
    * Example: "jupyterlab", "jupyterlab_git"
+   *
+   * #### Note
+   * Normalization replaces `-` by `_` in package name.
    */
   domain?: string;
 
@@ -143,7 +151,7 @@ class Gettext {
 
     // Ensure the correct separator is used
     this._locale = (options.locale || this._defaults.locale).replace('_', '-');
-    this._domain = options.domain || this._defaults.domain;
+    this._domain = normalizeDomain(options.domain || this._defaults.domain);
     this._contextDelimiter =
       options.contextDelimiter || this._defaults.contextDelimiter;
     this._stringsPrefix = options.stringsPrefix || this._defaults.stringsPrefix;
@@ -203,7 +211,7 @@ class Gettext {
    * @param domain - The domain to set.
    */
   setDomain(domain: string): void {
-    this._domain = domain;
+    this._domain = normalizeDomain(domain);
   }
 
   /**
@@ -274,6 +282,8 @@ class Gettext {
         `Wrong jsonData, it must have an empty key ("") with "language" and "pluralForms" information: ${jsonData}`
       );
     }
+
+    domain = normalizeDomain(domain);
 
     let headers = jsonData[''];
     let jsonDataCopy = JSON.parse(JSON.stringify(jsonData));
@@ -450,7 +460,7 @@ class Gettext {
     n: number,
     ...args: any[]
   ): string {
-    domain = domain || this._domain;
+    domain = normalizeDomain(domain) || this._domain;
 
     let translation: Array<string>;
     let key: string = msgctxt
@@ -645,6 +655,8 @@ class Gettext {
     messages: IJsonDataMessages,
     pluralForms: string
   ): void {
+    domain = normalizeDomain(domain);
+
     if (pluralForms) this._pluralForms[locale] = pluralForms;
 
     if (!this._dictionary[domain]) this._dictionary[domain] = {};

--- a/packages/translation/src/manager.ts
+++ b/packages/translation/src/manager.ts
@@ -3,6 +3,7 @@
 
 import { Gettext } from './gettext';
 import { ITranslator, TranslationBundle, TranslatorConnector } from './tokens';
+import { normalizeDomain } from './utils';
 
 /**
  * Translation Manager
@@ -39,6 +40,7 @@ export class TranslationManager implements ITranslator {
       if (this._currentLocale == 'en') {
         return this._englishBundle;
       } else {
+        domain = normalizeDomain(domain);
         if (!(domain in this._translationBundles)) {
           let translationBundle = new Gettext({
             domain: domain,

--- a/packages/translation/src/utils.ts
+++ b/packages/translation/src/utils.ts
@@ -1,0 +1,9 @@
+/**
+ * Normalize domain
+ *
+ * @param domain Domain to normalize
+ * @returns Normalized domain
+ */
+export function normalizeDomain(domain: string): string {
+  return domain.replace('-', '_');
+}


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Translation files are normalized. But the domain that reference it in the frontend is not. This breaks the ability to load translation if the domain requested is not normalized.
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Domain is automatically normalized to be tolerant to extension authors not knowing the correct normalization rule.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A