### PR TITLE
Support collapsible headers with virtual notebook rendering

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -550,7 +550,8 @@ export class StaticNotebook extends Widget {
       this._observer &&
       insertType === 'push' &&
       this._renderedCellsCount >=
-        this.notebookConfig.numberCellsToRenderDirectly
+        this.notebookConfig.numberCellsToRenderDirectly &&
+      cell.type !== 'markdown'
     ) {
       // We have an observer and we are have been asked to push (not to insert).
       // and we are above the number of cells to render directly, then


### PR DESCRIPTION
## References

https://github.com/jupyterlab/jupyterlab/issues/10714

## Code changes

Always render the markdown cells to ensure the logic for collapsible header applies.
