### PR TITLE
Extension upgrade script: Avoid throwing exceptions for certain package.json files

### DIFF
--- a/jupyterlab/upgrade_extension.py
+++ b/jupyterlab/upgrade_extension.py
@@ -96,8 +96,11 @@ def update_extension(target, branch=DEFAULT_COOKIECUTTER_BRANCH, interactive=Tru
     with open(osp.join(output_dir, 'package.json')) as fid:
         temp_data = json.load(fid)
 
-    for (key, value) in temp_data['devDependencies'].items():
-        data['devDependencies'][key] = value
+    if data.get('devDependencies'):
+        for (key, value) in temp_data['devDependencies'].items():
+            data['devDependencies'][key] = value
+    else:
+        data['devDependencies'] = temp_data['devDependencies'].copy()
 
     # Ask the user whether to upgrade the scripts automatically
     warnings = []
@@ -140,7 +143,7 @@ def update_extension(target, branch=DEFAULT_COOKIECUTTER_BRANCH, interactive=Tru
 
     # Update style settings
     data.setdefault('styleModule', 'style/index.js')
-    if 'sideEffects' in data and 'style/index.js' not in data['sideEffects']:
+    if isinstance(data.get('sideEffects'), list) and 'style/index.js' not in data['sideEffects']:
         data['sideEffects'].append('style/index.js')
     if 'files' in data and 'style/index.js' not in data['files']:
         data['files'].append('style/index.js')


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Resolves the exceptions thrown in #11277

**Disclaimer:** I am unable to test whether this actually produces a valid package file, as I have not figured out how to successfully build even the current version of the `pydeck` extension mentioned in the above issue. However looking at various `package.json` files around the internet, the script does seem to make assumptions that may not necessarily be true. Other sections of the upgrade script might also have similar bugs in it.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- upgrade script assumes `sideEffects` in `package.json` is a `list`, where as in pydeck and others I found on the internet it can also just be a `bool`.
- upgrade script assumes `devDependencies` exists

## User-facing changes

None

## Backwards-incompatible changes

None
