### PR TITLE
Galata: add `acceptDownloads` to the browser context

### DIFF
--- a/galata/src/playwright-config.ts
+++ b/galata/src/playwright-config.ts
@@ -17,6 +17,9 @@ module.exports = {
     viewport: { width: 1024, height: 768 },
 
     // Artifacts
-    video: 'retain-on-failure'
+    video: 'retain-on-failure',
+
+    // Allow downloading files
+    acceptDownloads: true
   }
 } as PlaywrightTestConfig;


### PR DESCRIPTION
## References

This should help test downloading content from the UI such as notebooks, and check they are correctly formatted.

The Playwright docs mention this flag must be explicitly set to `true`:

![image](https://user-images.githubusercontent.com/591645/141133162-e8d2379a-988c-4da5-aae6-b99d0b79f647.png)

https://playwright.dev/docs/api/class-download/

## Code changes

Add `acceptDownloads` to the default galata config.



## User-facing changes

None


## Backwards-incompatible changes

None

Can be backported to 3.2.x