### PR TITLE
Fix code names showing up in new translations, add docs

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1523,7 +1523,7 @@ export class DirListing extends Widget {
         }
         if (!isValidFileName(newName)) {
           void showErrorMessage(
-            this._trans.__('showErrorMessage', 'Rename Error'),
+            this._trans.__('Rename Error'),
             Error(
               this._trans._p(
                 'showErrorMessage',

--- a/packages/toc-extension/schema/plugin.json
+++ b/packages/toc-extension/schema/plugin.json
@@ -32,7 +32,7 @@
   "properties": {
     "numberingH1": {
       "title": "Enable h1 numbering",
-      "description": "Whether to number first level headings",
+      "description": "Whether to number first-level headings",
       "type": "boolean",
       "default": true
     },
@@ -44,8 +44,8 @@
     },
     "syncCollapseState": {
       "type": "boolean",
-      "title": "syncCollapseState",
-      "description": "If set to true, when a header is collapsed in the ToC the corresponding section in the notebook is collapsed as well and vice versa.",
+      "title": "Synchronize collapse state",
+      "description": "If set to true, when a header is collapsed in the table of contents the corresponding section in the notebook is collapsed as well and vice versa.",
       "default": false
     }
   },

--- a/packages/translation/src/tokens.ts
+++ b/packages/translation/src/tokens.ts
@@ -34,10 +34,48 @@ export class TranslatorConnector
   private _translationsUrl: string;
 }
 
+/**
+ * Bundle of gettext-based translation function.
+ *
+ * The calls to the functions in this bundle will be automatically
+ * extracted by `jupyterlab-translate` package to generate translation
+ * template files if the bundle is assigned to:
+ * - variable named `trans`,
+ * - public attribute named `trans` (`this.trans`),
+ * - private attribute named `trans` (`this._trans`),
+ * - `trans` attribute `props` variable (`props.trans`),
+ * - `trans` attribute `props` attribute (`this.props.trans`)
+ */
 export type TranslationBundle = {
+  /**
+   * Alias for `gettext` (translate strings without number inflection)
+   * @param msgid message (text to translate)
+   * @param args
+   */
   __(msgid: string, ...args: any[]): string;
+  /**
+   * Alias for `ngettext` (translate accounting for plural forms)
+   * @param msgid message for singular
+   * @param msgid_plural message for plural
+   * @param n determines which plural form to use
+   * @param args
+   */
   _n(msgid: string, msgid_plural: string, n: number, ...args: any[]): string;
+  /**
+   * Alias for `pgettext` (translate in given context)
+   * @param msgctxt context
+   * @param msgid message (text to translate)
+   * @param args
+   */
   _p(msgctxt: string, msgid: string, ...args: any[]): string;
+  /**
+   * Alias for `npgettext` (translate accounting for plural forms in given context)
+   * @param msgctxt context
+   * @param msgid message for singular
+   * @param msgid_plural message for plural
+   * @param n number used to determine which plural form to use
+   * @param args
+   */
   _np(
     msgctxt: string,
     msgid: string,

--- a/packages/translation/src/tokens.ts
+++ b/packages/translation/src/tokens.ts
@@ -35,7 +35,7 @@ export class TranslatorConnector
 }
 
 /**
- * Bundle of gettext-based translation function.
+ * Bundle of gettext-based translation functions.
  *
  * The calls to the functions in this bundle will be automatically
  * extracted by `jupyterlab-translate` package to generate translation


### PR DESCRIPTION
## References

Adds a minimum docs for `TranslationBundle`; ideally we would have that in developer documentation as mentioned in  https://github.com/jupyterlab/jupyterlab/pull/10762#discussion_r681679761

## Code changes

Fix a mix-up of `trans.__` with `trans._p` by removing context and keeping it as `trans.__`.

## User-facing changes

- "Rename Error" will show up correctly
- `syncCollapseState` will have a proper title

## Backwards-incompatible changes

None