### PR TITLE
Remove retry part from test folder name

### DIFF
--- a/galata/src/fixtures.ts
+++ b/galata/src/fixtures.ts
@@ -239,7 +239,8 @@ export const test: TestType<
    */
   tmpPath: async ({ baseURL, serverFiles }, use, testInfo) => {
     const parts = testInfo.outputDir.split('/');
-    const testFolder = parts[parts.length - 1];
+    // Remove appended retry part for reproductibility
+    const testFolder = parts[parts.length - 1].replace(/-retry\d+$/ig, '');
 
     const contents = new ContentsHelper(baseURL!);
 

--- a/galata/src/fixtures.ts
+++ b/galata/src/fixtures.ts
@@ -239,7 +239,7 @@ export const test: TestType<
    */
   tmpPath: async ({ baseURL, serverFiles }, use, testInfo) => {
     const parts = testInfo.outputDir.split('/');
-    // Remove appended retry part for reproductibility
+    // Remove appended retry part for reproducibility
     const testFolder = parts[parts.length - 1].replace(/-retry\d+$/i, '');
 
     const contents = new ContentsHelper(baseURL!);

--- a/galata/src/fixtures.ts
+++ b/galata/src/fixtures.ts
@@ -240,7 +240,7 @@ export const test: TestType<
   tmpPath: async ({ baseURL, serverFiles }, use, testInfo) => {
     const parts = testInfo.outputDir.split('/');
     // Remove appended retry part for reproductibility
-    const testFolder = parts[parts.length - 1].replace(/-retry\d+$/ig, '');
+    const testFolder = parts[parts.length - 1].replace(/-retry\d+$/i, '');
 
     const contents = new ContentsHelper(baseURL!);
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Follow-up https://github.com/jupyterlab/jupyterlab/pull/10868#issuecomment-918321577

When retrying a Playwright test, the unique test output name contains that information (`-retry\d+`). This removes 
that part of the name to create the temporary test folder for reproducibility (in particular in screenshots)

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
N/A

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A