### PR TITLE
Fix Release Check

### DIFF
--- a/builder/src/webpack.config.base.ts
+++ b/builder/src/webpack.config.base.ts
@@ -107,6 +107,9 @@ module.exports = {
     poll: 500,
     aggregateTimeout: 1000
   },
+  output: {
+    hashFunction: 'xxhash64'
+  },
   plugins: [
     new webpack.ProvidePlugin({
       process: 'process/browser'

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -43,7 +43,7 @@ python -m pip install $(ls dist/*.whl)
 # back to testing
 pushd $TEST_DIR
 
-jupyter lab build
+jupyter lab build --debug
 
 JLAB_BROWSER_CHECK_OUTPUT=${OUTPUT_DIR} python -m jupyterlab.browser_check
 


### PR DESCRIPTION

## References
Fix recent failures seen in [CI](https://github.com/jupyterlab/jupyterlab/runs/3802093368?check_suite_focus=true)

## Code changes
Use hash algorithm bundled with webpack instead of relying on the system provided hash.
Will require releases across the board to get `release_check` working again.

## User-facing changes
None

## Backwards-incompatible changes
None
