### PR TITLE
Increase notebook-cell margin in side-by-side mode

### DIFF
--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -304,7 +304,10 @@
 }
 
 .jp-mod-sideBySide.jp-Notebook .jp-Notebook-cell {
-  margin: 2%;
+  margin-top: 3em;
+  margin-bottom: 3em;
+  margin-left: 5%;
+  margin-right: 5%;
 }
 
 .jp-mod-sideBySide.jp-Notebook .jp-CodeCell {

--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -303,6 +303,10 @@
   --jp-side-by-side-resized-cell: var(--jp-side-by-side-output-size);
 }
 
+.jp-mod-sideBySide.jp-Notebook .jp-Notebook-cell {
+  margin: 3em;
+}
+
 .jp-mod-sideBySide.jp-Notebook .jp-CodeCell {
   display: grid;
   grid-template-columns: minmax(0, 1fr) min-content minmax(

--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -304,7 +304,7 @@
 }
 
 .jp-mod-sideBySide.jp-Notebook .jp-Notebook-cell {
-  margin: 3em;
+  margin: 2%;
 }
 
 .jp-mod-sideBySide.jp-Notebook .jp-CodeCell {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes https://github.com/jupyterlab/jupyterlab/issues/11376
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
When in side-by-side mode, increase top/bottom margins to `3em` & left/right margins to `5%`


## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->
Before:


https://user-images.githubusercontent.com/22648112/143334708-b1787149-063e-4e10-a603-331b88a71512.mov

After: 

https://user-images.githubusercontent.com/22648112/143334661-2a8c01b1-ce5d-4b5a-b336-61ab16df382b.mov



## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
