### PR TITLE
Render placeholder at correct index

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -582,9 +582,8 @@ export class StaticNotebook extends Widget {
       this._renderedCellsCount >=
         this.notebookConfig.numberCellsToRenderDirectly
     ) {
-      const index = this._renderedCellsCount;
-      const cell = this._cellsArray[index];
-      this._renderPlaceholderCell(cell, index);
+      let entry = this._toRenderMap.entries().next();
+      this._renderPlaceholderCell(entry.value[1].cell, entry.value[1].index);
     }
   }
 

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -582,8 +582,8 @@ export class StaticNotebook extends Widget {
       this._renderedCellsCount >=
         this.notebookConfig.numberCellsToRenderDirectly
     ) {
-      let entry = this._toRenderMap.entries().next();
-      this._renderPlaceholderCell(entry.value[1].cell, entry.value[1].index);
+      const ci = this._toRenderMap.entries().next();
+      this._renderPlaceholderCell(ci.value[1].cell, ci.value[1].index);
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/10895

## Code changes

Use the first entry in the map of cells to be rendered to define the index. Before, we were using the `_renderedCellsCount` value, which was fine before we took into account the collapsible cells (https://github.com/jupyterlab/jupyterlab/pull/10793)

## User-facing changes

The reproducer mentioned in https://github.com/jupyterlab/jupyterlab/issues/10895 should not fail.

## Backwards-incompatible changes

None.
