### PR TITLE
fix #10997 - increase max_message_size of websocket messages

### DIFF
--- a/jupyterlab/handlers/yjs_echo_ws.py
+++ b/jupyterlab/handlers/yjs_echo_ws.py
@@ -36,6 +36,11 @@ class YjsRoom:
 class YjsEchoWebSocket(WebSocketHandler):
     rooms = {}
 
+    # Override max_message size to 1GB
+    @property
+    def max_message_size(self):
+        return 1024 * 1024 * 1024
+
     def open(self, guid):
         #print("[YJSEchoWS]: open", guid)
         cls = self.__class__


### PR DESCRIPTION
## References

Closes #10997. As described in the ticket, with collaborative editing enabled the websocket connection closes when the client sends a message larger than 10mb. This ultimately leads to performance problems and being unable to save files. 

## Code changes

I increased the `max_message_size` of websocket messages to 1GB. We might want to increase this even further if we expect files larger than 1GB (e.g. because of large images).

## User-facing changes

None.

## Backwards-incompatible changes

None.
