### PR TITLE
fix up #11117 - typo in docs: page_config.json

### DIFF
--- a/docs/source/user/directories.rst
+++ b/docs/source/user/directories.rst
@@ -117,7 +117,7 @@ against the patterns in ``disabledExtensions`` and ``deferredExtensions``.
    ``"@jupyterlab/apputils-extension:set.*$"``),
    then that specific plugin is disabled (or deferred).
 
-An example ``<jupyter_config_path>/labconfig/pageconfig.json`` could look as follows:
+An example ``<jupyter_config_path>/labconfig/page_config.json`` could look as follows:
 
 .. code:: json
 

--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -186,13 +186,13 @@ Extensions or individual plugins within an extension can be disabled by another 
 
 The priority order for determining whether an extension is enabled or disabled is as follows:
 
-- Presence of ``<jupyter_config_path>/labconfig/pageconfig.json`` file(s) with a ``disabledExtensions`` key that is a object with package names as keys and boolean values.
-- (deprecated) Presence of ``disabledExtensions`` key in ``<lab_app_dir>/settings/pageconfig.json``.   This value is a list of extensions to disable, but is deprecated in favor of the layered configuration approach in the `labconfig` location(s).
+- Presence of ``<jupyter_config_path>/labconfig/page_config.json`` file(s) with a ``disabledExtensions`` key that is a object with package names as keys and boolean values.
+- (deprecated) Presence of ``disabledExtensions`` key in ``<lab_app_dir>/settings/page_config.json``.   This value is a list of extensions to disable, but is deprecated in favor of the layered configuration approach in the `labconfig` location(s).
 - Presence of ``disabledExtensions`` key in another JupyterLab extension's metadata that disables a given extension.  The key is ignored if that extension itself is disabled.
 
 When using the command line, you can target the ``--level`` of the config: ``user``, ``system``, or ``sys-prefix`` (default).
 
-An example ``<jupyter_config_path>/labconfig/pageconfig.json`` could look as follows:
+An example ``<jupyter_config_path>/labconfig/page_config.json`` could look as follows:
 
 .. code:: json
 


### PR DESCRIPTION
fix up #11117 - typo in docs: page_config.json

(I couldn't find out how to do a "Edit in github" using two files... so ended up using the command line again)