### PR TITLE
Add side-by-side rendering as global setting

### DIFF
--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -850,6 +850,12 @@
       "description": "Disable the undo/redo on the notebook document level, so actions independent cells can have their own history. The undo/redo never applies on the outputs, in other words, outputs don't have history. A moved cell completely looses history capability for now.",
       "type": "boolean",
       "default": false
+    },
+    "sideBySideRendering": {
+      "title": "Side-by-side rendering",
+      "description": "Global setting to enable side-by-side rendering in notebooks",
+      "type": "boolean",
+      "default": false
     }
   },
   "additionalProperties": false,

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1358,6 +1358,10 @@ function activateNotebookHandler(
       'experimentalDisableDocumentWideUndoRedo'
     ).composite as boolean;
 
+    Private.renderSideBySide = !settings.get('sideBySideRendering')
+      .composite as boolean;
+    commands.execute(CommandIDs.toggleRenderSideBySide);
+
     updateTracker({
       editorConfig: factory.editorConfig,
       notebookConfig: factory.notebookConfig,
@@ -2319,9 +2323,8 @@ function addCommands(
         if (wideget) {
           if (Private.renderSideBySide) {
             return NotebookActions.renderSideBySide(wideget.content);
-          } else {
-            return NotebookActions.renderNotSideBySide(wideget.content);
           }
+          return NotebookActions.renderNotSideBySide(wideget.content);
         }
       });
       tracker.currentChanged.connect(() => {

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -2319,12 +2319,12 @@ function addCommands(
     label: trans.__('Render Side-by-side'),
     execute: args => {
       Private.renderSideBySide = !Private.renderSideBySide;
-      tracker.forEach(wideget => {
-        if (wideget) {
+      tracker.forEach(widget => {
+        if (widget) {
           if (Private.renderSideBySide) {
-            return NotebookActions.renderSideBySide(wideget.content);
+            return NotebookActions.renderSideBySide(widget.content);
           }
-          return NotebookActions.renderNotSideBySide(wideget.content);
+          return NotebookActions.renderNotSideBySide(widget.content);
         }
       });
       tracker.currentChanged.connect(() => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
https://github.com/jupyterlab/jupyterlab/issues/11376
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
- Added `sideBySideRendering` to notebook setting schema
- Made `renderSideBySide` in `notebook-extension` listen to `sideBySideRendering` to notebook setting

## User-facing changes
- Enabled setting side-by-side rendering as default 
<!-- Describe any visual or user interaction changes and how they address the issue. -->
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
I am not aware of any. 
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
