### PR TITLE
Another Fix to Verdaccio Publishing

### DIFF
--- a/buildutils/src/local-repository.ts
+++ b/buildutils/src/local-repository.ts
@@ -219,14 +219,15 @@ function publishPackages(dist_dir: string) {
   paths.forEach(package_path => {
     const name = path.basename(package_path);
     try {
-      utils.run(`npm publish ${name}`, { cwd: dist_dir });
+      child_process.execSync(`npm publish ${name}`, { cwd: dist_dir });
     } catch (err) {
       // Packages may already exist if we are doing a patch release.
-      const stderr = err.stderr.toString();
+      const stderr = (err.stderr && err.stderr.toString()) || err.toString();
       if (
         stderr.indexOf('EPUBLISHCONFLICT') !== -1 ||
         stderr.indexOf('previously published versions') !== -1
       ) {
+        console.log('Skipping already published package');
         return;
       }
       throw err;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Follow up to https://github.com/jupyterlab/jupyterlab/pull/10743
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Fixing handling of execution error `stderr`.  [Build](https://github.com/jupyterlab/jupyterlab/actions/runs/1082456250) was still failing because the raised error did not have a `stderr` attribute.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

