### PR TITLE
Fix Publish Check

### DIFF
--- a/testutils/src/jest-config.ts
+++ b/testutils/src/jest-config.ts
@@ -33,7 +33,7 @@ module.exports = function (baseDir: string) {
     testRegex: '/test/.*.spec.ts[x]?$',
     globals: {
       'ts-jest': {
-        tsConfig: `./tsconfig.test.json`
+        tsconfig: `./tsconfig.test.json`
       }
     }
   };


### PR DESCRIPTION
### References
The previous publish check would pass and then we would still be unable to install the recently published packages if the npm cdns had not finished propagating. 

### Code changes
Changes the logic to actually attempt an install.
Also upgrades a deprecated config name used in `testutils`.

### User-facing changes
None

### Backwards-incompatible changes
None