### PR TITLE
don't continuously `cd('/')` when already in /

### DIFF
--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -297,7 +297,7 @@ export class FileBrowserModel implements IDisposable {
       .catch(error => {
         this._pendingPath = null;
         this._pending = null;
-        if (error.response && error.response.status === 404) {
+        if (error.response && error.response.status === 404 && newValue !== '/') {
           error.message = this._trans.__(
             'Directory not found: "%1"',
             this._model.path


### PR DESCRIPTION
## References

closes #11207

## Code changes

check if path is already `/` before triggering `cd('/')` shortcut on 404 to `/api/contents/...`

## User-facing changes

When a request to GET /api/contents fails with 404, failure will occur one time, rather than triggering an infinite loop on `cd('/')`, flooding the server with the same failing request
