### PR TITLE
Update to TypeScript 4.5

### DIFF
--- a/builder/package.json
+++ b/builder/package.json
@@ -75,7 +75,7 @@
     "@types/node": "^14.6.1",
     "@types/supports-color": "^5.3.0",
     "rimraf": "~3.0.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/buildutils/package.json
+++ b/buildutils/package.json
@@ -56,7 +56,7 @@
     "process": "^0.11.10",
     "semver": "^7.3.2",
     "sort-package-json": "~1.44.0",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.2",
     "verdaccio": "^5.2.2"
   },
   "devDependencies": {

--- a/buildutils/template/package.json
+++ b/buildutils/template/package.json
@@ -42,7 +42,7 @@
     "jest": "^26.4.2",
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -32,6 +32,9 @@ bumped their major version (following semver convention):
    See https://github.com/jupyterlab/jupyterlab/pull/11537 for more details.
 - ``@jupyterlab/toc:plugin`` renamed ``@jupyterlab/toc-extension:registry``
    This may impact application configuration (for instance if the plugin was disabled).
+- As a result of the update to TypeScript 4.5, a couple of interfaces have had their definitions changed.
+   The ``anchor`` parameter of ``HoverBox.IOptions` is now a ``DOMRect` instead of ``ClientRect``.
+   The ``CodeEditor.ICoordinate`` interface now extends ``DOMRectReadOnly`` instead of ``JSONObject, ClientRect``.
 
 JupyterLab 3.0 to 3.1
 ---------------------

--- a/examples/cell/package.json
+++ b/examples/cell/package.json
@@ -29,7 +29,7 @@
     "rimraf": "~3.0.0",
     "style-loader": "~2.0.0",
     "svg-url-loader": "~6.0.0",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.2",
     "url-loader": "~4.1.0",
     "watch": "~1.0.2",
     "webpack": "^5.55.1",

--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -27,7 +27,7 @@
     "raw-loader": "~4.0.0",
     "rimraf": "~3.0.0",
     "style-loader": "~2.0.0",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.2",
     "url-loader": "~4.1.0",
     "watch": "~1.0.2",
     "webpack": "^5.55.1",

--- a/examples/filebrowser/package.json
+++ b/examples/filebrowser/package.json
@@ -33,7 +33,7 @@
     "rimraf": "~3.0.0",
     "style-loader": "~2.0.0",
     "svg-url-loader": "~6.0.0",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.2",
     "url-loader": "~4.1.0",
     "watch": "~1.0.2",
     "webpack": "^5.55.1",

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -33,7 +33,7 @@
     "rimraf": "~3.0.0",
     "style-loader": "~2.0.0",
     "svg-url-loader": "~6.0.0",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.2",
     "url-loader": "~4.1.0",
     "watch": "~1.0.2",
     "webpack": "^5.55.1",

--- a/examples/terminal/package.json
+++ b/examples/terminal/package.json
@@ -23,7 +23,7 @@
     "rimraf": "~3.0.0",
     "style-loader": "~2.0.0",
     "svg-url-loader": "~6.0.0",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.2",
     "url-loader": "~4.1.0",
     "watch": "~1.0.2",
     "webpack": "^5.55.1",

--- a/galata/package.json
+++ b/galata/package.json
@@ -77,7 +77,7 @@
     "svg-url-loader": "~6.0.0",
     "svgo-loader": "^2.2.1",
     "ts-loader": "^6.2.1",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.2",
     "url-loader": "~4.1.0",
     "webpack": "^5.55.1",
     "webpack-cli": "^4.8.0"

--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -69,7 +69,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/apputils-extension/package.json
+++ b/packages/apputils-extension/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -73,7 +73,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/apputils/src/hoverbox.ts
+++ b/packages/apputils/src/hoverbox.ts
@@ -27,7 +27,7 @@ export namespace HoverBox {
      * coordinate position, which can be retrieved via calling the
      * `getCoordinateForPosition` method.
      */
-    anchor: ClientRect;
+    anchor: DOMRect;
 
     /**
      * The node that hosts the anchor.

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -75,7 +75,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/celltags-extension/package.json
+++ b/packages/celltags-extension/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/celltags/package.json
+++ b/packages/celltags/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -61,7 +61,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -61,7 +61,27 @@ export namespace CodeEditor {
   /**
    * An interface describing editor state coordinates.
    */
-  export interface ICoordinate extends JSONObject {}
+  export interface ICoordinate {
+    /**
+     * The left coordinate.
+     */
+    readonly left: number;
+
+    /**
+     * The right coordinate.
+     */
+    readonly right: number;
+
+    /**
+     * The top coordinate.
+     */
+    readonly top: number;
+
+    /**
+     * The bottom coordinate.
+     */
+    readonly bottom: number;
+  }
 
   /**
    * A range.

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -61,27 +61,7 @@ export namespace CodeEditor {
   /**
    * An interface describing editor state coordinates.
    */
-  export interface ICoordinate {
-    /**
-     * The left coordinate.
-     */
-    readonly left: number;
-
-    /**
-     * The right coordinate.
-     */
-    readonly right: number;
-
-    /**
-     * The top coordinate.
-     */
-    readonly top: number;
-
-    /**
-     * The bottom coordinate.
-     */
-    readonly bottom: number;
-  }
+  export interface ICoordinate extends DOMRectReadOnly {}
 
   /**
    * A range.

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -61,7 +61,7 @@ export namespace CodeEditor {
   /**
    * An interface describing editor state coordinates.
    */
-  export interface ICoordinate extends JSONObject, ClientRect {}
+  export interface ICoordinate extends JSONObject {}
 
   /**
    * A range.

--- a/packages/codeeditor/src/widget.ts
+++ b/packages/codeeditor/src/widget.ts
@@ -263,7 +263,7 @@ export class CodeEditorWrapper extends Widget {
       y: event.y,
       width: 0,
       height: 0
-    };
+    } as CodeEditor.ICoordinate;
     const position = this.editor.getPositionForCoordinate(coordinate);
     if (position === null) {
       return;

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -67,7 +67,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/completer-extension/package.json
+++ b/packages/completer-extension/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -62,7 +62,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -581,7 +581,7 @@ export class Completer extends Widget {
 
     const start = model.cursor.start;
     const position = editor.getPositionAt(start) as CodeEditor.IPosition;
-    const anchor = editor.getCoordinateForPosition(position) as ClientRect;
+    const anchor = editor.getCoordinateForPosition(position) as DOMRect;
     const style = window.getComputedStyle(node);
     const borderLeft = parseInt(style.borderLeftWidth!, 10) || 0;
     const paddingLeft = parseInt(style.paddingLeft!, 10) || 0;

--- a/packages/completer/test/model.spec.ts
+++ b/packages/completer/test/model.spec.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { CodeEditor } from '@jupyterlab/codeeditor';
 import {
   Completer,
   CompleterModel,
@@ -16,7 +15,7 @@ function makeState(text: string): Completer.ITextState {
     lineHeight: 0,
     charWidth: 0,
     line: 0,
-    coords: { left: 0, right: 0, top: 0, bottom: 0 } as CodeEditor.ICoordinate,
+    coords: { left: 0, right: 0, top: 0, bottom: 0 },
     text
   };
 }

--- a/packages/completer/test/widget.spec.ts
+++ b/packages/completer/test/widget.spec.ts
@@ -1547,7 +1547,7 @@ describe('completer/widget', () => {
           lineHeight: 0,
           charWidth: 0,
           line: 0,
-          coords: coords as CodeEditor.ICoordinate,
+          coords,
           text: 'f'
         };
 
@@ -1592,7 +1592,7 @@ describe('completer/widget', () => {
           lineHeight: 0,
           charWidth: 0,
           line: 0,
-          coords: coords as CodeEditor.ICoordinate,
+          coords,
           text: 'f'
         };
 
@@ -1624,7 +1624,7 @@ describe('completer/widget', () => {
           lineHeight: 0,
           charWidth: 0,
           line: 0,
-          coords: coords as CodeEditor.ICoordinate,
+          coords,
           text: 'f'
         };
 

--- a/packages/console-extension/package.json
+++ b/packages/console-extension/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -67,7 +67,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -56,7 +56,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/csvviewer-extension/package.json
+++ b/packages/csvviewer-extension/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/csvviewer/package.json
+++ b/packages/csvviewer/package.json
@@ -62,7 +62,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/debugger-extension/package.json
+++ b/packages/debugger-extension/package.json
@@ -69,7 +69,7 @@
     "shell-quote": "^1.7.2",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -93,7 +93,7 @@
     "text-encoding": "^0.7.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/docmanager/package.json
+++ b/packages/docmanager/package.json
@@ -65,7 +65,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/docprovider-extension/package.json
+++ b/packages/docprovider-extension/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/docprovider/package.json
+++ b/packages/docprovider/package.json
@@ -50,7 +50,7 @@
     "jest": "^26.4.2",
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -68,7 +68,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/documentsearch-extension/package.json
+++ b/packages/documentsearch-extension/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/documentsearch/package.json
+++ b/packages/documentsearch/package.json
@@ -60,7 +60,7 @@
     "jest": "^26.4.2",
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/documentsearch/src/providers/genericsearchprovider.ts
+++ b/packages/documentsearch/src/providers/genericsearchprovider.ts
@@ -114,8 +114,7 @@ export class GenericSearchProvider implements ISearchProvider<Widget> {
             ? NodeFilter.FILTER_ACCEPT
             : NodeFilter.FILTER_REJECT;
         }
-      },
-      false
+      }
     );
     const nodes: (Node | null)[] = [];
     const originalNodes: Node[] = [];

--- a/packages/extensionmanager-extension/package.json
+++ b/packages/extensionmanager-extension/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/extensionmanager/package.json
+++ b/packages/extensionmanager/package.json
@@ -55,7 +55,7 @@
     "@types/semver": "^7.3.3",
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/filebrowser-extension/package.json
+++ b/packages/filebrowser-extension/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -69,7 +69,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1129,7 +1129,7 @@ export class DirListing extends Widget {
     }
     for (let i = 0; i < length; i++) {
       let entry = event.dataTransfer?.items[i].webkitGetAsEntry();
-      if (entry.isDirectory) {
+      if (entry?.isDirectory) {
         console.log('currently not supporting drag + drop for folders');
         void showDialog({
           title: this._trans.__('Error Uploading Folder'),

--- a/packages/fileeditor-extension/package.json
+++ b/packages/fileeditor-extension/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/fileeditor/package.json
+++ b/packages/fileeditor/package.json
@@ -59,7 +59,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/help-extension/package.json
+++ b/packages/help-extension/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/htmlviewer-extension/package.json
+++ b/packages/htmlviewer-extension/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/htmlviewer/package.json
+++ b/packages/htmlviewer/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/hub-extension/package.json
+++ b/packages/hub-extension/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/imageviewer-extension/package.json
+++ b/packages/imageviewer-extension/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/imageviewer/package.json
+++ b/packages/imageviewer/package.json
@@ -55,7 +55,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/inspector-extension/package.json
+++ b/packages/inspector-extension/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -123,7 +123,7 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
     }
 
     // Create a proxy to pass the `source` to the current inspector.
-    const proxy: IInspector = Object.defineProperty({}, 'source', {
+    const proxy = Object.defineProperty({} as IInspector, 'source', {
       get: (): IInspector.IInspectable | null =>
         !inspector || inspector.isDisposed ? null : inspector.content.source,
       set: (src: IInspector.IInspectable | null) => {

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -61,7 +61,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/javascript-extension/package.json
+++ b/packages/javascript-extension/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/json-extension/package.json
+++ b/packages/json-extension/package.json
@@ -51,7 +51,7 @@
     "@types/react-json-tree": "^0.6.11",
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/launcher-extension/package.json
+++ b/packages/launcher-extension/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -51,7 +51,7 @@
     "@types/react": "^17.0.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/logconsole-extension/package.json
+++ b/packages/logconsole-extension/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/logconsole/package.json
+++ b/packages/logconsole/package.json
@@ -55,7 +55,7 @@
     "jest": "^26.4.2",
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mainmenu-extension/package.json
+++ b/packages/mainmenu-extension/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mainmenu/package.json
+++ b/packages/mainmenu/package.json
@@ -56,7 +56,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/markdownviewer-extension/package.json
+++ b/packages/markdownviewer-extension/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/markdownviewer/package.json
+++ b/packages/markdownviewer/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mathjax2-extension/package.json
+++ b/packages/mathjax2-extension/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mathjax2/package.json
+++ b/packages/mathjax2/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -126,7 +126,7 @@
     "fs-extra": "^9.0.1",
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/nbformat/package.json
+++ b/packages/nbformat/package.json
@@ -45,7 +45,7 @@
     "jest": "^26.4.2",
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -73,7 +73,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/observables/package.json
+++ b/packages/observables/package.json
@@ -49,7 +49,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/outputarea/package.json
+++ b/packages/outputarea/package.json
@@ -63,7 +63,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/outputarea/package.json
+++ b/packages/outputarea/package.json
@@ -54,7 +54,7 @@
     "@lumino/properties": "^1.8.1",
     "@lumino/signaling": "^1.10.1",
     "@lumino/widgets": "^1.30.0",
-    "resize-observer-polyfill": "^1.5.1"
+    "resize-observer": "^1.0.4"
   },
   "devDependencies": {
     "@jupyterlab/testutils": "^4.0.0-alpha.1",

--- a/packages/outputarea/package.json
+++ b/packages/outputarea/package.json
@@ -53,8 +53,7 @@
     "@lumino/messaging": "^1.10.1",
     "@lumino/properties": "^1.8.1",
     "@lumino/signaling": "^1.10.1",
-    "@lumino/widgets": "^1.30.0",
-    "resize-observer": "^1.0.4"
+    "@lumino/widgets": "^1.30.0"
   },
   "devDependencies": {
     "@jupyterlab/testutils": "^4.0.0-alpha.1",

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -17,7 +17,7 @@ import { Message } from '@lumino/messaging';
 import { AttachedProperty } from '@lumino/properties';
 import { Signal } from '@lumino/signaling';
 import { Panel, PanelLayout, Widget } from '@lumino/widgets';
-import ResizeObserver from 'resize-observer-polyfill';
+import { ResizeObserver } from 'resize-observer';
 import { IOutputAreaModel } from './model';
 
 /**

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -17,7 +17,6 @@ import { Message } from '@lumino/messaging';
 import { AttachedProperty } from '@lumino/properties';
 import { Signal } from '@lumino/signaling';
 import { Panel, PanelLayout, Widget } from '@lumino/widgets';
-import { ResizeObserver } from 'resize-observer';
 import { IOutputAreaModel } from './model';
 
 /**

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -412,7 +412,6 @@ export class OutputArea extends Widget {
       model.trusted ? 'any' : 'ensure'
     );
     if (
-      renderer.renderModel &&
       Private.currentPreferredMimetype.get(renderer) === mimeType &&
       OutputArea.isIsolated(mimeType, model.metadata) ===
         renderer instanceof Private.IsolatedRenderer

--- a/packages/pdf-extension/package.json
+++ b/packages/pdf-extension/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/property-inspector/package.json
+++ b/packages/property-inspector/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/rendermime-extension/package.json
+++ b/packages/rendermime-extension/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/rendermime-interfaces/package.json
+++ b/packages/rendermime-interfaces/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -68,7 +68,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/running-extension/package.json
+++ b/packages/running-extension/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/running/package.json
+++ b/packages/running/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/services/examples/browser/package.json
+++ b/packages/services/examples/browser/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.2",
     "webpack": "^5.55.1",
     "webpack-cli": "^4.8.0"
   }

--- a/packages/services/examples/typescript-browser-with-output/package.json
+++ b/packages/services/examples/typescript-browser-with-output/package.json
@@ -25,7 +25,7 @@
     "css-loader": "^5.0.1",
     "rimraf": "~3.0.0",
     "style-loader": "~2.0.0",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.2",
     "webpack": "^5.55.1",
     "webpack-cli": "^4.8.0"
   },

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -69,7 +69,7 @@
     "text-encoding": "^0.7.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.2",
     "webpack": "^5.55.1",
     "webpack-cli": "^4.8.0"
   },

--- a/packages/settingeditor-extension/package.json
+++ b/packages/settingeditor-extension/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/settingeditor/package.json
+++ b/packages/settingeditor/package.json
@@ -57,7 +57,7 @@
     "@types/react-dom": "^17.0.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/settingregistry/package.json
+++ b/packages/settingregistry/package.json
@@ -50,7 +50,7 @@
     "jest": "^26.4.2",
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/shared-models/package.json
+++ b/packages/shared-models/package.json
@@ -50,7 +50,7 @@
     "jest": "^26.4.2",
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/shortcuts-extension/package.json
+++ b/packages/shortcuts-extension/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/statedb/package.json
+++ b/packages/statedb/package.json
@@ -48,7 +48,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/statusbar-extension/package.json
+++ b/packages/statusbar-extension/package.json
@@ -55,7 +55,7 @@
     "@types/react-dom": "^17.0.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/statusbar/package.json
+++ b/packages/statusbar/package.json
@@ -57,7 +57,7 @@
     "jest": "^26.4.2",
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/terminal-extension/package.json
+++ b/packages/terminal-extension/package.json
@@ -54,7 +54,7 @@
     "@types/webpack-env": "^1.14.1",
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -59,7 +59,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/theme-dark-extension/package.json
+++ b/packages/theme-dark-extension/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/theme-light-extension/package.json
+++ b/packages/theme-light-extension/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/toc-extension/package.json
+++ b/packages/toc-extension/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/toc/package.json
+++ b/packages/toc/package.json
@@ -71,7 +71,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tooltip-extension/package.json
+++ b/packages/tooltip-extension/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tooltip/src/widget.ts
+++ b/packages/tooltip/src/widget.ts
@@ -219,7 +219,7 @@ export class Tooltip extends Widget {
 
     const editor = this._editor;
 
-    const anchor = editor.getCoordinateForPosition(position) as ClientRect;
+    const anchor = editor.getCoordinateForPosition(position);
     const style = window.getComputedStyle(this.node);
     const paddingLeft = parseInt(style.paddingLeft!, 10) || 0;
 

--- a/packages/translation-extension/package.json
+++ b/packages/translation-extension/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/translation/package.json
+++ b/packages/translation/package.json
@@ -49,7 +49,7 @@
     "@types/jest": "^26.0.10",
     "jest": "^26.4.2",
     "rimraf": "~3.0.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-components-extension/package.json
+++ b/packages/ui-components-extension/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -72,7 +72,7 @@
     "svgo": "^1.3.2",
     "ts-jest": "^26.3.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "peerDependencies": {
     "react": "^17.0.1"

--- a/packages/vdom-extension/package.json
+++ b/packages/vdom-extension/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/vdom/package.json
+++ b/packages/vdom/package.json
@@ -48,7 +48,7 @@
     "@types/react-dom": "^17.0.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/vega5-extension/package.json
+++ b/packages/vega5-extension/package.json
@@ -43,7 +43,7 @@
     "@types/webpack-env": "^1.14.1",
     "rimraf": "~3.0.0",
     "typedoc": "~0.21.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/testutils/package.json
+++ b/testutils/package.json
@@ -69,7 +69,7 @@
     "@types/node-fetch": "^2.5.4",
     "jest-retries": "^1.0.1",
     "lighthouse": "6.3.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/testutils/src/jest-shim.ts
+++ b/testutils/src/jest-shim.ts
@@ -29,7 +29,7 @@ const createContextualFragment = (html: string) => {
       /* no-op */
     },
     getBoundingClientRect: () => ({ right: 0 }),
-    getClientRects: (): ClientRect[] => [],
+    getClientRects: (): DOMRect[] => [],
     createContextualFragment
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -15124,10 +15124,10 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
-resize-observer-polyfill@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
-  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
+resize-observer@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/resize-observer/-/resize-observer-1.0.4.tgz#48beb64602ce408ebd1a433784d64ef76f38d321"
+  integrity sha512-AQ2MdkWTng9d6JtjHvljiQR949qdae91pjSNugGGeOFzKIuLHvoZIYhUTjePla5hCFDwQHrnkciAIzjzdsTZew==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15124,11 +15124,6 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
-resize-observer@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/resize-observer/-/resize-observer-1.0.4.tgz#48beb64602ce408ebd1a433784d64ef76f38d321"
-  integrity sha512-AQ2MdkWTng9d6JtjHvljiQR949qdae91pjSNugGGeOFzKIuLHvoZIYhUTjePla5hCFDwQHrnkciAIzjzdsTZew==
-
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16982,10 +16982,10 @@ typedoc@~0.21.2:
     shiki "^0.9.3"
     typedoc-default-themes "^0.12.10"
 
-typescript@~4.1.3:
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.6.tgz#1becd85d77567c3c741172339e93ce2e69932138"
-  integrity sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==
+typescript@~4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
+  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
 
 typestyle@^2.0.4:
   version "2.1.0"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Reviving the effort started in https://github.com/jupyterlab/jupyterlab/pull/10993 since we are a couple of versions behind now.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

TypeScript update:

- [x] ~Switching to another polyfill for `resize-observer` based on the discussions in https://github.com/que-etc/resize-observer-polyfill/issues/83~ -> **edit**: drop the polyfill based on the discussion in https://github.com/jupyterlab/jupyterlab/pull/11594#pullrequestreview-819423470
- [x] `ClientRect` has been removed in 4.4: https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1029#issuecomment-869224737
- [x] Update `CodeEditor.ICoordinate` interface
- [x] More `null` checks caught by the compiler
- [x] ~Bump major version of the packages affected by the breaking changes~ -> done in https://github.com/jupyterlab/jupyterlab/pull/11537
- [x] Document interface changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

- `lib.d.ts`
- Update `CodeEditor.ICoordinate` interface

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
