### PR TITLE
Use JupyterLab Probot for Binder Links

### DIFF
--- a/.github/jupyterlab-probot.yml
+++ b/.github/jupyterlab-probot.yml
@@ -1,0 +1,2 @@
+binderUrlSuffix: "?urlpath=lab-dev"
+addBinderLink: true


### PR DESCRIPTION
## References
https://github.com/jupyterlab/jupyterlab-probot/pull/1

## Code changes
Add configuration to use the [jupyterlab-probot](https://github.com/jupyterlab/jupyterlab-probot) to create binder links in pull requests.  Will replace our usage of the [jupyterlab-dev-mode-bot](https://github.com/ian-r-rose/jupyterlab-dev-mode-bot).

## User-facing changes
None

## Backwards-incompatible changes
None