### PR TITLE
Check i18n will pass on zeroed patch pre-release version

### DIFF
--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -61,7 +61,10 @@ jobs:
           EXPECTED=$(python scripts/i18n_check.py | tail -n1)
           if [[ "${CURRENT}" != "${EXPECTED}" ]]; then
             echo "Translatable strings have changed, this is only allowed on major or minor version bumps."
-            if [[ "${GITHUB_BASE_REF}" != "master" ]]; then
+            # Set job status as failed if
+            # - branch is not "master"
+            # - and current version is not a pre release of a zeroed patch version
+            if [[ "${GITHUB_BASE_REF}" != "master" && ! ( $(python setup.py --version) =~ ^[0-9]+\.[0-9]+\.0(\.dev|a|b|rc)[0-9]+$ ) ]]; then
               exit 1
             fi
           fi


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #11213
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Skip raising failure for check i18n if the python package version is a pre-release of X.Y.0 version

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A