### PR TITLE
Yet another fix for Verdaccio publish

### DIFF
--- a/buildutils/src/bumpversion.ts
+++ b/buildutils/src/bumpversion.ts
@@ -22,7 +22,7 @@ commander
 
     // For patch, defer to `patch:release` command
     if (spec === 'patch') {
-      let cmd = 'jlpm run patch:release';
+      let cmd = 'jlpm run patch:release --all';
       if (opts.force) {
         cmd += ' --force';
       }

--- a/buildutils/src/local-repository.ts
+++ b/buildutils/src/local-repository.ts
@@ -217,21 +217,8 @@ function fixLinks(package_dir: string) {
 function publishPackages(dist_dir: string) {
   const paths = glob.sync(path.join(dist_dir, '*.tgz'));
   paths.forEach(package_path => {
-    const name = path.basename(package_path);
-    try {
-      child_process.execSync(`npm publish ${name}`, { cwd: dist_dir });
-    } catch (err) {
-      // Packages may already exist if we are doing a patch release.
-      const stderr = (err.stderr && err.stderr.toString()) || err.toString();
-      if (
-        stderr.indexOf('EPUBLISHCONFLICT') !== -1 ||
-        stderr.indexOf('previously published versions') !== -1
-      ) {
-        console.log('Skipping already published package');
-        return;
-      }
-      throw err;
-    }
+    const filename = path.basename(package_path);
+    utils.run(`npm publish ${filename}`, { cwd: dist_dir });
   });
 }
 

--- a/buildutils/src/patch-release.ts
+++ b/buildutils/src/patch-release.ts
@@ -10,6 +10,7 @@ import * as utils from './utils';
 commander
   .description('Create a patch release')
   .option('--force', 'Force the upgrade')
+  .option('--all', 'Patch all JS packages instead of the changed ones')
   .action((options: any) => {
     // Make sure we can patch release.
     const pyVersion = utils.getPythonVersion();
@@ -26,6 +27,9 @@ commander
 
     // Version the changed
     let cmd = `lerna version patch -m \"New version\" --no-push`;
+    if (options.all) {
+      cmd += ' --force-publish=*';
+    }
     if (options.force) {
       cmd += ' --yes';
     }

--- a/buildutils/src/publish.ts
+++ b/buildutils/src/publish.ts
@@ -43,6 +43,11 @@ commander
   .option('--yes', 'Publish without confirmation')
   .option('--dry-run', 'Do not actually push any assets')
   .action(async (options: any) => {
+    // No-op if we're in release helper dry run
+    if (process.env.RH_DRY_RUN === 'true') {
+      return;
+    }
+
     if (!options.skipPublish) {
       if (!options.skipBuild) {
         utils.run('jlpm run build:packages');
@@ -112,6 +117,9 @@ commander
           await sleep(1 * 60 * 1000);
           attempt += 1;
         }
+      }
+      if (attempt == 10) {
+        throw new Error(`Could not find package ${specifier}`);
       }
     });
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/3.1.x/CONTRIBUTING.md
-->

## References
Follow up to https://github.com/jupyterlab/jupyterlab/pull/10747
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Ensure all packages are bumped in a patch release, to avoid package conflicts altogether.   In future versions we can improve this to check whether the package has been published, but it will require more invasive changes and adding dependencies.   This is a smaller change that can be backported to 3.1.x.   Also skip checking for published packages if we are in a dry run.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->