### PR TITLE
Retain the rtc lock until the user releases it

### DIFF
--- a/jupyterlab/handlers/yjs_echo_ws.py
+++ b/jupyterlab/handlers/yjs_echo_ws.py
@@ -63,12 +63,12 @@ class YjsEchoWebSocket(WebSocketHandler):
             now = int(time.time())
             if room.lock is None or now - room.lock > (10 * len(room.clients)) : # no lock or timeout
                 room.lock = now
-                room.lock_holder = self
+                room.lock_holder = self.id 
                 # print('Acquired new lock: ', room.lock)
                 # return acquired lock
                 self.write_message(bytes([ServerMessageType.ACQUIRE_LOCK]) + room.lock.to_bytes(4, byteorder = 'little'), binary=True)
             
-            elif room.lock_holder == self :
+            elif room.lock_holder == self.id :
                 room.lock = now
 
         elif message[0] == ServerMessageType.RELEASE_LOCK:

--- a/packages/docprovider/src/yprovider.ts
+++ b/packages/docprovider/src/yprovider.ts
@@ -195,7 +195,10 @@ export class WebSocketProviderWithLocks
     }
     this._sendMessage(new Uint8Array([127]));
     // try to acquire lock in regular interval
-    this._intervalID = setInterval(() => {
+    if (this._requestLockInterval) {
+      clearInterval(this._requestLockInterval);
+    }
+    this._requestLockInterval = setInterval(() => {
       if (this.wsconnected) {
         // try to acquire lock
         this._sendMessage(new Uint8Array([127]));
@@ -222,8 +225,8 @@ export class WebSocketProviderWithLocks
     encoding.writeUint32(encoder, lock);
     // releasing lock
     this._sendMessage(encoding.toUint8Array(encoder));
-    if (this._intervalID) {
-      clearInterval(this._intervalID);
+    if (this._requestLockInterval) {
+      clearInterval(this._requestLockInterval);
     }
   }
 
@@ -268,7 +271,7 @@ export class WebSocketProviderWithLocks
   private _contentType: string;
   private _serverUrl: string;
   private _isInitialized: boolean;
-  private _intervalID: number;
+  private _requestLockInterval: number;
   private _currentLockRequest: {
     promise: Promise<number>;
     resolve: (lock: number) => void;

--- a/packages/docprovider/src/yprovider.ts
+++ b/packages/docprovider/src/yprovider.ts
@@ -195,7 +195,7 @@ export class WebSocketProviderWithLocks
     }
     this._sendMessage(new Uint8Array([127]));
     // try to acquire lock in regular interval
-    const intervalID = setInterval(() => {
+    this._intervalID = setInterval(() => {
       if (this.wsconnected) {
         // try to acquire lock
         this._sendMessage(new Uint8Array([127]));
@@ -207,10 +207,6 @@ export class WebSocketProviderWithLocks
       reject = _reject;
     });
     this._currentLockRequest = { promise, resolve, reject };
-    const _finally = () => {
-      clearInterval(intervalID);
-    };
-    promise.then(_finally, _finally);
     return promise;
   }
 
@@ -226,6 +222,9 @@ export class WebSocketProviderWithLocks
     encoding.writeUint32(encoder, lock);
     // releasing lock
     this._sendMessage(encoding.toUint8Array(encoder));
+    if (this._intervalID) {
+      clearInterval(this._intervalID);
+    }
   }
 
   /**
@@ -269,6 +268,7 @@ export class WebSocketProviderWithLocks
   private _contentType: string;
   private _serverUrl: string;
   private _isInitialized: boolean;
+  private _intervalID: number;
   private _currentLockRequest: {
     promise: Promise<number>;
     resolve: (lock: number) => void;


### PR DESCRIPTION
In the JupyterLab weekly meeting, we sometimes observe the meeting notes being erased at the begging of the meeting when everyone is connecting to the binder instance at the same time.

When a client needs to save the document to disk, the client requires a lock to the server, and once it is assigned to him, then writes the content to disk. We suspect the issue comes from the lock that the server assigns to the client. If the server doesn't receive a new request from the client in a certain timeout, the server assumes that the client is gone and releases the lock.

**We have not been able to reproduce the issue. It's possible that this PR doesn't solve it.**

## References
Tries to solves #10962 and #10852.

## Code changes
The solution we are implementing in this PR increases the timeout on the server by the number of connected clients when the client requests the lock. In addition, the client keeps sending request messages to acquire the lock until it's done with it and ready to release it. This way, the knows that the client is not gone and doesn't release the lock.

## User-facing changes
N/A

## Backwards-incompatible changes
N/A

Pining @dmonad for a review.