### PR TITLE
Fix memory leak with notebooks and ANSI colors in Firefox (#9431)

### DIFF
--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -1001,7 +1001,7 @@ namespace Private {
    * This is supposed to have the same behavior as nbconvert.filters.ansi2html()
    */
   export function ansiSpan(str: string): string {
-    const ansiRe = /\x1b\[([^@-~]*?)([@-~])/g; // eslint-disable-line no-control-regex
+    const ansiRe = /\x1b\[([^@-~]*)([@-~])/g; // eslint-disable-line no-control-regex
     let fg: number | Array<number> = [];
     let bg: number | Array<number> = [];
     let bold = false;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Issue #9431

## Code changes

Do `/\x1b\[([^@-~]*?)([@-~])/g` instead of `/\x1b\[(.*?)([@-~])/g`

## User-facing changes

None

## Backwards-incompatible changes

No breaking change.
