### PR TITLE
Feature: Added a CLI subcommand 'list' to list all the workspaces

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -314,7 +314,8 @@ class LabWorkspaceListApp(JupyterApp):
             for workspace in workspaces:
                 print(json.dumps(workspace))
         else:
-            print(*items, sep="\n")
+            for workspace in workspaces:
+                print(workspace['metadata']['id'])
                 
 
 def _list_available_workspaces(directory, items):

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -258,6 +258,28 @@ class LabPathApp(JupyterApp):
         print('Workspaces directory: %s' % get_workspaces_dir())
 
 
+class LabWorkspaceListApp(JupyterApp):
+    version = version
+    description = """
+    Print name of all the workspaces available alongside their respective path
+    """
+    def start(self):
+        app = LabApp(config=self.config)
+        directory = app.workspaces_dir
+        app_url = app.app_url
+
+        items = [item
+                for item in os.listdir(directory)
+                if item.endswith(WORKSPACE_EXTENSION)]
+        items.sort()
+
+        for slug in items:
+            workspace_path = os.path.join(directory, slug)
+            if os.path.exists(workspace_path):
+                print(slug, workspace_path, json.dumps(dict(data=dict(), metadata=dict(id=app_url))))
+                
+
+
 class LabWorkspaceExportApp(JupyterApp):
     version = version
     description = """
@@ -396,9 +418,9 @@ class LabWorkspaceImportApp(JupyterApp):
 class LabWorkspaceApp(JupyterApp):
     version = version
     description = """
-    Import or export a JupyterLab workspace
+    Import or export a JupyterLab workspace or list all the JupyterLab workspaces
 
-    There are two sub-commands for export or import of workspaces. This app
+    There are three sub-commands for export, import or list of workspaces. This app
         should not otherwise do any work.
     """
     subcommands = dict()
@@ -410,11 +432,14 @@ class LabWorkspaceApp(JupyterApp):
         LabWorkspaceImportApp,
         LabWorkspaceImportApp.description.splitlines()[0]
     )
-
+    subcommands['list'] = (
+        LabWorkspaceListApp,
+        LabWorkspaceListApp.description.splitlines()[0]
+    )
     def start(self):
         try:
             super().start()
-            print('Either `export` or `import` must be specified.')
+            print('Anyone of `export`, `import` or `list` must be specified.')
             self.exit(1)
         except NoStart:
             pass

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -15,7 +15,7 @@ from jupyter_server._version import version_info as jpserver_version_info
 from jupyter_server.serverapp import flags
 from jupyter_server.utils import url_path_join as ujoin
 from jupyter_server import _tz as tz
-from jupyter_server.transutils import _i18n
+from jupyter_server.transutils import *
 
 from jupyterlab_server import WORKSPACE_EXTENSION, LabServerApp, slugify
 from nbclassic.shim import NBClassicConfigShimMixin

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -15,7 +15,7 @@ from jupyter_server._version import version_info as jpserver_version_info
 from jupyter_server.serverapp import flags
 from jupyter_server.utils import url_path_join as ujoin
 from jupyter_server import _tz as tz
-from jupyter_server.transutils import *
+from jupyter_server.transutils import _i18n
 
 from jupyterlab_server import WORKSPACE_EXTENSION, LabServerApp, slugify
 from nbclassic.shim import NBClassicConfigShimMixin

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -267,7 +267,7 @@ class LabWorkspaceListApp(JupyterApp):
 
     If '--json' flag is passed in, 'json' output of each workspace is printed.
     If '--jsonlist' flag is passed in, 'json' output of list of workspaces is printed.
-    If both of the above are not passed in, 'human-readable' output is printed.
+    If nothing is passed in, 'human-readable' output is printed.
     """
     flags = dict(
         jsonlist=(
@@ -302,27 +302,32 @@ class LabWorkspaceListApp(JupyterApp):
         app = LabApp(config=self.config)
         directory = app.workspaces_dir
 
-        if self.jsonlist:
-            workspaces = []
-
         items = [item
                 for item in os.listdir(directory)
                 if item.endswith(WORKSPACE_EXTENSION)]
         items.sort()
 
-        for slug in items:
-            workspace_path = os.path.join(directory, slug)
-            if os.path.exists(workspace_path):
-                workspace = _load_with_file_times(workspace_path)
-                if self.json:
-                    print(json.dumps(workspace))
-                if self.jsonlist:
-                    workspaces.append(workspace)
-                if not self.json and not self.jsonlist:
-                    print(slug, workspace_path, sep='\t')
+        workspaces = _list_available_workspaces(directory, items)
         if self.jsonlist:
             print(json.dumps(workspaces))
+        elif self.json:
+            for workspace in workspaces:
+                print(json.dumps(workspace))
+        else:
+            print(*items, sep="\n")
                 
+
+def _list_available_workspaces(directory, items):
+    """
+    Return a list containing all the workspaces
+    """
+    workspaces = []
+    for slug in items:
+        workspace_path = os.path.join(directory, slug)
+        if os.path.exists(workspace_path):
+            workspaces.append(_load_with_file_times(workspace_path))
+    return workspaces
+
 
 def _load_with_file_times(workspace_path):
     """
@@ -479,7 +484,7 @@ class LabWorkspaceApp(JupyterApp):
     description = """
     Import or export a JupyterLab workspace or list all the JupyterLab workspaces
 
-    There are three sub-commands for export, import or list of workspaces. This app
+    There are three sub-commands for export, import or listing of workspaces. This app
         should not otherwise do any work.
     """
     subcommands = dict()

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -15,10 +15,11 @@ from jupyter_server._version import version_info as jpserver_version_info
 from jupyter_server.serverapp import flags
 from jupyter_server.utils import url_path_join as ujoin
 from jupyter_server import _tz as tz
+from jupyter_server.transutils import _i18n
 
 from jupyterlab_server import WORKSPACE_EXTENSION, LabServerApp, slugify
 from nbclassic.shim import NBClassicConfigShimMixin
-from traitlets import Bool, Instance, Unicode, default, _i18n
+from traitlets import Bool, Instance, Unicode, default
 
 from ._version import __version__
 from .commands import (


### PR DESCRIPTION
## References

This PR is with respect to the issue [#10890](https://github.com/jupyterlab/jupyterlab/issues/10890).
No other PRs available for the same.

## Code changes

Changes are made to [jupyterlab/labapp.py](https://github.com/jupyterlab/jupyterlab/blob/master/jupyterlab/labapp.py) as below,
1). Created a class  **LabWorkspaceListApp** within which all the workspaces are collected and displayed with the help of helper functions below.
2). Added a helper function **_list_available_workspaces** which returns a list comprising of all available workspaces.
3). Added another helper function **_load_with_file_times** which will return the respective workspace's **json** from the disk with its stats overwritten accordingly.
4). Made changes to class **LabWorkspaceApp** in such a way that it can handle and call the above class when **list** subcommand is used.