### PR TITLE
Backport PR #10769 on branch 3.2.x (Add a menu entry to show/hide hidden files in the filebrowser)

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -303,7 +303,7 @@ Internationalization
 Translatable strings update
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The translatable strings update cannot occur on patch release. They 
+The translatable strings update cannot occur on patch release. They
 must be delayed on minor or major versions.
 
 Performance Testing
@@ -546,13 +546,13 @@ Main reasons for UI test failures are:
 
 1. **A visual regression caused by code changes**:
 
-   Sometimes unintentional UI changes are introduced by modifications to project source code. Goal of visual regression testing is to detect this kind of UI changes. If your PR / commit is causing visual regression, then debug and fix the regression caused. You can locally run and debug the UI tests to fix the visual regression. Follow the instructions in steps 5-7 of ``Adding a new UI test suite guide`` in `UI Testing documentation <https://github.com/jupyterlab/jupyterlab/blob/3.2.x/ui-tests/README.md#adding-a-new-ui-test-suite>`__ to locally debug and fix UI tests. Once you have a fix, you can push the change to your GitHub branch and test with GitHub actions.
+   Sometimes unintentional UI changes are introduced by modifications to project source code. Goal of visual regression testing is to detect this kind of UI changes. If your PR / commit is causing visual regression, then debug and fix the regression caused. You can locally run and debug the UI tests to fix the visual regression. Follow the instructions in steps 5-7 of ``Adding a new UI test suite guide`` in `UI Testing documentation <https://github.com/jupyterlab/jupyterlab/blob/3.2.x/galata/README.md#adding-a-new-ui-test-suite>`__ to locally debug and fix UI tests. Once you have a fix, you can push the change to your GitHub branch and test with GitHub actions.
 
 2. **An intended update to user interface**:
 
    If your code change is introducing an update to UI which causes existing UI Tests to fail, then you will need to update reference image(s) for the failing tests. In order to do that, simply go to GitHub Actions page for the failed test and download test artifacts. It will contain test captures in directory ``test/screenshots``. You can copy the capture for the failed test and paste into reference screenshots directory in JupyterLab source code, replacing the failing test's reference capture. Reference captures are located in ``ui-tests/reference-output/screenshots`` in JupyterLab source code.
 
-For more information on UI Testing, please read the `UI Testing developer documentation <.https://github.com/jupyterlab/jupyterlab/blob/3.2.x/ui-tests/README.md>`__ and `Galata documentation <https://github.com/jupyterlab/galata/blob/main/README.md>`__.
+For more information on UI Testing, please read the `UI Testing developer documentation <.https://github.com/jupyterlab/jupyterlab/blob/3.2.x/galata/README.md>`__ and `Galata documentation <https://github.com/jupyterlab/galata/blob/main/README.md>`__.
 
 Good Practices for Integration tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -722,6 +722,7 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
         page_config['exposeAppInBrowser'] = self.expose_app_in_browser
         page_config['quitButton'] = self.serverapp.quit_button
         page_config['collaborative'] = self.collaborative
+        page_config['allow_hidden_files'] = self.serverapp.contents_manager.allow_hidden
 
         # Client-side code assumes notebookVersion is a JSON-encoded string
         page_config['notebookVersion'] = json.dumps(jpserver_version_info)

