### PR TITLE
Added throttling for toolbar resize (#10826)

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -52,6 +52,7 @@
     "@lumino/coreutils": "^1.5.3",
     "@lumino/disposable": "^1.4.3",
     "@lumino/messaging": "^1.4.3",
+    "@lumino/polling": "^1.3.3",
     "@lumino/properties": "^1.2.3",
     "@lumino/signaling": "^1.4.3",
     "@lumino/virtualdom": "^1.8.0",


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->
This PR fixes [#10826](https://github.com/jupyterlab/jupyterlab/issues/10826).

## Code changes

<!-- Describe the code changes and how they address the issue. -->
- Replace custom debouncer with Throttler from @lumino/polling

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

https://user-images.githubusercontent.com/289369/129645838-0c3a1df2-9cd5-48f9-ac66-884f50411085.mov



## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None