### PR TITLE
Modify dump of webpack config to include RegEx expressions

### DIFF
--- a/builder/src/extensionConfig.ts
+++ b/builder/src/extensionConfig.ts
@@ -273,7 +273,14 @@ function generateConfig({
 
   if (mode === 'development') {
     const logPath = path.join(outputPath, 'build_log.json');
-    fs.writeFileSync(logPath, JSON.stringify(config, null, '  '));
+    function regExpReplacer(key, value) {
+      if (value instanceof RegExp) {
+        return value.toString();
+      } else {
+        return value;
+      }
+    }
+    fs.writeFileSync(logPath, JSON.stringify(config, regExpReplacer, '  '));
   }
   return config;
 }

--- a/builder/src/extensionConfig.ts
+++ b/builder/src/extensionConfig.ts
@@ -273,7 +273,7 @@ function generateConfig({
 
   if (mode === 'development') {
     const logPath = path.join(outputPath, 'build_log.json');
-    function regExpReplacer(key, value) {
+    function regExpReplacer(key: any, value: any) {
       if (value instanceof RegExp) {
         return value.toString();
       } else {


### PR DESCRIPTION
Today in the rules sections you can see empty "test" expressions in your log:
```
...
        {
          "test": {},
          "use": "raw-loader"
        },
        {
          "test": {},
          "use": "file-loader"
        },
...
```
This is because of the way JSON.stringify treats (or does not treat) RegExp expressions.  This PR would print the RegExp values as strings.  

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Small enough change that I thought I would skip a referenced issue (which I know from the contributor guide is normally best practice).  

## Code changes

By passing a processing function to `JSON.stringify` we can detect and replace RegExp objects with strings.

## User-facing changes

Only changes development builds.  The output file will now show RegExp values.

## Backwards-incompatible changes

n/a
