### PR TITLE
Tweak CSS for scrolled outputs

### DIFF
--- a/packages/cells/style/widget.css
+++ b/packages/cells/style/widget.css
@@ -70,9 +70,10 @@
 
 .jp-CodeCell.jp-mod-outputsScrolled .jp-Cell-outputArea {
   overflow-y: auto;
-  max-height: 200px;
+  max-height: 24em;
   box-shadow: inset 0 0 6px 2px rgba(0, 0, 0, 0.3);
   margin-left: var(--jp-private-cell-scrolling-output-offset);
+  padding-top: 6px;
 }
 
 .jp-CodeCell.jp-mod-outputsScrolled .jp-OutputArea-prompt {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Based on the feedback in https://github.com/berkeley-dsep-infra/datahub/issues/2993

Fixes #4253

## Code changes

CSS tweaks to make scrolled outputs look more like what the classic notebook does.

- set `max-height: 24em;` (defined [here](https://github.com/jupyter/notebook/blob/a9a31c096eeffe1bff4e9164c6a0442e0e13cdb3/notebook/static/notebook/less/outputarea.less#L12) in the classic notebook)
- add `padding-top` to match the box shadow blur radius)

## User-facing changes

### Before

![image](https://user-images.githubusercontent.com/591645/142075259-7f765544-f904-4246-870b-433535098194.png)


### After

![image](https://user-images.githubusercontent.com/591645/142075192-607d286c-14d8-463c-83ba-245f3c2d3fd9.png)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
