### PR TITLE
Markdown url resolver no longer throws for malformed URLs in `isLocal` check

### DIFF
--- a/packages/rendermime/src/registry.ts
+++ b/packages/rendermime/src/registry.ts
@@ -378,8 +378,25 @@ export namespace RenderMimeRegistry {
      * manager.
      */
     isLocal(url: string): boolean {
-      const path = decodeURI(url);
-      return URLExt.isLocal(url) || !!this._contents.driveName(path);
+      if (this.isMalformed(url)) {
+        return false;
+      }
+      return URLExt.isLocal(url) || !!this._contents.driveName(decodeURI(url));
+    }
+
+    /**
+     * Whether the URL can be decoded using `decodeURI`.
+     */
+    isMalformed(url: string): boolean {
+      try {
+        decodeURI(url);
+        return false;
+      } catch (error: unknown) {
+        if (error instanceof URIError) {
+          return true;
+        }
+        throw error;
+      }
     }
 
     private _path: string;

--- a/packages/rendermime/test/registry.spec.ts
+++ b/packages/rendermime/test/registry.spec.ts
@@ -478,6 +478,12 @@ describe('rendermime/registry', () => {
         it('should return true for a normal filesystem-like path`', () => {
           expect(resolverPath.isLocal('path/to/file')).toBe(true);
         });
+
+        it('should return false for malformed URLs', () => {
+          expect(resolverPath.isLocal('http://www.example.com%bad')).toBe(
+            false
+          );
+        });
       });
     });
   });


### PR DESCRIPTION


## References

Fix #10702 

## Code changes

The error stems from `decodeURI` in the `isLocal` check https://github.com/jupyterlab/jupyterlab/blob/master/packages/rendermime/src/registry.ts#L381 that throws for malformed URLs.

A check with a try/catch was added so that `isLocal` returns `false` for malformed URLs (I think it make sense to **not** try to resolve the URL if we cannot decode it...)

## User-facing changes

Markdown preview works even when containing malformed URLs
![image](https://user-images.githubusercontent.com/42204205/128190156-16c84266-4c64-4f20-9c02-cad17d514105.png)

## Backwards-incompatible changes

None.
