### PR TITLE
Make Test Server Configurable

### DIFF
--- a/testutils/package.json
+++ b/testutils/package.json
@@ -51,6 +51,7 @@
     "@lumino/properties": "^1.2.3",
     "@lumino/signaling": "^1.4.3",
     "child_process": "~1.0.2",
+    "deepmerge": "^4.2.2",
     "fs-extra": "^9.0.1",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.4.2",

--- a/testutils/src/start_jupyter_server.ts
+++ b/testutils/src/start_jupyter_server.ts
@@ -2,11 +2,12 @@
 // Copyright (c) Jupyter Development Team.
 
 import { ChildProcess, spawn } from 'child_process';
+import merge from 'deepmerge';
 import * as fs from 'fs';
 import * as path from 'path';
 
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
-import { PromiseDelegate, UUID } from '@lumino/coreutils';
+import { JSONObject, PromiseDelegate, UUID } from '@lumino/coreutils';
 import { sleep } from './common';
 
 /**
@@ -40,15 +41,15 @@ export class JupyterServer {
    *
    * @throws Error if another server is still running.
    */
-  async start(): Promise<string> {
+  async start(options: Partial<JupyterServer.IOptions> = {}): Promise<string> {
     if (Private.child !== null) {
       throw Error('Previous server was not disposed');
     }
     const startDelegate = new PromiseDelegate<string>();
 
     const env = {
-      JUPYTER_CONFIG_DIR: Private.handleConfig(),
-      JUPYTER_DATA_DIR: Private.handleData(),
+      JUPYTER_CONFIG_DIR: Private.handleConfig(options),
+      JUPYTER_DATA_DIR: Private.handleData(options),
       JUPYTER_RUNTIME_DIR: Private.mktempDir('jupyter_runtime'),
       IPYTHONDIR: Private.mktempDir('ipython'),
       PATH: process.env.PATH
@@ -116,6 +117,29 @@ export class JupyterServer {
 }
 
 /**
+ * A namespace for JupyterServer static values.
+ */
+export namespace JupyterServer {
+  /**
+   * Options used to create a new JupyterServer instance.
+   */
+  export interface IOptions {
+    /**
+     * Additional Page Config values.
+     */
+    pageConfig: { [name: string]: string };
+    /**
+     * Additional traitlet config data.
+     */
+    configData: JSONObject;
+    /**
+     * Map of additional kernelspec names to kernel.json dictionaries
+     */
+    additionalKernelSpecs: JSONObject;
+  }
+}
+
+/**
  * A namespace for module private data.
  */
 namespace Private {
@@ -142,6 +166,7 @@ namespace Private {
     const specDir = path.join(dataDir, 'kernels', name);
     fs.mkdirSync(specDir, { recursive: true });
     fs.writeFileSync(path.join(specDir, 'kernel.json'), JSON.stringify(spec));
+    PageConfig.setOption(`__kernelSpec_${name}`, JSON.stringify(spec));
   }
 
   /**
@@ -202,11 +227,19 @@ namespace Private {
   /**
    * Handle configuration.
    */
-  export function handleConfig(): string {
+  export function handleConfig(
+    options: Partial<JupyterServer.IOptions>
+  ): string {
     // Set up configuration.
     const token = UUID.uuid4();
     PageConfig.setOption('token', token);
     PageConfig.setOption('terminalsAvailable', 'true');
+
+    if (options.pageConfig) {
+      Object.keys(options.pageConfig).forEach(key => {
+        PageConfig.setOption(key, options.pageConfig![key]);
+      });
+    }
 
     const configDir = mktempDir('config');
     const configPath = path.join(configDir, 'jupyter_server_config.json');
@@ -216,26 +249,30 @@ namespace Private {
     const user_settings_dir = mktempDir('settings');
     const workspaces_dir = mktempDir('workspaces');
 
-    const configData = {
-      LabApp: {
-        user_settings_dir,
-        workspaces_dir,
-        app_dir,
-        open_browser: false,
-        log_level: 'DEBUG'
+    const configData = merge(
+      {
+        LabApp: {
+          user_settings_dir,
+          workspaces_dir,
+          app_dir,
+          open_browser: false,
+          log_level: 'DEBUG'
+        },
+        ServerApp: {
+          token,
+          root_dir,
+          log_level: 'DEBUG'
+        },
+        MultiKernelManager: {
+          default_kernel_name: 'echo'
+        },
+        KernelManager: {
+          shutdown_wait_time: 1.0
+        }
       },
-      ServerApp: {
-        token,
-        root_dir,
-        log_level: 'DEBUG'
-      },
-      MultiKernelManager: {
-        default_kernel_name: 'echo'
-      },
-      KernelManager: {
-        shutdown_wait_time: 1.0
-      }
-    };
+      options.configData || {}
+    );
+    PageConfig.setOption('__configData', JSON.stringify(configData));
     fs.writeFileSync(configPath, JSON.stringify(configData));
     return configDir;
   }
@@ -243,7 +280,7 @@ namespace Private {
   /**
    * Handle data.
    */
-  export function handleData(): string {
+  export function handleData(options: Partial<JupyterServer.IOptions>): string {
     const dataDir = mktempDir('data');
 
     // Install custom specs.
@@ -264,6 +301,12 @@ namespace Private {
       display_name: 'Python 3',
       language: 'python'
     });
+
+    if (options.additionalKernelSpecs) {
+      Object.keys(options.additionalKernelSpecs).forEach(key => {
+        installSpec(dataDir, key, options.additionalKernelSpecs![key]);
+      });
+    }
     return dataDir;
   }
 

--- a/testutils/test/start_jupyter_server.spec.ts
+++ b/testutils/test/start_jupyter_server.spec.ts
@@ -4,7 +4,7 @@
 const fetch = require('node-fetch');
 
 import { JupyterServer } from '../src';
-import { URLExt } from '@jupyterlab/coreutils';
+import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 
 describe('JupyterServer', () => {
   it('should start the server', async () => {
@@ -12,6 +12,39 @@ describe('JupyterServer', () => {
     const server = new JupyterServer();
     const url = await server.start();
     await fetch(URLExt.join(url, 'api'));
+    await expect(server.shutdown()).resolves.not.toThrow();
+  });
+
+  it('should accept options', async () => {
+    jest.setTimeout(20000);
+    const pageConfig = { foo: 'bar', fizz: 'buzz' };
+    const configData = {
+      FakeTrait: { fake_prop: 1 },
+      OtherTrait: { other_prop: 'hello' },
+      KernelManager: {
+        shutdown_wait_time: 1.11
+      }
+    };
+    const additionalKernelSpecs = {
+      foo: {
+        argv: ['python', '-m', 'ipykernel_launcher', '-f', '{connection_file}'],
+        display_name: 'Test Python',
+        language: 'python'
+      }
+    };
+    const server = new JupyterServer();
+    const url = await server.start({
+      pageConfig,
+      configData,
+      additionalKernelSpecs
+    });
+    await fetch(URLExt.join(url, 'api'));
+    expect(PageConfig.getOption('foo')).toEqual('bar');
+    expect(PageConfig.getOption('fizz')).toEqual('buzz');
+    expect(PageConfig.getOption('__configData')).toContain('FakeTrait');
+    expect(PageConfig.getOption('__configData')).toContain('OtherTrait');
+    expect(PageConfig.getOption('__configData')).toContain('1.11');
+    expect(PageConfig.getOption('__kernelSpec_foo')).toContain('Test Python');
     await expect(server.shutdown()).resolves.not.toThrow();
   });
 });


### PR DESCRIPTION
## References
Follow up to https://github.com/jupyterlab/jupyterlab/pull/8279

## Code changes
Add ability to configure page config, traitlet config, and additional kernel specs when launching a `JupyterServer` test server.

## User-facing changes
None

## Backwards-incompatible changes
None