### PR TITLE
Add background to the reference iframes to fix contrast

### DIFF
--- a/packages/help-extension/style/base.css
+++ b/packages/help-extension/style/base.css
@@ -12,6 +12,8 @@
 
 .jp-Help > iframe {
   border: none;
+  /* Forcing white color to avoid contrast issues see issue #11320 */
+  background: white;
 }
 
 .jp-About-body {


### PR DESCRIPTION
## References

Fixes #11320

## Code changes

Enforce white background in Help iframes irrespective of the theme.

## User-facing changes

Markdown help will be readable in dark mode.

Before:

![Screenshot from 2021-11-16 20-15-05](https://user-images.githubusercontent.com/5832902/142059750-02ea8f67-aff1-4704-aeb0-36d00a649783.png)

After:

![Screenshot from 2021-11-16 20-20-49](https://user-images.githubusercontent.com/5832902/142059730-a2e7117c-4e37-474c-9a08-fc8106e9db94.png)


## Backwards-incompatible changes

None