### PR TITLE
Use standard hash type in webpack build

### DIFF
--- a/builder/src/webpack.config.base.ts
+++ b/builder/src/webpack.config.base.ts
@@ -108,7 +108,7 @@ module.exports = {
     aggregateTimeout: 1000
   },
   output: {
-    hashFunction: 'xxhash64'
+    hashFunction: 'sha256'
   },
   plugins: [
     new webpack.ProvidePlugin({


### PR DESCRIPTION

## References
Follow up to https://github.com/jupyterlab/jupyterlab/pull/11218

## Code changes
Use standard hashing algorithm
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
