### PR TITLE
Fix malformed fenced code block Markdown rendering

### DIFF
--- a/packages/rendermime/src/latex.ts
+++ b/packages/rendermime/src/latex.ts
@@ -35,10 +35,17 @@ export function removeMath(text: string): { text: string; math: string[] } {
   // we still have to consider them at this point; the following issue has happened several times:
   //
   //     `$foo` and `$bar` are variables.  -->  <code>$foo ` and `$bar</code> are variables.
-  const hasCodeSpans = /`/.test(text);
+  const hasCodeSpans = text.includes('`') || text.includes('~~~');
   if (hasCodeSpans) {
     text = text
       .replace(/~/g, '~T')
+      // note: the `fence` (three or more consecutive tildes or backticks)
+      // can be followed by an `info string` but this cannot include backticks,
+      // see specification: https://spec.commonmark.org/0.30/#info-string
+      .replace(
+        /^(?<fence>`{3,}|(~T){3,})[^`\n]*\n([\s\S]*?)^\k<fence>`*$/gm,
+        wholematch => wholematch.replace(/\$/g, '~D')
+      )
       .replace(/(^|[^\\])(`+)([^\n]*?[^`\n])\2(?!`)/gm, wholematch =>
         wholematch.replace(/\$/g, '~D')
       );

--- a/packages/rendermime/test/latex.spec.ts
+++ b/packages/rendermime/test/latex.spec.ts
@@ -19,6 +19,34 @@ describe('jupyter-ui', () => {
       expect(math).toEqual([]);
     });
 
+    it('should handle fenced code blocks', () => {
+      const input = '```\n$foo\n$bar\n```';
+      const { text, math } = removeMath(input);
+      expect(text).toBe(input);
+      expect(math).toEqual([]);
+    });
+
+    it('should handle tilde fenced code blocks', () => {
+      const input = '~~~\n$foo\n$bar\n~~~';
+      const { text, math } = removeMath(input);
+      expect(text).toBe(input);
+      expect(math).toEqual([]);
+    });
+
+    it('should handle long fenced code blocks', () => {
+      const input = '````\n$foo\n$bar\n```\n``````';
+      const { text, math } = removeMath(input);
+      expect(text).toBe(input);
+      expect(math).toEqual([]);
+    });
+
+    it('should handle fenced code blocks with info string', () => {
+      const input = '```R\ndata[data$foo > 1 & data$bar < 2,]\n```';
+      const { text, math } = removeMath(input);
+      expect(text).toBe(input);
+      expect(math).toEqual([]);
+    });
+
     it('should handle math markers', () => {
       const input = ' @@0@@ hello, $ /alpha $, there';
       const { text, math } = removeMath(input);


### PR DESCRIPTION
## References

Fixes #10861

## Code changes

Add support for fenced code blocks following [CommonMark specs](https://spec.commonmark.org/0.30/#fenced-code-blocks) to prevent common gotchas. This PR does not add support for code blocks defined by whitespace indentation - I am not sure if those are safe to implement here (could those interfere with TeX?) and are IMO less of a priority.

## User-facing changes

Before:

![Screenshot from 2021-11-16 22-37-54](https://user-images.githubusercontent.com/5832902/142077849-18062192-0f7d-4813-b90d-66f348cab4d6.png)

After:

![Screenshot from 2021-11-16 23-00-45](https://user-images.githubusercontent.com/5832902/142079908-c5c0b968-3248-42a5-86e5-6fcf1b764a53.png)


Before:

![Screenshot from 2021-11-16 23-05-10](https://user-images.githubusercontent.com/5832902/142080370-eea3e685-9079-46dc-85c4-001719a36d17.png)

After:

![Screenshot from 2021-11-16 23-04-15](https://user-images.githubusercontent.com/5832902/142080388-68179736-b0af-4c38-a1a5-5909d35e211d.png)

## Backwards-incompatible changes

None