### PR TITLE
Backport PR #11031 on branch 3.1.x (Use posix paths explicitly)

### DIFF
--- a/buildutils/src/add-sibling.ts
+++ b/buildutils/src/add-sibling.ts
@@ -74,7 +74,7 @@ const tsconfigPath = path.join(
 );
 const tsconfig = utils.readJSONFile(tsconfigPath);
 tsconfig.references.push({
-  path: path.join('..', '..', packageDirName)
+  path: path.posix.join('..', '..', packageDirName)
 });
 utils.writeJSONFile(tsconfigPath, tsconfig);
 

--- a/buildutils/src/ensure-package.ts
+++ b/buildutils/src/ensure-package.ts
@@ -303,7 +303,7 @@ export async function ensurePackage(
       dirName = path.dirname(dirName);
       prefix += '../';
     }
-    tsConfigData.extends = path.join(prefix, 'tsconfigbase');
+    tsConfigData.extends = path.posix.join(prefix, 'tsconfigbase');
     utils.writeJSONFile(tsConfigPath, tsConfigData);
   }
 

--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -723,7 +723,7 @@ export async function ensureIntegrity(): Promise<boolean> {
     .getCorePaths()
     .filter(pth => !tsConfigDocExclude.some(pkg => pth.includes(pkg)))
     .map(pth => {
-      return { path: './' + path.relative('.', pth) };
+      return { path: './' + path.relative('.', pth).replace('\\/g', '/') };
     });
   utils.writeJSONFile(tsConfigdocPath, tsConfigdocData);
 

--- a/tsconfigdoc.json
+++ b/tsconfigdoc.json
@@ -12,7 +12,12 @@
       "@jupyterlab/*": [
         "./packages/*/src"
       ]
-    }
+    },
+    "moduleResolution": "node",
+    "types": [
+      "jest",
+      "node"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
Backport PR #11031: Use posix paths explicitly