### PR TITLE
Fix outdated `clearSignalData` reference (now `Signal.clearData`)

### DIFF
--- a/docs/source/developer/patterns.rst
+++ b/docs/source/developer/patterns.rst
@@ -84,7 +84,7 @@ the payload. Signals should generally not be used to trigger the
 "default" behavior for an action, but to enable others to trigger
 additional behavior. If a "default" behavior is intended to be provided
 by another object, then a callback should be provided by that object.
-Wherever possible as signal connection should be made with the pattern
+Wherever possible a signal connection should be made with the pattern
 ``.connect(this._onFoo, this)``. Providing the ``this`` context enables
 the connection to be properly cleared by ``Signal.clearData(this)``.
 Using a private method avoids allocating a closure for each connection.


### PR DESCRIPTION
## References

Update after refactor https://github.com/phosphorjs/phosphor/pull/178 `clearSignalData` -> `Signal.clearData` (five years ago).

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None