### PR TITLE
Configure sphinx for gettext

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -87,8 +87,10 @@ release = version_ns['__version__']
 # for a list of supported languages.
 #
 # This is also used if you do content translation via gettext catalogs.
-# Usually you set "language" from the command line for these cases.
-language = None
+# language = None # Must be set from the command line to generate various languages
+
+locale_dirs = ['locale/']
+gettext_compact = False
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -276,7 +278,9 @@ def setup(app):
     dest = osp.join(HERE, 'getting_started/changelog.md')
     shutil.copy(osp.join(HERE, '..', '..', 'CHANGELOG.md'), dest)
     app.add_css_file('css/custom.css')  # may also be an URL
-    build_api_docs(app.outdir)
+    # Skip we are dealing with internationalization
+    if os.path.basename(app.outdir) != "gettext":
+        build_api_docs(app.outdir)
 
     copy_code_files(osp.join(app.srcdir, SNIPPETS_FOLDER))
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Follow-up on translation of the UI. This introduces small tweak on the sphinx configuration to deal with internationalization

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Don't generate TS API when dealing with gettext subcommand

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A
