### PR TITLE
Remove format from fetching options if null

### DIFF
--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -660,9 +660,11 @@ export class Context<
    */
   private _revert(initializeModel: boolean = false): Promise<void> {
     const opts: Contents.IFetchOptions = {
-      format: this._factory.fileFormat,
       type: this._factory.contentType,
-      content: this._factory.fileFormat !== null
+      content: this._factory.fileFormat !== null,
+      ...(this._factory.fileFormat !== null
+        ? { format: this._factory.fileFormat }
+        : {})
     };
     const path = this._path;
     const model = this._model;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fix #10757 

Follows #7596

## Code changes

Format is removed from the fetching options if `null`. This avoids `format` to be misinterpreted (parsed as string `null`) on the server side.

## User-facing changes

None.

## Backwards-incompatible changes

None.
