### PR TITLE
Revert "Constrain ipykernel version on CI"

### DIFF
--- a/scripts/ci_install.sh
+++ b/scripts/ci_install.sh
@@ -20,10 +20,6 @@ pip install -q --upgrade pip --user
 pip --version
 # Show a verbose install if the install fails, for debugging
 pip install -e ".[test]" || pip install -v -e ".[test]"
-
-# TODO Temporary fix for https://github.com/ipython/ipykernel/issues/770
-pip install -U "ipykernel<6.4.0"
-
 jlpm versions
 jlpm config current
 


### PR DESCRIPTION
Reverts jupyterlab/jupyterlab#11052 as this pin should not be needed anymore.