### PR TITLE
Revert change in saveState Signal

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -673,7 +673,7 @@ function addCommands(
           }
 
           return context
-            .save(true)
+            .save()
             .then(() => context!.createCheckpoint())
             .catch(err => {
               // If the save was canceled by user-action, do nothing.

--- a/packages/docmanager/src/widgetmanager.ts
+++ b/packages/docmanager/src/widgetmanager.ts
@@ -307,7 +307,7 @@ export class DocumentWidgetManager implements IDisposable {
           return true;
         }
         if (context.contentsModel?.writable) {
-          await context.save(true);
+          await context.save();
         } else {
           await context.saveAs();
         }

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -286,17 +286,13 @@ export class Context<
   /**
    * Save the document contents to disk.
    */
-  async save(manual?: boolean): Promise<void> {
+  async save(): Promise<void> {
     const [lock] = await Promise.all([
       this._provider.acquireLock(),
       this.ready
     ]);
     let promise: Promise<void>;
-    if (manual) {
-      promise = this._save(manual);
-    } else {
-      promise = this._save();
-    }
+    promise = this._save();
     // if save completed successfully, we set the initialized content in the rtc server.
     promise = promise.then(() => {
       this._provider.putInitializedState();
@@ -583,7 +579,7 @@ export class Context<
   /**
    * Save the document contents to disk.
    */
-  private async _save(manual?: boolean): Promise<void> {
+  private async _save(): Promise<void> {
     this._saveState.emit('started');
     const model = this._model;
     let content: PartialJSONValue;
@@ -621,11 +617,7 @@ export class Context<
       }
 
       // Emit completion.
-      if (manual) {
-        this._saveState.emit('completed manually');
-      } else {
-        this._saveState.emit('completed');
-      }
+      this._saveState.emit('completed');
     } catch (err) {
       // If the save has been canceled by the user,
       // throw the error so that whoever called save()

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -905,7 +905,7 @@ export namespace DocumentRegistry {
     /**
      * Save the document contents to disk.
      */
-    save(manual?: boolean): Promise<void>;
+    save(): Promise<void>;
 
     /**
      * Save the document to a different path chosen by the user.
@@ -976,8 +976,7 @@ export namespace DocumentRegistry {
   export type SaveState =
     | 'started'
     | 'failed'
-    | 'completed'
-    | 'completed manually';
+    | 'completed';
 
   /**
    * A type alias for a context.

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -973,10 +973,7 @@ export namespace DocumentRegistry {
     addSibling(widget: Widget, options?: IOpenOptions): IDisposable;
   }
 
-  export type SaveState =
-    | 'started'
-    | 'failed'
-    | 'completed';
+  export type SaveState = 'started' | 'failed' | 'completed';
 
   /**
    * A type alias for a context.

--- a/packages/notebook/src/default-toolbar.tsx
+++ b/packages/notebook/src/default-toolbar.tsx
@@ -67,7 +67,7 @@ export namespace ToolbarItems {
           buttons: [Dialog.okButton({ label: trans.__('Ok') })]
         });
       }
-      void panel.context.save(true).then(() => {
+      void panel.context.save().then(() => {
         if (!panel.isDisposed) {
           return panel.context.createCheckpoint();
         }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

Fixes https://github.com/jupyterlab/jupyterlab/issues/10721

## Code changes

<!-- Describe the code changes and how they address the issue. -->

- Removed optional boolean argument in `save()`
- Removed backward incompatible change in saveState Signal i.e 'completed manually'

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
I don't think so. Please let me know if there is any!
