### PR TITLE
Fix link to the security documentation

### DIFF
--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1737,10 +1737,14 @@ export namespace NotebookActions {
           'Selecting trust will re-render this notebook in a trusted state.'
         )}
         <br />
-        {trans.__(
-          'For more information, see the <a href="https://jupyter-server.readthedocs.io/en/stable/operators/security.html">%1</a>',
-          trans.__('Jupyter security documentation')
-        )}
+        {trans.__('For more information, see')}{' '}
+        <a
+          href="https://jupyter-server.readthedocs.io/en/stable/operators/security.html"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {trans.__('the Jupyter security documentation')}
+        </a>
       </p>
     );
 


### PR DESCRIPTION
## References

Fixes #10831

## Code changes

- changed both translation strings so that the article is together with the noun,
- also added `target="_blank"` and `rel="noopener noreferrer"` for consistency with other links to RTD docs for safety

## User-facing changes

Link works:

![Screenshot from 2021-08-15 17-13-28](https://user-images.githubusercontent.com/5832902/129485059-a49fc82c-888e-42cf-8919-5ac9245673d1.png)

## Backwards-incompatible changes

None