### PR TITLE
Automated Changelog Entry for 3.2.0rc0 on 3.2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,29 +14,30 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 
 ### Enhancements made
 
-- Backport PR #10769 on branch 3.2.x (Add a menu entry to show/hide hidden files in the filebrowser) [#11206](https://github.com/jupyterlab/jupyterlab/pull/11206) ([@loichuder](https://github.com/loichuder))
-- Backport PR #11011 on branch 3.2.x (Restore Copy shareable link use of shareUrl) [#11188](https://github.com/jupyterlab/jupyterlab/pull/11188) ([@fcollonval](https://github.com/fcollonval))
-- Backport PR #10796 to 3.2.x: Add Galata in JupyterLab [#11179](https://github.com/jupyterlab/jupyterlab/pull/11179) ([@fcollonval](https://github.com/fcollonval))
-- Manual backport of #10720, #10790, #11108 [#11178](https://github.com/jupyterlab/jupyterlab/pull/11178) ([@3coins](https://github.com/3coins))
+- Add a menu entry to show/hide hidden files in the filebrowser [#11206](https://github.com/jupyterlab/jupyterlab/pull/11206) ([@loichuder](https://github.com/loichuder))
+- Restore Copy shareable link use of `shareUrl` [#11188](https://github.com/jupyterlab/jupyterlab/pull/11188) ([@fcollonval](https://github.com/fcollonval))
+- Add Galata in JupyterLab [#11179](https://github.com/jupyterlab/jupyterlab/pull/11179) ([@fcollonval](https://github.com/fcollonval))
+- Responsive Toolbar [#11178](https://github.com/jupyterlab/jupyterlab/pull/11178) ([@3coins](https://github.com/3coins))
 - Make check margin between last modified timestamps on disk and client configurable [#11153](https://github.com/jupyterlab/jupyterlab/pull/11153) ([@ph-ph](https://github.com/ph-ph))
-- reuse cell id of cut cell on cut + paste [#11138](https://github.com/jupyterlab/jupyterlab/pull/11138) ([@smacke](https://github.com/smacke))
-- Backport PR #10648 on branch 3.2.x (Add Side-by-side Rendering) [#11143](https://github.com/jupyterlab/jupyterlab/pull/11143) ([@blink1073](https://github.com/blink1073))
-- Backport PR #10632 on branch 3.2.x (Add show trailing whitespace option to Notebook and Text Editor [#11131](https://github.com/jupyterlab/jupyterlab/pull/11131) ([@blink1073](https://github.com/blink1073))
-- Backport PR #10462 on branch 3.2.x (Implemented Restart and debug) [#11129](https://github.com/jupyterlab/jupyterlab/pull/11129) ([@blink1073](https://github.com/blink1073))
-- PR: Add preferred-dir handling [#10667](https://github.com/jupyterlab/jupyterlab/pull/10667) ([@goanpeca](https://github.com/goanpeca))
+- Reuse cell id of cut cell on cut + paste [#11138](https://github.com/jupyterlab/jupyterlab/pull/11138) ([@smacke](https://github.com/smacke))
+- Add Side-by-side Rendering [#11143](https://github.com/jupyterlab/jupyterlab/pull/11143) ([@blink1073](https://github.com/blink1073))
+- Add show trailing whitespace option to Notebook and Text Editor [#11131](https://github.com/jupyterlab/jupyterlab/pull/11131) ([@blink1073](https://github.com/blink1073))
+- Implement Restart and debug [#11129](https://github.com/jupyterlab/jupyterlab/pull/11129) ([@blink1073](https://github.com/blink1073))
+- Add `preferred-dir` handling [#10667](https://github.com/jupyterlab/jupyterlab/pull/10667) ([@goanpeca](https://github.com/goanpeca))
 - Enable disabling document-wide history tracking [#10949](https://github.com/jupyterlab/jupyterlab/pull/10949) ([@echarles](https://github.com/echarles))
+- Removed debug switch [#11185](https://github.com/jupyterlab/jupyterlab/pull/11185) ([@3coins](https://github.com/3coins))
 
 ### Bugs fixed
 
 - Fix Webpack crypto handling [#11249](https://github.com/jupyterlab/jupyterlab/pull/11249) ([@blink1073](https://github.com/blink1073))
 - Use standard hash type in webpack build [#11234](https://github.com/jupyterlab/jupyterlab/pull/11234) ([@blink1073](https://github.com/blink1073))
 - Remove format from fetching options if null [#11229](https://github.com/jupyterlab/jupyterlab/pull/11229) ([@loichuder](https://github.com/loichuder))
-- don't continuously `cd('/')` when already in / [#11219](https://github.com/jupyterlab/jupyterlab/pull/11219) ([@minrk](https://github.com/minrk))
+- don't continuously `cd('/')` when already in `/` [#11219](https://github.com/jupyterlab/jupyterlab/pull/11219) ([@minrk](https://github.com/minrk))
 - Properly reset layout when toggling simple mode. [#11203](https://github.com/jupyterlab/jupyterlab/pull/11203) ([@jasongrout](https://github.com/jasongrout))
 - Fix renaming issue in collaborative mode [#11197](https://github.com/jupyterlab/jupyterlab/pull/11197) ([@dmonad](https://github.com/dmonad))
-- Backport PR #11168 on branch 3.2.x (Restore workspace and open tree path) [#11176](https://github.com/jupyterlab/jupyterlab/pull/11176) ([@blink1073](https://github.com/blink1073))
+- Restore workspace and open tree path [#11176](https://github.com/jupyterlab/jupyterlab/pull/11176) ([@blink1073](https://github.com/blink1073))
 - Share notebook's metadata [#11064](https://github.com/jupyterlab/jupyterlab/pull/11064) ([@hbcarlos](https://github.com/hbcarlos))
-- Normalize notebook cell line endings to \n [#11141](https://github.com/jupyterlab/jupyterlab/pull/11141) ([@jasongrout](https://github.com/jasongrout))
+- Normalize notebook cell line endings to `\n` [#11141](https://github.com/jupyterlab/jupyterlab/pull/11141) ([@jasongrout](https://github.com/jasongrout))
 - Fix auto close brackets for console [#11137](https://github.com/jupyterlab/jupyterlab/pull/11137) ([@ohrely](https://github.com/ohrely))
 - Add a guard to avoid kernel deadlock on multiple input request [#10792](https://github.com/jupyterlab/jupyterlab/pull/10792) ([@echarles](https://github.com/echarles))
 
@@ -45,25 +46,21 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 - Run Linter [#11238](https://github.com/jupyterlab/jupyterlab/pull/11238) ([@blink1073](https://github.com/blink1073))
 - Fix Release Check [#11218](https://github.com/jupyterlab/jupyterlab/pull/11218) ([@fcollonval](https://github.com/fcollonval))
 - Handle case when JupyterHub returns 424 for not running server [#11205](https://github.com/jupyterlab/jupyterlab/pull/11205) ([@yuvipanda](https://github.com/yuvipanda))
-- Check i18n will pass on zeroed patch pre-release version [#11214](https://github.com/jupyterlab/jupyterlab/pull/11214) ([@fcollonval](https://github.com/fcollonval))
-- refactor window.open to make it work also in desktop app [#11202](https://github.com/jupyterlab/jupyterlab/pull/11202) ([@mbektas](https://github.com/mbektas))
+- Check `i18n` will pass on zeroed patch pre-release version [#11214](https://github.com/jupyterlab/jupyterlab/pull/11214) ([@fcollonval](https://github.com/fcollonval))
+- Refactor `window.open` to make it work also in desktop app [#11202](https://github.com/jupyterlab/jupyterlab/pull/11202) ([@mbektas](https://github.com/mbektas))
 - Rename "JupyterLab Theme" to "Theme" [#11198](https://github.com/jupyterlab/jupyterlab/pull/11198) ([@jtpio](https://github.com/jtpio))
 - Use only context and id to check i18n [#11190](https://github.com/jupyterlab/jupyterlab/pull/11190) ([@fcollonval](https://github.com/fcollonval))
 - Fix the "Edit on GitHub" link [#11149](https://github.com/jupyterlab/jupyterlab/pull/11149) ([@krassowski](https://github.com/krassowski))
-- Backport PR #11021 on branch 3.2.x (Clean up notebook test utils) [#11133](https://github.com/jupyterlab/jupyterlab/pull/11133) ([@blink1073](https://github.com/blink1073))
-- Backport PR #10904 on branch 3.2.x (Change "Export Notebook As" to "Save and Export Notebook As") [#11132](https://github.com/jupyterlab/jupyterlab/pull/11132) ([@blink1073](https://github.com/blink1073))
+- Clean up notebook test utils [#11133](https://github.com/jupyterlab/jupyterlab/pull/11133) ([@blink1073](https://github.com/blink1073))
+- Change "Export Notebook As" to "Save and Export Notebook As" [#11132](https://github.com/jupyterlab/jupyterlab/pull/11132) ([@blink1073](https://github.com/blink1073))
 - Make Test Server Configurable [#11015](https://github.com/jupyterlab/jupyterlab/pull/11015) ([@fcollonval](https://github.com/fcollonval))
+- Use disableDocumentWideUndoRedo instead of enableDocumentWideUndoRedo [#11215](https://github.com/jupyterlab/jupyterlab/pull/11215) ([@echarles](https://github.com/echarles))
+- Fix kernelspec logo handling (#11175) [#11183](https://github.com/jupyterlab/jupyterlab/pull/11183) ([@jtpio](https://github.com/jtpio))
 
 ### Documentation improvements
 
-- Backport PR #10769 on branch 3.2.x (Add a menu entry to show/hide hidden files in the filebrowser) [#11206](https://github.com/jupyterlab/jupyterlab/pull/11206) ([@loichuder](https://github.com/loichuder))
+- Add a menu entry to show/hide hidden files in the filebrowser [#11206](https://github.com/jupyterlab/jupyterlab/pull/11206) ([@loichuder](https://github.com/loichuder))
 - Fix the "Edit on GitHub" link [#11149](https://github.com/jupyterlab/jupyterlab/pull/11149) ([@krassowski](https://github.com/krassowski))
-
-### Other merged PRs
-
-- Use disableDocumentWideUndoRedo instead of enableDocumentWideUndoRedo [#11215](https://github.com/jupyterlab/jupyterlab/pull/11215) ([@echarles](https://github.com/echarles))
-- Manual backport of PR #10727: Removed debug switch [#11185](https://github.com/jupyterlab/jupyterlab/pull/11185) ([@3coins](https://github.com/3coins))
-- [3.2.x] Backport: Fix kernelspec logo handling (#11175) [#11183](https://github.com/jupyterlab/jupyterlab/pull/11183) ([@jtpio](https://github.com/jtpio))
 
 ### Contributors to this release
 
@@ -72,66 +69,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 [@3coins](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3A3coins+updated%3A2021-09-01..2021-10-07&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-09-01..2021-10-07&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-09-01..2021-10-07&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2021-09-01..2021-10-07&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-09-01..2021-10-07&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-09-01..2021-10-07&type=Issues) | [@goanpeca](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agoanpeca+updated%3A2021-09-01..2021-10-07&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2021-09-01..2021-10-07&type=Issues) | [@isabela-pf](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aisabela-pf+updated%3A2021-09-01..2021-10-07&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-09-01..2021-10-07&type=Issues) | [@jess-x](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajess-x+updated%3A2021-09-01..2021-10-07&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-09-01..2021-10-07&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-09-01..2021-10-07&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-09-01..2021-10-07&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-09-01..2021-10-07&type=Issues) | [@loichuder](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aloichuder+updated%3A2021-09-01..2021-10-07&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-09-01..2021-10-07&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-09-01..2021-10-07&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASylvainCorlay+updated%3A2021-09-01..2021-10-07&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrungleduc+updated%3A2021-09-01..2021-10-07&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-09-01..2021-10-07&type=Issues)
 
 <!-- <END NEW CHANGELOG ENTRY> -->
-
-## 3.2.0b0
-
-([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.2.0a1...45377719fccb5db2185db4ac8ea5ad11e83ec1ec))
-
-### Enhancements made
-
-- Make check margin between last modified timestamps on disk and client configurable [#11153](https://github.com/jupyterlab/jupyterlab/pull/11153) ([@ph-ph](https://github.com/ph-ph))
-- reuse cell id of cut cell on cut + paste [#11138](https://github.com/jupyterlab/jupyterlab/pull/11138) ([@smacke](https://github.com/smacke))
-- Backport PR #10648 on branch 3.2.x (Add Side-by-side Rendering) [#11143](https://github.com/jupyterlab/jupyterlab/pull/11143) ([@blink1073](https://github.com/blink1073))
-
-### Bugs fixed
-
-- Share notebook's metadata [#11064](https://github.com/jupyterlab/jupyterlab/pull/11064) ([@hbcarlos](https://github.com/hbcarlos))
-- Normalize notebook cell line endings to \n [#11141](https://github.com/jupyterlab/jupyterlab/pull/11141) ([@jasongrout](https://github.com/jasongrout))
-- Fix auto close brackets for console [#11137](https://github.com/jupyterlab/jupyterlab/pull/11137) ([@ohrely](https://github.com/ohrely))
-
-### Maintenance and upkeep improvements
-
-- Fix the "Edit on GitHub" link [#11149](https://github.com/jupyterlab/jupyterlab/pull/11149) ([@krassowski](https://github.com/krassowski))
-
-### Documentation improvements
-
-- Fix the "Edit on GitHub" link [#11149](https://github.com/jupyterlab/jupyterlab/pull/11149) ([@krassowski](https://github.com/krassowski))
-
-### Contributors to this release
-
-([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-09-24&to=2021-09-28&type=c))
-
-[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-09-24..2021-09-28&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-09-24..2021-09-28&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-09-24..2021-09-28&type=Issues) | [@goanpeca](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agoanpeca+updated%3A2021-09-24..2021-09-28&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-09-24..2021-09-28&type=Issues) | [@jess-x](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajess-x+updated%3A2021-09-24..2021-09-28&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-09-24..2021-09-28&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-09-24..2021-09-28&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-09-24..2021-09-28&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-09-24..2021-09-28&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-09-24..2021-09-28&type=Issues)
-
-## 3.2.0a1
-
-([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.2.0a0...65580dabcb5f84dfbd3bbbe2371af66de56f800c))
-
-### Enhancements made
-
-- Add show trailing whitespace option to Notebook and Text Editor [#11131](https://github.com/jupyterlab/jupyterlab/pull/11131) ([@blink1073](https://github.com/blink1073))
-- Implemented Restart and debug [#11129](https://github.com/jupyterlab/jupyterlab/pull/11129) ([@blink1073](https://github.com/blink1073))
-- Add `preferred-dir` handling [#10667](https://github.com/jupyterlab/jupyterlab/pull/10667) ([@goanpeca](https://github.com/goanpeca))
-
-### Bugs fixed
-
-- Add a guard to avoid kernel deadlock on multiple input request [#10792](https://github.com/jupyterlab/jupyterlab/pull/10792) ([@echarles](https://github.com/echarles))
-
-### Maintenance and upkeep improvements
-
-- Clean up notebook test utils [#11133](https://github.com/jupyterlab/jupyterlab/pull/11133) ([@blink1073](https://github.com/blink1073))
-- Change "Export Notebook As" to "Save and Export Notebook As" [#11132](https://github.com/jupyterlab/jupyterlab/pull/11132) ([@blink1073](https://github.com/blink1073))
-- Make Test Server Configurable [#11015](https://github.com/jupyterlab/jupyterlab/pull/11015) ([@fcollonval](https://github.com/fcollonval))
-
-### Contributors to this release
-
-([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-09-23&to=2021-09-23&type=c))
-
-[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-09-23..2021-09-23&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-09-23..2021-09-23&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-09-23..2021-09-23&type=Issues)
-
-## 3.2.0a0
-
-No merged PRs
 
 ## v3.1
 


### PR DESCRIPTION
Automated Changelog Entry for 3.2.0rc0 on 3.2.x
Python version: 3.2.0rc0
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/application-top: 3.2.0-rc.0
@jupyterlab/example-console: 3.2.0-rc.0
@jupyterlab/example-cell: 3.2.0-rc.0
@jupyterlab/example-app: 3.2.0-rc.0
@jupyterlab/example-filebrowser: 3.2.0-rc.0
@jupyterlab/example-notebook: 3.2.0-rc.0
@jupyterlab/example-terminal: 3.2.0-rc.0
@jupyterlab/example-federated: 2.3.0-rc.0
@jupyterlab/example-federated-middle: 2.3.0-rc.0
@jupyterlab/example-federated-phosphor: 2.3.0-rc.0
@jupyterlab/example-federated-md: 2.3.0-rc.0
@jupyterlab/example-federated-core: 2.3.0-rc.0
@jupyterlab/notebook-extension: 3.2.0-rc.0
@jupyterlab/rendermime: 3.2.0-rc.0
@jupyterlab/console: 3.2.0-rc.0
@jupyterlab/console-extension: 3.2.0-rc.0
@jupyterlab/running-extension: 3.2.0-rc.0
@jupyterlab/services: 6.2.0-rc.0
@jupyterlab/settingregistry: 3.2.0-rc.0
@jupyterlab/inspector: 3.2.0-rc.0
@jupyterlab/celltags: 3.2.0-rc.0
@jupyterlab/docmanager-extension: 3.2.0-rc.0
@jupyterlab/statusbar-extension: 3.2.0-rc.0
@jupyterlab/settingeditor-extension: 3.2.0-rc.0
@jupyterlab/outputarea: 3.2.0-rc.0
@jupyterlab/imageviewer-extension: 3.2.0-rc.0
@jupyterlab/help-extension: 3.2.0-rc.0
@jupyterlab/debugger: 3.2.0-rc.0
@jupyterlab/documentsearch-extension: 3.2.0-rc.0
@jupyterlab/markdownviewer-extension: 3.2.0-rc.0
@jupyterlab/vdom-extension: 3.2.0-rc.0
@jupyterlab/cells: 3.2.0-rc.0
@jupyterlab/theme-dark-extension: 3.2.0-rc.0
@jupyterlab/attachments: 3.2.0-rc.0
@jupyterlab/nbconvert-css: 3.2.0-rc.0
@jupyterlab/mainmenu-extension: 3.2.0-rc.0
@jupyterlab/coreutils: 5.2.0-rc.0
@jupyterlab/debugger-extension: 3.2.0-rc.0
@jupyterlab/nbformat: 3.2.0-rc.0
@jupyterlab/hub-extension: 3.2.0-rc.0
@jupyterlab/toc-extension: 5.2.0-rc.0
@jupyterlab/fileeditor: 3.2.0-rc.0
@jupyterlab/inspector-extension: 3.2.0-rc.0
@jupyterlab/ui-components-extension: 3.2.0-rc.0
@jupyterlab/docmanager: 3.2.0-rc.0
@jupyterlab/codeeditor: 3.2.0-rc.0
@jupyterlab/toc: 5.2.0-rc.0
@jupyterlab/launcher-extension: 3.2.0-rc.0
@jupyterlab/csvviewer: 3.2.0-rc.0
@jupyterlab/shortcuts-extension: 3.2.0-rc.0
@jupyterlab/completer-extension: 3.2.0-rc.0
@jupyterlab/codemirror-extension: 3.2.0-rc.0
@jupyterlab/rendermime-extension: 3.2.0-rc.0
@jupyterlab/javascript-extension: 3.2.0-rc.0
@jupyterlab/docregistry: 3.2.0-rc.0
@jupyterlab/property-inspector: 3.2.0-rc.0
@jupyterlab/logconsole-extension: 3.2.0-rc.0
@jupyterlab/extensionmanager: 3.2.0-rc.0
@jupyterlab/settingeditor: 3.2.0-rc.0
@jupyterlab/launcher: 3.2.0-rc.0
@jupyterlab/statusbar: 3.2.0-rc.0
@jupyterlab/statedb: 3.2.0-rc.0
@jupyterlab/completer: 3.2.0-rc.0
@jupyterlab/application: 3.2.0-rc.0
@jupyterlab/logconsole: 3.2.0-rc.0
@jupyterlab/translation: 3.2.0-rc.0
@jupyterlab/filebrowser: 3.2.0-rc.0
@jupyterlab/metapackage: 3.2.0-rc.0
@jupyterlab/json-extension: 3.2.0-rc.0
@jupyterlab/docprovider: 3.2.0-rc.0
@jupyterlab/codemirror: 3.2.0-rc.0
@jupyterlab/terminal-extension: 3.2.0-rc.0
@jupyterlab/translation-extension: 3.2.0-rc.0
@jupyterlab/pdf-extension: 3.2.0-rc.0
@jupyterlab/tooltip-extension: 3.2.0-rc.0
@jupyterlab/tooltip: 3.2.0-rc.0
@jupyterlab/vega5-extension: 3.2.0-rc.0
@jupyterlab/imageviewer: 3.2.0-rc.0
@jupyterlab/notebook: 3.2.0-rc.0
@jupyterlab/celltags-extension: 3.2.0-rc.0
@jupyterlab/docprovider-extension: 3.2.0-rc.0
@jupyterlab/running: 3.2.0-rc.0
@jupyterlab/apputils-extension: 3.2.0-rc.0
@jupyterlab/documentsearch: 3.2.0-rc.0
@jupyterlab/ui-components: 3.2.0-rc.0
@jupyterlab/shared-models: 3.2.0-rc.0
@jupyterlab/fileeditor-extension: 3.2.0-rc.0
@jupyterlab/markdownviewer: 3.2.0-rc.0
@jupyterlab/mathjax2: 3.2.0-rc.0
@jupyterlab/theme-light-extension: 3.2.0-rc.0
@jupyterlab/htmlviewer: 3.2.0-rc.0
@jupyterlab/mathjax2-extension: 3.2.0-rc.0
@jupyterlab/mainmenu: 3.2.0-rc.0
@jupyterlab/terminal: 3.2.0-rc.0
@jupyterlab/htmlviewer-extension: 3.2.0-rc.0
@jupyterlab/apputils: 3.2.0-rc.0
@jupyterlab/extensionmanager-extension: 3.2.0-rc.0
@jupyterlab/csvviewer-extension: 3.2.0-rc.0
@jupyterlab/vdom: 3.2.0-rc.0
@jupyterlab/rendermime-interfaces: 3.2.0-rc.0
@jupyterlab/application-extension: 3.2.0-rc.0
@jupyterlab/observables: 4.2.0-rc.0
@jupyterlab/filebrowser-extension: 3.2.0-rc.0
node-example: 3.2.0-rc.0
@jupyterlab/example-services-browser: 3.2.0-rc.0
@jupyterlab/example-services-outputarea: 3.2.0-rc.0
@jupyterlab/builder: 3.2.0-rc.0
@jupyterlab/buildutils: 3.2.0-rc.0
@jupyterlab/template: 3.2.0-rc.0
@jupyterlab/galata: 4.0.0-rc.0
@jupyterlab/testutils: 3.2.0-rc.0
@jupyterlab/mock-extension: 3.2.0-rc.0
@jupyterlab/mock-provider: 3.2.0-rc.0
@jupyterlab/mock-token: 3.2.0-rc.0
@jupyterlab/mock-consumer: 3.2.0-rc.0

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.2.x  |
| Version Spec | release |
| Since Last Stable | true |