### PR TITLE
Makes restorer parameter optional in toc-extension

### DIFF
--- a/packages/toc-extension/src/index.ts
+++ b/packages/toc-extension/src/index.ts
@@ -52,26 +52,26 @@ namespace CommandIDs {
  * @private
  * @param app - Jupyter application
  * @param docmanager - document manager
- * @param editorTracker - editor tracker
- * @param markdownViewerTracker - Markdown viewer tracker
- * @param notebookTracker - notebook tracker
  * @param rendermime - rendered MIME registry
  * @param translator - translator
+ * @param editorTracker - editor tracker
  * @param restorer - application layout restorer
  * @param labShell - Jupyter lab shell
+ * @param markdownViewerTracker - Markdown viewer tracker
+ * @param notebookTracker - notebook tracker
  * @param settingRegistry - setting registry
  * @returns table of contents registry
  */
 async function activateTOC(
   app: JupyterFrontEnd,
   docmanager: IDocumentManager,
-  editorTracker: IEditorTracker,
-  markdownViewerTracker: IMarkdownViewerTracker,
-  notebookTracker: INotebookTracker,
   rendermime: IRenderMimeRegistry,
   translator: ITranslator,
+  editorTracker?: IEditorTracker,
   restorer?: ILayoutRestorer,
   labShell?: ILabShell,
+  markdownViewerTracker?: IMarkdownViewerTracker,
+  notebookTracker?: INotebookTracker,
   settingRegistry?: ISettingRegistry
 ): Promise<ITableOfContentsRegistry> {
   const trans = translator.load('jupyterlab');
@@ -96,6 +96,10 @@ async function activateTOC(
 
   app.commands.addCommand(CommandIDs.runCells, {
     execute: args => {
+      if (!notebookTracker) {
+        return null;
+      }
+
       const panel = notebookTracker.currentWidget;
       if (panel == null) {
         return;
@@ -154,42 +158,48 @@ async function activateTOC(
   }
 
   // Create a notebook generator:
-  const notebookGenerator = createNotebookGenerator(
-    notebookTracker,
-    toc,
-    rendermime.sanitizer,
-    translator,
-    settings
-  );
-  registry.add(notebookGenerator);
+  if (notebookTracker) {
+    const notebookGenerator = createNotebookGenerator(
+      notebookTracker,
+      toc,
+      rendermime.sanitizer,
+      translator,
+      settings
+    );
+    registry.add(notebookGenerator);
+  }
 
   // Create a Markdown generator:
-  const markdownGenerator = createMarkdownGenerator(
-    editorTracker,
-    toc,
-    rendermime.sanitizer,
-    translator,
-    settings
-  );
-  registry.add(markdownGenerator);
+  if (editorTracker) {
+    const markdownGenerator = createMarkdownGenerator(
+      editorTracker,
+      toc,
+      rendermime.sanitizer,
+      translator,
+      settings
+    );
+    registry.add(markdownGenerator);
+
+    // Create a LaTeX generator:
+    const latexGenerator = createLatexGenerator(editorTracker);
+    registry.add(latexGenerator);
+
+    // Create a Python generator:
+    const pythonGenerator = createPythonGenerator(editorTracker);
+    registry.add(pythonGenerator);
+  }
 
   // Create a rendered Markdown generator:
-  const renderedMarkdownGenerator = createRenderedMarkdownGenerator(
-    markdownViewerTracker,
-    toc,
-    rendermime.sanitizer,
-    translator,
-    settings
-  );
-  registry.add(renderedMarkdownGenerator);
-
-  // Create a LaTeX generator:
-  const latexGenerator = createLatexGenerator(editorTracker);
-  registry.add(latexGenerator);
-
-  // Create a Python generator:
-  const pythonGenerator = createPythonGenerator(editorTracker);
-  registry.add(pythonGenerator);
+  if (markdownViewerTracker) {
+    const renderedMarkdownGenerator = createRenderedMarkdownGenerator(
+      markdownViewerTracker,
+      toc,
+      rendermime.sanitizer,
+      translator,
+      settings
+    );
+    registry.add(renderedMarkdownGenerator);
+  }
 
   // Update the ToC when the active widget changes:
   if (labShell) {
@@ -232,13 +242,17 @@ const extension: JupyterFrontEndPlugin<ITableOfContentsRegistry> = {
   provides: ITableOfContentsRegistry,
   requires: [
     IDocumentManager,
-    IEditorTracker,
-    IMarkdownViewerTracker,
-    INotebookTracker,
     IRenderMimeRegistry,
     ITranslator
   ],
-  optional: [ILayoutRestorer, ILabShell, ISettingRegistry],
+  optional: [
+    IEditorTracker,
+    ILayoutRestorer,
+    ILabShell,
+    IMarkdownViewerTracker,
+    INotebookTracker,
+    ISettingRegistry
+  ],
   activate: activateTOC
 };
 

--- a/packages/toc-extension/src/index.ts
+++ b/packages/toc-extension/src/index.ts
@@ -240,11 +240,7 @@ const extension: JupyterFrontEndPlugin<ITableOfContentsRegistry> = {
   id: '@jupyterlab/toc:plugin',
   autoStart: true,
   provides: ITableOfContentsRegistry,
-  requires: [
-    IDocumentManager,
-    IRenderMimeRegistry,
-    ITranslator
-  ],
+  requires: [IDocumentManager, IRenderMimeRegistry, ITranslator],
   optional: [
     IEditorTracker,
     ILayoutRestorer,

--- a/packages/toc-extension/src/index.ts
+++ b/packages/toc-extension/src/index.ts
@@ -53,12 +53,12 @@ namespace CommandIDs {
  * @param app - Jupyter application
  * @param docmanager - document manager
  * @param editorTracker - editor tracker
- * @param labShell - Jupyter lab shell
- * @param restorer - application layout restorer
  * @param markdownViewerTracker - Markdown viewer tracker
  * @param notebookTracker - notebook tracker
  * @param rendermime - rendered MIME registry
  * @param translator - translator
+ * @param restorer - application layout restorer
+ * @param labShell - Jupyter lab shell
  * @param settingRegistry - setting registry
  * @returns table of contents registry
  */
@@ -66,11 +66,11 @@ async function activateTOC(
   app: JupyterFrontEnd,
   docmanager: IDocumentManager,
   editorTracker: IEditorTracker,
-  restorer: ILayoutRestorer,
   markdownViewerTracker: IMarkdownViewerTracker,
   notebookTracker: INotebookTracker,
   rendermime: IRenderMimeRegistry,
   translator: ITranslator,
+  restorer?: ILayoutRestorer,
   labShell?: ILabShell,
   settingRegistry?: ISettingRegistry
 ): Promise<ITableOfContentsRegistry> {
@@ -136,8 +136,10 @@ async function activateTOC(
     }
   });
 
-  // Add the ToC widget to the application restorer:
-  restorer.add(toc, '@jupyterlab/toc:plugin');
+  if (restorer) {
+    // Add the ToC widget to the application restorer:
+    restorer.add(toc, '@jupyterlab/toc:plugin');
+  }
 
   // Attempt to load plugin settings:
   let settings: ISettingRegistry.ISettings | undefined;
@@ -231,13 +233,12 @@ const extension: JupyterFrontEndPlugin<ITableOfContentsRegistry> = {
   requires: [
     IDocumentManager,
     IEditorTracker,
-    ILayoutRestorer,
     IMarkdownViewerTracker,
     INotebookTracker,
     IRenderMimeRegistry,
     ITranslator
   ],
-  optional: [ILabShell, ISettingRegistry],
+  optional: [ILayoutRestorer, ILabShell, ISettingRegistry],
   activate: activateTOC
 };
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #11444 .

## Code changes

Makes the `restorer` parameter in `toc-extension` optional so that shells that do not implement a layout restorer, such as `IRetroShell`, can use this extension.

## User-facing changes

None.

## Backwards-incompatible changes

None.