### PR TITLE
Feature/optional hidden cells button

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1462,6 +1462,10 @@ export class MarkdownCell extends AttachmentsCell<IMarkdownCellModel> {
       })
     });
 
+    // Store option for heading collapsing behaviour
+    this._showHiddenCellsButton = options.showHiddenCellsButton;
+    console.log('initialized sHCB', this._showHiddenCellsButton)
+
     // Stop codemirror handling paste
     this.editor.setOption('handlePaste', false);
 
@@ -1552,6 +1556,15 @@ export class MarkdownCell extends AttachmentsCell<IMarkdownCellModel> {
 
   get toggleCollapsedSignal(): Signal<this, boolean> {
     return this._toggleCollapsedSignal;
+  }
+
+  /**
+   * Allow updating 
+   */
+  set showHiddenCellsButton(value: boolean) {
+    this._showHiddenCellsButton = value;
+    
+    console.log('updated sHCB', this._showHiddenCellsButton)
   }
 
   /**
@@ -1730,7 +1743,8 @@ export class MarkdownCell extends AttachmentsCell<IMarkdownCellModel> {
       contentFactory: this.contentFactory,
       rendermime: this._rendermime,
       placeholder: false,
-      translator: this.translator
+      translator: this.translator,
+      showHiddenCellsButton: this._showHiddenCellsButton
     });
   }
 
@@ -1743,6 +1757,7 @@ export class MarkdownCell extends AttachmentsCell<IMarkdownCellModel> {
   private _rendered = true;
   private _prevText = '';
   private _ready = new PromiseDelegate<void>();
+  private _showHiddenCellsButton = true;
 }
 
 /**
@@ -1757,6 +1772,11 @@ export namespace MarkdownCell {
      * The mime renderer for the cell widget.
      */
     rendermime: IRenderMimeRegistry;
+
+    /**
+     * Option for showing hidden cells button if heading is collapsed.
+     */
+    showHiddenCellsButton: boolean;
   }
 }
 

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1464,7 +1464,6 @@ export class MarkdownCell extends AttachmentsCell<IMarkdownCellModel> {
 
     // Store option for heading collapsing behaviour
     this._showHiddenCellsButton = options.showHiddenCellsButton;
-    console.log('initialized sHCB', this._showHiddenCellsButton)
 
     // Stop codemirror handling paste
     this.editor.setOption('handlePaste', false);
@@ -1563,8 +1562,6 @@ export class MarkdownCell extends AttachmentsCell<IMarkdownCellModel> {
    */
   set showHiddenCellsButton(value: boolean) {
     this._showHiddenCellsButton = value;
-    
-    console.log('updated sHCB', this._showHiddenCellsButton)
   }
 
   /**
@@ -1613,6 +1610,14 @@ export class MarkdownCell extends AttachmentsCell<IMarkdownCellModel> {
     const expandButton = this.node.getElementsByClassName(
       SHOW_HIDDEN_CELLS_CLASS
     );
+    // Early exit and removal of button if button should not be shown
+    if(!this._showHiddenCellsButton) {
+      // remove the button if it is there
+      for (const el of expandButton) {
+        this.node.removeChild(el);
+      }
+      return;
+    }
     // Create the "show hidden" button if not already created
     if (
       this.headingCollapsed &&

--- a/packages/cells/style/widget.css
+++ b/packages/cells/style/widget.css
@@ -114,11 +114,20 @@
   background-color: var(--jp-border-color2) !important;
 }
 
-.jp-collapseHeadingButton {
+.jp-collapseHeadingButtonHover {
   display: none;
 }
 
-.jp-MarkdownCell:hover .jp-collapseHeadingButton {
+.jp-MarkdownCell:hover .jp-collapseHeadingButtonHover {
+  display: flex;
+  min-height: var(--jp-cell-collapser-min-height);
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+}
+
+.jp-MarkdownCell .jp-collapseHeadingButton {
   display: flex;
   min-height: var(--jp-cell-collapser-min-height);
   position: absolute;

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -857,6 +857,12 @@
       "description": "Disable the undo/redo on the notebook document level, so actions independent cells can have their own history. The undo/redo never applies on the outputs, in other words, outputs don't have history. A moved cell completely looses history capability for now.",
       "type": "boolean",
       "default": false
+    }, 
+    "showHiddenCellsButton": {
+      "type": "boolean",
+      "title": "Show hidden cells button if collapsed",
+      "description": "If set to true, a button is shown below collapsed headings, indicating how many cells are hidden beneath the collapsed heading.",
+      "default": true
     }
   },
   "additionalProperties": false,

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1337,6 +1337,7 @@ function activateNotebookHandler(
 
     factory.editorConfig = { code, markdown, raw };
     factory.notebookConfig = {
+      showHiddenCellsButton: settings.get('showHiddenCellsButton').composite as boolean,
       scrollPastEnd: settings.get('scrollPastEnd').composite as boolean,
       defaultCell: settings.get('defaultCell').composite as nbformat.CellType,
       recordTiming: settings.get('recordTiming').composite as boolean,

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -642,7 +642,8 @@ export class StaticNotebook extends Widget {
       rendermime,
       contentFactory,
       updateEditorOnShow: false,
-      placeholder: false
+      placeholder: false,
+      showHiddenCellsButton: this.notebookConfig.showHiddenCellsButton
     };
     const cell = this.contentFactory.createMarkdownCell(options, this);
     cell.syncCollapse = true;
@@ -784,6 +785,14 @@ export class StaticNotebook extends Widget {
       'jp-mod-scrollPastEnd',
       this._notebookConfig.scrollPastEnd
     );
+
+    // Update showHiddenCellsButton property in markdown cells
+    for (let i = 0; i < this.widgets.length; i++) {
+      const cell = this.widgets[i];
+      if (cell.model.type == 'markdown') {
+        (<MarkdownCell>cell).showHiddenCellsButton = this._notebookConfig.showHiddenCellsButton;
+      }
+    }
   }
 
   private _incrementRenderedCount() {

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -930,6 +930,11 @@ export namespace StaticNotebook {
    */
   export interface INotebookConfig {
     /**
+     * Show hidden cells button if collapsed
+     */
+     showHiddenCellsButton: boolean;
+
+    /**
      * Enable scrolling past the last cell
      */
     scrollPastEnd: boolean;
@@ -985,6 +990,7 @@ export namespace StaticNotebook {
    * Default configuration options for notebooks.
    */
   export const defaultNotebookConfig: INotebookConfig = {
+    showHiddenCellsButton: true,
     scrollPastEnd: true,
     defaultCell: 'code',
     recordTiming: false,

--- a/packages/ui-components/style/deprecated.css
+++ b/packages/ui-components/style/deprecated.css
@@ -21,6 +21,8 @@
   --jp-icon-caret-down: url('icons/arrow/caret-down.svg');
   --jp-icon-caret-left: url('icons/arrow/caret-left.svg');
   --jp-icon-caret-right: url('icons/arrow/caret-right.svg');
+  --jp-icon-caret-right-large-emph: url('icons/arrow/caret-right-large-emph.svg');
+  --jp-icon-caret-down-large: url('icons/arrow/caret-down-large.svg');
   --jp-icon-caret-up-empty-thin: url('icons/arrow/caret-up-empty-thin.svg');
   --jp-icon-caret-up: url('icons/arrow/caret-up.svg');
   --jp-icon-case-sensitive: url('icons/search/case-sensitive.svg');
@@ -121,6 +123,9 @@
 }
 .jp-CaretRightIcon {
   background-image: var(--jp-icon-caret-right);
+}
+.jp-CaretRightLargeEmphIcon {
+  background-image: var(--jp-icon-caret-right-large-emph);
 }
 .jp-CaretUpEmptyThinIcon {
   background-image: var(--jp-icon-caret-up-empty-thin);

--- a/packages/ui-components/style/icons/arrow/caret-down-large.svg
+++ b/packages/ui-components/style/icons/arrow/caret-down-large.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+  <g transform="matrix(0,1,-1,0,20,0)" class="jp-icon3" fill="#414141" shape-rendering="geometricPrecision">
+    <path d="M 5 2 L 15 10 L 5 18 Z"/>
+  </g>
+</svg>

--- a/packages/ui-components/style/icons/arrow/caret-right-large-emph.svg
+++ b/packages/ui-components/style/icons/arrow/caret-right-large-emph.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+  <g class="jp-icon3" fill="#000000" shape-rendering="geometricPrecision">
+    <path d="M 5 2 L 15 10 L 5 18 Z"/>
+  </g>
+  <g class="jp-icon-accent3" fill="#b3aeae" shape-rendering="geometricPrecision">
+    <path d="M 6 4 L 13.5 10 L 6 16 Z"/>
+  </g>
+</svg>


### PR DESCRIPTION
# References
First prototype for issue #11490 

Todo: Test scripts fail (probably I have to update them?) and not yet looked into galata.

## Code changes
* Added option `showHiddenCellsButton` to Notebook Settings and communicated it to `MarkdownCell` widget. Default = true.
* Made behavior of hidden cells button (show or not) and collapse arrow-head buttons (hover or not) dependent on this option .
* Added two somewhat larger arrow head svgs. Not sure about design, though.

## User-facing changes
* With the default `showHiddenCellsButton=true` option, the only noticeable difference are somewhat larger arrow head buttons (left of the headings).
* With `showHiddenCellsButton=false`, the arrow heads are always displayed (not only on hover) and the hidden cells button won't be displayed.

![optional_hidden_cells_button](https://user-images.githubusercontent.com/74381262/142603067-3d4b97cd-65a8-4c25-add6-b9fef826c8ea.gif)


