### PR TITLE
Clean Up Major Version Bump Handling

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -37,14 +37,15 @@ Choose and run an appropriate command to bump version numbers for this release.
 
 | Command                    | Python Version Change | NPM Version change                 |
 | -------------------------- | --------------------- | ---------------------------------- |
-| `jlpm bumpversion minor`   | x.y.z-> x.(y+1).0.a0  | All a.b.c -> a.(b+10).0-alpha.0    |
+| `jlpm bumpversion major`   | x.y.z-> (x+1).0.0.a0  | All a.b.c -> a.(b+10).0-alpha.0    |
+| `jlpm bumpversion minor`   | x.y.z-> x.(y+1).0.a0  | All a.b.c -> a.(b+1).0-alpha.0     |
 | `jlpm bumpversion build`   | x.y.z.a0-> x.y.z.a1   | All a.b.c-alpha.0 -> a.b.c-alpha.1 |
 | `jlpm bumpversion release` | x.y.z.a1-> x.y.z.b0   | All a.b.c-alpha.1 -> a.b.c-beta.0  |
 | `jlpm bumpversion release` | x.y.z.a1-> x.y.z.rc0  | All a.b.c-alpha.1 -> a.b.c-rc.0    |
 | `jlpm bumpversion release` | x.y.z.rc0-> x.y.z     | All a.b.c-rc0 -> a.b.c             |
 | `jlpm bumpversion patch`   | x.y.z -> x.y.(z+1)    | Changed a.b.c -> a.b.(c+1)         |
 
-Note: For a minor release, we bump the JS packages by 10 versions so that
+Note: For a major release, we bump the JS packages by 10 versions so that
 we are not competing amongst the minor releases for version numbers.
 We are essentially sub-dividing semver to allow us to bump minor versions
 of the JS packages as many times as we need to for minor releases of the

--- a/buildutils/src/bumpversion.ts
+++ b/buildutils/src/bumpversion.ts
@@ -61,18 +61,6 @@ commander
       return;
     }
 
-    // If this is a major release during the alpha cycle, bump
-    // just the Python version.
-    if (prev.indexOf('a') !== -1 && spec === 'major') {
-      // Bump the version.
-      utils.run(`bumpversion ${spec}`);
-
-      // Run the post-bump script.
-      utils.postbump(commit);
-
-      return;
-    }
-
     // Determine the version spec to use for lerna.
     let lernaVersion = 'preminor';
     if (spec === 'build') {
@@ -103,10 +91,10 @@ commander
       },
       true
     );
-    // For a preminor release, we bump 10 minor versions so that we do
+    // For a major release, we bump 10 minor versions so that we do
     // not conflict with versions during minor releases of the top
     // level package.
-    if (lernaVersion === 'preminor') {
+    if (spec === 'major') {
       for (let i = 0; i < 10; i++) {
         utils.run(cmd);
       }


### PR DESCRIPTION
References
Addresses shortfall seen during 4.0.0a0 release.

Code changes
Add documentation for `bumpversion major` and modify JS bumping logic to only bump 10 minor versions when making a major version change.

User-facing changes
None

Backwards-incompatible changes
None
