### PR TITLE
Use posix paths explicitly

### DIFF
--- a/buildutils/src/add-sibling.ts
+++ b/buildutils/src/add-sibling.ts
@@ -74,7 +74,7 @@ const tsconfigPath = path.join(
 );
 const tsconfig = utils.readJSONFile(tsconfigPath);
 tsconfig.references.push({
-  path: path.join('..', '..', packageDirName)
+  path: path.posix.join('..', '..', packageDirName)
 });
 utils.writeJSONFile(tsconfigPath, tsconfig);
 

--- a/buildutils/src/ensure-package.ts
+++ b/buildutils/src/ensure-package.ts
@@ -303,7 +303,7 @@ export async function ensurePackage(
       dirName = path.dirname(dirName);
       prefix += '../';
     }
-    tsConfigData.extends = path.join(prefix, 'tsconfigbase');
+    tsConfigData.extends = path.posix.join(prefix, 'tsconfigbase');
     utils.writeJSONFile(tsConfigPath, tsConfigData);
   }
 

--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -729,7 +729,7 @@ export async function ensureIntegrity(): Promise<boolean> {
     .getCorePaths()
     .filter(pth => !tsConfigDocExclude.some(pkg => pth.includes(pkg)))
     .map(pth => {
-      return { path: './' + path.relative('.', pth).replace('\\', '/') };
+      return { path: './' + path.relative('.', pth).replace('\\/g', '/') };
     });
   utils.writeJSONFile(tsConfigdocPath, tsConfigdocData);
 

--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -729,7 +729,7 @@ export async function ensureIntegrity(): Promise<boolean> {
     .getCorePaths()
     .filter(pth => !tsConfigDocExclude.some(pkg => pth.includes(pkg)))
     .map(pth => {
-      return { path: './' + path.relative('.', pth) };
+      return { path: './' + path.relative('.', pth).replace('\\', '/') };
     });
   utils.writeJSONFile(tsConfigdocPath, tsConfigdocData);
 

--- a/packages/vdom-extension/tsconfig.json
+++ b/packages/vdom-extension/tsconfig.json
@@ -22,13 +22,13 @@
       "path": "../rendermime"
     },
     {
+      "path": "../translation"
+    },
+    {
       "path": "../ui-components"
     },
     {
       "path": "../vdom"
-    },
-    {
-      "path": "../translation"
     }
   ]
 }

--- a/tsconfigdoc.json
+++ b/tsconfigdoc.json
@@ -13,7 +13,10 @@
       ]
     },
     "moduleResolution": "node",
-    "types": ["jest", "node"]
+    "types": [
+      "jest",
+      "node"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## References
Fixes #11030 

## Code changes

1. Using `path.posix.join` instead of `path.join` (only where needed).
2. Using `.replace('\\', '/')` to convert win path to posix.
3. Commit updated format for the json files not regarding paths.

Turns out there is no inbuilt function in Node.js path module to convert win paths to posix. Hence used replace.