### PR TITLE
Update variable renderer panels

### DIFF
--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -46,7 +46,6 @@ import {
 import { Session } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { ITranslator } from '@jupyterlab/translation';
-import { toArray } from '@lumino/algorithm';
 
 /**
  * A plugin that provides visual debugging support for consoles.
@@ -453,23 +452,9 @@ const variables: JupyterFrontEndPlugin<void> = {
 
         const variablesModel = service.model.variables;
 
-        // Trust the console panel by default
-        let isTrusted =
-          handler.activeWidget instanceof ConsolePanel ? true : false;
-        if (
-          handler.activeWidget instanceof NotebookPanel &&
-          handler.activeWidget.model
-        ) {
-          // Trust variable view if the notebook is trusted
-          isTrusted = !toArray(handler.activeWidget.model.cells).some(
-            cell => cell.trusted === false
-          );
-        }
-
         const widget = new Debugger.VariableRenderer({
           dataLoader: () => service.inspectRichVariable(name!, frameId),
           rendermime: activeRendermime,
-          isTrusted,
           translator
         });
         widget.addClass('jp-DebuggerRichVariable');

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -460,6 +460,7 @@ const variables: JupyterFrontEndPlugin<void> = {
           handler.activeWidget instanceof NotebookPanel &&
           handler.activeWidget.model
         ) {
+          // Trust variable view if the notebook is trusted
           isTrusted = !toArray(handler.activeWidget.model.cells).some(
             cell => cell.trusted === false
           );
@@ -474,7 +475,8 @@ const variables: JupyterFrontEndPlugin<void> = {
         widget.addClass('jp-DebuggerRichVariable');
         widget.id = id;
         widget.title.icon = Debugger.Icons.variableIcon;
-        widget.title.label = `${service.session?.connection?.name} - ${name}`;
+        widget.title.label = name;
+        widget.title.caption = `${name} - ${service.session?.connection?.name}`;
         void trackerMime.add(widget);
         const disposeWidget = () => {
           widget.dispose();
@@ -482,21 +484,7 @@ const variables: JupyterFrontEndPlugin<void> = {
           activeWidget?.disposed.disconnect(disposeWidget);
         };
         const refreshWidget = () => {
-          if (
-            name &&
-            variablesModel.scopes
-              .map(s => s.variables.map(v => v.name))
-              .findIndex(variables => variables.includes(name!)) >= 0
-          ) {
-            widget.refresh();
-          } else if (
-            !frameId &&
-            !service.model.callstack.frames.map(f => f.id).includes(frameId!)
-          ) {
-            // Dispose the widget if the frame in which the variable is defined
-            // does not exists any longer.
-            disposeWidget();
-          }
+          widget.refresh();
         };
         widget.disposed.connect(disposeWidget);
         variablesModel.changed.connect(refreshWidget);

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -354,7 +354,7 @@ const variables: JupyterFrontEndPlugin<void> = {
       isEnabled: args =>
         !!service.session?.isStarted &&
         (args.variableReference ??
-          sidebar.variables.latestSelection?.variablesReference ??
+          service.model.variables.selectedVariable?.variablesReference ??
           0) > 0,
       execute: async args => {
         let { variableReference, name } = args as {
@@ -364,10 +364,10 @@ const variables: JupyterFrontEndPlugin<void> = {
 
         if (!variableReference) {
           variableReference =
-            sidebar.variables.latestSelection?.variablesReference;
+            service.model.variables.selectedVariable?.variablesReference;
         }
         if (!name) {
-          name = sidebar.variables.latestSelection?.name;
+          name = service.model.variables.selectedVariable?.name;
         }
 
         const id = `jp-debugger-variable-${name}`;
@@ -426,7 +426,7 @@ const variables: JupyterFrontEndPlugin<void> = {
         };
 
         if (!name) {
-          name = sidebar.variables.latestSelection?.name;
+          name = service.model.variables.selectedVariable?.name;
         }
         if (!frameId) {
           frameId = service.model.callstack.frame?.id;

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -46,6 +46,7 @@ import {
 import { Session } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { ITranslator } from '@jupyterlab/translation';
+import { toArray } from '@lumino/algorithm';
 
 /**
  * A plugin that provides visual debugging support for consoles.
@@ -452,9 +453,23 @@ const variables: JupyterFrontEndPlugin<void> = {
 
         const variablesModel = service.model.variables;
 
+        // Trust the console panel by default
+        let isTrusted =
+          handler.activeWidget instanceof ConsolePanel ? true : false;
+        if (
+          handler.activeWidget instanceof NotebookPanel &&
+          handler.activeWidget.model
+        ) {
+          isTrusted = !toArray(handler.activeWidget.model.cells).some(
+            cell => cell.trusted === false
+          );
+        }
+
         const widget = new Debugger.VariableRenderer({
           dataLoader: () => service.inspectRichVariable(name!, frameId),
-          rendermime: activeRendermime
+          rendermime: activeRendermime,
+          isTrusted,
+          translator
         });
         widget.addClass('jp-DebuggerRichVariable');
         widget.id = id;

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -456,7 +456,7 @@ const variables: JupyterFrontEndPlugin<void> = {
           dataLoader: () => service.inspectRichVariable(name!, frameId),
           rendermime: activeRendermime
         });
-        widget.addClass('jp-DebuggerVariables');
+        widget.addClass('jp-DebuggerRichVariable');
         widget.id = id;
         widget.title.icon = Debugger.Icons.variableIcon;
         widget.title.label = `${service.session?.connection?.name} - ${name}`;
@@ -474,10 +474,16 @@ const variables: JupyterFrontEndPlugin<void> = {
               .findIndex(variables => variables.includes(name!)) >= 0
           ) {
             widget.refresh();
-          } else {
+          } else if (
+            !frameId &&
+            !service.model.callstack.frames.map(f => f.id).includes(frameId!)
+          ) {
+            // Dispose the widget if the frame in which the variable is defined
+            // does not exists any longer.
             disposeWidget();
           }
         };
+        widget.disposed.connect(disposeWidget);
         variablesModel.changed.connect(refreshWidget);
         activeWidget?.disposed.connect(disposeWidget);
 

--- a/packages/debugger/src/panels/variables/grid.ts
+++ b/packages/debugger/src/panels/variables/grid.ts
@@ -41,7 +41,7 @@ export class VariablesBodyGrid extends Panel {
   constructor(options: VariablesBodyGrid.IOptions) {
     super();
     const { model, commands, themeManager, scopes, translator } = options;
-    this._grid = new Grid({ commands, themeManager, translator });
+    this._grid = new Grid({ commands, model, themeManager, translator });
     this._grid.addClass('jp-DebuggerVariables-grid');
     this._model = model;
     this._model.changed.connect((model: VariablesModel): void => {
@@ -50,13 +50,6 @@ export class VariablesBodyGrid extends Panel {
     this._grid.dataModel.setData(scopes ?? []);
     this.addWidget(this._grid);
     this.addClass('jp-DebuggerVariables-body');
-  }
-
-  /**
-   * Get the latest hit variable
-   */
-  get latestSelection(): IDebugger.IVariableSelection | null {
-    return this._grid.latestSelection;
   }
 
   /**
@@ -136,7 +129,8 @@ class Grid extends Panel {
    */
   constructor(options: Grid.IOptions) {
     super();
-    const { commands, themeManager } = options;
+    const { commands, model, themeManager } = options;
+    this.model = model;
     const dataModel = new GridModel(options.translator);
     const grid = new DataGrid();
     const mouseHandler = new Private.MouseHandler();
@@ -148,7 +142,7 @@ class Grid extends Panel {
     );
     mouseHandler.selected.connect((_, hit) => {
       const { row } = hit;
-      this._latestSelection = {
+      this.model.selectedVariable = {
         name: dataModel.getVariableName(row),
         value: dataModel.data('body', row, 1),
         type: dataModel.data('body', row, 2),
@@ -200,13 +194,6 @@ class Grid extends Panel {
   }
 
   /**
-   * Get the latest hit variable
-   */
-  get latestSelection(): IDebugger.IVariableSelection | null {
-    return this._latestSelection;
-  }
-
-  /**
    * Handle `after-attach` messages.
    *
    * @param message - The `after-attach` message.
@@ -226,7 +213,7 @@ class Grid extends Panel {
   }
 
   private _grid: DataGrid;
-  private _latestSelection: IDebugger.IVariableSelection | null = null;
+  protected model: IDebugger.Model.IVariables;
 }
 
 /**
@@ -241,6 +228,11 @@ namespace Grid {
      * The commands registry.
      */
     commands: CommandRegistry;
+
+    /**
+     * The variables model.
+     */
+    model: IDebugger.Model.IVariables;
 
     /**
      * An optional application theme manager to detect theme changes.

--- a/packages/debugger/src/panels/variables/index.ts
+++ b/packages/debugger/src/panels/variables/index.ts
@@ -19,9 +19,7 @@ import { VariablesBodyTree } from './tree';
 /**
  * A Panel to show a variable explorer.
  */
-export class Variables
-  extends PanelWithToolbar
-  implements IDebugger.IVariablesPanel {
+export class Variables extends PanelWithToolbar {
   /**
    * Instantiate a new Variables Panel.
    *
@@ -99,7 +97,7 @@ export class Variables
       }
     };
 
-    markViewButtonSelection(this.viewMode);
+    markViewButtonSelection(this._table.isHidden ? 'tree' : 'table');
 
     this.toolbar.addItem('view-VariableTreeView', treeViewButton);
 
@@ -108,22 +106,6 @@ export class Variables
     this.addWidget(this._tree);
     this.addWidget(this._table);
     this.addClass('jp-DebuggerVariables');
-  }
-
-  /**
-   * Latest variable selected.
-   */
-  get latestSelection(): IDebugger.IVariableSelection | null {
-    return this._table.isHidden
-      ? this._tree.latestSelection
-      : this._table.latestSelection;
-  }
-
-  /**
-   * Get the variable explorer view mode
-   */
-  get viewMode(): 'tree' | 'table' {
-    return this._table.isHidden ? 'tree' : 'table';
   }
 
   /**

--- a/packages/debugger/src/panels/variables/mimerenderer.ts
+++ b/packages/debugger/src/panels/variables/mimerenderer.ts
@@ -2,6 +2,7 @@ import { MainAreaWidget } from '@jupyterlab/apputils';
 import { IRenderMimeRegistry, MimeModel } from '@jupyterlab/rendermime';
 import { PromiseDelegate } from '@lumino/coreutils';
 import { Panel } from '@lumino/widgets';
+import { murmur2 } from '../../hash';
 import { IDebugger } from '../../tokens';
 
 /**
@@ -19,30 +20,55 @@ export class VariableMimeRenderer extends MainAreaWidget<Panel> {
       content,
       reveal: Promise.all([dataLoader, loaded.promise])
     });
+    this.dataLoader = dataLoader;
+    this.renderMime = rendermime;
+    this._dataHash = null;
 
-    dataLoader
-      .then(async data => {
-        if (data.data) {
-          const mimeType = rendermime.preferredMimeType(data.data, 'any');
-
-          if (mimeType) {
-            const widget = rendermime.createRenderer(mimeType);
-            const model = new MimeModel(data);
-            await widget.renderModel(model);
-
-            content.addWidget(widget);
-            loaded.resolve();
-          } else {
-            loaded.reject('Unable to determine the preferred mime type.');
-          }
-        } else {
-          loaded.reject('Unable to get a view on the variable.');
-        }
+    this.refresh()
+      .then(() => {
+        loaded.resolve();
       })
-      .catch(reason => {
-        loaded.reject(reason);
-      });
+      .catch(reason => loaded.reject(reason));
   }
+
+  /**
+   * Refresh the variable view
+   */
+  async refresh(): Promise<void> {
+    const data = await this.dataLoader();
+
+    if (data.data) {
+      const hash = murmur2(JSON.stringify(data), 17);
+      if (this._dataHash !== hash) {
+        if (this.content.layout) {
+          this.content.widgets.forEach(w => {
+            this.content.layout?.removeWidget(w);
+          });
+        }
+
+        const mimeType = this.renderMime.preferredMimeType(data.data, 'any');
+
+        if (mimeType) {
+          const widget = this.renderMime.createRenderer(mimeType);
+          const model = new MimeModel(data);
+          this._dataHash = hash;
+          await widget.renderModel(model);
+
+          this.content.addWidget(widget);
+        } else {
+          this._dataHash = null;
+          return Promise.reject('Unable to determine the preferred mime type.');
+        }
+      }
+    } else {
+      this._dataHash = null;
+      Promise.reject('Unable to get a view on the variable.');
+    }
+  }
+
+  protected dataLoader: () => Promise<IDebugger.IRichVariable>;
+  protected renderMime: IRenderMimeRegistry;
+  private _dataHash: number | null;
 }
 
 /**
@@ -54,9 +80,9 @@ export namespace VariableMimeRenderer {
    */
   export interface IOptions {
     /**
-     * Variable to be rendered
+     * Loader of the variable to be rendered
      */
-    dataLoader: Promise<IDebugger.IRichVariable>;
+    dataLoader: () => Promise<IDebugger.IRichVariable>;
     /**
      * Render mime type registry
      */

--- a/packages/debugger/src/panels/variables/mimerenderer.ts
+++ b/packages/debugger/src/panels/variables/mimerenderer.ts
@@ -42,7 +42,7 @@ export class VariableMimeRenderer extends MainAreaWidget<Panel> {
       if (this._dataHash !== hash) {
         if (this.content.layout) {
           this.content.widgets.forEach(w => {
-            this.content.layout?.removeWidget(w);
+            this.content.layout!.removeWidget(w);
           });
         }
 

--- a/packages/debugger/src/panels/variables/mimerenderer.ts
+++ b/packages/debugger/src/panels/variables/mimerenderer.ts
@@ -62,7 +62,7 @@ export class VariableMimeRenderer extends MainAreaWidget<Panel> {
       }
     } else {
       this._dataHash = null;
-      Promise.reject('Unable to get a view on the variable.');
+      return Promise.reject('Unable to get a view on the variable.');
     }
   }
 

--- a/packages/debugger/src/panels/variables/mimerenderer.ts
+++ b/packages/debugger/src/panels/variables/mimerenderer.ts
@@ -63,7 +63,7 @@ export class VariableMimeRenderer extends MainAreaWidget<Panel> {
           });
         }
 
-        // We trust unconditionally the data has the user is required to
+        // We trust unconditionally the data as the user is required to
         // execute the code to load a particular variable in memory
         const mimeType = this.renderMime.preferredMimeType(data.data, 'any');
 

--- a/packages/debugger/src/panels/variables/model.ts
+++ b/packages/debugger/src/panels/variables/model.ts
@@ -38,6 +38,13 @@ export class VariablesModel implements IDebugger.Model.IVariables {
     return this._variableExpanded;
   }
 
+  get selectedVariable(): IDebugger.IVariableSelection | null {
+    return this._selectedVariable;
+  }
+  set selectedVariable(selection: IDebugger.IVariableSelection | null) {
+    this._selectedVariable = selection;
+  }
+
   /**
    * Expand a variable.
    *
@@ -47,6 +54,7 @@ export class VariablesModel implements IDebugger.Model.IVariables {
     this._variableExpanded.emit(variable);
   }
 
+  private _selectedVariable: IDebugger.IVariableSelection | null = null;
   private _state: IDebugger.IScope[] = [];
   private _variableExpanded = new Signal<this, IDebugger.IVariable>(this);
   private _changed = new Signal<this, void>(this);

--- a/packages/debugger/src/panels/variables/tree.tsx
+++ b/packages/debugger/src/panels/variables/tree.tsx
@@ -250,35 +250,42 @@ const VariableComponent = (props: IVariableComponentProps): JSX.Element => {
       <span>: </span>
       <span style={styleType}>{convertType(variable)}</span>
       <span className="jp-DebuggerVariables-hspacer"></span>
-      {service.model.hasRichVariableRendering && (
-        <button
-          className="jp-DebuggerVariables-renderVariable"
-          disabled={
-            !commands.isEnabled(Debugger.CommandIDs.renderMimeVariable, {
-              name: variable.name,
-              variablesReference: variable.variablesReference
-            } as any)
-          }
-          onClick={e => {
-            e.stopPropagation();
-            onSelection(variable);
-            commands
-              .execute(Debugger.CommandIDs.renderMimeVariable, {
+      {service.model.hasRichVariableRendering &&
+        // Don't add rich display for special entries
+        ![
+          'special variables',
+          'protected variables',
+          'function variables',
+          'class variables'
+        ].includes(variable.name) && (
+          <button
+            className="jp-DebuggerVariables-renderVariable"
+            disabled={
+              !commands.isEnabled(Debugger.CommandIDs.renderMimeVariable, {
                 name: variable.name,
                 variablesReference: variable.variablesReference
               } as any)
-              .catch(reason => {
-                console.error(
-                  `Failed to render variable ${variable.name}`,
-                  reason
-                );
-              });
-          }}
-          title={trans.__('Render variable')}
-        >
-          <searchIcon.react stylesheet="menuItem" tag="span" />
-        </button>
-      )}
+            }
+            onClick={e => {
+              e.stopPropagation();
+              onSelection(variable);
+              commands
+                .execute(Debugger.CommandIDs.renderMimeVariable, {
+                  name: variable.name,
+                  variablesReference: variable.variablesReference
+                } as any)
+                .catch(reason => {
+                  console.error(
+                    `Failed to render variable ${variable.name}`,
+                    reason
+                  );
+                });
+            }}
+            title={trans.__('Render variable')}
+          >
+            <searchIcon.react stylesheet="menuItem" tag="span" />
+          </button>
+        )}
 
       {expanded && variables && (
         <VariablesComponent

--- a/packages/debugger/src/panels/variables/tree.tsx
+++ b/packages/debugger/src/panels/variables/tree.tsx
@@ -252,6 +252,7 @@ const VariableComponent = (props: IVariableComponentProps): JSX.Element => {
       <span className="jp-DebuggerVariables-hspacer"></span>
       {service.model.hasRichVariableRendering &&
         // Don't add rich display for special entries
+        // debugpy: https://github.com/microsoft/debugpy/blob/cf0d684566edc339545b161da7c3dfc48af7c7d5/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_utils.py#L359
         ![
           'special variables',
           'protected variables',

--- a/packages/debugger/src/panels/variables/tree.tsx
+++ b/packages/debugger/src/panels/variables/tree.tsx
@@ -31,7 +31,7 @@ export class VariablesBodyTree extends ReactWidget {
     this._service = options.service;
     this._translator = options.translator;
 
-    const model = options.model;
+    const model = (this.model = options.model);
     model.changed.connect(this._updateScopes, this);
 
     this.addClass('jp-DebuggerVariables-body');
@@ -53,19 +53,12 @@ export class VariablesBodyTree extends ReactWidget {
         filter={this._filter}
         translator={this._translator}
         handleSelectVariable={variable => {
-          this._latestSelection = variable;
+          this.model.selectedVariable = variable;
         }}
       />
     ) : (
       <div></div>
     );
-  }
-
-  /**
-   * Get the latest hit variable
-   */
-  get latestSelection(): IDebugger.IVariableSelection | null {
-    return this._latestSelection;
   }
 
   /**
@@ -97,11 +90,11 @@ export class VariablesBodyTree extends ReactWidget {
     this.update();
   }
 
+  protected model: IDebugger.Model.IVariables;
   private _commands: CommandRegistry;
   private _scope = '';
   private _scopes: IDebugger.IScope[] = [];
   private _filter = new Set<string>();
-  private _latestSelection: IDebugger.IVariableSelection | null = null;
   private _service: IDebugger;
   private _translator: ITranslator | undefined;
 }

--- a/packages/debugger/src/sidebar.ts
+++ b/packages/debugger/src/sidebar.ts
@@ -24,7 +24,7 @@ import { IDebugger } from './tokens';
 /**
  * A debugger sidebar.
  */
-export class DebuggerSidebar extends SidePanel implements IDebugger.ISidebar {
+export class DebuggerSidebar extends SidePanel {
   /**
    * Instantiate a new Debugger.Sidebar
    *

--- a/packages/debugger/src/tokens.ts
+++ b/packages/debugger/src/tokens.ts
@@ -93,12 +93,12 @@ export interface IDebugger {
    * Request rich representation of a variable.
    *
    * @param variableName The variable name to request
-   * @param variablesReference The variable reference to request
+   * @param frameId The current frame id in which to request the variable
    * @returns The mime renderer data model
    */
   inspectRichVariable(
     variableName: string,
-    variablesReference?: number
+    frameId?: number
   ): Promise<IDebugger.IRichVariable>;
 
   /**

--- a/packages/debugger/src/tokens.ts
+++ b/packages/debugger/src/tokens.ts
@@ -616,6 +616,11 @@ export namespace IDebugger {
 
   /**
    * Select variable in the variables explorer.
+   *
+   * @hidden
+   *
+   * #### Notes
+   * This is experimental API
    */
   export interface IVariableSelection
     extends Pick<
@@ -624,28 +629,9 @@ export namespace IDebugger {
     > {}
 
   /**
-   * Debugger variables explorer interface.
-   */
-  export interface IVariablesPanel {
-    /**
-     * Select variable in the variables explorer.
-     */
-    latestSelection: IVariableSelection | null;
-    /**
-     * Variable view mode.
-     */
-    viewMode: 'tree' | 'table';
-  }
-
-  /**
    * Debugger sidebar interface.
    */
-  export interface ISidebar extends Panel {
-    /**
-     * Debugger variables explorer.
-     */
-    variables: IVariablesPanel;
-  }
+  export interface ISidebar extends Panel {}
 
   /**
    * A utility to find text editors used by the debugger.
@@ -880,6 +866,11 @@ export namespace IDebugger {
        * Signal emitted when the current variable has been expanded.
        */
       readonly variableExpanded: ISignal<this, IDebugger.IVariable>;
+
+      /**
+       * Selected variable in the variables explorer.
+       */
+      selectedVariable: IVariableSelection | null;
 
       /**
        * Expand a variable.

--- a/packages/debugger/style/variables.css
+++ b/packages/debugger/style/variables.css
@@ -124,3 +124,7 @@
       0.6
     );
 }
+
+.jp-DebuggerRichVariable div[data-mime-type='text/plain'] > pre {
+  white-space: normal;
+}

--- a/packages/debugger/style/variables.css
+++ b/packages/debugger/style/variables.css
@@ -114,3 +114,13 @@
 .jp-DebuggerVariables-colorPalette .jp-mod-text {
   color: var(--jp-content-font-color0);
 }
+
+.jp-VariableRenderer-TrustButton[aria-pressed='true'] {
+  box-shadow: inset 0 var(--jp-border-width) 4px
+    rgba(
+      var(--jp-shadow-base-lightness),
+      var(--jp-shadow-base-lightness),
+      var(--jp-shadow-base-lightness),
+      0.6
+    );
+}


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Addresses #10561 for variables exploration - does not fix it when debugging code with breakpoints.
Fixes #11009
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
- Trigger update of the variable renderer when the variables model changes.
- Keep the variable renderer window open but display an info message if the variable is not available in the current context
- Move the variable selection to the variables model instead of accessing it from the view (this is ok as that API has not yet been released except in v4 alphas).
- ~~Don't trust variables if the notebook is not trusted - unsure about this one as the variable needs to be in the kernel memory for it to be displayed.~~ Trust unconditionally as the user must execute some code to get the variable in-memory.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
The variable renderer panels stay open when running cells or changing the active cell.
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

The variable renderer widget takes a `dataLoader` function and not a promise to allow data refresh.