### PR TITLE
Prevent undo/redo in outputs

### DIFF
--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -759,7 +759,7 @@ export class YCodeCell
     this.transact(() => {
       youtputs.delete(0, youtputs.length);
       youtputs.insert(0, outputs);
-    });
+    }, false);
   }
 
   /**
@@ -781,7 +781,7 @@ export class YCodeCell
     this.transact(() => {
       youtputs.delete(start, fin);
       youtputs.insert(start, outputs);
-    });
+    }, false);
   }
 
   /**


### PR DESCRIPTION
This PR removes cell outputs from the undo/redo stack.

## References
Solves  #10694

## Code changes

Adds `undo = false` to the outputs transactions.

## User-facing changes

## Backwards-incompatible changes

