### PR TITLE
Add a usage request/reply on the Kernel Control channel

### DIFF
--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -761,6 +761,30 @@ export class KernelConnection implements Kernel.IKernelConnection {
     >;
   }
 
+  requestUsage(
+    content: KernelMessage.IUsageRequestMsg['content'],
+    disposeOnDone: boolean = true
+  ): Kernel.IControlFuture<
+    KernelMessage.IUsageRequestMsg,
+    KernelMessage.IUsageReplyMsg
+  > {
+    const msg = KernelMessage.createMessage({
+      msgType: 'usage_request',
+      channel: 'control',
+      username: this._username,
+      session: this._clientId,
+      content
+    });
+    return this.sendControlMessage(
+      msg,
+      true,
+      disposeOnDone
+    ) as Kernel.IControlFuture<
+      KernelMessage.IUsageRequestMsg,
+      KernelMessage.IUsageReplyMsg
+    >;
+  }
+
   /**
    * Send an `is_complete_request` message.
    *

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -325,6 +325,14 @@ export interface IKernelConnection extends IObservableDisposable {
     KernelMessage.IDebugReplyMsg
   >;
 
+  requestUsage(
+    content: KernelMessage.IUsageRequestMsg['content'],
+    disposeOnDone?: boolean
+  ): IControlFuture<
+    KernelMessage.IUsageRequestMsg,
+    KernelMessage.IUsageReplyMsg
+  >;
+
   /**
    * Send an `is_complete_request` message.
    *

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -109,6 +109,10 @@ export function createMessage<T extends IDebugRequestMsg>(
   options: IOptions<T>
 ): T;
 
+export function createMessage<T extends IUsageRequestMsg>(
+  options: IOptions<T>
+): T;
+
 /**
  * @hidden
  * #### Notes
@@ -117,6 +121,10 @@ export function createMessage<T extends IDebugRequestMsg>(
  * part of the public API, and may change without notice.
  */
 export function createMessage<T extends IDebugReplyMsg>(
+  options: IOptions<T>
+): T;
+
+export function createMessage<T extends IUsageReplyMsg>(
   options: IOptions<T>
 ): T;
 
@@ -183,7 +191,11 @@ export type ShellMessageType =
  * kernel message specification. As such, debug message types are *NOT*
  * considered part of the public API, and may change without notice.
  */
-export type ControlMessageType = 'debug_request' | 'debug_reply';
+export type ControlMessageType =
+  | 'usage_request'
+  | 'usage_reply'
+  | 'debug_request'
+  | 'debug_reply';
 
 /**
  * IOPub message types.
@@ -385,6 +397,8 @@ export type Message =
   | IUpdateDisplayDataMsg
   | IDebugRequestMsg
   | IDebugReplyMsg
+  | IUsageRequestMsg
+  | IUsageReplyMsg
   | IDebugEventMsg;
 
 // ////////////////////////////////////////////////
@@ -1150,6 +1164,15 @@ export interface IDebugRequestMsg extends IControlMessage<'debug_request'> {
   };
 }
 
+export interface IUsageRequestMsg extends IControlMessage<'usage_request'> {
+  content: {
+    seq: number;
+    type: 'request';
+    command: string;
+    arguments?: any;
+  };
+}
+
 /**
  * Test whether a kernel message is an experimental `'debug_request'` message.
  *
@@ -1175,6 +1198,18 @@ export function isDebugRequestMsg(msg: IMessage): msg is IDebugRequestMsg {
  * part of the public API, and may change without notice.
  */
 export interface IDebugReplyMsg extends IControlMessage<'debug_reply'> {
+  content: {
+    seq: number;
+    type: 'response';
+    request_seq: number;
+    success: boolean;
+    command: string;
+    message?: string;
+    body?: any;
+  };
+}
+
+export interface IUsageReplyMsg extends IControlMessage<'usage_reply'> {
   content: {
     seq: number;
     type: 'response';


### PR DESCRIPTION
This is an experimental PR to engage a discussion a how we should address the addition of new Kernel messages.

> This PR is not meant to be merged.

## Context

Third party developer may need to add optional/extension kernel messages and manage those message from JupyterLab. For example, in the case of a Remote Kernel, we can imagine the need to show the user the CPU and Memory usage for that specific Kernel (not the CPU/Memory of the server, but of each of the Kernels). A bit like https://github.com/jupyter-server/jupyter-resource-usage or https://github.com/jtpio/jupyterlab-system-monitor, but on a per- remote-kernel basis.

I have discussed with @Zsailer, @kevin-bates, @jess-x, @mlucool and @mwakaba2 options like OpenTelementry, but at the end, I have POCed another approach where a new Kernel protocol message (`usage_request` and `usage_reply`) would be transmitted on the non-blocking Control channel (with a new message type implemented in ipykernel).

## usage_request POC on JupyterLab

The `@jupyterlab/services` package is not meant to be extensible (as far as I understand). Therefor, I had to add a few types and methods (see the changes in this PR) in the `services` source to be able to query the Kernel usage from an extension and generate this view.

<img width="876" alt="Screenshot 2021-10-14 at 08 00 13" src="https://user-images.githubusercontent.com/226720/137260816-4edaa6da-2412-45b6-a2ec-bf964ae6d164.png">

## [DISCUSS] Allow extension authors to add kernel messages

Let's forget for now the question related to the validity for extension authors to add new kernel messages..

What would it mean for JupyterLab to support a more general case `Allow extension authors to add kernel messages`? 

cc/  @jasongrout @blink1073 @jtpio @vidartf @afshin @Carreau 