### PR TITLE
Fix for debugger not working for scripts

### DIFF
--- a/packages/debugger/src/handler.ts
+++ b/packages/debugger/src/handler.ts
@@ -17,6 +17,8 @@ import { FileHandler } from './handlers/file';
 import { NotebookHandler } from './handlers/notebook';
 import { IDebugger } from './tokens';
 
+const TOOLBAR_DEBUGGER_ITEM = 'debugger-icon';
+
 /**
  * Add a bug icon to the widget toolbar to enable and disable debugging.
  *
@@ -44,7 +46,9 @@ function updateIconButton(
     pressed,
     onClick
   });
-  widget.toolbar.insertBefore('kernelName', 'debugger-icon', icon);
+  if (!widget.toolbar.insertBefore('kernelName', TOOLBAR_DEBUGGER_ITEM, icon)) {
+    widget.toolbar.addItem(TOOLBAR_DEBUGGER_ITEM, icon);
+  }
 
   return icon;
 }
@@ -355,7 +359,11 @@ export class DebuggerHandler implements DebuggerHandler.IHandler {
       await this._service.displayDefinedVariables();
     }
 
-    updateIconButtonState(this._iconButtons[widget.id]!, false, true);
+    updateIconButtonState(
+      this._iconButtons[widget.id]!,
+      this._service.isStarted,
+      true
+    );
 
     // check the state of the debug session
     if (!this._service.isStarted) {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
This PR fixes [#11305](https://github.com/jupyterlab/jupyterlab/issues/11305)

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
- The existing code was inserting the debugger button before the kernel name widget. Kernel name widget is missing in lab views for scripts. To fix this, added a check if the debugger button is inserted before the kernel name widget, otherwise debugger button is just added directly to the toolbar.
- Additional change to make sure debugger button state is synced with the debugger service state.
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

#### Before
<img width="744" alt="Screen Shot 2021-10-18 at 4 20 12 PM" src="https://user-images.githubusercontent.com/289369/137819244-8efcfe96-be3c-4a48-a4d6-99ae9255bfc1.png">

#### After
<!-- Describe any visual or user interaction changes and how they address the issue. -->
![debugger-scripts](https://user-images.githubusercontent.com/289369/137817499-095c23e1-06dd-4145-b332-98092f71228d.gif)


<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
