### PR TITLE
Emit `indexChanged` on model state updates

### DIFF
--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -211,6 +211,7 @@ export class Completer extends Widget {
   protected onModelStateChanged(): void {
     if (this.isAttached) {
       this._activeIndex = 0;
+      this._indexChanged.emit(this._activeIndex);
       this.update();
     }
   }


### PR DESCRIPTION
## References

Active index can be changed not only by cycling, but also by typing (or other model updates).

Follow up after #10244, discovered when debugging a docpanel issue in LSP.

## Code changes

- emit `indexChanged` on model state updates.

## User-facing changes

None

## Backwards-incompatible changes

None.