### PR TITLE
Add "menu" context for translation of menu labels

### DIFF
--- a/packages/mainmenu/src/mainmenu.ts
+++ b/packages/mainmenu/src/mainmenu.ts
@@ -309,7 +309,7 @@ export class MainMenu extends MenuBar implements IMainMenu {
     }
 
     if (label) {
-      menu.title.label = trans.__(label);
+      menu.title.label = trans._p('menu', label);
     }
 
     return menu;


### PR DESCRIPTION
## References

This is a follow up after #10931 and https://github.com/jupyterlab/jupyterlab-translate/pull/8 adding "menu" context to the menu labels. This is needed for the translations to work (we lost the strings in pot file in transition the schema-based menus, and when re-introducing the them we decided to improve the translation context; this allows for example to translate "Edit" as "Edycja" (noun) for menu but "Edytuj" (verb) in another context, as appropriate.

## Code changes

Use `_p` alias.

## User-facing changes

It is the penultimate change needed to make the language packs cover all JupyterLab GUI :crossed_fingers: 

## Backwards-incompatible changes

None (current language packs are missing labels for menus).
