### PR TITLE
Save document from the backend using y-py

### DIFF
--- a/jupyterlab/handlers/ydoc.py
+++ b/jupyterlab/handlers/ydoc.py
@@ -1,0 +1,57 @@
+import y_py as Y
+
+
+class YBaseDoc:
+    def __init__(self):
+        self._ydoc = Y.YDoc()
+
+    @property
+    def ydoc(self):
+        return self._ydoc
+
+    @property
+    def source(self):
+        raise RuntimeError("Y document source generation not implemented")
+
+
+class YFile(YBaseDoc):
+    def __init__(self):
+        super().__init__()
+        self._ysource = self._ydoc.get_text("source")
+
+    @property
+    def source(self):
+        with self._ydoc.begin_transaction() as t:
+            return self._ysource.to_string(t)
+
+
+class YNotebook(YBaseDoc):
+    def __init__(self):
+        super().__init__()
+        self._ycells = self._ydoc.get_array("cells")
+        self._ymeta = self._ydoc.get_map("meta")
+        self._ystate = self._ydoc.get_map("state")
+
+    @property
+    def source(self):
+        with self._ydoc.begin_transaction() as t:
+            cells = self._ycells.to_json(t)
+            meta = self._ymeta.to_json(t)
+            state = self._ystate.to_json(t)
+        for cell in cells:
+            if "execution_count" in cell:
+                execution_count = cell["execution_count"]
+                if isinstance(execution_count, float):
+                    cell["execution_count"] = int(execution_count)
+            if "outputs" in cell:
+                for output in cell["outputs"]:
+                    if "execution_count" in output:
+                        execution_count = output["execution_count"]
+                        if isinstance(execution_count, float):
+                            output["execution_count"] = int(execution_count)
+        return dict(
+            cells=cells,
+            metadata=meta["metadata"],
+            nbformat=int(state["nbformat"]),
+            nbformat_minor=int(state["nbformatMinor"]),
+        )

--- a/jupyterlab/handlers/yjs_echo_ws.py
+++ b/jupyterlab/handlers/yjs_echo_ws.py
@@ -7,10 +7,20 @@ import time
 import uuid
 from enum import IntEnum
 
+import pkg_resources
+import y_py as Y
 from jupyter_server.base.handlers import JupyterHandler
 from tornado import web
 from tornado.ioloop import IOLoop
 from tornado.websocket import WebSocketHandler
+
+YDOCS = {}
+for ep in pkg_resources.iter_entry_points(group="jupyter_ydoc"):
+    YDOCS.update({ep.name: ep.load()})
+
+YFILE = YDOCS["file"]
+
+ROOMS = {}
 
 ## The y-protocol defines messages types that just need to be propagated to all other peers.
 ## Here, we define some additional messageTypes that the server can interpret.
@@ -32,16 +42,20 @@ class ServerMessageType(IntEnum):
 
 
 class YjsRoom:
-    def __init__(self):
+    def __init__(self, type):
+        self.type = type
         self.lock = None
         self.timeout = None
         self.lock_holder = None
         self.clients = {}
         self.content = bytes([])
+        self.ydoc = YDOCS.get(type, YFILE)()
+
+    def get_source(self):
+        return self.ydoc.source
 
 
 class YjsEchoWebSocket(WebSocketHandler, JupyterHandler):
-    rooms = {}
 
     # Override max_message size to 1GB
     @property
@@ -54,24 +68,23 @@ class YjsEchoWebSocket(WebSocketHandler, JupyterHandler):
             raise web.HTTPError(403)
         return await super().get(*args, **kwargs)
 
-    def open(self, guid):
-        # print("[YJSEchoWS]: open", guid)
-        cls = self.__class__
+    def open(self, type_path):
+        # print("[YJSEchoWS]: open", type_path)
+        type, path = type_path.split(":", 1)
         self.id = str(uuid.uuid4())
-        self.room_id = guid
-        room = cls.rooms.get(self.room_id)
+        self.room_id = path
+        room = ROOMS.get(self.room_id)
         if room is None:
-            room = YjsRoom()
-            cls.rooms[self.room_id] = room
+            room = YjsRoom(type)
+            ROOMS[self.room_id] = room
         room.clients[self.id] = (IOLoop.current(), self.hook_send_message, self)
         # Send SyncStep1 message (based on y-protocols)
         self.write_message(bytes([0, 0, 1, 0]), binary=True)
 
     def on_message(self, message):
