### PR TITLE
Fix browser tab name

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -350,7 +350,7 @@ async function updateTabTitle(workspace: string, db: IStateDB, name: string) {
     // Truncate to first 12 characters of current document name + ... if length > 15
     currentFile =
       currentFile.length > 15
-        ? currentFile.slice(0, 12).concat(`...`)
+        ? currentFile.slice(0, 12).concat(`…`)
         : currentFile;
     // Number of restorable items that are either notebooks or editors
     const count: number = Object.keys(data).filter(

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -341,7 +341,7 @@ async function updateTabTitle(workspace: string, db: IStateDB, name: string) {
     }`;
   } else {
     // File name from current path
-    let currentFile: string = PathExt.basename(current)?.split(':')[0];
+    let currentFile: string = PathExt.basename(current.split(':')[1]);
     // Truncate to first 12 characters of current document name + ... if length > 15
     currentFile =
       currentFile.length > 15

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -347,9 +347,9 @@ async function updateTabTitle(workspace: string, db: IStateDB, name: string) {
       workspace.startsWith('auto-') ? ` (${workspace})` : ``
     }`;
   } else {
-    // First 12 characters of current document name + ... if length > 12
+    // Truncate to first 12 characters of current document name + ... if length > 15
     currentFile =
-      currentFile.length > 12
+      currentFile.length > 15
         ? currentFile.slice(0, 12).concat(`...`)
         : currentFile;
     // Number of restorable items that are either notebooks or editors

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -335,13 +335,13 @@ export const toggleHeader: JupyterFrontEndPlugin<void> = {
 async function updateTabTitle(workspace: string, db: IStateDB, name: string) {
   const data: any = await db.toJSON();
   let current: string = data['layout-restorer:data']?.main?.current;
-  // File name from current path
-  let currentFile: string = PathExt.basename(current)?.split(':')[0];
-  if (currentFile === undefined) {
+  if (current === undefined) {
     document.title = `${PageConfig.getOption('appName') || 'JupyterLab'}${
       workspace.startsWith('auto-') ? ` (${workspace})` : ``
     }`;
   } else {
+    // File name from current path
+    let currentFile: string = PathExt.basename(current)?.split(':')[0];
     // Truncate to first 12 characters of current document name + ... if length > 15
     currentFile =
       currentFile.length > 15

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -26,7 +26,7 @@ import {
   sessionContextDialogs,
   WindowResolver
 } from '@jupyterlab/apputils';
-import { PageConfig, URLExt } from '@jupyterlab/coreutils';
+import { PageConfig, PathExt, URLExt } from '@jupyterlab/coreutils';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IStateDB, StateDB } from '@jupyterlab/statedb';
 import { ITranslator } from '@jupyterlab/translation';
@@ -336,12 +336,7 @@ async function updateTabTitle(workspace: string, db: IStateDB, name: string) {
   const data: any = await db.toJSON();
   let current: string = data['layout-restorer:data']?.main?.current;
   // File name from current path
-  let currentFile: string | undefined = current
-    ?.split(':')[1]
-    ?.split('\\')
-    ?.pop()
-    ?.split('/')
-    ?.pop();
+  let currentFile: string = PathExt.basename(current)?.split(':')[0];
   if (currentFile === undefined) {
     document.title = `${PageConfig.getOption('appName') || 'JupyterLab'}${
       workspace.startsWith('auto-') ? ` (${workspace})` : ``

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -335,24 +335,36 @@ export const toggleHeader: JupyterFrontEndPlugin<void> = {
 async function updateTabTitle(workspace: string, db: IStateDB, name: string) {
   const data: any = await db.toJSON();
   let current: string = data['layout-restorer:data']?.main?.current;
-  if (current === undefined) {
+  // File name from current path
+  let currentFile: string | undefined = current
+    ?.split(':')[1]
+    ?.split('\\')
+    ?.pop()
+    ?.split('/')
+    ?.pop();
+  if (currentFile === undefined) {
     document.title = `${PageConfig.getOption('appName') || 'JupyterLab'}${
       workspace.startsWith('auto-') ? ` (${workspace})` : ``
     }`;
   } else {
-    // First 15 characters of current document name
-    current = current.split(':')[1].slice(0, 15);
+    // First 12 characters of current document name + ... if length > 12
+    currentFile =
+      currentFile.length > 12
+        ? currentFile.slice(0, 12).concat(`...`)
+        : currentFile;
     // Number of restorable items that are either notebooks or editors
     const count: number = Object.keys(data).filter(
       item => item.startsWith('notebook') || item.startsWith('editor')
     ).length;
 
     if (workspace.startsWith('auto-')) {
-      document.title = `${current} (${workspace}${
+      document.title = `${currentFile} (${workspace}${
         count > 1 ? ` : ${count}` : ``
       }) - ${name}`;
     } else {
-      document.title = `${current}${count > 1 ? ` (${count})` : ``} - ${name}`;
+      document.title = `${currentFile}${
+        count > 1 ? ` (${count})` : ``
+      } - ${name}`;
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

This Pull Request addresses Issue #10902.

## Code changes

<!-- Describe the code changes and how they address the issue. -->

- Added a [currentFile](https://github.com/tejasmorkar/jupyterlab/blob/ee0713bd2409bd1c071a8724cd27aca794680d3c/packages/apputils-extension/src/index.ts#L338-L344) variable to get and store the file name from the current path. 
- [Truncated the file name](https://github.com/tejasmorkar/jupyterlab/blob/ee0713bd2409bd1c071a8724cd27aca794680d3c/packages/apputils-extension/src/index.ts#L350-L354) if it is greater than 12 characters and appended ellipsis (...) to it as suggested by @SarunasAzna in the mentioned issue. 

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

The browser tab title naming behavior has been changed. The tab title name showed the first 15 characters of the file path for longer names and the file name was not visible. Now, the file name is visible, and files with more than 15 characters are truncated to the first 12 characters + ellipsis (...). Previous data shown on tab name was not as useful and it has been changed to the file name which can be more useful for the user.  

### Before 

The tab name was `business-card/p - JupyterLab`

![image](https://user-images.githubusercontent.com/35477326/131243998-c022f255-3191-43ac-84f7-cdc68eb8a774.png)

### After

The tab name is `package-lock... - JupyterLab`

![image](https://user-images.githubusercontent.com/35477326/131243989-5978d7ea-2b0c-4be5-be89-e9964947d3e2.png)

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

None.