### PR TITLE
Enable document wide history tracking

### DIFF
--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -817,6 +817,12 @@
       "description": "Defines the maximum number of output cells to to to be rendered in the output area for cells with many outputs. The output area will have a head and a tail, and the outputs between will be trimmed and not displayed unless the user clicks on the information message.",
       "type": "number",
       "default": 50
+    },
+    "enableDocumentWideUndoRedo": {
+      "title": "Enable the undo/redo on the notebook document level.",
+      "description": "Enable the undo/redo on the notebook document level, so actions like cells move, change... can have history. The undo/redo never applies on the outputs, in other words, outputs don't have history.",
+      "type": "boolean",
+      "default": true
     }
   },
   "additionalProperties": false,

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -818,8 +818,8 @@
       "type": "number",
       "default": 50
     },
-    "enableDocumentWideUndoRedo": {
-      "title": "Enable the undo/redo on the notebook document level.",
+    "experimentalEnableDocumentWideUndoRedo": {
+      "title": "Experimental settings to enable the undo/redo on the notebook document level.",
       "description": "Enable the undo/redo on the notebook document level, so actions like cells move, change... can have history. The undo/redo never applies on the outputs, in other words, outputs don't have history.",
       "type": "boolean",
       "default": true

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1120,7 +1120,11 @@ function activateNotebookHandler(
   }
 
   const registry = app.docRegistry;
-  registry.addModelFactory(new NotebookModelFactory({}));
+  const modelFactory = new NotebookModelFactory({
+    enableDocumentWideUndoRedo:
+      factory.notebookConfig.enableDocumentWideUndoRedo
+  });
+  registry.addModelFactory(modelFactory);
 
   addCommands(app, tracker, translator, sessionDialogs);
 
@@ -1188,10 +1192,16 @@ function activateNotebookHandler(
       observedTopMargin: settings.get('observedTopMargin').composite as string,
       observedBottomMargin: settings.get('observedBottomMargin')
         .composite as string,
-      maxNumberOutputs: settings.get('maxNumberOutputs').composite as number
+      maxNumberOutputs: settings.get('maxNumberOutputs').composite as number,
+      enableDocumentWideUndoRedo: settings.get('enableDocumentWideUndoRedo')
+        .composite as boolean
     };
     factory.shutdownOnClose = settings.get('kernelShutdown')
       .composite as boolean;
+
+    modelFactory.enableDocumentWideUndoRedo = settings.get(
+      'enableDocumentWideUndoRedo'
+    ).composite as boolean;
 
     updateTracker({
       editorConfig: factory.editorConfig,

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1193,8 +1193,9 @@ function activateNotebookHandler(
       observedBottomMargin: settings.get('observedBottomMargin')
         .composite as string,
       maxNumberOutputs: settings.get('maxNumberOutputs').composite as number,
-      enableDocumentWideUndoRedo: settings.get('enableDocumentWideUndoRedo')
-        .composite as boolean
+      enableDocumentWideUndoRedo: settings.get(
+        'experimentalEnableDocumentWideUndoRedo'
+      ).composite as boolean
     };
     factory.shutdownOnClose = settings.get('kernelShutdown')
       .composite as boolean;

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1201,7 +1201,7 @@ function activateNotebookHandler(
       .composite as boolean;
 
     modelFactory.enableDocumentWideUndoRedo = settings.get(
-      'enableDocumentWideUndoRedo'
+      'experimentalEnableDocumentWideUndoRedo'
     ).composite as boolean;
 
     updateTracker({

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -89,6 +89,9 @@ export class NotebookModel implements INotebookModel {
     } else {
       this.modelDB = new ModelDB();
     }
+    this.sharedModel = models.YNotebook.create(
+      options.enableDocumentWideUndoRedo || false
+    ) as models.ISharedNotebook;
     this._isInitialized = options.isInitialized === false ? false : true;
     const factory =
       options.contentFactory || NotebookModel.defaultContentFactory;
@@ -497,7 +500,7 @@ close the notebook without saving it.`,
   /**
    * The shared notebook model.
    */
-  readonly sharedModel = models.YNotebook.create() as models.ISharedNotebook;
+  readonly sharedModel: models.ISharedNotebook;
 
   /**
    * A mutex to update the shared model.
@@ -558,6 +561,11 @@ export namespace NotebookModel {
      * If the model is initialized or not.
      */
     isInitialized?: boolean;
+
+    /**
+     * Defines if the document can be undo/redo.
+     */
+    enableDocumentWideUndoRedo?: boolean;
   }
 
   /**

--- a/packages/notebook/src/modelfactory.ts
+++ b/packages/notebook/src/modelfactory.ts
@@ -16,6 +16,8 @@ export class NotebookModelFactory
    * Construct a new notebook model factory.
    */
   constructor(options: NotebookModelFactory.IOptions) {
+    this._enableDocumentWideUndoRedo =
+      options.enableDocumentWideUndoRedo || false;
     const codeCellContentFactory = options.codeCellContentFactory;
     this.contentFactory =
       options.contentFactory ||
@@ -26,6 +28,13 @@ export class NotebookModelFactory
    * The content model factory used by the NotebookModelFactory.
    */
   readonly contentFactory: NotebookModel.IContentFactory;
+
+  /**
+   * Define the enableDocumentWideUndoRedo property.
+   */
+  set enableDocumentWideUndoRedo(enableDocumentWideUndoRedo: boolean) {
+    this._enableDocumentWideUndoRedo = enableDocumentWideUndoRedo;
+  }
 
   /**
    * The name of the model.
@@ -79,7 +88,8 @@ export class NotebookModelFactory
       languagePreference,
       contentFactory,
       modelDB,
-      isInitialized
+      isInitialized,
+      enableDocumentWideUndoRedo: this._enableDocumentWideUndoRedo
     });
   }
 
@@ -89,6 +99,11 @@ export class NotebookModelFactory
   preferredLanguage(path: string): string {
     return '';
   }
+
+  /**
+   * Defines if the document can be undo/redo.
+   */
+  private _enableDocumentWideUndoRedo: boolean;
 
   private _disposed = false;
 }
@@ -101,6 +116,11 @@ export namespace NotebookModelFactory {
    * The options used to initialize a NotebookModelFactory.
    */
   export interface IOptions {
+    /**
+     * Defines if the document can be undo/redo.
+     */
+    enableDocumentWideUndoRedo?: boolean;
+
     /**
      * The factory for code cell content.
      */

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -960,7 +960,13 @@ export namespace StaticNotebook {
      * Defines the maximum number of outputs per cell.
      */
     maxNumberOutputs: number;
+
+    /**
+     * Defines if the document can be undo/redo.
+     */
+    enableDocumentWideUndoRedo: boolean;
   }
+
   /**
    * Default configuration options for notebooks.
    */
@@ -972,7 +978,8 @@ export namespace StaticNotebook {
     renderCellOnIdle: true,
     observedTopMargin: '1000px',
     observedBottomMargin: '1000px',
-    maxNumberOutputs: 50
+    maxNumberOutputs: 50,
+    enableDocumentWideUndoRedo: true
   };
 
   /**

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -62,7 +62,9 @@ describe('@jupyterlab/notebook', () => {
         contentFactory: utils.createNotebookFactory(),
         mimeTypeService: utils.mimeTypeService
       });
-      const model = new NotebookModel();
+      const model = new NotebookModel({
+        enableDocumentWideUndoRedo: true
+      });
       model.fromJSON(utils.DEFAULT_CONTENT);
       widget.model = model;
       model.sharedModel.clearUndoHistory();

--- a/packages/notebook/test/model.spec.ts
+++ b/packages/notebook/test/model.spec.ts
@@ -13,7 +13,7 @@ describe('@jupyterlab/notebook', () => {
   describe('NotebookModel', () => {
     describe('#constructor()', () => {
       it('should create a notebook model', () => {
-        const model = new NotebookModel();
+        const model = new NotebookModel({});
         expect(model).toBeInstanceOf(NotebookModel);
       });
 
@@ -72,7 +72,9 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should allow undoing a change', () => {
-        const model = new NotebookModel();
+        const model = new NotebookModel({
+          enableDocumentWideUndoRedo: true
+        });
         const cell = model.contentFactory.createCodeCell({});
         cell.value.text = 'foo';
         const cellJSON = cell.toJSON();
@@ -378,7 +380,9 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should clear undo state', () => {
-        const model = new NotebookModel();
+        const model = new NotebookModel({
+          enableDocumentWideUndoRedo: true
+        });
         const cell = model.contentFactory.createCodeCell({});
         cell.value.text = 'foo';
         model.cells.push(cell);

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -41,7 +41,8 @@ const notebookConfig = {
   renderCellOnIdle: true,
   observedTopMargin: '1000px',
   observedBottomMargin: '1000px',
-  maxNumberOutputs: 50
+  maxNumberOutputs: 50,
+  enableDocumentWideUndoRedo: true
 };
 
 const options: Notebook.IOptions = {

--- a/packages/shared-models/src/api.ts
+++ b/packages/shared-models/src/api.ts
@@ -206,6 +206,30 @@ export interface ISharedNotebook extends ISharedDocument {
 }
 
 /**
+ * Definition of the map changes for yjs.
+ */
+export type MapChange = Map<
+  string,
+  { action: 'add' | 'update' | 'delete'; oldValue: any; newValue: any }
+>;
+
+/**
+ * The namespace for `ISharedNotebook` class statics.
+ */
+export namespace ISharedNotebook {
+  /**
+   * The options used to initialize a a ISharedNotebook
+   */
+  export interface IOptions {
+    /**
+     * Wether the the undo/redo logic should be
+     * considered on the full document across all cells.
+     */
+    enableDocumentWideUndoRedo: boolean;
+  }
+}
+
+/**
  * The Shared kernelspec metadata.
  */
 export interface ISharedKernelspecMetadata
@@ -490,11 +514,3 @@ export type DocumentChange = {
     newValue: any;
   }>;
 };
-
-/**
- * Definition of the map changes for yjs.
- */
-export type MapChange = Map<
-  string,
-  { action: 'add' | 'update' | 'delete'; oldValue: any; newValue: any }
->;

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -278,7 +278,6 @@ export class YNotebook
       if (this.enableDocumentWideUndoRedo) {
         cell.undoManager = this.undoManager;
       }
-      cell.undoManager = this.undoManager;
     });
     this.transact(() => {
       this.ycells.insert(
@@ -363,7 +362,13 @@ export class YNotebook
     return new YNotebook(enableDocumentWideUndoRedo);
   }
 
-  get enableDocumentWideUndoRedo() {
+  /**
+   * Wether the the undo/redo logic should be
+   * considered on the full document across all cells.
+   *
+   * @return The enableDocumentWideUndoRedo setting.
+   */
+  get enableDocumentWideUndoRedo(): boolean {
     return this._enableDocumentWideUndoRedo;
   }
 
@@ -616,7 +621,7 @@ export class YBaseCell<Metadata extends models.ISharedBaseCellMetadata>
     cell.isStandalone = true;
     new Y.Doc().getArray().insert(0, [cell.ymodel]);
     cell._undoManager = new Y.UndoManager([cell.ymodel], {
-      //      trackedOrigins: new Set([cell])
+      trackedOrigins: new Set([cell])
     });
     return cell;
   }

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -634,7 +634,11 @@ export class YBaseCell<Metadata extends models.ISharedBaseCellMetadata>
     ymodel.set('cell_type', this.cell_type);
     ymodel.set('id', this.getId());
     const Self: any = this.constructor;
-    return new Self(ymodel);
+    const clone = new Self(ymodel);
+    // TODO The assignmenet of the undoManager does not work for a clone.
+    // See https://github.com/jupyterlab/jupyterlab/issues/11035
+    clone._undoManager = this.undoManager;
+    return clone;
   }
 
   /**

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -9,7 +9,7 @@ import { ISignal, Signal } from '@lumino/signaling';
 import { Awareness } from 'y-protocols/awareness';
 import * as Y from 'yjs';
 import * as models from './api';
-import { Delta } from './api';
+import { Delta, ISharedNotebook } from './api';
 
 const deepCopy = (o: any) => JSON.parse(JSON.stringify(o));
 
@@ -199,9 +199,9 @@ export class YFile
 export class YNotebook
   extends YDocument<models.NotebookChange>
   implements models.ISharedNotebook {
-  constructor(enableDocumentWideUndoRedo: boolean) {
+  constructor(options: ISharedNotebook.IOptions) {
     super();
-    this._enableDocumentWideUndoRedo = enableDocumentWideUndoRedo;
+    this._enableDocumentWideUndoRedo = options.enableDocumentWideUndoRedo;
     this.ycells.observe(this._onYCellsChanged);
     this.cells = this.ycells.toArray().map(ycell => {
       if (!this._ycellMapping.has(ycell)) {
@@ -359,7 +359,7 @@ export class YNotebook
   public static create(
     enableDocumentWideUndoRedo: boolean
   ): models.ISharedNotebook {
-    return new YNotebook(enableDocumentWideUndoRedo);
+    return new YNotebook({ enableDocumentWideUndoRedo });
   }
 
   /**

--- a/testutils/src/common.ts
+++ b/testutils/src/common.ts
@@ -384,7 +384,9 @@ namespace Private {
 
   export const textFactory = new TextModelFactory();
 
-  export const notebookFactory = new NotebookModelFactory({});
+  export const notebookFactory = new NotebookModelFactory({
+    enableDocumentWideUndoRedo: true
+  });
 
   /**
    * Get or create the service manager singleton.


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/10791

## Code changes

Adds a notebook setting `enableDocumentWideUndoRedo` and propagates this value to the notebook factory and the YModel. YModel keeps track of the last value for that setting and uses in its `transact` method.

## User-facing changes

New `enableDocumentWideUndoRedo` setting for the Notebook.

## Backwards-incompatible changes

None.