-        # print("[YJSEchoWS]: message, ", message)
-        cls = self.__class__
+        # print("[YJSEchoWS]: message,", message)
         room_id = self.room_id
-        room = cls.rooms.get(room_id)
+        room = ROOMS.get(room_id)
         if message[0] == ServerMessageType.ACQUIRE_LOCK:
             now = int(time.time())
             if room.lock is None or now - room.timeout > (
@@ -80,7 +93,7 @@ class YjsEchoWebSocket(WebSocketHandler, JupyterHandler):
                 room.lock = now
                 room.timeout = now
                 room.lock_holder = self.id
-                # print('Acquired new lock: ', room.lock)
+                # print('Acquired new lock:', room.lock)
                 # return acquired lock
                 self.write_message(
                     bytes([ServerMessageType.ACQUIRE_LOCK])
@@ -89,14 +102,14 @@ class YjsEchoWebSocket(WebSocketHandler, JupyterHandler):
                 )
 
             elif room.lock_holder == self.id:
-                # print('Update lock: ', room.timeout)
+                # print('Update lock:', room.timeout)
                 room.timeout = now
 
         elif message[0] == ServerMessageType.RELEASE_LOCK:
             releasedLock = int.from_bytes(message[1:], byteorder="little")
-            # print("trying release lock: ", releasedLock)
+            # print("trying release lock:", releasedLock)
             if room.lock == releasedLock:
-                # print('released lock: ', room.lock)
+                # print('released lock:', room.lock)
                 room.lock = None
                 room.timeout = None
                 room.lock_holder = None
@@ -110,24 +123,27 @@ class YjsEchoWebSocket(WebSocketHandler, JupyterHandler):
             room.content = message[1:]
         elif message[0] == ServerMessageType.RENAME_SESSION:
             # We move the room to a different entry and also change the room_id property of each connected client
-            new_room_id = message[1:].decode("utf-8")
+            new_room_id = message[1:].decode("utf-8").split(":", 1)[1]
             for client_id, (loop, hook_send_message, client) in room.clients.items():
                 client.room_id = new_room_id
-            cls.rooms.pop(room_id)
-            cls.rooms[new_room_id] = room
+            ROOMS.pop(room_id)
+            ROOMS[new_room_id] = room
+            # send rename acknowledge
+            self.write_message(bytes([ServerMessageType.RENAME_SESSION, 1]), binary=True)
             # print("renamed room to " + new_room_id + ". Old room name was " + room_id)
         elif room:
+            if message[0] == 0:  # sync message
+                read_sync_message(self, room.ydoc.ydoc, message[1:])
             for client_id, (loop, hook_send_message, client) in room.clients.items():
                 if self.id != client_id:
                     loop.add_callback(hook_send_message, message)
 
     def on_close(self):
         # print("[YJSEchoWS]: close")
-        cls = self.__class__
-        room = cls.rooms.get(self.room_id)
+        room = ROOMS.get(self.room_id)
         room.clients.pop(self.id)
-        if len(room.clients) == 0:
-            cls.rooms.pop(self.room_id)
+        if not room.clients:
+            ROOMS.pop(self.room_id)
             # print("[YJSEchoWS]: close room " + self.room_id)
 
         return True
@@ -138,3 +154,71 @@ class YjsEchoWebSocket(WebSocketHandler, JupyterHandler):
 
     def hook_send_message(self, msg):
         self.write_message(msg, binary=True)
+
+
+message_yjs_sync_step1 = 0
+message_yjs_sync_step2 = 1
+message_yjs_update = 2
+
+
+def read_sync_step1(handler, doc, encoded_state_vector):
+    message = Y.encode_state_as_update(doc, encoded_state_vector)
+    message = bytes([message_yjs_sync_step2] + write_var_uint(len(message)) + message)
+    handler.write_message(message, binary=True)
+
+
+def read_sync_step2(doc, update):
+    try:
+        Y.apply_update(doc, update)
+    except Exception:
+        raise RuntimeError("Caught error while handling a Y update")
+
+
+def read_sync_message(handler, doc, message):
+    message_type = message[0]
+    message = message[1:]
+    if message_type == message_yjs_sync_step1:
+        for msg in get_message(message):
+            read_sync_step1(handler, doc, msg)
+    elif message_type == message_yjs_sync_step2:
+        for msg in get_message(message):
+            read_sync_step2(doc, msg)
+    elif message_type == message_yjs_update:
+        for msg in get_message(message):
+            read_sync_step2(doc, msg)
+    else:
+        raise RuntimeError("Unknown message type")
+
+
+def write_var_uint(num):
+    res = []
+    while num > 127:
+        res += [128 | (127 & num)]
+        num >>= 7
+    res += [num]
+    return res
+
+
+def get_message(message):
+    length = len(message)
+    i0 = 0
+    while True:
+        msg_len = 0
+        i = 0
+        while True:
+            byte = message[i0]
+            msg_len += (byte & 127) << i
+            i += 7
+            i0 += 1
+            length -= 1
+            if byte < 128:
+                break
+        i1 = i0 + msg_len
+        msg = message[i0:i1]
+        length -= msg_len
+        yield msg
+        if length <= 0:
+            if length < 0:
+                raise RuntimeError("Y protocol error")
+            break
+        i0 = i1

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -118,6 +118,11 @@ export interface ICodeCellModel extends ICellModel {
    * Clear execution, outputs, and related metadata
    */
   clearExecution(): void;
+
+  /**
+   * The code cell shared model
+   */
+  sharedModel: models.ISharedCodeCell;
 }
 
 /**
@@ -633,28 +638,34 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
     const cell = options.cell as nbformat.ICodeCell;
     let outputs: nbformat.IOutput[] = [];
     const executionCount = this.modelDB.createValue('executionCount');
-    if (!executionCount.get()) {
-      if (cell && cell.cell_type === 'code') {
-        executionCount.set(cell.execution_count || null);
-        outputs = cell.outputs ?? [];
-        // If execution count is not null presume the input code was the latest executed
-        // TODO load from the notebook file when the dirty state is stored in it
-        if (cell.execution_count != null) {
-          // True if execution_count is null or undefined
-          this._executedCode = this.value.text.trim();
-        }
-      } else {
-        executionCount.set(null);
+
+    if (cell && cell.cell_type === 'code') {
+      // Initialize from disk
+      executionCount.set(cell.execution_count || null);
+      outputs = cell.outputs ?? [];
+
+      // Add content loaded from disk to sharedModel
+      globalModelDBMutex(() => {
+        this.sharedModel.execution_count = cell.execution_count;
+        this.sharedModel.setOutputs(outputs);
+      });
+
+      // If execution count is not null presume the input code was the latest executed
+      // TODO load from the notebook file when the dirty state is stored in it
+      if (cell.execution_count != null) {
+        // True if execution_count is null or undefined
+        this._executedCode = this.value.text.trim();
       }
+    } else {
+      // Initialize from other clients
+      executionCount.set(this.sharedModel.execution_count);
+      outputs = this.sharedModel.getOutputs();
     }
+
     this.value.changed.connect(this._onValueChanged, this);
 
     executionCount.changed.connect(this._onExecutionCountChanged, this);
 
-    globalModelDBMutex(() => {
-      const sharedCell = this.sharedModel as models.ISharedCodeCell;
-      sharedCell.setOutputs(outputs);
-    });
     this._outputs = factory.createOutputArea({ trusted, values: outputs });
     this._outputs.changed.connect(this.onGenericChange, this);
     this._outputs.changed.connect(this.onModelDBOutputsChange, this);
@@ -692,10 +703,12 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
     reinitialize?: boolean
   ): void {
     if (reinitialize) {
-      this.clearExecution();
+      this.executionCount = sharedModel.execution_count;
+      this.outputs.clear();
       sharedModel.getOutputs().forEach(output => this._outputs.add(output));
     }
     super.switchSharedModel(sharedModel, reinitialize);
+    this._setDirty(false);
   }
 
   /**
@@ -901,6 +914,8 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
       this._setDirty(false);
     }
   }
+
+  sharedModel: models.ISharedCodeCell;
 
   private _executedCode: string = '';
   private _isDirty = false;

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -652,7 +652,7 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
 
       // If execution count is not null presume the input code was the latest executed
       // TODO load from the notebook file when the dirty state is stored in it
-      if (cell.execution_count != null) {
+      if (cell.execution_count !== null) {
         // True if execution_count is null or undefined
         this._executedCode = this.value.text.trim();
       }

--- a/packages/docprovider/src/mock.ts
+++ b/packages/docprovider/src/mock.ts
@@ -19,4 +19,7 @@ export class ProviderMock implements IDocumentProvider {
   setPath(path: string): void {
     /* nop */
   }
