### PR TITLE
Translate factory names by adding `label`

### DIFF
--- a/packages/apputils-extension/src/workspacesplugin.ts
+++ b/packages/apputils-extension/src/workspacesplugin.ts
@@ -186,7 +186,8 @@ namespace Private {
     constructor(options: WorkspaceFactory.IOptions) {
       const trans = (options.translator || nullTranslator).load('jupyterlab');
       super({
-        name: trans.__('Workspace loader'),
+        name: 'Workspace loader',
+        label: trans.__('Workspace loader'),
         fileTypes: [WORKSPACE_NAME],
         defaultFor: [WORKSPACE_NAME],
         readOnly: true

--- a/packages/csvviewer-extension/src/index.ts
+++ b/packages/csvviewer-extension/src/index.ts
@@ -138,8 +138,11 @@ function activateCsv(
     }
   }
 
+  const trans = translator.load('jupyterlab');
+
   const factory = new CSVViewerFactory({
     name: FACTORY_CSV,
+    label: trans.__('CSV Viewer'),
     fileTypes: ['csv'],
     defaultFor: ['csv'],
     readOnly: true,
@@ -249,8 +252,11 @@ function activateTsv(
     }
   }
 
+  const trans = translator.load('jupyterlab');
+
   const factory = new TSVViewerFactory({
     name: FACTORY_TSV,
+    label: trans.__('TSV Viewer'),
     fileTypes: ['tsv'],
     defaultFor: ['tsv'],
     readOnly: true,

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -284,6 +284,7 @@ export abstract class ABCWidgetFactory<
   constructor(options: DocumentRegistry.IWidgetFactoryOptions<T>) {
     this._translator = options.translator || nullTranslator;
     this._name = options.name;
+    this._label = options.label || options.name;
     this._readOnly = options.readOnly === undefined ? false : options.readOnly;
     this._defaultFor = options.defaultFor ? options.defaultFor.slice() : [];
     this._defaultRendered = (options.defaultRendered || []).slice();
@@ -329,10 +330,18 @@ export abstract class ABCWidgetFactory<
   }
 
   /**
-   * The name of the widget to display in dialogs.
+   * A unique name identifying of the widget.
    */
   get name(): string {
     return this._name;
+  }
+
+  /**
+   * The label of the widget to display in dialogs.
+   * If not given, name is used instead.
+   */
+  get label(): string {
+    return this._label;
   }
 
   /**
@@ -443,6 +452,7 @@ export abstract class ABCWidgetFactory<
   private _isDisposed = false;
   private _translator: ITranslator;
   private _name: string;
+  private _label: string;
   private _readOnly: boolean;
   private _canStartKernel: boolean;
   private _shutdownOnClose: boolean;

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -989,9 +989,15 @@ export namespace DocumentRegistry {
    */
   export interface IWidgetFactoryOptions<T extends Widget = Widget> {
     /**
-     * The name of the widget to display in dialogs.
+     * A unique name identifying of the widget.
      */
     readonly name: string;
+
+    /**
+     * The label of the widget to display in dialogs.
+     * If not given, name is used instead.
+     */
+    readonly label?: string;
 
     /**
      * The file types the widget can view.
@@ -1515,7 +1521,7 @@ namespace Private {
   /**
    * Get the extension name of a path.
    *
-   * @param file - string.
+   * @param path - string.
    *
    * #### Notes
    * Dotted filenames (e.g. `".table.json"` are allowed).

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -545,17 +545,17 @@ const openWithPlugin: JupyterFrontEndPlugin<void> = {
       // get the widget factories that could be used to open all of the items
       // in the current filebrowser selection
       const factories = tracker.currentWidget
-        ? Private.OpenWith.intersection<string>(
+        ? Private.OpenWith.intersection<DocumentRegistry.WidgetFactory>(
             map(tracker.currentWidget.selectedItems(), i => {
               return Private.OpenWith.getFactories(docRegistry, i);
             })
           )
-        : new Set<string>();
+        : new Set<DocumentRegistry.WidgetFactory>();
 
       // make new menu items from the widget factories
       factories.forEach(factory => {
         openWith.addItem({
-          args: { factory: factory },
+          args: { factory: factory.name, label: factory.label || factory.name },
           command: CommandIDs.open
         });
       });
@@ -1214,11 +1214,9 @@ namespace Private {
     export function getFactories(
       docRegistry: DocumentRegistry,
       item: Contents.IModel
-    ): Array<string> {
-      const factories = docRegistry
-        .preferredWidgetFactories(item.path)
-        .map(f => f.name);
-      const notebookFactory = docRegistry.getWidgetFactory('notebook')?.name;
+    ): Array<DocumentRegistry.WidgetFactory> {
+      const factories = docRegistry.preferredWidgetFactories(item.path);
+      const notebookFactory = docRegistry.getWidgetFactory('notebook');
       if (
         notebookFactory &&
         item.type === 'notebook' &&

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -182,6 +182,7 @@ function activate(
     editorServices,
     factoryOptions: {
       name: FACTORY,
+      label: trans.__('Editor'),
       fileTypes: ['markdown', '*'], // Explicitly add the markdown fileType so
       defaultFor: ['markdown', '*'], // it outranks the defaultRendered viewer.
       toolbarFactory,

--- a/packages/htmlviewer-extension/src/index.tsx
+++ b/packages/htmlviewer-extension/src/index.tsx
@@ -108,6 +108,7 @@ function activateHTMLViewer(
   // Create a new viewer factory.
   const factory = new HTMLViewerFactory({
     name: FACTORY,
+    label: trans.__('HTML Viewer'),
     fileTypes: ['html'],
     defaultFor: ['html'],
     readOnly: true,

--- a/packages/imageviewer-extension/src/index.ts
+++ b/packages/imageviewer-extension/src/index.ts
@@ -115,6 +115,7 @@ function activate(
 
   const factory = new ImageViewerFactory({
     name: FACTORY,
+    label: trans.__('Image'),
     modelName: 'base64',
     fileTypes: [...FILE_TYPES, ...TEXT_FILE_TYPES],
     defaultFor: FILE_TYPES,
@@ -123,6 +124,7 @@ function activate(
 
   const textFactory = new ImageViewerFactory({
     name: TEXT_FACTORY,
+    label: trans.__('Image (Text)'),
     modelName: 'text',
     fileTypes: TEXT_FILE_TYPES,
     defaultFor: TEXT_FILE_TYPES,

--- a/packages/json-extension/src/index.tsx
+++ b/packages/json-extension/src/index.tsx
@@ -97,6 +97,7 @@ const extensions: IRenderMime.IExtension | IRenderMime.IExtension[] = [
     dataType: 'json',
     documentWidgetFactoryOptions: {
       name: 'JSON',
+      // TODO: how to translate label of the factory?
       primaryFileType: 'json',
       fileTypes: ['json', 'notebook', 'geojson'],
       defaultFor: ['json']

--- a/packages/markdownviewer-extension/src/index.ts
+++ b/packages/markdownviewer-extension/src/index.ts
@@ -110,6 +110,7 @@ function activate(
   const factory = new MarkdownViewerFactory({
     rendermime,
     name: FACTORY,
+    label: trans.__('Markdown Preview'),
     primaryFileType: docRegistry.getFileType('markdown'),
     fileTypes: ['markdown'],
     defaultRendered: ['markdown']

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -736,8 +736,11 @@ function activateWidgetFactory(
     );
   }
 
+  const trans = translator.load('jupyterlab');
+
   const factory = new NotebookWidgetFactory({
     name: FACTORY,
+    label: trans.__('Notebook'),
     fileTypes: ['notebook'],
     modelName: 'notebook',
     defaultFor: ['notebook'],

--- a/packages/pdf-extension/src/index.ts
+++ b/packages/pdf-extension/src/index.ts
@@ -138,6 +138,7 @@ const extensions: IRenderMime.IExtension | IRenderMime.IExtension[] = [
     dataType: 'string',
     documentWidgetFactoryOptions: {
       name: 'PDF',
+      // TODO: translate label
       modelName: 'base64',
       primaryFileType: 'PDF',
       fileTypes: ['PDF'],

--- a/packages/vdom-extension/package.json
+++ b/packages/vdom-extension/package.json
@@ -37,6 +37,7 @@
     "@jupyterlab/docregistry": "^3.3.0-alpha.7",
     "@jupyterlab/notebook": "^3.3.0-alpha.7",
     "@jupyterlab/rendermime": "^3.3.0-alpha.7",
+    "@jupyterlab/translation": "^3.3.0-alpha.7",
     "@jupyterlab/ui-components": "^3.3.0-alpha.7",
     "@jupyterlab/vdom": "^3.3.0-alpha.7"
   },

--- a/packages/vdom-extension/src/index.ts
+++ b/packages/vdom-extension/src/index.ts
@@ -16,6 +16,7 @@ import { INotebookTracker } from '@jupyterlab/notebook';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { reactIcon } from '@jupyterlab/ui-components';
 import { IVDOMTracker, RenderedVDOM } from '@jupyterlab/vdom';
+import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 
 /**
  * The MIME type for VDOM.
@@ -30,14 +31,15 @@ const FACTORY_NAME = 'VDOM';
 const plugin: JupyterFrontEndPlugin<IVDOMTracker> = {
   id: '@jupyterlab/vdom-extension:factory',
   requires: [IRenderMimeRegistry],
-  optional: [INotebookTracker, ILayoutRestorer],
+  optional: [INotebookTracker, ILayoutRestorer, ITranslator],
   provides: IVDOMTracker,
   autoStart: true,
   activate: (
     app: JupyterFrontEnd,
     rendermime: IRenderMimeRegistry,
     notebooks: INotebookTracker | null,
-    restorer: ILayoutRestorer | null
+    restorer: ILayoutRestorer | null,
+    translator: ITranslator | null
   ) => {
     const tracker = new WidgetTracker<MimeDocument>({
       namespace: 'vdom-widget'
@@ -80,11 +82,14 @@ const plugin: JupyterFrontEndPlugin<IVDOMTracker> = {
       icon: reactIcon
     });
 
+    const trans = (translator || nullTranslator).load('jupyterlab');
+
     const factory = new MimeDocumentFactory({
       renderTimeout: 1000,
       dataType: 'json',
       rendermime,
       name: FACTORY_NAME,
+      label: trans.__('VDOM'),
       primaryFileType: app.docRegistry.getFileType('vdom')!,
       fileTypes: ['vdom', 'json'],
       defaultFor: ['vdom']

--- a/packages/vdom-extension/tsconfig.json
+++ b/packages/vdom-extension/tsconfig.json
@@ -26,6 +26,9 @@
     },
     {
       "path": "../vdom"
+    },
+    {
+      "path": "../translation"
     }
   ]
 }


### PR DESCRIPTION
## References

Fixes a translation point from https://github.com/jupyterlab/jupyterlab/issues/10737#issuecomment-910619040

## Code changes

- clarify that `name` acts as a de-facto identifier, remove translation from `Workspace loader` name (ideally `name` would be renamed to `id`, but this would be a breaking change for quite a few extensions).
- interface `IWidgetFactoryOptions` has an optional (for now) `label` member

## User-facing changes

Open with menu entries will now be translated; also the CSV/TSV viewers will have a proper label:

Before

![Screenshot from 2021-09-03 21-27-40](https://user-images.githubusercontent.com/5832902/132063366-19da94e9-fbc6-476d-b9f5-37e13915db0f.png)

After

![Screenshot from 2021-09-03 21-41-45](https://user-images.githubusercontent.com/5832902/132063360-0e075729-40b0-452f-aa54-20e54497ae10.png)

## Backwards-incompatible changes

I am never sure what makes a cut - I would say this can be backported, but I did add an optional dependency on translator to `vdom-extension` and the interface `IWidgetFactoryOptions` has an optional `label` member.