### PR TITLE
Bump `url-parse~1.5.4`

### DIFF
--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -45,7 +45,7 @@
     "minimist": "~1.2.0",
     "moment": "^2.24.0",
     "path-browserify": "^1.0.0",
-    "url-parse": "~1.5.1"
+    "url-parse": "~1.5.4"
   },
   "devDependencies": {
     "@jupyterlab/testutils": "^4.0.0-alpha.2",

--- a/packages/coreutils/src/url.ts
+++ b/packages/coreutils/src/url.ts
@@ -53,10 +53,16 @@ export namespace URLExt {
    * @returns the joined url.
    */
   export function join(...parts: string[]): string {
-    const u = urlparse(parts[0], {});
-    const prefix = `${u.protocol}${u.slashes ? '//' : ''}${u.auth}${
-      u.auth ? '@' : ''
-    }${u.host}`;
+    let u = urlparse(parts[0], {});
+    // Schema-less URL can be only parsed as relative to a base URL
+    // see https://github.com/unshiftio/url-parse/issues/219#issuecomment-1002219326
+    const isSchemaLess = u.protocol === '' && u.slashes;
+    if (isSchemaLess) {
+      u = urlparse(parts[0], 'https:' + parts[0]);
+    }
+    const prefix = `${isSchemaLess ? '' : u.protocol}${u.slashes ? '//' : ''}${
+      u.auth
+    }${u.auth ? '@' : ''}${u.host}`;
     // If there was a prefix, then the first path must start at the root.
     const path = posix.join(
       `${!!prefix && u.pathname[0] !== '/' ? '/' : ''}${u.pathname}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13147,10 +13147,10 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-parse@~1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.1.tgz#d5fa9890af8a5e1f274a2c98376510f6425f6e3b"
-  integrity sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==
+url-parse@~1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.4.tgz#e4f645a7e2a0852cc8a66b14b292a3e9a11a97fd"
+  integrity sha512-ITeAByWWoqutFClc/lRZnFplgXgEZr3WJ6XngMM/N9DMIm4K8zXPCZ1Jdu0rERwO84w1WC5wkle2ubwTA4NTBg==
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"


### PR DESCRIPTION
## References

#10753. Jumping on this one just in case to make sure it gets updated to 1.5.3+ and I don't have to make downstream patch releases with workarounds for bugs in <1.5.3.

## Code changes

- [x] bump `url-parse": "~1.5.4"` for `coreutils` (1.5.3 was breaking tests due to https://github.com/unshiftio/url-parse/issues/219)
  - [ ] fix tests?
- [x] we are still stuck with url-parse 1.4.x because of `storybook` 5.2.8. We would probably need to move to 6.x. Any concerns about bumping the major version here? CC @jasongrout who was updating it last month for 3.1.

## User-facing changes

None

## Backwards-incompatible changes

None
