### PR TITLE
Automated Changelog Entry for 3.1.12 on 3.1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.1.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.1.12
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.1.11...1af92c9bbae0eab61938bbbba0ae8cc5e9b59fdd))
+
+### Bugs fixed
+
+- Retain the rtc lock until the user releases it [#11026](https://github.com/jupyterlab/jupyterlab/pull/11026) ([@hbcarlos](https://github.com/hbcarlos))
+- Backport PR #11031 on branch 3.1.x (Use posix paths explicitly) [#11045](https://github.com/jupyterlab/jupyterlab/pull/11045) ([@Mithil467](https://github.com/Mithil467))
+- Adds the variable reference to the key of the component [#11029](https://github.com/jupyterlab/jupyterlab/pull/11029) ([@hbcarlos](https://github.com/hbcarlos))
+
+### Maintenance and upkeep improvements
+
+- Clean up bumpversion [#11056](https://github.com/jupyterlab/jupyterlab/pull/11056) ([@blink1073](https://github.com/blink1073))
+- Make debugger jest test more robust [#11032](https://github.com/jupyterlab/jupyterlab/pull/11032) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+- Added Table of contents (toc.rst) to user guide documentation [#10699](https://github.com/jupyterlab/jupyterlab/pull/10699) ([@AnudeepGunukula](https://github.com/AnudeepGunukula))
+
+### Other merged PRs
+
+- Remove status bar item flickering [#11065](https://github.com/jupyterlab/jupyterlab/pull/11065) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #10954 on branch 3.1.x (Improve release notes for 3.1) [#11053](https://github.com/jupyterlab/jupyterlab/pull/11053) ([@Mithil467](https://github.com/Mithil467))
+- use path.posix explicitly for URLs [#11048](https://github.com/jupyterlab/jupyterlab/pull/11048) ([@mbektas](https://github.com/mbektas))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-09-08&to=2021-09-14&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-09-08..2021-09-14&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-09-08..2021-09-14&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-09-08..2021-09-14&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-09-08..2021-09-14&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-09-08..2021-09-14&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-09-08..2021-09-14&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-09-08..2021-09-14&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-09-08..2021-09-14&type=Issues) | [@Mithil467](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AMithil467+updated%3A2021-09-08..2021-09-14&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.1.11
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.1.10...f04391135c11c6c5e3e8c4706ec26e675f0db4d6))
@@ -36,8 +69,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.1.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-09-01&to=2021-09-08&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-09-01..2021-09-08&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-09-01..2021-09-08&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-09-01..2021-09-08&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-09-01..2021-09-08&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-09-01..2021-09-08&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-09-01..2021-09-08&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.1.10
 


### PR DESCRIPTION
Automated Changelog Entry for 3.1.12 on 3.1.x
Python version: 3.1.12
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/application-top: 3.1.12
@jupyterlab/example-federated: 2.2.11
@jupyterlab/example-cell: 3.1.11
@jupyterlab/example-filebrowser: 3.1.11
@jupyterlab/example-console: 3.1.11
@jupyterlab/example-notebook: 3.1.11
@jupyterlab/example-app: 3.1.12
@jupyterlab/example-terminal: 3.1.11
@jupyterlab/example-federated-core: 2.2.12
@jupyterlab/example-federated-md: 2.2.12
@jupyterlab/example-federated-middle: 2.2.12
@jupyterlab/example-federated-phosphor: 2.2.12
@jupyterlab/services: 6.1.11
@jupyterlab/completer: 3.1.11
@jupyterlab/vega5-extension: 3.1.12
@jupyterlab/rendermime-interfaces: 3.1.11
@jupyterlab/outputarea: 3.1.11
@jupyterlab/terminal-extension: 3.1.11
@jupyterlab/tooltip-extension: 3.1.11
@jupyterlab/translation-extension: 3.1.11
@jupyterlab/csvviewer-extension: 3.1.11
@jupyterlab/documentsearch-extension: 3.1.11
@jupyterlab/attachments: 3.1.11
@jupyterlab/ui-components-extension: 3.1.11
@jupyterlab/javascript-extension: 3.1.12
@jupyterlab/console-extension: 3.1.11
@jupyterlab/pdf-extension: 3.1.11
@jupyterlab/apputils: 3.1.11
@jupyterlab/codemirror: 3.1.11
@jupyterlab/toc: 5.1.11
@jupyterlab/logconsole: 3.1.11
@jupyterlab/extensionmanager: 3.1.11
@jupyterlab/help-extension: 3.1.11
@jupyterlab/running-extension: 3.1.11
@jupyterlab/statedb: 3.1.11
@jupyterlab/translation: 3.1.11
@jupyterlab/mainmenu-extension: 3.1.11
@jupyterlab/hub-extension: 3.1.11
@jupyterlab/fileeditor: 3.1.11
@jupyterlab/inspector-extension: 3.1.11
@jupyterlab/rendermime-extension: 3.1.11
@jupyterlab/docregistry: 3.1.11
@jupyterlab/rendermime: 3.1.11
@jupyterlab/mathjax2-extension: 3.1.11
@jupyterlab/theme-light-extension: 3.1.11
@jupyterlab/docprovider-extension: 3.1.11
@jupyterlab/extensionmanager-extension: 3.1.11
@jupyterlab/debugger: 3.1.11
@jupyterlab/htmlviewer: 3.1.11
@jupyterlab/statusbar-extension: 3.1.11
@jupyterlab/logconsole-extension: 3.1.11
@jupyterlab/shortcuts-extension: 3.1.11
@jupyterlab/codemirror-extension: 3.1.11
@jupyterlab/notebook-extension: 3.1.11
@jupyterlab/fileeditor-extension: 3.1.11
@jupyterlab/json-extension: 3.1.12
@jupyterlab/mathjax2: 3.1.11
@jupyterlab/shared-models: 3.1.11
@jupyterlab/filebrowser: 3.1.11
@jupyterlab/metapackage: 3.1.12
@jupyterlab/celltags-extension: 3.1.11
@jupyterlab/launcher: 3.1.11
@jupyterlab/vdom: 3.1.12
@jupyterlab/cells: 3.1.11
@jupyterlab/coreutils: 5.1.11
@jupyterlab/application-extension: 3.1.11
@jupyterlab/vdom-extension: 3.1.12
@jupyterlab/settingregistry: 3.1.11
@jupyterlab/application: 3.1.11
@jupyterlab/docmanager: 3.1.11
@jupyterlab/debugger-extension: 3.1.11
@jupyterlab/console: 3.1.11
@jupyterlab/completer-extension: 3.1.11
@jupyterlab/property-inspector: 3.1.11
@jupyterlab/filebrowser-extension: 3.1.11
@jupyterlab/notebook: 3.1.11
@jupyterlab/imageviewer-extension: 3.1.11
@jupyterlab/toc-extension: 5.1.11
@jupyterlab/imageviewer: 3.1.11
@jupyterlab/nbformat: 3.1.11
@jupyterlab/nbconvert-css: 3.1.11
@jupyterlab/codeeditor: 3.1.11
@jupyterlab/documentsearch: 3.1.11
@jupyterlab/mainmenu: 3.1.11
@jupyterlab/theme-dark-extension: 3.1.11
@jupyterlab/csvviewer: 3.1.11
@jupyterlab/docmanager-extension: 3.1.11
@jupyterlab/ui-components: 3.1.11
@jupyterlab/settingeditor: 3.1.11
@jupyterlab/statusbar: 3.1.11
@jupyterlab/docprovider: 3.1.11
@jupyterlab/observables: 4.1.11
@jupyterlab/htmlviewer-extension: 3.1.11
@jupyterlab/markdownviewer-extension: 3.1.11
@jupyterlab/settingeditor-extension: 3.1.11
@jupyterlab/inspector: 3.1.11
@jupyterlab/terminal: 3.1.11
@jupyterlab/markdownviewer: 3.1.11
@jupyterlab/celltags: 3.1.11
@jupyterlab/apputils-extension: 3.1.12
@jupyterlab/tooltip: 3.1.11
@jupyterlab/launcher-extension: 3.1.11
@jupyterlab/running: 3.1.11
node-example: 3.1.11
@jupyterlab/example-services-browser: 3.1.11
@jupyterlab/example-services-outputarea: 3.1.11
@jupyterlab/builder: 3.1.12
@jupyterlab/buildutils: 3.1.12
@jupyterlab/template: 3.1.11
@jupyterlab/testutils: 3.1.11
@jupyterlab/mock-extension: 3.1.12
@jupyterlab/mock-token: 3.1.11
@jupyterlab/mock-provider: 3.1.12
@jupyterlab/mock-consumer: 3.1.12

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.1.x  |
| Version Spec | next |
| Since | v3.1.11 |