### PR TITLE
Improve the reactive toolbar

### DIFF
--- a/packages/apputils/src/mainareawidget.ts
+++ b/packages/apputils/src/mainareawidget.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
-import { Spinner, Toolbar } from '@jupyterlab/ui-components';
+import { ReactiveToolbar, Spinner, Toolbar } from '@jupyterlab/ui-components';
 import { Message, MessageLoop } from '@lumino/messaging';
 import { BoxLayout, BoxPanel, Widget } from '@lumino/widgets';
 import { DOMUtils } from './domutils';
@@ -39,7 +39,7 @@ export class MainAreaWidget<T extends Widget = Widget>
     const content = (this._content = options.content);
     content.node.setAttribute('role', 'region');
     content.node.setAttribute('aria-label', trans.__('notebook content'));
-    const toolbar = (this._toolbar = options.toolbar || new Toolbar());
+    const toolbar = (this._toolbar = options.toolbar || new ReactiveToolbar());
     toolbar.node.setAttribute('role', 'navigation');
     toolbar.node.setAttribute('aria-label', trans.__('notebook actions'));
     const contentHeader = (this._contentHeader =
@@ -321,7 +321,7 @@ export namespace MainAreaWidget {
     content?: T;
 
     /**
-     * The toolbar to use for the widget.  Defaults to an empty toolbar.
+     * The toolbar to use for the widget. Defaults to an empty toolbar.
      */
     toolbar?: Toolbar;
 

--- a/packages/debugger/test/debugger.spec.ts
+++ b/packages/debugger/test/debugger.spec.ts
@@ -185,9 +185,9 @@ describe('Debugger', () => {
         expect(title.length).toBe(1);
         expect(title[0].innerHTML).toContain('Variables');
       });
-      it('should have three buttons', () => {
+      it('should have two buttons', () => {
         const buttons = toolbar.querySelectorAll('button');
-        expect(buttons.length).toBe(3);
+        expect(buttons.length).toBe(2);
         expect(buttons[0].title).toBe('Tree View');
         expect(buttons[1].title).toBe('Table View');
       });
@@ -210,9 +210,9 @@ describe('Debugger', () => {
         expect(title.length).toBe(1);
         expect(title[0].innerHTML).toContain('Callstack');
       });
-      it('should have seven buttons', () => {
+      it('should have six buttons', () => {
         const buttons = toolbar.querySelectorAll('button');
-        expect(buttons.length).toBe(7);
+        expect(buttons.length).toBe(6);
       });
     });
     describe('Breakpoints toolbar', () => {
@@ -233,9 +233,9 @@ describe('Debugger', () => {
         expect(title.length).toBe(1);
         expect(title[0].innerHTML).toContain('Breakpoints');
       });
-      it('should have two buttons', () => {
+      it('should have one button', () => {
         const buttons = toolbar.querySelectorAll('button');
-        expect(buttons.length).toBe(2);
+        expect(buttons.length).toBe(1);
       });
     });
     describe('Source toolbar', () => {
@@ -257,9 +257,9 @@ describe('Debugger', () => {
         expect(title[0].innerHTML).toContain('Source');
       });
 
-      it('should have two buttons', () => {
+      it('should have one button', () => {
         const buttons = toolbar.querySelectorAll('button');
-        expect(buttons.length).toBe(2);
+        expect(buttons.length).toBe(1);
       });
     });
   });

--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -346,6 +346,7 @@ export class Toolbar<T extends Widget = Widget> extends Widget {
   }
 }
 
+const TOOLBAR_OPENER_NAME = 'toolbar-popup-opener';
 /**
  * A class which provides a toolbar widget.
  */
@@ -355,11 +356,7 @@ export class ReactiveToolbar<T extends Widget = Widget> extends Toolbar<T> {
    */
   constructor() {
     super();
-    this.insertItem(
-      0,
-      'toolbar-popup-opener',
-      (this.popupOpener as unknown) as T
-    );
+    this.insertItem(0, TOOLBAR_OPENER_NAME, (this.popupOpener as unknown) as T);
     this.popupOpener.hide();
     this._resizer = new Throttler(this._onResize.bind(this), 500);
   }
@@ -377,6 +374,30 @@ export class ReactiveToolbar<T extends Widget = Widget> extends Toolbar<T> {
     }
 
     super.dispose();
+  }
+
+  /**
+   * Insert an item into the toolbar at the after a target item.
+   *
+   * @param at - The target item to insert after.
+   *
+   * @param name - The name of the item.
+   *
+   * @param widget - The widget to add.
+   *
+   * @returns Whether the item was added to the toolbar. Returns false if
+   *   an item of the same name is already in the toolbar or if the target
+   *   is the toolbar pop-up opener.
+   *
+   * #### Notes
+   * The index will be clamped to the bounds of the items.
+   * The item can be removed from the toolbar by setting its parent to `null`.
+   */
+  insertAfter(at: string, name: string, widget: T): boolean {
+    if (at === TOOLBAR_OPENER_NAME) {
+      return false;
+    }
+    return super.insertAfter(at, name, widget);
   }
 
   /**

--- a/packages/ui-components/test/toolbar.spec.ts
+++ b/packages/ui-components/test/toolbar.spec.ts
@@ -7,6 +7,7 @@ import {
   bugIcon,
   CommandToolbarButton,
   jupyterIcon,
+  ReactiveToolbar,
   Toolbar,
   ToolbarButton
 } from '@jupyterlab/ui-components';
@@ -14,7 +15,7 @@ import { framePromise, JupyterServer } from '@jupyterlab/testutils';
 import { toArray } from '@lumino/algorithm';
 import { CommandRegistry } from '@lumino/commands';
 import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
-import { Widget } from '@lumino/widgets';
+import { PanelLayout, Widget } from '@lumino/widgets';
 import { simulate } from 'simulate-event';
 
 const server = new JupyterServer();
@@ -149,12 +150,7 @@ describe('@jupyterlab/ui-components', () => {
         widget.addItem('foo', new Widget());
         widget.addItem('bar', new Widget());
         widget.addItem('baz', new Widget());
-        expect(toArray(widget.names())).toEqual([
-          'foo',
-          'bar',
-          'baz',
-          'toolbar-popup-opener'
-        ]);
+        expect(toArray(widget.names())).toEqual(['foo', 'bar', 'baz']);
       });
     });
 
@@ -182,24 +178,14 @@ describe('@jupyterlab/ui-components', () => {
         widget.addItem('a', new Widget());
         widget.addItem('b', new Widget());
         widget.insertItem(1, 'c', new Widget());
-        expect(toArray(widget.names())).toEqual([
-          'a',
-          'c',
-          'b',
-          'toolbar-popup-opener'
-        ]);
+        expect(toArray(widget.names())).toEqual(['a', 'c', 'b']);
       });
 
       it('should clamp the bounds', () => {
         widget.addItem('a', new Widget());
         widget.addItem('b', new Widget());
         widget.insertItem(10, 'c', new Widget());
-        expect(toArray(widget.names())).toEqual([
-          'a',
-          'b',
-          'c',
-          'toolbar-popup-opener'
-        ]);
+        expect(toArray(widget.names())).toEqual(['a', 'b', 'c']);
       });
     });
 
@@ -209,13 +195,7 @@ describe('@jupyterlab/ui-components', () => {
         widget.addItem('b', new Widget());
         widget.insertItem(1, 'c', new Widget());
         widget.insertAfter('c', 'd', new Widget());
-        expect(toArray(widget.names())).toEqual([
-          'a',
-          'c',
-          'd',
-          'b',
-          'toolbar-popup-opener'
-        ]);
+        expect(toArray(widget.names())).toEqual(['a', 'c', 'd', 'b']);
       });
 
       it('should return false if the target item does not exist', () => {
@@ -232,13 +212,7 @@ describe('@jupyterlab/ui-components', () => {
         widget.addItem('b', new Widget());
         widget.insertItem(1, 'c', new Widget());
         widget.insertBefore('c', 'd', new Widget());
-        expect(toArray(widget.names())).toEqual([
-          'a',
-          'd',
-          'c',
-          'b',
-          'toolbar-popup-opener'
-        ]);
+        expect(toArray(widget.names())).toEqual(['a', 'd', 'c', 'b']);
       });
 
       it('should return false if the target item does not exist', () => {
@@ -395,6 +369,60 @@ describe('@jupyterlab/ui-components', () => {
         const iconNode = wrapperNode.firstChild as HTMLElement;
         expect(iconNode.classList.contains(iconClassValue)).toBe(true);
         cmd.dispose();
+      });
+    });
+  });
+
+  describe('ReactiveToolbar', () => {
+    let toolbar: ReactiveToolbar;
+
+    beforeEach(() => {
+      toolbar = new ReactiveToolbar();
+      Widget.attach(toolbar, document.body);
+    });
+
+    afterEach(() => {
+      toolbar.dispose();
+    });
+
+    describe('#constructor()', () => {
+      it('should append a node to body for the pop-up', () => {
+        const popup = document.body.querySelector(
+          '.jp-Toolbar-responsive-popup'
+        );
+        expect(popup).toBeDefined();
+        expect(popup!.parentNode!.nodeName).toEqual('BODY');
+      });
+    });
+
+    describe('#addItem()', () => {
+      it('should insert item before the toolbar pop-up button', () => {
+        const w = new Widget();
+        toolbar.addItem('test', w);
+        expect(
+          (toolbar.layout as PanelLayout).widgets.findIndex(v => v === w)
+        ).toEqual((toolbar.layout as PanelLayout).widgets.length - 2);
+      });
+    });
+
+    describe('#insertItem()', () => {
+      it('should insert item before the toolbar pop-up button', () => {
+        const w = new Widget();
+        toolbar.insertItem(2, 'test', w);
+        expect(
+          (toolbar.layout as PanelLayout).widgets.findIndex(v => v === w)
+        ).toEqual((toolbar.layout as PanelLayout).widgets.length - 2);
+      });
+    });
+
+    describe('#insertAfter()', () => {
+      it('should not insert item after the toolbar pop-up button', () => {
+        const w = new Widget();
+        const r = toolbar.insertAfter('toolbar-popup-opener', 'test', w);
+        expect(r).toEqual(false);
+        expect(
+          (toolbar.layout as PanelLayout).widgets.findIndex(v => v === w)
+        ).toEqual(-1);
       });
     });
   });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #11102
Fix also a small glitch seen when the pop up is opened and the user switches tabs:

| Before | After |
| --- | --- |
| ![toolbar_hidden_before](https://user-images.githubusercontent.com/8435071/134139711-964acffe-bf93-46fc-9f9b-49142ae27bb8.gif) | ![toolbar_hidden_after](https://user-images.githubusercontent.com/8435071/134139718-d05c9123-8393-4899-87e5-0e4fa3fb3ca9.gif) |

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Create `ReactiveToolbar` class that subclass `Toolbar` to easily choose between a toolbar with a pop up or not; the small toolbars like in the debugger or in the filebrowser are `Toolbar` but the ones for document widget are `ReactiveToolbar`.

Dispose the pop-up with the opener button.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
This splits a class but it was not released on the 3.1.x branch. So we are fine.