### PR TITLE
Add a guard to avoid kernel deadlock on multiple input request

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -107,6 +107,11 @@ export interface ISessionContext extends IObservableDisposable {
   readonly connectionStatusChanged: ISignal<this, Kernel.ConnectionStatus>;
 
   /**
+   * A flag indicating if session is has pending input, proxied from the session connection.
+   */
+  readonly pendingInput: boolean;
+
+  /**
    * A signal emitted for a kernel messages, proxied from the session connection.
    */
   readonly iopubMessage: ISignal<this, KernelMessage.IMessage>;
@@ -393,6 +398,13 @@ export class SessionContext implements ISessionContext {
    */
   get statusChanged(): ISignal<this, Kernel.Status> {
     return this._statusChanged;
+  }
+
+  /**
+   * A flag indicating if the session has ending input, proxied from the kernel.
+   */
+  get pendingInput(): boolean {
+    return this._pendingInput;
   }
 
   /**
@@ -906,6 +918,7 @@ export class SessionContext implements ISessionContext {
         this._onConnectionStatusChanged,
         this
       );
+      session.pendingInput.connect(this._onPendingInput, this);
       session.iopubMessage.connect(this._onIopubMessage, this);
       session.unhandledMessage.connect(this._onUnhandledMessage, this);
 
@@ -1057,6 +1070,17 @@ export class SessionContext implements ISessionContext {
   }
 
   /**
+   * Handle a change to the pending input.
+   */
+  private _onPendingInput(
+    sender: Session.ISessionConnection,
+    value: boolean
+  ): void {
+    // Set the signal value
+    this._pendingInput = value;
+  }
+
+  /**
    * Handle an iopub message.
    */
   private _onIopubMessage(
@@ -1109,6 +1133,7 @@ export class SessionContext implements ISessionContext {
   );
   private translator: ITranslator;
   private _trans: TranslationBundle;
+  private _pendingInput = false;
   private _iopubMessage = new Signal<this, KernelMessage.IIOPubMessage>(this);
   private _unhandledMessage = new Signal<this, KernelMessage.IMessage>(this);
   private _propertyChanged = new Signal<this, 'path' | 'name' | 'type'>(this);

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -1087,6 +1087,9 @@ export class SessionContext implements ISessionContext {
     sender: Session.ISessionConnection,
     message: KernelMessage.IIOPubMessage
   ): void {
+    if (message.header.msg_type === 'shutdown_reply') {
+      this.session!.kernel!.removeInputGuard();
+    }
     this._iopubMessage.emit(message);
   }
 

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1978,6 +1978,16 @@ namespace Private {
             });
             break;
           }
+          if (sessionContext.pendingInput) {
+            void showDialog({
+              title: trans.__('Cell not executed due to pending input'),
+              body: trans.__(
+                'The cell has not been executed to avoid kernel deadlock as there is another pending input! Submit your pending input and try again.'
+              ),
+              buttons: [Dialog.okButton({ label: trans.__('Ok') })]
+            });
+            return Promise.resolve(false);
+          }
           const deletedCells = notebook.model?.deletedCells ?? [];
           executionScheduled.emit({ notebook, cell });
           return CodeCell.execute(cell as CodeCell, sessionContext, {

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -967,6 +967,13 @@ export class KernelConnection implements Kernel.IKernelConnection {
   }
 
   /**
+   * Remove the input guard, if any.
+   */
+  removeInputGuard() {
+    this.hasPendingInput = false;
+  }
+
+  /**
    * Handle a message with a display id.
    *
    * @returns Whether the message was handled.

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -143,6 +143,13 @@ export class KernelConnection implements Kernel.IKernelConnection {
   }
 
   /**
+   * A signal emitted when a kernel has pending inputs from the user.
+   */
+  get pendingInput(): ISignal<this, boolean> {
+    return this._pendingInput;
+  }
+
+  /**
    * The id of the server-side kernel.
    */
   get id(): string {
@@ -437,6 +444,7 @@ export class KernelConnection implements Kernel.IKernelConnection {
    * request fails or the response is invalid.
    */
   async interrupt(): Promise<void> {
+    this.hasPendingInput = false;
     if (this.status === 'dead') {
       throw new Error('Kernel is dead');
     }
@@ -472,6 +480,7 @@ export class KernelConnection implements Kernel.IKernelConnection {
     // Reconnect to the kernel to address cases where kernel ports
     // have changed during the restart.
     await this.reconnect();
+    this.hasPendingInput = false;
   }
 
   /**
@@ -815,6 +824,8 @@ export class KernelConnection implements Kernel.IKernelConnection {
 
     this._sendMessage(msg);
     this._anyMessage.emit({ msg, direction: 'send' });
+
+    this.hasPendingInput = false;
   }
 
   /**
@@ -1501,6 +1512,14 @@ export class KernelConnection implements Kernel.IKernelConnection {
     }
   };
 
+  get hasPendingInput(): boolean {
+    return this._hasPendingInput;
+  }
+  set hasPendingInput(value: boolean) {
+    this._hasPendingInput = value;
+    this._pendingInput.emit(value);
+  }
+
   private _id = '';
   private _name = '';
   private _status: KernelMessage.Status = 'unknown';
@@ -1541,10 +1560,12 @@ export class KernelConnection implements Kernel.IKernelConnection {
   private _disposed = new Signal<this, void>(this);
   private _iopubMessage = new Signal<this, KernelMessage.IIOPubMessage>(this);
   private _anyMessage = new Signal<this, Kernel.IAnyMessageArgs>(this);
+  private _pendingInput = new Signal<this, boolean>(this);
   private _unhandledMessage = new Signal<this, KernelMessage.IMessage>(this);
   private _displayIdToParentIds = new Map<string, string[]>();
   private _msgIdToDisplayIds = new Map<string, string[]>();
   private _msgChain: Promise<void> = Promise.resolve();
+  private _hasPendingInput = false;
   private _noOp = () => {
     /* no-op */
   };

--- a/packages/services/src/kernel/future.ts
+++ b/packages/services/src/kernel/future.ts
@@ -238,6 +238,7 @@ export abstract class KernelFutureHandler<
   }
 
   private async _handleStdin(msg: KernelMessage.IStdinMessage): Promise<void> {
+    this._kernel.hasPendingInput = true;
     const stdin = this._stdin;
     if (stdin) {
       // tslint:disable-next-line:await-promise

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -111,6 +111,15 @@ export interface IKernelConnection extends IObservableDisposable {
   handleComms: boolean;
 
   /**
+   * Whether the kernel connection has pending input.
+   *
+   * #### Notes
+   * This is a guard to avoid deadlock is the user asks input
+   * as second time before submitting his first input
+   */
+  hasPendingInput: boolean;
+
+  /**
    * Send a shell message to the kernel.
    *
    * @param msg - The fully-formed shell message to send.
@@ -485,6 +494,11 @@ export interface IKernelConnection extends IObservableDisposable {
    * message should be treated as read-only.
    */
   anyMessage: ISignal<this, IAnyMessageArgs>;
+
+  /**
+   * A signal emitted when a kernel has pending inputs from the user.
+   */
+  pendingInput: ISignal<this, boolean>;
 
   /**
    * The server settings for the kernel.

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -466,6 +466,11 @@ export interface IKernelConnection extends IObservableDisposable {
   ): void;
 
   /**
+   * Remove the input guard, if any.
+   */
+  removeInputGuard(): void;
+
+  /**
    * A signal emitted when the kernel status changes.
    */
   statusChanged: ISignal<this, KernelMessage.Status>;

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -202,6 +202,7 @@ export type IOPubMessageType =
   | 'error'
   | 'execute_input'
   | 'execute_result'
+  | 'shutdown_reply'
   | 'status'
   | 'stream'
   | 'update_display_data'

--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -71,6 +71,13 @@ export class SessionConnection implements Session.ISessionConnection {
   }
 
   /**
+   * A signal proxied from the kernel pending input.
+   */
+  get pendingInput(): ISignal<this, boolean> {
+    return this._pendingInput;
+  }
+
+  /**
    * A signal proxied from the kernel about iopub kernel messages.
    */
   get iopubMessage(): ISignal<this, KernelMessage.IIOPubMessage> {
@@ -315,6 +322,7 @@ export class SessionConnection implements Session.ISessionConnection {
     this._kernel = kc;
     kc.statusChanged.connect(this.onKernelStatus, this);
     kc.connectionStatusChanged.connect(this.onKernelConnectionStatus, this);
+    kc.pendingInput.connect(this.onPendingInput, this);
     kc.unhandledMessage.connect(this.onUnhandledMessage, this);
     kc.iopubMessage.connect(this.onIOPubMessage, this);
     kc.anyMessage.connect(this.onAnyMessage, this);
@@ -338,6 +346,13 @@ export class SessionConnection implements Session.ISessionConnection {
     state: Kernel.ConnectionStatus
   ) {
     this._connectionStatusChanged.emit(state);
+  }
+
+  /**
+   * Handle a change in the pendingInput.
+   */
+  protected onPendingInput(sender: Kernel.IKernelConnection, state: boolean) {
+    this._pendingInput.emit(state);
   }
 
   /**
@@ -416,6 +431,7 @@ export class SessionConnection implements Session.ISessionConnection {
   private _connectionStatusChanged = new Signal<this, Kernel.ConnectionStatus>(
     this
   );
+  private _pendingInput = new Signal<this, boolean>(this);
   private _iopubMessage = new Signal<this, KernelMessage.IIOPubMessage>(this);
   private _unhandledMessage = new Signal<this, KernelMessage.IMessage>(this);
   private _anyMessage = new Signal<this, Kernel.IAnyMessageArgs>(this);

--- a/packages/services/src/session/session.ts
+++ b/packages/services/src/session/session.ts
@@ -56,6 +56,12 @@ export interface ISessionConnection extends IObservableDisposable {
   connectionStatusChanged: ISignal<this, Kernel.ConnectionStatus>;
 
   /**
+   * The kernel pendingInput signal, proxied from the current
+   * kernel.
+   */
+  pendingInput: ISignal<this, boolean>;
+
+  /**
    * The kernel iopubMessage signal, proxied from the current kernel.
    */
   iopubMessage: ISignal<this, KernelMessage.IIOPubMessage>;

--- a/packages/services/test/kernel/ikernel.spec.ts
+++ b/packages/services/test/kernel/ikernel.spec.ts
@@ -92,6 +92,27 @@ describe('Kernel.IKernel', () => {
     });
   });
 
+  describe('#pendingInput', () => {
+    it('should be a signal following input request', async () => {
+      let called = false;
+      defaultKernel.pendingInput.connect((sender, args) => {
+        if (!called) {
+          called = true;
+          defaultKernel.sendInputReply({ status: 'ok', value: 'foo' });
+        }
+      });
+      const code = `input("Input something")`;
+      await defaultKernel.requestExecute(
+        {
+          code: code,
+          allow_stdin: true
+        },
+        true
+      ).done;
+      expect(called).toBe(true);
+    });
+  });
+
   describe('#iopubMessage', () => {
     it('should be emitted for an iopub message', async () => {
       let called = false;

--- a/testutils/src/mock.ts
+++ b/testutils/src/mock.ts
@@ -245,9 +245,12 @@ export const KernelMock = jest.fn<
     Kernel.IKernelConnection,
     Kernel.Status
   >(thisObject);
-
+  const pendingInputSignal = new Signal<Kernel.IKernelConnection, boolean>(
+    thisObject
+  );
   (thisObject as any).statusChanged = statusChangedSignal;
   (thisObject as any).iopubMessage = iopubMessageSignal;
+  (thisObject as any).pendingInput = pendingInputSignal;
   (thisObject as any).hasPendingInput = false;
   return thisObject;
 });

--- a/testutils/src/mock.ts
+++ b/testutils/src/mock.ts
@@ -245,6 +245,9 @@ export const KernelMock = jest.fn<
     Kernel.IKernelConnection,
     Kernel.Status
   >(thisObject);
+  const pendingInputSignal = new Signal<Kernel.IKernelConnection, boolean>(
+    thisObject
+  );
   (thisObject as any).statusChanged = statusChangedSignal;
   (thisObject as any).iopubMessage = iopubMessageSignal;
   (thisObject as any).hasPendingInput = false;
@@ -330,12 +333,20 @@ export const SessionConnectionMock = jest.fn<
     KernelMessage.IMessage
   >(thisObject);
 
+  const pendingInputSignal = new Signal<Session.ISessionConnection, boolean>(
+    thisObject
+  );
+
   kernel!.iopubMessage.connect((_, args) => {
     iopubMessageSignal.emit(args);
   }, thisObject);
 
   kernel!.statusChanged.connect((_, args) => {
     statusChangedSignal.emit(args);
+  }, thisObject);
+
+  kernel!.pendingInput.connect((_, args) => {
+    pendingInputSignal.emit(args);
   }, thisObject);
 
   (thisObject as any).disposed = disposedSignal;
@@ -345,6 +356,7 @@ export const SessionConnectionMock = jest.fn<
   (thisObject as any).kernelChanged = kernelChangedSignal;
   (thisObject as any).iopubMessage = iopubMessageSignal;
   (thisObject as any).unhandledMessage = unhandledMessageSignal;
+  (thisObject as any).pendingInput = pendingInputSignal;
   return thisObject;
 });
 
@@ -421,12 +433,17 @@ export const SessionContextMock = jest.fn<
     kernelChangedSignal.emit(args);
   });
 
+  session!.pendingInput.connect((_, args) => {
+    (thisObject as any).pendingInput = args;
+  });
+
   (thisObject as any).statusChanged = statusChangedSignal;
   (thisObject as any).kernelChanged = kernelChangedSignal;
   (thisObject as any).iopubMessage = iopubMessageSignal;
   (thisObject as any).propertyChanged = propertyChangedSignal;
   (thisObject as any).disposed = disposedSignal;
   (thisObject as any).session = session;
+  (thisObject as any).pendingInput = false;
 
   return thisObject;
 });

--- a/testutils/src/mock.ts
+++ b/testutils/src/mock.ts
@@ -245,9 +245,7 @@ export const KernelMock = jest.fn<
     Kernel.IKernelConnection,
     Kernel.Status
   >(thisObject);
-  const pendingInputSignal = new Signal<Kernel.IKernelConnection, boolean>(
-    thisObject
-  );
+
   (thisObject as any).statusChanged = statusChangedSignal;
   (thisObject as any).iopubMessage = iopubMessageSignal;
   (thisObject as any).hasPendingInput = false;


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/10732

## Code changes

This PR add a guard in the kernel service and shows to the user a modal in case of multiple input request.

The guard is reseted on kernel interrupt, shutdown or restart.

## User-facing changes

A modal is shown only when a input is pending.

![Untitled](https://user-images.githubusercontent.com/226720/128860199-d134ed88-8e95-44ee-bf9b-3960bf3d8c50.gif)

## Backwards-incompatible changes

None.