### PR TITLE
Clean up handling of npm dist tag

### DIFF
--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -736,6 +736,27 @@ export async function ensureIntegrity(): Promise<boolean> {
   // Handle buildutils
   ensureBuildUtils();
 
+  // Handle the pyproject.toml package
+  const pyprojectPath = path.resolve('.', 'pyproject.toml');
+  const curr = utils.getPythonVersion();
+  let tag = 'latest';
+  if (!/\d+\.\d+\.\d+$/.test(curr)) {
+    tag = 'next';
+  }
+  const publishCommand = `npm publish --tag ${tag}`;
+  let pyprojectText = fs.readFileSync(pyprojectPath, { encoding: 'utf8' });
+  if (pyprojectText.indexOf(publishCommand) === -1) {
+    pyprojectText = pyprojectText.replace(
+      /npm publish --tag [a-z]+/,
+      publishCommand
+    );
+    fs.writeFileSync(pyprojectPath, pyprojectText, { encoding: 'utf8' });
+    if (!messages['top']) {
+      messages['top'] = [];
+    }
+    messages['top'].push('Update npm publish command in pyproject.toml');
+  }
+
   // Handle the JupyterLab application top package.
   pkgMessages = ensureJupyterlab();
   if (pkgMessages.length > 0) {

--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -736,7 +736,7 @@ export async function ensureIntegrity(): Promise<boolean> {
   // Handle buildutils
   ensureBuildUtils();
 
-  // Handle the pyproject.toml package
+  // Handle the pyproject.toml file
   const pyprojectPath = path.resolve('.', 'pyproject.toml');
   const curr = utils.getPythonVersion();
   let tag = 'latest';

--- a/buildutils/src/local-repository.ts
+++ b/buildutils/src/local-repository.ts
@@ -251,9 +251,17 @@ function fixLinks(package_dir: string) {
  */
 function publishPackages(dist_dir: string) {
   const paths = glob.sync(path.join(dist_dir, '*.tgz'));
+  const curr = utils.getPythonVersion();
+  let tag = 'latest';
+  if (!/\d+\.\d+\.\d+$/.test(curr)) {
+    tag = 'next';
+  }
   paths.forEach(package_path => {
     const filename = path.basename(package_path);
-    utils.run(`npm publish ${filename}`, { cwd: dist_dir });
+    utils.run(`npm publish ${filename} --tag ${tag}`, {
+      cwd: dist_dir,
+      stdio: 'pipe'
+    });
   });
 }
 

--- a/buildutils/src/publish.ts
+++ b/buildutils/src/publish.ts
@@ -66,11 +66,12 @@ commander
       if (options.yes) {
         cmd += '  --yes ';
       }
-      if (curr.indexOf('rc') === -1 && curr.indexOf('a') === -1) {
-        utils.run(`${cmd} -m "Publish"`);
-      } else {
-        utils.run(`${cmd} --dist-tag=next -m "Publish"`);
+
+      let tag = 'latest';
+      if (!/\d+\.\d+\.\d+$/.test(curr)) {
+        tag = 'next';
       }
+      utils.run(`${cmd} --dist-tag=${tag} -m "Publish"`);
     }
 
     // Fix up any tagging issues.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ ignore-glob = ["packages/ui-components/docs/source/ui_components.rst"]
 ignore-links = ["../api/*.*"]
 version-cmd = "jlpm bumpversion --force --skip-commit"
 npm-install-options = "--legacy-peer-deps"
+npm-cmd = "npm publish --tag next"
 release-message = "[ci skip] Publish {version}"
 tag-message = "[ci skip] Release {tag_name}"
 


### PR DESCRIPTION
## References
More progress toward https://github.com/jupyterlab/jupyterlab/issues/10340

## Code changes
Improve handling of `npm` `dist-tag` in `buildutils` and when using Jupyter Releaser.

## User-facing changes
None

## Backwards-incompatible changes
None
