### PR TITLE
Explicitly build JupyterLab in dev-mode

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -93,6 +93,8 @@ jobs:
       - name: Install dependencies
         run: |
           bash ./scripts/ci_install.sh
+          # Build dev-mode
+          jlpm run build
 
       - name: Launch JupyterLab
         shell: bash
@@ -138,7 +140,7 @@ jobs:
           # Reset installation
           jlpm run clean:slate
           jlpm run build
-          
+
           # Reset the reference after clean:slate as it removes non-versioned files
           cp /tmp/lab-benchmark-expected.json galata/
 

--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -47,6 +47,8 @@ jobs:
       - name: Install dependencies
         run: |
           bash ./scripts/ci_install.sh
+          # Build dev-mode
+          jlpm run build
 
       - name: Launch JupyterLab
         run: |


### PR DESCRIPTION
Otherwise it was hidden in the waiting time for JupyterLab to be available

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Follow-up #11575
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Explicitly call `jlpm run build` on UI tests so the dev version is not built indirectly when waiting for JupyterLab server to be available.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->
N/A

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A