### PR TITLE
Add undoManager to inserted cells

### DIFF
--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -88,6 +88,7 @@ export class YDocument<T> implements models.ISharedDocument {
   public source = this.ydoc.getText('source');
   public ystate: Y.Map<any> = this.ydoc.getMap('state');
   public undoManager = new Y.UndoManager([this.source], {
+    captureTimeout: 200,
     trackedOrigins: new Set([this])
   });
   public awareness = new Awareness(this.ydoc);
@@ -272,8 +273,8 @@ export class YNotebook
   insertCells(index: number, cells: YCellType[]): void {
     cells.forEach(cell => {
       this._ycellMapping.set(cell.ymodel, cell);
-      // cell.yawareness = this.yawareness;
-      // cell.yUndoManager = this.yUndoManager;
+      //cell.awareness = this.yawareness;
+      cell.undoManager = this.undoManager;
     });
     this.transact(() => {
       this.ycells.insert(
@@ -423,6 +424,7 @@ export class YNotebook
   public ymeta: Y.Map<any> = this.ydoc.getMap('meta');
   public ymodel: Y.Map<any> = this.ydoc.getMap('model');
   public undoManager = new Y.UndoManager([this.ycells], {
+    captureTimeout: 200,
     trackedOrigins: new Set([this])
   });
   private _ycellMapping: Map<Y.Map<any>, YCellType> = new Map();
@@ -495,6 +497,13 @@ export class YBaseCell<Metadata extends models.ISharedBaseCellMetadata>
    */
   get undoManager(): Y.UndoManager | null {
     return this.notebook ? this.notebook.undoManager : this._undoManager;
+  }
+
+  /**
+   * Set the undoManager when adding new cells.
+   */
+  set undoManager(undoManager: Y.UndoManager | null) {
+    this._undoManager = undoManager;
   }
 
   /**
@@ -576,6 +585,7 @@ export class YBaseCell<Metadata extends models.ISharedBaseCellMetadata>
     cell.isStandalone = true;
     new Y.Doc().getArray().insert(0, [cell.ymodel]);
     cell._undoManager = new Y.UndoManager([cell.ymodel], {
+      captureTimeout: 200,
       trackedOrigins: new Set([cell])
     });
     return cell;


### PR DESCRIPTION
This PR adds a public API to access the `undoManager` on a YBaseCell to be able to change the undo manager of a cell from the YNotebook.

When inserting cells into the YNotebook, those cells are created as standalone cells, so they don't have the same undo manager as the notebook, which leads to losing part of the history of changes.

Also, decreased the capture time of the undo manager from 500 to 200 milliseconds to reduce the number of actions in an undoable change.

## References
Solves #10816

## Code changes
Adds a public API to access the `undoManager` on a YBaseCell.
Changes the capture timeout of the undo manager.

## User-facing changes
N/A

## Backwards-incompatible changes
N/A
