### PR TITLE
Use the root yarn.lock in staging when making a release.

### DIFF
--- a/buildutils/src/update-core-mode.ts
+++ b/buildutils/src/update-core-mode.ts
@@ -57,7 +57,11 @@ const notice =
   }
 });
 
-// Create a new yarn.lock file to ensure it is correct.
+// Copy the root yarn.lock, then update and deduplicate to prune it.
+fs.copySync(
+  path.join('.', 'yarn.lock'),
+  path.join('.', 'jupyterlab', 'staging', 'yarn.lock')
+);
 utils.run('jlpm', { cwd: staging });
 try {
   utils.run('jlpm yarn-deduplicate -s fewer --fail', { cwd: staging });


### PR DESCRIPTION




<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #11429

## Code changes

Essentially, since we were creating a new yarn.lock when making a release, we were possibly upgrading dependencies in a release that we were not using in our dev branches. This meant we could introduce changes or regressions right when making a release that we would not see in our dev workflow. This change locks the release to the versions of packages we had been using in the dev process.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

I think this change is risky enough (given that is changing how release dependencies have been done since pre-1.0) that we should not backport it.
