### PR TITLE
Remove unused command id in the translation extension

### DIFF
--- a/packages/translation-extension/src/index.ts
+++ b/packages/translation-extension/src/index.ts
@@ -21,14 +21,6 @@ import {
 } from '@jupyterlab/translation';
 
 /**
- * A namespace for command IDs.
- */
-export namespace CommandIDs {
-  export const installAdditionalLanguages =
-    'jupyterlab-translation:install-additional-languages';
-}
-
-/**
  * Translation plugins
  */
 const PLUGIN_ID = '@jupyterlab/translation-extension:plugin';


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This command id doesn't seem to be used across the code base.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Remove unused command.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
