### PR TITLE
Translate labels of menus and submenus

### DIFF
--- a/packages/apputils/src/menufactory.ts
+++ b/packages/apputils/src/menufactory.ts
@@ -1,3 +1,4 @@
+import { Text } from '@jupyterlab/coreutils';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { LabIcon } from '@jupyterlab/ui-components';
 import { JSONExt } from '@lumino/coreutils';
@@ -58,7 +59,12 @@ export namespace MenuFactory {
   ): Menu {
     const menu = menuFactory(item);
     menu.id = item.id;
-    menu.title.label = item.label ?? capitalize(menu.id);
+
+    // Set the label in case the menu factory did not.
+    if (!menu.title.label) {
+      menu.title.label = item.label ?? Text.titleCase(menu.id.trim());
+    }
+
     if (item.icon) {
       menu.title.icon = LabIcon.resolve({ icon: item.icon });
     }
@@ -186,20 +192,5 @@ export namespace MenuFactory {
         }
       });
     }
-  }
-
-  /**
-   * Capitalize a string
-   *
-   * @param s String to capitalize
-   * @returns The capitalized string
-   */
-  function capitalize(s: string): string {
-    return s
-      .trim()
-      .split(' ')
-      .filter(part => part.trim().length > 0)
-      .map(part => part.replace(/^\w/, c => c.toLocaleUpperCase()))
-      .join(' ');
   }
 }

--- a/packages/coreutils/src/text.ts
+++ b/packages/coreutils/src/text.ts
@@ -99,7 +99,7 @@ export namespace Text {
    *
    * @returns the same string, but with each word capitalized.
    */
-  export function titleCase(str: string) {
+  export function titleCase(str: string): string {
     return (str || '')
       .toLowerCase()
       .split(' ')

--- a/packages/mainmenu/src/mainmenu.ts
+++ b/packages/mainmenu/src/mainmenu.ts
@@ -234,12 +234,12 @@ export class MainMenu extends MenuBar implements IMainMenu {
    *
    * @param commands The command registry
    * @param options The main menu options.
-   * @param translator - The application language translator.
+   * @param trans - The application language translator.
    */
   static generateMenu(
     commands: CommandRegistry,
     options: IMainMenu.IMenuOptions,
-    translator: TranslationBundle
+    trans: TranslationBundle
   ): RankedMenu {
     let menu: RankedMenu;
     const { id, label, rank } = options;
@@ -309,8 +309,9 @@ export class MainMenu extends MenuBar implements IMainMenu {
     }
 
     if (label) {
-      menu.title.label = translator.__(label);
+      menu.title.label = trans.__(label);
     }
+
     return menu;
   }
 

--- a/packages/ui-components/src/components/menu.ts
+++ b/packages/ui-components/src/components/menu.ts
@@ -72,6 +72,8 @@ export namespace IRankedMenu {
    */
   export interface IOptions extends Menu.IOptions {
     /**
+     * Whether to include separators between the
+     *   groups that are added to the menu.
      *
      * Default: true
      */
@@ -90,10 +92,7 @@ export class RankedMenu extends Menu implements IRankedMenu {
   /**
    * Construct a new menu.
    *
-   * @param options - Options for the phosphor menu.
-   *
-   * @param includeSeparators - whether to include separators between the
-   *   groups that are added to the menu.
+   * @param options - Options for the lumino menu.
    */
   constructor(options: IRankedMenu.IOptions) {
     super(options);


### PR DESCRIPTION
## References

Translate the labels in top-level menus and submenus, a part of #10737.

## Code changes

- Move setting the label to the mainmenu package from the menufactory utility as the translation bundle needs to be available
- Fix a docstring for `RankedMenu`

## User-facing changes

Before:

![Screenshot from 2021-07-29 22-55-48](https://user-images.githubusercontent.com/5832902/127570904-3ddc109e-5ef0-49cd-a28b-e1d6e4956330.png)

After:

![Screenshot from 2021-07-29 22-54-09](https://user-images.githubusercontent.com/5832902/127570914-17a1061c-2bc1-4693-a0eb-272e8315ed39.png)

## Backwards-incompatible changes

None.
