### PR TITLE
Automated Changelog Entry for 3.1.13 on 3.1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.1.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.1.13
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.1.12...a8d8f3dbceb9c852e6196b0ebd368759232e2626))
+
+### Enhancements made
+
+- Fetch translations via the `ServerConnection.ISettings` [#11091](https://github.com/jupyterlab/jupyterlab/pull/11091) ([@jtpio](https://github.com/jtpio))
+
+### Bugs fixed
+
+- Update the lock after every request [#11092](https://github.com/jupyterlab/jupyterlab/pull/11092) ([@hbcarlos](https://github.com/hbcarlos))
+- use posix explicitly for PathExt [#11099](https://github.com/jupyterlab/jupyterlab/pull/11099) ([@mbektas](https://github.com/mbektas))
+- Backport PR #10868 on branch 3.1.x (Fix user preferences not being considered for Text Editor) [#11087](https://github.com/jupyterlab/jupyterlab/pull/11087) ([@Mithil467](https://github.com/Mithil467))
+- Indent comments (#6957) [#11063](https://github.com/jupyterlab/jupyterlab/pull/11063) ([@josephrocca](https://github.com/josephrocca))
+
+### Maintenance and upkeep improvements
+
+- Check changes on translatable strings [#11036](https://github.com/jupyterlab/jupyterlab/pull/11036) ([@fcollonval](https://github.com/fcollonval))
+- Skip flaky debugger test [#11083](https://github.com/jupyterlab/jupyterlab/pull/11083) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+- Add a note on the Jupyter Releaser in the extension tutorial [#11085](https://github.com/jupyterlab/jupyterlab/pull/11085) ([@jtpio](https://github.com/jtpio))
+
+### Other merged PRs
+
+- Remove item from changelog that slips through [#11110](https://github.com/jupyterlab/jupyterlab/pull/11110) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-09-14&to=2021-09-22&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-09-14..2021-09-22&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-09-14..2021-09-22&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-09-14..2021-09-22&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-09-14..2021-09-22&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-09-14..2021-09-22&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-09-14..2021-09-22&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-09-14..2021-09-22&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-09-14..2021-09-22&type=Issues) | [@Mithil467](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AMithil467+updated%3A2021-09-14..2021-09-22&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrungleduc+updated%3A2021-09-14..2021-09-22&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-09-14..2021-09-22&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.1.12
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.1.11...1af92c9bbae0eab61938bbbba0ae8cc5e9b59fdd))
@@ -38,8 +74,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.1.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-09-08&to=2021-09-14&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-09-08..2021-09-14&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-09-08..2021-09-14&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-09-08..2021-09-14&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-09-08..2021-09-14&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-09-08..2021-09-14&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-09-08..2021-09-14&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-09-08..2021-09-14&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-09-08..2021-09-14&type=Issues) | [@Mithil467](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AMithil467+updated%3A2021-09-08..2021-09-14&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.1.11
 


### PR DESCRIPTION
Automated Changelog Entry for 3.1.13 on 3.1.x
Python version: 3.1.13
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/application-top: 3.1.13
@jupyterlab/example-console: 3.1.12
@jupyterlab/example-cell: 3.1.12
@jupyterlab/example-terminal: 3.1.12
@jupyterlab/example-federated: 2.2.12
@jupyterlab/example-app: 3.1.13
@jupyterlab/example-filebrowser: 3.1.12
@jupyterlab/example-notebook: 3.1.12
@jupyterlab/example-federated-md: 2.2.13
@jupyterlab/example-federated-core: 2.2.13
@jupyterlab/example-federated-phosphor: 2.2.13
@jupyterlab/example-federated-middle: 2.2.13
@jupyterlab/statusbar: 3.1.12
@jupyterlab/console: 3.1.12
@jupyterlab/translation-extension: 3.1.12
@jupyterlab/tooltip-extension: 3.1.12
@jupyterlab/application-extension: 3.1.12
@jupyterlab/htmlviewer: 3.1.12
@jupyterlab/console-extension: 3.1.12
@jupyterlab/terminal: 3.1.12
@jupyterlab/codemirror-extension: 3.1.12
@jupyterlab/docmanager: 3.1.12
@jupyterlab/imageviewer: 3.1.12
@jupyterlab/debugger-extension: 3.1.12
@jupyterlab/inspector: 3.1.12
@jupyterlab/rendermime-interfaces: 3.1.12
@jupyterlab/notebook-extension: 3.1.12
@jupyterlab/fileeditor-extension: 3.1.12
@jupyterlab/observables: 4.1.12
@jupyterlab/settingeditor: 3.1.12
@jupyterlab/attachments: 3.1.12
@jupyterlab/rendermime: 3.1.12
@jupyterlab/running: 3.1.12
@jupyterlab/docmanager-extension: 3.1.12
@jupyterlab/shortcuts-extension: 3.1.12
@jupyterlab/json-extension: 3.1.13
@jupyterlab/filebrowser-extension: 3.1.12
@jupyterlab/pdf-extension: 3.1.12
@jupyterlab/logconsole: 3.1.12
@jupyterlab/inspector-extension: 3.1.12
@jupyterlab/toc: 5.1.12
@jupyterlab/nbformat: 3.1.12
@jupyterlab/toc-extension: 5.1.12
@jupyterlab/apputils: 3.1.12
@jupyterlab/settingregistry: 3.1.12
@jupyterlab/codeeditor: 3.1.12
@jupyterlab/vdom-extension: 3.1.13
@jupyterlab/outputarea: 3.1.12
@jupyterlab/translation: 3.1.12
@jupyterlab/running-extension: 3.1.12
@jupyterlab/htmlviewer-extension: 3.1.12
@jupyterlab/settingeditor-extension: 3.1.12
@jupyterlab/fileeditor: 3.1.12
@jupyterlab/mainmenu: 3.1.12
@jupyterlab/celltags-extension: 3.1.12
@jupyterlab/extensionmanager-extension: 3.1.12
@jupyterlab/statedb: 3.1.12
@jupyterlab/csvviewer: 3.1.12
@jupyterlab/javascript-extension: 3.1.13
@jupyterlab/statusbar-extension: 3.1.12
@jupyterlab/vega5-extension: 3.1.13
@jupyterlab/theme-light-extension: 3.1.12
@jupyterlab/extensionmanager: 3.1.12
@jupyterlab/celltags: 3.1.12
@jupyterlab/launcher-extension: 3.1.12
@jupyterlab/ui-components-extension: 3.1.12
@jupyterlab/services: 6.1.12
@jupyterlab/filebrowser: 3.1.12
@jupyterlab/theme-dark-extension: 3.1.12
@jupyterlab/documentsearch: 3.1.12
@jupyterlab/hub-extension: 3.1.12
@jupyterlab/markdownviewer: 3.1.12
@jupyterlab/apputils-extension: 3.1.13
@jupyterlab/nbconvert-css: 3.1.12
@jupyterlab/vdom: 3.1.13
@jupyterlab/docprovider: 3.1.12
@jupyterlab/documentsearch-extension: 3.1.12
@jupyterlab/launcher: 3.1.12
@jupyterlab/mathjax2-extension: 3.1.12
@jupyterlab/terminal-extension: 3.1.12
@jupyterlab/mathjax2: 3.1.12
@jupyterlab/codemirror: 3.1.12
@jupyterlab/metapackage: 3.1.13
@jupyterlab/completer-extension: 3.1.12
@jupyterlab/imageviewer-extension: 3.1.12
@jupyterlab/help-extension: 3.1.12
@jupyterlab/logconsole-extension: 3.1.12
@jupyterlab/ui-components: 3.1.12
@jupyterlab/shared-models: 3.1.12
@jupyterlab/tooltip: 3.1.12
@jupyterlab/csvviewer-extension: 3.1.12
@jupyterlab/mainmenu-extension: 3.1.12
@jupyterlab/debugger: 3.1.12
@jupyterlab/coreutils: 5.1.12
@jupyterlab/docregistry: 3.1.12
@jupyterlab/completer: 3.1.12
@jupyterlab/notebook: 3.1.12
@jupyterlab/markdownviewer-extension: 3.1.12
@jupyterlab/docprovider-extension: 3.1.12
@jupyterlab/application: 3.1.12
@jupyterlab/cells: 3.1.12
@jupyterlab/property-inspector: 3.1.12
@jupyterlab/rendermime-extension: 3.1.12
node-example: 3.1.12
@jupyterlab/example-services-browser: 3.1.12
@jupyterlab/example-services-outputarea: 3.1.12
@jupyterlab/builder: 3.1.13
@jupyterlab/buildutils: 3.1.13
@jupyterlab/template: 3.1.12
@jupyterlab/testutils: 3.1.12
@jupyterlab/mock-extension: 3.1.13
@jupyterlab/mock-provider: 3.1.13
@jupyterlab/mock-token: 3.1.12
@jupyterlab/mock-consumer: 3.1.13

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.1.x  |
| Version Spec | next |
| Since | v3.1.12 |