### PR TITLE
Add editable selector

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -585,6 +585,7 @@ function activateNotebookTools(
   const id = 'notebook-tools';
   const notebookTools = new NotebookTools({ tracker, translator });
   const activeCellTool = new NotebookTools.ActiveCellTool();
+  const editable = NotebookTools.createEditableToggle(translator);
   const slideShow = NotebookTools.createSlideShowSelector(translator);
   const editorFactory = editorServices.factoryService.newInlineEditor;
   const cellMetadataEditor = new NotebookTools.CellMetadataEditorTool({
@@ -660,7 +661,8 @@ function activateNotebookTools(
   notebookTools.id = id;
 
   notebookTools.addItem({ tool: activeCellTool, section: 'common', rank: 1 });
-  notebookTools.addItem({ tool: slideShow, section: 'common', rank: 2 });
+  notebookTools.addItem({ tool: editable, section: 'common', rank: 2 });
+  notebookTools.addItem({ tool: slideShow, section: 'common', rank: 3 });
 
   notebookTools.addItem({
     tool: cellMetadataEditor,

--- a/packages/notebook/src/notebooktools.ts
+++ b/packages/notebook/src/notebooktools.ts
@@ -922,6 +922,23 @@ export namespace NotebookTools {
       validCellTypes: ['raw']
     });
   }
+
+  /**
+   * Create read-only toggle.
+   */
+  export function createEditableToggle(translator?: ITranslator): KeySelector {
+    translator = translator || nullTranslator;
+    const trans = translator.load('jupyterlab');
+    return new KeySelector({
+      key: 'editable',
+      title: trans.__('Editable'),
+      optionValueArray: [
+        [trans.__('Editable'), true],
+        [trans.__('Read-Only'), false]
+      ],
+      default: true
+    });
+  }
 }
 
 /**
@@ -964,7 +981,11 @@ namespace Private {
     each(options.optionValueArray, item => {
       option = item[0];
       value = JSON.stringify(item[1]);
-      optionNodes.push(h.option({ value }, option));
+      const attrs =
+        options.default == item[1]
+          ? { value, selected: 'selected' }
+          : { value };
+      optionNodes.push(h.option(attrs, option));
     });
     const node = VirtualDOM.realize(
       h.div({}, h.label(title, h.select({}, optionNodes)))


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Task 3 in #9976

## Code changes

- modified `createSelectorNode` to display default value,
- add selector for `editable`

## User-facing changes

Enable user to choose Editable/Read-Only option in the cell metadata menu. Option "Editable" is set and displayed as default.
![Screenshot from 2021-08-29 22-23-27](https://user-images.githubusercontent.com/39529572/131265811-23deda15-de81-49eb-b90b-4265e8221066.png)
![Screenshot from 2021-08-29 22-23-05](https://user-images.githubusercontent.com/39529572/131265812-2c459646-890d-43ad-96c4-96eb8bd0b019.png)


## Backwards-incompatible changes

None
