### PR TITLE
Fix renaming issue in collaborative mode

### DIFF
--- a/packages/docprovider/src/yprovider.ts
+++ b/packages/docprovider/src/yprovider.ts
@@ -135,10 +135,6 @@ export class WebSocketProviderWithLocks
   setPath(newPath: string): void {
     if (newPath !== this._path) {
       this._path = newPath;
-      // The next time the provider connects, we should connect through a different server url
-      this.bcChannel =
-        this._serverUrl + '/' + this._contentType + ':' + this._path;
-      this.url = this.bcChannel;
       const encoder = encoding.createEncoder();
       encoding.write(encoder, 123);
       // writing a utf8 string to the encoder
@@ -152,6 +148,13 @@ export class WebSocketProviderWithLocks
         );
       }
       this._sendMessage(encoding.toUint8Array(encoder));
+      // prevent publishing messages to the old channel id.
+      this.disconnectBc();
+      // The next time the provider connects, we should connect through a different server url
+      this.bcChannel =
+        this._serverUrl + '/' + this._contentType + ':' + this._path;
+      this.url = this.bcChannel;
+      this.connectBc();
     }
   }
 


### PR DESCRIPTION
## References

Fixes the issue described in #11116. I briefly described the problem in the mentioned ticket. The y-websocket provider distributes updates through two channels: via the websocket connection to the jupyter server and via broadcastchannel - a technology for cross-window communication. The problem was that we didn't properly unsubscribe from messages of the broadcastchannel when a file is renamed. Hence we still received messages from the "Untitled" document.

## Code changes

Properly unsubscribe and resubscribe to messages from the new document-path.

## User-facing changes

None.

## Backwards-incompatible changes

None.
