### PR TITLE
Backport PR #11420 on branch 3.2.x (Makes ILabShell optional in toc extension)

### DIFF
--- a/packages/toc-extension/src/index.ts
+++ b/packages/toc-extension/src/index.ts
@@ -36,7 +36,6 @@ import { runNestedCodeCells } from '@jupyterlab/toc';
  */
 namespace CommandIDs {
   export const runCells = 'toc:run-cells';
-  export const showPanel = 'toc:show-panel';
 }
 
 /**
@@ -92,13 +91,6 @@ async function activateTOC(
       return runNestedCodeCells(toc.headings, toc.activeEntry);
     },
     label: trans.__('Run Cell(s)')
-  });
-
-  app.commands.addCommand(CommandIDs.showPanel, {
-    label: trans.__('Table of Contents'),
-    execute: () => {
-      app.shell.activateById(toc.id);
-    }
   });
 
   // Add the ToC widget to the application restorer:

--- a/packages/toc-extension/src/index.ts
+++ b/packages/toc-extension/src/index.ts
@@ -58,12 +58,12 @@ async function activateTOC(
   app: JupyterFrontEnd,
   docmanager: IDocumentManager,
   editorTracker: IEditorTracker,
-  labShell: ILabShell,
   restorer: ILayoutRestorer,
   markdownViewerTracker: IMarkdownViewerTracker,
   notebookTracker: INotebookTracker,
   rendermime: IRenderMimeRegistry,
   translator: ITranslator,
+  labShell?: ILabShell,
   settingRegistry?: ISettingRegistry
 ): Promise<ITableOfContentsRegistry> {
   const trans = translator.load('jupyterlab');
@@ -84,7 +84,7 @@ async function activateTOC(
   toc.node.setAttribute('role', 'region');
   toc.node.setAttribute('aria-label', trans.__('Table of Contents section'));
 
-  labShell.add(toc, 'left', { rank: 400 });
+  app.shell.add(toc, 'left', { rank: 400 });
 
   app.commands.addCommand(CommandIDs.runCells, {
     execute: args => {
@@ -152,7 +152,9 @@ async function activateTOC(
   registry.add(pythonGenerator);
 
   // Update the ToC when the active widget changes:
-  labShell.currentChanged.connect(onConnect);
+  if (labShell) {
+    labShell.currentChanged.connect(onConnect);
+  }
 
   return registry;
 

--- a/packages/toc-extension/src/index.ts
+++ b/packages/toc-extension/src/index.ts
@@ -191,14 +191,13 @@ const extension: JupyterFrontEndPlugin<ITableOfContentsRegistry> = {
   requires: [
     IDocumentManager,
     IEditorTracker,
-    ILabShell,
     ILayoutRestorer,
     IMarkdownViewerTracker,
     INotebookTracker,
     IRenderMimeRegistry,
     ITranslator
   ],
-  optional: [ISettingRegistry],
+  optional: [ILabShell, ISettingRegistry],
   activate: activateTOC
 };
 

--- a/packages/toc-extension/src/index.ts
+++ b/packages/toc-extension/src/index.ts
@@ -36,6 +36,7 @@ import { runNestedCodeCells } from '@jupyterlab/toc';
  */
 namespace CommandIDs {
   export const runCells = 'toc:run-cells';
+  export const showPanel = 'toc:show-panel';
 }
 
 /**
@@ -93,9 +94,11 @@ async function activateTOC(
     label: trans.__('Run Cell(s)')
   });
 
-  app.contextMenu.addItem({
-    selector: '.jp-tocItem',
-    command: CommandIDs.runCells
+  app.commands.addCommand(CommandIDs.showPanel, {
+    label: trans.__('Table of Contents'),
+    execute: () => {
+      app.shell.activateById(toc.id);
+    }
   });
 
   // Add the ToC widget to the application restorer:
@@ -197,7 +200,7 @@ const extension: JupyterFrontEndPlugin<ITableOfContentsRegistry> = {
     IMarkdownViewerTracker,
     INotebookTracker,
     IRenderMimeRegistry,
-    ITranslator
+    ITranslator,
   ],
   optional: [ILabShell, ISettingRegistry],
   activate: activateTOC

--- a/packages/toc-extension/src/index.ts
+++ b/packages/toc-extension/src/index.ts
@@ -192,7 +192,7 @@ const extension: JupyterFrontEndPlugin<ITableOfContentsRegistry> = {
     IMarkdownViewerTracker,
     INotebookTracker,
     IRenderMimeRegistry,
-    ITranslator,
+    ITranslator
   ],
   optional: [ILabShell, ISettingRegistry],
   activate: activateTOC


### PR DESCRIPTION
## References

This backports the change from PR #11420 to address issue #11419 in the 3.2.x branch.

## Code changes

See prior PRs

## User-facing changes

See prior PRs

## Backwards-incompatible changes

See prior PRs
