### PR TITLE
Remove `@types/webpack-env` from `ui-components`

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -66,7 +66,6 @@
     "@storybook/react": "6.0.20",
     "@types/jest": "^26.0.10",
     "@types/react": "^17.0.0",
-    "@types/webpack-env": "^1.14.1",
     "babel-loader": "^8.0.6",
     "jest": "^26.4.2",
     "rimraf": "~3.0.0",

--- a/packages/ui-components/tsconfig.json
+++ b/packages/ui-components/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "lib",
     "rootDir": "src",
-    "types": ["webpack-env", "node"]
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "references": [


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/11567

Opening this PR to check whether `webpack-env` is still needed in the `ui-components` package.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Dependencies

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
