### PR TITLE
Do not update contextual help inspector if there would be no change.

### DIFF
--- a/packages/inspector/src/handler.ts
+++ b/packages/inspector/src/handler.ts
@@ -5,7 +5,7 @@ import { CodeEditor } from '@jupyterlab/codeeditor';
 import { Text } from '@jupyterlab/coreutils';
 import { IRenderMimeRegistry, MimeModel } from '@jupyterlab/rendermime';
 import { IDataConnector } from '@jupyterlab/statedb';
-import { ReadonlyJSONObject } from '@lumino/coreutils';
+import { JSONExt, ReadonlyJSONObject } from '@lumino/coreutils';
 import { IDisposable } from '@lumino/disposable';
 import { Debouncer } from '@lumino/polling';
 import { ISignal, Signal } from '@lumino/signaling';
@@ -135,13 +135,22 @@ export class InspectionHandler implements IDisposable, IInspector.IInspectable {
       .then(reply => {
         // If handler has been disposed or a newer request is pending, bail.
         if (!reply || this.isDisposed || pending !== this._pending) {
+          this._lastInspectedReply = null;
           this._inspected.emit(update);
           return;
         }
 
         const { data } = reply;
-        const mimeType = this._rendermime.preferredMimeType(data);
 
+        // Do not update if there would be no change.
+        if (
+          this._lastInspectedReply &&
+          JSONExt.deepEqual(this._lastInspectedReply, data)
+        ) {
+          return;
+        }
+
+        const mimeType = this._rendermime.preferredMimeType(data);
         if (mimeType) {
           const widget = this._rendermime.createRenderer(mimeType);
           const model = new MimeModel({ data });
@@ -150,10 +159,12 @@ export class InspectionHandler implements IDisposable, IInspector.IInspectable {
           update.content = widget;
         }
 
+        this._lastInspectedReply = reply.data;
         this._inspected.emit(update);
       })
       .catch(reason => {
         // Since almost all failures are benign, fail silently.
+        this._lastInspectedReply = null;
         this._inspected.emit(update);
       });
   }
@@ -179,6 +190,7 @@ export class InspectionHandler implements IDisposable, IInspector.IInspectable {
   private _rendermime: IRenderMimeRegistry;
   private _standby = true;
   private _debouncer: Debouncer;
+  private _lastInspectedReply: InspectionHandler.IReply['data'] | null = null;
 }
 
 /**


### PR DESCRIPTION



<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #11410

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Keep the last inspection reply data and do not reset the inspector if the new reply is the same as the old one.

## User-facing changes

This means that slight changes in the editor cursor which give the same inspection output (such as moving the cursor inside the name of a function call) won’t reset the help content (thus resetting the scroll position, losing your place, etc.).

To test, execute the following code:

```python
with open('a', 'w') as f:
    f.write('a')
```
Then open the contextual help panel, put your cursor in the word `open`. Then scroll the contextual help panel to see the bottom of the text there.

Now, click anywhere else in the word `open` (or move your cursor). Before this PR, the contextual help panel would reset, losing the scroll position. After this PR, the contextual help panel will not be reset, preserving the scroll position in the panel.

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

