### PR TITLE
The dirty indicator does not get cleared up after reverting changes

### DIFF
--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -614,7 +614,8 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
         outputs = cell.outputs ?? [];
         // If execution count is not null presume the input code was the latest executed
         // TODO load from the notebook file when the dirty state is stored in it
-        if (cell.execution_count) {
+        if (cell.execution_count != null) {
+          // True if execution_count is null or undefined
           this._executedCode = this.value.text.trim();
         }
       } else {

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -612,9 +612,9 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
       if (cell && cell.cell_type === 'code') {
         executionCount.set(cell.execution_count || null);
         outputs = cell.outputs ?? [];
-        // If output is not empty presume it results of the input code execution
+        // If execution count is not null presume the input code was the latest executed
         // TODO load from the notebook file when the dirty state is stored in it
-        if (outputs.length > 0) {
+        if (cell.execution_count) {
           this._executedCode = this.value.text.trim();
         }
       } else {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #10431
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
The initial state of `executedCode` is set to match the cell input if and only if the execution count saved in the notebook is not `null`.

![indicator](https://user-images.githubusercontent.com/8435071/129172109-bf3e501e-89bf-4ddc-b0d5-36d99524c0fc.gif)


## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
The dirty indicator will be triggered for executed cell without outputs.
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A