### PR TITLE
Publish Cleanup

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -76,7 +76,7 @@ jobs:
           else
             version_spec=build
           fi
-          echo "::set-spec name=dir::${version_spec}"
+          echo "::set-output name=spec::${version_spec}"
 
       - name: Check Release
         if: ${{ matrix.group == 'check_release' }}

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -65,11 +65,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-linkcheck-
 
+      - name: Configure Version Spec
+        id: version-spec
+        if: ${{ matrix.group == 'check_release' }}
+        run: |
+          set -eux
+          version=$(python setup.py --version)
+          if [[ $version =~ ^[0-9]\.[0-9]\.[0-9]$ ]]; then
+            version_spec=patch
+          else
+            version_spec=build
+          fi
+          echo "::set-spec name=dir::${version_spec}"
+
       - name: Check Release
         if: ${{ matrix.group == 'check_release' }}
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v1
         env:
-          RH_VERSION_SPEC: build
+          RH_VERSION_SPEC: ${{ steps.version-spec.outputs.spec }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/builder/package.json
+++ b/builder/package.json
@@ -29,7 +29,6 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -w --listEmittedFiles"
   },
   "dependencies": {

--- a/buildutils/package.json
+++ b/buildutils/package.json
@@ -36,7 +36,6 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -w --listEmittedFiles"
   },
   "dependencies": {

--- a/buildutils/src/ensure-package.ts
+++ b/buildutils/src/ensure-package.ts
@@ -529,10 +529,11 @@ export async function ensurePackage(
     data['publishConfig'] = { access: 'public' };
   }
 
-  // Ensure there is a minimal prepublishOnly script
-  if (!data.private && !data.scripts.prepublishOnly) {
-    messages.push(`prepublishOnly script missing in ${pkgPath}`);
-    data.scripts.prepublishOnly = 'npm run build';
+  // Ensure there is not a prepublishOnly script.
+  // Since publishing is handled by an automated script and we don't
+  // Want to run individual scripts during publish.
+  if (data.scripts.prepublishOnly) {
+    delete data.scripts.prepublishOnly;
   }
 
   // Ensure the main module has an @packageDocumentation comment

--- a/buildutils/src/prepublish-check.ts
+++ b/buildutils/src/prepublish-check.ts
@@ -8,8 +8,7 @@ import * as glob from 'glob';
 import * as path from 'path';
 import * as utils from './utils';
 
-utils.run('npm run clean:slate');
-utils.run('lerna run prepublishOnly');
+utils.run('npm run build:packages');
 
 utils.getLernaPaths().forEach(pkgPath => {
   const pkgData = utils.readJSONFile(path.join(pkgPath, 'package.json'));

--- a/buildutils/src/publish.ts
+++ b/buildutils/src/publish.ts
@@ -23,7 +23,7 @@ commander
   .description('Publish the JS packages')
   .option(
     '--skip-build',
-    'Skip the clean and build step (if there was a network error during a JS publish'
+    'Skip the build step (if there was a network error during a JS publish'
   )
   .option('--skip-publish', 'Skip publish and only handle tags')
   .option('--skip-tags', 'publish assets but do not handle tags')
@@ -50,7 +50,7 @@ commander
 
       // Ensure a clean git environment
       try {
-        utils.run('git commit -am "bump version"');
+        utils.run('git commit -am "[ci skip] bump version"');
       } catch (e) {
         // do nothing
       }
@@ -102,7 +102,7 @@ commander
     let attempt = 0;
     while (attempt < 10) {
       try {
-        utils.run(`npm install ${specifiers}`, { cwd: installDir });
+        utils.run(`npm install ${specifiers.join(' ')}`, { cwd: installDir });
         break;
       } catch (e) {
         console.error(e);
@@ -112,7 +112,8 @@ commander
       }
     }
     if (attempt == 10) {
-      throw new Error('Could not install packages');
+      console.error('Could not install packages');
+      process.exit(1);
     }
 
     // Emit a system beep.

--- a/buildutils/src/utils.ts
+++ b/buildutils/src/utils.ts
@@ -220,7 +220,7 @@ export function postbump(commit = true): void {
 
   // Commit changes.
   if (commit) {
-    run('git commit -am "bump version"');
+    run('git commit -am "[ci skip] bump version"');
   }
 }
 

--- a/buildutils/template/package.json
+++ b/buildutils/template/package.json
@@ -29,7 +29,6 @@
     "build": "tsc -b",
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -34,7 +34,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -34,7 +34,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/apputils-extension/package.json
+++ b/packages/apputils-extension/package.json
@@ -34,7 +34,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -37,7 +37,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -33,7 +33,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -34,7 +34,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/celltags-extension/package.json
+++ b/packages/celltags-extension/package.json
@@ -35,7 +35,6 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/celltags/package.json
+++ b/packages/celltags/package.json
@@ -36,7 +36,6 @@
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -34,7 +34,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -34,7 +34,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -32,7 +32,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/completer-extension/package.json
+++ b/packages/completer-extension/package.json
@@ -34,7 +34,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -34,7 +34,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/console-extension/package.json
+++ b/packages/console-extension/package.json
@@ -34,7 +34,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -34,7 +34,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -32,7 +32,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/csvviewer-extension/package.json
+++ b/packages/csvviewer-extension/package.json
@@ -34,7 +34,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/csvviewer/package.json
+++ b/packages/csvviewer/package.json
@@ -34,7 +34,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/debugger-extension/package.json
+++ b/packages/debugger-extension/package.json
@@ -41,7 +41,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo && rimraf tsconfig.test.tsbuildinfo && rimraf tests/build",
     "docs": "typedoc --options tdoptions.json --theme ../../typedoc-theme src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -41,7 +41,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo && rimraf tsconfig.test.tsbuildinfo && rimraf tests/build",
     "docs": "typedoc --options tdoptions.json --theme ../../typedoc-theme src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -34,7 +34,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/docmanager/package.json
+++ b/packages/docmanager/package.json
@@ -34,7 +34,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/docprovider-extension/package.json
+++ b/packages/docprovider-extension/package.json
@@ -31,7 +31,6 @@
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -w --listEmittedFiles"
   },
   "dependencies": {

--- a/packages/docprovider/package.json
+++ b/packages/docprovider/package.json
@@ -30,7 +30,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -34,7 +34,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/documentsearch-extension/package.json
+++ b/packages/documentsearch-extension/package.json
@@ -30,7 +30,6 @@
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -w --listEmittedFiles"
   },
   "dependencies": {

--- a/packages/documentsearch/package.json
+++ b/packages/documentsearch/package.json
@@ -30,7 +30,6 @@
     "build": "tsc -b",
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/extensionmanager-extension/package.json
+++ b/packages/extensionmanager-extension/package.json
@@ -35,7 +35,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/extensionmanager/package.json
+++ b/packages/extensionmanager/package.json
@@ -33,7 +33,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/filebrowser-extension/package.json
+++ b/packages/filebrowser-extension/package.json
@@ -34,7 +34,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -34,7 +34,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/fileeditor-extension/package.json
+++ b/packages/fileeditor-extension/package.json
@@ -34,7 +34,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/fileeditor/package.json
+++ b/packages/fileeditor/package.json
@@ -34,7 +34,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/help-extension/package.json
+++ b/packages/help-extension/package.json
@@ -34,7 +34,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/htmlviewer-extension/package.json
+++ b/packages/htmlviewer-extension/package.json
@@ -31,7 +31,6 @@
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/htmlviewer/package.json
+++ b/packages/htmlviewer/package.json
@@ -29,7 +29,6 @@
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -w --listEmittedFiles"
   },
   "dependencies": {

--- a/packages/hub-extension/package.json
+++ b/packages/hub-extension/package.json
@@ -30,7 +30,6 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -w --listEmittedFiles"
   },
   "dependencies": {

--- a/packages/imageviewer-extension/package.json
+++ b/packages/imageviewer-extension/package.json
@@ -34,7 +34,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/imageviewer/package.json
+++ b/packages/imageviewer/package.json
@@ -34,7 +34,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/inspector-extension/package.json
+++ b/packages/inspector-extension/package.json
@@ -34,7 +34,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -34,7 +34,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/javascript-extension/package.json
+++ b/packages/javascript-extension/package.json
@@ -29,7 +29,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/json-extension/package.json
+++ b/packages/json-extension/package.json
@@ -29,7 +29,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/launcher-extension/package.json
+++ b/packages/launcher-extension/package.json
@@ -34,7 +34,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -33,7 +33,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/logconsole-extension/package.json
+++ b/packages/logconsole-extension/package.json
@@ -30,7 +30,6 @@
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -w --listEmittedFiles"
   },
   "dependencies": {

--- a/packages/logconsole/package.json
+++ b/packages/logconsole/package.json
@@ -30,7 +30,6 @@
     "build": "tsc -b",
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/mainmenu-extension/package.json
+++ b/packages/mainmenu-extension/package.json
@@ -34,7 +34,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/mainmenu/package.json
+++ b/packages/mainmenu/package.json
@@ -34,7 +34,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/markdownviewer-extension/package.json
+++ b/packages/markdownviewer-extension/package.json
@@ -34,7 +34,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/markdownviewer/package.json
+++ b/packages/markdownviewer/package.json
@@ -33,7 +33,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/mathjax2-extension/package.json
+++ b/packages/mathjax2-extension/package.json
@@ -30,7 +30,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/mathjax2/package.json
+++ b/packages/mathjax2/package.json
@@ -30,7 +30,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -27,7 +27,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "node build-doc-index.js",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/nbformat/package.json
+++ b/packages/nbformat/package.json
@@ -30,7 +30,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -33,7 +33,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -33,7 +33,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/observables/package.json
+++ b/packages/observables/package.json
@@ -29,7 +29,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/outputarea/package.json
+++ b/packages/outputarea/package.json
@@ -34,7 +34,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/pdf-extension/package.json
+++ b/packages/pdf-extension/package.json
@@ -33,7 +33,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/property-inspector/package.json
+++ b/packages/property-inspector/package.json
@@ -30,7 +30,6 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -w --listEmittedFiles"
   },
   "dependencies": {

--- a/packages/rendermime-extension/package.json
+++ b/packages/rendermime-extension/package.json
@@ -30,7 +30,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/rendermime-interfaces/package.json
+++ b/packages/rendermime-interfaces/package.json
@@ -27,7 +27,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc  src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -34,7 +34,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/running-extension/package.json
+++ b/packages/running-extension/package.json
@@ -34,7 +34,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/running/package.json
+++ b/packages/running/package.json
@@ -33,7 +33,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/services/examples/browser/package.json
+++ b/packages/services/examples/browser/package.json
@@ -7,8 +7,7 @@
   ],
   "scripts": {
     "build": "tsc && webpack",
-    "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
-    "prepublishOnly": "npm run build"
+    "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo"
   },
   "dependencies": {
     "@jupyterlab/coreutils": "^5.3.0-alpha.4",

--- a/packages/services/examples/typescript-browser-with-output/package.json
+++ b/packages/services/examples/typescript-browser-with-output/package.json
@@ -13,8 +13,7 @@
   ],
   "scripts": {
     "build": "tsc && webpack",
-    "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
-    "prepublishOnly": "npm run build"
+    "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo"
   },
   "dependencies": {
     "@jupyterlab/coreutils": "^5.3.0-alpha.4",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -38,7 +38,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "jlpm run build && webpack",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/settingeditor-extension/package.json
+++ b/packages/settingeditor-extension/package.json
@@ -34,7 +34,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/settingeditor/package.json
+++ b/packages/settingeditor/package.json
@@ -33,7 +33,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/settingregistry/package.json
+++ b/packages/settingregistry/package.json
@@ -28,7 +28,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src --tsconfig typedoc-tsconfig.json",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/shared-models/package.json
+++ b/packages/shared-models/package.json
@@ -30,7 +30,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/shortcuts-extension/package.json
+++ b/packages/shortcuts-extension/package.json
@@ -28,7 +28,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/statedb/package.json
+++ b/packages/statedb/package.json
@@ -28,7 +28,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/statusbar-extension/package.json
+++ b/packages/statusbar-extension/package.json
@@ -33,7 +33,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/statusbar/package.json
+++ b/packages/statusbar/package.json
@@ -29,7 +29,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/terminal-extension/package.json
+++ b/packages/terminal-extension/package.json
@@ -34,7 +34,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -34,7 +34,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/theme-dark-extension/package.json
+++ b/packages/theme-dark-extension/package.json
@@ -28,7 +28,6 @@
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/theme-light-extension/package.json
+++ b/packages/theme-light-extension/package.json
@@ -28,7 +28,6 @@
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/toc-extension/package.json
+++ b/packages/toc-extension/package.json
@@ -37,7 +37,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/toc/package.json
+++ b/packages/toc/package.json
@@ -33,7 +33,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/tooltip-extension/package.json
+++ b/packages/tooltip-extension/package.json
@@ -34,7 +34,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -33,7 +33,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/translation-extension/package.json
+++ b/packages/translation-extension/package.json
@@ -35,7 +35,6 @@
     "clean": "rimraf lib tsconfig.tsbuildinfo",
     "eslint": "eslint . --ext .ts,.tsx --fix",
     "eslint:check": "eslint . --ext .ts,.tsx",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/translation/package.json
+++ b/packages/translation/package.json
@@ -32,7 +32,6 @@
     "docs": "typedoc src",
     "eslint": "eslint . --ext .ts,.tsx --fix",
     "eslint:check": "eslint . --ext .ts,.tsx",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/packages/ui-components-extension/package.json
+++ b/packages/ui-components-extension/package.json
@@ -29,7 +29,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -34,7 +34,6 @@
     "cleansvg": "svgo --config svgo.yaml",
     "docs": "typedoc src",
     "docs:init": "bash docs/build.sh",
-    "prepublishOnly": "npm run build",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "test": "jest",
     "test:cov": "jest --collect-coverage",

--- a/packages/vdom-extension/package.json
+++ b/packages/vdom-extension/package.json
@@ -29,7 +29,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/vdom/package.json
+++ b/packages/vdom/package.json
@@ -29,7 +29,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/vega5-extension/package.json
+++ b/packages/vega5-extension/package.json
@@ -29,7 +29,6 @@
     "build": "tsc -b",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ ignore-glob = ["packages/ui-components/docs/source/ui_components.rst"]
 ignore-links = ["../api/*.*"]
 version-cmd = "jlpm bumpversion --force --skip-commit"
 npm-install-options = "--legacy-peer-deps"
+release-message = "[ci skip] Publish {version}"
+tag-message = "[ci skip] Release {tag_name}"
 
 [tool.jupyter-releaser.hooks]
 before-bump-version = ["git checkout .", "pip install bump2version"]

--- a/scripts/ensure-buildutils.js
+++ b/scripts/ensure-buildutils.js
@@ -54,6 +54,10 @@ function ensurePackage(p) {
   if (!current) {
     // This must be "npm" because it is run during `pip install -e .` before
     // jlpm is installed.
+    childProcess.execSync('npm run clean', {
+      stdio: [0, 1, 2],
+      cwd: path.resolve('./' + p)
+    });
     childProcess.execSync('npm run build', {
       stdio: [0, 1, 2],
       cwd: path.resolve('./' + p)

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -23,8 +23,6 @@ pushd $TEST_DIR
 
 JLAB_BROWSER_CHECK_OUTPUT=${OUTPUT_DIR} python -m jupyterlab.browser_check
 
-jupyter lab clean --all
-
 popd
 
 pushd jupyterlab/tests/mock_packages

--- a/testutils/package.json
+++ b/testutils/package.json
@@ -28,7 +28,6 @@
     "build": "tsc -b",
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
-    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",


### PR DESCRIPTION
- Remove cleans used during publish and release test to save time - cleans are tested in CI
- Remove individual `prepublishOnly` scripts to save time - we use `build:packages`
- Fix `ensure-buildutils` logic to clean before building so the `mtime` comparison does not get out of sync
- Add config to skip CI for `draft_release` commits and tag since the npm packages are not yet published