### PR TITLE
Fix formatting of a link in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,7 +369,7 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.0.6...60f37be54a714c391fad5500cb57055af1492591))
 
 From JupyterLab 3.1, file documents and notebooks have collaborative
-editing using the `Yjs shared editing framework <https://github.com/yjs/yjs>`\_.
+editing using the [Yjs shared editing framework](https://github.com/yjs/yjs).
 Editors are not collaborative by default; to activate it, start JupyterLab
 with the `--collaborative` flag. See full documentation on [collaboration](https://jupyterlab.readthedocs.io/en/latest/user/rtc.html).
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fix the formatting of a link in the changelog that appeared to not be rendered properly:

![image](https://user-images.githubusercontent.com/591645/131224200-ac6e5561-40bd-4dd9-9d07-6cdf32a49535.png)


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Documentation changes.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
