### PR TITLE
Get metadata from shared model when serializing the notebook to JSON

### DIFF
--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -262,7 +262,7 @@ export class NotebookModel implements INotebookModel {
       cells.push(cell);
     }
     this._ensureMetadata();
-    const metadata = Object.create(null) as nbformat.INotebookMetadata;
+    const metadata = this.sharedModel.getMetadata();
     for (const key of this.metadata.keys()) {
       metadata[key] = JSON.parse(JSON.stringify(this.metadata.get(key)));
     }


### PR DESCRIPTION
Solves #10800 

## References
#10800 

## Code changes
Add shared model metadata before ModelDB metadata in the serialization of the notebook.

## User-facing changes

## Backwards-incompatible changes
I think no, since the metadata from ModelDB has priority.
