### PR TITLE
Automated Changelog Entry for 3.2.1 on 3.2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 
 - Updated button styles to accessible colors [#11321](https://github.com/jupyterlab/jupyterlab/pull/11321) ([@3coins](https://github.com/3coins))
 - Fix for debugger not working for scripts [#11311](https://github.com/jupyterlab/jupyterlab/pull/11311) ([@3coins](https://github.com/3coins))
-- Added handling of '\r' ended files [#11310](https://github.com/jupyterlab/jupyterlab/pull/11310) ([@lucabarcelos](https://github.com/lucabarcelos))
+- Added handling of `'\r'` ended files [#11310](https://github.com/jupyterlab/jupyterlab/pull/11310) ([@lucabarcelos](https://github.com/lucabarcelos))
 - Emit `indexChanged` on model state updates [#11298](https://github.com/jupyterlab/jupyterlab/pull/11298) ([@krassowski](https://github.com/krassowski))
 - Fix ANSI vs URL conflict, prefix `www.` with `https://` [#11272](https://github.com/jupyterlab/jupyterlab/pull/11272) ([@krassowski](https://github.com/krassowski))
 
@@ -28,10 +28,7 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 
 - Updated button styles to accessible colors [#11321](https://github.com/jupyterlab/jupyterlab/pull/11321) ([@3coins](https://github.com/3coins))
 - Add note on the server parameter for hidden files. [#11293](https://github.com/jupyterlab/jupyterlab/pull/11293) ([@fcollonval](https://github.com/fcollonval))
-
-### Other merged PRs
-
-- amend changelog - follow up issue 11304 [#11309](https://github.com/jupyterlab/jupyterlab/pull/11309) ([@achimgaedke](https://github.com/achimgaedke))
+- Amend changelog - follow up issue 11304 [#11309](https://github.com/jupyterlab/jupyterlab/pull/11309) ([@achimgaedke](https://github.com/achimgaedke))
 
 ### Contributors to this release
 


### PR DESCRIPTION
Automated Changelog Entry for 3.2.1 on 3.2.x
```
Python version: 3.2.1
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/application-top: 3.2.1
@jupyterlab/example-console: 3.2.1
@jupyterlab/example-cell: 3.2.1
@jupyterlab/example-app: 3.2.1
@jupyterlab/example-filebrowser: 3.2.1
@jupyterlab/example-notebook: 3.2.1
@jupyterlab/example-terminal: 3.2.1
@jupyterlab/example-federated: 2.3.1
@jupyterlab/example-federated-middle: 2.3.1
@jupyterlab/example-federated-phosphor: 2.3.1
@jupyterlab/example-federated-md: 2.3.1
@jupyterlab/example-federated-core: 2.3.1
@jupyterlab/notebook-extension: 3.2.1
@jupyterlab/rendermime: 3.2.1
@jupyterlab/console: 3.2.1
@jupyterlab/console-extension: 3.2.1
@jupyterlab/running-extension: 3.2.1
@jupyterlab/services: 6.2.1
@jupyterlab/settingregistry: 3.2.1
@jupyterlab/inspector: 3.2.1
@jupyterlab/celltags: 3.2.1
@jupyterlab/docmanager-extension: 3.2.1
@jupyterlab/statusbar-extension: 3.2.1
@jupyterlab/settingeditor-extension: 3.2.1
@jupyterlab/outputarea: 3.2.1
@jupyterlab/imageviewer-extension: 3.2.1
@jupyterlab/help-extension: 3.2.1
@jupyterlab/debugger: 3.2.1
@jupyterlab/documentsearch-extension: 3.2.1
@jupyterlab/markdownviewer-extension: 3.2.1
@jupyterlab/vdom-extension: 3.2.1
@jupyterlab/cells: 3.2.1
@jupyterlab/theme-dark-extension: 3.2.1
@jupyterlab/attachments: 3.2.1
@jupyterlab/nbconvert-css: 3.2.1
@jupyterlab/mainmenu-extension: 3.2.1
@jupyterlab/coreutils: 5.2.1
@jupyterlab/debugger-extension: 3.2.1
@jupyterlab/nbformat: 3.2.1
@jupyterlab/hub-extension: 3.2.1
@jupyterlab/toc-extension: 5.2.1
@jupyterlab/fileeditor: 3.2.1
@jupyterlab/inspector-extension: 3.2.1
@jupyterlab/ui-components-extension: 3.2.1
@jupyterlab/docmanager: 3.2.1
@jupyterlab/codeeditor: 3.2.1
@jupyterlab/toc: 5.2.1
@jupyterlab/launcher-extension: 3.2.1
@jupyterlab/csvviewer: 3.2.1
@jupyterlab/shortcuts-extension: 3.2.1
@jupyterlab/completer-extension: 3.2.1
@jupyterlab/codemirror-extension: 3.2.1
@jupyterlab/rendermime-extension: 3.2.1
@jupyterlab/javascript-extension: 3.2.1
@jupyterlab/docregistry: 3.2.1
@jupyterlab/property-inspector: 3.2.1
@jupyterlab/logconsole-extension: 3.2.1
@jupyterlab/extensionmanager: 3.2.1
@jupyterlab/settingeditor: 3.2.1
@jupyterlab/launcher: 3.2.1
@jupyterlab/statusbar: 3.2.1
@jupyterlab/statedb: 3.2.1
@jupyterlab/completer: 3.2.1
@jupyterlab/application: 3.2.1
@jupyterlab/logconsole: 3.2.1
@jupyterlab/translation: 3.2.1
@jupyterlab/filebrowser: 3.2.1
@jupyterlab/metapackage: 3.2.1
@jupyterlab/json-extension: 3.2.1
@jupyterlab/docprovider: 3.2.1
@jupyterlab/codemirror: 3.2.1
@jupyterlab/terminal-extension: 3.2.1
@jupyterlab/translation-extension: 3.2.1
@jupyterlab/pdf-extension: 3.2.1
@jupyterlab/tooltip-extension: 3.2.1
@jupyterlab/tooltip: 3.2.1
@jupyterlab/vega5-extension: 3.2.1
@jupyterlab/imageviewer: 3.2.1
@jupyterlab/notebook: 3.2.1
@jupyterlab/celltags-extension: 3.2.1
@jupyterlab/docprovider-extension: 3.2.1
@jupyterlab/running: 3.2.1
@jupyterlab/apputils-extension: 3.2.1
@jupyterlab/documentsearch: 3.2.1
@jupyterlab/ui-components: 3.2.1
@jupyterlab/shared-models: 3.2.1
@jupyterlab/fileeditor-extension: 3.2.1
@jupyterlab/markdownviewer: 3.2.1
@jupyterlab/mathjax2: 3.2.1
@jupyterlab/theme-light-extension: 3.2.1
@jupyterlab/htmlviewer: 3.2.1
@jupyterlab/mathjax2-extension: 3.2.1
@jupyterlab/mainmenu: 3.2.1
@jupyterlab/terminal: 3.2.1
@jupyterlab/htmlviewer-extension: 3.2.1
@jupyterlab/apputils: 3.2.1
@jupyterlab/extensionmanager-extension: 3.2.1
@jupyterlab/csvviewer-extension: 3.2.1
@jupyterlab/vdom: 3.2.1
@jupyterlab/rendermime-interfaces: 3.2.1
@jupyterlab/application-extension: 3.2.1
@jupyterlab/observables: 4.2.1
@jupyterlab/filebrowser-extension: 3.2.1
node-example: 3.2.1
@jupyterlab/example-services-browser: 3.2.1
@jupyterlab/example-services-outputarea: 3.2.1
@jupyterlab/builder: 3.2.1
@jupyterlab/buildutils: 3.2.1
@jupyterlab/template: 3.2.1
@jupyterlab/galata: 4.0.1
@jupyterlab/testutils: 3.2.1
@jupyterlab/mock-extension: 3.2.1
@jupyterlab/mock-provider: 3.2.1
@jupyterlab/mock-token: 3.2.1
@jupyterlab/mock-consumer: 3.2.1
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.2.x  |
| Version Spec | next |
| Since | v3.2.0 |