### PR TITLE
Remove terminal theme menu if terminal feature is disabled

### DIFF
--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -96,6 +96,14 @@ function activate(
     console.warn(
       'Disabling terminals plugin because they are not available on the server'
     );
+    const terminalThemeMenu = mainMenu?.settingsMenu.items.find(
+      item =>
+        item.type === 'submenu' &&
+        item.submenu?.id === 'jp-mainmenu-settings-terminaltheme'
+    );
+    if (terminalThemeMenu) {
+      mainMenu?.settingsMenu.removeItem(terminalThemeMenu);
+    }
     return tracker;
   }
 

--- a/packages/ui-components/src/components/menu.ts
+++ b/packages/ui-components/src/components/menu.ts
@@ -13,7 +13,7 @@ import { Menu } from '@lumino/widgets';
  * application menus that may be extended by plugins as well,
  * such as "Edit" and "View"
  */
-export interface IRankedMenu extends IDisposable {
+export interface IRankedMenu extends Menu {
   /**
    * Add a group of menu items specific to a particular
    * plugin.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes https://github.com/jupyterlab/jupyterlab/issues/10879

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

`IRankedMenu` now extends from `Menu` instead of `IDisposable`.
 Remove `Terminal Theme` menu if terminal feature is disabled on server.
