### PR TITLE
Automated Changelog Entry for 4.0.0a8 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,45 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 4.0.0a8
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v4.0.0a7...094056ad2d728327dbeef26aabeee29ece584487))
+
+### Bugs fixed
+
+- use correct nbformat version - fixes #11005 [#11017](https://github.com/jupyterlab/jupyterlab/pull/11017) ([@dmonad](https://github.com/dmonad))
+- Restore Copy shareable link use of shareUrl [#11011](https://github.com/jupyterlab/jupyterlab/pull/11011) ([@fcollonval](https://github.com/fcollonval))
+- Fix ignored promise leading to incorrect initial tooltip position [#11010](https://github.com/jupyterlab/jupyterlab/pull/11010) ([@krassowski](https://github.com/krassowski))
+- Add a guard to avoid kernel deadlock on multiple input request [#10792](https://github.com/jupyterlab/jupyterlab/pull/10792) ([@echarles](https://github.com/echarles))
+- Translate factory names by adding `label` [#11006](https://github.com/jupyterlab/jupyterlab/pull/11006) ([@krassowski](https://github.com/krassowski))
+- fix #10997 - increase max_message_size of websocket messages [#11003](https://github.com/jupyterlab/jupyterlab/pull/11003) ([@dmonad](https://github.com/dmonad))
+- Fix typo in nbformat dialog [#11001](https://github.com/jupyterlab/jupyterlab/pull/11001) ([@davidbrochart](https://github.com/davidbrochart))
+- Fix missing translation wrappers in the debugger [#10989](https://github.com/jupyterlab/jupyterlab/pull/10989) ([@krassowski](https://github.com/krassowski))
+
+### Maintenance and upkeep improvements
+
+- Cache ESLint Data [#11025](https://github.com/jupyterlab/jupyterlab/pull/11025) ([@blink1073](https://github.com/blink1073))
+- Clean up notebook test utils [#11021](https://github.com/jupyterlab/jupyterlab/pull/11021) ([@fcollonval](https://github.com/fcollonval))
+- Make Test Server Configurable [#11015](https://github.com/jupyterlab/jupyterlab/pull/11015) ([@fcollonval](https://github.com/fcollonval))
+- Clean up handling of npm dist tag [#10999](https://github.com/jupyterlab/jupyterlab/pull/10999) ([@fcollonval](https://github.com/fcollonval))
+- Fix version regex [#10994](https://github.com/jupyterlab/jupyterlab/pull/10994) ([@fcollonval](https://github.com/fcollonval))
+- Move RankedMenu test to ui-components [#10992](https://github.com/jupyterlab/jupyterlab/pull/10992) ([@fcollonval](https://github.com/fcollonval))
+- Fix link to Playwright fixtures in the galata README [#10988](https://github.com/jupyterlab/jupyterlab/pull/10988) ([@jtpio](https://github.com/jtpio))
+- Change "Export Notebook As" to "Save and Export Notebook As" [#10904](https://github.com/jupyterlab/jupyterlab/pull/10904) ([@bsyouness](https://github.com/bsyouness))
+
+### Documentation improvements
+
+- Update documentation for internationalization [#11024](https://github.com/jupyterlab/jupyterlab/pull/11024) ([@fcollonval](https://github.com/fcollonval))
+- Configure sphinx for gettext [#11022](https://github.com/jupyterlab/jupyterlab/pull/11022) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-09-01&to=2021-09-08&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-09-01..2021-09-08&type=Issues) | [@bsyouness](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Absyouness+updated%3A2021-09-01..2021-09-08&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2021-09-01..2021-09-08&type=Issues) | [@dmonad](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Admonad+updated%3A2021-09-01..2021-09-08&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-09-01..2021-09-08&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-09-01..2021-09-08&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-09-01..2021-09-08&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-09-01..2021-09-08&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-09-01..2021-09-08&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 4.0.0a7
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v4.0.0a6...0350c6e6cafa06e0a4903507524789d938b75710))
@@ -58,8 +97,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-08-25&to=2021-09-01&type=c))
 
 [@3coins](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3A3coins+updated%3A2021-08-25..2021-09-01&type=Issues) | [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2021-08-25..2021-09-01&type=Issues) | [@agoose77](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aagoose77+updated%3A2021-08-25..2021-09-01&type=Issues) | [@baggiponte](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abaggiponte+updated%3A2021-08-25..2021-09-01&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-08-25..2021-09-01&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-08-25..2021-09-01&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2021-08-25..2021-09-01&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-08-25..2021-09-01&type=Issues) | [@goanpeca](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agoanpeca+updated%3A2021-08-25..2021-09-01&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2021-08-25..2021-09-01&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-08-25..2021-09-01&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-08-25..2021-09-01&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-08-25..2021-09-01&type=Issues) | [@krassowska](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowska+updated%3A2021-08-25..2021-09-01&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-08-25..2021-09-01&type=Issues) | [@mbektas](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ambektas+updated%3A2021-08-25..2021-09-01&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-08-25..2021-09-01&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-08-25..2021-09-01&type=Issues) | [@SarunasAzna](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASarunasAzna+updated%3A2021-08-25..2021-09-01&type=Issues) | [@tejasmorkar](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atejasmorkar+updated%3A2021-08-25..2021-09-01&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-08-25..2021-09-01&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 4.0.0a6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -295,6 +295,35 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 
 ## v3.1
 
+## 3.1.11
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.1.10...f04391135c11c6c5e3e8c4706ec26e675f0db4d6))
+
+### Bugs fixed
+
+- Revert pending input PR #10792 merged in 3.1.x branch [#11020](https://github.com/jupyterlab/jupyterlab/pull/11020) ([@echarles](https://github.com/echarles))
+- fix #10997 - increase max_message_size of websocket messages [#11003](https://github.com/jupyterlab/jupyterlab/pull/11003) ([@dmonad](https://github.com/dmonad))
+- use correct nbformat version - fixes #11005 [#11017](https://github.com/jupyterlab/jupyterlab/pull/11017) ([@dmonad](https://github.com/dmonad))
+- Fix ignored promise leading to incorrect initial tooltip position [#11010](https://github.com/jupyterlab/jupyterlab/pull/11010) ([@krassowski](https://github.com/krassowski))
+- Fix typo in nbformat dialog [#11001](https://github.com/jupyterlab/jupyterlab/pull/11001) ([@davidbrochart](https://github.com/davidbrochart))
+- Backport PR #10943 on branch 3.1.x (Simplify IRankedMenu interface) [#10991](https://github.com/jupyterlab/jupyterlab/pull/10991) ([@fcollonval](https://github.com/fcollonval))
+- Add a guard to avoid kernel deadlock on multiple input request [#10792](https://github.com/jupyterlab/jupyterlab/pull/10792) ([@echarles](https://github.com/echarles))
+
+### Maintenance and upkeep improvements
+
+- Clean up handling of npm dist tag [#10999](https://github.com/jupyterlab/jupyterlab/pull/10999) ([@fcollonval](https://github.com/fcollonval))
+- Fix version regex [#10994](https://github.com/jupyterlab/jupyterlab/pull/10994) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+- Update documentation for internationalization [#11024](https://github.com/jupyterlab/jupyterlab/pull/11024) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-09-01&to=2021-09-08&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-09-01..2021-09-08&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-09-01..2021-09-08&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-09-01..2021-09-08&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-09-01..2021-09-08&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-09-01..2021-09-08&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-09-01..2021-09-08&type=Issues)
+
 ## 3.1.10
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.1.9...646b708cdb76f6d0e4e622b0546cc4dc7d2854c7))


### PR DESCRIPTION
Automated Changelog Entry for 4.0.0a8 on master
Python version: 4.0.0a8
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/application-top: 3.3.0-alpha.8
@jupyterlab/example-federated: 2.4.0-alpha.8
@jupyterlab/example-cell: 3.3.0-alpha.8
@jupyterlab/example-filebrowser: 3.3.0-alpha.8
@jupyterlab/example-console: 3.3.0-alpha.8
@jupyterlab/example-notebook: 3.3.0-alpha.8
@jupyterlab/example-app: 3.3.0-alpha.8
@jupyterlab/example-terminal: 3.3.0-alpha.8
@jupyterlab/example-federated-core: 2.4.0-alpha.8
@jupyterlab/example-federated-md: 2.4.0-alpha.8
@jupyterlab/example-federated-middle: 2.4.0-alpha.8
@jupyterlab/example-federated-phosphor: 2.4.0-alpha.8
@jupyterlab/services: 6.3.0-alpha.8
@jupyterlab/completer: 3.3.0-alpha.8
@jupyterlab/vega5-extension: 3.3.0-alpha.8
@jupyterlab/rendermime-interfaces: 3.3.0-alpha.8
@jupyterlab/outputarea: 3.3.0-alpha.8
@jupyterlab/terminal-extension: 3.3.0-alpha.8
@jupyterlab/tooltip-extension: 3.3.0-alpha.8
@jupyterlab/translation-extension: 3.3.0-alpha.8
@jupyterlab/csvviewer-extension: 3.3.0-alpha.8
@jupyterlab/documentsearch-extension: 3.3.0-alpha.8
@jupyterlab/attachments: 3.3.0-alpha.8
@jupyterlab/ui-components-extension: 3.3.0-alpha.8
@jupyterlab/javascript-extension: 3.3.0-alpha.8
@jupyterlab/console-extension: 3.3.0-alpha.8
@jupyterlab/pdf-extension: 3.3.0-alpha.8
@jupyterlab/apputils: 3.3.0-alpha.8
@jupyterlab/codemirror: 3.3.0-alpha.8
@jupyterlab/toc: 5.3.0-alpha.8
@jupyterlab/logconsole: 3.3.0-alpha.8
@jupyterlab/extensionmanager: 3.3.0-alpha.8
@jupyterlab/help-extension: 3.3.0-alpha.8
@jupyterlab/running-extension: 3.3.0-alpha.8
@jupyterlab/statedb: 3.3.0-alpha.8
@jupyterlab/translation: 3.3.0-alpha.8
@jupyterlab/mainmenu-extension: 3.3.0-alpha.8
@jupyterlab/hub-extension: 3.3.0-alpha.8
@jupyterlab/fileeditor: 3.3.0-alpha.8
@jupyterlab/inspector-extension: 3.3.0-alpha.8
@jupyterlab/rendermime-extension: 3.3.0-alpha.8
@jupyterlab/docregistry: 3.3.0-alpha.8
@jupyterlab/rendermime: 3.3.0-alpha.8
@jupyterlab/mathjax2-extension: 3.3.0-alpha.8
@jupyterlab/theme-light-extension: 3.3.0-alpha.8
@jupyterlab/docprovider-extension: 3.3.0-alpha.8
@jupyterlab/extensionmanager-extension: 3.3.0-alpha.8
@jupyterlab/debugger: 3.3.0-alpha.8
@jupyterlab/htmlviewer: 3.3.0-alpha.8
@jupyterlab/statusbar-extension: 3.3.0-alpha.8
@jupyterlab/logconsole-extension: 3.3.0-alpha.8
@jupyterlab/shortcuts-extension: 3.3.0-alpha.8
@jupyterlab/codemirror-extension: 3.3.0-alpha.8
@jupyterlab/notebook-extension: 3.3.0-alpha.8
@jupyterlab/fileeditor-extension: 3.3.0-alpha.8
@jupyterlab/json-extension: 3.3.0-alpha.8
@jupyterlab/mathjax2: 3.3.0-alpha.8
@jupyterlab/shared-models: 3.3.0-alpha.8
@jupyterlab/filebrowser: 3.3.0-alpha.8
@jupyterlab/metapackage: 3.3.0-alpha.8
@jupyterlab/celltags-extension: 3.3.0-alpha.8
@jupyterlab/launcher: 3.3.0-alpha.8
@jupyterlab/vdom: 3.3.0-alpha.8
@jupyterlab/cells: 3.3.0-alpha.8
@jupyterlab/coreutils: 5.3.0-alpha.8
@jupyterlab/application-extension: 3.3.0-alpha.8
@jupyterlab/vdom-extension: 3.3.0-alpha.8
@jupyterlab/settingregistry: 3.3.0-alpha.8
@jupyterlab/application: 3.3.0-alpha.8
@jupyterlab/docmanager: 3.3.0-alpha.8
@jupyterlab/debugger-extension: 3.3.0-alpha.8
@jupyterlab/console: 3.3.0-alpha.8
@jupyterlab/completer-extension: 3.3.0-alpha.8
@jupyterlab/property-inspector: 3.3.0-alpha.8
@jupyterlab/filebrowser-extension: 3.3.0-alpha.8
@jupyterlab/notebook: 3.3.0-alpha.8
@jupyterlab/imageviewer-extension: 3.3.0-alpha.8
@jupyterlab/toc-extension: 5.3.0-alpha.8
@jupyterlab/imageviewer: 3.3.0-alpha.8
@jupyterlab/nbformat: 3.3.0-alpha.8
@jupyterlab/nbconvert-css: 3.3.0-alpha.8
@jupyterlab/codeeditor: 3.3.0-alpha.8
@jupyterlab/documentsearch: 3.3.0-alpha.8
@jupyterlab/mainmenu: 3.3.0-alpha.8
@jupyterlab/theme-dark-extension: 3.3.0-alpha.8
@jupyterlab/csvviewer: 3.3.0-alpha.8
@jupyterlab/docmanager-extension: 3.3.0-alpha.8
@jupyterlab/ui-components: 3.3.0-alpha.8
@jupyterlab/settingeditor: 3.3.0-alpha.8
@jupyterlab/statusbar: 3.3.0-alpha.8
@jupyterlab/docprovider: 3.3.0-alpha.8
@jupyterlab/observables: 4.3.0-alpha.8
@jupyterlab/htmlviewer-extension: 3.3.0-alpha.8
@jupyterlab/markdownviewer-extension: 3.3.0-alpha.8
@jupyterlab/settingeditor-extension: 3.3.0-alpha.8
@jupyterlab/inspector: 3.3.0-alpha.8
@jupyterlab/terminal: 3.3.0-alpha.8
@jupyterlab/markdownviewer: 3.3.0-alpha.8
@jupyterlab/celltags: 3.3.0-alpha.8
@jupyterlab/apputils-extension: 3.3.0-alpha.8
@jupyterlab/tooltip: 3.3.0-alpha.8
@jupyterlab/launcher-extension: 3.3.0-alpha.8
@jupyterlab/running: 3.3.0-alpha.8
node-example: 3.3.0-alpha.8
@jupyterlab/example-services-browser: 3.3.0-alpha.8
@jupyterlab/example-services-outputarea: 3.3.0-alpha.8
@jupyterlab/builder: 3.3.0-alpha.8
@jupyterlab/buildutils: 3.3.0-alpha.8
@jupyterlab/template: 3.3.0-alpha.8
@jupyterlab/galata: 4.3.0-alpha.8
@jupyterlab/testutils: 3.3.0-alpha.8
@jupyterlab/mock-extension: 3.3.0-alpha.8
@jupyterlab/mock-token: 3.3.0-alpha.8
@jupyterlab/mock-provider: 3.3.0-alpha.8
@jupyterlab/mock-consumer: 3.3.0-alpha.8

After merging this PR run the "Draft Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | master  |
| Version Spec | build |
| Since | v4.0.0a7 |