### PR TITLE
Add missing link in passing translator down to kernel selector

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -1225,7 +1225,7 @@ export const sessionContextDialogs: ISessionContext.IDialogs = {
 
     const dialog = new Dialog({
       title: trans.__('Select Kernel'),
-      body: new Private.KernelSelector(sessionContext),
+      body: new Private.KernelSelector(sessionContext, translator),
       buttons
     });
 
@@ -1306,8 +1306,8 @@ namespace Private {
     /**
      * Create a new kernel selector widget.
      */
-    constructor(sessionContext: ISessionContext) {
-      super({ node: createSelectorNode(sessionContext) });
+    constructor(sessionContext: ISessionContext, translator?: ITranslator) {
+      super({ node: createSelectorNode(sessionContext, translator) });
     }
 
     /**


### PR DESCRIPTION
## References

Fixes one of the points in #10737

## Code changes

Add missing translator link

## User-facing changes

Before:

![Screenshot from 2021-08-18 09-52-04](https://user-images.githubusercontent.com/5832902/129868663-ff306403-20dc-45f4-abee-dcdcf13f4a87.png)

After:

![Screenshot from 2021-08-18 10-11-08](https://user-images.githubusercontent.com/5832902/129871624-33ca752e-2205-4a30-909d-84504b766abb.png)

## Backwards-incompatible changes

None - the change is limited to a private constructor and the added argument is optional.