### PR TITLE
Translate the titles and descriptions in the default settings

### DIFF
--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -60,6 +60,7 @@
     "ws": "^7.4.6"
   },
   "devDependencies": {
+    "@jupyterlab/settingregistry": "^3.3.0-alpha.0",
     "@jupyterlab/testutils": "^3.3.0-alpha.0",
     "@types/jest": "^26.0.10",
     "@types/node": "^14.6.1",

--- a/packages/services/src/setting/index.ts
+++ b/packages/services/src/setting/index.ts
@@ -3,7 +3,7 @@
 
 import { URLExt } from '@jupyterlab/coreutils';
 
-import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import type { ISettingRegistry } from '@jupyterlab/settingregistry';
 
 import { DataConnector } from '@jupyterlab/statedb';
 

--- a/packages/services/tsconfig.json
+++ b/packages/services/tsconfig.json
@@ -18,10 +18,10 @@
       "path": "../observables"
     },
     {
-      "path": "../settingregistry"
+      "path": "../statedb"
     },
     {
-      "path": "../statedb"
+      "path": "../settingregistry"
     }
   ]
 }

--- a/packages/services/tsconfig.test.json
+++ b/packages/services/tsconfig.test.json
@@ -12,10 +12,10 @@
       "path": "../observables"
     },
     {
-      "path": "../settingregistry"
+      "path": "../statedb"
     },
     {
-      "path": "../statedb"
+      "path": "../settingregistry"
     },
     {
       "path": "."
@@ -33,10 +33,10 @@
       "path": "../observables"
     },
     {
-      "path": "../settingregistry"
+      "path": "../statedb"
     },
     {
-      "path": "../statedb"
+      "path": "../settingregistry"
     }
   ]
 }

--- a/packages/settingeditor/src/raweditor.ts
+++ b/packages/settingeditor/src/raweditor.ts
@@ -272,7 +272,8 @@ export class RawEditor extends SplitPanel {
     const defaults = this._defaults;
     const user = this._user;
 
-    defaults.editor.model.value.text = settings?.annotatedDefaults() ?? '';
+    defaults.editor.model.value.text =
+      settings?.annotatedDefaults(this.translator) ?? '';
     user.editor.model.value.text = settings?.raw ?? '';
   }
 

--- a/packages/settingregistry/package.json
+++ b/packages/settingregistry/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@jupyterlab/statedb": "^3.3.0-alpha.0",
+    "@jupyterlab/translation": "^3.3.0-alpha.0",
     "@lumino/commands": "^1.12.0",
     "@lumino/coreutils": "^1.5.3",
     "@lumino/disposable": "^1.4.3",

--- a/packages/settingregistry/src/tokens.ts
+++ b/packages/settingregistry/src/tokens.ts
@@ -14,6 +14,7 @@ import {
 import { IDisposable } from '@lumino/disposable';
 import { ISignal } from '@lumino/signaling';
 import { ISchemaValidator } from './settingregistry';
+import { ITranslator } from '@jupyterlab/translation';
 
 /* tslint:disable */
 /**
@@ -382,6 +383,12 @@ export namespace ISettingRegistry {
     };
 
     /**
+     * The translation domain to be used for translating setting titles and
+     * descriptions.
+     */
+    'jupyter.lab.translation-domain'?: string;
+
+    /**
      * Whether the schema is deprecated.
      *
      * #### Notes
@@ -496,7 +503,7 @@ export namespace ISettingRegistry {
     /**
      * Return the defaults in a commented JSON format.
      */
-    annotatedDefaults(): string;
+    annotatedDefaults(translator?: ITranslator): string;
 
     /**
      * Calculate the default value of a setting by iterating through the schema.

--- a/packages/settingregistry/tsconfig.json
+++ b/packages/settingregistry/tsconfig.json
@@ -9,6 +9,9 @@
   "references": [
     {
       "path": "../statedb"
+    },
+    {
+      "path": "../translation"
     }
   ]
 }

--- a/packages/settingregistry/tsconfig.test.json
+++ b/packages/settingregistry/tsconfig.test.json
@@ -6,6 +6,9 @@
       "path": "../statedb"
     },
     {
+      "path": "../translation"
+    },
+    {
       "path": "."
     },
     {
@@ -13,6 +16,9 @@
     },
     {
       "path": "../statedb"
+    },
+    {
+      "path": "../translation"
     }
   ]
 }


### PR DESCRIPTION
While we already extract titles and descriptions we are not showing the translated versions in the UI. Further, we do not have a way to determine which translation domain to apply to each specific settings file.

## References

#10739 and somehow related to #10414

## Code changes

- **[Needs discussion]** Added a new optional key in schema `jupyter.lab.translation-domain` to allow extensions to declare which domain should be used for specific settings file.
- Added optional `translator` argument to public method `ISettings.annotatedDefaults`

## User-facing changes

Before

![image](https://user-images.githubusercontent.com/5832902/127719816-08425e8b-4780-447c-a58b-214b190d30af.png)

After (this is not representative, there are tabs with more complete coverage)

![Screenshot from 2021-07-31 00-07-50](https://user-images.githubusercontent.com/5832902/127719873-4d7d87c1-8510-4b11-988b-b60ff36eae60.png)


## Backwards-incompatible changes

None