### PR TITLE
Render widgets on all clients in collaborative mode

### DIFF
--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -734,10 +734,16 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
     return this._needTrustButton;
   }
 
+  /**
+   * Set the flag that indicates the cell output widget need to have a trust button.
+   */
   set needTrustButton(value: boolean) {
     this._needTrustButton = value;
   }
 
+  /**
+   * A signal emitted when a `display_data` message is processed.
+   */
   get displayModelRequested(): ISignal<ICodeCellModel, void> {
     return this._displayModelRequested;
   }
@@ -1012,6 +1018,11 @@ export namespace CodeCellModel {
 
 namespace Private {
   /**
+   * The list of mime type that can be displayed immediately in RTC mode.
+   */
+  const MIME_WHITE_LIST = ['text/plain'];
+
+  /**
    * Check the output message for its type and data content. If the message type
    * is one of `execute_result`, `display_data`, or `update_display_data` and its
    * data contains  at least one `application/*` key, returns `true`.
@@ -1028,7 +1039,7 @@ namespace Private {
       out.data
     ) {
       for (const key in out.data as nbformat.IMimeBundle) {
-        if (key.startsWith('application/')) {
+        if (!MIME_WHITE_LIST.includes(key)) {
           return true;
         }
       }

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -727,6 +727,9 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
     this._setDirty(false);
   }
 
+  /**
+   * A flag that indicates the cell output widget need to have a trust button.
+   */
   get needTrustButton(): boolean {
     return this._needTrustButton;
   }
@@ -909,10 +912,10 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
       if (change.outputsChange) {
         this.clearExecution();
         sender.getOutputs().forEach(output => {
+          this._outputs.add(output);
           if (output.output_type === DISPLAY_DATA_TYPE) {
             this._displayModelRequested.emit();
           }
-          this._outputs.add(output);
         });
       }
 

--- a/packages/cells/style/widget.css
+++ b/packages/cells/style/widget.css
@@ -25,9 +25,7 @@
 
 .jp-Cell-trustButton {
   position: absolute;
-  left: calc(
-    0.5 * var(--jp-cell-collapser-width) + 0.5 * var(--jp-cell-prompt-width)
-  );
+  right: 5px;
   top: calc(50% - 9px);
 }
 

--- a/packages/cells/style/widget.css
+++ b/packages/cells/style/widget.css
@@ -23,6 +23,23 @@
   background: transparent;
 }
 
+.jp-Cell-trustButton {
+  position: absolute;
+  left: calc(
+    0.5 * var(--jp-cell-collapser-width) + 0.5 * var(--jp-cell-prompt-width)
+  );
+  top: calc(50% - 9px);
+}
+
+.jp-Cell-trustButton > button {
+  height: 14px;
+}
+
+.jp-Cell-trustButton > button svg {
+  width: 14px;
+  height: 14px;
+}
+
 /*-----------------------------------------------------------------------------
 | Common input/output
 |----------------------------------------------------------------------------*/

--- a/packages/cells/test/model.spec.ts
+++ b/packages/cells/test/model.spec.ts
@@ -644,21 +644,47 @@ describe('cells/model', () => {
     });
 
     describe('#switchSharedModel', () => {
-      it('should request for a trust button on `display_data` output', () => {
-        const model = new CodeCellModel({});
-        expect(model.needTrustButton).toEqual(false);
-        const sharedModel = {
-          getOutputs: jest
-            .fn()
-            .mockReturnValue([{ output_type: 'display_data' }]),
-          getSource: jest.fn().mockReturnValue(''),
-          getMetadata: jest.fn(),
-          changed: new Signal<any, any>(this)
-        } as any;
-        model.switchSharedModel(sharedModel, true);
-        expect(model.needTrustButton).toEqual(true);
-        expect(model.outputs.length).toEqual(1);
-      });
+      it.each([['display_data'], ['update_display_data'], ['execute_result']])(
+        'should request for a trust button on %s output with application data',
+        (output_type: string) => {
+          const model = new CodeCellModel({});
+          expect(model.needTrustButton).toEqual(false);
+          const sharedModel = {
+            getOutputs: jest.fn().mockReturnValue([
+              {
+                output_type,
+                data: { 'application/vnd.jupyter.widget-view+json': null }
+              }
+            ]),
+            getSource: jest.fn().mockReturnValue(''),
+            getMetadata: jest.fn(),
+            changed: new Signal<any, any>(this)
+          } as any;
+          model.switchSharedModel(sharedModel, true);
+          expect(model.needTrustButton).toEqual(true);
+          expect(model.outputs.length).toEqual(1);
+        }
+      );
+      it.each([['display_data'], ['update_display_data'], ['execute_result']])(
+        'should not request for a trust button on %s output without application data',
+        (output_type: string) => {
+          const model = new CodeCellModel({});
+          expect(model.needTrustButton).toEqual(false);
+          const sharedModel = {
+            getOutputs: jest.fn().mockReturnValue([
+              {
+                output_type,
+                data: { 'plain/text': null }
+              }
+            ]),
+            getSource: jest.fn().mockReturnValue(''),
+            getMetadata: jest.fn(),
+            changed: new Signal<any, any>(this)
+          } as any;
+          model.switchSharedModel(sharedModel, true);
+          expect(model.needTrustButton).toEqual(false);
+        }
+      );
     });
 
     describe('.metadata', () => {

--- a/packages/cells/test/model.spec.ts
+++ b/packages/cells/test/model.spec.ts
@@ -1,24 +1,20 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { toArray } from '@lumino/algorithm';
-
-import { IChangedArgs } from '@jupyterlab/coreutils';
-
 import {
   CellModel,
   CodeCellModel,
   MarkdownCellModel,
   RawCellModel
 } from '@jupyterlab/cells';
-
+import { IChangedArgs } from '@jupyterlab/coreutils';
 import * as nbformat from '@jupyterlab/nbformat';
-
 import { OutputAreaModel } from '@jupyterlab/outputarea';
-
-import { NBTestUtils } from '@jupyterlab/testutils';
-import { JSONObject } from '@lumino/coreutils';
 import { YCodeCell } from '@jupyterlab/shared-models';
+import { NBTestUtils } from '@jupyterlab/testutils';
+import { toArray } from '@lumino/algorithm';
+import { JSONObject } from '@lumino/coreutils';
+import { Signal } from '@lumino/signaling';
 
 class TestModel extends CellModel {
   get type(): 'raw' {
@@ -644,6 +640,24 @@ describe('cells/model', () => {
         } as any;
         model['onModelDBOutputsChange'](null as any, newEvent0);
         expect(sharedModel.ymodel.get('outputs').length).toBe(0);
+      });
+    });
+
+    describe('#switchSharedModel', () => {
+      it('should request for a trust button on `display_data` output', () => {
+        const model = new CodeCellModel({});
+        expect(model.needTrustButton).toEqual(false);
+        const sharedModel = {
+          getOutputs: jest
+            .fn()
+            .mockReturnValue([{ output_type: 'display_data' }]),
+          getSource: jest.fn().mockReturnValue(''),
+          getMetadata: jest.fn(),
+          changed: new Signal<any, any>(this)
+        } as any;
+        model.switchSharedModel(sharedModel, true);
+        expect(model.needTrustButton).toEqual(true);
+        expect(model.outputs.length).toEqual(1);
       });
     });
 

--- a/packages/cells/test/widget.spec.ts
+++ b/packages/cells/test/widget.spec.ts
@@ -83,6 +83,11 @@ class LogCodeCell extends CodeCell {
     super.onMetadataChanged(model, args);
     this.methods.push('onMetadataChanged');
   }
+
+  protected onStateChanged(model: any, args: any): void {
+    super.onStateChanged(model, args);
+    this.methods.push('onStateChanged');
+  }
 }
 
 class LogMarkdownCell extends MarkdownCell {
@@ -482,6 +487,14 @@ describe('cells/widget', () => {
         widget.initializeState();
         expect(widget).toBeInstanceOf(CodeCell);
       });
+
+      it('should add a trust button', () => {
+        const contentFactory = NBTestUtils.createCodeCellFactory();
+        model.needTrustButton = true;
+        const widget = new CodeCell({ model, contentFactory, rendermime });
+        widget.initializeState();
+        expect(widget['_outputWrapper'].layout.widgets.length).toEqual(3);
+      });
     });
 
     describe('#outputArea', () => {
@@ -725,6 +738,42 @@ describe('cells/widget', () => {
         expect(widget.methods).not.toContain(method);
         widget.model.metadata.set('foo', 1);
         expect(widget.methods).toContain(method);
+      });
+    });
+
+    describe('#onStateChanged()', () => {
+      it('should fire when model state changes', () => {
+        const method = 'onStateChanged';
+        const widget = new LogCodeCell().initializeState();
+        expect(widget.methods).not.toContain(method);
+        widget.model.trusted = true;
+        expect(widget.methods).toContain(method);
+      });
+
+      it('should remove the trust button on trust status change', () => {
+        const contentFactory = NBTestUtils.createCodeCellFactory();
+        const model = new CodeCellModel({});
+        model.needTrustButton = true;
+        const widget = new CodeCell({ model, contentFactory, rendermime });
+        widget.initializeState();
+        expect(widget['_trustButton']).toBeDefined();
+        widget.model.trusted = true;
+        expect(widget['_trustButton']).toBeUndefined();
+      });
+    });
+
+    describe('#addTrustButton()', () => {
+      it('should add a button to the output widget', () => {
+        const contentFactory = NBTestUtils.createCodeCellFactory();
+        const model = new CodeCellModel({});
+        model.needTrustButton = true;
+        const widget = new CodeCell({ model, contentFactory, rendermime });
+        widget.initializeState();
+        widget.addTrustButton();
+        expect(widget['_trustButton']).toBeDefined();
+        expect(widget['_trustButton'].hasClass('jp-Cell-trustButton')).toBe(
+          true
+        );
       });
     });
 

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -644,7 +644,7 @@ export const notebookTrustItem: JupyterFrontEndPlugin<void> = {
     // Keep the status item up-to-date with the current notebook.
     tracker.currentChanged.connect(() => {
       const current = tracker.currentWidget;
-      item.model.notebook = current && current.content;
+      item.model.notebook = current;
     });
 
     statusBar.registerStatusItem(

--- a/packages/notebook/src/truststatus.tsx
+++ b/packages/notebook/src/truststatus.tsx
@@ -279,7 +279,7 @@ export namespace NotebookTrustStatus {
         }
         const cells = toArray(content.model.cells);
         cells.forEach(cell => (cell.trusted = trust));
-        context.save();
+        context.save().catch(console.error);
         if (!trust) {
           content.model.cells.changed.disconnect(this.trustCell);
         }

--- a/packages/notebook/test/truststatus.spec.ts
+++ b/packages/notebook/test/truststatus.spec.ts
@@ -1,0 +1,80 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+import { CellModel } from '@jupyterlab/cells';
+import { Context } from '@jupyterlab/docregistry';
+import {
+  INotebookModel,
+  NotebookPanel,
+  NotebookTrustStatus
+} from '@jupyterlab/notebook';
+import { initNotebookContext } from '@jupyterlab/testutils';
+import { JupyterServer } from '@jupyterlab/testutils/lib/start_jupyter_server';
+
+import * as utils from './utils';
+
+const server = new JupyterServer();
+beforeAll(async () => {
+  jest.setTimeout(20000);
+  await server.start();
+});
+
+afterAll(async () => {
+  await server.shutdown();
+});
+
+describe('@jupyterlab/notebook', () => {
+  describe('truststatus', () => {
+    describe('NotebookTrustStatus.Model', () => {
+      let model: NotebookTrustStatus.Model;
+      let context: Context<INotebookModel>;
+      let panel: NotebookPanel;
+      beforeEach(async () => {
+        model = new NotebookTrustStatus.Model();
+        context = await initNotebookContext();
+        const content = utils.createNotebook();
+        panel = new NotebookPanel({ context, content });
+      });
+      afterEach(() => {
+        model.dispose();
+        // context.dispose();
+      });
+      describe('#notebook', () => {
+        it('should set the notebook', () => {
+          model.notebook = panel;
+          expect(model.notebook).toBe(panel);
+          expect(model.totalCells).toBe(1);
+          expect(model.trustedCells).toBe(0);
+        });
+      });
+      describe('#trustCell', () => {
+        it('should trust the cells in passed argument', () => {
+          const args = { type: 'add', newValues: [{ trusted: false }] } as any;
+          model.trustCell(undefined as any, args);
+          expect(args.newValues[0].trusted).toBe(true);
+        });
+      });
+      describe('#toggleTrustNotebook', () => {
+        it('should toggle the trust the notebook', () => {
+          model.notebook = panel;
+
+          model.toggleTrustNotebook(true);
+          expect(model.trustedCells).toBe(1);
+
+          model.toggleTrustNotebook(false);
+          expect(model.trustedCells).toBe(0);
+        });
+      });
+      describe('#alwaysTrustNotebook', () => {
+        it('should trust the cells added to notebook', () => {
+          model.notebook = panel;
+          model.alwaysTrustNotebook();
+          const cellModel = new CellModel({});
+
+          expect(cellModel.trusted).toBe(false);
+          panel.content.model!.cells.push(cellModel);
+          expect(cellModel.trusted).toBe(true);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## References

Fixes #11435 

## Code changes

- Add a new signal `displayModelRequested` in `CodeCellModel`, this signal is emitted when  a `display_data` message is processed.
- Attach a trust button to the cell output area when a `display_data` message from other clients is processed.
- Make the trust icon in the status bar clickable, which will open a dialog asking users for the trust status of the current notebook.  

## User-facing changes

- When a widget display command is executed in one client, all other clients will display the "plain/text" version of the output with a button that allows switching to the rich mime types.

https://user-images.githubusercontent.com/4451292/172399783-b8d0be55-b5f0-4e80-a3d0-a60f2ef84a24.mp4


- The trust shield status bar indicator is now a button, users can open a dialog to set the trust status of the notebook:
  - Selecting "No" will untrust all contents of the notebook.
  - Selecting "Yes" will trust all contents of the notebook.
  - Selecting "Always" will trust all current contents and new contents coming from other users.

https://user-images.githubusercontent.com/4451292/156331740-288e3ea5-1a0f-4f2e-b550-b9ff91bf1df7.mp4

## Backwards-incompatible changes

N/A
