### PR TITLE
Make debugger jest test more robust

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "prepare:python-release": "node buildutils/lib/prepare-python-release.js",
     "prepublish:check": "node buildutils/lib/prepublish-check.js",
     "prettier": "prettier --write \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
-    "prettier:check": "prettier --list-different \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
+    "prettier:check": "prettier --check \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
     "publish:js": "node buildutils/lib/publish.js",
     "remove:dependency": "node buildutils/lib/remove-dependency.js",
     "remove:package": "node buildutils/lib/remove-package.js",

--- a/packages/debugger/test/service.spec.ts
+++ b/packages/debugger/test/service.spec.ts
@@ -55,24 +55,8 @@ describe('Debugging support', () => {
   let specsManager: TestKernelSpecManager;
   let service: Debugger.Service;
   let config: IDebugger.IConfig;
-  let xpython: Session.ISessionConnection;
-  let pyNoDebug: Session.ISessionConnection;
 
   beforeAll(async () => {
-    xpython = await createSession({
-      name: '',
-      type: 'test',
-      path: UUID.uuid4()
-    });
-    await xpython.changeKernel({ name: 'xpython' });
-
-    pyNoDebug = await createSession({
-      name: '',
-      type: 'test',
-      path: UUID.uuid4()
-    });
-    await pyNoDebug.changeKernel({ name: 'python3' });
-
     specsManager = new TestKernelSpecManager({ standby: 'never' });
     specsManager.intercept = specs;
     await specsManager.refreshSpecs();
@@ -81,20 +65,19 @@ describe('Debugging support', () => {
   });
 
   afterAll(async () => {
-    await Promise.all([xpython.shutdown(), pyNoDebug.shutdown()]);
     service.dispose();
     specsManager.dispose();
   });
 
   describe('#isAvailable', () => {
     it('should return true for kernels that have support for debugging', async () => {
-      const enabled = await service.isAvailable(xpython);
+      const enabled = await service.isAvailable({kernel: {name: 'xpython'}} as any);
       expect(enabled).toBe(true);
     });
 
     it('should return false for kernels that do not have support for debugging', async () => {
       // The kernel spec are mocked in KERNELSPECS
-      const enabled = await service.isAvailable(pyNoDebug);
+      const enabled = await service.isAvailable({kernel: {name: 'python3'}} as any);
       expect(enabled).toBe(false);
     });
   });

--- a/packages/debugger/test/service.spec.ts
+++ b/packages/debugger/test/service.spec.ts
@@ -71,13 +71,17 @@ describe('Debugging support', () => {
 
   describe('#isAvailable', () => {
     it('should return true for kernels that have support for debugging', async () => {
-      const enabled = await service.isAvailable({kernel: {name: 'xpython'}} as any);
+      const enabled = await service.isAvailable({
+        kernel: { name: 'xpython' }
+      } as any);
       expect(enabled).toBe(true);
     });
 
     it('should return false for kernels that do not have support for debugging', async () => {
       // The kernel spec are mocked in KERNELSPECS
-      const enabled = await service.isAvailable({kernel: {name: 'python3'}} as any);
+      const enabled = await service.isAvailable({
+        kernel: { name: 'python3' }
+      } as any);
       expect(enabled).toBe(false);
     });
   });

--- a/packages/vdom-extension/tsconfig.json
+++ b/packages/vdom-extension/tsconfig.json
@@ -22,13 +22,13 @@
       "path": "../rendermime"
     },
     {
+      "path": "../translation"
+    },
+    {
       "path": "../ui-components"
     },
     {
       "path": "../vdom"
-    },
-    {
-      "path": "../translation"
     }
   ]
 }


### PR DESCRIPTION

### References

`isAvailable` debugger unit test is failing often on the CI. This makes it more robust.

### Code changes

Mock the session connection instead of creating one.

### User changes

N/A

### Breaking changes

N/A