### PR TITLE
Handle relative paths to `themePath` and `schemaDir`

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -2071,10 +2071,10 @@ def _validate_extension(data):
     if mime_extension and mime_extension not in files:
         messages.append('Missing mimeExtension module "%s"' % mime_extension)
 
-    if themePath and not any(f.startswith(themePath) for f in files):
+    if themePath and not any(f.startswith(str(Path(themePath))) for f in files):
         messages.append('themePath is empty: "%s"' % themePath)
 
-    if schemaDir and not any(f.startswith(schemaDir) for f in files):
+    if schemaDir and not any(f.startswith(str(Path(schemaDir))) for f in files):
         messages.append('schemaDir is empty: "%s"' % schemaDir)
 
     return messages


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyter-widgets/ipywidgets/issues/3307

The `@jupyter-widgets/jupyterlab-manager` extension uses `./schema` as the `schemaDir` here:

https://github.com/jupyter-widgets/ipywidgets/blob/6dff84d5fec69d95c860b3039024fc688cf0c413/python/jupyterlab_widgets/package.json#L95

Which makes the string comparison fail here when the extension is installed with `jupyter labextension install`:

https://github.com/jupyterlab/jupyterlab/blob/2b8a2cedcdb7cd4d3aac556692b146e8712a0e8f/jupyterlab/commands.py#L2078

## Code changes

Normalize the path to `schemaDir` and `themePath` to drop the leading `./` if any.

## User-facing changes

Should fix installing some extensions with `jupyter labextension install`.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
