### PR TITLE
Automated Changelog Entry for 3.1.10 on 3.1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.1.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.1.10
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.1.9...646b708cdb76f6d0e4e622b0546cc4dc7d2854c7))
+
+### Bugs fixed
+
+- Add "menu" context for translation of menu labels [#10932](https://github.com/jupyterlab/jupyterlab/pull/10932) ([@krassowski](https://github.com/krassowski))
+- Fix lack of translation of part of "Saving completed" and friends [#10958](https://github.com/jupyterlab/jupyterlab/pull/10958) ([@krassowski](https://github.com/krassowski))
+- Add undoManager to inserted cells [#10899](https://github.com/jupyterlab/jupyterlab/pull/10899) ([@hbcarlos](https://github.com/hbcarlos))
+- Render placeholder at correct index [#10898](https://github.com/jupyterlab/jupyterlab/pull/10898) ([@echarles](https://github.com/echarles))
+
+### Maintenance and upkeep improvements
+
+- Backport PR #10983 on branch 3.1.x (Update to lerna 4) [#10985](https://github.com/jupyterlab/jupyterlab/pull/10985) ([@blink1073](https://github.com/blink1073))
+- Clarify usage of mock in debugger test [#10979](https://github.com/jupyterlab/jupyterlab/pull/10979) ([@fcollonval](https://github.com/fcollonval))
+- Restore test for kernel that does not support debugger [#10973](https://github.com/jupyterlab/jupyterlab/pull/10973) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #10937: More Publish Integrity [#10938](https://github.com/jupyterlab/jupyterlab/pull/10938) ([@blink1073](https://github.com/blink1073))
+
+### Documentation improvements
+
+- Backport #10893 on branch 3.1.x (Add internationalization documentation) [#10974](https://github.com/jupyterlab/jupyterlab/pull/10974) ([@fcollonval](https://github.com/fcollonval))
+
+### Other merged PRs
+
+- Fix formatting of a link in the changelog [#10945](https://github.com/jupyterlab/jupyterlab/pull/10945) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-08-25&to=2021-09-01&type=c))
+
+[@agoose77](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aagoose77+updated%3A2021-08-25..2021-09-01&type=Issues) | [@baggiponte](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abaggiponte+updated%3A2021-08-25..2021-09-01&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-08-25..2021-09-01&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-08-25..2021-09-01&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2021-08-25..2021-09-01&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-08-25..2021-09-01&type=Issues) | [@goanpeca](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agoanpeca+updated%3A2021-08-25..2021-09-01&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-08-25..2021-09-01&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-08-25..2021-09-01&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-08-25..2021-09-01&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-08-25..2021-09-01&type=Issues) | [@mbektas](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ambektas+updated%3A2021-08-25..2021-09-01&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-08-25..2021-09-01&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-08-25..2021-09-01&type=Issues) | [@SarunasAzna](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASarunasAzna+updated%3A2021-08-25..2021-09-01&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-08-25..2021-09-01&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.1.9
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.1.8...8f8cfc548c7c91e9dcf0dc51fd6eafc98f3fcfef))
@@ -26,8 +60,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.1.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-08-24&to=2021-08-25&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-08-24..2021-08-25&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-08-24..2021-08-25&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-08-24..2021-08-25&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-08-24..2021-08-25&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-08-24..2021-08-25&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.1.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.1.x/CHANGELOG.md'
 ### Documentation improvements
 
 - Backport #10893 on branch 3.1.x (Add internationalization documentation) [#10974](https://github.com/jupyterlab/jupyterlab/pull/10974) ([@fcollonval](https://github.com/fcollonval))
-
-### Other merged PRs
-
 - Fix formatting of a link in the changelog [#10945](https://github.com/jupyterlab/jupyterlab/pull/10945) ([@jtpio](https://github.com/jtpio))
 
 ### Contributors to this release


### PR DESCRIPTION
Automated Changelog Entry for 3.1.10 on 3.1.x
Python version: 3.1.10
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/application-top: 3.1.10
@jupyterlab/example-terminal: 3.1.9
@jupyterlab/example-console: 3.1.9
@jupyterlab/example-app: 3.1.10
@jupyterlab/example-cell: 3.1.9
@jupyterlab/example-notebook: 3.1.9
@jupyterlab/example-filebrowser: 3.1.9
@jupyterlab/example-federated: 2.2.9
@jupyterlab/example-federated-middle: 2.2.10
@jupyterlab/example-federated-core: 2.2.10
@jupyterlab/example-federated-md: 2.2.10
@jupyterlab/example-federated-phosphor: 2.2.10
@jupyterlab/pdf-extension: 3.1.9
@jupyterlab/celltags-extension: 3.1.9
@jupyterlab/application-extension: 3.1.9
@jupyterlab/javascript-extension: 3.1.10
@jupyterlab/translation: 3.1.9
@jupyterlab/outputarea: 3.1.9
@jupyterlab/extensionmanager-extension: 3.1.9
@jupyterlab/property-inspector: 3.1.9
@jupyterlab/filebrowser-extension: 3.1.9
@jupyterlab/logconsole-extension: 3.1.9
@jupyterlab/extensionmanager: 3.1.9
@jupyterlab/metapackage: 3.1.10
@jupyterlab/running-extension: 3.1.9
@jupyterlab/theme-light-extension: 3.1.9
@jupyterlab/codeeditor: 3.1.9
@jupyterlab/nbformat: 3.1.9
@jupyterlab/terminal: 3.1.9
@jupyterlab/toc-extension: 5.1.9
@jupyterlab/documentsearch-extension: 3.1.9
@jupyterlab/mainmenu-extension: 3.1.9
@jupyterlab/rendermime: 3.1.9
@jupyterlab/htmlviewer-extension: 3.1.9
@jupyterlab/markdownviewer: 3.1.9
@jupyterlab/statusbar-extension: 3.1.9
@jupyterlab/csvviewer-extension: 3.1.9
@jupyterlab/console: 3.1.9
@jupyterlab/imageviewer-extension: 3.1.9
@jupyterlab/debugger: 3.1.9
@jupyterlab/settingregistry: 3.1.9
@jupyterlab/running: 3.1.9
@jupyterlab/apputils-extension: 3.1.10
@jupyterlab/attachments: 3.1.9
@jupyterlab/rendermime-extension: 3.1.9
@jupyterlab/launcher-extension: 3.1.9
@jupyterlab/docmanager: 3.1.9
@jupyterlab/statusbar: 3.1.9
@jupyterlab/htmlviewer: 3.1.9
@jupyterlab/nbconvert-css: 3.1.9
@jupyterlab/documentsearch: 3.1.9
@jupyterlab/docprovider: 3.1.9
@jupyterlab/shared-models: 3.1.9
@jupyterlab/settingeditor-extension: 3.1.9
@jupyterlab/statedb: 3.1.9
@jupyterlab/fileeditor: 3.1.9
@jupyterlab/celltags: 3.1.9
@jupyterlab/ui-components: 3.1.9
@jupyterlab/docprovider-extension: 3.1.9
@jupyterlab/json-extension: 3.1.10
@jupyterlab/inspector: 3.1.9
@jupyterlab/completer-extension: 3.1.9
@jupyterlab/coreutils: 5.1.9
@jupyterlab/cells: 3.1.9
@jupyterlab/application: 3.1.9
@jupyterlab/logconsole: 3.1.9
@jupyterlab/tooltip: 3.1.9
@jupyterlab/hub-extension: 3.1.9
@jupyterlab/console-extension: 3.1.9
@jupyterlab/csvviewer: 3.1.9
@jupyterlab/ui-components-extension: 3.1.9
@jupyterlab/codemirror-extension: 3.1.9
@jupyterlab/markdownviewer-extension: 3.1.9
@jupyterlab/launcher: 3.1.9
@jupyterlab/theme-dark-extension: 3.1.9
@jupyterlab/help-extension: 3.1.9
@jupyterlab/notebook: 3.1.9
@jupyterlab/translation-extension: 3.1.9
@jupyterlab/docregistry: 3.1.9
@jupyterlab/apputils: 3.1.9
@jupyterlab/inspector-extension: 3.1.9
@jupyterlab/rendermime-interfaces: 3.1.9
@jupyterlab/vdom-extension: 3.1.10
@jupyterlab/imageviewer: 3.1.9
@jupyterlab/filebrowser: 3.1.9
@jupyterlab/mathjax2: 3.1.9
@jupyterlab/vdom: 3.1.10
@jupyterlab/toc: 5.1.9
@jupyterlab/completer: 3.1.9
@jupyterlab/services: 6.1.9
@jupyterlab/debugger-extension: 3.1.9
@jupyterlab/tooltip-extension: 3.1.9
@jupyterlab/vega5-extension: 3.1.10
@jupyterlab/notebook-extension: 3.1.9
@jupyterlab/mathjax2-extension: 3.1.9
@jupyterlab/codemirror: 3.1.9
@jupyterlab/mainmenu: 3.1.9
@jupyterlab/terminal-extension: 3.1.9
@jupyterlab/fileeditor-extension: 3.1.9
@jupyterlab/settingeditor: 3.1.9
@jupyterlab/observables: 4.1.9
@jupyterlab/shortcuts-extension: 3.1.9
@jupyterlab/docmanager-extension: 3.1.9
node-example: 3.1.9
@jupyterlab/example-services-browser: 3.1.9
@jupyterlab/example-services-outputarea: 3.1.9
@jupyterlab/builder: 3.1.10
@jupyterlab/buildutils: 3.1.10
@jupyterlab/template: 3.1.9
@jupyterlab/testutils: 3.1.9
@jupyterlab/mock-extension: 3.1.10
@jupyterlab/mock-consumer: 3.1.10
@jupyterlab/mock-token: 3.1.9
@jupyterlab/mock-provider: 3.1.10

After merging this PR run the "Draft Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.1.x  |
| Version Spec | patch |
| Since | v3.1.9 |