### PR TITLE
Automated Changelog Entry for 3.1.14 on 3.1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.1.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.1.14
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.1.13...fb6df989b70ce096c9769fc728bb158f311b48a9))
+
+### Bugs fixed
+
+- Normalize notebook cell line endings to \n [#11141](https://github.com/jupyterlab/jupyterlab/pull/11141) ([@jasongrout](https://github.com/jasongrout))
+
+### Maintenance and upkeep improvements
+
+- Fix the "Edit on GitHub" link [#11149](https://github.com/jupyterlab/jupyterlab/pull/11149) ([@krassowski](https://github.com/krassowski))
+
+### Documentation improvements
+
+- Fix the "Edit on GitHub" link [#11149](https://github.com/jupyterlab/jupyterlab/pull/11149) ([@krassowski](https://github.com/krassowski))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-09-22&to=2021-09-27&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-09-22..2021-09-27&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-09-22..2021-09-27&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-09-22..2021-09-27&type=Issues) | [@goanpeca](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agoanpeca+updated%3A2021-09-22..2021-09-27&type=Issues) | [@jess-x](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajess-x+updated%3A2021-09-22..2021-09-27&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-09-22..2021-09-27&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-09-22..2021-09-27&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-09-22..2021-09-27&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-09-22..2021-09-27&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-09-22..2021-09-27&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.1.13
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.1.12...a8d8f3dbceb9c852e6196b0ebd368759232e2626))
@@ -41,8 +65,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.1.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-09-14&to=2021-09-22&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-09-14..2021-09-22&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-09-14..2021-09-22&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-09-14..2021-09-22&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-09-14..2021-09-22&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-09-14..2021-09-22&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-09-14..2021-09-22&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-09-14..2021-09-22&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-09-14..2021-09-22&type=Issues) | [@Mithil467](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AMithil467+updated%3A2021-09-14..2021-09-22&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrungleduc+updated%3A2021-09-14..2021-09-22&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-09-14..2021-09-22&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.1.12
 


### PR DESCRIPTION
Automated Changelog Entry for 3.1.14 on 3.1.x
Python version: 3.1.14
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/application-top: 3.1.14
@jupyterlab/example-console: 3.1.13
@jupyterlab/example-cell: 3.1.13
@jupyterlab/example-terminal: 3.1.13
@jupyterlab/example-federated: 2.2.13
@jupyterlab/example-app: 3.1.14
@jupyterlab/example-filebrowser: 3.1.13
@jupyterlab/example-notebook: 3.1.13
@jupyterlab/example-federated-md: 2.2.14
@jupyterlab/example-federated-core: 2.2.14
@jupyterlab/example-federated-phosphor: 2.2.14
@jupyterlab/example-federated-middle: 2.2.14
@jupyterlab/statusbar: 3.1.13
@jupyterlab/console: 3.1.13
@jupyterlab/translation-extension: 3.1.13
@jupyterlab/tooltip-extension: 3.1.13
@jupyterlab/application-extension: 3.1.13
@jupyterlab/htmlviewer: 3.1.13
@jupyterlab/console-extension: 3.1.13
@jupyterlab/terminal: 3.1.13
@jupyterlab/codemirror-extension: 3.1.13
@jupyterlab/docmanager: 3.1.13
@jupyterlab/imageviewer: 3.1.13
@jupyterlab/debugger-extension: 3.1.13
@jupyterlab/inspector: 3.1.13
@jupyterlab/rendermime-interfaces: 3.1.13
@jupyterlab/notebook-extension: 3.1.13
@jupyterlab/fileeditor-extension: 3.1.13
@jupyterlab/observables: 4.1.13
@jupyterlab/settingeditor: 3.1.13
@jupyterlab/attachments: 3.1.13
@jupyterlab/rendermime: 3.1.13
@jupyterlab/running: 3.1.13
@jupyterlab/docmanager-extension: 3.1.13
@jupyterlab/shortcuts-extension: 3.1.13
@jupyterlab/json-extension: 3.1.14
@jupyterlab/filebrowser-extension: 3.1.13
@jupyterlab/pdf-extension: 3.1.13
@jupyterlab/logconsole: 3.1.13
@jupyterlab/inspector-extension: 3.1.13
@jupyterlab/toc: 5.1.13
@jupyterlab/nbformat: 3.1.13
@jupyterlab/toc-extension: 5.1.13
@jupyterlab/apputils: 3.1.13
@jupyterlab/settingregistry: 3.1.13
@jupyterlab/codeeditor: 3.1.13
@jupyterlab/vdom-extension: 3.1.14
@jupyterlab/outputarea: 3.1.13
@jupyterlab/translation: 3.1.13
@jupyterlab/running-extension: 3.1.13
@jupyterlab/htmlviewer-extension: 3.1.13
@jupyterlab/settingeditor-extension: 3.1.13
@jupyterlab/fileeditor: 3.1.13
@jupyterlab/mainmenu: 3.1.13
@jupyterlab/celltags-extension: 3.1.13
@jupyterlab/extensionmanager-extension: 3.1.13
@jupyterlab/statedb: 3.1.13
@jupyterlab/csvviewer: 3.1.13
@jupyterlab/javascript-extension: 3.1.14
@jupyterlab/statusbar-extension: 3.1.13
@jupyterlab/vega5-extension: 3.1.14
@jupyterlab/theme-light-extension: 3.1.13
@jupyterlab/extensionmanager: 3.1.13
@jupyterlab/celltags: 3.1.13
@jupyterlab/launcher-extension: 3.1.13
@jupyterlab/ui-components-extension: 3.1.13
@jupyterlab/services: 6.1.13
@jupyterlab/filebrowser: 3.1.13
@jupyterlab/theme-dark-extension: 3.1.13
@jupyterlab/documentsearch: 3.1.13
@jupyterlab/hub-extension: 3.1.13
@jupyterlab/markdownviewer: 3.1.13
@jupyterlab/apputils-extension: 3.1.14
@jupyterlab/nbconvert-css: 3.1.13
@jupyterlab/vdom: 3.1.14
@jupyterlab/docprovider: 3.1.13
@jupyterlab/documentsearch-extension: 3.1.13
@jupyterlab/launcher: 3.1.13
@jupyterlab/mathjax2-extension: 3.1.13
@jupyterlab/terminal-extension: 3.1.13
@jupyterlab/mathjax2: 3.1.13
@jupyterlab/codemirror: 3.1.13
@jupyterlab/metapackage: 3.1.14
@jupyterlab/completer-extension: 3.1.13
@jupyterlab/imageviewer-extension: 3.1.13
@jupyterlab/help-extension: 3.1.13
@jupyterlab/logconsole-extension: 3.1.13
@jupyterlab/ui-components: 3.1.13
@jupyterlab/shared-models: 3.1.13
@jupyterlab/tooltip: 3.1.13
@jupyterlab/csvviewer-extension: 3.1.13
@jupyterlab/mainmenu-extension: 3.1.13
@jupyterlab/debugger: 3.1.13
@jupyterlab/coreutils: 5.1.13
@jupyterlab/docregistry: 3.1.13
@jupyterlab/completer: 3.1.13
@jupyterlab/notebook: 3.1.13
@jupyterlab/markdownviewer-extension: 3.1.13
@jupyterlab/docprovider-extension: 3.1.13
@jupyterlab/application: 3.1.13
@jupyterlab/cells: 3.1.13
@jupyterlab/property-inspector: 3.1.13
@jupyterlab/rendermime-extension: 3.1.13
node-example: 3.1.13
@jupyterlab/example-services-browser: 3.1.13
@jupyterlab/example-services-outputarea: 3.1.13
@jupyterlab/builder: 3.1.14
@jupyterlab/buildutils: 3.1.14
@jupyterlab/template: 3.1.13
@jupyterlab/testutils: 3.1.13
@jupyterlab/mock-extension: 3.1.14
@jupyterlab/mock-provider: 3.1.14
@jupyterlab/mock-token: 3.1.13
@jupyterlab/mock-consumer: 3.1.14

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.1.x  |
| Version Spec | next |
| Since | v3.1.13 |