### PR TITLE
Automated Changelog Entry for 3.2.4 on 3.2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,20 +15,20 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 ### Enhancements made
 
 - Recommend trying prebuilt extension version in the build failure dialog [#11476](https://github.com/jupyterlab/jupyterlab/pull/11476) ([@krassowski](https://github.com/krassowski))
-- Backport PR #11128 on branch 3.2.x (Run comparative benchmark) [#11441](https://github.com/jupyterlab/jupyterlab/pull/11441) ([@fcollonval](https://github.com/fcollonval))
+- Run comparative benchmark [#11441](https://github.com/jupyterlab/jupyterlab/pull/11441) ([@fcollonval](https://github.com/fcollonval))
 
 ### Bugs fixed
 
 - Add background to the reference iframes to fix contrast [#11477](https://github.com/jupyterlab/jupyterlab/pull/11477) ([@krassowski](https://github.com/krassowski))
 - Fix `undomanager` paste regression - fixes #10928 [#11471](https://github.com/jupyterlab/jupyterlab/pull/11471) ([@dmonad](https://github.com/dmonad))
-- regenerate server connection settings for printing [#11454](https://github.com/jupyterlab/jupyterlab/pull/11454) ([@mbektas](https://github.com/mbektas))
+- Regenerate server connection settings for printing [#11454](https://github.com/jupyterlab/jupyterlab/pull/11454) ([@mbektas](https://github.com/mbektas))
 - Fix browser tab name [#10952](https://github.com/jupyterlab/jupyterlab/pull/10952) ([@tejasmorkar](https://github.com/tejasmorkar))
 - Do not update contextual help inspector if there would be no change. [#11447](https://github.com/jupyterlab/jupyterlab/pull/11447) ([@jasongrout](https://github.com/jasongrout))
 
 ### Maintenance and upkeep improvements
 
 - Reduce flake on non-LaTeX highlighting test [#11470](https://github.com/jupyterlab/jupyterlab/pull/11470) ([@krassowski](https://github.com/krassowski))
-- Backport PR #11445 on branch 3.2.x (Makes restorer parameter optional in toc-extension) [#11460](https://github.com/jupyterlab/jupyterlab/pull/11460) ([@fcollonval](https://github.com/fcollonval))
+- Makes restorer parameter optional in `toc-extension` [#11460](https://github.com/jupyterlab/jupyterlab/pull/11460) ([@fcollonval](https://github.com/fcollonval))
 - Enforce ascii-only identifiers [#11449](https://github.com/jupyterlab/jupyterlab/pull/11449) ([@jasongrout](https://github.com/jasongrout))
 
 ### Contributors to this release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.2.4
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.2.3...3bf36235a2521944b2b0b034e7986630ee83de18))
+
+### Enhancements made
+
+- Recommend trying prebuilt extension version in the build failure dialog [#11476](https://github.com/jupyterlab/jupyterlab/pull/11476) ([@krassowski](https://github.com/krassowski))
+- Backport PR #11128 on branch 3.2.x (Run comparative benchmark) [#11441](https://github.com/jupyterlab/jupyterlab/pull/11441) ([@fcollonval](https://github.com/fcollonval))
+
+### Bugs fixed
+
+- Add background to the reference iframes to fix contrast [#11477](https://github.com/jupyterlab/jupyterlab/pull/11477) ([@krassowski](https://github.com/krassowski))
+- Fix `undomanager` paste regression - fixes #10928 [#11471](https://github.com/jupyterlab/jupyterlab/pull/11471) ([@dmonad](https://github.com/dmonad))
+- regenerate server connection settings for printing [#11454](https://github.com/jupyterlab/jupyterlab/pull/11454) ([@mbektas](https://github.com/mbektas))
+- Fix browser tab name [#10952](https://github.com/jupyterlab/jupyterlab/pull/10952) ([@tejasmorkar](https://github.com/tejasmorkar))
+- Do not update contextual help inspector if there would be no change. [#11447](https://github.com/jupyterlab/jupyterlab/pull/11447) ([@jasongrout](https://github.com/jasongrout))
+
+### Maintenance and upkeep improvements
+
+- Reduce flake on non-LaTeX highlighting test [#11470](https://github.com/jupyterlab/jupyterlab/pull/11470) ([@krassowski](https://github.com/krassowski))
+- Backport PR #11445 on branch 3.2.x (Makes restorer parameter optional in toc-extension) [#11460](https://github.com/jupyterlab/jupyterlab/pull/11460) ([@fcollonval](https://github.com/fcollonval))
+- Enforce ascii-only identifiers [#11449](https://github.com/jupyterlab/jupyterlab/pull/11449) ([@jasongrout](https://github.com/jasongrout))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-11-11&to=2021-11-17&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-11-11..2021-11-17&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-11-11..2021-11-17&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-11-11..2021-11-17&type=Issues) | [@isabela-pf](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aisabela-pf+updated%3A2021-11-11..2021-11-17&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-11-11..2021-11-17&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-11-11..2021-11-17&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-11-11..2021-11-17&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-11-11..2021-11-17&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-11-11..2021-11-17&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-11-11..2021-11-17&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-11-11..2021-11-17&type=Issues) | [@williamstein](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awilliamstein+updated%3A2021-11-11..2021-11-17&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.2.3
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.2.2...49b2dfa5b74d5139dcbc55940ee5ed93b48e9db2))
@@ -30,8 +61,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-11-04&to=2021-11-11&type=c))
 
 [@dmonad](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Admonad+updated%3A2021-11-04..2021-11-11&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-11-04..2021-11-11&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-11-04..2021-11-11&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-11-04..2021-11-11&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-11-04..2021-11-11&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-11-04..2021-11-11&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2021-11-04..2021-11-11&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-11-04..2021-11-11&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-11-04..2021-11-11&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-11-04..2021-11-11&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.2.2
 


### PR DESCRIPTION
Automated Changelog Entry for 3.2.4 on 3.2.x
```
Python version: 3.2.4
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/application-top: 3.2.4
@jupyterlab/example-federated: 2.3.4
@jupyterlab/example-cell: 3.2.4
@jupyterlab/example-terminal: 3.2.4
@jupyterlab/example-console: 3.2.4
@jupyterlab/example-filebrowser: 3.2.4
@jupyterlab/example-app: 3.2.4
@jupyterlab/example-notebook: 3.2.4
@jupyterlab/example-federated-core: 2.3.4
@jupyterlab/example-federated-middle: 2.3.4
@jupyterlab/example-federated-phosphor: 2.3.4
@jupyterlab/example-federated-md: 2.3.4
@jupyterlab/translation-extension: 3.2.4
@jupyterlab/logconsole: 3.2.4
@jupyterlab/nbconvert-css: 3.2.4
@jupyterlab/rendermime-interfaces: 3.2.4
@jupyterlab/extensionmanager: 3.2.4
@jupyterlab/launcher-extension: 3.2.4
@jupyterlab/settingeditor: 3.2.4
@jupyterlab/vdom: 3.2.4
@jupyterlab/apputils: 3.2.4
@jupyterlab/shared-models: 3.2.4
@jupyterlab/settingeditor-extension: 3.2.4
@jupyterlab/toc: 5.2.4
@jupyterlab/pdf-extension: 3.2.4
@jupyterlab/celltags: 3.2.4
@jupyterlab/property-inspector: 3.2.4
@jupyterlab/statedb: 3.2.4
@jupyterlab/shortcuts-extension: 3.2.4
@jupyterlab/terminal: 3.2.4
@jupyterlab/docprovider: 3.2.4
@jupyterlab/inspector-extension: 3.2.4
@jupyterlab/application-extension: 3.2.4
@jupyterlab/docprovider-extension: 3.2.4
@jupyterlab/mathjax2: 3.2.4
@jupyterlab/attachments: 3.2.4
@jupyterlab/metapackage: 3.2.4
@jupyterlab/htmlviewer-extension: 3.2.4
@jupyterlab/documentsearch: 3.2.4
@jupyterlab/vdom-extension: 3.2.4
@jupyterlab/filebrowser-extension: 3.2.4
@jupyterlab/mathjax2-extension: 3.2.4
@jupyterlab/theme-dark-extension: 3.2.4
@jupyterlab/inspector: 3.2.4
@jupyterlab/imageviewer-extension: 3.2.4
@jupyterlab/docmanager: 3.2.4
@jupyterlab/mainmenu: 3.2.4
@jupyterlab/settingregistry: 3.2.4
@jupyterlab/celltags-extension: 3.2.4
@jupyterlab/documentsearch-extension: 3.2.4
@jupyterlab/codeeditor: 3.2.4
@jupyterlab/cells: 3.2.4
@jupyterlab/completer: 3.2.4
@jupyterlab/observables: 4.2.4
@jupyterlab/fileeditor-extension: 3.2.4
@jupyterlab/javascript-extension: 3.2.4
@jupyterlab/help-extension: 3.2.4
@jupyterlab/rendermime: 3.2.4
@jupyterlab/htmlviewer: 3.2.4
@jupyterlab/theme-light-extension: 3.2.4
@jupyterlab/services: 6.2.4
@jupyterlab/docmanager-extension: 3.2.4
@jupyterlab/tooltip: 3.2.4
@jupyterlab/vega5-extension: 3.2.4
@jupyterlab/statusbar: 3.2.4
@jupyterlab/outputarea: 3.2.4
@jupyterlab/nbformat: 3.2.4
@jupyterlab/debugger: 3.2.4
@jupyterlab/csvviewer: 3.2.4
@jupyterlab/console: 3.2.4
@jupyterlab/extensionmanager-extension: 3.2.4
@jupyterlab/tooltip-extension: 3.2.4
@jupyterlab/statusbar-extension: 3.2.4
@jupyterlab/terminal-extension: 3.2.4
@jupyterlab/rendermime-extension: 3.2.4
@jupyterlab/filebrowser: 3.2.4
@jupyterlab/apputils-extension: 3.2.4
@jupyterlab/imageviewer: 3.2.4
@jupyterlab/running-extension: 3.2.4
@jupyterlab/launcher: 3.2.4
@jupyterlab/ui-components-extension: 3.2.4
@jupyterlab/translation: 3.2.4
@jupyterlab/application: 3.2.4
@jupyterlab/coreutils: 5.2.4
@jupyterlab/debugger-extension: 3.2.4
@jupyterlab/ui-components: 3.2.4
@jupyterlab/hub-extension: 3.2.4
@jupyterlab/codemirror: 3.2.4
@jupyterlab/logconsole-extension: 3.2.4
@jupyterlab/json-extension: 3.2.4
@jupyterlab/toc-extension: 5.2.4
@jupyterlab/completer-extension: 3.2.4
@jupyterlab/mainmenu-extension: 3.2.4
@jupyterlab/fileeditor: 3.2.4
@jupyterlab/docregistry: 3.2.4
@jupyterlab/console-extension: 3.2.4
@jupyterlab/running: 3.2.4
@jupyterlab/markdownviewer-extension: 3.2.4
@jupyterlab/codemirror-extension: 3.2.4
@jupyterlab/csvviewer-extension: 3.2.4
@jupyterlab/markdownviewer: 3.2.4
@jupyterlab/notebook-extension: 3.2.4
@jupyterlab/notebook: 3.2.4
node-example: 3.2.4
@jupyterlab/example-services-browser: 3.2.4
@jupyterlab/example-services-outputarea: 3.2.4
@jupyterlab/builder: 3.2.4
@jupyterlab/buildutils: 3.2.4
@jupyterlab/template: 3.2.4
@jupyterlab/galata: 4.1.1
@jupyterlab/testutils: 3.2.4
@jupyterlab/mock-extension: 3.2.4
@jupyterlab/mock-token: 3.2.4
@jupyterlab/mock-provider: 3.2.4
@jupyterlab/mock-consumer: 3.2.4
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.2.x  |
| Version Spec | next |
| Since | v3.2.3 |