### PR TITLE
Cell YModel: Fix setAttachment method

### DIFF
--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -731,9 +731,9 @@ export class YBaseCell<Metadata extends models.ISharedBaseCellMetadata>
   public setAttachments(attachments: nbformat.IAttachments | undefined): void {
     this.transact(() => {
       if (attachments == null) {
-        this.ymodel.set('attachments', attachments);
-      } else {
         this.ymodel.delete('attachments');
+      } else {
+        this.ymodel.set('attachments', attachments);
       }
     });
   }


### PR DESCRIPTION
## References

None

This looks like an issue. Though, as far as I can tell, this method isn't used anywhere (yet?).

## Code changes

Remove the `attachment` value from the cell `ymodel` if it's null, instead of adding it.

## User-facing changes

None

## Backwards-incompatible changes

None