### PR TITLE
Make check margin between last modified timestamps on disk and client configurable

### DIFF
--- a/packages/docmanager-extension/schema/plugin.json
+++ b/packages/docmanager-extension/schema/plugin.json
@@ -117,6 +117,12 @@
       "description": "Length of save interval in seconds",
       "default": 120
     },
+    "lastModifiedCheckMargin": {
+      "type": "number",
+      "title": "Margin for last modified timestamp check",
+      "description": "Max acceptable difference, in milliseconds, between last modified timestamps on disk and client",
+      "default": 500
+    },
     "defaultViewers": {
       "type": "object",
       "title": "Default Viewers",

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -184,6 +184,12 @@ const docManagerPlugin: JupyterFrontEndPlugin<IDocumentManager> = {
         | null;
       docManager.autosaveInterval = autosaveInterval || 120;
 
+      // Handle last modified timestamp check margin
+      const lastModifiedCheckMargin = settings.get('lastModifiedCheckMargin').composite as
+        | number
+        | null;
+      docManager.lastModifiedCheckMargin = lastModifiedCheckMargin || 500;
+
       // Handle default widget factory overrides.
       const defaultViewers = settings.get('defaultViewers').composite as {
         [ft: string]: string;

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -185,9 +185,8 @@ const docManagerPlugin: JupyterFrontEndPlugin<IDocumentManager> = {
       docManager.autosaveInterval = autosaveInterval || 120;
 
       // Handle last modified timestamp check margin
-      const lastModifiedCheckMargin = settings.get('lastModifiedCheckMargin').composite as
-        | number
-        | null;
+      const lastModifiedCheckMargin = settings.get('lastModifiedCheckMargin')
+        .composite as number | null;
       docManager.lastModifiedCheckMargin = lastModifiedCheckMargin || 500;
 
       // Handle default widget factory overrides.

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -118,6 +118,22 @@ export class DocumentManager implements IDocumentManager {
   }
 
   /**
+   * Defines max acceptable difference, in milliseconds, between last modified timestamps on disk and client
+   */
+  get lastModifiedCheckMargin(): number {
+    return this._lastModifiedCheckMargin;
+  }
+
+  set lastModifiedCheckMargin(value: number) {
+    this._lastModifiedCheckMargin = value;
+
+    // For each existing context, update the margin value.
+    this._contexts.forEach(context => {
+      context.lastModifiedCheckMargin = value;
+    })
+  }
+
+  /**
    * Get whether the document manager has been disposed.
    */
   get isDisposed(): boolean {
@@ -474,7 +490,8 @@ export class DocumentManager implements IDocumentManager {
       setBusy: this._setBusy,
       sessionDialogs: this._dialogs,
       collaborative: this._collaborative,
-      docProviderFactory: this._docProviderFactory
+      docProviderFactory: this._docProviderFactory,
+      lastModifiedCheckMargin: this._lastModifiedCheckMargin
     });
     const handler = new SaveHandler({
       context,
@@ -599,6 +616,7 @@ export class DocumentManager implements IDocumentManager {
   private _isDisposed = false;
   private _autosave = true;
   private _autosaveInterval = 120;
+  private _lastModifiedCheckMargin = 500;
   private _when: Promise<void>;
   private _setBusy: (() => IDisposable) | undefined;
   private _dialogs: ISessionContext.IDialogs;

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -130,7 +130,7 @@ export class DocumentManager implements IDocumentManager {
     // For each existing context, update the margin value.
     this._contexts.forEach(context => {
       context.lastModifiedCheckMargin = value;
-    })
+    });
   }
 
   /**

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -735,7 +735,10 @@ export class Context<
         const modified = ycontextModified || this.contentsModel?.last_modified;
         const tClient = modified ? new Date(modified) : new Date();
         const tDisk = new Date(model.last_modified);
-        if (modified && tDisk.getTime() - tClient.getTime() > lastModifiedCheckMargin) {
+        if (
+          modified &&
+          tDisk.getTime() - tClient.getTime() > lastModifiedCheckMargin
+        ) {
           return this._timeConflict(tClient, model, options);
         }
         return this._manager.contents.save(path, options);

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -55,6 +55,7 @@ export class Context<
     this._dialogs = options.sessionDialogs || sessionContextDialogs;
     this._opener = options.opener || Private.noOp;
     this._path = this._manager.contents.normalize(options.path);
+    this._lastModifiedCheckMargin = options.lastModifiedCheckMargin || 500;
     const localPath = this._manager.contents.localPath(this._path);
     const lang = this._factory.preferredLanguage(PathExt.basename(localPath));
 
@@ -143,6 +144,17 @@ export class Context<
    */
   get disposed(): ISignal<this, void> {
     return this._disposed;
+  }
+
+  /**
+   * Configurable margin used to detect document modification conflicts, in milliseconds
+   */
+  get lastModifiedCheckMargin(): number {
+    return this._lastModifiedCheckMargin;
+  }
+
+  set lastModifiedCheckMargin(value: number) {
+    this._lastModifiedCheckMargin = value;
   }
 
   /**
@@ -716,15 +728,14 @@ export class Context<
         }
         // We want to check last_modified (disk) > last_modified (client)
         // (our last save)
-        // In some cases the filesystem reports an inconsistent time,
-        // so we allow 0.5 seconds difference before complaining.
+        // In some cases the filesystem reports an inconsistent time, so we allow buffer when comparing.
+        const lastModifiedCheckMargin = this._lastModifiedCheckMargin;
         const ycontextModified = this._ycontext.get('last_modified');
         // prefer using the timestamp from ycontext because it is more up to date
         const modified = ycontextModified || this.contentsModel?.last_modified;
         const tClient = modified ? new Date(modified) : new Date();
         const tDisk = new Date(model.last_modified);
-        if (modified && tDisk.getTime() - tClient.getTime() > 500) {
-          // 500 ms
+        if (modified && tDisk.getTime() - tClient.getTime() > lastModifiedCheckMargin) {
           return this._timeConflict(tClient, model, options);
         }
         return this._manager.contents.save(path, options);
@@ -887,6 +898,7 @@ or load the version on disk (revert)?`,
   private _provider: IDocumentProvider;
   private _ydoc: Y.Doc;
   private _ycontext: Y.Map<string>;
+  private _lastModifiedCheckMargin = 500;
 }
 
 /**
@@ -951,6 +963,11 @@ export namespace Context {
      * The application language translator.
      */
     translator?: ITranslator;
+
+    /**
+     * Max acceptable difference, in milliseconds, between last modified timestamps on disk and client
+     */
+    lastModifiedCheckMargin?: number;
   }
 }
 

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -851,6 +851,11 @@ export namespace DocumentRegistry {
     disposed: ISignal<this, void>;
 
     /**
+     * Configurable margin used to detect document modification conflicts, in milliseconds
+     */
+    lastModifiedCheckMargin: number;
+
+    /**
      * The data model for the document.
      */
     readonly model: T;

--- a/packages/docregistry/test/context.spec.ts
+++ b/packages/docregistry/test/context.spec.ts
@@ -240,6 +240,17 @@ describe('docregistry/context', () => {
       });
     });
 
+    describe('#lastModifiedCheckMargin', () => {
+      it('should be 500ms by default', () => {
+        expect(context.lastModifiedCheckMargin).toBe(500);
+      });
+
+      it('should be set-able', () => {
+        context.lastModifiedCheckMargin = 600;
+        expect(context.lastModifiedCheckMargin).toBe(600);
+      })
+    })
+
     describe('#contentsModel', () => {
       it('should be `null` before population', () => {
         expect(context.contentsModel).toBeNull();

--- a/packages/docregistry/test/context.spec.ts
+++ b/packages/docregistry/test/context.spec.ts
@@ -248,8 +248,8 @@ describe('docregistry/context', () => {
       it('should be set-able', () => {
         context.lastModifiedCheckMargin = 600;
         expect(context.lastModifiedCheckMargin).toBe(600);
-      })
-    })
+      });
+    });
 
     describe('#contentsModel', () => {
       it('should be `null` before population', () => {


### PR DESCRIPTION
## References
Addresses the issue https://github.com/jupyterlab/jupyterlab/issues/8556 .

## Code changes
I tried to follow the same pattern as "auto save interval" setting, where configuration is piped through docmanager into save handler (or document context, in my case).

My Binder url: https://mybinder.org/v2/gh/ph-ph/jupyterlab/dzmitry-make-last-saved-modified-buffer-time-configurable

## User-facing changes
The only user-facing change is the new setting in Document Manager settings.

## Backwards-incompatible changes
None that I'm aware of.