### PR TITLE
Fix lack of translation of part of "Saving completed" and friends

### DIFF
--- a/packages/docmanager/src/savingstatus.tsx
+++ b/packages/docmanager/src/savingstatus.tsx
@@ -18,14 +18,9 @@ namespace SavingStatusComponent {
    */
   export interface IProps {
     /**
-     * The current saving status.
+     * The current saving status, after translation.
      */
-    fileStatus: DocumentRegistry.SaveState | null;
-
-    /**
-     * The application language translator.
-     */
-    translator?: ITranslator;
+    fileStatus: string;
   }
 }
 
@@ -39,9 +34,7 @@ namespace SavingStatusComponent {
 function SavingStatusComponent(
   props: SavingStatusComponent.IProps
 ): React.ReactElement<SavingStatusComponent.IProps> {
-  const translator = props.translator || nullTranslator;
-  const trans = translator.load('jupyterlab');
-  return <TextItem source={trans.__('Saving %1', props.fileStatus)} />;
+  return <TextItem source={props.fileStatus} />;
 }
 
 /**
@@ -59,7 +52,13 @@ export class SavingStatus extends VDomRenderer<SavingStatus.Model> {
    */
   constructor(opts: SavingStatus.IOptions) {
     super(new SavingStatus.Model(opts.docManager));
-    this.translator = opts.translator || nullTranslator;
+    const translator = opts.translator || nullTranslator;
+    const trans = translator.load('jupyterlab');
+    this._statusMap = {
+      completed: trans.__('Saving completed'),
+      started: trans.__('Saving started'),
+      failed: trans.__('Saving failed')
+    };
   }
 
   /**
@@ -71,14 +70,13 @@ export class SavingStatus extends VDomRenderer<SavingStatus.Model> {
     } else {
       return (
         <SavingStatusComponent
-          fileStatus={this.model.status}
-          translator={this.translator}
+          fileStatus={this._statusMap[this.model.status]}
         />
       );
     }
   }
 
-  private translator?: ITranslator;
+  private _statusMap: Record<DocumentRegistry.SaveState, string>;
 }
 
 /**


### PR DESCRIPTION
## References

Closing the gap to completion of #10737.

## Code changes

Added a record mapping the statuses to translation strings. The use of explicit strings is beneficial to allow quality translations.

## User-facing changes

"Saving completed", "Saving failed", and "Saving started" messages on status bar can be fully translated.

## Backwards-incompatible changes

All changes limited to non-exported/private members.