### PR TITLE
Only trigger dirty status update on value changes

### DIFF
--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -625,6 +625,8 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
         executionCount.set(null);
       }
     }
+    this.value.changed.connect(this._onValueChanged, this);
+
     executionCount.changed.connect(this._onExecutionCountChanged, this);
 
     this._modelDBMutex(() => {
@@ -818,13 +820,12 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
   }
 
   /**
-   * Handle a change to the observable value.
+   * Handle a change to the code cell value.
    */
-  protected onGenericChange(): void {
+  private _onValueChanged(): void {
     if (this.executionCount !== null) {
       this._setDirty(this._executedCode !== this.value.text.trim());
     }
-    this.contentChanged.emit(void 0);
   }
 
   /**


### PR DESCRIPTION
## References

Fixes #11341

## Code changes

Only trigger dirty check on value (not metadata) changes.

Previously the logic setting the dirty indicator was called `onGenericChange` which for `CodeCell` was connected to:
- `observableMetadata.changed`
- `this.value.changed`
- `this._outputs.changed`

After this change only `this.value.changed` will invoke this change. It fixes the issue with `recordTiming` and may improve performance very slightly.

## User-facing changes

No more false positives when:

```
{ 
     "recordTiming": true
}
```

## Backwards-incompatible changes

None