### PR TITLE
Fix Handling of WebSocket Startup Errors

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -1048,7 +1048,7 @@ export class SessionContext implements ISessionContext {
       const model = sender.kernel?.model;
       if (model?.reason) {
         const traceback = (model as any).traceback || '';
-        this._displayKernelError(model.reason, traceback);
+        void this._displayKernelError(model.reason, traceback);
       }
     }
 

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -965,6 +965,13 @@ export class SessionContext implements ISessionContext {
     } catch (err) {
       // no-op
     }
+    await this._displayKernelError(message, traceback);
+  }
+
+  /**
+   * Display kernel error
+   */
+  private async _displayKernelError(message: string, traceback: string) {
     const body = (
       <div>
         {message && <pre>{message}</pre>}
@@ -1037,6 +1044,14 @@ export class SessionContext implements ISessionContext {
     sender: Session.ISessionConnection,
     status: Kernel.Status
   ): void {
+    if (status === 'dead') {
+      const model = sender.kernel?.model;
+      if (model?.reason) {
+        const traceback = (model as any).traceback || '';
+        this._displayKernelError(model.reason, traceback);
+      }
+    }
+
     // Set that this kernel is busy, if we haven't already
     // If we have already, and now we aren't busy, dispose
     // of the busy disposable.

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -119,10 +119,13 @@ export class KernelConnection implements Kernel.IKernelConnection {
    * The kernel model
    */
   get model(): Kernel.IModel {
-    return {
-      id: this.id,
-      name: this.name
-    };
+    return (
+      this._model || {
+        id: this.id,
+        name: this.name,
+        reason: this._reason
+      }
+    );
   }
 
   /**
@@ -1257,10 +1260,40 @@ export class KernelConnection implements Kernel.IKernelConnection {
     // Ensure incoming binary messages are not Blobs
     this._ws.binaryType = 'arraybuffer';
 
+    let alreadyCalledOnclose = false;
+
+    const earlyClose = async (evt: Event) => {
+      // If the websocket was closed early, that could mean
+      // that the kernel is actually dead. Try getting
+      // information about the kernel from the API call --
+      // if that fails, then assume the kernel is dead,
+      // otherwise just follow the typical websocket closed
+      // protocol.
+      if (alreadyCalledOnclose) {
+        return;
+      }
+      alreadyCalledOnclose = true;
+      this._reason = '';
+      this._model = undefined;
+      try {
+        const model = await restapi.getKernelModel(this._id, settings);
+        this._model = model;
+        if (model?.execution_state === 'dead') {
+          this._updateStatus('dead');
+        } else {
+          this._onWSClose(evt);
+        }
+      } catch (e) {
+        this._reason = 'Kernel died unexpectedly';
+        this._updateStatus('dead');
+      }
+      return undefined;
+    };
+
     this._ws.onmessage = this._onWSMessage;
     this._ws.onopen = this._onWSOpen;
-    this._ws.onclose = this._onWSClose;
-    this._ws.onerror = this._onWSClose;
+    this._ws.onclose = earlyClose;
+    this._ws.onerror = earlyClose;
   };
 
   /**
@@ -1469,6 +1502,8 @@ export class KernelConnection implements Kernel.IKernelConnection {
    * Handle a websocket open event.
    */
   private _onWSOpen = (evt: Event) => {
+    this._ws!.onclose = this._onWSClose;
+    this._ws!.onerror = this._onWSClose;
     this._updateConnectionStatus('connected');
   };
 
@@ -1513,7 +1548,7 @@ export class KernelConnection implements Kernel.IKernelConnection {
   /**
    * Handle a websocket close event.
    */
-  private _onWSClose = (evt: CloseEvent) => {
+  private _onWSClose = (evt: Event) => {
     if (!this.isDisposed) {
       this._reconnect();
     }
@@ -1529,6 +1564,7 @@ export class KernelConnection implements Kernel.IKernelConnection {
 
   private _id = '';
   private _name = '';
+  private _model: Kernel.IModel | undefined;
   private _status: KernelMessage.Status = 'unknown';
   private _connectionStatus: Kernel.ConnectionStatus = 'connecting';
   private _kernelSession = '';
@@ -1573,6 +1609,7 @@ export class KernelConnection implements Kernel.IKernelConnection {
   private _msgIdToDisplayIds = new Map<string, string[]>();
   private _msgChain: Promise<void> = Promise.resolve();
   private _hasPendingInput = false;
+  private _reason = '';
   private _noOp = () => {
     /* no-op */
   };

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -1287,7 +1287,7 @@ export class KernelConnection implements Kernel.IKernelConnection {
         this._reason = 'Kernel died unexpectedly';
         this._updateStatus('dead');
       }
-      return undefined;
+      return;
     };
 
     this._ws.onmessage = this._onWSMessage;

--- a/packages/services/src/kernel/restapi.ts
+++ b/packages/services/src/kernel/restapi.ts
@@ -21,6 +21,32 @@ export interface IModel {
    * The name of the kernel.
    */
   readonly name: string;
+
+  /**
+   * The kernel execution state.
+   */
+  readonly execution_state?: string;
+
+  /**
+   * The timestamp of the last activity on the kernel.
+   */
+  // eslint-disable-next-line camelcase
+  readonly last_activity?: string;
+
+  /**
+   * The number of active connections to the kernel.
+   */
+  readonly connections?: number;
+
+  /**
+   * The reason the kernel died, if applicable.
+   */
+  readonly reason?: string;
+
+  /**
+   * The traceback for a dead kernel, if applicable.
+   */
+  readonly traceback?: string;
 }
 
 /**

--- a/tsconfigdoc.json
+++ b/tsconfigdoc.json
@@ -18,6 +18,13 @@
       "node"
     ]
   },
+  "lib": [
+    "es2015",
+    "es2015.collection",
+    "dom",
+    "es2015.iterable",
+    "es2017.object"
+  ],
   "references": [
     {
       "path": "./packages/application"

--- a/tsconfigdoc.json
+++ b/tsconfigdoc.json
@@ -18,13 +18,6 @@
       "node"
     ]
   },
-  "lib": [
-    "es2015",
-    "es2015.collection",
-    "dom",
-    "es2015.iterable",
-    "es2017.object"
-  ],
   "references": [
     {
       "path": "./packages/application"


### PR DESCRIPTION
## References
Required for slow starting kernels work proposed https://github.com/jupyter-server/jupyter_server/issues/592.
The linked proposal fixes a race condition in the server for slow starting kernels, but it changes the behavior of 
how an error during kernel process start is handled.  The error is surfaced on WebSocket connect instead of 
as a response to a POST to `/api/sessions`.  The change in this PR detects those errors and displays them to the user.
This is also a feature parity with the classic notebook, which had similar handling for errors seen during initial WebSocket
[connect](https://github.com/jupyter/notebook/blob/2cfff07a39fa486a3f05c26b400fa26e1802a053/notebook/static/services/kernels/kernel.js#L479).

## Code changes
Add handling of WebSocket startup errors in the `Kernel` class and display associated errors to the user in `SessionContext`.

## User-facing changes
Surface kernel WebSocket startup errors to the user.

## Backwards-incompatible changes
None