### PR TITLE
Fix links

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -38,7 +38,7 @@ and `Code of
 Conduct <https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md>`__.
 
 All source code is written in
-`TypeScript <http://www.typescriptlang.org/Handbook>`__. See the `Style
+`TypeScript <https://www.typescriptlang.org/Handbook>`__. See the `Style
 Guide <https://github.com/jupyterlab/jupyterlab/wiki/TypeScript-Style-Guide>`__.
 
 All source code is formatted using `prettier <https://prettier.io>`__.
@@ -119,7 +119,7 @@ If you use ``conda``, you can get it with:
 
    conda install -c conda-forge 'nodejs'
 
-If you use `Homebrew <http://brew.sh>`__ on Mac OS X:
+If you use `Homebrew <https://brew.sh>`__ on Mac OS X:
 
 .. code:: bash
 

--- a/docs/source/developer/internationalization.rst
+++ b/docs/source/developer/internationalization.rst
@@ -46,14 +46,14 @@ file in *language-packs* repository. The workflow to trigger an update is as fol
 4. That workflow will open a new pull request that will update the source strings and optionally the Crowdin configuration.
 5. Once that pull request is merged, Crowdin will upload the new source strings automatically.
 6. If the placement of strings in the user interface changed (or new interface components were added) consider preparing new screenshots for Crowdin (see note below) and either
-   upload them directly to Crowdin (filename should include the version number), or open an issue in the `language-packs <https://github.com/jupyterlab/language-packs>` repository.
+   upload them directly to Crowdin (filename should include the version number), or open an issue in the `language-packs <https://github.com/jupyterlab/language-packs>`_ repository.
 
 .. note::
    Translating on Crowdin can be difficult when no sufficient context information is present, especially for Jupyter-specific terms.
    While some technically skilled translators will navigate to the codebase to check the context of a string, it is not an efficient workflow
    and prevents other translators from contributing. To enable more translators to contribute, and achieve higher accuracy of translations
    we should provide translators with annotated screenshots of the relevant usage of specific translatable strings
-   (see `Crowdin guide on screenshots <https://support.crowdin.com/adding-screenshots/>`).
+   (see `Crowdin guide on screenshots <https://support.crowdin.com/adding-screenshots/>`_).
 
 .. note::
 

--- a/docs/source/extension/extension_points.rst
+++ b/docs/source/extension/extension_points.rst
@@ -11,7 +11,7 @@ Following the list of core tokens is a guide for using some of JupyterLab's most
 However, it is not an exhaustive account of how to extend the application components,
 and more detailed descriptions of their public APIs may be found in the
 `JupyterLab <../api/index.html>`__ and
-`Lumino <http://jupyterlab.github.io/lumino/index.html>`__ API documentation.
+`Lumino <https://jupyterlab.github.io/lumino/index.html>`__ API documentation.
 
 .. contents:: Table of contents
     :local:
@@ -178,7 +178,7 @@ a string value or a function that returns a string value.
 
 There are several more options which can be passed into the command registry when
 adding new commands. These are documented
-`here <http://jupyterlab.github.io/lumino/commands/interfaces/commandregistry.icommandoptions.html>`__.
+`here <https://jupyterlab.github.io/lumino/commands/interfaces/commandregistry.icommandoptions.html>`__.
 
 After a command has been added to the application command registry
 you can add them to various places in the application user interface,
@@ -400,7 +400,7 @@ the shortcut handler propagates up the DOM tree from the focused element
 and tests each element against the registered selectors. If a match is found,
 then that command is executed with the provided ``args``.
 Full documentation for the options for ``addKeyBinding`` can be found
-`here <http://jupyterlab.github.io/lumino/commands/interfaces/commandregistry.ikeybindingoptions.html>`__.
+`here <https://jupyterlab.github.io/lumino/commands/interfaces/commandregistry.ikeybindingoptions.html>`__.
 
 JupyterLab also provides integration with its settings system for keyboard shortcuts.
 Your extension can provide a settings schema with a ``jupyter.lab.shortcuts`` key,

--- a/docs/source/user/directories.rst
+++ b/docs/source/user/directories.rst
@@ -186,7 +186,7 @@ schemas
 ^^^^^^^
 
 The ``schemas`` directory contains `JSON
-Schemas <http://json-schema.org/>`__ that describe the settings used by
+Schemas <https://json-schema.org/>`__ that describe the settings used by
 individual extensions. Users may edit these settings using the
 JupyterLab Advanced Settings Editor.
 


### PR DESCRIPTION
## References

Follow-up on #11357 + changes links which used http to https.

I wonder if we should have:

```
grep -r -P 'http(s):(?:.*?)>`([^_])' docs/
```

somewhere in CI

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None
