### PR TITLE
Fix missing translation wrappers in the debugger

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -1484,7 +1484,7 @@ namespace Private {
     }
 
     // Add an option for no kernel
-    node.appendChild(optionForNone());
+    node.appendChild(optionForNone(translator));
 
     const other = document.createElement('optgroup');
     other.label = trans.__('Start Other Kernel');

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -267,16 +267,18 @@ const service: JupyterFrontEndPlugin<IDebugger> = {
   autoStart: true,
   provides: IDebugger,
   requires: [IDebuggerConfig],
-  optional: [IDebuggerSources],
+  optional: [IDebuggerSources, ITranslator],
   activate: (
     app: JupyterFrontEnd,
     config: IDebugger.IConfig,
-    debuggerSources: IDebugger.ISources | null
+    debuggerSources: IDebugger.ISources | null,
+    translator: ITranslator | null
   ) =>
     new Debugger.Service({
       config,
       debuggerSources,
-      specsManager: app.serviceManager.kernelspecs
+      specsManager: app.serviceManager.kernelspecs,
+      translator
     })
 };
 

--- a/packages/debugger/src/panels/variables/index.ts
+++ b/packages/debugger/src/panels/variables/index.ts
@@ -38,7 +38,12 @@ export class Variables extends Panel implements IDebugger.IVariablesPanel {
       commands,
       translator
     });
-    this._table = new VariablesBodyGrid({ model, commands, themeManager });
+    this._table = new VariablesBodyGrid({
+      model,
+      commands,
+      themeManager,
+      translator
+    });
     this._table.hide();
 
     this._header.toolbar.addItem(

--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -3,6 +3,12 @@
 
 import { KernelSpec, Session } from '@jupyterlab/services';
 
+import {
+  ITranslator,
+  nullTranslator,
+  TranslationBundle
+} from '@jupyterlab/translation';
+
 import { IDisposable } from '@lumino/disposable';
 
 import { ISignal, Signal } from '@lumino/signaling';
@@ -35,6 +41,7 @@ export class DebuggerService implements IDebugger, IDisposable {
     this._specsManager = options.specsManager ?? null;
     this._model = new Debugger.Model();
     this._debuggerSources = options.debuggerSources ?? null;
+    this._trans = (options.translator || nullTranslator).load('jupyterlab');
   }
 
   /**
@@ -318,7 +325,7 @@ export class DebuggerService implements IDebugger, IDisposable {
 
     const variableScopes = [
       {
-        name: 'Globals',
+        name: this._trans.__('Globals'),
         variables: variables
       }
     ];
@@ -853,6 +860,7 @@ export class DebuggerService implements IDebugger, IDisposable {
     this
   );
   private _specsManager: KernelSpec.IManager | null;
+  private _trans: TranslationBundle;
 }
 
 /**
@@ -877,5 +885,10 @@ export namespace DebuggerService {
      * The optional kernel specs manager.
      */
     specsManager?: KernelSpec.IManager | null;
+
+    /**
+     * The application language translator.
+     */
+    translator?: ITranslator | null;
   }
 }


### PR DESCRIPTION
## References

More fixes for #10737.

## Code changes

- pass translator all the way down to the `GridModel`,
- pass translator to `DebuggerService`
- translate "Name", "Value", "Type", "Globals"

## User-facing changes

All debugger strings are now translate-able.

## Backwards-incompatible changes

None?