### PR TITLE
use correct nbformat version - fixes #11005

### DIFF
--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -326,7 +326,7 @@ export class YNotebook
    */
   getMetadata(): nbformat.INotebookMetadata {
     const meta = this.ymeta.get('metadata');
-    return meta ? deepCopy(meta) : { orig_nbformat: 1 };
+    return meta ? deepCopy(meta) : { orig_nbformat: 4 };
   }
 
   /**


### PR DESCRIPTION

## References

As described in #11005 we are currently setting an invalid nbformat version number. This leads to problems in some backends. 

## Code changes

Bump default schema version number.

## User-facing changes

None. It is unlikely that this even has an effect in JupyterLab.

## Backwards-incompatible changes

None.