+  get renameAck(): Promise<boolean> {
+    return Promise.resolve(false);
+  }
 }

--- a/packages/docprovider/src/tokens.ts
+++ b/packages/docprovider/src/tokens.ts
@@ -36,6 +36,12 @@ export interface IDocumentProvider {
   releaseLock(lock: number): void;
 
   /**
+   * Returns a Promise that resolves when renaming is ackownledged.
+   * TODO: make it non-optional in JupyterLab 4.0
+   */
+  readonly renameAck?: Promise<boolean>;
+
+  /**
    * This should be called by the docregistry when the file has been renamed to update the websocket connection url
    */
   setPath(newPath: string): void;

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -596,7 +596,7 @@ export class Context<
     this._saveState.emit('started');
     const model = this._model;
     let content: PartialJSONValue = null;
-    if (PageConfig.getOption('collaborative') != 'true') {
+    if (PageConfig.getOption('collaborative') !== 'true') {
       if (this._factory.fileFormat === 'json') {
         content = model.toJSON();
       } else {

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -33,8 +33,6 @@ import { JSONObject, ReadonlyPartialJSONValue, UUID } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 import { CellList } from './celllist';
 
-const UNSHARED_KEYS = ['kernelspec', 'language_info'];
-
 /**
  * The definition of a model object for a notebook widget.
  */
@@ -114,7 +112,6 @@ export class NotebookModel implements INotebookModel {
     metadata.changed.connect(this._onMetadataChanged, this);
     this._deletedCells = [];
 
-    (this.sharedModel as models.YNotebook).dirty = false;
     this.sharedModel.changed.connect(this._onStateChanged, this);
   }
   /**
@@ -447,11 +444,9 @@ close the notebook without saving it.`,
     metadata: IObservableJSON,
     change: IObservableMap.IChangedArgs<ReadonlyPartialJSONValue | undefined>
   ): void {
-    if (!UNSHARED_KEYS.includes(change.key)) {
-      this._modelDBMutex(() => {
-        this.sharedModel.updateMetadata(metadata.toJSON());
-      });
-    }
+    this._modelDBMutex(() => {
+      this.sharedModel.updateMetadata(metadata.toJSON());
+    });
     this.triggerContentChange();
   }
 

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -151,7 +151,9 @@ export class YFile
   };
 
   public static create(): YFile {
-    return new YFile();
+    const model = new YFile();
+    model.dirty = false;
+    return model;
   }
 
   /**
@@ -371,7 +373,9 @@ export class YNotebook
   public static create(
     disableDocumentWideUndoRedo: boolean
   ): models.ISharedNotebook {
-    return new YNotebook({ disableDocumentWideUndoRedo });
+    const model = new YNotebook({ disableDocumentWideUndoRedo });
+    model.dirty = false;
+    return model;
   }
 
   /**

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,10 +35,11 @@ install_requires =
     packaging
     tornado>=6.1.0
     jupyter_core
-    jupyterlab_server~=2.10
-    jupyter_server~=1.8
+    jupyterlab_server>=2.11.1,<3
+    jupyter_server>=1.15.6,<2
     notebook_shim>=0.1
     jinja2>=3.0.3
+    y-py>=0.2.3,<1
 
 [options.extras_require]
 docs =
@@ -64,7 +65,7 @@ docs-screenshots =
 test =
     check-manifest
     coverage
-    jupyterlab_server[test]~=2.10
+    jupyterlab_server[test]>=2.11.1,<3
     pytest>=6.0
     pytest-check-links>=0.5
     pytest-cov
@@ -81,6 +82,9 @@ console_scripts =
     jupyter-labextension = jupyterlab.labextensions:main
     jupyter-labhub = jupyterlab.labhubapp:main
     jlpm = jupyterlab.jlpmapp:main
+jupyter_ydoc =
+    file = jupyterlab.handlers.ydoc:YFile
+    notebook = jupyterlab.handlers.ydoc:YNotebook
 
 [options.packages.find]
 exclude = ['docs*', 'examples*']


### PR DESCRIPTION
## Code changes

When collaborative mode is enabled, the save command still goes through the HTTP endpoint, but the document source is computed in the back-end using `y-py`.
When collaborative mode is disabled, the previous behavior is kept: the document content is sent from the front-end to the back-end through the HTTP endpoint.
The back-end raises an error if:
- the document content is sent from the front-end through the HTTP endpoint and there is a Yjs shared "room" corresponding to that document,
- no document content is sent from the front-end through the HTTP endpoint and no Yjs shared "room" corresponds to that document.

Otherwise, the back-end gets the document content either from the HTTP endpoint or computes it from the Yjs shared "room" corresponding to that document.

cc @dmonad

## Backwards-incompatible changes

None