### PR TITLE
Automated Changelog Entry for 3.2.3 on 3.2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.2.3
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.2.2...49b2dfa5b74d5139dcbc55940ee5ed93b48e9db2))
+
+### Enhancements made
+
+- [3.2.x] Expose `window.jupyterapp` [#11417](https://github.com/jupyterlab/jupyterlab/pull/11417) ([@jtpio](https://github.com/jtpio))
+
+### Bugs fixed
+
+- Handle relative paths to `themePath` and `schemaDir` [#11427](https://github.com/jupyterlab/jupyterlab/pull/11427) ([@jtpio](https://github.com/jtpio))
+- Backport PR #11398 on branch 3.2.x (fix #11377 & bump Yjs dependencies & fix modeldb overwriting yjs content) [#11408](https://github.com/jupyterlab/jupyterlab/pull/11408) ([@dmonad](https://github.com/dmonad))
+
+### Maintenance and upkeep improvements
+
+- Backport PR #11420 on branch 3.2.x (Makes ILabShell optional in toc extension) [#11421](https://github.com/jupyterlab/jupyterlab/pull/11421) ([@jweill-aws](https://github.com/jweill-aws))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-11-04&to=2021-11-11&type=c))
+
+[@dmonad](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Admonad+updated%3A2021-11-04..2021-11-11&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-11-04..2021-11-11&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-11-04..2021-11-11&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-11-04..2021-11-11&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-11-04..2021-11-11&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-11-04..2021-11-11&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2021-11-04..2021-11-11&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-11-04..2021-11-11&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-11-04..2021-11-11&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-11-04..2021-11-11&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.2.2
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.2.1...0fcd2f5bfbe857a416dfad0c177f3f1299fef96e))
@@ -39,8 +64,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-10-20&to=2021-11-04&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-10-20..2021-11-04&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2021-10-20..2021-11-04&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2021-10-20..2021-11-04&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-10-20..2021-11-04&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-10-20..2021-11-04&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-10-20..2021-11-04&type=Issues) | [@jess-x](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajess-x+updated%3A2021-10-20..2021-11-04&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-10-20..2021-11-04&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-10-20..2021-11-04&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-10-20..2021-11-04&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-10-20..2021-11-04&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-10-20..2021-11-04&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrungleduc+updated%3A2021-10-20..2021-11-04&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-10-20..2021-11-04&type=Issues) | [@williamstein](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awilliamstein+updated%3A2021-10-20..2021-11-04&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AZsailer+updated%3A2021-10-20..2021-11-04&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.2.1
 


### PR DESCRIPTION
Automated Changelog Entry for 3.2.3 on 3.2.x
```
Python version: 3.2.3
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/application-top: 3.2.3
@jupyterlab/example-federated: 2.3.3
@jupyterlab/example-cell: 3.2.3
@jupyterlab/example-terminal: 3.2.3
@jupyterlab/example-console: 3.2.3
@jupyterlab/example-filebrowser: 3.2.3
@jupyterlab/example-app: 3.2.3
@jupyterlab/example-notebook: 3.2.3
@jupyterlab/example-federated-core: 2.3.3
@jupyterlab/example-federated-middle: 2.3.3
@jupyterlab/example-federated-phosphor: 2.3.3
@jupyterlab/example-federated-md: 2.3.3
@jupyterlab/translation-extension: 3.2.3
@jupyterlab/logconsole: 3.2.3
@jupyterlab/nbconvert-css: 3.2.3
@jupyterlab/rendermime-interfaces: 3.2.3
@jupyterlab/extensionmanager: 3.2.3
@jupyterlab/launcher-extension: 3.2.3
@jupyterlab/settingeditor: 3.2.3
@jupyterlab/vdom: 3.2.3
@jupyterlab/apputils: 3.2.3
@jupyterlab/shared-models: 3.2.3
@jupyterlab/settingeditor-extension: 3.2.3
@jupyterlab/toc: 5.2.3
@jupyterlab/pdf-extension: 3.2.3
@jupyterlab/celltags: 3.2.3
@jupyterlab/property-inspector: 3.2.3
@jupyterlab/statedb: 3.2.3
@jupyterlab/shortcuts-extension: 3.2.3
@jupyterlab/terminal: 3.2.3
@jupyterlab/docprovider: 3.2.3
@jupyterlab/inspector-extension: 3.2.3
@jupyterlab/application-extension: 3.2.3
@jupyterlab/docprovider-extension: 3.2.3
@jupyterlab/mathjax2: 3.2.3
@jupyterlab/attachments: 3.2.3
@jupyterlab/metapackage: 3.2.3
@jupyterlab/htmlviewer-extension: 3.2.3
@jupyterlab/documentsearch: 3.2.3
@jupyterlab/vdom-extension: 3.2.3
@jupyterlab/filebrowser-extension: 3.2.3
@jupyterlab/mathjax2-extension: 3.2.3
@jupyterlab/theme-dark-extension: 3.2.3
@jupyterlab/inspector: 3.2.3
@jupyterlab/imageviewer-extension: 3.2.3
@jupyterlab/docmanager: 3.2.3
@jupyterlab/mainmenu: 3.2.3
@jupyterlab/settingregistry: 3.2.3
@jupyterlab/celltags-extension: 3.2.3
@jupyterlab/documentsearch-extension: 3.2.3
@jupyterlab/codeeditor: 3.2.3
@jupyterlab/cells: 3.2.3
@jupyterlab/completer: 3.2.3
@jupyterlab/observables: 4.2.3
@jupyterlab/fileeditor-extension: 3.2.3
@jupyterlab/javascript-extension: 3.2.3
@jupyterlab/help-extension: 3.2.3
@jupyterlab/rendermime: 3.2.3
@jupyterlab/htmlviewer: 3.2.3
@jupyterlab/theme-light-extension: 3.2.3
@jupyterlab/services: 6.2.3
@jupyterlab/docmanager-extension: 3.2.3
@jupyterlab/tooltip: 3.2.3
@jupyterlab/vega5-extension: 3.2.3
@jupyterlab/statusbar: 3.2.3
@jupyterlab/outputarea: 3.2.3
@jupyterlab/nbformat: 3.2.3
@jupyterlab/debugger: 3.2.3
@jupyterlab/csvviewer: 3.2.3
@jupyterlab/console: 3.2.3
@jupyterlab/extensionmanager-extension: 3.2.3
@jupyterlab/tooltip-extension: 3.2.3
@jupyterlab/statusbar-extension: 3.2.3
@jupyterlab/terminal-extension: 3.2.3
@jupyterlab/rendermime-extension: 3.2.3
@jupyterlab/filebrowser: 3.2.3
@jupyterlab/apputils-extension: 3.2.3
@jupyterlab/imageviewer: 3.2.3
@jupyterlab/running-extension: 3.2.3
@jupyterlab/launcher: 3.2.3
@jupyterlab/ui-components-extension: 3.2.3
@jupyterlab/translation: 3.2.3
@jupyterlab/application: 3.2.3
@jupyterlab/coreutils: 5.2.3
@jupyterlab/debugger-extension: 3.2.3
@jupyterlab/ui-components: 3.2.3
@jupyterlab/hub-extension: 3.2.3
@jupyterlab/codemirror: 3.2.3
@jupyterlab/logconsole-extension: 3.2.3
@jupyterlab/json-extension: 3.2.3
@jupyterlab/toc-extension: 5.2.3
@jupyterlab/completer-extension: 3.2.3
@jupyterlab/mainmenu-extension: 3.2.3
@jupyterlab/fileeditor: 3.2.3
@jupyterlab/docregistry: 3.2.3
@jupyterlab/console-extension: 3.2.3
@jupyterlab/running: 3.2.3
@jupyterlab/markdownviewer-extension: 3.2.3
@jupyterlab/codemirror-extension: 3.2.3
@jupyterlab/csvviewer-extension: 3.2.3
@jupyterlab/markdownviewer: 3.2.3
@jupyterlab/notebook-extension: 3.2.3
@jupyterlab/notebook: 3.2.3
node-example: 3.2.3
@jupyterlab/example-services-browser: 3.2.3
@jupyterlab/example-services-outputarea: 3.2.3
@jupyterlab/builder: 3.2.3
@jupyterlab/buildutils: 3.2.3
@jupyterlab/template: 3.2.3
@jupyterlab/galata: 4.0.3
@jupyterlab/testutils: 3.2.3
@jupyterlab/mock-extension: 3.2.3
@jupyterlab/mock-token: 3.2.3
@jupyterlab/mock-provider: 3.2.3
@jupyterlab/mock-consumer: 3.2.3
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.2.x  |
| Version Spec | next |
| Since | v3.2.2 |