### PR TITLE
Handle case when JupyterHub returns 424 for not running server

### DIFF
--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -239,11 +239,13 @@ export class KernelManager extends BaseManager implements Kernel.IManager {
     try {
       models = await listRunning(this.serverSettings);
     } catch (err) {
-      // Check for a network error, or a 503 error, which is returned
-      // by a JupyterHub when a server is shut down.
+      // Handle network errors, as well as cases where we are on a
+      // JupyterHub and the server is not running. JupyterHub returns a
+      // 503 (<2.0) or 404 (>2.0) in that case.
       if (
         err instanceof ServerConnection.NetworkError ||
-        err.response?.status === 503
+        err.response?.status === 503 ||
+        err.response?.status === 404
       ) {
         this._connectionFailure.emit(err);
       }

--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -241,11 +241,11 @@ export class KernelManager extends BaseManager implements Kernel.IManager {
     } catch (err) {
       // Handle network errors, as well as cases where we are on a
       // JupyterHub and the server is not running. JupyterHub returns a
-      // 503 (<2.0) or 404 (>2.0) in that case.
+      // 503 (<2.0) or 424 (>2.0) in that case.
       if (
         err instanceof ServerConnection.NetworkError ||
         err.response?.status === 503 ||
-        err.response?.status === 404
+        err.response?.status === 424
       ) {
         this._connectionFailure.emit(err);
       }

--- a/packages/services/src/session/manager.ts
+++ b/packages/services/src/session/manager.ts
@@ -251,11 +251,11 @@ export class SessionManager extends BaseManager implements Session.IManager {
     } catch (err) {
       // Handle network errors, as well as cases where we are on a
       // JupyterHub and the server is not running. JupyterHub returns a
-      // 503 (<2.0) or 404 (>2.0) in that case.
+      // 503 (<2.0) or 424 (>2.0) in that case.
       if (
         err instanceof ServerConnection.NetworkError ||
         err.response?.status === 503 ||
-        err.response?.status === 404
+        err.response?.status === 424
       ) {
         this._connectionFailure.emit(err);
       }

--- a/packages/services/src/session/manager.ts
+++ b/packages/services/src/session/manager.ts
@@ -249,11 +249,13 @@ export class SessionManager extends BaseManager implements Session.IManager {
     try {
       models = await listRunning(this.serverSettings);
     } catch (err) {
-      // Check for a network error, or a 503 error, which is returned
-      // by a JupyterHub when a server is shut down.
+      // Handle network errors, as well as cases where we are on a
+      // JupyterHub and the server is not running. JupyterHub returns a
+      // 503 (<2.0) or 404 (>2.0) in that case.
       if (
         err instanceof ServerConnection.NetworkError ||
-        err.response?.status === 503
+        err.response?.status === 503 ||
+        err.response?.status === 404
       ) {
         this._connectionFailure.emit(err);
       }

--- a/packages/services/src/terminal/manager.ts
+++ b/packages/services/src/terminal/manager.ts
@@ -214,11 +214,11 @@ export class TerminalManager extends BaseManager implements Terminal.IManager {
     } catch (err) {
       // Handle network errors, as well as cases where we are on a
       // JupyterHub and the server is not running. JupyterHub returns a
-      // 503 (<2.0) or 404 (>2.0) in that case.
+      // 503 (<2.0) or 424 (>2.0) in that case.
       if (
         err instanceof ServerConnection.NetworkError ||
         err.response?.status === 503 ||
-        err.response?.status === 404
+        err.response?.status === 424
       ) {
         this._connectionFailure.emit(err);
       }

--- a/packages/services/src/terminal/manager.ts
+++ b/packages/services/src/terminal/manager.ts
@@ -212,11 +212,13 @@ export class TerminalManager extends BaseManager implements Terminal.IManager {
     try {
       models = await listRunning(this.serverSettings);
     } catch (err) {
-      // Check for a network error, or a 503 error, which is returned
-      // by a JupyterHub when a server is shut down.
+      // Handle network errors, as well as cases where we are on a
+      // JupyterHub and the server is not running. JupyterHub returns a
+      // 503 (<2.0) or 404 (>2.0) in that case.
       if (
         err instanceof ServerConnection.NetworkError ||
-        err.response?.status === 503
+        err.response?.status === 503 ||
+        err.response?.status === 404
       ) {
         this._connectionFailure.emit(err);
       }


### PR DESCRIPTION
## References

Companion to https://github.com/jupyterhub/jupyterhub/pull/3636,
should be merged only if that is.

## Code changes

Treat a 424 response from the server as 'server is not running' as well, not just a 503.
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Users will see a pop-up about restarting their server correctly once
https://github.com/jupyterhub/jupyterhub/pull/3636 lands.

## Backwards-incompatible changes

If the change in JupyterHub lands, I think people using previous versions of JupyterLab
will not see a popup asking them to restart their server. However, once this change lands,
JupyterLab can detect this problem in old and new versions of JupyterHub. So in some ways,
this is a backwards compatibility break in JupyterHub.
