### PR TITLE
[3.2.x] Expose `window.jupyterapp`

### DIFF
--- a/dev_mode/index.js
+++ b/dev_mode/index.js
@@ -213,6 +213,7 @@ export async function main() {
 
   if (exposeAppInBrowser || devMode) {
     window.jupyterlab = lab;
+    window.jupyterapp = lab;
   }
 
   // Handle a browser test.

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -538,7 +538,8 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
     )
     flags['expose-app-in-browser'] = (
         {'LabApp': {'expose_app_in_browser': True}},
-        "Expose the global app instance to browser via window.jupyterlab."
+        """Expose the global app instance to browser via window.jupyterapp.
+        It is also available via the deprecated window.jupyterlab name."""
     )
     flags['extensions-in-dev-mode'] = (
         {'LabApp': {'extensions_in_dev_mode': True}},


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Partial backport of https://github.com/jupyterlab/jupyterlab/pull/10936 to the `3.2.x` branch.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Backport `window.jupyterapp` for consistency with the other lab-based applications.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

User can then access `window.jupyterapp` from the dev tools console after setting `--expose-app-in-browser`.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
