### PR TITLE
Automated Changelog Entry for 3.2.2 on 3.2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.2.2
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.2.1...0fcd2f5bfbe857a416dfad0c177f3f1299fef96e))
+
+### Bugs fixed
+
+- Make orig_nbformat optional #11005 [#11370](https://github.com/jupyterlab/jupyterlab/pull/11370) ([@nanoant](https://github.com/nanoant))
+- Updated dialog with text to a reasonable width [#11331](https://github.com/jupyterlab/jupyterlab/pull/11331) ([@3coins](https://github.com/3coins))
+- Fix for terminal theme style [#11291](https://github.com/jupyterlab/jupyterlab/pull/11291) ([@3coins](https://github.com/3coins))
+- Only trigger dirty status update on value changes [#11346](https://github.com/jupyterlab/jupyterlab/pull/11346) ([@krassowski](https://github.com/krassowski))
+
+### Maintenance and upkeep improvements
+
+- Fix release_test [#11390](https://github.com/jupyterlab/jupyterlab/pull/11390) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+- Fix links [#11378](https://github.com/jupyterlab/jupyterlab/pull/11378) ([@krassowski](https://github.com/krassowski))
+- Adds command to docs to install canvas dependencies [#11365](https://github.com/jupyterlab/jupyterlab/pull/11365) ([@jweill-aws](https://github.com/jweill-aws))
+- Recommend providing screenshots for translators [#11357](https://github.com/jupyterlab/jupyterlab/pull/11357) ([@krassowski](https://github.com/krassowski))
+- Fix outdated `clearSignalData` reference (now `Signal.clearData`) [#11339](https://github.com/jupyterlab/jupyterlab/pull/11339) ([@krassowski](https://github.com/krassowski))
+
+### Other merged PRs
+
+- Improve documentation on galata setup [#11391](https://github.com/jupyterlab/jupyterlab/pull/11391) ([@fcollonval](https://github.com/fcollonval))
+- removed cat package.json [#11372](https://github.com/jupyterlab/jupyterlab/pull/11372) ([@ceesu](https://github.com/ceesu))
+- Backport PR #10729 on branch 3.2.x (Toc: Run nested code cells directly from markdown headings) [#11375](https://github.com/jupyterlab/jupyterlab/pull/11375) ([@jess-x](https://github.com/jess-x))
+- [3.2.x] Relax `@playright/test` dependency in Galata [#11371](https://github.com/jupyterlab/jupyterlab/pull/11371) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-10-20&to=2021-11-04&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-10-20..2021-11-04&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2021-10-20..2021-11-04&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2021-10-20..2021-11-04&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-10-20..2021-11-04&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-10-20..2021-11-04&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-10-20..2021-11-04&type=Issues) | [@jess-x](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajess-x+updated%3A2021-10-20..2021-11-04&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-10-20..2021-11-04&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-10-20..2021-11-04&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-10-20..2021-11-04&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-10-20..2021-11-04&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-10-20..2021-11-04&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrungleduc+updated%3A2021-10-20..2021-11-04&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-10-20..2021-11-04&type=Issues) | [@williamstein](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awilliamstein+updated%3A2021-10-20..2021-11-04&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AZsailer+updated%3A2021-10-20..2021-11-04&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.2.1
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.2.0...2b7e4ea681ad11b2df16124b588448aac9562aef))
@@ -35,8 +72,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-10-14&to=2021-10-20&type=c))
 
 [@3coins](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3A3coins+updated%3A2021-10-14..2021-10-20&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-10-14..2021-10-20&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2021-10-14..2021-10-20&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-10-14..2021-10-20&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-10-14..2021-10-20&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-10-14..2021-10-20&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-10-14..2021-10-20&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-10-14..2021-10-20&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-10-14..2021-10-20&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-10-14..2021-10-20&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,17 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 
 ### Bugs fixed
 
-- Make orig_nbformat optional #11005 [#11370](https://github.com/jupyterlab/jupyterlab/pull/11370) ([@nanoant](https://github.com/nanoant))
+- Make `orig_nbformat` optional #11005 [#11370](https://github.com/jupyterlab/jupyterlab/pull/11370) ([@nanoant](https://github.com/nanoant))
 - Updated dialog with text to a reasonable width [#11331](https://github.com/jupyterlab/jupyterlab/pull/11331) ([@3coins](https://github.com/3coins))
 - Fix for terminal theme style [#11291](https://github.com/jupyterlab/jupyterlab/pull/11291) ([@3coins](https://github.com/3coins))
 - Only trigger dirty status update on value changes [#11346](https://github.com/jupyterlab/jupyterlab/pull/11346) ([@krassowski](https://github.com/krassowski))
+- Run nested code cells directly from markdown headings [#11375](https://github.com/jupyterlab/jupyterlab/pull/11375) ([@jess-x](https://github.com/jess-x))
 
 ### Maintenance and upkeep improvements
 
-- Fix release_test [#11390](https://github.com/jupyterlab/jupyterlab/pull/11390) ([@fcollonval](https://github.com/fcollonval))
+- Fix `release_test` [#11390](https://github.com/jupyterlab/jupyterlab/pull/11390) ([@fcollonval](https://github.com/fcollonval))
+- Removed `cat package.json` [#11372](https://github.com/jupyterlab/jupyterlab/pull/11372) ([@ceesu](https://github.com/ceesu))
+- Relax `@playright/test` dependency in Galata [#11371](https://github.com/jupyterlab/jupyterlab/pull/11371) ([@jtpio](https://github.com/jtpio))
 
 ### Documentation improvements
 
@@ -29,13 +32,7 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 - Adds command to docs to install canvas dependencies [#11365](https://github.com/jupyterlab/jupyterlab/pull/11365) ([@jweill-aws](https://github.com/jweill-aws))
 - Recommend providing screenshots for translators [#11357](https://github.com/jupyterlab/jupyterlab/pull/11357) ([@krassowski](https://github.com/krassowski))
 - Fix outdated `clearSignalData` reference (now `Signal.clearData`) [#11339](https://github.com/jupyterlab/jupyterlab/pull/11339) ([@krassowski](https://github.com/krassowski))
-
-### Other merged PRs
-
 - Improve documentation on galata setup [#11391](https://github.com/jupyterlab/jupyterlab/pull/11391) ([@fcollonval](https://github.com/fcollonval))
-- removed cat package.json [#11372](https://github.com/jupyterlab/jupyterlab/pull/11372) ([@ceesu](https://github.com/ceesu))
-- Backport PR #10729 on branch 3.2.x (Toc: Run nested code cells directly from markdown headings) [#11375](https://github.com/jupyterlab/jupyterlab/pull/11375) ([@jess-x](https://github.com/jess-x))
-- [3.2.x] Relax `@playright/test` dependency in Galata [#11371](https://github.com/jupyterlab/jupyterlab/pull/11371) ([@jtpio](https://github.com/jtpio))
 
 ### Contributors to this release
 


### PR DESCRIPTION
Automated Changelog Entry for 3.2.2 on 3.2.x
```
Python version: 3.2.2
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/application-top: 3.2.2
@jupyterlab/example-federated: 2.3.2
@jupyterlab/example-cell: 3.2.2
@jupyterlab/example-terminal: 3.2.2
@jupyterlab/example-console: 3.2.2
@jupyterlab/example-filebrowser: 3.2.2
@jupyterlab/example-app: 3.2.2
@jupyterlab/example-notebook: 3.2.2
@jupyterlab/example-federated-core: 2.3.2
@jupyterlab/example-federated-middle: 2.3.2
@jupyterlab/example-federated-phosphor: 2.3.2
@jupyterlab/example-federated-md: 2.3.2
@jupyterlab/translation-extension: 3.2.2
@jupyterlab/logconsole: 3.2.2
@jupyterlab/nbconvert-css: 3.2.2
@jupyterlab/rendermime-interfaces: 3.2.2
@jupyterlab/extensionmanager: 3.2.2
@jupyterlab/launcher-extension: 3.2.2
@jupyterlab/settingeditor: 3.2.2
@jupyterlab/vdom: 3.2.2
@jupyterlab/apputils: 3.2.2
@jupyterlab/shared-models: 3.2.2
@jupyterlab/settingeditor-extension: 3.2.2
@jupyterlab/toc: 5.2.2
@jupyterlab/pdf-extension: 3.2.2
@jupyterlab/celltags: 3.2.2
@jupyterlab/property-inspector: 3.2.2
@jupyterlab/statedb: 3.2.2
@jupyterlab/shortcuts-extension: 3.2.2
@jupyterlab/terminal: 3.2.2
@jupyterlab/docprovider: 3.2.2
@jupyterlab/inspector-extension: 3.2.2
@jupyterlab/application-extension: 3.2.2
@jupyterlab/docprovider-extension: 3.2.2
@jupyterlab/mathjax2: 3.2.2
@jupyterlab/attachments: 3.2.2
@jupyterlab/metapackage: 3.2.2
@jupyterlab/htmlviewer-extension: 3.2.2
@jupyterlab/documentsearch: 3.2.2
@jupyterlab/vdom-extension: 3.2.2
@jupyterlab/filebrowser-extension: 3.2.2
@jupyterlab/mathjax2-extension: 3.2.2
@jupyterlab/theme-dark-extension: 3.2.2
@jupyterlab/inspector: 3.2.2
@jupyterlab/imageviewer-extension: 3.2.2
@jupyterlab/docmanager: 3.2.2
@jupyterlab/mainmenu: 3.2.2
@jupyterlab/settingregistry: 3.2.2
@jupyterlab/celltags-extension: 3.2.2
@jupyterlab/documentsearch-extension: 3.2.2
@jupyterlab/codeeditor: 3.2.2
@jupyterlab/cells: 3.2.2
@jupyterlab/completer: 3.2.2
@jupyterlab/observables: 4.2.2
@jupyterlab/fileeditor-extension: 3.2.2
@jupyterlab/javascript-extension: 3.2.2
@jupyterlab/help-extension: 3.2.2
@jupyterlab/rendermime: 3.2.2
@jupyterlab/htmlviewer: 3.2.2
@jupyterlab/theme-light-extension: 3.2.2
@jupyterlab/services: 6.2.2
@jupyterlab/docmanager-extension: 3.2.2
@jupyterlab/tooltip: 3.2.2
@jupyterlab/vega5-extension: 3.2.2
@jupyterlab/statusbar: 3.2.2
@jupyterlab/outputarea: 3.2.2
@jupyterlab/nbformat: 3.2.2
@jupyterlab/debugger: 3.2.2
@jupyterlab/csvviewer: 3.2.2
@jupyterlab/console: 3.2.2
@jupyterlab/extensionmanager-extension: 3.2.2
@jupyterlab/tooltip-extension: 3.2.2
@jupyterlab/statusbar-extension: 3.2.2
@jupyterlab/terminal-extension: 3.2.2
@jupyterlab/rendermime-extension: 3.2.2
@jupyterlab/filebrowser: 3.2.2
@jupyterlab/apputils-extension: 3.2.2
@jupyterlab/imageviewer: 3.2.2
@jupyterlab/running-extension: 3.2.2
@jupyterlab/launcher: 3.2.2
@jupyterlab/ui-components-extension: 3.2.2
@jupyterlab/translation: 3.2.2
@jupyterlab/application: 3.2.2
@jupyterlab/coreutils: 5.2.2
@jupyterlab/debugger-extension: 3.2.2
@jupyterlab/ui-components: 3.2.2
@jupyterlab/hub-extension: 3.2.2
@jupyterlab/codemirror: 3.2.2
@jupyterlab/logconsole-extension: 3.2.2
@jupyterlab/json-extension: 3.2.2
@jupyterlab/toc-extension: 5.2.2
@jupyterlab/completer-extension: 3.2.2
@jupyterlab/mainmenu-extension: 3.2.2
@jupyterlab/fileeditor: 3.2.2
@jupyterlab/docregistry: 3.2.2
@jupyterlab/console-extension: 3.2.2
@jupyterlab/running: 3.2.2
@jupyterlab/markdownviewer-extension: 3.2.2
@jupyterlab/codemirror-extension: 3.2.2
@jupyterlab/csvviewer-extension: 3.2.2
@jupyterlab/markdownviewer: 3.2.2
@jupyterlab/notebook-extension: 3.2.2
@jupyterlab/notebook: 3.2.2
node-example: 3.2.2
@jupyterlab/example-services-browser: 3.2.2
@jupyterlab/example-services-outputarea: 3.2.2
@jupyterlab/builder: 3.2.2
@jupyterlab/buildutils: 3.2.2
@jupyterlab/template: 3.2.2
@jupyterlab/galata: 4.0.2
@jupyterlab/testutils: 3.2.2
@jupyterlab/mock-extension: 3.2.2
@jupyterlab/mock-token: 3.2.2
@jupyterlab/mock-provider: 3.2.2
@jupyterlab/mock-consumer: 3.2.2
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.2.x  |
| Version Spec | next |
| Since | v3.2.1 |