### PR TITLE
Fix ignored promise leading to incorrect initial tooltip position

### DIFF
--- a/packages/tooltip/src/widget.ts
+++ b/packages/tooltip/src/widget.ts
@@ -69,7 +69,10 @@ export class Tooltip extends Widget {
     }
 
     this._content = this._rendermime.createRenderer(mimeType);
-    void this._content.renderModel(model);
+    this._content
+      .renderModel(model)
+      .then(() => this._setGeometry())
+      .catch(error => console.error('tooltip rendering failed', error));
     this._content.addClass(CONTENT_CLASS);
     layout.addWidget(this._content);
   }


### PR DESCRIPTION
## References

While working on improved signature display in https://github.com/krassowski/jupyterlab-lsp/pull/671 I noticed that the first position of tooltip is incorrect, but upon any user action (scroll, keypress , anything which triggers lumino update message) it gets automatically fixed. I figured it is because the position is calculated prior to the content being set by the model rendering (so the proper size information is not yet available).

## Code changes

This PR fixes the issue by properly handling the promise returned by `renderModel()` in the tooltip widget constructor (setting geometry after it resolves, and showing error if anything goes wrong).

## User-facing changes

Tooltips will be positioned better on first render. This allows to consistently place LSP signature tooltip above the line:

![Screenshot from 2021-09-04 13-18-07](https://user-images.githubusercontent.com/5832902/132094161-204e2c68-7828-4490-ae57-6ce578b97a28.png)

## Backwards-incompatible changes

None