### PR TITLE
Add translations for kernel statuses

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -1635,7 +1635,7 @@ namespace Private {
     const trans = translator.load('jupyterlab');
 
     const group = document.createElement('optgroup');
-    group.label = 'Use No Kernel';
+    group.label = trans.__('Use No Kernel');
     const option = document.createElement('option');
     option.text = trans.__('No Kernel');
     option.value = 'null';

--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { Text } from '@jupyterlab/coreutils';
 import {
   ITranslator,
   nullTranslator,
@@ -767,6 +766,22 @@ namespace Private {
       this.translator = translator || nullTranslator;
       this._trans = this.translator.load('jupyterlab');
       this.addClass(TOOLBAR_KERNEL_STATUS_CLASS);
+      // TODO-FIXME: this mapping is duplicated in statusbar/kernelStatus.tsx
+      this._statusNames = {
+        unknown: this._trans.__('Unknown'),
+        starting: this._trans.__('Starting'),
+        idle: this._trans.__('Idle'),
+        busy: this._trans.__('Busy'),
+        terminating: this._trans.__('Terminating'),
+        restarting: this._trans.__('Restarting'),
+        autorestarting: this._trans.__('Autorestarting'),
+        dead: this._trans.__('Dead'),
+        connected: this._trans.__('Connected'),
+        connecting: this._trans.__('Connecting'),
+        disconnected: this._trans.__('Disconnected'),
+        initializing: this._trans.__('Initializing'),
+        '': ''
+      };
       this._onStatusChanged(sessionContext);
       sessionContext.statusChanged.connect(this._onStatusChanged, this);
       sessionContext.connectionStatusChanged.connect(
@@ -787,7 +802,7 @@ namespace Private {
 
       const circleIconProps: LabIcon.IProps = {
         container: this.node,
-        title: this._trans.__('Kernel %1', Text.titleCase(status)),
+        title: this._trans.__('Kernel %1', this._statusNames[status] || status),
         stylesheet: 'toolbarButton',
         alignSelf: 'normal',
         height: '24px'
@@ -816,5 +831,9 @@ namespace Private {
 
     protected translator: ITranslator;
     private _trans: TranslationBundle;
+    private readonly _statusNames: Record<
+      ISessionContext.KernelDisplayStatus,
+      string
+    >;
   }
 }

--- a/packages/statusbar/package.json
+++ b/packages/statusbar/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@jupyterlab/apputils": "^3.3.0-alpha.0",
     "@jupyterlab/codeeditor": "^3.3.0-alpha.0",
-    "@jupyterlab/coreutils": "^5.3.0-alpha.0",
     "@jupyterlab/services": "^6.3.0-alpha.0",
     "@jupyterlab/translation": "^3.3.0-alpha.0",
     "@jupyterlab/ui-components": "^3.3.0-alpha.0",

--- a/packages/statusbar/tsconfig.json
+++ b/packages/statusbar/tsconfig.json
@@ -13,9 +13,6 @@
       "path": "../codeeditor"
     },
     {
-      "path": "../coreutils"
-    },
-    {
       "path": "../services"
     },
     {

--- a/packages/statusbar/tsconfig.test.json
+++ b/packages/statusbar/tsconfig.test.json
@@ -9,9 +9,6 @@
       "path": "../codeeditor"
     },
     {
-      "path": "../coreutils"
-    },
-    {
       "path": "../services"
     },
     {
@@ -31,9 +28,6 @@
     },
     {
       "path": "../codeeditor"
-    },
-    {
-      "path": "../coreutils"
     },
     {
       "path": "../services"


### PR DESCRIPTION
## References

Part 1 of #10737

## Code changes

- Introduces a `Record` mapping the possible kernel statuses to translated equivalents.
- Removes the use of `Text.titleCase` which is not localization-friendly

Implementation wise I went for most backward and forward-compatible way of duplicating this `Record` in both places where it is needed (status bar and toolbar). It is not great and we should think of something better:
- I did not want to touch the actual status strings as manny extensions may depend on those (and we use them in code too!),
- I also did not wan't to introduce any public API dedicated to translations on `SessionContext` class (I was thinking `SessionContext.translateKernelStatus(status): string` or `SessionContext.translatedKernelStatus`) because that would require longer discussion and seems very different to the current pattern of not having explicit translation methods.

## User-facing changes

Statuses will be translated.

## Backwards-incompatible changes

None.
