### PR TITLE
Fix executionScheduled emit order issue

### DIFF
--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2023,10 +2023,14 @@ namespace Private {
             return Promise.resolve(false);
           }
           const deletedCells = notebook.model?.deletedCells ?? [];
-          const executePromise = CodeCell.execute(cell as CodeCell, sessionContext, {
-            deletedCells,
-            recordTiming: notebook.notebookConfig.recordTiming
-          })
+          const executePromise = CodeCell.execute(
+            cell as CodeCell,
+            sessionContext,
+            {
+              deletedCells,
+              recordTiming: notebook.notebookConfig.recordTiming
+            }
+          )
             .then(reply => {
               deletedCells.splice(0, deletedCells.length);
               if (cell.isDisposed) {

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2023,8 +2023,7 @@ namespace Private {
             return Promise.resolve(false);
           }
           const deletedCells = notebook.model?.deletedCells ?? [];
-          executionScheduled.emit({ notebook, cell });
-          return CodeCell.execute(cell as CodeCell, sessionContext, {
+          const executePromise = CodeCell.execute(cell as CodeCell, sessionContext, {
             deletedCells,
             recordTiming: notebook.notebookConfig.recordTiming
           })
@@ -2063,6 +2062,8 @@ namespace Private {
 
               return ran;
             });
+          executionScheduled.emit({ notebook, cell });
+          return executePromise;
         }
         (cell.model as ICodeCellModel).clearExecution();
         break;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

#11452 

## Code changes

The order of `emit()` and `execute()` is swapped.

## User-facing changes

No user-facing changes

## Backwards-incompatible changes

There should be no backwards-incompatible issues
