### PR TITLE
reuse cell id of cut cell on cut + paste

### DIFF
--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -989,7 +989,18 @@ export namespace NotebookActions {
     const newCells = values.map(cell => {
       switch (cell.cell_type) {
         case 'code':
-          return model.contentFactory.createCodeCell({ cell });
+          if (
+            notebook.lastClipboardInteraction === 'cut' &&
+            typeof cell.id === 'string'
+          ) {
+            let cell_id = cell.id as string;
+            return model.contentFactory.createCodeCell({
+              id: cell_id,
+              cell: cell
+            });
+          } else {
+            return model.contentFactory.createCodeCell({ cell });
+          }
         case 'markdown':
           return model.contentFactory.createMarkdownCell({ cell });
         default:
@@ -1043,6 +1054,7 @@ export namespace NotebookActions {
 
     notebook.activeCellIndex += newCells.length;
     notebook.deselectAll();
+    notebook.lastClipboardInteraction = 'paste';
     Private.handleState(notebook, state);
   }
 
@@ -1943,6 +1955,7 @@ namespace Private {
           notebook,
           lastCell: notebook.widgets[lastIndex]
         });
+
         notebook.update();
 
         return false;
@@ -2115,6 +2128,11 @@ namespace Private {
       deleteCells(notebook);
     } else {
       notebook.deselectAll();
+    }
+    if (cut) {
+      notebook.lastClipboardInteraction = 'cut';
+    } else {
+      notebook.lastClipboardInteraction = 'copy';
     }
     handleState(notebook, state);
   }

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1187,6 +1187,13 @@ export class Notebook extends StaticNotebook {
     return this._activeCell;
   }
 
+  get lastClipboardInteraction(): 'copy' | 'cut' | 'paste' | null {
+    return this._lastClipboardInteraction;
+  }
+  set lastClipboardInteraction(newValue: 'copy' | 'cut' | 'paste' | null) {
+    this._lastClipboardInteraction = newValue;
+  }
+
   /**
    * Dispose of the resources held by the widget.
    */
@@ -2391,6 +2398,8 @@ export class Notebook extends StaticNotebook {
   // Attributes for optimized cell refresh:
   private _cellLayoutStateCache?: { width: number };
   private _checkCacheOnNextResize = false;
+
+  private _lastClipboardInteraction: 'copy' | 'cut' | 'paste' | null = null;
 }
 
 /**


### PR DESCRIPTION
## References

This PR addresses issue #11106. The idea is to keep track of the last cell-level clipboard interaction (i.e. copy, cut, or paste), so that if a cell is cut + paste, we can reuse the previous id, making it easier for extensions to maintain cell-level metadata across cut + paste.

## Code changes

Add a "prevClipboardInteraction" field + getters + setters to the Notebook widget. On paste, we check if the previous clipboard interaction was a cut, and if so, reuse the cut cell's id.

## User-facing changes

No visual changes for users of core Jupyter. For extensions that track additional cell-level metadata, this metadata will be persisted on cut + paste. For example, we can track the cell's "dirty" status in an extension and set it to "dirty" if we see a cell id that we know is dirty:

![image](https://user-images.githubusercontent.com/325653/133956824-3b4a4d31-7fa2-4e19-9dbe-cf0a4d0d2515.gif)

Without this change, the dirty indicator is not present after the paste, despite the extension tracking the dirty status as additional metadata.

## Backwards-incompatible changes

None.