### PR TITLE
Automated Changelog Entry for 4.0.0a10 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 4.0.0a10
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v4.0.0a9...52f961be656da60e2a39ef502de7991ee0436e26))
+
+### Enhancements made
+
+- Remove retry part from test folder name [#11070](https://github.com/jupyterlab/jupyterlab/pull/11070) ([@fcollonval](https://github.com/fcollonval))
+
+### Bugs fixed
+
+- Indent comments (#6957) [#11063](https://github.com/jupyterlab/jupyterlab/pull/11063) ([@josephrocca](https://github.com/josephrocca))
+- Retain the rtc lock until the user releases it [#11026](https://github.com/jupyterlab/jupyterlab/pull/11026) ([@hbcarlos](https://github.com/hbcarlos))
+- Fix user preferences not being considered for Text Editor [#10868](https://github.com/jupyterlab/jupyterlab/pull/10868) ([@Mithil467](https://github.com/Mithil467))
+- Improve resizing behavior of debugger panels [#10653](https://github.com/jupyterlab/jupyterlab/pull/10653) ([@trungleduc](https://github.com/trungleduc))
+
+### Maintenance and upkeep improvements
+
+- Skip flaky debugger test [#11083](https://github.com/jupyterlab/jupyterlab/pull/11083) ([@fcollonval](https://github.com/fcollonval))
+- Fix/duplicate-statement [#11082](https://github.com/jupyterlab/jupyterlab/pull/11082) ([@fcollonval](https://github.com/fcollonval))
+- Revert "Constrain ipykernel version on CI" [#11076](https://github.com/jupyterlab/jupyterlab/pull/11076) ([@jtpio](https://github.com/jtpio))
+- Check changes on translatable strings [#11036](https://github.com/jupyterlab/jupyterlab/pull/11036) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+- Split settings schema for inclusion in documentation [#11067](https://github.com/jupyterlab/jupyterlab/pull/11067) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-09-13&to=2021-09-15&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-09-13..2021-09-15&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-09-13..2021-09-15&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-09-13..2021-09-15&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2021-09-13..2021-09-15&type=Issues) | [@josephrocca](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajosephrocca+updated%3A2021-09-13..2021-09-15&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-09-13..2021-09-15&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-09-13..2021-09-15&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-09-13..2021-09-15&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-09-13..2021-09-15&type=Issues) | [@Mithil467](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AMithil467+updated%3A2021-09-13..2021-09-15&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrungleduc+updated%3A2021-09-13..2021-09-15&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-09-13..2021-09-15&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 4.0.0a9
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v4.0.0a8...d103ccc3d16db524bed90fb1eebb6ce7616e224f))
@@ -46,8 +80,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-09-08&to=2021-09-13&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-09-08..2021-09-13&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-09-08..2021-09-13&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-09-08..2021-09-13&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2021-09-08..2021-09-13&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-09-08..2021-09-13&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-09-08..2021-09-13&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-09-08..2021-09-13&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-09-08..2021-09-13&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-09-08..2021-09-13&type=Issues) | [@legendb317](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Alegendb317+updated%3A2021-09-08..2021-09-13&type=Issues) | [@mbektas](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ambektas+updated%3A2021-09-08..2021-09-13&type=Issues) | [@Mithil467](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AMithil467+updated%3A2021-09-08..2021-09-13&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 4.0.0a8
 


### PR DESCRIPTION
Automated Changelog Entry for 4.0.0a10 on master
Python version: 4.0.0a10
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/application-top: 3.3.0-alpha.10
@jupyterlab/example-federated: 2.4.0-alpha.10
@jupyterlab/example-cell: 3.3.0-alpha.10
@jupyterlab/example-filebrowser: 3.3.0-alpha.10
@jupyterlab/example-console: 3.3.0-alpha.10
@jupyterlab/example-notebook: 3.3.0-alpha.10
@jupyterlab/example-app: 3.3.0-alpha.10
@jupyterlab/example-terminal: 3.3.0-alpha.10
@jupyterlab/example-federated-core: 2.4.0-alpha.10
@jupyterlab/example-federated-md: 2.4.0-alpha.10
@jupyterlab/example-federated-middle: 2.4.0-alpha.10
@jupyterlab/example-federated-phosphor: 2.4.0-alpha.10
@jupyterlab/services: 6.3.0-alpha.10
@jupyterlab/completer: 3.3.0-alpha.10
@jupyterlab/vega5-extension: 3.3.0-alpha.10
@jupyterlab/rendermime-interfaces: 3.3.0-alpha.10
@jupyterlab/outputarea: 3.3.0-alpha.10
@jupyterlab/terminal-extension: 3.3.0-alpha.10
@jupyterlab/tooltip-extension: 3.3.0-alpha.10
@jupyterlab/translation-extension: 3.3.0-alpha.10
@jupyterlab/csvviewer-extension: 3.3.0-alpha.10
@jupyterlab/documentsearch-extension: 3.3.0-alpha.10
@jupyterlab/attachments: 3.3.0-alpha.10
@jupyterlab/ui-components-extension: 3.3.0-alpha.10
@jupyterlab/javascript-extension: 3.3.0-alpha.10
@jupyterlab/console-extension: 3.3.0-alpha.10
@jupyterlab/pdf-extension: 3.3.0-alpha.10
@jupyterlab/apputils: 3.3.0-alpha.10
@jupyterlab/codemirror: 3.3.0-alpha.10
@jupyterlab/toc: 5.3.0-alpha.10
@jupyterlab/logconsole: 3.3.0-alpha.10
@jupyterlab/extensionmanager: 3.3.0-alpha.10
@jupyterlab/help-extension: 3.3.0-alpha.10
@jupyterlab/running-extension: 3.3.0-alpha.10
@jupyterlab/statedb: 3.3.0-alpha.10
@jupyterlab/translation: 3.3.0-alpha.10
@jupyterlab/mainmenu-extension: 3.3.0-alpha.10
@jupyterlab/hub-extension: 3.3.0-alpha.10
@jupyterlab/fileeditor: 3.3.0-alpha.10
@jupyterlab/inspector-extension: 3.3.0-alpha.10
@jupyterlab/rendermime-extension: 3.3.0-alpha.10
@jupyterlab/docregistry: 3.3.0-alpha.10
@jupyterlab/rendermime: 3.3.0-alpha.10
@jupyterlab/mathjax2-extension: 3.3.0-alpha.10
@jupyterlab/theme-light-extension: 3.3.0-alpha.10
@jupyterlab/docprovider-extension: 3.3.0-alpha.10
@jupyterlab/extensionmanager-extension: 3.3.0-alpha.10
@jupyterlab/debugger: 3.3.0-alpha.10
@jupyterlab/htmlviewer: 3.3.0-alpha.10
@jupyterlab/statusbar-extension: 3.3.0-alpha.10
@jupyterlab/logconsole-extension: 3.3.0-alpha.10
@jupyterlab/shortcuts-extension: 3.3.0-alpha.10
@jupyterlab/codemirror-extension: 3.3.0-alpha.10
@jupyterlab/notebook-extension: 3.3.0-alpha.10
@jupyterlab/fileeditor-extension: 3.3.0-alpha.10
@jupyterlab/json-extension: 3.3.0-alpha.10
@jupyterlab/mathjax2: 3.3.0-alpha.10
@jupyterlab/shared-models: 3.3.0-alpha.10
@jupyterlab/filebrowser: 3.3.0-alpha.10
@jupyterlab/metapackage: 3.3.0-alpha.10
@jupyterlab/celltags-extension: 3.3.0-alpha.10
@jupyterlab/launcher: 3.3.0-alpha.10
@jupyterlab/vdom: 3.3.0-alpha.10
@jupyterlab/cells: 3.3.0-alpha.10
@jupyterlab/coreutils: 5.3.0-alpha.10
@jupyterlab/application-extension: 3.3.0-alpha.10
@jupyterlab/vdom-extension: 3.3.0-alpha.10
@jupyterlab/settingregistry: 3.3.0-alpha.10
@jupyterlab/application: 3.3.0-alpha.10
@jupyterlab/docmanager: 3.3.0-alpha.10
@jupyterlab/debugger-extension: 3.3.0-alpha.10
@jupyterlab/console: 3.3.0-alpha.10
@jupyterlab/completer-extension: 3.3.0-alpha.10
@jupyterlab/property-inspector: 3.3.0-alpha.10
@jupyterlab/filebrowser-extension: 3.3.0-alpha.10
@jupyterlab/notebook: 3.3.0-alpha.10
@jupyterlab/imageviewer-extension: 3.3.0-alpha.10
@jupyterlab/toc-extension: 5.3.0-alpha.10
@jupyterlab/imageviewer: 3.3.0-alpha.10
@jupyterlab/nbformat: 3.3.0-alpha.10
@jupyterlab/nbconvert-css: 3.3.0-alpha.10
@jupyterlab/codeeditor: 3.3.0-alpha.10
@jupyterlab/documentsearch: 3.3.0-alpha.10
@jupyterlab/mainmenu: 3.3.0-alpha.10
@jupyterlab/theme-dark-extension: 3.3.0-alpha.10
@jupyterlab/csvviewer: 3.3.0-alpha.10
@jupyterlab/docmanager-extension: 3.3.0-alpha.10
@jupyterlab/ui-components: 3.3.0-alpha.10
@jupyterlab/settingeditor: 3.3.0-alpha.10
@jupyterlab/statusbar: 3.3.0-alpha.10
@jupyterlab/docprovider: 3.3.0-alpha.10
@jupyterlab/observables: 4.3.0-alpha.10
@jupyterlab/htmlviewer-extension: 3.3.0-alpha.10
@jupyterlab/markdownviewer-extension: 3.3.0-alpha.10
@jupyterlab/settingeditor-extension: 3.3.0-alpha.10
@jupyterlab/inspector: 3.3.0-alpha.10
@jupyterlab/terminal: 3.3.0-alpha.10
@jupyterlab/markdownviewer: 3.3.0-alpha.10
@jupyterlab/celltags: 3.3.0-alpha.10
@jupyterlab/apputils-extension: 3.3.0-alpha.10
@jupyterlab/tooltip: 3.3.0-alpha.10
@jupyterlab/launcher-extension: 3.3.0-alpha.10
@jupyterlab/running: 3.3.0-alpha.10
node-example: 3.3.0-alpha.10
@jupyterlab/example-services-browser: 3.3.0-alpha.10
@jupyterlab/example-services-outputarea: 3.3.0-alpha.10
@jupyterlab/builder: 3.3.0-alpha.10
@jupyterlab/buildutils: 3.3.0-alpha.10
@jupyterlab/template: 3.3.0-alpha.10
@jupyterlab/galata: 4.3.0-alpha.10
@jupyterlab/testutils: 3.3.0-alpha.10
@jupyterlab/mock-extension: 3.3.0-alpha.10
@jupyterlab/mock-token: 3.3.0-alpha.10
@jupyterlab/mock-provider: 3.3.0-alpha.10
@jupyterlab/mock-consumer: 3.3.0-alpha.10

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | master  |
| Version Spec | next |
| Since Last Stable | true |