### PR TITLE
Share notebook's metadata

### DIFF
--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -305,7 +305,6 @@ export class CellModel extends CodeEditor.Model implements ICellModel {
     event: IObservableJSON.IChangedArgs
   ): void {
     const metadata = this.sharedModel.getMetadata();
-    console.debug('CELL.onModelDBMetadataChange:', event);
     this._modelDBMutex(() => {
       switch (event.type) {
         case 'add':
@@ -334,7 +333,6 @@ export class CellModel extends CodeEditor.Model implements ICellModel {
     metadata: Partial<models.ISharedBaseCellMetadata>,
     event: IObservableJSON.IChangedArgs
   ): void {
-    console.debug('CELL._changeCellMetadata:', event);
     switch (event.key) {
       case 'jupyter':
         metadata.jupyter = event.newValue as any;
@@ -375,7 +373,6 @@ export class CellModel extends CodeEditor.Model implements ICellModel {
     sender: models.ISharedCodeCell,
     change: models.CellChange<models.ISharedBaseCellMetadata>
   ): void {
-    console.debug('CELL._onSharedModelChanged:', change);
     super._onSharedModelChanged(sender, change);
     this._modelDBMutex(() => {
       if (change.metadataChange) {
@@ -383,7 +380,6 @@ export class CellModel extends CodeEditor.Model implements ICellModel {
           ?.newValue as models.ISharedBaseCellMetadata;
         if (newValue) {
           Object.keys(newValue).map(key => {
-            console.debug(key);
             switch (key) {
               case 'collapsed':
                 this.metadata.set('collapsed', newValue.jupyter);

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -305,6 +305,7 @@ export class CellModel extends CodeEditor.Model implements ICellModel {
     event: IObservableJSON.IChangedArgs
   ): void {
     const metadata = this.sharedModel.getMetadata();
+    console.debug('CELL.onModelDBMetadataChange:', event);
     this._modelDBMutex(() => {
       switch (event.type) {
         case 'add':
@@ -333,6 +334,7 @@ export class CellModel extends CodeEditor.Model implements ICellModel {
     metadata: Partial<models.ISharedBaseCellMetadata>,
     event: IObservableJSON.IChangedArgs
   ): void {
+    console.debug('CELL._changeCellMetadata:', event);
     switch (event.key) {
       case 'jupyter':
         metadata.jupyter = event.newValue as any;
@@ -373,6 +375,7 @@ export class CellModel extends CodeEditor.Model implements ICellModel {
     sender: models.ISharedCodeCell,
     change: models.CellChange<models.ISharedBaseCellMetadata>
   ): void {
+    console.debug('CELL._onSharedModelChanged:', change);
     super._onSharedModelChanged(sender, change);
     this._modelDBMutex(() => {
       if (change.metadataChange) {
@@ -380,6 +383,7 @@ export class CellModel extends CodeEditor.Model implements ICellModel {
           ?.newValue as models.ISharedBaseCellMetadata;
         if (newValue) {
           Object.keys(newValue).map(key => {
+            console.debug(key);
             switch (key) {
               case 'collapsed':
                 this.metadata.set('collapsed', newValue.jupyter);

--- a/packages/celltags/src/tool.ts
+++ b/packages/celltags/src/tool.ts
@@ -209,6 +209,10 @@ export class TagTool extends NotebookTools.Tool {
         this.refreshTags();
         this.loadActiveTags();
       });
+      this.tracker.currentWidget.content.activeCellChanged.connect(() => {
+        this.refreshTags();
+        this.loadActiveTags();
+      });
     }
     this.tracker.currentChanged.connect(() => {
       this.refreshTags();

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -447,11 +447,13 @@ close the notebook without saving it.`,
     change: IObservableMap.IChangedArgs<ReadonlyPartialJSONValue | undefined>
   ): void {
     console.debug('_onMetadataChanged');
-    console.debug(metadata.toJSON());
     console.debug(change);
-    this._modelDBMutex(() => {
-      this.sharedModel.updateMetadata(metadata.toJSON());
-    });
+    if (change.key !== 'kernelspec' && change.key !== 'language_info') {
+      this._modelDBMutex(() => {
+        console.debug(metadata.toJSON());
+        this.sharedModel.updateMetadata(metadata.toJSON());
+      });
+    }
     this.triggerContentChange();
   }
 

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -433,9 +433,7 @@ close the notebook without saving it.`,
     if (changes.metadataChange) {
       const metadata = changes.metadataChange.newValue as JSONObject;
       this._modelDBMutex(() => {
-        console.debug('_onStateChanged:');
         Object.entries(metadata).forEach(([key, value]) => {
-          console.debug(key, value);
           this.metadata.set(key, value);
         });
       });
@@ -446,11 +444,8 @@ close the notebook without saving it.`,
     metadata: IObservableJSON,
     change: IObservableMap.IChangedArgs<ReadonlyPartialJSONValue | undefined>
   ): void {
-    console.debug('_onMetadataChanged');
-    console.debug(change);
     if (change.key !== 'kernelspec' && change.key !== 'language_info') {
       this._modelDBMutex(() => {
-        console.debug(metadata.toJSON());
         this.sharedModel.updateMetadata(metadata.toJSON());
       });
     }

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -19,6 +19,7 @@ import {
   IModelDB,
   IObservableJSON,
   IObservableList,
+  IObservableMap,
   IObservableUndoableList,
   ModelDB
 } from '@jupyterlab/observables';
@@ -28,7 +29,7 @@ import {
   nullTranslator,
   TranslationBundle
 } from '@jupyterlab/translation';
-import { UUID } from '@lumino/coreutils';
+import { JSONObject, ReadonlyPartialJSONValue, UUID } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 import { CellList } from './celllist';
 
@@ -105,7 +106,7 @@ export class NotebookModel implements INotebookModel {
       metadata.set('language_info', { name });
     }
     this._ensureMetadata();
-    metadata.changed.connect(this.triggerContentChange, this);
+    metadata.changed.connect(this._onMetadataChanged, this);
     this._deletedCells = [];
 
     this.sharedModel.changed.connect(this._onStateChanged, this);
@@ -428,6 +429,30 @@ close the notebook without saving it.`,
         this.triggerStateChange(value);
       });
     }
+
+    if (changes.metadataChange) {
+      const metadata = changes.metadataChange.newValue as JSONObject;
+      this._modelDBMutex(() => {
+        console.debug('_onStateChanged:');
+        Object.entries(metadata).forEach(([key, value]) => {
+          console.debug(key, value);
+          this.metadata.set(key, value);
+        });
+      });
+    }
+  }
+
+  private _onMetadataChanged(
+    metadata: IObservableJSON,
+    change: IObservableMap.IChangedArgs<ReadonlyPartialJSONValue | undefined>
+  ): void {
+    console.debug('_onMetadataChanged');
+    console.debug(metadata.toJSON());
+    console.debug(change);
+    this._modelDBMutex(() => {
+      this.sharedModel.updateMetadata(metadata.toJSON());
+    });
+    this.triggerContentChange();
   }
 
   /**
@@ -474,6 +499,11 @@ close the notebook without saving it.`,
    * The shared notebook model.
    */
   readonly sharedModel = models.YNotebook.create() as models.ISharedNotebook;
+
+  /**
+   * A mutex to update the shared model.
+   */
+  protected readonly _modelDBMutex = models.createMutex();
 
   /**
    * The underlying `IModelDB` instance in which model

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -33,6 +33,8 @@ import { JSONObject, ReadonlyPartialJSONValue, UUID } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 import { CellList } from './celllist';
 
+const UNSHARED_KEYS = ['kernelspec', 'language_info'];
+
 /**
  * The definition of a model object for a notebook widget.
  */
@@ -444,7 +446,7 @@ close the notebook without saving it.`,
     metadata: IObservableJSON,
     change: IObservableMap.IChangedArgs<ReadonlyPartialJSONValue | undefined>
   ): void {
-    if (change.key !== 'kernelspec' && change.key !== 'language_info') {
+    if (!UNSHARED_KEYS.includes(change.key)) {
       this._modelDBMutex(() => {
         this.sharedModel.updateMetadata(metadata.toJSON());
       });

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -408,7 +408,6 @@ export class YNotebook
    * Handle a change to the ystate.
    */
   private _onMetadataChanged = (event: Y.YMapEvent<any>) => {
-    console.debug('YModel: ', event);
     if (event.keysChanged.has('metadata')) {
       const change = event.changes.keys.get('metadata');
       const metadataChange = {

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -209,6 +209,7 @@ export class YNotebook
       return this._ycellMapping.get(ycell) as YCellType;
     });
 
+    this.ymeta.observe(this._onMetadataChanged);
     this.ystate.observe(this._onStateChanged);
   }
 
@@ -237,6 +238,7 @@ export class YNotebook
    */
   dispose(): void {
     this.ycells.unobserve(this._onYCellsChanged);
+    this.ymeta.unobserve(this._onMetadataChanged);
     this.ystate.unobserve(this._onStateChanged);
   }
 
@@ -344,6 +346,7 @@ export class YNotebook
    * @param value: Metadata's attribute to update.
    */
   updateMetadata(value: Partial<nbformat.INotebookMetadata>): void {
+    // TODO: Maybe modify only attributes instead of replacing the whole metadata?
     this.ymeta.set('metadata', Object.assign({}, this.getMetadata(), value));
   }
 
@@ -399,6 +402,21 @@ export class YNotebook
     this._changed.emit({
       cellsChange: cellsChange
     });
+  };
+
+  /**
+   * Handle a change to the ystate.
+   */
+  private _onMetadataChanged = (event: Y.YMapEvent<any>) => {
+    console.debug('YModel: ', event);
+    if (event.keysChanged.has('metadata')) {
+      const change = event.changes.keys.get('metadata');
+      const metadataChange = {
+        oldValue: change?.oldValue ? change!.oldValue : undefined,
+        newValue: this.getMetadata()
+      };
+      this._changed.emit({ metadataChange });
+    }
   };
 
   /**


### PR DESCRIPTION
As discussed in #11038, by default the metadata is not shared because there are some attributes that we do not want to share. This makes every use of the metadata in the JupyterLab, not collaborative. In the case you want to share the metadata, you need to explicitly add the content to the shared model instead of modelDB. With this PR, we listen to changes in modelDB and apply them to the shared model to make everything collaborative.

In this PR we are facing one small problem. ModelDB allows modifying the attributes independently while the shared model doesn't. To update the modelDB on a remote client we need to update the whole metadata because is the update we receive from the shared model. Maybe we should change how we update the metadata in the shared model.

## References
Solves #11038

## Code changes
Listening for changes on modelDB metadata to update the shared model. The problem with this approach is that we need to update the modelDB on other clients and that triggers the change event. For this reason, we create some sort of a mutex to avoid updating again the client.

## User-facing changes
Now the metadata is shared between clients.

## Backwards-incompatible changes

