### PR TITLE
refactor window.open to make it work also in desktop app

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -394,20 +394,16 @@ export const exportPlugin: JupyterFrontEndPlugin<void> = {
           download: true,
           path: current.context.path
         });
-        const child = window.open('', '_blank');
         const { context } = current;
 
-        if (child) {
-          child.opener = null;
-        }
         if (context.model.dirty && !context.model.readOnly) {
           return context.save().then(() => {
-            child?.location.assign(url);
+            window.open(url, '_blank', 'noopener');
           });
         }
 
         return new Promise<void>(resolve => {
-          child?.location.assign(url);
+          window.open(url, '_blank', 'noopener');
           resolve(undefined);
         });
       },


### PR DESCRIPTION
Export Notebook downloads are not working in Desktop App as reported in https://github.com/jupyterlab/jupyterlab_app/issues/270 . Because, in Electron `window.open` is returning null and setting a URL later on fails.

## Code changes

Instead of creating popup with no URL first and then setting a URL, now download URL is set directly in `window.open` call.

## User-facing changes

none

## Backwards-incompatible changes

none
