### PR TITLE
Automated Changelog Entry for 4.0.0a7 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,6 +258,35 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 
 ## v3.1
 
+## 3.1.10
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.1.9...646b708cdb76f6d0e4e622b0546cc4dc7d2854c7))
+
+### Bugs fixed
+
+- Add "menu" context for translation of menu labels [#10932](https://github.com/jupyterlab/jupyterlab/pull/10932) ([@krassowski](https://github.com/krassowski))
+- Fix lack of translation of part of "Saving completed" and friends [#10958](https://github.com/jupyterlab/jupyterlab/pull/10958) ([@krassowski](https://github.com/krassowski))
+- Add undoManager to inserted cells [#10899](https://github.com/jupyterlab/jupyterlab/pull/10899) ([@hbcarlos](https://github.com/hbcarlos))
+- Render placeholder at correct index [#10898](https://github.com/jupyterlab/jupyterlab/pull/10898) ([@echarles](https://github.com/echarles))
+
+### Maintenance and upkeep improvements
+
+- Backport PR #10983 on branch 3.1.x (Update to lerna 4) [#10985](https://github.com/jupyterlab/jupyterlab/pull/10985) ([@blink1073](https://github.com/blink1073))
+- Clarify usage of mock in debugger test [#10979](https://github.com/jupyterlab/jupyterlab/pull/10979) ([@fcollonval](https://github.com/fcollonval))
+- Restore test for kernel that does not support debugger [#10973](https://github.com/jupyterlab/jupyterlab/pull/10973) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #10937: More Publish Integrity [#10938](https://github.com/jupyterlab/jupyterlab/pull/10938) ([@blink1073](https://github.com/blink1073))
+
+### Documentation improvements
+
+- Backport #10893 on branch 3.1.x (Add internationalization documentation) [#10974](https://github.com/jupyterlab/jupyterlab/pull/10974) ([@fcollonval](https://github.com/fcollonval))
+- Fix formatting of a link in the changelog [#10945](https://github.com/jupyterlab/jupyterlab/pull/10945) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-08-25&to=2021-09-01&type=c))
+
+[@agoose77](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aagoose77+updated%3A2021-08-25..2021-09-01&type=Issues) | [@baggiponte](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abaggiponte+updated%3A2021-08-25..2021-09-01&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-08-25..2021-09-01&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-08-25..2021-09-01&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2021-08-25..2021-09-01&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-08-25..2021-09-01&type=Issues) | [@goanpeca](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agoanpeca+updated%3A2021-08-25..2021-09-01&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-08-25..2021-09-01&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-08-25..2021-09-01&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-08-25..2021-09-01&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-08-25..2021-09-01&type=Issues) | [@mbektas](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ambektas+updated%3A2021-08-25..2021-09-01&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-08-25..2021-09-01&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-08-25..2021-09-01&type=Issues) | [@SarunasAzna](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASarunasAzna+updated%3A2021-08-25..2021-09-01&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-08-25..2021-09-01&type=Issues)
+
 ## 3.1.9
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.1.8...8f8cfc548c7c91e9dcf0dc51fd6eafc98f3fcfef))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,59 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 4.0.0a7
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v4.0.0a6...0350c6e6cafa06e0a4903507524789d938b75710))
+
+### Enhancements made
+
+- Add editable selector [#10957](https://github.com/jupyterlab/jupyterlab/pull/10957) ([@krassowska](https://github.com/krassowska))
+- Removed debug switch, added bug button state update [#10727](https://github.com/jupyterlab/jupyterlab/pull/10727) ([@3coins](https://github.com/3coins))
+- Add debugger variable renderer based on mime type [#10299](https://github.com/jupyterlab/jupyterlab/pull/10299) ([@fcollonval](https://github.com/fcollonval))
+
+### Bugs fixed
+
+- Remove the non-null assertion on `IDebugger.ISources` [#10976](https://github.com/jupyterlab/jupyterlab/pull/10976) ([@fcollonval](https://github.com/fcollonval))
+- Protect against undefined delegated label [#10972](https://github.com/jupyterlab/jupyterlab/pull/10972) ([@fcollonval](https://github.com/fcollonval))
+- ForwardPort PR #10898 on master: Render placeholder at correct index [#10959](https://github.com/jupyterlab/jupyterlab/pull/10959) ([@echarles](https://github.com/echarles))
+- Fix lack of translation of part of "Saving completed" and friends [#10958](https://github.com/jupyterlab/jupyterlab/pull/10958) ([@krassowski](https://github.com/krassowski))
+- Fix browser tab name [#10952](https://github.com/jupyterlab/jupyterlab/pull/10952) ([@tejasmorkar](https://github.com/tejasmorkar))
+- Simplify IRankedMenu interface [#10943](https://github.com/jupyterlab/jupyterlab/pull/10943) ([@fcollonval](https://github.com/fcollonval))
+- Add "menu" context for translation of menu labels [#10932](https://github.com/jupyterlab/jupyterlab/pull/10932) ([@krassowski](https://github.com/krassowski))
+- Add undoManager to inserted cells [#10899](https://github.com/jupyterlab/jupyterlab/pull/10899) ([@hbcarlos](https://github.com/hbcarlos))
+
+### Maintenance and upkeep improvements
+
+- Update to lerna 4 [#10983](https://github.com/jupyterlab/jupyterlab/pull/10983) ([@jtpio](https://github.com/jtpio))
+- Galata: Update reference screenshots [#10982](https://github.com/jupyterlab/jupyterlab/pull/10982) ([@jtpio](https://github.com/jtpio))
+- Improve Galata documentation and setup [#10980](https://github.com/jupyterlab/jupyterlab/pull/10980) ([@fcollonval](https://github.com/fcollonval))
+- Clarify usage of mock in debugger test [#10979](https://github.com/jupyterlab/jupyterlab/pull/10979) ([@fcollonval](https://github.com/fcollonval))
+- Restore test for kernel that does not support debugger [#10973](https://github.com/jupyterlab/jupyterlab/pull/10973) ([@fcollonval](https://github.com/fcollonval))
+- Chore: fix typo in comments [#10953](https://github.com/jupyterlab/jupyterlab/pull/10953) ([@agoose77](https://github.com/agoose77))
+- Bump major Galata version [#10951](https://github.com/jupyterlab/jupyterlab/pull/10951) ([@fcollonval](https://github.com/fcollonval))
+- More robust UI tests [#10950](https://github.com/jupyterlab/jupyterlab/pull/10950) ([@fcollonval](https://github.com/fcollonval))
+- More Publish Integrity [#10937](https://github.com/jupyterlab/jupyterlab/pull/10937) ([@afshin](https://github.com/afshin))
+- Add Galata in JupyterLab [#10796](https://github.com/jupyterlab/jupyterlab/pull/10796) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+- Improve Galata documentation and setup [#10980](https://github.com/jupyterlab/jupyterlab/pull/10980) ([@fcollonval](https://github.com/fcollonval))
+- Add process for adding a language [#10961](https://github.com/jupyterlab/jupyterlab/pull/10961) ([@fcollonval](https://github.com/fcollonval))
+- Improve release notes for 3.1 [#10954](https://github.com/jupyterlab/jupyterlab/pull/10954) ([@krassowski](https://github.com/krassowski))
+- Fix formatting of a link in the changelog [#10945](https://github.com/jupyterlab/jupyterlab/pull/10945) ([@jtpio](https://github.com/jtpio))
+
+### API and Breaking Changes
+
+- Add debugger variable renderer based on mime type [#10299](https://github.com/jupyterlab/jupyterlab/pull/10299) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-08-25&to=2021-09-01&type=c))
+
+[@3coins](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3A3coins+updated%3A2021-08-25..2021-09-01&type=Issues) | [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2021-08-25..2021-09-01&type=Issues) | [@agoose77](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aagoose77+updated%3A2021-08-25..2021-09-01&type=Issues) | [@baggiponte](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abaggiponte+updated%3A2021-08-25..2021-09-01&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-08-25..2021-09-01&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-08-25..2021-09-01&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2021-08-25..2021-09-01&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-08-25..2021-09-01&type=Issues) | [@goanpeca](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agoanpeca+updated%3A2021-08-25..2021-09-01&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2021-08-25..2021-09-01&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-08-25..2021-09-01&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-08-25..2021-09-01&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-08-25..2021-09-01&type=Issues) | [@krassowska](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowska+updated%3A2021-08-25..2021-09-01&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-08-25..2021-09-01&type=Issues) | [@mbektas](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ambektas+updated%3A2021-08-25..2021-09-01&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-08-25..2021-09-01&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-08-25..2021-09-01&type=Issues) | [@SarunasAzna](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASarunasAzna+updated%3A2021-08-25..2021-09-01&type=Issues) | [@tejasmorkar](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atejasmorkar+updated%3A2021-08-25..2021-09-01&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-08-25..2021-09-01&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 4.0.0a6
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v4.0.0a5...8a727b71bde05944214a2c53fe1f7e6e33864701))
@@ -28,8 +81,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-08-24&to=2021-08-25&type=c))
 
 [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2021-08-24..2021-08-25&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-08-24..2021-08-25&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-08-24..2021-08-25&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-08-24..2021-08-25&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-08-24..2021-08-25&type=Issues) | [@Mithil467](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AMithil467+updated%3A2021-08-24..2021-08-25&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-08-24..2021-08-25&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 4.0.0a5
 


### PR DESCRIPTION
Automated Changelog Entry for 4.0.0a7 on master
Python version: 4.0.0a7
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/application-top: 3.3.0-alpha.7
@jupyterlab/example-terminal: 3.3.0-alpha.7
@jupyterlab/example-console: 3.3.0-alpha.7
@jupyterlab/example-app: 3.3.0-alpha.7
@jupyterlab/example-cell: 3.3.0-alpha.7
@jupyterlab/example-notebook: 3.3.0-alpha.7
@jupyterlab/example-filebrowser: 3.3.0-alpha.7
@jupyterlab/example-federated: 2.4.0-alpha.7
@jupyterlab/example-federated-middle: 2.4.0-alpha.7
@jupyterlab/example-federated-core: 2.4.0-alpha.7
@jupyterlab/example-federated-md: 2.4.0-alpha.7
@jupyterlab/example-federated-phosphor: 2.4.0-alpha.7
@jupyterlab/pdf-extension: 3.3.0-alpha.7
@jupyterlab/celltags-extension: 3.3.0-alpha.7
@jupyterlab/application-extension: 3.3.0-alpha.7
@jupyterlab/javascript-extension: 3.3.0-alpha.7
@jupyterlab/translation: 3.3.0-alpha.7
@jupyterlab/outputarea: 3.3.0-alpha.7
@jupyterlab/extensionmanager-extension: 3.3.0-alpha.7
@jupyterlab/property-inspector: 3.3.0-alpha.7
@jupyterlab/filebrowser-extension: 3.3.0-alpha.7
@jupyterlab/logconsole-extension: 3.3.0-alpha.7
@jupyterlab/extensionmanager: 3.3.0-alpha.7
@jupyterlab/metapackage: 3.3.0-alpha.7
@jupyterlab/running-extension: 3.3.0-alpha.7
@jupyterlab/theme-light-extension: 3.3.0-alpha.7
@jupyterlab/codeeditor: 3.3.0-alpha.7
@jupyterlab/nbformat: 3.3.0-alpha.7
@jupyterlab/terminal: 3.3.0-alpha.7
@jupyterlab/toc-extension: 5.3.0-alpha.7
@jupyterlab/documentsearch-extension: 3.3.0-alpha.7
@jupyterlab/mainmenu-extension: 3.3.0-alpha.7
@jupyterlab/rendermime: 3.3.0-alpha.7
@jupyterlab/htmlviewer-extension: 3.3.0-alpha.7
@jupyterlab/markdownviewer: 3.3.0-alpha.7
@jupyterlab/statusbar-extension: 3.3.0-alpha.7
@jupyterlab/csvviewer-extension: 3.3.0-alpha.7
@jupyterlab/console: 3.3.0-alpha.7
@jupyterlab/imageviewer-extension: 3.3.0-alpha.7
@jupyterlab/debugger: 3.3.0-alpha.7
@jupyterlab/settingregistry: 3.3.0-alpha.7
@jupyterlab/running: 3.3.0-alpha.7
@jupyterlab/apputils-extension: 3.3.0-alpha.7
@jupyterlab/attachments: 3.3.0-alpha.7
@jupyterlab/rendermime-extension: 3.3.0-alpha.7
@jupyterlab/launcher-extension: 3.3.0-alpha.7
@jupyterlab/docmanager: 3.3.0-alpha.7
@jupyterlab/statusbar: 3.3.0-alpha.7
@jupyterlab/htmlviewer: 3.3.0-alpha.7
@jupyterlab/nbconvert-css: 3.3.0-alpha.7
@jupyterlab/documentsearch: 3.3.0-alpha.7
@jupyterlab/docprovider: 3.3.0-alpha.7
@jupyterlab/shared-models: 3.3.0-alpha.7
@jupyterlab/settingeditor-extension: 3.3.0-alpha.7
@jupyterlab/statedb: 3.3.0-alpha.7
@jupyterlab/fileeditor: 3.3.0-alpha.7
@jupyterlab/celltags: 3.3.0-alpha.7
@jupyterlab/ui-components: 3.3.0-alpha.7
@jupyterlab/docprovider-extension: 3.3.0-alpha.7
@jupyterlab/json-extension: 3.3.0-alpha.7
@jupyterlab/inspector: 3.3.0-alpha.7
@jupyterlab/completer-extension: 3.3.0-alpha.7
@jupyterlab/coreutils: 5.3.0-alpha.7
@jupyterlab/cells: 3.3.0-alpha.7
@jupyterlab/application: 3.3.0-alpha.7
@jupyterlab/logconsole: 3.3.0-alpha.7
@jupyterlab/tooltip: 3.3.0-alpha.7
@jupyterlab/hub-extension: 3.3.0-alpha.7
@jupyterlab/console-extension: 3.3.0-alpha.7
@jupyterlab/csvviewer: 3.3.0-alpha.7
@jupyterlab/ui-components-extension: 3.3.0-alpha.7
@jupyterlab/codemirror-extension: 3.3.0-alpha.7
@jupyterlab/markdownviewer-extension: 3.3.0-alpha.7
@jupyterlab/launcher: 3.3.0-alpha.7
@jupyterlab/theme-dark-extension: 3.3.0-alpha.7
@jupyterlab/help-extension: 3.3.0-alpha.7
@jupyterlab/notebook: 3.3.0-alpha.7
@jupyterlab/translation-extension: 3.3.0-alpha.7
@jupyterlab/docregistry: 3.3.0-alpha.7
@jupyterlab/apputils: 3.3.0-alpha.7
@jupyterlab/inspector-extension: 3.3.0-alpha.7
@jupyterlab/rendermime-interfaces: 3.3.0-alpha.7
@jupyterlab/vdom-extension: 3.3.0-alpha.7
@jupyterlab/imageviewer: 3.3.0-alpha.7
@jupyterlab/filebrowser: 3.3.0-alpha.7
@jupyterlab/mathjax2: 3.3.0-alpha.7
@jupyterlab/vdom: 3.3.0-alpha.7
@jupyterlab/toc: 5.3.0-alpha.7
@jupyterlab/completer: 3.3.0-alpha.7
@jupyterlab/services: 6.3.0-alpha.7
@jupyterlab/debugger-extension: 3.3.0-alpha.7
@jupyterlab/tooltip-extension: 3.3.0-alpha.7
@jupyterlab/vega5-extension: 3.3.0-alpha.7
@jupyterlab/notebook-extension: 3.3.0-alpha.7
@jupyterlab/mathjax2-extension: 3.3.0-alpha.7
@jupyterlab/codemirror: 3.3.0-alpha.7
@jupyterlab/mainmenu: 3.3.0-alpha.7
@jupyterlab/terminal-extension: 3.3.0-alpha.7
@jupyterlab/fileeditor-extension: 3.3.0-alpha.7
@jupyterlab/settingeditor: 3.3.0-alpha.7
@jupyterlab/observables: 4.3.0-alpha.7
@jupyterlab/shortcuts-extension: 3.3.0-alpha.7
@jupyterlab/docmanager-extension: 3.3.0-alpha.7
node-example: 3.3.0-alpha.7
@jupyterlab/example-services-browser: 3.3.0-alpha.7
@jupyterlab/example-services-outputarea: 3.3.0-alpha.7
@jupyterlab/builder: 3.3.0-alpha.7
@jupyterlab/buildutils: 3.3.0-alpha.7
@jupyterlab/template: 3.3.0-alpha.7
@jupyterlab/galata: 4.3.0-alpha.7
@jupyterlab/testutils: 3.3.0-alpha.7
@jupyterlab/mock-extension: 3.3.0-alpha.7
@jupyterlab/mock-consumer: 3.3.0-alpha.7
@jupyterlab/mock-token: 3.3.0-alpha.7
@jupyterlab/mock-provider: 3.3.0-alpha.7

After merging this PR run the "Draft Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | master  |
| Version Spec | build |
| Since | v4.0.0a6 |