### PR TITLE
Automated Changelog Entry for 3.1.17 on 3.1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.1.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.1.17
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.1.16...a899a8b9da2216d91a2426c4956bc2e711a93ecd))
+
+### Bugs fixed
+
+- Use standard hash type in webpack build [#11234](https://github.com/jupyterlab/jupyterlab/pull/11234) ([@blink1073](https://github.com/blink1073))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-10-05&to=2021-10-05&type=c))
+
+[@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-10-05..2021-10-05&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-10-05..2021-10-05&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.1.15
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.1.14...fc00631f2088d90655b0e09a96f14da86a02f911))
@@ -32,8 +48,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.1.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-09-27&to=2021-10-05&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-09-27..2021-10-05&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-09-27..2021-10-05&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2021-09-27..2021-10-05&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-09-27..2021-10-05&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-09-27..2021-10-05&type=Issues) | [@goanpeca](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agoanpeca+updated%3A2021-09-27..2021-10-05&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2021-09-27..2021-10-05&type=Issues) | [@isabela-pf](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aisabela-pf+updated%3A2021-09-27..2021-10-05&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-09-27..2021-10-05&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-09-27..2021-10-05&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-09-27..2021-10-05&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-09-27..2021-10-05&type=Issues) | [@loichuder](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aloichuder+updated%3A2021-09-27..2021-10-05&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-09-27..2021-10-05&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-09-27..2021-10-05&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASylvainCorlay+updated%3A2021-09-27..2021-10-05&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-09-27..2021-10-05&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.1.14
 


### PR DESCRIPTION
Automated Changelog Entry for 3.1.17 on 3.1.x
Python version: 3.1.17
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/application-top: 3.1.17
@jupyterlab/example-console: 3.1.16
@jupyterlab/example-cell: 3.1.16
@jupyterlab/example-terminal: 3.1.16
@jupyterlab/example-federated: 2.2.16
@jupyterlab/example-app: 3.1.17
@jupyterlab/example-filebrowser: 3.1.16
@jupyterlab/example-notebook: 3.1.16
@jupyterlab/example-federated-md: 2.2.17
@jupyterlab/example-federated-core: 2.2.17
@jupyterlab/example-federated-phosphor: 2.2.17
@jupyterlab/example-federated-middle: 2.2.17
@jupyterlab/statusbar: 3.1.16
@jupyterlab/console: 3.1.16
@jupyterlab/translation-extension: 3.1.16
@jupyterlab/tooltip-extension: 3.1.16
@jupyterlab/application-extension: 3.1.16
@jupyterlab/htmlviewer: 3.1.16
@jupyterlab/console-extension: 3.1.16
@jupyterlab/terminal: 3.1.16
@jupyterlab/codemirror-extension: 3.1.16
@jupyterlab/docmanager: 3.1.16
@jupyterlab/imageviewer: 3.1.16
@jupyterlab/debugger-extension: 3.1.16
@jupyterlab/inspector: 3.1.16
@jupyterlab/rendermime-interfaces: 3.1.16
@jupyterlab/notebook-extension: 3.1.16
@jupyterlab/fileeditor-extension: 3.1.16
@jupyterlab/observables: 4.1.16
@jupyterlab/settingeditor: 3.1.16
@jupyterlab/attachments: 3.1.16
@jupyterlab/rendermime: 3.1.16
@jupyterlab/running: 3.1.16
@jupyterlab/docmanager-extension: 3.1.16
@jupyterlab/shortcuts-extension: 3.1.16
@jupyterlab/json-extension: 3.1.17
@jupyterlab/filebrowser-extension: 3.1.16
@jupyterlab/pdf-extension: 3.1.16
@jupyterlab/logconsole: 3.1.16
@jupyterlab/inspector-extension: 3.1.16
@jupyterlab/toc: 5.1.16
@jupyterlab/nbformat: 3.1.16
@jupyterlab/toc-extension: 5.1.16
@jupyterlab/apputils: 3.1.16
@jupyterlab/settingregistry: 3.1.16
@jupyterlab/codeeditor: 3.1.16
@jupyterlab/vdom-extension: 3.1.17
@jupyterlab/outputarea: 3.1.16
@jupyterlab/translation: 3.1.16
@jupyterlab/running-extension: 3.1.16
@jupyterlab/htmlviewer-extension: 3.1.16
@jupyterlab/settingeditor-extension: 3.1.16
@jupyterlab/fileeditor: 3.1.16
@jupyterlab/mainmenu: 3.1.16
@jupyterlab/celltags-extension: 3.1.16
@jupyterlab/extensionmanager-extension: 3.1.16
@jupyterlab/statedb: 3.1.16
@jupyterlab/csvviewer: 3.1.16
@jupyterlab/javascript-extension: 3.1.17
@jupyterlab/statusbar-extension: 3.1.16
@jupyterlab/vega5-extension: 3.1.17
@jupyterlab/theme-light-extension: 3.1.16
@jupyterlab/extensionmanager: 3.1.16
@jupyterlab/celltags: 3.1.16
@jupyterlab/launcher-extension: 3.1.16
@jupyterlab/ui-components-extension: 3.1.16
@jupyterlab/services: 6.1.16
@jupyterlab/filebrowser: 3.1.16
@jupyterlab/theme-dark-extension: 3.1.16
@jupyterlab/documentsearch: 3.1.16
@jupyterlab/hub-extension: 3.1.16
@jupyterlab/markdownviewer: 3.1.16
@jupyterlab/apputils-extension: 3.1.17
@jupyterlab/nbconvert-css: 3.1.16
@jupyterlab/vdom: 3.1.17
@jupyterlab/docprovider: 3.1.16
@jupyterlab/documentsearch-extension: 3.1.16
@jupyterlab/launcher: 3.1.16
@jupyterlab/mathjax2-extension: 3.1.16
@jupyterlab/terminal-extension: 3.1.16
@jupyterlab/mathjax2: 3.1.16
@jupyterlab/codemirror: 3.1.16
@jupyterlab/metapackage: 3.1.17
@jupyterlab/completer-extension: 3.1.16
@jupyterlab/imageviewer-extension: 3.1.16
@jupyterlab/help-extension: 3.1.16
@jupyterlab/logconsole-extension: 3.1.16
@jupyterlab/ui-components: 3.1.16
@jupyterlab/shared-models: 3.1.16
@jupyterlab/tooltip: 3.1.16
@jupyterlab/csvviewer-extension: 3.1.16
@jupyterlab/mainmenu-extension: 3.1.16
@jupyterlab/debugger: 3.1.16
@jupyterlab/coreutils: 5.1.16
@jupyterlab/docregistry: 3.1.16
@jupyterlab/completer: 3.1.16
@jupyterlab/notebook: 3.1.16
@jupyterlab/markdownviewer-extension: 3.1.16
@jupyterlab/docprovider-extension: 3.1.16
@jupyterlab/application: 3.1.16
@jupyterlab/cells: 3.1.16
@jupyterlab/property-inspector: 3.1.16
@jupyterlab/rendermime-extension: 3.1.16
node-example: 3.1.16
@jupyterlab/example-services-browser: 3.1.16
@jupyterlab/example-services-outputarea: 3.1.16
@jupyterlab/builder: 3.1.17
@jupyterlab/buildutils: 3.1.17
@jupyterlab/template: 3.1.16
@jupyterlab/testutils: 3.1.16
@jupyterlab/mock-extension: 3.1.17
@jupyterlab/mock-provider: 3.1.17
@jupyterlab/mock-token: 3.1.16
@jupyterlab/mock-consumer: 3.1.17

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.1.x  |
| Version Spec | next |
| Since | v3.1.16 |