### PR TITLE
Sync dirty property between clients

### DIFF
--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -676,7 +676,6 @@ export class Context<
         if (this.isDisposed) {
           return;
         }
-        const dirty = false;
         if (contents.format === 'json') {
           model.fromJSON(contents.content);
           if (initializeModel) {
@@ -701,7 +700,7 @@ export class Context<
           }
         }
         this._updateContentsModel(contents);
-        model.dirty = dirty;
+        model.dirty = false;
         if (!this._isPopulated) {
           return this._populate();
         }

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -29,6 +29,9 @@ export class DocumentModel
     const filemodel = new models.YFile() as models.ISharedFile;
     this.switchSharedModel(filemodel, true);
     this.value.changed.connect(this.triggerContentChange, this);
+
+    (this.sharedModel as models.YFile).dirty = false;
+    this.sharedModel.changed.connect(this._onStateChanged, this);
   }
 
   /**
@@ -49,15 +52,14 @@ export class DocumentModel
    * The dirty state of the document.
    */
   get dirty(): boolean {
-    return this._dirty;
+    return this.sharedModel.dirty;
   }
   set dirty(newValue: boolean) {
-    if (newValue === this._dirty) {
+    const oldValue = this.sharedModel.dirty;
+    if (newValue === oldValue) {
       return;
     }
-    const oldValue = this._dirty;
-    this._dirty = newValue;
-    this.triggerStateChange({ name: 'dirty', oldValue, newValue });
+    (this.sharedModel as models.YFile).dirty = newValue;
   }
 
   /**
@@ -151,12 +153,22 @@ export class DocumentModel
     this.dirty = true;
   }
 
+  private _onStateChanged(
+    sender: models.ISharedFile,
+    changes: models.NotebookChange
+  ): void {
+    if (changes.stateChange) {
+      changes.stateChange.forEach(value => {
+        this.triggerStateChange(value);
+      });
+    }
+  }
+
   /**
    * The shared notebook model.
    */
   readonly sharedModel: models.ISharedFile;
   private _defaultLang = '';
-  private _dirty = false;
   private _readOnly = false;
   private _contentChanged = new Signal<this, void>(this);
   private _stateChanged = new Signal<this, IChangedArgs<any>>(this);

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -55,8 +55,7 @@ export class DocumentModel
     return this.sharedModel.dirty;
   }
   set dirty(newValue: boolean) {
-    const oldValue = this.sharedModel.dirty;
-    if (newValue === oldValue) {
+    if (newValue === this.dirty) {
       return;
     }
     (this.sharedModel as models.YFile).dirty = newValue;
@@ -159,7 +158,9 @@ export class DocumentModel
   ): void {
     if (changes.stateChange) {
       changes.stateChange.forEach(value => {
-        this.triggerStateChange(value);
+        if (value.name !== 'dirty' || value.oldValue !== value.newValue) {
+          this.triggerStateChange(value);
+        }
       });
     }
   }
@@ -569,7 +570,10 @@ export class DocumentWidget<
    * Handle the dirty state of the context model.
    */
   private _handleDirtyState(): void {
-    if (this.context.model.dirty) {
+    if (
+      this.context.model.dirty &&
+      !this.title.className.includes(DIRTY_CLASS)
+    ) {
       this.title.className += ` ${DIRTY_CLASS}`;
     } else {
       this.title.className = this.title.className.replace(DIRTY_CLASS, '');

--- a/packages/docregistry/test/default.spec.ts
+++ b/packages/docregistry/test/default.spec.ts
@@ -581,6 +581,14 @@ describe('docregistry/default', () => {
         expect(widget.title.className).toContain('jp-mod-dirty');
       });
 
+      it('should remove the dirty class', () => {
+        context.model.dirty = true;
+        context.model.dirty = true;
+        expect(widget.title.className).toContain('jp-mod-dirty');
+        context.model.dirty = false;
+        expect(widget.title.className).not.toContain('jp-mod-dirty');
+      });
+
       it('should store the context', () => {
         expect(widget.context).toBe(context);
       });

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -138,8 +138,7 @@ export class NotebookModel implements INotebookModel {
     return this.sharedModel.dirty;
   }
   set dirty(newValue: boolean) {
-    const oldValue = this.sharedModel.dirty;
-    if (newValue === oldValue) {
+    if (newValue === this.dirty) {
       return;
     }
     (this.sharedModel as models.YNotebook).dirty = newValue;
@@ -428,7 +427,9 @@ close the notebook without saving it.`,
         if (value.name === 'nbformatMinor') {
           this._nbformatMinor = value.newValue;
         }
-        this.triggerStateChange(value);
+        if (value.name !== 'dirty' || value.oldValue !== value.newValue) {
+          this.triggerStateChange(value);
+        }
       });
     }
 

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -114,6 +114,7 @@ export class NotebookModel implements INotebookModel {
     metadata.changed.connect(this._onMetadataChanged, this);
     this._deletedCells = [];
 
+    (this.sharedModel as models.YNotebook).dirty = false;
     this.sharedModel.changed.connect(this._onStateChanged, this);
   }
   /**
@@ -134,15 +135,14 @@ export class NotebookModel implements INotebookModel {
    * The dirty state of the document.
    */
   get dirty(): boolean {
-    return this._dirty;
+    return this.sharedModel.dirty;
   }
   set dirty(newValue: boolean) {
-    if (newValue === this._dirty) {
+    const oldValue = this.sharedModel.dirty;
+    if (newValue === oldValue) {
       return;
     }
-    const oldValue = this._dirty;
-    this._dirty = newValue;
-    this.triggerStateChange({ name: 'dirty', oldValue, newValue });
+    (this.sharedModel as models.YNotebook).dirty = newValue;
   }
 
   /**
@@ -428,9 +428,6 @@ close the notebook without saving it.`,
         if (value.name === 'nbformatMinor') {
           this._nbformatMinor = value.newValue;
         }
-        if (value.name === 'dirty') {
-          this._dirty = value.newValue;
-        }
         this.triggerStateChange(value);
       });
     }
@@ -513,7 +510,6 @@ close the notebook without saving it.`,
    */
   readonly modelDB: IModelDB;
 
-  private _dirty = false;
   private _readOnly = false;
   private _contentChanged = new Signal<this, void>(this);
   private _stateChanged = new Signal<this, IChangedArgs<any>>(this);

--- a/packages/shared-models/src/api.ts
+++ b/packages/shared-models/src/api.ts
@@ -59,6 +59,11 @@ export interface ISharedBase extends IDisposable {
  */
 export interface ISharedDocument extends ISharedBase {
   /**
+   * Whether the document is saved to disk or not.
+   */
+  readonly dirty: boolean;
+
+  /**
    * The changed signal.
    */
   readonly changed: ISignal<this, DocumentChange>;

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -456,11 +456,13 @@ export class YNotebook
     const stateChange: any = [];
     event.keysChanged.forEach(key => {
       const change = event.changes.keys.get(key);
-      stateChange.push({
-        name: key,
-        oldValue: change?.oldValue ? change!.oldValue : 0,
-        newValue: this.ystate.get(key)
-      });
+      if (change) {
+        stateChange.push({
+          name: key,
+          oldValue: change.oldValue,
+          newValue: this.ystate.get(key)
+        });
+      }
     });
 
     this._changed.emit({ stateChange });

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -26,6 +26,16 @@ export interface IYText extends models.ISharedText {
 export type YCellType = YRawCell | YCodeCell | YMarkdownCell;
 
 export class YDocument<T> implements models.ISharedDocument {
+  get dirty(): boolean {
+    return this.ystate.get('dirty');
+  }
+
+  set dirty(value: boolean) {
+    this.transact(() => {
+      this.ystate.set('dirty', value);
+    }, false);
+  }
+
   /**
    * Perform a transaction. While the function f is called, all changes to the shared
    * document are bundled into a single event.
@@ -128,11 +138,13 @@ export class YFile
 
     event.keysChanged.forEach(key => {
       const change = event.changes.keys.get(key);
-      stateChange.push({
-        name: key,
-        oldValue: change?.oldValue ? change!.oldValue : 0,
-        newValue: this.ystate.get(key)
-      });
+      if (change) {
+        stateChange.push({
+          name: key,
+          oldValue: change.oldValue,
+          newValue: this.ystate.get(key)
+        });
+      }
     });
 
     this._changed.emit({ stateChange });


### PR DESCRIPTION
Solves a minor bug with the dirty property when saving the document.

## References
I think we never opened an issue, and I can not find the issue/PR where this bug was detected, but @jasongrout detected a bug in the dirty property while working on something else.

## Code changes
Sync the dirty property using the SharedDocument and improve the initialization.

## User-facing changes
Now when someone saves the document, this change is notified to every client.

## Backwards-incompatible changes
Not sure. Added a new property in SharedDocument and removed a private one from DocumentWidget.

[@fcollonval] This is ok as you added something to the public API (no changes, nor deletion)