### PR TITLE
Implement Save as option 

### DIFF
--- a/packages/apputils/src/inputdialog.ts
+++ b/packages/apputils/src/inputdialog.ts
@@ -151,7 +151,8 @@ export namespace InputDialog {
       body: new InputItemsDialog(options),
       buttons: [
         Dialog.cancelButton({ label: options.cancelLabel }),
-        Dialog.okButton({ label: options.okLabel })
+        Dialog.okButton({ label: options.okLabel }),
+        Dialog.saveasButton({ label: options.saveasLabel })
       ],
       focusNodeSelector: options.editable ? 'input' : 'select'
     });
@@ -186,7 +187,8 @@ export namespace InputDialog {
       body: new InputTextDialog(options),
       buttons: [
         Dialog.cancelButton({ label: options.cancelLabel }),
-        Dialog.okButton({ label: options.okLabel })
+        Dialog.okButton({ label: options.okLabel }),
+        Dialog.saveasButton({ label: options.saveasLabel })
       ],
       focusNodeSelector: 'input'
     });

--- a/packages/filebrowser/src/opendialog.ts
+++ b/packages/filebrowser/src/opendialog.ts
@@ -81,7 +81,8 @@ export namespace FileDialog {
         Dialog.cancelButton({ label: trans.__('Cancel') }),
         Dialog.okButton({
           label: trans.__('Select')
-        })
+        }),
+        Dialog.saveasButton({ label: trans.__('Save as') })
       ],
       focusNodeSelector: options.focusNodeSelector,
       host: options.host,


### PR DESCRIPTION
## References : https://github.com/jupyterlab/jupyterlab/issues/9271

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Add some code to create a save as button 
changes in those files: 
- [inputdialog.ts](https://github.com/jupyterlab/jupyterlab/blob/master/packages/apputils/src/inputdialog.ts)
- [opendialog.ts](https://github.com/jupyterlab/jupyterlab/blob/master/packages/filebrowser/src/opendialog.ts)

 
## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
NA
<!-- For visual changes, including before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backward-incompatible changes to JupyterLab public APIs. -->
NA