### PR TITLE
Automated Changelog Entry for 3.1.11 on 3.1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.1.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.1.11
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.1.10...f04391135c11c6c5e3e8c4706ec26e675f0db4d6))
+
+### Bugs fixed
+
+- Revert pending input PR #10792 merged in 3.1.x branch [#11020](https://github.com/jupyterlab/jupyterlab/pull/11020) ([@echarles](https://github.com/echarles))
+- fix #10997 - increase max_message_size of websocket messages [#11003](https://github.com/jupyterlab/jupyterlab/pull/11003) ([@dmonad](https://github.com/dmonad))
+- use correct nbformat version - fixes #11005 [#11017](https://github.com/jupyterlab/jupyterlab/pull/11017) ([@dmonad](https://github.com/dmonad))
+- Fix ignored promise leading to incorrect initial tooltip position [#11010](https://github.com/jupyterlab/jupyterlab/pull/11010) ([@krassowski](https://github.com/krassowski))
+- Fix typo in nbformat dialog [#11001](https://github.com/jupyterlab/jupyterlab/pull/11001) ([@davidbrochart](https://github.com/davidbrochart))
+- Backport PR #10943 on branch 3.1.x (Simplify IRankedMenu interface) [#10991](https://github.com/jupyterlab/jupyterlab/pull/10991) ([@fcollonval](https://github.com/fcollonval))
+- Add a guard to avoid kernel deadlock on multiple input request [#10792](https://github.com/jupyterlab/jupyterlab/pull/10792) ([@echarles](https://github.com/echarles))
+
+### Maintenance and upkeep improvements
+
+- Clean up handling of npm dist tag [#10999](https://github.com/jupyterlab/jupyterlab/pull/10999) ([@fcollonval](https://github.com/fcollonval))
+- Fix version regex [#10994](https://github.com/jupyterlab/jupyterlab/pull/10994) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+- Update documentation for internationalization [#11024](https://github.com/jupyterlab/jupyterlab/pull/11024) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-09-01&to=2021-09-08&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-09-01..2021-09-08&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-09-01..2021-09-08&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-09-01..2021-09-08&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-09-01..2021-09-08&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-09-01..2021-09-08&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-09-01..2021-09-08&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.1.10
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.1.9...646b708cdb76f6d0e4e622b0546cc4dc7d2854c7))
@@ -36,8 +67,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.1.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-08-25&to=2021-09-01&type=c))
 
 [@agoose77](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aagoose77+updated%3A2021-08-25..2021-09-01&type=Issues) | [@baggiponte](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abaggiponte+updated%3A2021-08-25..2021-09-01&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-08-25..2021-09-01&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-08-25..2021-09-01&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2021-08-25..2021-09-01&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-08-25..2021-09-01&type=Issues) | [@goanpeca](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agoanpeca+updated%3A2021-08-25..2021-09-01&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-08-25..2021-09-01&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-08-25..2021-09-01&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-08-25..2021-09-01&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-08-25..2021-09-01&type=Issues) | [@mbektas](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ambektas+updated%3A2021-08-25..2021-09-01&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-08-25..2021-09-01&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-08-25..2021-09-01&type=Issues) | [@SarunasAzna](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASarunasAzna+updated%3A2021-08-25..2021-09-01&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-08-25..2021-09-01&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.1.9
 


### PR DESCRIPTION
Automated Changelog Entry for 3.1.11 on 3.1.x
Python version: 3.1.11
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/application-top: 3.1.11
@jupyterlab/example-federated: 2.2.10
@jupyterlab/example-cell: 3.1.10
@jupyterlab/example-filebrowser: 3.1.10
@jupyterlab/example-console: 3.1.10
@jupyterlab/example-notebook: 3.1.10
@jupyterlab/example-app: 3.1.11
@jupyterlab/example-terminal: 3.1.10
@jupyterlab/example-federated-core: 2.2.11
@jupyterlab/example-federated-md: 2.2.11
@jupyterlab/example-federated-middle: 2.2.11
@jupyterlab/example-federated-phosphor: 2.2.11
@jupyterlab/services: 6.1.10
@jupyterlab/completer: 3.1.10
@jupyterlab/vega5-extension: 3.1.11
@jupyterlab/rendermime-interfaces: 3.1.10
@jupyterlab/outputarea: 3.1.10
@jupyterlab/terminal-extension: 3.1.10
@jupyterlab/tooltip-extension: 3.1.10
@jupyterlab/translation-extension: 3.1.10
@jupyterlab/csvviewer-extension: 3.1.10
@jupyterlab/documentsearch-extension: 3.1.10
@jupyterlab/attachments: 3.1.10
@jupyterlab/ui-components-extension: 3.1.10
@jupyterlab/javascript-extension: 3.1.11
@jupyterlab/console-extension: 3.1.10
@jupyterlab/pdf-extension: 3.1.10
@jupyterlab/apputils: 3.1.10
@jupyterlab/codemirror: 3.1.10
@jupyterlab/toc: 5.1.10
@jupyterlab/logconsole: 3.1.10
@jupyterlab/extensionmanager: 3.1.10
@jupyterlab/help-extension: 3.1.10
@jupyterlab/running-extension: 3.1.10
@jupyterlab/statedb: 3.1.10
@jupyterlab/translation: 3.1.10
@jupyterlab/mainmenu-extension: 3.1.10
@jupyterlab/hub-extension: 3.1.10
@jupyterlab/fileeditor: 3.1.10
@jupyterlab/inspector-extension: 3.1.10
@jupyterlab/rendermime-extension: 3.1.10
@jupyterlab/docregistry: 3.1.10
@jupyterlab/rendermime: 3.1.10
@jupyterlab/mathjax2-extension: 3.1.10
@jupyterlab/theme-light-extension: 3.1.10
@jupyterlab/docprovider-extension: 3.1.10
@jupyterlab/extensionmanager-extension: 3.1.10
@jupyterlab/debugger: 3.1.10
@jupyterlab/htmlviewer: 3.1.10
@jupyterlab/statusbar-extension: 3.1.10
@jupyterlab/logconsole-extension: 3.1.10
@jupyterlab/shortcuts-extension: 3.1.10
@jupyterlab/codemirror-extension: 3.1.10
@jupyterlab/notebook-extension: 3.1.10
@jupyterlab/fileeditor-extension: 3.1.10
@jupyterlab/json-extension: 3.1.11
@jupyterlab/mathjax2: 3.1.10
@jupyterlab/shared-models: 3.1.10
@jupyterlab/filebrowser: 3.1.10
@jupyterlab/metapackage: 3.1.11
@jupyterlab/celltags-extension: 3.1.10
@jupyterlab/launcher: 3.1.10
@jupyterlab/vdom: 3.1.11
@jupyterlab/cells: 3.1.10
@jupyterlab/coreutils: 5.1.10
@jupyterlab/application-extension: 3.1.10
@jupyterlab/vdom-extension: 3.1.11
@jupyterlab/settingregistry: 3.1.10
@jupyterlab/application: 3.1.10
@jupyterlab/docmanager: 3.1.10
@jupyterlab/debugger-extension: 3.1.10
@jupyterlab/console: 3.1.10
@jupyterlab/completer-extension: 3.1.10
@jupyterlab/property-inspector: 3.1.10
@jupyterlab/filebrowser-extension: 3.1.10
@jupyterlab/notebook: 3.1.10
@jupyterlab/imageviewer-extension: 3.1.10
@jupyterlab/toc-extension: 5.1.10
@jupyterlab/imageviewer: 3.1.10
@jupyterlab/nbformat: 3.1.10
@jupyterlab/nbconvert-css: 3.1.10
@jupyterlab/codeeditor: 3.1.10
@jupyterlab/documentsearch: 3.1.10
@jupyterlab/mainmenu: 3.1.10
@jupyterlab/theme-dark-extension: 3.1.10
@jupyterlab/csvviewer: 3.1.10
@jupyterlab/docmanager-extension: 3.1.10
@jupyterlab/ui-components: 3.1.10
@jupyterlab/settingeditor: 3.1.10
@jupyterlab/statusbar: 3.1.10
@jupyterlab/docprovider: 3.1.10
@jupyterlab/observables: 4.1.10
@jupyterlab/htmlviewer-extension: 3.1.10
@jupyterlab/markdownviewer-extension: 3.1.10
@jupyterlab/settingeditor-extension: 3.1.10
@jupyterlab/inspector: 3.1.10
@jupyterlab/terminal: 3.1.10
@jupyterlab/markdownviewer: 3.1.10
@jupyterlab/celltags: 3.1.10
@jupyterlab/apputils-extension: 3.1.11
@jupyterlab/tooltip: 3.1.10
@jupyterlab/launcher-extension: 3.1.10
@jupyterlab/running: 3.1.10
node-example: 3.1.10
@jupyterlab/example-services-browser: 3.1.10
@jupyterlab/example-services-outputarea: 3.1.10
@jupyterlab/builder: 3.1.11
@jupyterlab/buildutils: 3.1.11
@jupyterlab/template: 3.1.10
@jupyterlab/testutils: 3.1.10
@jupyterlab/mock-extension: 3.1.11
@jupyterlab/mock-token: 3.1.10
@jupyterlab/mock-provider: 3.1.11
@jupyterlab/mock-consumer: 3.1.11

After merging this PR run the "Draft Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.1.x  |
| Version Spec | patch |
| Since | v3.1.10 |