### PR TITLE
Improve tab navigation for notebook

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1505,10 +1505,10 @@ export class Notebook extends StaticNotebook {
         this._evtDblClick(event as MouseEvent);
         break;
       case 'focusin':
-        this._evtFocusIn(event as MouseEvent);
+        this._evtFocusIn(event as FocusEvent);
         break;
       case 'focusout':
-        this._evtFocusOut(event as MouseEvent);
+        this._evtFocusOut(event as FocusEvent);
         break;
       case 'lm-dragenter':
         this._evtDragEnter(event as IDragEvent);
@@ -2275,7 +2275,7 @@ export class Notebook extends StaticNotebook {
   /**
    * Handle `focus` events for the widget.
    */
-  private _evtFocusIn(event: MouseEvent): void {
+  private _evtFocusIn(event: FocusEvent): void {
     const target = event.target as HTMLElement;
     const index = this._findCell(target);
     if (index !== -1) {
@@ -2300,7 +2300,7 @@ export class Notebook extends StaticNotebook {
   /**
    * Handle `focusout` events for the notebook.
    */
-  private _evtFocusOut(event: MouseEvent): void {
+  private _evtFocusOut(event: FocusEvent): void {
     const relatedTarget = event.relatedTarget as HTMLElement;
 
     // Bail if the window is losing focus, to preserve edit mode. This test

--- a/ui-tests/tests/notebook-edit.test.ts
+++ b/ui-tests/tests/notebook-edit.test.ts
@@ -168,6 +168,14 @@ describe('Notebook Edit', () => {
     expect(await galata.capture.compareScreenshot(imageName)).toBe('same');
   });
 
+  test('Navigate back from panel using Tab key', async () => {
+    await galata.notebook.selectCells(2);
+    const nbPanel = await galata.notebook.getNotebookInPanel();
+    await nbPanel.focus();
+    await galata.context.page.keyboard.press('Tab');
+    expect(await galata.notebook.isCellSelected(2)).toBe(true);
+  });
+
   test('Delete Notebook', async () => {
     await galata.contents.deleteFile(fileName);
     expect(await galata.contents.fileExists(fileName)).toBeFalsy();


### PR DESCRIPTION
## References

Fixes the core issue causing #10440, but does not implement a full tab-based navigation yet.

TODO:
- [ ] I will try to implement the full navigation before taking this one out of draft; I hit some issues with the focusing logic when not switching to edit mode. I can workaround this by switching to edit mode and back to command mode, but I want to find a clean solution.
- [ ] fix the added galata test
- [ ] address two TODOs inline below

## Code changes

`focus in` handler of notebook was:
- written assuming that this is a mouse event, but this event can also come from a keyboard-based event,
- changing the active cell to cell that received focus, whether by mouse event or keyboard event, causing the undesirable behaviour
  - this was actually duplicating the `mousedown` handler for 3/4 code paths, so I closed the fourth path by removing a button condition check

The proposed code always focuses on the active cell when the focusin event is triggered (if it would lead to focusing a different cell otherwise). The old mode-switching logic is kept if the event target is within active cell, preserving the intended mode-switch for mouse-click behaviour (TODO add a comment on this). This proposal is guaranteed to be an improvement over the previous behaviour which always focused the first cell in the notebook, regardless of which cell was active.

Edit: the problem is in that the current implementation of command mode is that no cell has focus, but notebook has focus; instead cells should be focusable and command mode == focus on a specific cell. This would be a substantial change.
 
## User-facing changes

TODO add nice GIF here.

## Backwards-incompatible changes

None.