### PR TITLE
Automated Changelog Entry for 3.1.18 on 3.1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.1.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.1.18
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.1.17...c6dc40f16ea6fd1b5a58167dec6ed066de3304a9))
+
+### Bugs fixed
+
+- Backport PR #11249 on branch 3.1.x (Fix Webpack crypto handling) [#11252](https://github.com/jupyterlab/jupyterlab/pull/11252) ([@blink1073](https://github.com/blink1073))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-10-05&to=2021-10-07&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-10-05..2021-10-07&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-10-05..2021-10-07&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-10-05..2021-10-07&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.1.17
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.1.16...a899a8b9da2216d91a2426c4956bc2e711a93ecd))
@@ -21,8 +37,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.1.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-10-05&to=2021-10-05&type=c))
 
 [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-10-05..2021-10-05&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-10-05..2021-10-05&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.1.16
 


### PR DESCRIPTION
Automated Changelog Entry for 3.1.18 on 3.1.x
Python version: 3.1.18
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/application-top: 3.1.18
@jupyterlab/example-console: 3.1.17
@jupyterlab/example-cell: 3.1.17
@jupyterlab/example-app: 3.1.18
@jupyterlab/example-filebrowser: 3.1.17
@jupyterlab/example-notebook: 3.1.17
@jupyterlab/example-terminal: 3.1.17
@jupyterlab/example-federated: 2.2.17
@jupyterlab/example-federated-middle: 2.2.18
@jupyterlab/example-federated-phosphor: 2.2.18
@jupyterlab/example-federated-md: 2.2.18
@jupyterlab/example-federated-core: 2.2.18
@jupyterlab/notebook-extension: 3.1.17
@jupyterlab/rendermime: 3.1.17
@jupyterlab/console: 3.1.17
@jupyterlab/console-extension: 3.1.17
@jupyterlab/running-extension: 3.1.17
@jupyterlab/services: 6.1.17
@jupyterlab/settingregistry: 3.1.17
@jupyterlab/inspector: 3.1.17
@jupyterlab/celltags: 3.1.17
@jupyterlab/docmanager-extension: 3.1.17
@jupyterlab/statusbar-extension: 3.1.17
@jupyterlab/settingeditor-extension: 3.1.17
@jupyterlab/outputarea: 3.1.17
@jupyterlab/imageviewer-extension: 3.1.17
@jupyterlab/help-extension: 3.1.17
@jupyterlab/debugger: 3.1.17
@jupyterlab/documentsearch-extension: 3.1.17
@jupyterlab/markdownviewer-extension: 3.1.17
@jupyterlab/vdom-extension: 3.1.18
@jupyterlab/cells: 3.1.17
@jupyterlab/theme-dark-extension: 3.1.17
@jupyterlab/attachments: 3.1.17
@jupyterlab/nbconvert-css: 3.1.17
@jupyterlab/mainmenu-extension: 3.1.17
@jupyterlab/coreutils: 5.1.17
@jupyterlab/debugger-extension: 3.1.17
@jupyterlab/nbformat: 3.1.17
@jupyterlab/hub-extension: 3.1.17
@jupyterlab/toc-extension: 5.1.17
@jupyterlab/fileeditor: 3.1.17
@jupyterlab/inspector-extension: 3.1.17
@jupyterlab/ui-components-extension: 3.1.17
@jupyterlab/docmanager: 3.1.17
@jupyterlab/codeeditor: 3.1.17
@jupyterlab/toc: 5.1.17
@jupyterlab/launcher-extension: 3.1.17
@jupyterlab/csvviewer: 3.1.17
@jupyterlab/shortcuts-extension: 3.1.17
@jupyterlab/completer-extension: 3.1.17
@jupyterlab/codemirror-extension: 3.1.17
@jupyterlab/rendermime-extension: 3.1.17
@jupyterlab/javascript-extension: 3.1.18
@jupyterlab/docregistry: 3.1.17
@jupyterlab/property-inspector: 3.1.17
@jupyterlab/logconsole-extension: 3.1.17
@jupyterlab/extensionmanager: 3.1.17
@jupyterlab/settingeditor: 3.1.17
@jupyterlab/launcher: 3.1.17
@jupyterlab/statusbar: 3.1.17
@jupyterlab/statedb: 3.1.17
@jupyterlab/completer: 3.1.17
@jupyterlab/application: 3.1.17
@jupyterlab/logconsole: 3.1.17
@jupyterlab/translation: 3.1.17
@jupyterlab/filebrowser: 3.1.17
@jupyterlab/metapackage: 3.1.18
@jupyterlab/json-extension: 3.1.18
@jupyterlab/docprovider: 3.1.17
@jupyterlab/codemirror: 3.1.17
@jupyterlab/terminal-extension: 3.1.17
@jupyterlab/translation-extension: 3.1.17
@jupyterlab/pdf-extension: 3.1.17
@jupyterlab/tooltip-extension: 3.1.17
@jupyterlab/tooltip: 3.1.17
@jupyterlab/vega5-extension: 3.1.18
@jupyterlab/imageviewer: 3.1.17
@jupyterlab/notebook: 3.1.17
@jupyterlab/celltags-extension: 3.1.17
@jupyterlab/docprovider-extension: 3.1.17
@jupyterlab/running: 3.1.17
@jupyterlab/apputils-extension: 3.1.18
@jupyterlab/documentsearch: 3.1.17
@jupyterlab/ui-components: 3.1.17
@jupyterlab/shared-models: 3.1.17
@jupyterlab/fileeditor-extension: 3.1.17
@jupyterlab/markdownviewer: 3.1.17
@jupyterlab/mathjax2: 3.1.17
@jupyterlab/theme-light-extension: 3.1.17
@jupyterlab/htmlviewer: 3.1.17
@jupyterlab/mathjax2-extension: 3.1.17
@jupyterlab/mainmenu: 3.1.17
@jupyterlab/terminal: 3.1.17
@jupyterlab/htmlviewer-extension: 3.1.17
@jupyterlab/apputils: 3.1.17
@jupyterlab/extensionmanager-extension: 3.1.17
@jupyterlab/csvviewer-extension: 3.1.17
@jupyterlab/vdom: 3.1.18
@jupyterlab/rendermime-interfaces: 3.1.17
@jupyterlab/application-extension: 3.1.17
@jupyterlab/observables: 4.1.17
@jupyterlab/filebrowser-extension: 3.1.17
node-example: 3.1.17
@jupyterlab/example-services-browser: 3.1.17
@jupyterlab/example-services-outputarea: 3.1.17
@jupyterlab/builder: 3.1.18
@jupyterlab/buildutils: 3.1.18
@jupyterlab/template: 3.1.17
@jupyterlab/testutils: 3.1.17
@jupyterlab/mock-extension: 3.1.18
@jupyterlab/mock-provider: 3.1.18
@jupyterlab/mock-token: 3.1.17
@jupyterlab/mock-consumer: 3.1.18

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.1.x  |
| Version Spec | next |
| Since | v3.1.17 |