### PR TITLE
Adds command to docs to install canvas dependencies

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -171,6 +171,12 @@ Notes:
    installation, make sure Python 3.0+ is installed. Also, try using the
    Python 3.0+ version of ``pip`` or ``pip3 install -e .`` command to
    install JupyterLab from the forked repository.
+-  If you see an error that says ``Call to 'pkg-config pixman-1 --libs'
+   returned exit status 127 while in binding.gyp`` while running the 
+   ``pip install`` command above, you may be missing packages required
+   by ``canvas``. On macOS with Homebrew, you can add these packages by
+   running 
+   ``brew install pkg-config cairo pango libpng jpeg giflib librsvg``.
 -  The ``jlpm`` command is a JupyterLab-provided, locked version of the
    `yarn <https://yarnpkg.com/en>`__ package manager. If you have
    ``yarn`` installed already, you can use the ``yarn`` command when


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

#11364 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Modify contributor documentation to mention a command that will help with the `canvas` dependencies on a fresh macOS installation.

## User-facing changes

No functional changes. Updated this section of the docs: https://jupyterlab--11365.org.readthedocs.build/en/11365/developer/contributing.html#installing-jupyterlab

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

None