### PR TITLE
Restore Copy shareable link use of shareUrl

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -460,7 +460,8 @@ const main: JupyterFrontEndPlugin<ITreePathUpdater> = {
     function updateTreePath(treePath: string) {
       _defaultBrowserTreePath = treePath;
       if (!_docTreePath) {
-        const path = PageConfig.getUrl({ treePath });
+        const url = PageConfig.getUrl({ treePath });
+        const path = URLExt.parse(url).pathname;
         router.navigate(path, { skipRouting: true });
         // Persist the new tree path to PageConfig as it is used elsewhere at runtime.
         PageConfig.setOption('treePath', treePath);
@@ -494,7 +495,8 @@ const main: JupyterFrontEndPlugin<ITreePathUpdater> = {
     // Watch the mode and update the page URL to /lab or /doc to reflect the
     // change.
     app.shell.modeChanged.connect((_, args: DockPanel.Mode) => {
-      const path = PageConfig.getUrl({ mode: args as string });
+      const url = PageConfig.getUrl({ mode: args as string });
+      const path = URLExt.parse(url).pathname;
       router.navigate(path, { skipRouting: true });
       // Persist this mode change to PageConfig as it is used elsewhere at runtime.
       PageConfig.setOption('mode', args as string);
@@ -505,7 +507,8 @@ const main: JupyterFrontEndPlugin<ITreePathUpdater> = {
     app.shell.currentPathChanged.connect((_, args) => {
       const maybeTreePath = args.newValue as string;
       const treePath = maybeTreePath || _defaultBrowserTreePath;
-      const path = PageConfig.getUrl({ treePath: treePath });
+      const url = PageConfig.getUrl({ treePath: treePath });
+      const path = URLExt.parse(url).pathname;
       router.navigate(path, { skipRouting: true });
       // Persist the new tree path to PageConfig as it is used elsewhere at runtime.
       PageConfig.setOption('treePath', treePath);

--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -140,16 +140,16 @@ export namespace PageConfig {
    * @param options - IGetUrlOptions for the new path.
    */
   export function getUrl(options: IGetUrlOptions): string {
-    let path = getOption('baseUrl') || '/';
+    let path = options.toShare ? getShareUrl() : getBaseUrl();
     const mode = options.mode ?? getOption('mode');
     const workspace = options.workspace ?? getOption('workspace');
-    const labOrDoc = mode === 'multiple-document' ? 'lab' : 'doc';
+    const labOrDoc = mode === 'single-document' ? 'doc' : 'lab';
     path = URLExt.join(path, labOrDoc);
     if (workspace !== defaultWorkspace) {
       path = URLExt.join(
         path,
         'workspaces',
-        encodeURIComponent(getOption('workspace'))
+        encodeURIComponent(getOption('workspace') ?? defaultWorkspace)
       );
     }
     const treePath = options.treePath ?? getOption('treePath');
@@ -178,6 +178,11 @@ export namespace PageConfig {
      * URL segment will be included) pass the string PageConfig.defaultWorkspace.
      */
     workspace?: string;
+
+    /**
+     * Whether the url is meant to be shared or not; default false.
+     */
+    toShare?: boolean;
 
     /**
      * The optional tree path as as string. If treePath is not provided it will be

--- a/packages/coreutils/test/pageconfig.spec.ts
+++ b/packages/coreutils/test/pageconfig.spec.ts
@@ -7,6 +7,7 @@ describe('@jupyterlab/coreutils', () => {
   describe('PageConfig', () => {
     beforeEach(() => {
       PageConfig.setOption('foo', 'bar');
+      PageConfig.setOption('workspace', 'default');
     });
 
     describe('#getOption()', () => {
@@ -59,6 +60,43 @@ describe('@jupyterlab/coreutils', () => {
       it('should be an empty string for a bad base url', () => {
         const url = 'blargh://foo.com';
         expect(PageConfig.getWsUrl(url)).toBe('');
+      });
+    });
+
+    describe('#getUrl()', () => {
+      const path = '/path/to/file.ext';
+
+      it('should return shortest url by default', () => {
+        const url = PageConfig.getUrl({});
+        expect(url).toEqual('http://localhost/lab/workspaces/default');
+      });
+
+      it('should return a local shareable url if shareUrl is undefined', () => {
+        const url = PageConfig.getUrl({
+          workspace: PageConfig.defaultWorkspace,
+          treePath: path,
+          toShare: true
+        });
+
+        expect(url).toEqual(`http://localhost/lab/tree${path}`);
+      });
+
+      describe('hub environment', () => {
+        const shareUrl = 'http://hub.host.lab/hub/user-redirect';
+
+        beforeEach(() => {
+          PageConfig.setOption('shareUrl', shareUrl);
+        });
+
+        it('should return a non-local shareable url if shareUrl is defined', () => {
+          const url = PageConfig.getUrl({
+            workspace: PageConfig.defaultWorkspace,
+            treePath: path,
+            toShare: true
+          });
+
+          expect(url).toEqual(`${shareUrl}/lab/tree${path}`);
+        });
       });
     });
   });

--- a/packages/coreutils/test/pageconfig.spec.ts
+++ b/packages/coreutils/test/pageconfig.spec.ts
@@ -7,7 +7,7 @@ describe('@jupyterlab/coreutils', () => {
   describe('PageConfig', () => {
     beforeEach(() => {
       PageConfig.setOption('foo', 'bar');
-      PageConfig.setOption('workspace', 'default');
+      PageConfig.setOption('workspace', PageConfig.defaultWorkspace);
     });
 
     describe('#getOption()', () => {
@@ -68,7 +68,7 @@ describe('@jupyterlab/coreutils', () => {
 
       it('should return shortest url by default', () => {
         const url = PageConfig.getUrl({});
-        expect(url).toEqual('http://localhost/lab/workspaces/default');
+        expect(url).toEqual('http://localhost/lab');
       });
 
       it('should return a local shareable url if shareUrl is undefined', () => {

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -22,7 +22,7 @@ import {
   showErrorMessage,
   WidgetTracker
 } from '@jupyterlab/apputils';
-import { PageConfig, PathExt, URLExt } from '@jupyterlab/coreutils';
+import { PageConfig, PathExt } from '@jupyterlab/coreutils';
 import { IDocumentManager } from '@jupyterlab/docmanager';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import {
@@ -495,13 +495,11 @@ const shareFile: JupyterFrontEndPlugin<void> = {
         }
 
         Clipboard.copyToSystem(
-          URLExt.normalize(
-            PageConfig.getUrl({
-              workspace: PageConfig.defaultWorkspace,
-              treePath: model.path,
-              toShare: true
-            })
-          )
+          PageConfig.getUrl({
+            workspace: PageConfig.defaultWorkspace,
+            treePath: model.path,
+            toShare: true
+          })
         );
       },
       isVisible: () =>

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -497,9 +497,9 @@ const shareFile: JupyterFrontEndPlugin<void> = {
         Clipboard.copyToSystem(
           URLExt.normalize(
             PageConfig.getUrl({
-              mode: 'single-document',
               workspace: PageConfig.defaultWorkspace,
-              treePath: model.path
+              treePath: model.path,
+              toShare: true
             })
           )
         );


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fix #10369
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Add new option on `PageConfig.getUrl` to use `shareUrl` instead of `baseUrl`.
Change default mode behavior to ensure it target `multi-document` on default workspace
Create a _shareable_ link with the current mode (don't force `single-document`).

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Shareable link open in the same mode than the active mode
Shareable link use `shareUrl` if it is defined
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A