### PR TITLE
Fix kernelspec logo handling

### DIFF
--- a/packages/console-extension/package.json
+++ b/packages/console-extension/package.json
@@ -41,7 +41,6 @@
     "@jupyterlab/apputils": "^3.3.0-alpha.11",
     "@jupyterlab/codeeditor": "^3.3.0-alpha.11",
     "@jupyterlab/console": "^3.3.0-alpha.11",
-    "@jupyterlab/coreutils": "^5.3.0-alpha.11",
     "@jupyterlab/filebrowser": "^3.3.0-alpha.11",
     "@jupyterlab/launcher": "^3.3.0-alpha.11",
     "@jupyterlab/mainmenu": "^3.3.0-alpha.11",

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -22,7 +22,6 @@ import {
 } from '@jupyterlab/apputils';
 import { CodeEditor, IEditorServices } from '@jupyterlab/codeeditor';
 import { ConsolePanel, IConsoleTracker } from '@jupyterlab/console';
-import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
 import { ILauncher } from '@jupyterlab/launcher';
 import {
@@ -192,15 +191,10 @@ async function activateConsole(
           return;
         }
         disposables = new DisposableSet();
-        const baseUrl = PageConfig.getBaseUrl();
         for (const name in specs.kernelspecs) {
           const rank = name === specs.default ? 0 : Infinity;
           const spec = specs.kernelspecs[name]!;
           let kernelIconUrl = spec.resources['logo-64x64'];
-          if (kernelIconUrl) {
-            const index = kernelIconUrl.indexOf('kernelspecs');
-            kernelIconUrl = URLExt.join(baseUrl, kernelIconUrl.slice(index));
-          }
           disposables.add(
             launcher.add({
               command: CommandIDs.create,

--- a/packages/console-extension/tsconfig.json
+++ b/packages/console-extension/tsconfig.json
@@ -19,9 +19,6 @@
       "path": "../console"
     },
     {
-      "path": "../coreutils"
-    },
-    {
       "path": "../filebrowser"
     },
     {

--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -243,7 +243,6 @@ const resources: JupyterFrontEndPlugin<void> = {
     let counter = 0;
     const category = trans.__('Help');
     const namespace = 'help-doc';
-    const baseUrl = PageConfig.getBaseUrl();
     const { commands, shell, serviceManager } = app;
     const tracker = new WidgetTracker<MainAreaWidget<IFrame>>({ namespace });
     const resources = [

--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -371,10 +371,6 @@ const resources: JupyterFrontEndPlugin<void> = {
         }
         const kernelName = spec.display_name;
         let kernelIconUrl = spec.resources['logo-64x64'];
-        if (kernelIconUrl) {
-          const index = kernelIconUrl.indexOf('kernelspecs');
-          kernelIconUrl = baseUrl + kernelIconUrl.slice(index);
-        }
         commands.addCommand(bannerCommand, {
           label: trans.__('About the %1 Kernel', kernelName),
           isVisible: usesKernel,

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -25,7 +25,7 @@ import {
 } from '@jupyterlab/apputils';
 import { Cell, CodeCell, ICellModel, MarkdownCell } from '@jupyterlab/cells';
 import { IEditorServices } from '@jupyterlab/codeeditor';
-import { PageConfig, URLExt } from '@jupyterlab/coreutils';
+import { PageConfig } from '@jupyterlab/coreutils';
 import { IDocumentManager } from '@jupyterlab/docmanager';
 import { ToolbarItems as DocToolbarItems } from '@jupyterlab/docmanager-extension';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
@@ -1300,16 +1300,11 @@ function activateNotebookHandler(
           return;
         }
         disposables = new DisposableSet();
-        const baseUrl = PageConfig.getBaseUrl();
 
         for (const name in specs.kernelspecs) {
           const rank = name === specs.default ? 0 : Infinity;
           const spec = specs.kernelspecs[name]!;
           let kernelIconUrl = spec.resources['logo-64x64'];
-          if (kernelIconUrl) {
-            const index = kernelIconUrl.indexOf('kernelspecs');
-            kernelIconUrl = URLExt.join(baseUrl, kernelIconUrl.slice(index));
-          }
           disposables.add(
             launcher.add({
               command: CommandIDs.createNew,


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fix the handling of kernelspec logos to allow for arbitrary URLs.

This came up in https://github.com/jupyterlite/jupyterlite/pull/352 where we use the federated extension mechanism to load federated kernels in the browser. The kernels bring their own resources such as the logos, which are then served under a different URL that does not necessarily include `kernelspecs` in it (or could be absolute URLs to external sites like CDNs).

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Looks like the handling of the base url is already done in `jupyter_server`:

https://github.com/jupyter-server/jupyter_server/blob/ac93dd8f60de54db99167016f0396959826b8ed9/jupyter_server/services/kernelspecs/handlers.py#L33

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

Since this logic already lives in Jupyter Server, this should be backwards compatible and can be backported to 3.1.x and 3.2.x.