### PR TITLE
Clarify sidebar switching settings

### DIFF
--- a/packages/application-extension/schema/sidebar.json
+++ b/packages/application-extension/schema/sidebar.json
@@ -16,7 +16,7 @@
       "type": "object",
       "title": "Overrides",
       "default": {},
-      "description": "Overrides for where to show sidebar items\ne.g., {\"tab-manager\": \"right\"}",
+      "description": "Overrides for where to show sidebar items\ne.g., {\"jp-debugger-sidebar\": \"left\"}\nYou can also change this by right-clicking the sidebar icons.",
       "properties": {},
       "additionalProperties": {
         "type": "string",


### PR DESCRIPTION
I had issues when trying to modify the sidebar settings because I didn't know the names of the different icons and they don't follow a predicatable pattern. This PR updates the outdated example and includes a note about the right-clicking of side bar icons, which I only found out myself after searching the GitHub repo and stumbling upon the changelog entry for when that was introduced.