### PR TITLE
Improve Galata documentation and setup

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -530,8 +530,8 @@ Visual Regression and UI Tests
 ------------------------------
 
 As part of JupyterLab CI workflows, UI tests are run with visual regression checks.
-`Galata <https://github.com/jupyterlab/jupyterlab/tree/master/galata>`__is used for UI 
-testing. Galata provides `Playwright <https://playwright.dev>`_ helpers to control and 
+`Galata <https://github.com/jupyterlab/jupyterlab/tree/master/galata>`__ is used for UI 
+testing. Galata provides `Playwright <https://playwright.dev>`__ helpers to control and 
 inspect JupyterLab UI programmatically.
 
 UI tests are run for each commit into JupyterLab project in PRs or direct commits. Code 
@@ -566,7 +566,7 @@ Main reasons for UI test failures are:
    copy the capture for the failed test suffixed with *actual* and paste it into reference 
    screenshots directory in JupyterLab source code, replacing the failing test's reference
    capture. Reference captures are located in directories named as the test files with the
-   suffix ``-snapshots` in JupyterLab source code.
+   suffix ``-snapshots`` in JupyterLab source code.
 
 For more information on UI Testing, please read the `UI Testing developer documentation <https://github.com/jupyterlab/jupyterlab/blob/master/galata/README.md>`__
 and `Playwright documentation <https://playwright.dev/docs/intro>`__.

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -529,28 +529,55 @@ the two reports:
 Visual Regression and UI Tests
 ------------------------------
 
-As part of JupyterLab CI workflows, UI tests are run with visual regression checks. `Galata <https://github.com/jupyterlab/galata>`__ is used for UI testing. Galata provides a high level API to control and inspect JupyterLab UI programmatically, testing tools and CLI to manage tests and other tasks.
+As part of JupyterLab CI workflows, UI tests are run with visual regression checks.
+`Galata <https://github.com/jupyterlab/jupyterlab/tree/master/galata>`__is used for UI 
+testing. Galata provides `Playwright <https://playwright.dev>`_ helpers to control and 
+inspect JupyterLab UI programmatically.
 
-UI tests are run for each commit into JupyterLab project in PRs or direct commits. Code changes can sometimes cause UI tests to fail for various reasons. After each test run, Galata generates a user friendly test result report which can be used to inspect failing UI tests. Result report shows the failure reason, call-stack up to the failure and detailed information on visual regression issues. For visual regression errors, reference image and test capture image, along with diff image generated during comparison are provided in the report. You can use these information to debug failing tests. Galata test report can be downloaded from GitHub Actions page for a UI test run. Test artifact is named ``ui-test-output`` and once you extract it, you can access the report by opening ``test/report/index.html`` in a browser window.
+UI tests are run for each commit into JupyterLab project in PRs or direct commits. Code 
+changes can sometimes cause UI tests to fail for various reasons. After each test run, 
+Galata generates a user friendly test result report which can be used to inspect failing 
+UI tests. Result report shows the failure reason, call-stack up to the failure and 
+detailed information on visual regression issues. For visual regression errors, reference 
+image and test capture image, along with diff image generated during comparison are 
+provided in the report. You can use these information to debug failing tests. Galata test 
+report can be downloaded from GitHub Actions page for a UI test run. Test artifact is 
+named ``galata-report`` and once you extract it, you can access the report by launching 
+a server to serve the files ``python -m http.server -d <path-to-extracted-report>``. 
+Then open *http://localhost:8000* with your web browser.
 
 Main reasons for UI test failures are:
 
 1. **A visual regression caused by code changes**:
 
-   Sometimes unintentional UI changes are introduced by modifications to project source code. Goal of visual regression testing is to detect this kind of UI changes. If your PR / commit is causing visual regression, then debug and fix the regression caused. You can locally run and debug the UI tests to fix the visual regression. Follow the instructions in steps 5-7 of ``Adding a new UI test suite guide`` in `UI Testing documentation <https://github.com/jupyterlab/jupyterlab/blob/master/ui-tests/README.md#adding-a-new-ui-test-suite>`__ to locally debug and fix UI tests. Once you have a fix, you can push the change to your GitHub branch and test with GitHub actions.
+   Sometimes unintentional UI changes are introduced by modifications to project source 
+   code. Goal of visual regression testing is to detect this kind of UI changes. If your 
+   PR / commit is causing visual regression, then debug and fix the regression caused. 
+   You can locally run and debug the UI tests to fix the visual regression. To debug your
+   test, you may run ``PWDEBUG=1 jlpm playwright test <path-to-test-file>``. Once you 
+   have a fix, you can push the change to your GitHub branch and test with GitHub actions.
 
 2. **An intended update to user interface**:
 
