### PR TITLE
Automated Changelog Entry for 4.0.0a9 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,47 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 4.0.0a9
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v4.0.0a8...d103ccc3d16db524bed90fb1eebb6ce7616e224f))
+
+### Enhancements made
+
+- update inspector label [#11049](https://github.com/jupyterlab/jupyterlab/pull/11049) ([@legendb317](https://github.com/legendb317))
+
+### Bugs fixed
+
+- Use posix paths explicitly [#11031](https://github.com/jupyterlab/jupyterlab/pull/11031) ([@Mithil467](https://github.com/Mithil467))
+- Adds the variable reference to the key of the component [#11029](https://github.com/jupyterlab/jupyterlab/pull/11029) ([@hbcarlos](https://github.com/hbcarlos))
+
+### Maintenance and upkeep improvements
+
+- Clean up bumpversion [#11056](https://github.com/jupyterlab/jupyterlab/pull/11056) ([@blink1073](https://github.com/blink1073))
+- Use `details` block in benchmark report [#11054](https://github.com/jupyterlab/jupyterlab/pull/11054) ([@fcollonval](https://github.com/fcollonval))
+- Constrain ipykernel version on CI [#11052](https://github.com/jupyterlab/jupyterlab/pull/11052) ([@fcollonval](https://github.com/fcollonval))
+- Fix benchmark PR commenting for forks [#11047](https://github.com/jupyterlab/jupyterlab/pull/11047) ([@fcollonval](https://github.com/fcollonval))
+- Fix prettier error [#11043](https://github.com/jupyterlab/jupyterlab/pull/11043) ([@fcollonval](https://github.com/fcollonval))
+- Use JupyterLab Probot for Binder Links [#11039](https://github.com/jupyterlab/jupyterlab/pull/11039) ([@blink1073](https://github.com/blink1073))
+- Make debugger jest test more robust [#11032](https://github.com/jupyterlab/jupyterlab/pull/11032) ([@fcollonval](https://github.com/fcollonval))
+- Add benchmark tests [#10936](https://github.com/jupyterlab/jupyterlab/pull/10936) ([@fcollonval](https://github.com/fcollonval))
+
+### API and Breaking Changes
+
+- Add benchmark tests [#10936](https://github.com/jupyterlab/jupyterlab/pull/10936) ([@fcollonval](https://github.com/fcollonval))
+
+### Other merged PRs
+
+- Remove status bar item flickering [#11065](https://github.com/jupyterlab/jupyterlab/pull/11065) ([@fcollonval](https://github.com/fcollonval))
+- use path.posix explicitly for URLs [#11048](https://github.com/jupyterlab/jupyterlab/pull/11048) ([@mbektas](https://github.com/mbektas))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-09-08&to=2021-09-13&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-09-08..2021-09-13&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-09-08..2021-09-13&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-09-08..2021-09-13&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2021-09-08..2021-09-13&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-09-08..2021-09-13&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-09-08..2021-09-13&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-09-08..2021-09-13&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-09-08..2021-09-13&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-09-08..2021-09-13&type=Issues) | [@legendb317](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Alegendb317+updated%3A2021-09-08..2021-09-13&type=Issues) | [@mbektas](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ambektas+updated%3A2021-09-08..2021-09-13&type=Issues) | [@Mithil467](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AMithil467+updated%3A2021-09-08..2021-09-13&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 4.0.0a8
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v4.0.0a7...094056ad2d728327dbeef26aabeee29ece584487))
@@ -44,8 +85,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-09-01&to=2021-09-08&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-09-01..2021-09-08&type=Issues) | [@bsyouness](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Absyouness+updated%3A2021-09-01..2021-09-08&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2021-09-01..2021-09-08&type=Issues) | [@dmonad](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Admonad+updated%3A2021-09-01..2021-09-08&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-09-01..2021-09-08&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-09-01..2021-09-08&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-09-01..2021-09-08&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-09-01..2021-09-08&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-09-01..2021-09-08&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 4.0.0a7
 


### PR DESCRIPTION
Automated Changelog Entry for 4.0.0a9 on master
Python version: 4.0.0a9
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/application-top: 3.3.0-alpha.9
@jupyterlab/example-federated: 2.4.0-alpha.9
@jupyterlab/example-cell: 3.3.0-alpha.9
@jupyterlab/example-filebrowser: 3.3.0-alpha.9
@jupyterlab/example-console: 3.3.0-alpha.9
@jupyterlab/example-notebook: 3.3.0-alpha.9
@jupyterlab/example-app: 3.3.0-alpha.9
@jupyterlab/example-terminal: 3.3.0-alpha.9
@jupyterlab/example-federated-core: 2.4.0-alpha.9
@jupyterlab/example-federated-md: 2.4.0-alpha.9
@jupyterlab/example-federated-middle: 2.4.0-alpha.9
@jupyterlab/example-federated-phosphor: 2.4.0-alpha.9
@jupyterlab/services: 6.3.0-alpha.9
@jupyterlab/completer: 3.3.0-alpha.9
@jupyterlab/vega5-extension: 3.3.0-alpha.9
@jupyterlab/rendermime-interfaces: 3.3.0-alpha.9
@jupyterlab/outputarea: 3.3.0-alpha.9
@jupyterlab/terminal-extension: 3.3.0-alpha.9
@jupyterlab/tooltip-extension: 3.3.0-alpha.9
@jupyterlab/translation-extension: 3.3.0-alpha.9
@jupyterlab/csvviewer-extension: 3.3.0-alpha.9
@jupyterlab/documentsearch-extension: 3.3.0-alpha.9
@jupyterlab/attachments: 3.3.0-alpha.9
@jupyterlab/ui-components-extension: 3.3.0-alpha.9
@jupyterlab/javascript-extension: 3.3.0-alpha.9
@jupyterlab/console-extension: 3.3.0-alpha.9
@jupyterlab/pdf-extension: 3.3.0-alpha.9
@jupyterlab/apputils: 3.3.0-alpha.9
@jupyterlab/codemirror: 3.3.0-alpha.9
@jupyterlab/toc: 5.3.0-alpha.9
@jupyterlab/logconsole: 3.3.0-alpha.9
@jupyterlab/extensionmanager: 3.3.0-alpha.9
@jupyterlab/help-extension: 3.3.0-alpha.9
@jupyterlab/running-extension: 3.3.0-alpha.9
@jupyterlab/statedb: 3.3.0-alpha.9
@jupyterlab/translation: 3.3.0-alpha.9
@jupyterlab/mainmenu-extension: 3.3.0-alpha.9
@jupyterlab/hub-extension: 3.3.0-alpha.9
@jupyterlab/fileeditor: 3.3.0-alpha.9
@jupyterlab/inspector-extension: 3.3.0-alpha.9
@jupyterlab/rendermime-extension: 3.3.0-alpha.9
@jupyterlab/docregistry: 3.3.0-alpha.9
@jupyterlab/rendermime: 3.3.0-alpha.9
@jupyterlab/mathjax2-extension: 3.3.0-alpha.9
@jupyterlab/theme-light-extension: 3.3.0-alpha.9
@jupyterlab/docprovider-extension: 3.3.0-alpha.9
@jupyterlab/extensionmanager-extension: 3.3.0-alpha.9
@jupyterlab/debugger: 3.3.0-alpha.9
@jupyterlab/htmlviewer: 3.3.0-alpha.9
@jupyterlab/statusbar-extension: 3.3.0-alpha.9
@jupyterlab/logconsole-extension: 3.3.0-alpha.9
@jupyterlab/shortcuts-extension: 3.3.0-alpha.9
@jupyterlab/codemirror-extension: 3.3.0-alpha.9
@jupyterlab/notebook-extension: 3.3.0-alpha.9
@jupyterlab/fileeditor-extension: 3.3.0-alpha.9
@jupyterlab/json-extension: 3.3.0-alpha.9
@jupyterlab/mathjax2: 3.3.0-alpha.9
@jupyterlab/shared-models: 3.3.0-alpha.9
@jupyterlab/filebrowser: 3.3.0-alpha.9
@jupyterlab/metapackage: 3.3.0-alpha.9
@jupyterlab/celltags-extension: 3.3.0-alpha.9
@jupyterlab/launcher: 3.3.0-alpha.9
@jupyterlab/vdom: 3.3.0-alpha.9
@jupyterlab/cells: 3.3.0-alpha.9
@jupyterlab/coreutils: 5.3.0-alpha.9
@jupyterlab/application-extension: 3.3.0-alpha.9
@jupyterlab/vdom-extension: 3.3.0-alpha.9
@jupyterlab/settingregistry: 3.3.0-alpha.9
@jupyterlab/application: 3.3.0-alpha.9
@jupyterlab/docmanager: 3.3.0-alpha.9
@jupyterlab/debugger-extension: 3.3.0-alpha.9
@jupyterlab/console: 3.3.0-alpha.9
@jupyterlab/completer-extension: 3.3.0-alpha.9
@jupyterlab/property-inspector: 3.3.0-alpha.9
@jupyterlab/filebrowser-extension: 3.3.0-alpha.9
@jupyterlab/notebook: 3.3.0-alpha.9
@jupyterlab/imageviewer-extension: 3.3.0-alpha.9
@jupyterlab/toc-extension: 5.3.0-alpha.9
@jupyterlab/imageviewer: 3.3.0-alpha.9
@jupyterlab/nbformat: 3.3.0-alpha.9
@jupyterlab/nbconvert-css: 3.3.0-alpha.9
@jupyterlab/codeeditor: 3.3.0-alpha.9
@jupyterlab/documentsearch: 3.3.0-alpha.9
@jupyterlab/mainmenu: 3.3.0-alpha.9
@jupyterlab/theme-dark-extension: 3.3.0-alpha.9
@jupyterlab/csvviewer: 3.3.0-alpha.9
@jupyterlab/docmanager-extension: 3.3.0-alpha.9
@jupyterlab/ui-components: 3.3.0-alpha.9
@jupyterlab/settingeditor: 3.3.0-alpha.9
@jupyterlab/statusbar: 3.3.0-alpha.9
@jupyterlab/docprovider: 3.3.0-alpha.9
@jupyterlab/observables: 4.3.0-alpha.9
@jupyterlab/htmlviewer-extension: 3.3.0-alpha.9
@jupyterlab/markdownviewer-extension: 3.3.0-alpha.9
@jupyterlab/settingeditor-extension: 3.3.0-alpha.9
@jupyterlab/inspector: 3.3.0-alpha.9
@jupyterlab/terminal: 3.3.0-alpha.9
@jupyterlab/markdownviewer: 3.3.0-alpha.9
@jupyterlab/celltags: 3.3.0-alpha.9
@jupyterlab/apputils-extension: 3.3.0-alpha.9
@jupyterlab/tooltip: 3.3.0-alpha.9
@jupyterlab/launcher-extension: 3.3.0-alpha.9
@jupyterlab/running: 3.3.0-alpha.9
node-example: 3.3.0-alpha.9
@jupyterlab/example-services-browser: 3.3.0-alpha.9
@jupyterlab/example-services-outputarea: 3.3.0-alpha.9
@jupyterlab/builder: 3.3.0-alpha.9
@jupyterlab/buildutils: 3.3.0-alpha.9
@jupyterlab/template: 3.3.0-alpha.9
@jupyterlab/galata: 4.3.0-alpha.9
@jupyterlab/testutils: 3.3.0-alpha.9
@jupyterlab/mock-extension: 3.3.0-alpha.9
@jupyterlab/mock-token: 3.3.0-alpha.9
@jupyterlab/mock-provider: 3.3.0-alpha.9
@jupyterlab/mock-consumer: 3.3.0-alpha.9

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | master  |
| Version Spec | next |
| Since | v4.0.0a8 |