### PR TITLE
Properly reset layout when toggling simple mode.

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -537,11 +537,10 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
 
     const applicationCurrentWidget = this.currentWidget;
 
-    // Toggle back to multiple document mode.
-    dock.mode = mode;
-
     if (mode === 'single-document') {
+      // Cache the current multi-document layout before changing the mode.
       this._cachedLayout = dock.saveLayout();
+      dock.mode = mode;
 
       // In case the active widget in the dock panel is *not* the active widget
       // of the application, defer to the application.
@@ -557,8 +556,10 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
         this._topHandler.panel.hide();
       }
     } else {
-      // Cache a reference to every widget currently in the dock panel.
+      // Cache a reference to every widget currently in the dock panel before
+      // changing its mode.
       const widgets = toArray(dock.widgets());
+      dock.mode = mode;
 
       // Restore the original layout.
       if (this._cachedLayout) {


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #10947

This reverts part of ea9aa707c2537d2b89c30375a1225648f0b948d1.

## Code changes

This caches the multi-document layout *before* setting the mode to single-document, so that it can be restored later.

## User-facing changes

Toggling the simple mode on and off now restores the window layout.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