-   If your code change is introducing an update to UI which causes existing UI Tests to fail, then you will need to update reference image(s) for the failing tests. In order to do that, simply go to GitHub Actions page for the failed test and download test artifacts. It will contain test captures in directory ``test/screenshots``. You can copy the capture for the failed test and paste into reference screenshots directory in JupyterLab source code, replacing the failing test's reference capture. Reference captures are located in ``ui-tests/reference-output/screenshots`` in JupyterLab source code.
+   If your code change is introducing an update to UI which causes existing UI Tests to
+   fail, then you will need to update reference image(s) for the failing tests. In order
+   to do that, go to GitHub Actions page for the failed test and download test 
+   artifacts ``galata-test-assets``. It will contain test captures. You can 
+   copy the capture for the failed test suffixed with *actual* and paste it into reference 
+   screenshots directory in JupyterLab source code, replacing the failing test's reference
+   capture. Reference captures are located in directories named as the test files with the
+   suffix ``-snapshots` in JupyterLab source code.
 
-For more information on UI Testing, please read the `UI Testing developer documentation <.https://github.com/jupyterlab/jupyterlab/blob/master/ui-tests/README.md>`__ and `Galata documentation <https://github.com/jupyterlab/galata/blob/main/README.md>`__.
+For more information on UI Testing, please read the `UI Testing developer documentation <https://github.com/jupyterlab/jupyterlab/blob/master/galata/README.md>`__
+and `Playwright documentation <https://playwright.dev/docs/intro>`__.
 
 Good Practices for Integration tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Here are some good practices to follow when writing integration tests:
 
-- Don't compare multiple screenshots in the same test; if the first comparison breaks, it will require running multiple times the CI workflow to fix all tests.
+- Don't compare multiple screenshots in the same test; if the first comparison breaks,
+  it will require running multiple times the CI workflow to fix all tests.
 
 Contributing to the debugger front-end
 --------------------------------------

--- a/galata/playwright.config.js
+++ b/galata/playwright.config.js
@@ -16,7 +16,7 @@ module.exports = {
     }
   ],
   // Switch to 'always' to keep raw assets for all tests
-  preserveOutput: 'failures-only',
+  // preserveOutput: 'failures-only', // FIXME Breaks HTML report
   // Try one retry as some tests are flaky
   retries: 2
 };

--- a/galata/playwright.config.js
+++ b/galata/playwright.config.js
@@ -16,7 +16,7 @@ module.exports = {
     }
   ],
   // Switch to 'always' to keep raw assets for all tests
-  // preserveOutput: 'failures-only', // FIXME Breaks HTML report
+  preserveOutput: 'failures-only', // Breaks HTML report if use.video == 'on'
   // Try one retry as some tests are flaky
   retries: 2
 };

--- a/galata/playwright.config.js
+++ b/galata/playwright.config.js
@@ -14,5 +14,9 @@ module.exports = {
       name: 'jupyterlab',
       testMatch: 'test/jupyterlab/**'
     }
-  ]
+  ],
+  // Switch to 'always' to keep raw assets for all tests
+  preserveOutput: 'failures-only',
+  // Try one retry as some tests are flaky
+  retries: 2
 };

--- a/galata/playwright.config.js
+++ b/galata/playwright.config.js
@@ -18,5 +18,5 @@ module.exports = {
   // Switch to 'always' to keep raw assets for all tests
   preserveOutput: 'failures-only', // Breaks HTML report if use.video == 'on'
   // Try one retry as some tests are flaky
-  retries: 2
+  retries: 1
 };

