### PR TITLE
regenerate server connection settings for printing

### DIFF
--- a/packages/apputils/src/printing.ts
+++ b/packages/apputils/src/printing.ts
@@ -66,13 +66,13 @@ export namespace Printing {
     return printContent(widget.node);
   }
 
-  const settings = ServerConnection.makeSettings();
   /**
    * Prints a URL by loading it into an iframe.
    *
    * @param url URL to load into an iframe.
    */
   export async function printURL(url: string): Promise<void> {
+    const settings = ServerConnection.makeSettings();
     const text = await (
       await ServerConnection.makeRequest(url, {}, settings)
     ).text();


### PR DESCRIPTION
## References

[printURL](https://github.com/jupyterlab/jupyterlab/blob/master/packages/apputils/src/printing.ts#L75) method is using server connection settings which were created during launch time that doesn't reflect any updates via `PageConfig.setOption()` calls. This is causing printing to fail in JupyterLab Desktop as mentioned in https://github.com/jupyterlab/jupyterlab-desktop/issues/331 because JupyterLab Desktop updates `baseUrl` config lazily once a backend is ready to connect to.

## Code changes

Server connection settings are regenerated each time `printURL` is called which enables using latest configuration options.

## User-facing changes

N.A.

## Backwards-incompatible changes

N.A.
