### PR TITLE
Indent comments (#6957)

### DIFF
--- a/packages/codemirror/src/factory.ts
+++ b/packages/codemirror/src/factory.ts
@@ -25,8 +25,8 @@ export class CodeMirrorEditorFactory implements IEditorFactoryService {
         'Cmd-Left': 'goLineLeft',
         Tab: 'indentMoreOrinsertTab',
         'Shift-Tab': 'indentLess',
-        'Cmd-/': cm => cm.toggleComment({indent:true}),
-        'Ctrl-/': cm => cm.toggleComment({indent:true}),
+        'Cmd-/': cm => cm.toggleComment({ indent: true }),
+        'Ctrl-/': cm => cm.toggleComment({ indent: true }),
         'Ctrl-G': 'find',
         'Cmd-G': 'find'
       },
@@ -37,8 +37,8 @@ export class CodeMirrorEditorFactory implements IEditorFactoryService {
       extraKeys: {
         Tab: 'indentMoreOrinsertTab',
         'Shift-Tab': 'indentLess',
-        'Cmd-/': cm => cm.toggleComment({indent:true}),
-        'Ctrl-/': cm => cm.toggleComment({indent:true}),
+        'Cmd-/': cm => cm.toggleComment({ indent: true }),
+        'Ctrl-/': cm => cm.toggleComment({ indent: true }),
         'Shift-Enter': () => {
           /* no-op */
         }

--- a/packages/codemirror/src/factory.ts
+++ b/packages/codemirror/src/factory.ts
@@ -25,8 +25,8 @@ export class CodeMirrorEditorFactory implements IEditorFactoryService {
         'Cmd-Left': 'goLineLeft',
         Tab: 'indentMoreOrinsertTab',
         'Shift-Tab': 'indentLess',
-        'Cmd-/': 'toggleComment',
-        'Ctrl-/': 'toggleComment',
+        'Cmd-/': (cm) => cm.toggleComment({indent:true}),
+        'Ctrl-/': (cm) => cm.toggleComment({indent:true}),
         'Ctrl-G': 'find',
         'Cmd-G': 'find'
       },
@@ -37,8 +37,8 @@ export class CodeMirrorEditorFactory implements IEditorFactoryService {
       extraKeys: {
         Tab: 'indentMoreOrinsertTab',
         'Shift-Tab': 'indentLess',
-        'Cmd-/': 'toggleComment',
-        'Ctrl-/': 'toggleComment',
+        'Cmd-/': (cm) => cm.toggleComment({indent:true}),
+        'Ctrl-/': (cm) => cm.toggleComment({indent:true}),
         'Shift-Enter': () => {
           /* no-op */
         }

--- a/packages/codemirror/src/factory.ts
+++ b/packages/codemirror/src/factory.ts
@@ -25,8 +25,8 @@ export class CodeMirrorEditorFactory implements IEditorFactoryService {
         'Cmd-Left': 'goLineLeft',
         Tab: 'indentMoreOrinsertTab',
         'Shift-Tab': 'indentLess',
-        'Cmd-/': (cm) => cm.toggleComment({indent:true}),
-        'Ctrl-/': (cm) => cm.toggleComment({indent:true}),
+        'Cmd-/': cm => cm.toggleComment({indent:true}),
+        'Ctrl-/': cm => cm.toggleComment({indent:true}),
         'Ctrl-G': 'find',
         'Cmd-G': 'find'
       },
@@ -37,8 +37,8 @@ export class CodeMirrorEditorFactory implements IEditorFactoryService {
       extraKeys: {
         Tab: 'indentMoreOrinsertTab',
         'Shift-Tab': 'indentLess',
-        'Cmd-/': (cm) => cm.toggleComment({indent:true}),
-        'Ctrl-/': (cm) => cm.toggleComment({indent:true}),
+        'Cmd-/': cm => cm.toggleComment({indent:true}),
+        'Ctrl-/': cm => cm.toggleComment({indent:true}),
         'Shift-Enter': () => {
           /* no-op */
         }


### PR DESCRIPTION
## References

https://github.com/jupyterlab/jupyterlab/issues/6957

## Code changes

Pass `{indent:true}` option object to `toggleComment` (on `Ctrl + /` and `Cmd + /` keypress) so that it indents properly, per @jasongrout's [comment](https://github.com/jupyterlab/jupyterlab/issues/6957#issuecomment-655199796) on #6957.

Please `Ctrl+f` for "comment.js" on [this page](https://codemirror.net/doc/manual.html) so see the relevant part of the CodeMirror manual. Note that the comment.js addon adds the "toggleComment" command (which is what is currently used) as a shortcut for option-less usage, but it also adds the `.toggleComment(opts)` method to the CodeMirror instance, which is what's being in the new code introduced by this pull request.

## Edit:
I tried to use the binder test link provided by jupyterlab-probot, but after seeming to successfully build, it logged "Failed to connect to event stream":
```
Pushing image
Pushing image
Pushing image
Successfully pushed gesiscss/binder-r2d-g5b5b759-josephrocca-2djupyterlab-48e787:0bbdd9526cc16beafa5d0a04c93f98a515db2f93Built image, launching...
Launching server...
Failed to connect to event stream
```
I tried a second time and the same thing happened.