--- a/galata/src/fixtures.ts
+++ b/galata/src/fixtures.ts
@@ -60,8 +60,8 @@ export type GalataOptions = {
   autoGoto: boolean;
   /**
    * Galata can keep the uploaded and created files in ``tmpPath`` on
-   * the server root for debugging purpose. By default the files are kept
-   * on failure.
+   * the server root for debugging purpose. By default the files are
+   * always deleted
    *
    * - 'off' - ``tmpPath`` is deleted after each tests
    * - 'on' - ``tmpPath`` is never deleted
@@ -180,14 +180,14 @@ export const test: TestType<
   mockSettings: galata.DEFAULT_SETTINGS,
   /**
    * Galata can keep the uploaded and created files in ``tmpPath`` on
-   * the server root for debugging purpose. By default the files are kept
-   * on failure.
+   * the server root for debugging purpose. By default the files are
+   * always deleted.
    *
    * - 'off' - ``tmpPath`` is deleted after each tests
    * - 'on' - ``tmpPath`` is never deleted
    * - 'only-on-failure' - ``tmpPath`` is deleted except if a test failed or timed out.
    */
-  serverFiles: 'only-on-failure',
+  serverFiles: 'off',
   /**
    * Sessions created during the test.
    *

--- a/galata/src/inpage/index.ts
+++ b/galata/src/inpage/index.ts
@@ -2,10 +2,10 @@
 // Copyright (c) Bloomberg Finance LP.
 // Distributed under the terms of the Modified BSD License.
 
-import { IRouter, JupyterFrontEnd } from '@jupyterlab/application';
-import { Cell, MarkdownCell } from '@jupyterlab/cells';
-import * as nbformat from '@jupyterlab/nbformat';
-import { Notebook, NotebookActions, NotebookPanel } from '@jupyterlab/notebook';
+import type { IRouter, JupyterFrontEnd } from '@jupyterlab/application';
+import type { Cell, MarkdownCell } from '@jupyterlab/cells';
+import type * as nbformat from '@jupyterlab/nbformat';
+import type { Notebook, NotebookPanel } from '@jupyterlab/notebook';
 import { toArray } from '@lumino/algorithm';
 import {
   IGalataInpage,
@@ -235,7 +235,7 @@ export class GalataInpage implements IGalataInpage {
     const nbPanel = this._app.shell.currentWidget as NotebookPanel;
     const nb = nbPanel.content;
 
-    NotebookActions.deleteCells(nb);
+    this._app.commands.execute('notebook:delete-cell');
 
     nb.update();
   }
@@ -251,7 +251,7 @@ export class GalataInpage implements IGalataInpage {
     const nb = nbPanel.content;
 
     if (nb !== null) {
-      NotebookActions.insertBelow(nb);
+      this._app.commands.execute('notebook:insert-cell-below');
 
       const numCells = nb.widgets.length;
 
@@ -351,9 +351,7 @@ export class GalataInpage implements IGalataInpage {
    * Run the active notebook
    */
   async runActiveNotebook(): Promise<void> {
-    const nbPanel = this._app.shell.currentWidget as NotebookPanel;
-
-    await NotebookActions.runAll(nbPanel.content);
+    await this._app.commands.execute('notebook:run-all-cells');
   }
 
   /**
@@ -538,14 +536,14 @@ export class GalataInpage implements IGalataInpage {
       return;
     }
 
-    NotebookActions.deselectAll(notebook);
+    this._app.commands.execute('notebook:deselect-all');
 
     for (let i = 0; i < numCells; ++i) {
       const cell = notebook.widgets[i];
       notebook.activeCellIndex = i;
       notebook.select(cell);
 
-      await NotebookActions.run(notebook, nbPanel.context.sessionContext);
+      await this._app.commands.execute('notebook:run-cell');
 
       const output = await this.waitForCellRun(cell);
 

--- a/galata/src/playwright-config.ts
+++ b/galata/src/playwright-config.ts
@@ -20,6 +20,6 @@ module.exports = {
     viewport: { width: 1024, height: 768 },
 
     // Artifacts
-    video: 'on'
+    video: 'retain-on-failure'
   }
 } as PlaywrightTestConfig;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Address some points raised in #10955
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Galata tests will by default not keep uploaded and created files even in case of failure.

Use `retries` equals 1 to mitigate flaky UI tests without retrying too much when something is really broken.

Raw assets kept are only for failures tests (but all are kept in the other artifact with the report).

in-page code make use only of JupyterLab app object (replace `NotebookActions` calls by commands calls) to reduce the injected JS artifact size from 4Mo to 120ko.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A