### PR TITLE
RTC: Sync Notebook view information (activeCell, current mode)

### DIFF
--- a/packages/shared-models/src/api.ts
+++ b/packages/shared-models/src/api.ts
@@ -116,6 +116,12 @@ export interface ISharedNotebook extends ISharedDocument {
    * The changed signal.
    */
   readonly changed: ISignal<this, NotebookChange>;
+
+  /**
+   * The ui-changed signal.
+   */
+   readonly uiChanged: ISignal<this, NotebookUIChange>;
+
   /**
    * The minor version number of the nbformat.
    */
@@ -478,6 +484,17 @@ export type NotebookChange = {
     oldValue: any;
     newValue: any;
   }>;
+};
+
+export type NotebookUIChange = {
+  modeChange?: {
+    oldValue: 'command' | 'edit';
+    newValue: 'command' | 'edit';
+  };
+  activeCellIndexChange?: {
+    oldValue: number;
+    newValue: number;
+  };
 };
 
 export type FileChange = {

--- a/packages/shared-models/tsconfig.json
+++ b/packages/shared-models/tsconfig.json
@@ -4,7 +4,9 @@
     "outDir": "lib",
     "rootDir": "src"
   },
-  "include": ["src/*"],
+  "include": [
+    "src/*"
+  ],
   "references": [
     {
       "path": "../nbformat"

--- a/packages/shared-models/tsconfig.test.json
+++ b/packages/shared-models/tsconfig.test.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfigbase.test",
-  "include": ["src/*", "test/*"],
+  "include": [
+    "src/*",
+    "test/*"
+  ],
   "references": [
     {
       "path": "../nbformat"


### PR DESCRIPTION
## References

Fix https://github.com/jupyterlab/jupyterlab/issues/11406

## Code changes

With RTC, we sync the Notebook model (its actual content), but some things related to the view are not synced. This leads to the issue mentioned above.

This PR adds a new event `uiChanged` to the YJS shared model that lets us implement UI related sharing.

## User-facing changes

![markdown](https://user-images.githubusercontent.com/21197331/142888645-47088e53-fee3-43be-9f81-f2571a972278.gif)

## Backwards-incompatible changes

None?