### PR TITLE
Add ability to hide the header bar in simple mode

### DIFF
--- a/packages/application-extension/schema/commands.json
+++ b/packages/application-extension/schema/commands.json
@@ -112,6 +112,10 @@
                   }
                 },
                 {
+                  "command": "application:toggle-header",
+                  "rank": 15
+                },
+                {
                   "type": "separator",
                   "rank": 50
                 },

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -77,6 +77,8 @@ namespace CommandIDs {
 
   export const resetLayout: string = 'application:reset-layout';
 
+  export const toggleHeader: string = 'application:toggle-header';
+
   export const toggleMode: string = 'application:toggle-mode';
 
   export const toggleLeftArea: string = 'application:toggle-left-area';
@@ -281,8 +283,19 @@ const mainCommands: JupyterFrontEndPlugin<void> = {
         }
       });
 
+      commands.addCommand(CommandIDs.toggleHeader, {
+        label: trans.__('Show Header'),
+        execute: () => {
+          if (labShell.mode === 'single-document') {
+            labShell.toggleTopInSimpleModeVisibility();
+          }
+        },
+        isToggled: () => labShell.isTopInSimpleModeVisible(),
+        isVisible: () => labShell.mode === 'single-document'
+      });
+
       commands.addCommand(CommandIDs.toggleLeftArea, {
-        label: () => trans.__('Show Left Sidebar'),
+        label: trans.__('Show Left Sidebar'),
         execute: () => {
           if (labShell.leftCollapsed) {
             labShell.expandLeft();
@@ -298,7 +311,7 @@ const mainCommands: JupyterFrontEndPlugin<void> = {
       });
 
       commands.addCommand(CommandIDs.toggleRightArea, {
-        label: () => trans.__('Show Right Sidebar'),
+        label: trans.__('Show Right Sidebar'),
         execute: () => {
           if (labShell.rightCollapsed) {
             labShell.expandRight();
@@ -381,6 +394,15 @@ const mainCommands: JupyterFrontEndPlugin<void> = {
               .catch(reason => {
                 console.error('Failed to undo presentation mode.', reason);
               });
+          }
+          // Display title header
+          if (
+            labShell.mode === 'single-document' &&
+            !labShell.isTopInSimpleModeVisible()
+          ) {
+            commands.execute(CommandIDs.resetLayout).catch(reason => {
+              console.error('Failed to display title header.', reason);
+            });
           }
           // Display side tabbar
           (['left', 'right'] as ('left' | 'right')[]).forEach(side => {

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -395,12 +395,12 @@ const mainCommands: JupyterFrontEndPlugin<void> = {
                 console.error('Failed to undo presentation mode.', reason);
               });
           }
-          // Display title header
+          // Display top header
           if (
             labShell.mode === 'single-document' &&
             !labShell.isTopInSimpleModeVisible()
           ) {
-            commands.execute(CommandIDs.resetLayout).catch(reason => {
+            commands.execute(CommandIDs.toggleHeader).catch(reason => {
               console.error('Failed to display title header.', reason);
             });
           }
@@ -434,6 +434,7 @@ const mainCommands: JupyterFrontEndPlugin<void> = {
         CommandIDs.closeAll,
         CommandIDs.closeOtherTabs,
         CommandIDs.closeRightTabs,
+        CommandIDs.toggleHeader,
         CommandIDs.toggleLeftArea,
         CommandIDs.toggleRightArea,
         CommandIDs.togglePresentationMode,

--- a/packages/application/src/layoutrestorer.ts
+++ b/packages/application/src/layoutrestorer.ts
@@ -162,6 +162,7 @@ export class LayoutRestorer implements ILayoutRestorer {
       downArea: null,
       leftArea: null,
       rightArea: null,
+      topArea: null,
       relativeSizes: null
     };
     const layout = this._connector.fetch(KEY);
@@ -178,7 +179,8 @@ export class LayoutRestorer implements ILayoutRestorer {
         down,
         left,
         right,
-        relativeSizes
+        relativeSizes,
+        top
       } = data as Private.ILayout;
 
       // If any data exists, then this is not a fresh session.
@@ -202,7 +204,8 @@ export class LayoutRestorer implements ILayoutRestorer {
         downArea,
         leftArea,
         rightArea,
-        relativeSizes: relativeSizes || null
+        relativeSizes: relativeSizes || null,
+        topArea: (top as any) ?? null
       };
     } catch (error) {
       return blank;
@@ -292,6 +295,7 @@ export class LayoutRestorer implements ILayoutRestorer {
     dehydrated.left = this._dehydrateSideArea(data.leftArea);
     dehydrated.right = this._dehydrateSideArea(data.rightArea);
     dehydrated.relativeSizes = data.relativeSizes;
+    dehydrated.top = { ...data.topArea };
 
     return this._connector.save(KEY, dehydrated);
   }
@@ -537,6 +541,11 @@ namespace Private {
      * The relatives sizes of the areas of the user interface.
      */
     relativeSizes?: number[] | null;
+
+    /**
+     * The restorable description of the top area in the user interface.
+     */
+    top?: ITopArea | null;
   }
 
   /**
@@ -602,6 +611,16 @@ namespace Private {
      * The index of the selected tab.
      */
     currentIndex: number;
+  }
+
+  /**
+   * The restorable description of the top area in the user interface.
+   */
+  export interface ITopArea extends PartialJSONObject {
+    /**
+     * Top area visibility in simple mode.
+     */
+    readonly simpleVisibility?: boolean;
   }
 
   /**

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -258,6 +258,10 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
       this
     ));
     this._skipLinkWidget.show();
+    //  Wrap the skip widget to customize its position and size
+    const skipLinkWrapper = new Panel();
+    skipLinkWrapper.addClass('jp-skiplink-wrapper');
+    skipLinkWrapper.addWidget(skipLinkWidget);
 
     const headerPanel = (this._headerPanel = new BoxPanel());
     const menuHandler = (this._menuHandler = new Private.PanelHandler());
@@ -365,7 +369,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     BoxLayout.setStretch(hboxPanel, 1);
     BoxLayout.setStretch(bottomPanel, 0);
 
-    rootLayout.addWidget(skipLinkWidget);
+    rootLayout.addWidget(skipLinkWrapper);
     rootLayout.addWidget(headerPanel);
     rootLayout.addWidget(topHandler.panel);
     rootLayout.addWidget(hboxPanel);

--- a/packages/application/style/skiplink.css
+++ b/packages/application/style/skiplink.css
@@ -4,6 +4,10 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
+.jp-skiplink-wrapper {
+  overflow: visible;
+}
+
 .jp-skiplink {
   position: absolute;
   top: -100em;

--- a/packages/application/test/layoutrestorer.spec.ts
+++ b/packages/application/test/layoutrestorer.spec.ts
@@ -68,7 +68,8 @@ describe('apputils', () => {
             widgets: null,
             visible: false
           },
-          relativeSizes: null
+          relativeSizes: null,
+          topArea: { simpleVisibility: true }
         };
         restorer.add(currentWidget, 'test-one');
         ready.resolve(void 0);
@@ -101,7 +102,8 @@ describe('apputils', () => {
             widgets: null,
             visible: false
           },
-          relativeSizes: null
+          relativeSizes: null,
+          topArea: { simpleVisibility: true }
         };
         restorer.add(currentWidget, 'test-one');
         ready.resolve(void 0);
@@ -148,7 +150,8 @@ describe('apputils', () => {
             widgets: null,
             visible: false
           },
-          relativeSizes: null
+          relativeSizes: null,
+          topArea: { simpleVisibility: true }
         };
         restorer.add(currentWidget, 'test-one');
         ready.resolve(void 0);
@@ -213,7 +216,8 @@ describe('apputils', () => {
             widgets: null,
             visible: false
           },
-          relativeSizes: null
+          relativeSizes: null,
+          topArea: { simpleVisibility: true }
         };
 
         await expect(restorer.save(dehydrated)).rejects.toBe(
@@ -246,7 +250,8 @@ describe('apputils', () => {
             widgets: null,
             visible: false
           },
-          relativeSizes: null
+          relativeSizes: null,
+          topArea: { simpleVisibility: true }
         };
         restorer.add(currentWidget, 'test-one');
         ready.resolve(void 0);

--- a/packages/application/test/shell.spec.ts
+++ b/packages/application/test/shell.spec.ts
@@ -174,14 +174,14 @@ describe('LabShell', () => {
       widget.id = 'foo';
       shell.add(widget, 'top');
       // top-level title and menu area are added by default
-      expect(toArray(shell.widgets('top')).length).toEqual(4);
+      expect(toArray(shell.widgets('top')).length).toEqual(3);
     });
 
     it('should be a no-op if the widget has no id', () => {
       const widget = new Widget();
       shell.add(widget, 'top');
       // top-level title and menu area are added by default
-      expect(toArray(shell.widgets('top')).length).toEqual(3);
+      expect(toArray(shell.widgets('top')).length).toEqual(2);
     });
 
     it('should accept options', () => {
@@ -189,7 +189,7 @@ describe('LabShell', () => {
       widget.id = 'foo';
       shell.add(widget, 'top', { rank: 10 });
       // top-level title and menu area are added by default
-      expect(toArray(shell.widgets('top')).length).toEqual(4);
+      expect(toArray(shell.widgets('top')).length).toEqual(3);
     });
 
     it('should add widgets according to their ranks', () => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Partially addressed https://github.com/jupyterlab/jupyterlab/issues/2031
Fixes https://github.com/jupyterlab/jupyterlab/issues/9135
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

![toggle_header](https://user-images.githubusercontent.com/8435071/134139948-b3b486b6-9a34-4b14-a1e7-e15abf3dd0c2.gif)

## Code changes

<!-- Describe the code changes and how they address the issue. -->
A new flag keeping track of the visibility status of the header bar in simple has been added to the shell as well as a new command to add that feature in the `View->Appearance` menu.

The skip link widget is placed directly on the shell root layout as we don't want to hide it with the header bar.
This required to use a wrapper to be able to use the same position and styling.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Ability to show/hide the header bar in simple mode
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A