### PR TITLE
RTC: Sync markdown cell  "rendered" state

### DIFF
--- a/packages/shared-models/src/api.ts
+++ b/packages/shared-models/src/api.ts
@@ -116,6 +116,7 @@ export interface ISharedNotebook extends ISharedDocument {
    * The changed signal.
    */
   readonly changed: ISignal<this, NotebookChange>;
+
   /**
    * The minor version number of the nbformat.
    */
@@ -504,6 +505,11 @@ export type CellChange<MetadataType> = {
     oldValue: Partial<MetadataType> | undefined;
     newValue: Partial<MetadataType> | undefined;
   };
+  stateChange?: Array<{
+    name: string;
+    oldValue: any;
+    newValue: any;
+  }>;
 };
 
 export type DocumentChange = {


### PR DESCRIPTION
## References

Fix #11406, follow up of https://github.com/jupyterlab/jupyterlab/pull/11518

## Code changes

We now sync more cell state between collaborators

## User-facing changes

https://user-images.githubusercontent.com/21197331/143414840-f3fee846-149f-4122-ab2a-e9a73b6eae6a.mp4

## Backwards-incompatible changes

None