### PR TITLE
Correct the documentation for packaging

### DIFF
--- a/docs/source/extension/extension_tutorial.rst
+++ b/docs/source/extension/extension_tutorial.rst
@@ -897,7 +897,7 @@ Packaging your extension
 
 JupyterLab extensions for JupyterLab 3.0 can be distributed as Python
 packages. The cookiecutter template we used contains all of the Python
-packaging instructions in the ``setup.py`` file to wrap your extension in a
+packaging instructions in the ``pyproject.toml`` file to wrap your extension in a
 Python package. Before generating a package, we first need to install ``build``.
 
 .. code:: bash
@@ -917,9 +917,9 @@ To create a Python wheel package (``.whl``) in the ``dist/`` directory, do:
     python -m build
 
 Both of these commands will build the JavaScript into a bundle in the
-``jupyterlab_apod/static`` directory, which is then distributed with the
+``jupyterlab_apod/labextension/static`` directory, which is then distributed with the
 Python package. This bundle will include any necessary JavaScript dependencies
-as well. You may want to check in the ``jupyterlab_apod/static`` directory to
+as well. You may want to check in the ``jupyterlab_apod/labextension/static`` directory to
 retain a record of what JavaScript is distributed in your package, or you may
 want to keep this "build artifact" out of your source repository history.
 


### PR DESCRIPTION
Mention that the instruction for packaging are in `pyproject.toml` and that the JS assets are in `jupyterlab_apod/labextension/static`