### PR TITLE
Add a note on the Jupyter Releaser in the extension tutorial

### DIFF
--- a/docs/source/extension/extension_tutorial.rst
+++ b/docs/source/extension/extension_tutorial.rst
@@ -966,6 +966,22 @@ You may want to also publish your extension as a JavaScript package to the
    package to npm so other extensions can depend on it and import and require
    your token.
 
+
+Automated Releases
+~~~~~~~~~~~~~~~~~~
+
+If you used the cookiecutter to bootstrap your extension, the repository should already
+be compatible with the `Jupyter Releaser <https://github.com/jupyter-server/jupyter_releaser>`_.
+
+The Jupyter Releaser provides a set of GitHub Actions Workflows to:
+
+- Generate a new entry in the Changelog
+- Draft a new release
+- Publish the release to ``PyPI`` and ``npm``
+
+For more information on how to run the release workflows,
+check out the documentation: https://github.com/jupyter-server/jupyter_releaser
+
 Learn more
 ----------
 

--- a/docs/source/extension/extension_tutorial.rst
+++ b/docs/source/extension/extension_tutorial.rst
@@ -968,7 +968,7 @@ You may want to also publish your extension as a JavaScript package to the
 
 
 Automated Releases
-~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^
 
 If you used the cookiecutter to bootstrap your extension, the repository should already
 be compatible with the `Jupyter Releaser <https://github.com/jupyter-server/jupyter_releaser>`_.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

The [extension cookiecutter](https://github.com/jupyterlab/extension-cookiecutter-ts) should now be compatible with the [Jupyter Releaser](https://github.com/jupyter-server/jupyter_releaser) for making automated releases.

## Code changes

Documentation changes.

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
