### PR TITLE
Enforce ascii-only identifiers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,6 +53,7 @@ module.exports = {
     '@typescript-eslint/no-inferrable-types': 'off',
     'jest/no-conditional-expect': 'warn',
     'jest/valid-title': 'warn',
+    'id-match': ['error', '^[a-zA-Z_]+[a-zA-Z0-9_]*$'], // https://certitude.consulting/blog/en/invisible-backdoor/
     'no-inner-declarations': 'off',
     'no-prototype-builtins': 'off',
     'no-control-regex': 'warn',


### PR DESCRIPTION





<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This backports #11432 to 3.2.x.


## Code changes

The article at https://certitude.consulting/blog/en/invisible-backdoor/ and the HackerNews comment https://news.ycombinator.com/item?id=29172889 inspired adding this rule. Essentially, this guards against having tricky unicode identifiers (like invisible characters) create a backdoor that is not visible during code review.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
