### PR TITLE
Updated dialog with text to a reasonable width

### DIFF
--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -101,6 +101,9 @@ export class Dialog<T> extends Widget {
     const layout = (this.layout = new PanelLayout());
     const content = new Panel();
     content.addClass('jp-Dialog-content');
+    if (typeof options.body === 'string') {
+      content.addClass('jp-Dialog-content-small');
+    }
     layout.addWidget(content);
 
     this._body = normalized.body;

--- a/packages/apputils/style/dialog.css
+++ b/packages/apputils/style/dialog.css
@@ -26,8 +26,7 @@
   margin-left: auto;
   margin-right: auto;
   background: var(--jp-layout-color1);
-  padding: 24px;
-  padding-bottom: 12px;
+  padding: 24px 24px 12px 24px;
   min-width: 300px;
   min-height: 150px;
   max-width: 1000px;
@@ -41,6 +40,10 @@
   font-size: var(--jp-ui-font-size1);
   color: var(--jp-ui-font-color1);
   resize: both;
+}
+
+.jp-Dialog-content.jp-Dialog-content-small {
+  max-width: 500px;
 }
 
 .jp-Dialog-button {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
This PR fixes #11330

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
- Add a new css class to dialog content with string body
- Update max width of text only dialog to 600px

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

#### Before
<img width="1090" alt="dialog-large-width" src="https://user-images.githubusercontent.com/289369/138206106-23c5f72c-85e4-4382-89cf-0cd7991c74a4.png">

#### After
<img width="838" alt="dialog-small-width" src="https://user-images.githubusercontent.com/289369/138206135-01bc080d-14c8-4c1b-88d9-3f4dd6a63ecc.png">
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
