### PR TITLE
update inspector label

### DIFF
--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -55,6 +55,7 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
     const { commands, shell } = app;
     const command = CommandIDs.open;
     const label = trans.__('Show Contextual Help');
+    const openedLabel = trans.__('Contextual Help');
     const namespace = 'inspector';
     const tracker = new WidgetTracker<MainAreaWidget<InspectorPanel>>({
       namespace
@@ -72,7 +73,7 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
           content: new InspectorPanel({ translator })
         });
         inspector.id = 'jp-inspector';
-        inspector.title.label = label;
+        inspector.title.label = openedLabel;
         inspector.title.icon = inspectorIcon;
         void tracker.add(inspector);
         source = source && !source.isDisposed ? source : null;


### PR DESCRIPTION
### Description of Change
- Change the label on top of the inspector to say "Contextual Help" instead of "Show Contextual Help." There is no need for "Show" once the inspector is open.

#### before 
<img width="886" alt="image" src="https://user-images.githubusercontent.com/40677673/132756671-c92bcdb2-f881-4822-a453-4614ba2008de.png">


#### after 
<img width="893" alt="image" src="https://user-images.githubusercontent.com/40677673/132755419-fa723c11-1baa-4e5c-a175-df9c204e1434.png">
