### PR TITLE
More Releaser Fixes

### DIFF
--- a/buildutils/src/bumpversion.ts
+++ b/buildutils/src/bumpversion.ts
@@ -26,6 +26,9 @@ commander
       if (opts.force) {
         cmd += ' --force';
       }
+      if (opts.skipCommit) {
+        cmd += ' --skip-commit';
+      }
       utils.run(cmd);
       process.exit(0);
     }

--- a/buildutils/src/patch-release.ts
+++ b/buildutils/src/patch-release.ts
@@ -11,6 +11,7 @@ commander
   .description('Create a patch release')
   .option('--force', 'Force the upgrade')
   .option('--all', 'Patch all JS packages instead of the changed ones')
+  .option('--skip-commit', 'Whether to skip commit changes')
   .action((options: any) => {
     // Make sure we can patch release.
     const pyVersion = utils.getPythonVersion();
@@ -63,7 +64,8 @@ commander
     utils.run('bumpversion release --allow-dirty'); // switches to final.
 
     // Run post-bump actions.
-    utils.postbump();
+    const commit = options.skipCommit !== true;
+    utils.postbump(commit);
   });
 
 commander.parse(process.argv);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "add:sibling": "node buildutils/lib/add-sibling.js",
-    "after:publish:assets": "node buildutils/lib/publish --skip-publish",
+    "after:publish:assets": "jlpm && jlpm run build:utils && node buildutils/lib/publish --skip-publish",
     "analyze": "jlpm run analyze:dev",
     "analyze:dev": "cd dev_mode && jlpm run build --analyze",
     "analyze:prod": "cd dev_mode && jlpm run build:prod --analyze",


### PR DESCRIPTION


## References
Fixes error seen in [changelog pr](https://github.com/jupyterlab/jupyterlab/actions/runs/1120675679) and fixes `after-publish-release` hook.

## Code changes
Add `--skip-commit` option to patch release logic and use it when bumping version

## User-facing changes
None

## Backwards-incompatible changes
None

