### PR TITLE
Shutdown sessions/terminals on shutdown

### DIFF
--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -391,10 +391,15 @@ export function createFileMenu(
           Dialog.cancelButton(),
           Dialog.warnButton({ label: trans.__('Shut Down') })
         ]
-      }).then(result => {
+      }).then(async result => {
         if (result.button.accept) {
           const setting = ServerConnection.makeSettings();
           const apiURL = URLExt.join(setting.baseUrl, 'api/shutdown');
+
+          // Shutdown all kernel and terminal sessions before shutting down the server
+          await app.serviceManager.sessions.shutdownAll();
+          await app.serviceManager.terminals.shutdownAll();
+
           return ServerConnection.makeRequest(
             apiURL,
             { method: 'POST' },

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -397,10 +397,15 @@ export function createFileMenu(
           const apiURL = URLExt.join(setting.baseUrl, 'api/shutdown');
 
           // Shutdown all kernel and terminal sessions before shutting down the server
-          await Promise.all([
-            app.serviceManager.sessions.shutdownAll(),
-            app.serviceManager.terminals.shutdownAll()
-          ]);
+          // If this fails, we continue execution so we can post an api/shutdown request
+          try {
+            await Promise.all([
+              app.serviceManager.sessions.shutdownAll(),
+              app.serviceManager.terminals.shutdownAll()
+            ]);
+          } catch (e) {
+            // Do nothing
+          }
 
           return ServerConnection.makeRequest(
             apiURL,

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -405,6 +405,7 @@ export function createFileMenu(
             ]);
           } catch (e) {
             // Do nothing
+            console.log(`Failed to shutdown sessions and terminals: ${e}`);
           }
 
           return ServerConnection.makeRequest(

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -397,8 +397,10 @@ export function createFileMenu(
           const apiURL = URLExt.join(setting.baseUrl, 'api/shutdown');
 
           // Shutdown all kernel and terminal sessions before shutting down the server
-          await app.serviceManager.sessions.shutdownAll();
-          await app.serviceManager.terminals.shutdownAll();
+          await Promise.all([
+            app.serviceManager.sessions.shutdownAll(),
+            app.serviceManager.terminals.shutdownAll()
+          ]);
 
           return ServerConnection.makeRequest(
             apiURL,


### PR DESCRIPTION
cc. @avaissi

This fixes an issue where there were hanging kernel processes after JupyterLab was shutdown with `File` -> `Shut Down`

## Code changes

Shutdown all sessions and terminals before sending the shutdown request on `File` -> `Shut Down`