### PR TITLE
perf: scroll active toc item into view

### DIFF
--- a/packages/toc/package.json
+++ b/packages/toc/package.json
@@ -53,7 +53,6 @@
     "@jupyterlab/translation": "^3.3.0-alpha.14",
     "@jupyterlab/ui-components": "^4.0.0-alpha.14",
     "@lumino/coreutils": "^1.10.0",
-    "@lumino/domutils": "^1.7.0",
     "@lumino/messaging": "^1.9.0",
     "@lumino/signaling": "^1.9.0",
     "@lumino/widgets": "^1.28.0",

--- a/packages/toc/package.json
+++ b/packages/toc/package.json
@@ -53,6 +53,7 @@
     "@jupyterlab/translation": "^3.3.0-alpha.14",
     "@jupyterlab/ui-components": "^4.0.0-alpha.14",
     "@lumino/coreutils": "^1.10.0",
+    "@lumino/domutils": "^1.7.0",
     "@lumino/messaging": "^1.9.0",
     "@lumino/signaling": "^1.9.0",
     "@lumino/widgets": "^1.28.0",

--- a/packages/toc/src/generators/notebook/index.ts
+++ b/packages/toc/src/generators/notebook/index.ts
@@ -104,7 +104,7 @@ function createNotebookGenerator(
    * @returns rendered item
    */
   function renderItem(item: INotebookHeading, toc: INotebookHeading[] = []) {
-    return render(options, tracker, item, toc);
+    return render(options, tracker, widget, item, toc);
   }
 
   /**

--- a/packages/toc/src/generators/notebook/render.tsx
+++ b/packages/toc/src/generators/notebook/render.tsx
@@ -153,11 +153,12 @@ function render(
               previousHeader(tracker, item, toc)
             }
             className={'toc-entry-holder ' + fontSizeClass}
-            button={button}
-            jsx={jsx}
-            ellipseButton={ellipseButton}
             area={widget.node.querySelector(`.${TOC_TREE_CLASS}`) as Element}
-          />
+          >
+            {button}
+            {jsx}
+            {ellipseButton}
+          </NotebookHeading>
         );
       }
       return jsx;
@@ -258,18 +259,17 @@ function previousHeader(
   return false;
 }
 
+type NotebookHeadingProps = React.PropsWithChildren<{
+  isActive: boolean;
+  className: string;
+  area: Element;
+}>
+
 /** React component for a single toc heading
  *
  * @private
  */
-function NotebookHeading(props: {
-  isActive: boolean;
-  className: string;
-  button: JSX.Element;
-  jsx: JSX.Element;
-  ellipseButton: JSX.Element;
-  area: Element;
-}): JSX.Element {
+function NotebookHeading(props: NotebookHeadingProps): JSX.Element {
   const itemRef = React.useRef<HTMLDivElement>(null);
   const isActive = props.isActive;
   React.useEffect(() => {
@@ -285,9 +285,7 @@ function NotebookHeading(props: {
       ref={itemRef}
       className={[props.className, isActive ? 'toc-active-cell' : ''].join(' ')}
     >
-      {props.button}
-      {props.jsx}
-      {props.ellipseButton}
+      {props.children}
     </div>
   );
 }

--- a/packages/toc/src/generators/notebook/render.tsx
+++ b/packages/toc/src/generators/notebook/render.tsx
@@ -99,11 +99,12 @@ function render(
               previousHeader(tracker, item, toc)
             }
             className={'toc-entry-holder ' + fontSizeClass}
-            button={button}
-            jsx={jsx}
-            ellipseButton={ellipseButton}
             area={widget.node.querySelector(`.${TOC_TREE_CLASS}`) as Element}
-          />
+          >
+            {button}
+            {jsx}
+            {ellipseButton}
+          </NotebookHeading>
         );
       }
       return jsx;
@@ -263,7 +264,7 @@ type NotebookHeadingProps = React.PropsWithChildren<{
   isActive: boolean;
   className: string;
   area: Element;
-}>
+}>;
 
 /** React component for a single toc heading
  *

--- a/packages/toc/src/generators/notebook/render.tsx
+++ b/packages/toc/src/generators/notebook/render.tsx
@@ -9,6 +9,15 @@ import { INotebookHeading } from '../../utils/headings';
 import { sanitizerOptions } from '../../utils/sanitizer_options';
 import { CodeComponent } from './codemirror';
 import { OptionsManager } from './options_manager';
+import { ElementExt } from '@lumino/domutils';
+import { TableOfContents } from '../..';
+
+/**
+ * Class name of the toc item list.
+ *
+ * @private
+ */
+const TOC_TREE_CLASS = 'jp-TableOfContents-content';
 
 /**
  * Renders a notebook table of contents item.
@@ -23,6 +32,7 @@ import { OptionsManager } from './options_manager';
 function render(
   options: OptionsManager,
   tracker: INotebookTracker,
+  widget: TableOfContents,
   item: INotebookHeading,
   toc: INotebookHeading[] = []
 ): JSX.Element | null {
@@ -83,21 +93,17 @@ function render(
 
         // Render the heading item:
         jsx = (
-          <div
-            className={
-              'toc-entry-holder ' +
-              fontSizeClass +
-              (tracker.activeCell === item.cellRef
-                ? ' toc-active-cell'
-                : previousHeader(tracker, item, toc)
-                ? ' toc-active-cell'
-                : '')
+          <NotebookHeading
+            isActive={
+              tracker.activeCell === item.cellRef ||
+              previousHeader(tracker, item, toc)
             }
-          >
-            {button}
-            {jsx}
-            {ellipseButton}
-          </div>
+            className={'toc-entry-holder ' + fontSizeClass}
+            button={button}
+            jsx={jsx}
+            ellipseButton={ellipseButton}
+            area={widget.node.querySelector(`.${TOC_TREE_CLASS}`) as Element}
+          />
         );
       }
       return jsx;
@@ -141,21 +147,17 @@ function render(
           <div />
         );
         jsx = (
-          <div
-            className={
-              'toc-entry-holder ' +
-              fontSizeClass +
-              (tracker.activeCell === item.cellRef
-                ? ' toc-active-cell'
-                : previousHeader(tracker, item, toc)
-                ? ' toc-active-cell'
-                : '')
+          <NotebookHeading
+            isActive={
+              tracker.activeCell === item.cellRef ||
+              previousHeader(tracker, item, toc)
             }
-          >
-            {button}
-            {jsx}
-            {ellipseButton}
-          </div>
+            className={'toc-entry-holder ' + fontSizeClass}
+            button={button}
+            jsx={jsx}
+            ellipseButton={ellipseButton}
+            area={widget.node.querySelector(`.${TOC_TREE_CLASS}`) as Element}
+          />
         );
       }
       return jsx;
@@ -254,6 +256,40 @@ function previousHeader(
     }
   }
   return false;
+}
+
+/** React component for a single toc heading
+ *
+ * @private
+ */
+function NotebookHeading(props: {
+  isActive: boolean;
+  className: string;
+  button: JSX.Element;
+  jsx: JSX.Element;
+  ellipseButton: JSX.Element;
+  area: Element;
+}): JSX.Element {
+  const itemRef = React.useRef<HTMLDivElement>(null);
+  const isActive = props.isActive;
+  React.useEffect(() => {
+    if (isActive && itemRef.current) {
+      ElementExt.scrollIntoViewIfNeeded(
+        props.area,
+        itemRef.current.parentElement as Element
+      );
+    }
+  }, [isActive]);
+  return (
+    <div
+      ref={itemRef}
+      className={[props.className, isActive ? 'toc-active-cell' : ''].join(' ')}
+    >
+      {props.button}
+      {props.jsx}
+      {props.ellipseButton}
+    </div>
+  );
 }
 
 /**

--- a/packages/toc/src/toc.tsx
+++ b/packages/toc/src/toc.tsx
@@ -18,6 +18,7 @@ import { TableOfContentsRegistry as Registry } from './registry';
 import { TOCTree } from './toc_tree';
 import { Signal } from '@lumino/signaling';
 import { TOCItem } from './toc_item';
+import { ElementExt } from '@lumino/domutils';
 
 /**
  * Timeout for throttling ToC rendering.
@@ -25,6 +26,20 @@ import { TOCItem } from './toc_item';
  * @private
  */
 const RENDER_TIMEOUT = 1000;
+
+/**
+ * Class name of the active toc item.
+ *
+ * @private
+ */
+const ACTIVE_ITEM_CLASS = 'toc-active-cell';
+
+/**
+ * Class name of the toc item list.
+ *
+ * @private
+ */
+const TOC_TREE_CLASS = 'jp-TableOfContents-content';
 
 /**
  * Widget for hosting a notebook table of contents.
@@ -168,6 +183,13 @@ export class TableOfContents extends Widget {
         this._rendermime.latexTypesetter.typeset(this.node);
       }
     });
+
+    // scroll active toc item into view
+    let activeItem = this.node.querySelector(`.${ACTIVE_ITEM_CLASS}`)?.parentElement as Element;
+    let tocItems = this.node.querySelector(`.${TOC_TREE_CLASS}`) as Element;
+    if (tocItems && activeItem) {
+      ElementExt.scrollIntoViewIfNeeded(tocItems, activeItem);
+    }
   }
 
   /**

--- a/packages/toc/src/toc.tsx
+++ b/packages/toc/src/toc.tsx
@@ -18,7 +18,6 @@ import { TableOfContentsRegistry as Registry } from './registry';
 import { TOCTree } from './toc_tree';
 import { Signal } from '@lumino/signaling';
 import { TOCItem } from './toc_item';
-import { ElementExt } from '@lumino/domutils';
 
 /**
  * Timeout for throttling ToC rendering.
@@ -26,20 +25,6 @@ import { ElementExt } from '@lumino/domutils';
  * @private
  */
 const RENDER_TIMEOUT = 1000;
-
-/**
- * Class name of the active toc item.
- *
- * @private
- */
-const ACTIVE_ITEM_CLASS = 'toc-active-cell';
-
-/**
- * Class name of the toc item list.
- *
- * @private
- */
-const TOC_TREE_CLASS = 'jp-TableOfContents-content';
 
 /**
  * Widget for hosting a notebook table of contents.
@@ -183,14 +168,6 @@ export class TableOfContents extends Widget {
         this._rendermime.latexTypesetter.typeset(this.node);
       }
     });
-
-    // scroll active toc item into view
-    let activeItem = this.node.querySelector(`.${ACTIVE_ITEM_CLASS}`)
-      ?.parentElement as Element;
-    let tocItems = this.node.querySelector(`.${TOC_TREE_CLASS}`) as Element;
-    if (tocItems && activeItem) {
-      ElementExt.scrollIntoViewIfNeeded(tocItems, activeItem);
-    }
   }
 
   /**

--- a/packages/toc/src/toc.tsx
+++ b/packages/toc/src/toc.tsx
@@ -185,7 +185,8 @@ export class TableOfContents extends Widget {
     });
 
     // scroll active toc item into view
-    let activeItem = this.node.querySelector(`.${ACTIVE_ITEM_CLASS}`)?.parentElement as Element;
+    let activeItem = this.node.querySelector(`.${ACTIVE_ITEM_CLASS}`)
+      ?.parentElement as Element;
     let tocItems = this.node.querySelector(`.${TOC_TREE_CLASS}`) as Element;
     if (tocItems && activeItem) {
       ElementExt.scrollIntoViewIfNeeded(tocItems, activeItem);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

Fix #11263 .

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Used a slightly different approach from proposed solution in the issue. When widget is called to update, it will find active cell and scroll into view if needed. 

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

Before:

![before](https://user-images.githubusercontent.com/5832902/136464459-4a773828-f2d2-4331-bcc1-89b80d129c2e.gif)

After: 

![after](https://user-images.githubusercontent.com/16680640/140652655-d3e1d448-95c1-4a02-9aef-869dc038ca2f.gif)

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

None.