### PR TITLE
Don't update styles import for `metapackage`

### DIFF
--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -642,18 +642,20 @@ export async function ensureIntegrity(): Promise<boolean> {
     cssImports[name] = [];
     cssModuleImports[name] = [];
 
-    graph.dependenciesOf(name).forEach(depName => {
-      if (depName in cssData) {
-        cssData[depName].forEach(cssPath => {
-          cssImports[name].push(`${depName}/${cssPath}`);
-        });
-      }
-      if (depName in cssModuleData) {
-        cssModuleData[depName].forEach(cssModulePath => {
-          cssModuleImports[name].push(`${depName}/${cssModulePath}`);
-        });
-      }
-    });
+    if (name !== '@jupyterlab/metapackage') {
+      graph.dependenciesOf(name).forEach(depName => {
+        if (depName in cssData) {
+          cssData[depName].forEach(cssPath => {
+            cssImports[name].push(`${depName}/${cssPath}`);
+          });
+        }
+        if (depName in cssModuleData) {
+          cssModuleData[depName].forEach(cssModulePath => {
+            cssModuleImports[name].push(`${depName}/${cssModulePath}`);
+          });
+        }
+      });
+    }
   });
 
   // Update the metapackage.


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
In recent PRs (#11079, #11443) adding new packages, the `metapackage` is updated to list their styles. This should not happen.
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Skip listing css imports for metapackage

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A