--- a/packages/filebrowser-extension/schema/browser.json
+++ b/packages/filebrowser-extension/schema/browser.json
@@ -21,6 +21,15 @@
         ]
       },
       {
+        "id": "jp-mainmenu-view",
+        "items": [
+          {
+            "command": "filebrowser:toggle-hidden-files",
+            "rank": 9.95
+          }
+        ]
+      },
+      {
         "id": "jp-mainmenu-settings",
         "items": [
           {
@@ -198,6 +207,12 @@
       "title": "Show last modified column",
       "description": "Whether to show the last modified column",
       "default": true
+    },
+    "showHiddenFiles": {
+      "type": "boolean",
+      "title": "Show hidden files",
+      "description": "Whether to show hidden files",
+      "default": false
     }
   },
   "additionalProperties": false,

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -118,6 +118,8 @@ namespace CommandIDs {
   export const toggleLastModified = 'filebrowser:toggle-last-modified';
 
   export const search = 'filebrowser:search';
+
+  export const toggleHiddenFiles = 'filebrowser:toggle-hidden-files';
 }
 
 /**
@@ -199,6 +201,7 @@ const browser: JupyterFrontEndPlugin<void> = {
       let navigateToCurrentDirectory: boolean = false;
       let showLastModifiedColumn: boolean = true;
       let useFuzzyFilter: boolean = true;
+      let showHiddenFiles: boolean = false;
 
       if (settingRegistry) {
         void settingRegistry
@@ -233,6 +236,16 @@ const browser: JupyterFrontEndPlugin<void> = {
             useFuzzyFilter = settings.get('useFuzzyFilter')
               .composite as boolean;
             browser.useFuzzyFilter = useFuzzyFilter;
+
+            settings.changed.connect(settings => {
+              showHiddenFiles = settings.get('showHiddenFiles')
+                .composite as boolean;
+              browser.showHiddenFiles = showHiddenFiles;
+            });
+            showHiddenFiles = settings.get('showHiddenFiles')
+              .composite as boolean;
+
+            browser.showHiddenFiles = showHiddenFiles;
           });
       }
     });
@@ -1020,6 +1033,23 @@ function addCommands(
           .set('@jupyterlab/filebrowser-extension:browser', key, value)
           .catch((reason: Error) => {
             console.error(`Failed to set showLastModifiedColumn setting`);
+          });
+      }
+    }
+  });
+
+  commands.addCommand(CommandIDs.toggleHiddenFiles, {
+    label: trans.__('Show Hidden Files'),
+    isToggled: () => browser.showHiddenFiles,
+    isVisible: () => PageConfig.getOption('allow_hidden_files') === 'true',
+    execute: () => {
+      const value = !browser.showHiddenFiles;
+      const key = 'showHiddenFiles';
+      if (settingRegistry) {
+        return settingRegistry
+          .set('@jupyterlab/filebrowser-extension:browser', key, value)
+          .catch((reason: Error) => {
+            console.error(`Failed to set showHiddenFiles setting`);
           });
       }
     }

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -199,6 +199,18 @@ export class FileBrowser extends Widget {
   }
 
   /**
+   * Whether to show hidden files
+   */
+  get showHiddenFiles(): boolean {
+    return this._showHiddenFiles;
+  }
+
+  set showHiddenFiles(value: boolean) {
+    this.model.showHiddenFiles(value);
+    this._showHiddenFiles = value;
+  }
+
+  /**
    * Create an iterator over the listing's selected items.
    *
    * @returns A new iterator over the listing's selected items.
@@ -413,6 +425,7 @@ export class FileBrowser extends Widget {
   private _navigateToCurrentDirectory: boolean;
   private _showLastModifiedColumn: boolean = true;
   private _useFuzzyFilter: boolean = true;
+  private _showHiddenFiles: boolean = false;
 }
 
 /**

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -709,12 +709,57 @@ export namespace FileBrowserModel {
 }
 
 /**
+ * File browser model where hidden files inclusion can be toggled on/off.
+ */
+export class TogglableHiddenFileBrowserModel extends FileBrowserModel {
+  constructor(options: TogglableHiddenFileBrowserModel.IOptions) {
+    super(options);
+    this._includeHiddenFiles = options.includeHiddenFiles || false;
+  }
+
+  /**
+   * Create an iterator over the model's items filtering hidden files out if necessary.
+   *
+   * @returns A new iterator over the model's items.
+   */
+  items(): IIterator<Contents.IModel> {
+    return this._includeHiddenFiles
+      ? super.items()
+      : filter(super.items(), value => !value.name.startsWith('.'));
+  }
+
+  /**
+   * Set the inclusion of hidden files. Triggers a model refresh.
+   */
+  showHiddenFiles(value: boolean): void {
+    this._includeHiddenFiles = value;
+    void this.refresh();
+  }
+
+  private _includeHiddenFiles: boolean;
+}
+
+/**
+ * Namespace for the togglable hidden file browser model
+ */
+export namespace TogglableHiddenFileBrowserModel {
+  /**
+   * Constructor options
+   */
+  export interface IOptions extends FileBrowserModel.IOptions {
+    /**
+     * Whether hidden files should be included in the items.
+     */
+    includeHiddenFiles?: boolean;
+  }
+}
+
+/**
  * File browser model with optional filter on element.
  */
-export class FilterFileBrowserModel extends FileBrowserModel {
+export class FilterFileBrowserModel extends TogglableHiddenFileBrowserModel {
   constructor(options: FilterFileBrowserModel.IOptions) {
     super(options);
-    this.translator = options.translator || nullTranslator;
     this._filter = options.filter ? options.filter : model => true;
   }
 
@@ -748,7 +793,7 @@ export namespace FilterFileBrowserModel {
   /**
    * Constructor options
    */
-  export interface IOptions extends FileBrowserModel.IOptions {
+  export interface IOptions extends TogglableHiddenFileBrowserModel.IOptions {
     /**
      * Filter function on file browser item model
      */


### PR DESCRIPTION
Backport PR #10769: Add a menu entry to show/hide hidden files in the filebrowser