### PR TITLE
Automated Changelog Entry for 3.2.0b0 on 3.2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.2.0b0
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.2.0a1...45377719fccb5db2185db4ac8ea5ad11e83ec1ec))
+
+### Enhancements made
+
+- Make check margin between last modified timestamps on disk and client configurable [#11153](https://github.com/jupyterlab/jupyterlab/pull/11153) ([@ph-ph](https://github.com/ph-ph))
+- reuse cell id of cut cell on cut + paste [#11138](https://github.com/jupyterlab/jupyterlab/pull/11138) ([@smacke](https://github.com/smacke))
+- Backport PR #10648 on branch 3.2.x (Add Side-by-side Rendering) [#11143](https://github.com/jupyterlab/jupyterlab/pull/11143) ([@blink1073](https://github.com/blink1073))
+
+### Bugs fixed
+
+- Share notebook's metadata [#11064](https://github.com/jupyterlab/jupyterlab/pull/11064) ([@hbcarlos](https://github.com/hbcarlos))
+- Normalize notebook cell line endings to \n [#11141](https://github.com/jupyterlab/jupyterlab/pull/11141) ([@jasongrout](https://github.com/jasongrout))
+- Fix auto close brackets for console [#11137](https://github.com/jupyterlab/jupyterlab/pull/11137) ([@ohrely](https://github.com/ohrely))
+
+### Maintenance and upkeep improvements
+
+- Fix the "Edit on GitHub" link [#11149](https://github.com/jupyterlab/jupyterlab/pull/11149) ([@krassowski](https://github.com/krassowski))
+
+### Documentation improvements
+
+- Fix the "Edit on GitHub" link [#11149](https://github.com/jupyterlab/jupyterlab/pull/11149) ([@krassowski](https://github.com/krassowski))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-09-24&to=2021-09-28&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-09-24..2021-09-28&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-09-24..2021-09-28&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-09-24..2021-09-28&type=Issues) | [@goanpeca](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agoanpeca+updated%3A2021-09-24..2021-09-28&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-09-24..2021-09-28&type=Issues) | [@jess-x](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajess-x+updated%3A2021-09-24..2021-09-28&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-09-24..2021-09-28&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-09-24..2021-09-28&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-09-24..2021-09-28&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-09-24..2021-09-28&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-09-24..2021-09-28&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.2.0a1
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.2.0a0...65580dabcb5f84dfbd3bbbe2371af66de56f800c))
@@ -33,8 +65,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-09-23&to=2021-09-23&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-09-23..2021-09-23&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-09-23..2021-09-23&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-09-23..2021-09-23&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.2.0a0
 


### PR DESCRIPTION
Automated Changelog Entry for 3.2.0b0 on 3.2.x
Python version: 3.2.0b0
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/application-top: 3.2.0-beta.0
@jupyterlab/example-console: 3.2.0-beta.0
@jupyterlab/example-cell: 3.2.0-beta.0
@jupyterlab/example-terminal: 3.2.0-beta.0
@jupyterlab/example-federated: 2.3.0-beta.0
@jupyterlab/example-app: 3.2.0-beta.0
@jupyterlab/example-filebrowser: 3.2.0-beta.0
@jupyterlab/example-notebook: 3.2.0-beta.0
@jupyterlab/example-federated-md: 2.3.0-beta.0
@jupyterlab/example-federated-core: 2.3.0-beta.0
@jupyterlab/example-federated-phosphor: 2.3.0-beta.0
@jupyterlab/example-federated-middle: 2.3.0-beta.0
@jupyterlab/statusbar: 3.2.0-beta.0
@jupyterlab/console: 3.2.0-beta.0
@jupyterlab/translation-extension: 3.2.0-beta.0
@jupyterlab/tooltip-extension: 3.2.0-beta.0
@jupyterlab/application-extension: 3.2.0-beta.0
@jupyterlab/htmlviewer: 3.2.0-beta.0
@jupyterlab/console-extension: 3.2.0-beta.0
@jupyterlab/terminal: 3.2.0-beta.0
@jupyterlab/codemirror-extension: 3.2.0-beta.0
@jupyterlab/docmanager: 3.2.0-beta.0
@jupyterlab/imageviewer: 3.2.0-beta.0
@jupyterlab/debugger-extension: 3.2.0-beta.0
@jupyterlab/inspector: 3.2.0-beta.0
@jupyterlab/rendermime-interfaces: 3.2.0-beta.0
@jupyterlab/notebook-extension: 3.2.0-beta.0
@jupyterlab/fileeditor-extension: 3.2.0-beta.0
@jupyterlab/observables: 4.2.0-beta.0
@jupyterlab/settingeditor: 3.2.0-beta.0
@jupyterlab/attachments: 3.2.0-beta.0
@jupyterlab/rendermime: 3.2.0-beta.0
@jupyterlab/running: 3.2.0-beta.0
@jupyterlab/docmanager-extension: 3.2.0-beta.0
@jupyterlab/shortcuts-extension: 3.2.0-beta.0
@jupyterlab/json-extension: 3.2.0-beta.0
@jupyterlab/filebrowser-extension: 3.2.0-beta.0
@jupyterlab/pdf-extension: 3.2.0-beta.0
@jupyterlab/logconsole: 3.2.0-beta.0
@jupyterlab/inspector-extension: 3.2.0-beta.0
@jupyterlab/toc: 5.2.0-beta.0
@jupyterlab/nbformat: 3.2.0-beta.0
@jupyterlab/toc-extension: 5.2.0-beta.0
@jupyterlab/apputils: 3.2.0-beta.0
@jupyterlab/settingregistry: 3.2.0-beta.0
@jupyterlab/codeeditor: 3.2.0-beta.0
@jupyterlab/vdom-extension: 3.2.0-beta.0
@jupyterlab/outputarea: 3.2.0-beta.0
@jupyterlab/translation: 3.2.0-beta.0
@jupyterlab/running-extension: 3.2.0-beta.0
@jupyterlab/htmlviewer-extension: 3.2.0-beta.0
@jupyterlab/settingeditor-extension: 3.2.0-beta.0
@jupyterlab/fileeditor: 3.2.0-beta.0
@jupyterlab/mainmenu: 3.2.0-beta.0
@jupyterlab/celltags-extension: 3.2.0-beta.0
@jupyterlab/extensionmanager-extension: 3.2.0-beta.0
@jupyterlab/statedb: 3.2.0-beta.0
@jupyterlab/csvviewer: 3.2.0-beta.0
@jupyterlab/javascript-extension: 3.2.0-beta.0
@jupyterlab/statusbar-extension: 3.2.0-beta.0
@jupyterlab/vega5-extension: 3.2.0-beta.0
@jupyterlab/theme-light-extension: 3.2.0-beta.0
@jupyterlab/extensionmanager: 3.2.0-beta.0
@jupyterlab/celltags: 3.2.0-beta.0
@jupyterlab/launcher-extension: 3.2.0-beta.0
@jupyterlab/ui-components-extension: 3.2.0-beta.0
@jupyterlab/services: 6.2.0-beta.0
@jupyterlab/filebrowser: 3.2.0-beta.0
@jupyterlab/theme-dark-extension: 3.2.0-beta.0
@jupyterlab/documentsearch: 3.2.0-beta.0
@jupyterlab/hub-extension: 3.2.0-beta.0
@jupyterlab/markdownviewer: 3.2.0-beta.0
@jupyterlab/apputils-extension: 3.2.0-beta.0
@jupyterlab/nbconvert-css: 3.2.0-beta.0
@jupyterlab/vdom: 3.2.0-beta.0
@jupyterlab/docprovider: 3.2.0-beta.0
@jupyterlab/documentsearch-extension: 3.2.0-beta.0
@jupyterlab/launcher: 3.2.0-beta.0
@jupyterlab/mathjax2-extension: 3.2.0-beta.0
@jupyterlab/terminal-extension: 3.2.0-beta.0
@jupyterlab/mathjax2: 3.2.0-beta.0
@jupyterlab/codemirror: 3.2.0-beta.0
@jupyterlab/metapackage: 3.2.0-beta.0
@jupyterlab/completer-extension: 3.2.0-beta.0
@jupyterlab/imageviewer-extension: 3.2.0-beta.0
@jupyterlab/help-extension: 3.2.0-beta.0
@jupyterlab/logconsole-extension: 3.2.0-beta.0
@jupyterlab/ui-components: 3.2.0-beta.0
@jupyterlab/shared-models: 3.2.0-beta.0
@jupyterlab/tooltip: 3.2.0-beta.0
@jupyterlab/csvviewer-extension: 3.2.0-beta.0
@jupyterlab/mainmenu-extension: 3.2.0-beta.0
@jupyterlab/debugger: 3.2.0-beta.0
@jupyterlab/coreutils: 5.2.0-beta.0
@jupyterlab/docregistry: 3.2.0-beta.0
@jupyterlab/completer: 3.2.0-beta.0
@jupyterlab/notebook: 3.2.0-beta.0
@jupyterlab/markdownviewer-extension: 3.2.0-beta.0
@jupyterlab/docprovider-extension: 3.2.0-beta.0
@jupyterlab/application: 3.2.0-beta.0
@jupyterlab/cells: 3.2.0-beta.0
@jupyterlab/property-inspector: 3.2.0-beta.0
@jupyterlab/rendermime-extension: 3.2.0-beta.0
node-example: 3.2.0-beta.0
@jupyterlab/example-services-browser: 3.2.0-beta.0
@jupyterlab/example-services-outputarea: 3.2.0-beta.0
@jupyterlab/builder: 3.2.0-beta.0
@jupyterlab/buildutils: 3.2.0-beta.0
@jupyterlab/template: 3.2.0-beta.0
@jupyterlab/testutils: 3.2.0-beta.0
@jupyterlab/mock-extension: 3.2.0-beta.0
@jupyterlab/mock-provider: 3.2.0-beta.0
@jupyterlab/mock-token: 3.2.0-beta.0
@jupyterlab/mock-consumer: 3.2.0-beta.0

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.2.x  |
| Version Spec | release |
| Since | v3.2.0a1 |