### PR TITLE
Automated Changelog Entry for 4.0.0a5 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 4.0.0a5
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v4.0.0a4...0cf99e5d3e3881df8b406d097a46e91569a02f52))
+
+### Bugs fixed
+
+- Improve language choice menu and dialog [#10885](https://github.com/jupyterlab/jupyterlab/pull/10885) ([@krassowski](https://github.com/krassowski))
+- Keep cursor at the previous position after cell split [#10884](https://github.com/jupyterlab/jupyterlab/pull/10884) ([@krassowski](https://github.com/krassowski))
+- Compose only the needed property when transforming the settings [#10880](https://github.com/jupyterlab/jupyterlab/pull/10880) ([@fcollonval](https://github.com/fcollonval))
+- Workaround invasive use of tex mode inside of code elements and blocks [#10867](https://github.com/jupyterlab/jupyterlab/pull/10867) ([@krassowski](https://github.com/krassowski))
+- Add translations for notebook mode name [#10865](https://github.com/jupyterlab/jupyterlab/pull/10865) ([@krassowski](https://github.com/krassowski))
+- Add missing link in passing translator down to kernel selector [#10864](https://github.com/jupyterlab/jupyterlab/pull/10864) ([@krassowski](https://github.com/krassowski))
+- Fix code names showing up in new translations, add docs [#10860](https://github.com/jupyterlab/jupyterlab/pull/10860) ([@krassowski](https://github.com/krassowski))
+- Added throttling for toolbar resize (#10826) [#10854](https://github.com/jupyterlab/jupyterlab/pull/10854) ([@3coins](https://github.com/3coins))
+- Shutdown sessions/terminals on shutdown [#10843](https://github.com/jupyterlab/jupyterlab/pull/10843) ([@martinRenou](https://github.com/martinRenou))
+- Get metadata from shared model when serializing the notebook to JSON [#10804](https://github.com/jupyterlab/jupyterlab/pull/10804) ([@hbcarlos](https://github.com/hbcarlos))
+
+### Maintenance and upkeep improvements
+
+- Lint Cleanup [#10900](https://github.com/jupyterlab/jupyterlab/pull/10900) ([@blink1073](https://github.com/blink1073))
+- Publish Cleanup [#10891](https://github.com/jupyterlab/jupyterlab/pull/10891) ([@fcollonval](https://github.com/fcollonval))
+- Edit binder ref for demo [#10877](https://github.com/jupyterlab/jupyterlab/pull/10877) ([@fcollonval](https://github.com/fcollonval))
+- Fix Publish Check [#10846](https://github.com/jupyterlab/jupyterlab/pull/10846) ([@afshin](https://github.com/afshin))
+- Translate labels of menus and submenus [#10739](https://github.com/jupyterlab/jupyterlab/pull/10739) ([@krassowski](https://github.com/krassowski))
+- Set the `camelcase` ESLint rule to `warn` [#10500](https://github.com/jupyterlab/jupyterlab/pull/10500) ([@jtpio](https://github.com/jtpio))
+
+### Other merged PRs
+
+- Forwardport 3.1.7 Changelog entry [#10845](https://github.com/jupyterlab/jupyterlab/pull/10845) ([@blink1073](https://github.com/blink1073))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-08-16&to=2021-08-24&type=c))
+
+[@3coins](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3A3coins+updated%3A2021-08-16..2021-08-24&type=Issues) | [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2021-08-16..2021-08-24&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-08-16..2021-08-24&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-08-16..2021-08-24&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2021-08-16..2021-08-24&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-08-16..2021-08-24&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-08-16..2021-08-24&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-08-16..2021-08-24&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AmartinRenou+updated%3A2021-08-16..2021-08-24&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-08-16..2021-08-24&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 4.0.0a4
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v4.0.0a3...26c35fef04a6b34564662965741f561701becf05))
@@ -42,8 +80,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-08-12&to=2021-08-16&type=c))
 
 [@3coins](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3A3coins+updated%3A2021-08-12..2021-08-16&type=Issues) | [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2021-08-12..2021-08-16&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-08-12..2021-08-16&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-08-12..2021-08-16&type=Issues) | [@goanpeca](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agoanpeca+updated%3A2021-08-12..2021-08-16&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-08-12..2021-08-16&type=Issues) | [@JohanMabille](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AJohanMabille+updated%3A2021-08-12..2021-08-16&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-08-12..2021-08-16&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-08-12..2021-08-16&type=Issues) | [@richardkang112](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Arichardkang112+updated%3A2021-08-12..2021-08-16&type=Issues) | [@vkaidalov-rft](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Avkaidalov-rft+updated%3A2021-08-12..2021-08-16&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 4.0.0a3
 


### PR DESCRIPTION
Automated Changelog Entry for 4.0.0a5 on master
Python version: 4.0.0a5
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/application-top: 3.3.0-alpha.5
@jupyterlab/example-terminal: 3.3.0-alpha.5
@jupyterlab/example-console: 3.3.0-alpha.5
@jupyterlab/example-app: 3.3.0-alpha.5
@jupyterlab/example-cell: 3.3.0-alpha.5
@jupyterlab/example-notebook: 3.3.0-alpha.5
@jupyterlab/example-filebrowser: 3.3.0-alpha.5
@jupyterlab/example-federated: 2.4.0-alpha.5
@jupyterlab/example-federated-middle: 2.4.0-alpha.5
@jupyterlab/example-federated-core: 2.4.0-alpha.5
@jupyterlab/example-federated-md: 2.4.0-alpha.5
@jupyterlab/example-federated-phosphor: 2.4.0-alpha.5
@jupyterlab/pdf-extension: 3.3.0-alpha.5
@jupyterlab/celltags-extension: 3.3.0-alpha.5
@jupyterlab/application-extension: 3.3.0-alpha.5
@jupyterlab/javascript-extension: 3.3.0-alpha.5
@jupyterlab/translation: 3.3.0-alpha.5
@jupyterlab/outputarea: 3.3.0-alpha.5
@jupyterlab/extensionmanager-extension: 3.3.0-alpha.5
@jupyterlab/property-inspector: 3.3.0-alpha.5
@jupyterlab/filebrowser-extension: 3.3.0-alpha.5
@jupyterlab/logconsole-extension: 3.3.0-alpha.5
@jupyterlab/extensionmanager: 3.3.0-alpha.5
@jupyterlab/metapackage: 3.3.0-alpha.5
@jupyterlab/running-extension: 3.3.0-alpha.5
@jupyterlab/theme-light-extension: 3.3.0-alpha.5
@jupyterlab/codeeditor: 3.3.0-alpha.5
@jupyterlab/nbformat: 3.3.0-alpha.5
@jupyterlab/terminal: 3.3.0-alpha.5
@jupyterlab/toc-extension: 5.3.0-alpha.5
@jupyterlab/documentsearch-extension: 3.3.0-alpha.5
@jupyterlab/mainmenu-extension: 3.3.0-alpha.5
@jupyterlab/rendermime: 3.3.0-alpha.5
@jupyterlab/htmlviewer-extension: 3.3.0-alpha.5
@jupyterlab/markdownviewer: 3.3.0-alpha.5
@jupyterlab/statusbar-extension: 3.3.0-alpha.5
@jupyterlab/csvviewer-extension: 3.3.0-alpha.5
@jupyterlab/console: 3.3.0-alpha.5
@jupyterlab/imageviewer-extension: 3.3.0-alpha.5
@jupyterlab/debugger: 3.3.0-alpha.5
@jupyterlab/settingregistry: 3.3.0-alpha.5
@jupyterlab/running: 3.3.0-alpha.5
@jupyterlab/apputils-extension: 3.3.0-alpha.5
@jupyterlab/attachments: 3.3.0-alpha.5
@jupyterlab/rendermime-extension: 3.3.0-alpha.5
@jupyterlab/launcher-extension: 3.3.0-alpha.5
@jupyterlab/docmanager: 3.3.0-alpha.5
@jupyterlab/statusbar: 3.3.0-alpha.5
@jupyterlab/htmlviewer: 3.3.0-alpha.5
@jupyterlab/nbconvert-css: 3.3.0-alpha.5
@jupyterlab/documentsearch: 3.3.0-alpha.5
@jupyterlab/docprovider: 3.3.0-alpha.5
@jupyterlab/shared-models: 3.3.0-alpha.5
@jupyterlab/settingeditor-extension: 3.3.0-alpha.5
@jupyterlab/statedb: 3.3.0-alpha.5
@jupyterlab/fileeditor: 3.3.0-alpha.5
@jupyterlab/celltags: 3.3.0-alpha.5
@jupyterlab/ui-components: 3.3.0-alpha.5
@jupyterlab/docprovider-extension: 3.3.0-alpha.5
@jupyterlab/json-extension: 3.3.0-alpha.5
@jupyterlab/inspector: 3.3.0-alpha.5
@jupyterlab/completer-extension: 3.3.0-alpha.5
@jupyterlab/coreutils: 5.3.0-alpha.5
@jupyterlab/cells: 3.3.0-alpha.5
@jupyterlab/application: 3.3.0-alpha.5
@jupyterlab/logconsole: 3.3.0-alpha.5
@jupyterlab/tooltip: 3.3.0-alpha.5
@jupyterlab/hub-extension: 3.3.0-alpha.5
@jupyterlab/console-extension: 3.3.0-alpha.5
@jupyterlab/csvviewer: 3.3.0-alpha.5
@jupyterlab/ui-components-extension: 3.3.0-alpha.5
@jupyterlab/codemirror-extension: 3.3.0-alpha.5
@jupyterlab/markdownviewer-extension: 3.3.0-alpha.5
@jupyterlab/launcher: 3.3.0-alpha.5
@jupyterlab/theme-dark-extension: 3.3.0-alpha.5
@jupyterlab/help-extension: 3.3.0-alpha.5
@jupyterlab/notebook: 3.3.0-alpha.5
@jupyterlab/translation-extension: 3.3.0-alpha.5
@jupyterlab/docregistry: 3.3.0-alpha.5
@jupyterlab/apputils: 3.3.0-alpha.5
@jupyterlab/inspector-extension: 3.3.0-alpha.5
@jupyterlab/rendermime-interfaces: 3.3.0-alpha.5
@jupyterlab/vdom-extension: 3.3.0-alpha.5
@jupyterlab/imageviewer: 3.3.0-alpha.5
@jupyterlab/filebrowser: 3.3.0-alpha.5
@jupyterlab/mathjax2: 3.3.0-alpha.5
@jupyterlab/vdom: 3.3.0-alpha.5
@jupyterlab/toc: 5.3.0-alpha.5
@jupyterlab/completer: 3.3.0-alpha.5
@jupyterlab/services: 6.3.0-alpha.5
@jupyterlab/debugger-extension: 3.3.0-alpha.5
@jupyterlab/tooltip-extension: 3.3.0-alpha.5
@jupyterlab/vega5-extension: 3.3.0-alpha.5
@jupyterlab/notebook-extension: 3.3.0-alpha.5
@jupyterlab/mathjax2-extension: 3.3.0-alpha.5
@jupyterlab/codemirror: 3.3.0-alpha.5
@jupyterlab/mainmenu: 3.3.0-alpha.5
@jupyterlab/terminal-extension: 3.3.0-alpha.5
@jupyterlab/fileeditor-extension: 3.3.0-alpha.5
@jupyterlab/settingeditor: 3.3.0-alpha.5
@jupyterlab/observables: 4.3.0-alpha.5
@jupyterlab/shortcuts-extension: 3.3.0-alpha.5
@jupyterlab/docmanager-extension: 3.3.0-alpha.5
node-example: 3.3.0-alpha.5
@jupyterlab/example-services-browser: 3.3.0-alpha.5
@jupyterlab/example-services-outputarea: 3.3.0-alpha.5
@jupyterlab/builder: 3.3.0-alpha.5
@jupyterlab/buildutils: 3.3.0-alpha.5
@jupyterlab/template: 3.3.0-alpha.5
@jupyterlab/testutils: 3.3.0-alpha.5
@jupyterlab/mock-extension: 3.3.0-alpha.5
@jupyterlab/mock-consumer: 3.3.0-alpha.5
@jupyterlab/mock-token: 3.3.0-alpha.5
@jupyterlab/mock-provider: 3.3.0-alpha.5

After merging this PR run the "Draft Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | master  |
| Version Spec | build |
| Since | v4.0.0a4 |