### PR TITLE
Make orig_nbformat optional #11005

### DIFF
--- a/galata/src/galata.ts
+++ b/galata/src/galata.ts
@@ -383,8 +383,7 @@ export namespace galata {
             nbconvert_exporter: 'python',
             pygments_lexer: 'ipython3',
             version: '3.8.0'
-          },
-          orig_nbformat: 4
+          }
         },
         nbformat: 4,
         nbformat_minor: 4

--- a/packages/nbformat/src/index.ts
+++ b/packages/nbformat/src/index.ts
@@ -46,7 +46,7 @@ export interface ILanguageInfoMetadata extends PartialJSONObject {
 export interface INotebookMetadata extends PartialJSONObject {
   kernelspec?: IKernelspecMetadata;
   language_info?: ILanguageInfoMetadata;
-  orig_nbformat: number;
+  orig_nbformat?: number;
 }
 
 /**

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -331,7 +331,7 @@ export class YNotebook
    */
   getMetadata(): nbformat.INotebookMetadata {
     const meta = this.ymeta.get('metadata');
-    return meta ? deepCopy(meta) : { orig_nbformat: 4 };
+    return meta ? deepCopy(meta) : {};
   }
 
   /**


### PR DESCRIPTION
According to https://github.com/jupyter/nbformat/blob/master/nbformat/v4/
schemas orig_nbformat is not required, and is only present when nbformat
upgrades the notebook from earlier major version. Therefore JupyterLab
should make it optional on its side and not set it anywhere by default.

## References

- Issue #11005

## Code changes

This PR addresses issue making `orig_nbformat` optional according to nbformat spec rather than setting it to 4 unconditionally.

## User-facing changes

None

## Backwards-incompatible changes

None
