### PR TITLE
Share nbformat and nbformatMinor

### DIFF
--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -308,7 +308,7 @@ export class NotebookModel implements INotebookModel {
     this.cells.pushAll(cells);
     this.cells.endCompoundOperation();
 
-    (this.sharedModel as models.YNotebook).nbformatMinor =
+    (this.sharedModel as models.YNotebook).nbformat_minor =
       nbformat.MINOR_VERSION;
     (this.sharedModel as models.YNotebook).nbformat = nbformat.MAJOR_VERSION;
     const origNbformat = value.metadata.orig_nbformat;
@@ -317,7 +317,7 @@ export class NotebookModel implements INotebookModel {
       (this.sharedModel as models.YNotebook).nbformat = value.nbformat;
     }
     if (value.nbformat_minor > this._nbformatMinor) {
-      (this.sharedModel as models.YNotebook).nbformatMinor =
+      (this.sharedModel as models.YNotebook).nbformat_minor =
         value.nbformat_minor;
     }
 

--- a/packages/shared-models/src/api.ts
+++ b/packages/shared-models/src/api.ts
@@ -119,7 +119,7 @@ export interface ISharedNotebook extends ISharedDocument {
   /**
    * The minor version number of the nbformat.
    */
-  readonly nbformatMinor: number;
+  readonly nbformat_minor: number;
 
   /**
    * The major version number of the nbformat.

--- a/packages/shared-models/src/api.ts
+++ b/packages/shared-models/src/api.ts
@@ -119,7 +119,7 @@ export interface ISharedNotebook extends ISharedDocument {
   /**
    * The minor version number of the nbformat.
    */
-  readonly nbformat_minor: number;
+  readonly nbformatMinor: number;
 
   /**
    * The major version number of the nbformat.
@@ -449,11 +449,21 @@ export type NotebookChange = {
     newValue: nbformat.INotebookMetadata | undefined;
   };
   contextChange?: MapChange;
+  stateChange?: Array<{
+    name: string;
+    oldValue: any;
+    newValue: any;
+  }>;
 };
 
 export type FileChange = {
   sourceChange?: Delta<string>;
   contextChange?: MapChange;
+  stateChange?: Array<{
+    name: string;
+    oldValue: any;
+    newValue: any;
+  }>;
 };
 
 /**
@@ -474,6 +484,11 @@ export type CellChange<MetadataType> = {
 
 export type DocumentChange = {
   contextChange?: MapChange;
+  stateChange?: Array<{
+    name: string;
+    oldValue: any;
+    newValue: any;
+  }>;
 };
 
 /**

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -222,11 +222,11 @@ export class YNotebook
     }, false);
   }
 
-  get nbformatMinor(): number {
+  get nbformat_minor(): number {
     return this.ystate.get('nbformatMinor');
   }
 
-  set nbformatMinor(value: number) {
+  set nbformat_minor(value: number) {
     this.transact(() => {
       this.ystate.set('nbformatMinor', value);
     }, false);


### PR DESCRIPTION
Added a shared attribute `ystate` to share some of the state attributes of a notebook:

https://github.com/jupyterlab/jupyterlab/issues/10784#issuecomment-895963752

## References

Solves #10784 

## Code changes

Added a shared attribute `ystate` to share the attributes `nbformat` and `nbformatMinor`.
Now we apply the changes to the shared attributes, and when the shared model triggers the change event, we apply the changes to `nbformat` and `nbformatMinor`.

## User-facing changes

## Backwards-incompatible changes

Probably this: https://github.com/hbcarlos/jupyterlab/blob/d1404419139236cd3d6a6fd9db038adc28b3bb96/packages/shared-models/src/api.ts#L122