### PR TITLE
Clean up version integrity handling

### DIFF
--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -522,6 +522,10 @@ function ensureJupyterlab(): string[] {
     corePackage.jupyterlab.linkedPackages[data.name] = relativePath;
   });
 
+  // Update the dev mode version.
+  const curr = utils.getPythonVersion();
+  corePackage.jupyterlab.version = curr;
+
   // Write the package.json back to disk.
   if (utils.writePackageData(corePath, corePackage)) {
     return ['Updated dev mode'];

--- a/buildutils/src/utils.ts
+++ b/buildutils/src/utils.ts
@@ -216,14 +216,7 @@ ${status}`
  * Post-bump.
  */
 export function postbump(commit = true): void {
-  // Get the current version.
-  const curr = getPythonVersion();
-
-  // Update the dev mode version.
-  const filePath = path.resolve(path.join('.', 'dev_mode', 'package.json'));
-  const data = readJSONFile(filePath);
-  data.jupyterlab.version = curr;
-  writeJSONFile(filePath, data);
+  run('jlpm run integrity');
 
   // Commit changes.
   if (commit) {

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ def post_dist():
         version = json.load(fid)['jupyterlab']['version']
 
     if Version(version) != Version(get_version(f'{NAME}/_version.py')):
-        raise ValueError('Version mismatch, please run `build:update`')
+        raise ValueError('Version mismatch, please run `npm run prepare:python-release`')
 
 
 try:


### PR DESCRIPTION
## References
Cleans up handling of versions based on errors seen in release process.

## Code changes
Moves handling of app version to the integrity script and cleans up version mismatch error.

## User-facing changes
None

## Backwards-incompatible changes
None