### PR TITLE
Clean up notebook test utils

### DIFF
--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -14,7 +14,7 @@ import {
 import { JupyterServer } from '@jupyterlab/testutils/lib/start_jupyter_server';
 import { each } from '@lumino/algorithm';
 import { JSONArray, JSONObject, UUID } from '@lumino/coreutils';
-import { KernelError, Notebook, NotebookActions, NotebookModel } from '../src';
+import { KernelError, Notebook, NotebookActions, NotebookModel } from '..';
 import * as utils from './utils';
 
 const ERROR_INPUT = 'a = foo';

--- a/packages/notebook/test/default-toolbar.spec.ts
+++ b/packages/notebook/test/default-toolbar.spec.ts
@@ -18,7 +18,7 @@ import {
   NotebookActions,
   NotebookPanel,
   ToolbarItems
-} from '../src';
+} from '..';
 import * as utils from './utils';
 
 const JUPYTER_CELL_MIME = 'application/vnd.jupyter.cells';

--- a/packages/notebook/test/model.spec.ts
+++ b/packages/notebook/test/model.spec.ts
@@ -6,7 +6,7 @@ import * as nbformat from '@jupyterlab/nbformat';
 import { ModelDB } from '@jupyterlab/observables';
 import { acceptDialog } from '@jupyterlab/testutils';
 import { ArrayExt, toArray } from '@lumino/algorithm';
