### PR TITLE
Allow cross-file anchors with leading number

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1677,7 +1677,11 @@ export class Notebook extends StaticNotebook {
     if (this._fragment) {
       let el;
       try {
-        el = this.node.querySelector(this._fragment);
+        el = this.node.querySelector(
+          this._fragment.startsWith('#')
+            ? `#${CSS.escape(this._fragment.slice(1))}`
+            : this._fragment
+        );
       } catch (error) {
         console.warn('Unable to set URI fragment identifier', error);
       }

--- a/packages/rendermime/src/widgets.ts
+++ b/packages/rendermime/src/widgets.ts
@@ -134,7 +134,11 @@ export abstract class RenderedHTMLCommon extends RenderedCommon {
   setFragment(fragment: string): void {
     let el;
     try {
-      el = this.node.querySelector(fragment);
+      el = this.node.querySelector(
+        fragment.startsWith('#')
+          ? `#${CSS.escape(fragment.slice(1))}`
+          : fragment
+      );
     } catch (error) {
       console.warn('Unable to set URI fragment identifier.', error);
     }


### PR DESCRIPTION

## References

Fix #11374. Note that this issue was also present for MD files.

## Code changes

The resolution of anchors between files goes through `document.querySelector(anchor)`. This raises errors when the anchor name starts with a number (`2. Test` in #11374)

A [SO thread](https://stackoverflow.com/questions/20306204/using-queryselector-with-ids-that-are-numbers) describes several strategies to go around this. I implemented something using [CSS.escape](https://developer.mozilla.org/en-US/docs/Web/API/CSS/escape) but this is tagged as experimental technology so I am open to suggestions.

The ternary might be simplified: I was unsure if `fragment` was always an anchor (?)

## User-facing changes

Anchors starting with numbers pointing to another file should work for notebooks and markdown files.

## Backwards-incompatible changes

None that I know of.
