### PR TITLE
Fix nbconvert compatibility with fips-enabled openssl

### DIFF
--- a/packages/nbconvert-css/webpack.config.js
+++ b/packages/nbconvert-css/webpack.config.js
@@ -5,7 +5,8 @@ module.exports = {
   entry: './raw.js',
   output: {
     filename: 'index.js',
-    path: path.resolve(__dirname, 'style')
+    path: path.resolve(__dirname, 'style'),
+    hashFunction: 'sha256'
   },
   plugins: [
     new MiniCssExtractPlugin({


### PR DESCRIPTION

## References
Follow up to https://github.com/jupyterlab/jupyterlab/pull/11249

## Code changes
Add appropriate `hashFunction` `webpack` config for `nbconvert-css`

## User-facing changes
None

## Backwards-incompatible changes
None