### PR TITLE
Run UI test on 3.2.x push

### DIFF
--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -3,7 +3,7 @@ name: UI Tests
 on:
   push:
     branches:
-      - master
+      - '3.2.x'
   pull_request:
     branches:
       - '*'


### PR DESCRIPTION
UI tests are run on PR against 3.2.x but not on push. This corrects it.