### PR TITLE
Fix cell type dropdown behaviour in Firefox on 3.1.x branch

### DIFF
--- a/packages/apputils/style/toolbar.css
+++ b/packages/apputils/style/toolbar.css
@@ -21,10 +21,6 @@
   min-height: var(--jp-toolbar-micro-height);
   padding: 2px;
   z-index: 1;
-  overflow-x: hidden;
-}
-
-.jp-Toolbar:hover {
   overflow-x: auto;
 }
 


### PR DESCRIPTION
## References

Fixes #10189 without removing the tiny scrollbar. Supersedes #10849 (backport of a clean fix which is already in 4.0).

## Code changes

Removed the change of overflow on hover triggering the Firefox bug.

## User-facing changes

Instead of removing the tiny scrollbar, always show it if there is an overflow, see:

![alternative](https://user-images.githubusercontent.com/5832902/129951911-85e8346c-7367-414f-8753-e42e71b59ca9.gif)

## Backwards-incompatible changes

None