### PR TITLE
Updated button styles to accessible colors

### DIFF
--- a/packages/application/style/buttons.css
+++ b/packages/application/style/buttons.css
@@ -17,55 +17,67 @@ button {
 }
 
 button:focus-visible {
-  border: 1px solid var(--jp-brand-color1);
+  border: 1px solid var(--md-blue-900);
 }
 
 button.jp-mod-styled.jp-mod-accept {
-  background: var(--md-blue-500);
+  background: var(--md-blue-700);
   border: 0;
   color: white;
 }
 
 button.jp-mod-styled.jp-mod-accept:hover {
-  background: var(--md-blue-600);
+  background: var(--md-blue-800);
 }
 
 button.jp-mod-styled.jp-mod-accept:active {
-  background: var(--md-blue-700);
+  background: var(--md-blue-900);
+}
+
+button.jp-mod-styled.jp-mod-accept:focus-visible {
+  border: 1px solid var(--md-blue-900);
 }
 
 button.jp-mod-styled.jp-mod-reject {
-  background: var(--md-grey-500);
+  background: var(--md-grey-600);
   border: 0;
   color: white;
 }
 
 button.jp-mod-styled.jp-mod-reject:hover {
-  background: var(--md-grey-600);
-}
-
-button.jp-mod-styled.jp-mod-reject:active {
   background: var(--md-grey-700);
 }
 
+button.jp-mod-styled.jp-mod-reject:active {
+  background: var(--md-grey-800);
+}
+
+button.jp-mod-styled.jp-mod-reject:focus-visible {
+  border: 1px solid var(--md-grey-800);
+}
+
 button.jp-mod-styled.jp-mod-warn {
-  background: var(--jp-error-color1);
+  background: var(--md-red-700);
   border: 0;
   color: white;
 }
 
 button.jp-mod-styled.jp-mod-warn:hover {
-  background: var(--md-red-600);
+  background: var(--md-red-800);
 }
 
 button.jp-mod-styled.jp-mod-warn:active {
-  background: var(--md-red-700);
+  background: var(--md-red-900);
+}
+
+button.jp-mod-styled.jp-mod-warn:focus-visible {
+  border: 1px solid var(--md-red-900);
 }
 
 .jp-Button-flat {
   text-decoration: none;
   padding: var(--jp-flat-button-padding);
-  color: var(--jp-warn-color1);
+  color: var(--md-grey-600);
   font-weight: 500;
   background-color: transparent;
   height: var(--jp-private-running-shutdown-button-height);
@@ -75,11 +87,11 @@ button.jp-mod-styled.jp-mod-warn:active {
 }
 
 .jp-Button-flat:hover {
-  background-color: rgba(153, 153, 153, 0.1);
+  background-color: var(--md-grey-700);
 }
 
 .jp-Button-flat:focus {
   border: none;
   box-shadow: none;
-  background-color: rgba(153, 153, 153, 0.2);
+  background-color: var(--md-grey-800);
 }

--- a/packages/apputils/style/dialog.css
+++ b/packages/apputils/style/dialog.css
@@ -57,6 +57,25 @@ button.jp-Dialog-button:focus::-moz-focus-inner {
   border: 0;
 }
 
+button.jp-Dialog-button.jp-mod-styled.jp-mod-accept:focus,
+button.jp-Dialog-button.jp-mod-styled.jp-mod-warn:focus,
+button.jp-Dialog-button.jp-mod-styled.jp-mod-reject:focus {
+  outline-offset: 4px;
+  -moz-outline-radius: 0px;
+}
+
+button.jp-Dialog-button.jp-mod-styled.jp-mod-accept:focus {
+  outline: 1px solid var(--md-blue-700);
+}
+
+button.jp-Dialog-button.jp-mod-styled.jp-mod-warn:focus {
+  outline: 1px solid var(--md-red-600);
+}
+
+button.jp-Dialog-button.jp-mod-styled.jp-mod-reject:focus {
+  outline: 1px solid var(--md-grey-700);
+}
+
 button.jp-Dialog-close-button {
   padding: 0;
   height: 100%;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
This PR is related to [#11260](https://github.com/jupyterlab/jupyterlab/issues/11260) and PR [#11264](https://github.com/jupyterlab/jupyterlab/pull/11264). This change is a short term patch fix for 3.2.x until 3.3.x version is released. 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
- Updated accept button colors to Material blue 700, 800, and 900.
- Updated reject button colors to Material grey 600, 700, and 800.
- Updated warn button colors to Material red 700, 800, and 900. 

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

#### Before
![button-colors](https://user-images.githubusercontent.com/289369/136884621-b2f5ada0-68d6-4bc1-a855-4cbb6ffc968e.gif)

#### After

![button-a11y-colors](https://user-images.githubusercontent.com/289369/138013575-4de6f1f8-52ab-4b2b-84c6-ad1916050765.gif)

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
