### PR TITLE
Backport PR #10790 on branch 3.1.x (Removed toolbar scrollbar)

### DIFF
--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -183,7 +183,6 @@ export class Toolbar<T extends Widget = Widget> extends Widget {
   constructor() {
     super();
     this.addClass(TOOLBAR_CLASS);
-    this.addClass('jp-scrollbar-tiny');
     this.layout = new ToolbarLayout();
   }
 

--- a/packages/apputils/style/toolbar.css
+++ b/packages/apputils/style/toolbar.css
@@ -24,10 +24,6 @@
   overflow-x: hidden;
 }
 
-.jp-Toolbar:hover {
-  overflow-x: auto;
-}
-
 /* Toolbar items */
 
 .jp-Toolbar > .jp-Toolbar-item.jp-Toolbar-spacer {


### PR DESCRIPTION
It will fix the FireFox issue #10189; but it will remove the scroll bar if the widget width is too small. So

Question: should we backport it?