### PR TITLE
Add `jupyterlab` prefix to the Galata artifacts

### DIFF
--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -76,7 +76,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: galata-test-assets
+          name: jupyterlab-galata-test-assets
           path: |
             galata/test-results
 
@@ -84,7 +84,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: galata-report
+          name: jupyterlab-galata-report
           path: |
             galata/playwright-report
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

A small naming change to add the `jupyterlab-` prefix to the Galata test assets.

This is useful when working on multiple projects that have a Galata setup, and downloading the test report locally.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

CI workflow update.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
