### PR TITLE
use posix explicitly for PathExt

### DIFF
--- a/packages/coreutils/src/path.ts
+++ b/packages/coreutils/src/path.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import * as posix from 'path';
+import { posix } from 'path';
 
 /**
  * The namespace for path-related functions.


### PR DESCRIPTION
Similar to https://github.com/jupyterlab/jupyterlab/pull/11048, JupyterLab Desktop App is not working on Windows due to PathExt generating paths with backward slash `\`. In order to reproduce, install Windows App and try to open a directory in File Explorer (https://github.com/jupyterlab/jupyterlab_app/actions/runs/1242380607)

## Code changes

instead of using `path` which is platform dependent, now using `path.posix` for PathExt functions.

## User-facing changes

none

## Backwards-incompatible changes

none
