### PR TITLE
Bump major Galata version

### DIFF
--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -1,4 +1,4 @@
-name: Galata Tests
+name: UI Tests
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    name: Galata
+    name: Visual Regression Tests
     timeout-minutes: 40
     runs-on: ubuntu-20.04
     steps:

--- a/galata/package.json
+++ b/galata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/galata",
-  "version": "3.3.0-alpha.6",
+  "version": "4.3.0-alpha.6",
   "description": "JupyterLab UI Testing Framework",
   "homepage": "https://github.com/jupyterlab/galata",
   "bugs": {


### PR DESCRIPTION
Follow up of #10796 
Bump major version of @jupyterlab/Galata as the interpreted package to core as completely changed the API and usage.

> + Rename the workflow to follow original UI tests naming