### PR TITLE
Add translations for notebook mode name

### DIFF
--- a/packages/notebook/src/modestatus.tsx
+++ b/packages/notebook/src/modestatus.tsx
@@ -1,4 +1,3 @@
-import { Text } from '@jupyterlab/coreutils';
 import { TextItem } from '@jupyterlab/statusbar';
 import {
   ITranslator,
@@ -22,7 +21,7 @@ function CommandEditComponent(
   const trans = (props.translator || nullTranslator).load('jupyterlab');
   return (
     <TextItem
-      source={trans.__('Mode: %1', Text.titleCase(props.notebookMode))}
+      source={trans.__('Mode: %1', props.modeNames[props.notebookMode])}
     />
   );
 }
@@ -44,6 +43,11 @@ namespace CommandEditComponent {
      * Language translator.
      */
     translator?: ITranslator;
+
+    /**
+     * Mapping translating the names of modes.
+     */
+    modeNames: Record<NotebookMode, string>;
   }
 }
 
@@ -58,6 +62,10 @@ export class CommandEditStatus extends VDomRenderer<CommandEditStatus.Model> {
     super(new CommandEditStatus.Model());
     this.translator = translator || nullTranslator;
     this._trans = this.translator.load('jupyterlab');
+    this._modeNames = {
+      command: this._trans.__('Command'),
+      edit: this._trans.__('Edit')
+    };
   }
 
   /**
@@ -69,18 +77,20 @@ export class CommandEditStatus extends VDomRenderer<CommandEditStatus.Model> {
     }
     this.node.title = this._trans.__(
       'Notebook is in %1 mode',
-      this.model.notebookMode
+      this._modeNames[this.model.notebookMode]
     );
     return (
       <CommandEditComponent
         notebookMode={this.model.notebookMode}
         translator={this.translator}
+        modeNames={this._modeNames}
       />
     );
   }
 
   protected translator: ITranslator;
   private _trans: TranslationBundle;
+  private readonly _modeNames: Record<NotebookMode, string>;
 }
 
 /**


### PR DESCRIPTION
## References

Fixes another of the points in #10737

## Code changes

Added an explicit mapping of mode names.

## User-facing changes

Before:

![Screenshot from 2021-08-18 10-18-38](https://user-images.githubusercontent.com/5832902/129874119-efceb7db-a4a1-48e5-b4a1-6f7aced79f4b.png)
![Screenshot from 2021-08-18 10-18-00](https://user-images.githubusercontent.com/5832902/129874123-380047e0-7c39-4cfb-bcec-62cf0a7b54d9.png)

After:

![Screenshot from 2021-08-18 10-42-28](https://user-images.githubusercontent.com/5832902/129876686-6e7e427f-7bcb-43b7-8918-5206927cde16.png)
![Screenshot from 2021-08-18 10-42-20](https://user-images.githubusercontent.com/5832902/129876676-d07402da-9a1b-4046-a457-5863b2af78a5.png)

## Backwards-incompatible changes

None, changes limited to private attributes and to `CommandEditComponent` which is not exported.