### PR TITLE
Fetch translations via the `ServerConnection.ISettings`

### DIFF
--- a/packages/translation-extension/src/index.ts
+++ b/packages/translation-extension/src/index.ts
@@ -50,9 +50,11 @@ const translator: JupyterFrontEndPlugin<ITranslator> = {
     const displayStringsPrefix: boolean = setting.get('displayStringsPrefix')
       .composite as boolean;
     stringsPrefix = displayStringsPrefix ? stringsPrefix : '';
+    const serverSettings = app.serviceManager.serverSettings;
     const translationManager = new TranslationManager(
       paths.urls.translations,
-      stringsPrefix
+      stringsPrefix,
+      serverSettings
     );
     await translationManager.fetch(currentLocale);
     return translationManager;
@@ -104,8 +106,9 @@ const langMenu: JupyterFrontEndPlugin<void> = {
 
         let command: string;
 
+        const serverSettings = app.serviceManager.serverSettings;
         // Get list of available locales
-        requestTranslationsAPI<any>('')
+        requestTranslationsAPI<any>('', '', {}, serverSettings)
           .then(data => {
             for (const locale in data['data']) {
               const value = data['data'][locale];

--- a/packages/translation/src/manager.ts
+++ b/packages/translation/src/manager.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import { ServerConnection } from '@jupyterlab/services';
 import { Gettext } from './gettext';
 import { ITranslator, TranslationBundle, TranslatorConnector } from './tokens';
 import { normalizeDomain } from './utils';
@@ -9,8 +10,12 @@ import { normalizeDomain } from './utils';
  * Translation Manager
  */
 export class TranslationManager implements ITranslator {
-  constructor(translationsUrl: string = '', stringsPrefix?: string) {
-    this._connector = new TranslatorConnector(translationsUrl);
+  constructor(
+    translationsUrl: string = '',
+    stringsPrefix?: string,
+    serverSettings?: ServerConnection.ISettings
+  ) {
+    this._connector = new TranslatorConnector(translationsUrl, serverSettings);
     this._stringsPrefix = stringsPrefix || '';
     this._englishBundle = new Gettext({ stringsPrefix: this._stringsPrefix });
   }

--- a/packages/translation/src/server.ts
+++ b/packages/translation/src/server.ts
@@ -2,7 +2,13 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { URLExt } from '@jupyterlab/coreutils';
+
 import { ServerConnection } from '@jupyterlab/services';
+
+/**
+ * The url for the translations service.
+ */
+const TRANSLATIONS_SETTINGS_URL = 'api/translations';
 
 /**
  * Call the API extension
@@ -14,11 +20,13 @@ import { ServerConnection } from '@jupyterlab/services';
 export async function requestTranslationsAPI<T>(
   translationsUrl: string = '',
   locale = '',
-  init: RequestInit = {}
+  init: RequestInit = {},
+  serverSettings: ServerConnection.ISettings | undefined = undefined
 ): Promise<T> {
   // Make request to Jupyter API
-  const settings = ServerConnection.makeSettings();
-  translationsUrl = translationsUrl || `${settings.appUrl}/api/translations/`;
+  const settings = serverSettings ?? ServerConnection.makeSettings();
+  translationsUrl =
+    translationsUrl || `${settings.appUrl}/${TRANSLATIONS_SETTINGS_URL}/`;
   const requestUrl = URLExt.join(settings.baseUrl, translationsUrl, locale);
   let response: Response;
   try {

--- a/packages/translation/src/tokens.ts
+++ b/packages/translation/src/tokens.ts
@@ -3,6 +3,7 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
+import { ServerConnection } from '@jupyterlab/services';
 import { DataConnector, IDataConnector } from '@jupyterlab/statedb';
 import { Token } from '@lumino/coreutils';
 import { requestTranslationsAPI } from './server';
@@ -22,15 +23,25 @@ export const ITranslatorConnector = new Token<ITranslatorConnector>(
 export class TranslatorConnector
   extends DataConnector<Language, Language, { language: string }>
   implements ITranslatorConnector {
-  constructor(translationsUrl: string = '') {
+  constructor(
+    translationsUrl: string = '',
+    serverSettings?: ServerConnection.ISettings
+  ) {
     super();
     this._translationsUrl = translationsUrl;
+    this._serverSettings = serverSettings;
   }
 
   async fetch(opts: { language: string }): Promise<Language> {
-    return requestTranslationsAPI(this._translationsUrl, opts.language);
+    return requestTranslationsAPI(
+      this._translationsUrl,
+      opts.language,
+      {},
+      this._serverSettings
+    );
   }
 
+  private _serverSettings: ServerConnection.ISettings | undefined;
   private _translationsUrl: string;
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Other distributions like [JupyterLite](https://github.com/jupyterlite/jupyterlite/) use the `ServerConnection.ISettings` to route requests to a different place than the regular Jupyter Server backend. In the case of JupyterLite they go to an alternative Jupyter Server implementation running in the browser.

This change ensures the translation requests also go through the `ServiceManager`'s `ServerConnection.ISettings`, so alternate downstream application can have more control on the behavior and add support for localization.

## Code changes

Make the translation plugin fetch translation data using the `ServerConnection.ISettings`.

## User-facing changes

Enable users of downstream distributions like JupyterLite to switch their UI to other languages.

## Backwards-incompatible changes

New parameters are added as optional arguments, so this should be backward compatible so we can backport to 3.1.x.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