-import { NotebookModel } from '../src';
+import { NotebookModel } from '..';
 import * as utils from './utils';
 
 describe('@jupyterlab/notebook', () => {

--- a/packages/notebook/test/notebooktools.spec.ts
+++ b/packages/notebook/test/notebooktools.spec.ts
@@ -15,7 +15,7 @@ import {
   NotebookPanel,
   NotebookTools,
   NotebookTracker
-} from '../src';
+} from '..';
 import * as utils from './utils';
 
 class LogTool extends NotebookTools.Tool {

--- a/packages/notebook/test/panel.spec.ts
+++ b/packages/notebook/test/panel.spec.ts
@@ -5,7 +5,7 @@ import { Context } from '@jupyterlab/docregistry';
 import { initNotebookContext } from '@jupyterlab/testutils';
 import { JupyterServer } from '@jupyterlab/testutils/lib/start_jupyter_server';
 import { Toolbar } from '@jupyterlab/ui-components';
-import { INotebookModel, Notebook, NotebookPanel } from '../src';
+import { INotebookModel, Notebook, NotebookPanel } from '..';
 import * as utils from './utils';
 
 /**

--- a/packages/notebook/test/tracker.spec.ts
+++ b/packages/notebook/test/tracker.spec.ts
@@ -5,7 +5,7 @@ import { Cell } from '@jupyterlab/cells';
 import { Context } from '@jupyterlab/docregistry';
 import { initNotebookContext } from '@jupyterlab/testutils';
 import { JupyterServer } from '@jupyterlab/testutils/lib/start_jupyter_server';
-import { INotebookModel, NotebookPanel, NotebookTracker } from '../src';
+import { INotebookModel, NotebookPanel, NotebookTracker } from '..';
 import * as utils from './utils';
 
 const namespace = 'notebook-tracker-test';

--- a/packages/notebook/test/utils.ts
+++ b/packages/notebook/test/utils.ts
@@ -1,15 +1,13 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { Context } from '@jupyterlab/docregistry';
-import { Mock, NBTestUtils } from '@jupyterlab/testutils';
-import { UUID } from '@lumino/coreutils';
+import { Context, DocumentRegistry } from '@jupyterlab/docregistry';
+import { NBTestUtils } from '@jupyterlab/testutils';
 import {
   INotebookModel,
   Notebook,
-  NotebookModel,
-  NotebookModelFactory,
-  NotebookPanel
+  NotebookPanel,
+  NotebookWidgetFactory
 } from '../src';
 
 /**
@@ -20,29 +18,21 @@ import {
  * Create a default notebook content factory.
  */
 export function createNotebookFactory(): Notebook.IContentFactory {
-  return new Notebook.ContentFactory({
-    editorFactory: NBTestUtils.editorFactory
-  });
+  return NBTestUtils.createNotebookFactory();
 }
 
 /**
  * Create a default notebook panel content factory.
  */
 export function createNotebookPanelFactory(): NotebookPanel.IContentFactory {
-  return new NotebookPanel.ContentFactory({
-    editorFactory: NBTestUtils.editorFactory
-  });
+  return NBTestUtils.createNotebookPanelFactory();
 }
 
 /**
  * Create a notebook widget.
  */
 export function createNotebook(): Notebook {
-  return new Notebook({
-    rendermime: NBTestUtils.defaultRenderMime(),
-    contentFactory: createNotebookFactory(),
-    mimeTypeService: NBTestUtils.mimeTypeService
-  });
+  return NBTestUtils.createNotebook();
 }
 
 /**
@@ -51,19 +41,14 @@ export function createNotebook(): Notebook {
 export function createNotebookPanel(
   context: Context<INotebookModel>
 ): NotebookPanel {
-  return new NotebookPanel({
-    content: createNotebook(),
-    context
-  });
+  return NBTestUtils.createNotebookPanel(context);
 }
 
 /**
  * Populate a notebook with default content.
  */
 export function populateNotebook(notebook: Notebook): void {
-  const model = new NotebookModel();
-  model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-  notebook.model = model;
+  NBTestUtils.populateNotebook(notebook);
 }
 
 export const DEFAULT_CONTENT = NBTestUtils.DEFAULT_CONTENT;
@@ -77,27 +62,17 @@ export function defaultRenderMime(): any {
   return NBTestUtils.defaultRenderMime();
 }
 
+export function createNotebookWidgetFactory(
+  toolbarFactory?: (widget: NotebookPanel) => DocumentRegistry.IToolbarItem[]
+): NotebookWidgetFactory {
+  return NBTestUtils.createNotebookWidgetFactory(toolbarFactory);
+}
+
 /**
  * Create a context for a file.
  */
 export async function createMockContext(
   startKernel = false
 ): Promise<Context<INotebookModel>> {
-  const path = UUID.uuid4() + '.txt';
-  const manager = new Mock.ServiceManagerMock();
-  const factory = new NotebookModelFactory({});
-
-  const context = new Context({
-    manager,
-    factory,
-    path,
-    kernelPreference: {
-      shouldStart: startKernel,
-      canStart: startKernel,
-      autoStartDefault: startKernel
-    }
-  });
-  await context.initialize(true);
-  await context.sessionContext.initialize();
-  return context;
+  return NBTestUtils.createMockContext(startKernel);
 }

--- a/packages/notebook/test/utils.ts
+++ b/packages/notebook/test/utils.ts
@@ -8,7 +8,7 @@ import {
   Notebook,
   NotebookPanel,
   NotebookWidgetFactory
-} from '../src';
+} from '..';
 
 /**
  * Local versions of the NBTestUtils that import from `src` instead of `lib`.

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -16,12 +16,7 @@ import { Message, MessageLoop } from '@lumino/messaging';
 import { Widget } from '@lumino/widgets';
 import { generate, simulate } from 'simulate-event';
 import * as nbformat from '@jupyterlab/nbformat';
-import {
-  INotebookModel,
-  Notebook,
-  NotebookModel,
-  StaticNotebook
-} from '../src';
+import { INotebookModel, Notebook, NotebookModel, StaticNotebook } from '..';
 import * as utils from './utils';
 
 const server = new JupyterServer();

--- a/packages/notebook/test/widgetfactory.spec.ts
+++ b/packages/notebook/test/widgetfactory.spec.ts
@@ -2,14 +2,13 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { ToolbarButton } from '@jupyterlab/apputils';
-import { Context, DocumentRegistry } from '@jupyterlab/docregistry';
+import { Context } from '@jupyterlab/docregistry';
 import { initNotebookContext } from '@jupyterlab/testutils';
 import { JupyterServer } from '@jupyterlab/testutils/lib/start_jupyter_server';
 import { toArray } from '@lumino/algorithm';
 import { INotebookModel, NotebookPanel, NotebookWidgetFactory } from '../src';
 import * as utils from './utils';
 
-const contentFactory = utils.createNotebookPanelFactory();
 const rendermime = utils.defaultRenderMime();
 
 const server = new JupyterServer();
@@ -23,19 +22,6 @@ afterAll(async () => {
   await server.shutdown();
 });
 
-function createFactory(
-  toolbarFactory?: (widget: NotebookPanel) => DocumentRegistry.IToolbarItem[]
-): NotebookWidgetFactory {
-  return new NotebookWidgetFactory({
-    name: 'notebook',
-    fileTypes: ['notebook'],
-    rendermime,
-    toolbarFactory,
-    contentFactory,
-    mimeTypeService: utils.mimeTypeService,
-    editorConfig: utils.defaultEditorConfig
-  });
-}
 
 describe('@jupyterlab/notebook', () => {
   describe('NotebookWidgetFactory', () => {
@@ -51,14 +37,14 @@ describe('@jupyterlab/notebook', () => {
 
     describe('#constructor()', () => {
       it('should create a notebook widget factory', () => {
-        const factory = createFactory();
+        const factory = utils.createNotebookWidgetFactory();
         expect(factory).toBeInstanceOf(NotebookWidgetFactory);
       });
     });
 
     describe('#isDisposed', () => {
       it('should get whether the factory has been disposed', () => {
-        const factory = createFactory();
+        const factory = utils.createNotebookWidgetFactory();
         expect(factory.isDisposed).toBe(false);
         factory.dispose();
         expect(factory.isDisposed).toBe(true);
@@ -67,13 +53,13 @@ describe('@jupyterlab/notebook', () => {
 
     describe('#dispose()', () => {
       it('should dispose of the resources held by the factory', () => {
-        const factory = createFactory();
+        const factory = utils.createNotebookWidgetFactory();
         factory.dispose();
         expect(factory.isDisposed).toBe(true);
       });
 
       it('should be safe to call multiple times', () => {
-        const factory = createFactory();
+        const factory = utils.createNotebookWidgetFactory();
         factory.dispose();
         factory.dispose();
         expect(factory.isDisposed).toBe(true);
@@ -82,12 +68,12 @@ describe('@jupyterlab/notebook', () => {
 
     describe('#editorConfig', () => {
       it('should be the editor config passed into the constructor', () => {
-        const factory = createFactory();
+        const factory = utils.createNotebookWidgetFactory();
         expect(factory.editorConfig).toBe(utils.defaultEditorConfig);
       });
 
       it('should be settable', () => {
-        const factory = createFactory();
+        const factory = utils.createNotebookWidgetFactory();
         const newConfig = { ...utils.defaultEditorConfig };
         factory.editorConfig = newConfig;
         expect(factory.editorConfig).toBe(newConfig);
@@ -96,25 +82,25 @@ describe('@jupyterlab/notebook', () => {
 
     describe('#createNew()', () => {
       it('should create a new `NotebookPanel` widget', () => {
-        const factory = createFactory();
+        const factory = utils.createNotebookWidgetFactory();
         const panel = factory.createNew(context);
         expect(panel).toBeInstanceOf(NotebookPanel);
       });
 
       it('should create a clone of the rendermime', () => {
-        const factory = createFactory();
+        const factory = utils.createNotebookWidgetFactory();
         const panel = factory.createNew(context);
         expect(panel.content.rendermime).not.toBe(rendermime);
       });
 
       it('should pass the editor config to the notebook', () => {
-        const factory = createFactory();
+        const factory = utils.createNotebookWidgetFactory();
         const panel = factory.createNew(context);
         expect(panel.content.editorConfig).toBe(utils.defaultEditorConfig);
       });
 
       it('should populate the default toolbar items', () => {
-        const factory = createFactory();
+        const factory = utils.createNotebookWidgetFactory();
         const panel = factory.createNew(context);
         const items = toArray(panel.toolbar.names());
         expect(items).toEqual(expect.arrayContaining(['save']));
@@ -127,7 +113,7 @@ describe('@jupyterlab/notebook', () => {
           { name: 'foo', widget: new ToolbarButton() },
           { name: 'bar', widget: new ToolbarButton() }
         ];
-        const factory = createFactory(toolbarFactory);
+        const factory = utils.createNotebookWidgetFactory(toolbarFactory);
         const panel = factory.createNew(context);
         const panel2 = factory.createNew(context);
         expect(toArray(panel.toolbar.names())).toEqual([
@@ -145,7 +131,7 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should clone from the optional source widget', () => {
-        const factory = createFactory();
+        const factory = utils.createNotebookWidgetFactory();
         const panel = factory.createNew(context);
         const clone = factory.createNew(panel.context, panel);
         expect(clone).toBeInstanceOf(NotebookPanel);

--- a/packages/notebook/test/widgetfactory.spec.ts
+++ b/packages/notebook/test/widgetfactory.spec.ts
@@ -6,7 +6,7 @@ import { Context } from '@jupyterlab/docregistry';
 import { initNotebookContext } from '@jupyterlab/testutils';
 import { JupyterServer } from '@jupyterlab/testutils/lib/start_jupyter_server';
 import { toArray } from '@lumino/algorithm';
-import { INotebookModel, NotebookPanel, NotebookWidgetFactory } from '../src';
+import { INotebookModel, NotebookPanel, NotebookWidgetFactory } from '..';
 import * as utils from './utils';
 
 const rendermime = utils.defaultRenderMime();
@@ -21,7 +21,6 @@ beforeAll(async () => {
 afterAll(async () => {
   await server.shutdown();
 });
-
 
 describe('@jupyterlab/notebook', () => {
   describe('NotebookWidgetFactory', () => {

--- a/testutils/src/notebook-utils.ts
+++ b/testutils/src/notebook-utils.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import { UUID } from '@lumino/coreutils';
+
 import { editorServices } from '@jupyterlab/codemirror';
 
 import { CodeEditorWrapper } from '@jupyterlab/codeeditor';
@@ -9,13 +11,15 @@ import { Clipboard } from '@jupyterlab/apputils';
 
 import * as nbformat from '@jupyterlab/nbformat';
 
-import { Context } from '@jupyterlab/docregistry';
+import { Context, DocumentRegistry } from '@jupyterlab/docregistry';
 
 import {
   INotebookModel,
   Notebook,
   NotebookModel,
+  NotebookModelFactory,
   NotebookPanel,
+  NotebookWidgetFactory,
   StaticNotebook
 } from '@jupyterlab/notebook';
 
@@ -24,6 +28,8 @@ import { RenderMimeRegistry } from '@jupyterlab/rendermime';
 import { Cell, CodeCellModel } from '@jupyterlab/cells';
 
 import { defaultRenderMime as localRendermime } from './rendermime';
+
+import * as Mock from './mock';
 
 /**
  * Stub for the require() function.
@@ -162,5 +168,44 @@ export namespace NBTestUtils {
     const model = new NotebookModel();
     model.fromJSON(DEFAULT_CONTENT);
     notebook.model = model;
+  }
+
+  export function createNotebookWidgetFactory(
+  toolbarFactory?: (widget: NotebookPanel) => DocumentRegistry.IToolbarItem[]
+  ): NotebookWidgetFactory {
+    return new NotebookWidgetFactory({
+      name: 'notebook',
+      fileTypes: ['notebook'],
+      rendermime: defaultRenderMime(),
+      toolbarFactory,
+      contentFactory: createNotebookPanelFactory(),
+      mimeTypeService: mimeTypeService,
+      editorConfig: defaultEditorConfig
+    });
+  }
+
+  /**
+   * Create a context for a file.
+   */
+  export async function createMockContext(
+    startKernel = false
+  ): Promise<Context<INotebookModel>> {
+    const path = UUID.uuid4() + '.txt';
+    const manager = new Mock.ServiceManagerMock();
+    const factory = new NotebookModelFactory({});
+
+    const context = new Context({
+      manager,
+      factory,
+      path,
+      kernelPreference: {
+        shouldStart: startKernel,
+        canStart: startKernel,
+        autoStartDefault: startKernel
+      }
+    });
+    await context.initialize(true);
+    await context.sessionContext.initialize();
+    return context;
   }
 }

--- a/testutils/src/notebook-utils.ts
+++ b/testutils/src/notebook-utils.ts
@@ -171,7 +171,7 @@ export namespace NBTestUtils {
   }
 
   export function createNotebookWidgetFactory(
-  toolbarFactory?: (widget: NotebookPanel) => DocumentRegistry.IToolbarItem[]
+    toolbarFactory?: (widget: NotebookPanel) => DocumentRegistry.IToolbarItem[]
   ): NotebookWidgetFactory {
     return new NotebookWidgetFactory({
       name: 'notebook',


### PR DESCRIPTION

## References
Follow up to https://github.com/jupyterlab/jupyterlab/pull/5000

## Code changes
Export a notebook widget factory helper and mock context creator in `NBTestUtils` and fully use the utils in `testutils` from the notebook tests to ensure full capability for other extensions.

## User-facing changes
Improved testing utilities for extension authors.

## Backwards-incompatible changes
None
