### PR TITLE
use path.posix explicitly for URLs

### DIFF
--- a/packages/coreutils/src/url.ts
+++ b/packages/coreutils/src/url.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { PartialJSONObject } from '@lumino/coreutils';
-import * as posix from 'path';
+import { posix } from 'path';
 import urlparse from 'url-parse';
 
 /**


### PR DESCRIPTION
JupyterLab Desktop App (https://github.com/mbektas/jupyterlab_app/tree/jlab3_upgrade) uses webpack target `electron-renderer` and it bundles JupyterLab packages as part of app's js bundle. When Desktop App is built for Windows, during runtime, the URLs generated by `URLExt.join` end up having path components with backward slash (i.e. http://localhost:8888\api\kernels). It is caused by path.join using Windows specific win32.join. This PR enforces using `posix.join` for URL generation.

## Code changes

istead of using `path.join` which is platform dependent, now using `path.posix` for URL path component joins.

## User-facing changes

none

## Backwards-incompatible changes

none
