### PR TITLE
Makes ILabShell optional in toc extension

### DIFF
--- a/packages/toc-extension/src/index.ts
+++ b/packages/toc-extension/src/index.ts
@@ -235,12 +235,9 @@ const extension: JupyterFrontEndPlugin<ITableOfContentsRegistry> = {
     IMarkdownViewerTracker,
     INotebookTracker,
     IRenderMimeRegistry,
-    ITranslator,
+    ITranslator
   ],
-  optional: [
-    ILabShell,
-    ISettingRegistry,
-  ],
+  optional: [ILabShell, ISettingRegistry],
   activate: activateTOC
 };
 

--- a/packages/toc-extension/src/index.ts
+++ b/packages/toc-extension/src/index.ts
@@ -66,7 +66,7 @@ async function activateTOC(
   app: JupyterFrontEnd,
   docmanager: IDocumentManager,
   editorTracker: IEditorTracker,
-  labShell: ILabShell,
+  labShell: ILabShell | null,
   restorer: ILayoutRestorer,
   markdownViewerTracker: IMarkdownViewerTracker,
   notebookTracker: INotebookTracker,
@@ -92,7 +92,7 @@ async function activateTOC(
   toc.node.setAttribute('role', 'region');
   toc.node.setAttribute('aria-label', trans.__('Table of Contents section'));
 
-  labShell.add(toc, 'left', { rank: 400 });
+  app.shell.add(toc, 'left', { rank: 400 });
 
   app.commands.addCommand(CommandIDs.runCells, {
     execute: args => {
@@ -132,7 +132,7 @@ async function activateTOC(
   app.commands.addCommand(CommandIDs.showPanel, {
     label: trans.__('Table of Contents'),
     execute: () => {
-      labShell.activateById(toc.id);
+      app.shell.activateById(toc.id);
     }
   });
 
@@ -190,7 +190,9 @@ async function activateTOC(
   registry.add(pythonGenerator);
 
   // Update the ToC when the active widget changes:
-  labShell.currentChanged.connect(onConnect);
+  if (labShell) {
+    labShell.currentChanged.connect(onConnect);
+  }
 
   return registry;
 
@@ -229,14 +231,16 @@ const extension: JupyterFrontEndPlugin<ITableOfContentsRegistry> = {
   requires: [
     IDocumentManager,
     IEditorTracker,
-    ILabShell,
     ILayoutRestorer,
     IMarkdownViewerTracker,
     INotebookTracker,
     IRenderMimeRegistry,
-    ITranslator
+    ITranslator,
   ],
-  optional: [ISettingRegistry],
+  optional: [
+    ILabShell,
+    ISettingRegistry,
+  ],
   activate: activateTOC
 };
 

--- a/packages/toc-extension/src/index.ts
+++ b/packages/toc-extension/src/index.ts
@@ -66,12 +66,12 @@ async function activateTOC(
   app: JupyterFrontEnd,
   docmanager: IDocumentManager,
   editorTracker: IEditorTracker,
-  labShell: ILabShell | null,
   restorer: ILayoutRestorer,
   markdownViewerTracker: IMarkdownViewerTracker,
   notebookTracker: INotebookTracker,
   rendermime: IRenderMimeRegistry,
   translator: ITranslator,
+  labShell?: ILabShell,
   settingRegistry?: ISettingRegistry
 ): Promise<ITableOfContentsRegistry> {
   const trans = translator.load('jupyterlab');


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

#11419 

## Code changes

Per suggestion by @jtpio in https://github.com/jupyterlab/retrolab/issues/272#issuecomment-963475247, make the `toc` extension optionally dependent on `ILabShell` and, where `ILabShell` is not required, use `app.shell` to refer to the shell (an instance of `IShell`).

## User-facing changes

None expected.

## Backwards-incompatible changes

None expected.