### PR TITLE
RTC shared model: Rename createCellFromType into createCellFromModel

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -38,7 +38,7 @@ bumped their major version (following semver convention):
 - ``@jupyterlab/notebook`` from 3.x to 4.x
    The ``NotebookPanel._onSave`` method is now ``private``.
 - ``@jupyterlab/shared-models`` from 3.x to 4.x
-  The ``createCellFromType`` functoin is now named ``createCellModelFromSharedType``
+  The ``createCellFromType`` function has been renamed to ``createCellModelFromSharedType``
 
 JupyterLab 3.0 to 3.1
 ---------------------

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -37,6 +37,8 @@ bumped their major version (following semver convention):
    The ``CodeEditor.ICoordinate`` interface now extends ``DOMRectReadOnly`` instead of ``JSONObject, ClientRect``.
 - ``@jupyterlab/notebook`` from 3.x to 4.x
    The ``NotebookPanel._onSave`` method is now ``private``.
+- ``@jupyterlab/shared-models`` from 3.x to 4.x
+  The ``createCellFromType`` functoin is now named ``createCellModelFromSharedType``
 
 JupyterLab 3.0 to 3.1
 ---------------------

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -217,7 +217,7 @@ export class YNotebook
     this.ycells.observe(this._onYCellsChanged);
     this.cells = this.ycells.toArray().map(ycell => {
       if (!this._ycellMapping.has(ycell)) {
-        this._ycellMapping.set(ycell, createCellFromType(ycell));
+        this._ycellMapping.set(ycell, createCellModelFromSharedType(ycell));
       }
       return this._ycellMapping.get(ycell) as YCellType;
     });
@@ -392,7 +392,7 @@ export class YNotebook
     event.changes.added.forEach(item => {
       const type = (item.content as Y.ContentType).type as Y.Map<any>;
       if (!this._ycellMapping.has(type)) {
-        this._ycellMapping.set(type, createCellFromType(type));
+        this._ycellMapping.set(type, createCellModelFromSharedType(type));
       }
       const cell = this._ycellMapping.get(type) as any;
       cell._notebook = this;
@@ -480,9 +480,9 @@ export class YNotebook
 }
 
 /**
- * Create a new shared cell given the type.
+ * Create a new shared cell model given the YJS shared type.
  */
-export const createCellFromType = (type: Y.Map<any>): YCellType => {
+export const createCellModelFromSharedType = (type: Y.Map<any>): YCellType => {
   switch (type.get('cell_type')) {
     case 'code':
       return new YCodeCell(type);


### PR DESCRIPTION
## References

None

## Code changes

Rename `createCellFromType` function into `createCellFromModel`. This function creates a new YBaseCell given the ymodel, so this new name makes more sense

## User-facing changes

None

## Backwards-incompatible changes

It's an exported function, so this could be backward incompatible