### PR TITLE
Added button theme variables, updated button style

### DIFF
--- a/packages/application/style/buttons.css
+++ b/packages/application/style/buttons.css
@@ -17,67 +17,67 @@ button {
 }
 
 button:focus-visible {
-  border: 1px solid var(--jp-button-accept-active-color, var(--jp-brand-color1));
+  border: 1px solid var(--jp-accept-color-active, var(--jp-brand-color1));
 }
 
 button.jp-mod-styled.jp-mod-accept {
-  background: var(--jp-button-accept-normal-color, var(--md-blue-500));
+  background: var(--jp-accept-color-normal, var(--md-blue-500));
   border: 0;
   color: white;
 }
 
 button.jp-mod-styled.jp-mod-accept:hover {
-  background: var(--jp-button-accept-hover-color, var(--md-blue-600));
+  background: var(--jp-accept-color-hover, var(--md-blue-600));
 }
 
 button.jp-mod-styled.jp-mod-accept:active {
-  background: var(--jp-button-accept-active-color, var(--md-blue-700));
+  background: var(--jp-accept-color-active, var(--md-blue-700));
 }
 
 button.jp-mod-styled.jp-mod-accept:focus-visible {
-  border: 1px solid var(--jp-button-accept-active-color, var(--jp-brand-color1));
+  border: 1px solid var(--jp-accept-color-active, var(--jp-brand-color1));
 }
 
 button.jp-mod-styled.jp-mod-reject {
-  background: var(--jp-button-reject-normal-color, var(--md-grey-500));
+  background: var(--jp-reject-color-normal, var(--md-grey-500));
   border: 0;
   color: white;
 }
 
 button.jp-mod-styled.jp-mod-reject:hover {
-  background: var(--jp-button-reject-hover-color, var(--md-grey-600));
+  background: var(--jp-reject-color-hover, var(--md-grey-600));
 }
 
 button.jp-mod-styled.jp-mod-reject:active {
-  background: var(--jp-button-reject-active-color, var(--md-grey-700));
+  background: var(--jp-reject-color-active, var(--md-grey-700));
 }
 
 button.jp-mod-styled.jp-mod-reject:focus-visible {
-  border: 1px solid var(--jp-button-reject-active-color, var(--md-grey-700));
+  border: 1px solid var(--jp-reject-color-active, var(--md-grey-700));
 }
 
 button.jp-mod-styled.jp-mod-warn {
-  background: var(--jp-button-warn-normal-color, var(--jp-error-color1));
+  background: var(--jp-warn-color-normal, var(--jp-error-color1));
   border: 0;
   color: white;
 }
 
 button.jp-mod-styled.jp-mod-warn:hover {
-  background: var(--jp-button-warn-hover-color, var(--md-red-600));
+  background: var(--jp-warn-color-hover, var(--md-red-600));
 }
 
 button.jp-mod-styled.jp-mod-warn:active {
-  background: var(--jp-button-warn-active-color, var(--md-red-700));
+  background: var(--jp-warn-color-active, var(--md-red-700));
 }
 
 button.jp-mod-styled.jp-mod-warn:focus-visible {
-  border: 1px solid var(--jp-button-warn-active-color, var(--md-red-700));
+  border: 1px solid var(--jp-warn-color-active, var(--md-red-700));
 }
 
 .jp-Button-flat {
   text-decoration: none;
   padding: var(--jp-flat-button-padding);
-  color: var(--jp-button-warn-normal-color, var(--jp-warn-color1));
+  color: var(--jp-warn-color-normal, var(--jp-warn-color1));
   font-weight: 500;
   background-color: transparent;
   height: var(--jp-private-running-shutdown-button-height);
@@ -87,14 +87,11 @@ button.jp-mod-styled.jp-mod-warn:focus-visible {
 }
 
 .jp-Button-flat:hover {
-  background-color: var(--jp-button-warn-hover-color, rgba(153, 153, 153, 0.1));
+  background-color: var(--jp-warn-color-hover, rgba(153, 153, 153, 0.1));
 }
 
 .jp-Button-flat:focus {
   border: none;
   box-shadow: none;
-  background-color: var(
-    --jp-button-warn-active-color,
-    rgba(153, 153, 153, 0.2)
-  );
+  background-color: var(--jp-warn-color-active, rgba(153, 153, 153, 0.2));
 }

--- a/packages/apputils/style/dialog.css
+++ b/packages/apputils/style/dialog.css
@@ -65,16 +65,15 @@ button.jp-Dialog-button.jp-mod-styled.jp-mod-reject:focus {
 }
 
 button.jp-Dialog-button.jp-mod-styled.jp-mod-accept:focus {
-  outline: 1px solid
-    var(--jp-button-accept-normal-color, var(--jp-brand-color1));
+  outline: 1px solid var(--jp-accept-color-normal, var(--jp-brand-color1));
 }
 
 button.jp-Dialog-button.jp-mod-styled.jp-mod-warn:focus {
-  outline: 1px solid var(--jp-button-warn-normal-color, var(--jp-error-color1));
+  outline: 1px solid var(--jp-warn-color-normal, var(--jp-error-color1));
 }
 
 button.jp-Dialog-button.jp-mod-styled.jp-mod-reject:focus {
-  outline: 1px solid var(--jp-button-reject-normal-color, var(--md-grey-600));
+  outline: 1px solid var(--jp-reject-color-normal, var(--md-grey-600));
 }
 
 button.jp-Dialog-close-button {

--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -86,16 +86,13 @@
   .jp-Toolbar-item:first-child
   .jp-ToolbarButtonComponent {
   width: 72px;
-  background: var(--jp-button-accept-normal-color, var(--jp-brand-color1));
+  background: var(--jp-accept-color-normal, var(--jp-brand-color1));
 }
 
 .jp-FileBrowser-toolbar.jp-Toolbar
   .jp-Toolbar-item:first-child
   .jp-ToolbarButtonComponent:focus-visible {
-  background-color: var(
-    --jp-button-accept-active-color,
-    var(--jp-brand-color0)
-  );
+  background-color: var(--jp-accept-color-active, var(--jp-brand-color0));
 }
 
 .jp-FileBrowser-toolbar.jp-Toolbar

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -408,15 +408,15 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-icon-contrast-color3: var(--md-blue-600);
 
   /* Button colors */
-  --jp-button-accept-normal-color: var(--md-blue-700);
-  --jp-button-accept-hover-color: var(--md-blue-800);
-  --jp-button-accept-active-color: var(--md-blue-900);
+  --jp-accept-color-normal: var(--md-blue-700);
+  --jp-accept-color-hover: var(--md-blue-800);
+  --jp-accept-color-active: var(--md-blue-900);
 
-  --jp-button-warn-normal-color: var(--md-red-700);
-  --jp-button-warn-hover-color: var(--md-red-800);
-  --jp-button-warn-active-color: var(--md-red-900);
+  --jp-warn-color-normal: var(--md-red-700);
+  --jp-warn-color-hover: var(--md-red-800);
+  --jp-warn-color-active: var(--md-red-900);
 
-  --jp-button-reject-normal-color: var(--md-grey-600);
-  --jp-button-reject-hover-color: var(--md-grey-700);
-  --jp-button-reject-active-color: var(--md-grey-800);
+  --jp-reject-color-normal: var(--md-grey-600);
+  --jp-reject-color-hover: var(--md-grey-700);
+  --jp-reject-color-active: var(--md-grey-800);
 }

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -391,15 +391,15 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-icon-contrast-color3: var(--md-blue-600);
 
   /* Button colors */
-  --jp-button-accept-normal-color: var(--md-blue-700);
-  --jp-button-accept-hover-color: var(--md-blue-800);
-  --jp-button-accept-active-color: var(--md-blue-900);
+  --jp-accept-color-normal: var(--md-blue-700);
+  --jp-accept-color-hover: var(--md-blue-800);
+  --jp-accept-color-active: var(--md-blue-900);
 
-  --jp-button-warn-normal-color: var(--md-red-700);
-  --jp-button-warn-hover-color: var(--md-red-800);
-  --jp-button-warn-active-color: var(--md-red-900);
+  --jp-warn-color-normal: var(--md-red-700);
+  --jp-warn-color-hover: var(--md-red-800);
+  --jp-warn-color-active: var(--md-red-900);
 
-  --jp-button-reject-normal-color: var(--md-grey-600);
-  --jp-button-reject-hover-color: var(--md-grey-700);
-  --jp-button-reject-active-color: var(--md-grey-800);
+  --jp-reject-color-normal: var(--md-grey-600);
+  --jp-reject-color-hover: var(--md-grey-700);
+  --jp-reject-color-active: var(--md-grey-800);
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
This PR fixes [#11260](https://github.com/jupyterlab/jupyterlab/issues/11260)

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Introduce new theme variables for button styles in all variants (accept, reject, warn) and states (normal, hover, active)
- [x] For default values, use a sequence of material design colors that are WCAG accessible.
- [x] Update focus state with a 1px border color to match the non-hover/active state.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->
#### Before
![buttons-before](https://user-images.githubusercontent.com/289369/136884621-b2f5ada0-68d6-4bc1-a855-4cbb6ffc968e.gif)

#### After
![buttons-after](https://user-images.githubusercontent.com/289369/136884661-cc8f538c-924b-485f-b165-387658ad072d.gif)

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
