### PR TITLE
Remove source from modelDB

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -44,6 +44,27 @@ bumped their major version (following semver convention):
    As a result of the update to TypeScript 4.5, a couple of interfaces have had their definitions changed.
    The ``anchor`` parameter of ``HoverBox.IOptions`` is now a ``DOMRect`` instead of ``ClientRect``.
    The ``CodeEditor.ICoordinate`` interface now extends ``DOMRectReadOnly`` instead of ``JSONObject, ClientRect``.
+- ``@jupyterlab/codeeditor`` from 3.x to 4.x
+  The property ``value`` from ``IModel`` interface has been removed. Instead you can access the document's source
+  through the property ``sharedModel``:
+  - ``value.changed`` -> ``sharedModel.changed``
+  - ``value.text`` -> ``sharedModel.getSource``
+  - ``value.remove`` -> ``sharedModel.updateSource``
+  - ``value.insert`` -> ``sharedModel.updateSource``
+- ``@jupyterlab/cells`` from 3.x to 4.x
+  The property ``value`` from ``CodeEditor.IModel`` interface has been removed. This change affect the
+  following interfaces:
+  - ``ICellModel``
+  - ``ICodeCellModel``
+  - ``IAttachmentsCellModel``
+  - ``IMarkdownCellModel``
+  - ``IRawCellModel``
+  Check the migration tips on ``@jupyterlab/codeeditor``.
+- ``@jupyterlab/docregistry`` from 3.x to 4.x
+  The property ``value`` from ``CodeEditor.IModel`` interface has been removed. This change affect the
+  interface ``ICodeModel`` and the class ``DocumentModel``
+  Check the migration tips on ``@jupyterlab/codeeditor``.
+
 
 JupyterLab 3.0 to 3.1
 ---------------------

--- a/galata/src/inpage/index.ts
+++ b/galata/src/inpage/index.ts
@@ -413,7 +413,7 @@ export class GalataInpage implements IGalataInpage {
    */
   async waitForCellRun(cell: Cell, timeout = 2000): Promise<Node | null> {
     const model = cell.model;
-    const code = model.value.text;
+    const code = model.value;
     if (!code.trim()) {
       return null;
     }

--- a/galata/src/inpage/index.ts
+++ b/galata/src/inpage/index.ts
@@ -413,7 +413,7 @@ export class GalataInpage implements IGalataInpage {
    */
   async waitForCellRun(cell: Cell, timeout = 2000): Promise<Node | null> {
     const model = cell.model;
-    const code = model.value;
+    const code = model.sharedModel.getSource();
     if (!code.trim()) {
       return null;
     }

--- a/galata/src/inpage/index.ts
+++ b/galata/src/inpage/index.ts
@@ -413,7 +413,7 @@ export class GalataInpage implements IGalataInpage {
    */
   async waitForCellRun(cell: Cell, timeout = 2000): Promise<Node | null> {
     const model = cell.model;
-    const code = model.sharedModel.getSource();
+    const code = model.source;
     if (!code.trim()) {
       return null;
     }

--- a/packages/cells/src/celldragutils.ts
+++ b/packages/cells/src/celldragutils.ts
@@ -153,10 +153,7 @@ export namespace CellDragUtils {
       promptNumber = '';
     }
 
-    const cellContent = activeCell.model.sharedModel
-      .getSource()
-      .split('\n')[0]
-      .slice(0, 26);
+    const cellContent = activeCell.model.source.split('\n')[0].slice(0, 26);
     if (count > 1) {
       if (promptNumber !== '') {
         return VirtualDOM.realize(

--- a/packages/cells/src/celldragutils.ts
+++ b/packages/cells/src/celldragutils.ts
@@ -153,7 +153,10 @@ export namespace CellDragUtils {
       promptNumber = '';
     }
 
-    const cellContent = activeCell.model.value.split('\n')[0].slice(0, 26);
+    const cellContent = activeCell.model.sharedModel
+      .getSource()
+      .split('\n')[0]
+      .slice(0, 26);
     if (count > 1) {
       if (promptNumber !== '') {
         return VirtualDOM.realize(

--- a/packages/cells/src/celldragutils.ts
+++ b/packages/cells/src/celldragutils.ts
@@ -153,7 +153,7 @@ export namespace CellDragUtils {
       promptNumber = '';
     }
 
-    const cellContent = activeCell.model.value.text.split('\n')[0].slice(0, 26);
+    const cellContent = activeCell.model.value.split('\n')[0].slice(0, 26);
     if (count > 1) {
       if (promptNumber !== '') {
         return VirtualDOM.realize(

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -52,6 +52,8 @@ export interface ICellModel extends CodeEditor.IModel {
    */
   readonly id: string;
 
+  readonly isStandalone: boolean;
+
   /**
    * A signal emitted when the content of the model changes.
    */
@@ -81,6 +83,8 @@ export interface ICellModel extends CodeEditor.IModel {
    * Serialize the model to JSON.
    */
   toJSON(): nbformat.ICell;
+
+  cloneSharedModel(): ISharedCell;
 }
 
 /**
@@ -241,6 +245,10 @@ export class CellModel extends CodeEditor.Model implements ICellModel {
     return 'raw';
   }
 
+  get isStandalone(): boolean {
+    return this._sharedModel.isStandalone;
+  }
+
   /**
    * A signal emitted when the state of the model changes.
    */
@@ -332,6 +340,10 @@ export class CellModel extends CodeEditor.Model implements ICellModel {
       }
     }
     super.switchSharedModel(sharedModel, reinitialize);
+  }
+
+  cloneSharedModel(): ISharedCell {
+    return this._sharedModel.clone() as ISharedCell;
   }
 
   /**

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -188,9 +188,6 @@ export class CellModel extends CodeEditor.Model implements ICellModel {
       id: options.id || (options.cell?.id as string) || UUID.uuid4()
     });
 
-    // Deprecate: triggered when the shared model's source changes
-    //this.value.changed.connect(this.onGenericChange, this);
-
     const cellType = this.modelDB.createValue('type');
     cellType.set(this.type);
 
@@ -670,8 +667,6 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
         executionCount.set(null);
       }
     }
-    // Deprecated: Tracked on this._onSharedModelChanged
-    //this.value.changed.connect(this._onValueChanged, this);
 
     executionCount.changed.connect(this._onExecutionCountChanged, this);
 

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -211,11 +211,15 @@ export class CellModel extends CodeEditor.Model implements ICellModel {
 
     // Set the text value, normalizing line endings to \n
     if (Array.isArray(cell.source)) {
-      this.value = cell.source
-        .map(s => s.replace(/\r\n/g, '\n').replace(/\r/g, '\n'))
-        .join('');
+      this.sharedModel.setSource(
+        cell.source
+          .map(s => s.replace(/\r\n/g, '\n').replace(/\r/g, '\n'))
+          .join('')
+      );
     } else {
-      this.value = cell.source.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+      this.sharedModel.setSource(
+        cell.source.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+      );
     }
     const metadata = JSONExt.deepCopy(cell.metadata);
     if (this.type !== 'raw') {
@@ -303,7 +307,7 @@ export class CellModel extends CodeEditor.Model implements ICellModel {
     }
     return {
       cell_type: this.type,
-      source: this.value,
+      source: this.sharedModel.getSource(),
       metadata
     } as nbformat.ICell;
   }
@@ -667,7 +671,7 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
         // TODO load from the notebook file when the dirty state is stored in it
         if (cell.execution_count != null) {
           // True if execution_count is null or undefined
-          this._executedCode = this.value.trim();
+          this._executedCode = this.sharedModel.getSource().trim();
         }
       } else {
         executionCount.set(null);
@@ -755,7 +759,7 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
   private _setDirty(v: boolean) {
     if (v !== this._isDirty) {
       if (!v) {
-        this._executedCode = this.value.trim();
+        this._executedCode = this.sharedModel.getSource().trim();
       }
       this._isDirty = v;
       this.stateChanged.emit({
@@ -912,7 +916,9 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
    */
   private _onValueChanged(): void {
     if (this.executionCount !== null) {
-      this._setDirty(this._executedCode !== this.value.trim());
+      this._setDirty(
+        this._executedCode !== this.sharedModel.getSource().trim()
+      );
     }
   }
 

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -233,8 +233,6 @@ export class CellModel extends CodeEditor.Model implements ICellModel {
     for (const key in metadata) {
       observableMetadata.set(key, metadata[key]);
     }
-
-    this.sharedModel.changed.connect(this.onSharedModelChanged, this);
   }
 
   /**
@@ -341,12 +339,7 @@ export class CellModel extends CodeEditor.Model implements ICellModel {
         this._updateModelDBMetadata(newValue);
       }
     }
-    // Disconnect from old model
-    this.sharedModel.changed.disconnect(this.onSharedModelChanged, this);
-    // parent class changes the model
     super.switchSharedModel(sharedModel, reinitialize);
-    // connect to new model
-    this.sharedModel.changed.connect(this.onSharedModelChanged, this);
   }
 
   /**

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1099,7 +1099,7 @@ export namespace CodeCell {
     metadata?: JSONObject
   ): Promise<KernelMessage.IExecuteReplyMsg | void> {
     const model = cell.model;
-    const code = model.value.text;
+    const code = model.value;
     if (!code.trim() || !sessionContext.session?.kernel) {
       model.clearExecution();
       return;
@@ -1500,7 +1500,7 @@ export class MarkdownCell extends AttachmentsCell<IMarkdownCellModel> {
    * Returns empty string if not a heading.
    */
   get headingInfo(): { text: string; level: number } {
-    let text = this.model.value.text;
+    let text = this.model.value;
     const lines = marked.lexer(text);
     let line: any;
     for (line of lines) {
@@ -1716,7 +1716,7 @@ export class MarkdownCell extends AttachmentsCell<IMarkdownCellModel> {
    */
   private _updateRenderedInput(): Promise<void> {
     const model = this.model;
-    const text = (model && model.value.text) || DEFAULT_MARKDOWN_TEXT;
+    const text = (model && model.value) || DEFAULT_MARKDOWN_TEXT;
     // Do not re-render if the text has not changed.
     if (text !== this._prevText) {
       const mimeModel = new MimeModel({ data: { 'text/markdown': text } });

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1099,7 +1099,7 @@ export namespace CodeCell {
     metadata?: JSONObject
   ): Promise<KernelMessage.IExecuteReplyMsg | void> {
     const model = cell.model;
-    const code = model.sharedModel.getSource();
+    const code = model.source;
     if (!code.trim() || !sessionContext.session?.kernel) {
       model.clearExecution();
       return;
@@ -1500,7 +1500,7 @@ export class MarkdownCell extends AttachmentsCell<IMarkdownCellModel> {
    * Returns empty string if not a heading.
    */
   get headingInfo(): { text: string; level: number } {
-    let text = this.model.sharedModel.getSource();
+    let text = this.model.source;
     const lines = marked.lexer(text);
     let line: any;
     for (line of lines) {
@@ -1716,8 +1716,7 @@ export class MarkdownCell extends AttachmentsCell<IMarkdownCellModel> {
    */
   private _updateRenderedInput(): Promise<void> {
     const model = this.model;
-    const text =
-      (model && model.sharedModel.getSource()) || DEFAULT_MARKDOWN_TEXT;
+    const text = (model && model.source) || DEFAULT_MARKDOWN_TEXT;
     // Do not re-render if the text has not changed.
     if (text !== this._prevText) {
       const mimeModel = new MimeModel({ data: { 'text/markdown': text } });

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1099,7 +1099,7 @@ export namespace CodeCell {
     metadata?: JSONObject
   ): Promise<KernelMessage.IExecuteReplyMsg | void> {
     const model = cell.model;
-    const code = model.value;
+    const code = model.sharedModel.getSource();
     if (!code.trim() || !sessionContext.session?.kernel) {
       model.clearExecution();
       return;
@@ -1500,7 +1500,7 @@ export class MarkdownCell extends AttachmentsCell<IMarkdownCellModel> {
    * Returns empty string if not a heading.
    */
   get headingInfo(): { text: string; level: number } {
-    let text = this.model.value;
+    let text = this.model.sharedModel.getSource();
     const lines = marked.lexer(text);
     let line: any;
     for (line of lines) {
@@ -1716,7 +1716,8 @@ export class MarkdownCell extends AttachmentsCell<IMarkdownCellModel> {
    */
   private _updateRenderedInput(): Promise<void> {
     const model = this.model;
-    const text = (model && model.value) || DEFAULT_MARKDOWN_TEXT;
+    const text =
+      (model && model.sharedModel.getSource()) || DEFAULT_MARKDOWN_TEXT;
     // Do not re-render if the text has not changed.
     if (text !== this._prevText) {
       const mimeModel = new MimeModel({ data: { 'text/markdown': text } });

--- a/packages/cells/test/model.spec.ts
+++ b/packages/cells/test/model.spec.ts
@@ -41,7 +41,7 @@ describe('cells/model', () => {
         };
         const model = new CellModel({ cell });
         expect(model).toBeInstanceOf(CellModel);
-        expect(model.value.text).toBe(cell.source);
+        expect(model.sharedModel.getSource()).toBe(cell.source);
       });
 
       it('should accept a base cell argument with a multiline source', () => {
@@ -53,7 +53,9 @@ describe('cells/model', () => {
         };
         const model = new CellModel({ cell });
         expect(model).toBeInstanceOf(CellModel);
-        expect(model.value.text).toBe((cell.source as string[]).join(''));
+        expect(model.sharedModel.getSource()).toBe(
+          (cell.source as string[]).join('')
+        );
       });
 
       it('should use the id argument', () => {
@@ -100,7 +102,7 @@ describe('cells/model', () => {
           called = true;
         });
         expect(called).toBe(false);
-        model.value.text = 'foo';
+        model.sharedModel.setSource('foo');
         expect(called).toBe(true);
       });
     });
@@ -186,14 +188,14 @@ describe('cells/model', () => {
     describe('#source', () => {
       it('should default to an empty string', () => {
         const model = new CellModel({});
-        expect(model.value.text).toHaveLength(0);
+        expect(model.sharedModel.getSource()).toHaveLength(0);
       });
 
       it('should be settable', () => {
         const model = new CellModel({});
-        expect(model.value.text).toHaveLength(0);
-        model.value.text = 'foo';
-        expect(model.value.text).toBe('foo');
+        expect(model.sharedModel.getSource()).toHaveLength(0);
+        model.sharedModel.setSource('foo');
+        expect(model.sharedModel.getSource()).toBe('foo');
       });
     });
 
@@ -346,7 +348,7 @@ describe('cells/model', () => {
         };
         const model = new CodeCellModel({ cell });
         expect(model).toBeInstanceOf(CodeCellModel);
-        expect(model.value.text).toBe(cell.source);
+        expect(model.sharedModel.getSource()).toBe(cell.source);
       });
 
       it('should connect the outputs changes to content change signal', () => {
@@ -479,7 +481,7 @@ describe('cells/model', () => {
         expect(model.isDirty).toBe(false);
         expect(called).toBe(0);
 
-        model.value.text = 'foo';
+        model.sharedModel.setSource('foo');
         expect(model.isDirty).toBe(true);
         expect(called).toBe(1);
 

--- a/packages/cells/test/widget.spec.ts
+++ b/packages/cells/test/widget.spec.ts
@@ -753,7 +753,7 @@ describe('cells/widget', () => {
         const widget = new CodeCell({ model, rendermime, contentFactory });
         widget.initializeState();
         let originalCount: number;
-        widget.model.value.text = 'foo';
+        widget.model.sharedModel.setSource('foo');
         originalCount = widget.model.executionCount!;
         await CodeCell.execute(widget, sessionContext);
         const executionCount = widget.model.executionCount;
@@ -786,7 +786,7 @@ describe('cells/widget', () => {
       it('should set the cell prompt properly while executing', async () => {
         const widget = new CodeCell({ model, rendermime, contentFactory });
         widget.initializeState();
-        widget.model.value.text = 'foo';
+        widget.model.sharedModel.setSource('foo');
         const future1 = CodeCell.execute(widget, sessionContext);
         expect(widget.promptNode.textContent).toEqual('[*]:');
         const future2 = CodeCell.execute(widget, sessionContext);

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -179,12 +179,6 @@ export namespace CodeEditor {
     sharedModelSwitched: ISignal<IModel, boolean>;
 
     /**
-     * The text stored in the model.
-     */
-    //readonly value: IObservableString;
-    value: string;
-
-    /**
      * A mime type of the model.
      *
      * #### Notes
@@ -271,16 +265,6 @@ export namespace CodeEditor {
      */
     get sharedModelSwitched(): ISignal<this, boolean> {
       return this._sharedModelSwitched;
-    }
-
-    /**
-     * Get the value of the model.
-     */
-    get value(): string {
-      return this.sharedModel.getSource();
-    }
-    set value(source: string) {
-      this.sharedModel.setSource(source);
     }
 
     /**

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -210,7 +210,7 @@ export namespace CodeEditor {
      */
     readonly selections: IObservableMap<ITextSelection[]>;
 
-    readonly ymodel: IYText;
+    readonly ymodel?: IYText;
 
     /**
      * Undo an operation.

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -13,7 +13,7 @@ import {
 import {
   createStandaloneCell,
   ISharedText,
-  IYText,
+  IYModel,
   SourceChange,
   TextChange
 } from '@jupyterlab/shared-models';
@@ -210,7 +210,7 @@ export namespace CodeEditor {
      */
     readonly selections: IObservableMap<ITextSelection[]>;
 
-    readonly ymodel?: IYText;
+    readonly ymodel?: IYModel;
 
     /**
      * Undo an operation.
@@ -330,8 +330,8 @@ export namespace CodeEditor {
       this._sharedModel.setSource(newValue);
     }
 
-    get ymodel(): IYText {
-      return this._sharedModel as IYText;
+    get ymodel(): IYModel {
+      return this._sharedModel as any;
     }
 
     /**

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -10,7 +10,11 @@ import {
   ModelDB,
   ObservableValue
 } from '@jupyterlab/observables';
-import { createStandaloneCell, ISharedText } from '@jupyterlab/shared-models';
+import {
+  createStandaloneCell,
+  ISharedText,
+  TextChange
+} from '@jupyterlab/shared-models';
 import { ITranslator } from '@jupyterlab/translation';
 import { JSONObject } from '@lumino/coreutils';
 import { IDisposable } from '@lumino/disposable';
@@ -236,6 +240,7 @@ export namespace CodeEditor {
       this.modelDB.createMap('selections');
 
       this.sharedModel.setSource(options.value || '');
+      this.sharedModel.changed.connect(this.onSharedModelChanged, this);
     }
 
     get type(): nbformat.CellType {
@@ -314,7 +319,9 @@ export namespace CodeEditor {
      * @param reinitialize Whether to reinitialize the shared model adding the content from modelDB.
      */
     switchSharedModel(sharedModel: ISharedText, reinitialize?: boolean): void {
+      this.sharedModel.changed.disconnect(this.onSharedModelChanged, this);
       this.sharedModel = sharedModel;
+      this.sharedModel.changed.connect(this.onSharedModelChanged, this);
       this._sharedModelSwitched.emit(true);
     }
 
@@ -327,6 +334,19 @@ export namespace CodeEditor {
         oldValue: args.oldValue as string,
         newValue: args.newValue as string
       });
+    }
+
+    /**
+     * Handle a change to the shared model.
+     *
+     * NOTE: This method is here to trigger the changes on
+     * classes that extend Model.
+     */
+    protected onSharedModelChanged(
+      sender: ISharedText,
+      change: TextChange
+    ): void {
+      /* NO OP */
     }
 
     private _isDisposed = false;

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -6,7 +6,6 @@ import * as nbformat from '@jupyterlab/nbformat';
 import {
   IModelDB,
   IObservableMap,
-  IObservableString,
   IObservableValue,
   ModelDB,
   ObservableValue
@@ -14,6 +13,7 @@ import {
 import {
   createStandaloneCell,
   ISharedText,
+  SourceChange,
   TextChange
 } from '@jupyterlab/shared-models';
 import { ITranslator } from '@jupyterlab/translation';
@@ -184,7 +184,7 @@ export namespace CodeEditor {
      * @todo Better arguments?
      */
     //sourceChanged: ISignal<IModel, IObservableString.IChangedArgs>;
-    sourceChanged: ISignal<IModel, string>;
+    sourceChanged: ISignal<IModel, Array<SourceChange>>;
 
     /**
      * A signal emitted when the shared model was switched.
@@ -273,7 +273,7 @@ export namespace CodeEditor {
     /**
      * A signal emitted when a mimetype changes.
      */
-    get sourceChanged(): ISignal<IModel, string> {
+    get sourceChanged(): ISignal<IModel, Array<SourceChange>> {
       return this._sourceChanged;
     }
 
@@ -377,28 +377,9 @@ export namespace CodeEditor {
       // TODO: emit a better signal with the changes.
       // Problem: the signal from the shared model makes it
       // hard to implement the IObservableString.IChangedArgs
-      this._sourceChanged.emit(this._sharedModel.getSource());
-      /* if (change.sourceChange) {
-        let currpos = 0;
-        change.sourceChange.forEach(delta => {
-          if (delta.insert != null) {
-            this._sourceChanged.emit({
-              type: 'insert',
-              start: currpos,
-              end: currpos + delta.insert.length,
-              value: delta.insert
-            });
-            currpos += delta.insert.length;
-          } else if (delta.delete != null) {
-            this._sourceChanged.emit({
-              type: 'remove',
-              start: currpos,
-              end: currpos + delta.delete,
-              value: ""
-            });
-          }
-        });
-      } */
+      if (change.sourceChange) {
+        this._sourceChanged.emit(change.sourceChange);
+      }
     }
 
     protected _modelDB: IModelDB;
@@ -406,7 +387,7 @@ export namespace CodeEditor {
 
     private _isDisposed = false;
     private _mimeTypeChanged = new Signal<this, IChangedArgs<string>>(this);
-    private _sourceChanged = new Signal<this, string>(this);
+    private _sourceChanged = new Signal<this, Array<SourceChange>>(this);
     private _sharedModelSwitched = new Signal<this, boolean>(this);
   }
 

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -13,6 +13,7 @@ import {
 import {
   createStandaloneCell,
   ISharedText,
+  IYText,
   SourceChange,
   TextChange
 } from '@jupyterlab/shared-models';
@@ -209,6 +210,18 @@ export namespace CodeEditor {
      */
     readonly selections: IObservableMap<ITextSelection[]>;
 
+    readonly ymodel: IYText;
+
+    /**
+     * Undo an operation.
+     */
+    undo(): void;
+
+    /**
+     * Redo an operation.
+     */
+    redo(): void;
+
     /**
      * Update the source by inserting/removing
      * characters from a certain position.
@@ -317,6 +330,10 @@ export namespace CodeEditor {
       this._sharedModel.setSource(newValue);
     }
 
+    get ymodel(): IYText {
+      return this._sharedModel as IYText;
+    }
+
     /**
      * Whether the model is disposed.
      */
@@ -332,7 +349,26 @@ export namespace CodeEditor {
         return;
       }
       this._isDisposed = true;
+      this._sharedModel.dispose();
       Signal.clearData(this);
+    }
+
+    /**
+     * Undo an operation.
+     */
+    undo(): void {
+      this._sharedModel.undo();
+    }
+
+    /**
+     * Redo an operation.
+     */
+    redo(): void {
+      this._sharedModel.redo();
+    }
+
+    updateSource(start: number, end: number, value?: string | undefined): void {
+      this._sharedModel.updateSource(start, end, value);
     }
 
     /**
@@ -347,10 +383,6 @@ export namespace CodeEditor {
       this._sharedModel = sharedModel;
       this._sharedModel.changed.connect(this.onSharedModelChanged, this);
       this._sharedModelSwitched.emit(true);
-    }
-
-    updateSource(start: number, end: number, value?: string | undefined): void {
-      this._sharedModel.updateSource(start, end, value);
     }
 
     private _onModelDBMimeTypeChanged(

--- a/packages/codeeditor/src/jsoneditor.ts
+++ b/packages/codeeditor/src/jsoneditor.ts
@@ -75,7 +75,7 @@ export class JSONEditor extends Widget {
 
     const model = new CodeEditor.Model();
 
-    model.value = this._trans.__('No data!');
+    model.sharedModel.setSource(this._trans.__('No data!'));
     model.mimeType = 'application/json';
     model.sharedModel.changed.connect(this._onValueChanged, this);
     this.model = model;
@@ -226,7 +226,7 @@ export class JSONEditor extends Widget {
   private _onValueChanged(): void {
     let valid = true;
     try {
-      const value = JSON.parse(this.editor.model.value);
+      const value = JSON.parse(this.editor.model.sharedModel.getSource());
       this.removeClass(ERROR_CLASS);
       this._inputDirty =
         !this._changeGuard && !JSONExt.deepEqual(value, this._originalValue);
@@ -274,7 +274,7 @@ export class JSONEditor extends Widget {
   private _mergeContent(): void {
     const model = this.editor.model;
     const old = this._originalValue;
-    const user = JSON.parse(model.value) as JSONObject;
+    const user = JSON.parse(model.sharedModel.getSource()) as JSONObject;
     const source = this.source;
     if (!source) {
       return;
@@ -308,11 +308,11 @@ export class JSONEditor extends Widget {
     const content = this._source ? this._source.toJSON() : {};
     this._changeGuard = true;
     if (content === void 0) {
-      model.value = this._trans.__('No data!');
+      model.sharedModel.setSource(this._trans.__('No data!'));
       this._originalValue = JSONExt.emptyObject;
     } else {
       const value = JSON.stringify(content, null, 4);
-      model.value = value;
+      model.sharedModel.setSource(value);
       this._originalValue = content;
       // Move the cursor to within the brace.
       if (value.length > 1 && value[0] === '{') {

--- a/packages/codeeditor/src/jsoneditor.ts
+++ b/packages/codeeditor/src/jsoneditor.ts
@@ -75,9 +75,9 @@ export class JSONEditor extends Widget {
 
     const model = new CodeEditor.Model();
 
-    model.sharedModel.setSource(this._trans.__('No data!'));
+    model.source = this._trans.__('No data!');
     model.mimeType = 'application/json';
-    model.sharedModel.changed.connect(this._onValueChanged, this);
+    model.sourceChanged.connect(this._onValueChanged, this);
     this.model = model;
     this.editor = options.editorFactory({ host: this.editorHostNode, model });
     this.editor.setOption('readOnly', true);
@@ -226,7 +226,7 @@ export class JSONEditor extends Widget {
   private _onValueChanged(): void {
     let valid = true;
     try {
-      const value = JSON.parse(this.editor.model.sharedModel.getSource());
+      const value = JSON.parse(this.editor.model.source);
       this.removeClass(ERROR_CLASS);
       this._inputDirty =
         !this._changeGuard && !JSONExt.deepEqual(value, this._originalValue);
@@ -274,7 +274,7 @@ export class JSONEditor extends Widget {
   private _mergeContent(): void {
     const model = this.editor.model;
     const old = this._originalValue;
-    const user = JSON.parse(model.sharedModel.getSource()) as JSONObject;
+    const user = JSON.parse(model.source) as JSONObject;
     const source = this.source;
     if (!source) {
       return;
@@ -308,11 +308,11 @@ export class JSONEditor extends Widget {
     const content = this._source ? this._source.toJSON() : {};
     this._changeGuard = true;
     if (content === void 0) {
-      model.sharedModel.setSource(this._trans.__('No data!'));
+      model.source = this._trans.__('No data!');
       this._originalValue = JSONExt.emptyObject;
     } else {
       const value = JSON.stringify(content, null, 4);
-      model.sharedModel.setSource(value);
+      model.source = value;
       this._originalValue = content;
       // Move the cursor to within the brace.
       if (value.length > 1 && value[0] === '{') {

--- a/packages/codeeditor/src/jsoneditor.ts
+++ b/packages/codeeditor/src/jsoneditor.ts
@@ -75,9 +75,9 @@ export class JSONEditor extends Widget {
 
     const model = new CodeEditor.Model();
 
-    model.value.text = this._trans.__('No data!');
+    model.value = this._trans.__('No data!');
     model.mimeType = 'application/json';
-    model.value.changed.connect(this._onValueChanged, this);
+    model.sharedModel.changed.connect(this._onValueChanged, this);
     this.model = model;
     this.editor = options.editorFactory({ host: this.editorHostNode, model });
     this.editor.setOption('readOnly', true);
@@ -226,7 +226,7 @@ export class JSONEditor extends Widget {
   private _onValueChanged(): void {
     let valid = true;
     try {
-      const value = JSON.parse(this.editor.model.value.text);
+      const value = JSON.parse(this.editor.model.value);
       this.removeClass(ERROR_CLASS);
       this._inputDirty =
         !this._changeGuard && !JSONExt.deepEqual(value, this._originalValue);
@@ -274,7 +274,7 @@ export class JSONEditor extends Widget {
   private _mergeContent(): void {
     const model = this.editor.model;
     const old = this._originalValue;
-    const user = JSON.parse(model.value.text) as JSONObject;
+    const user = JSON.parse(model.value) as JSONObject;
     const source = this.source;
     if (!source) {
       return;
@@ -308,11 +308,11 @@ export class JSONEditor extends Widget {
     const content = this._source ? this._source.toJSON() : {};
     this._changeGuard = true;
     if (content === void 0) {
-      model.value.text = this._trans.__('No data!');
+      model.value = this._trans.__('No data!');
       this._originalValue = JSONExt.emptyObject;
     } else {
       const value = JSON.stringify(content, null, 4);
-      model.value.text = value;
+      model.value = value;
       this._originalValue = content;
       // Move the cursor to within the brace.
       if (value.length > 1 && value[0] === '{') {

--- a/packages/codeeditor/src/widget.ts
+++ b/packages/codeeditor/src/widget.ts
@@ -276,7 +276,7 @@ export class CodeEditorWrapper extends Widget {
       return;
     }
     const offset = this.editor.getOffsetAt(position);
-    this.model.sharedModel.updateSource(offset, offset, data);
+    this.model.updateSource(offset, offset, data);
   }
 
   private _updateOnShow: boolean;

--- a/packages/codeeditor/src/widget.ts
+++ b/packages/codeeditor/src/widget.ts
@@ -276,7 +276,7 @@ export class CodeEditorWrapper extends Widget {
       return;
     }
     const offset = this.editor.getOffsetAt(position);
-    this.model.value.insert(offset, data);
+    this.model.sharedModel.updateSource(offset, offset, data);
   }
 
   private _updateOnShow: boolean;

--- a/packages/codeeditor/test/jsoneditor.spec.ts
+++ b/packages/codeeditor/test/jsoneditor.spec.ts
@@ -106,9 +106,9 @@ describe('codeeditor', () => {
 
       it('should update the text area value', () => {
         const model = editor.model;
-        expect(model.value.text).toBe('No data!');
+        expect(model.sharedModel.getSource()).toBe('No data!');
         editor.source = new ObservableJSON();
-        expect(model.value.text).toBe('{}');
+        expect(model.sharedModel.getSource()).toBe('{}');
       });
     });
 
@@ -116,7 +116,7 @@ describe('codeeditor', () => {
       it('should test whether the editor value is dirty', () => {
         expect(editor.isDirty).toBe(false);
         Widget.attach(editor, document.body);
-        editor.model.value.text = 'a';
+        editor.model.sharedModel.setSource('a');
         expect(editor.isDirty).toBe(true);
       });
 
@@ -140,23 +140,23 @@ describe('codeeditor', () => {
 
     describe('model.value.changed', () => {
       it('should add the error flag if invalid JSON', () => {
-        editor.model.value.text = 'foo';
+        editor.model.sharedModel.setSource('foo');
         expect(editor.hasClass('jp-mod-error')).toBe(true);
       });
 
       it('should show the commit button if the value has changed', () => {
-        editor.model.value.text = '{"foo": 2}';
-        editor.model.value.text = '{"foo": 1}';
+        editor.model.sharedModel.setSource('{"foo": 2}');
+        editor.model.sharedModel.setSource('{"foo": 1}');
         expect(editor.commitButtonNode.hidden).toBe(false);
       });
 
       it('should not show the commit button if the value is invalid', () => {
-        editor.model.value.text = 'foo';
+        editor.model.sharedModel.setSource('foo');
         expect(editor.commitButtonNode.hidden).toBe(true);
       });
 
       it('should show the revert button if the value has changed', () => {
-        editor.model.value.text = 'foo';
+        editor.model.sharedModel.setSource('foo');
         expect(editor.revertButtonNode.hidden).toBe(false);
       });
     });
@@ -178,19 +178,19 @@ describe('codeeditor', () => {
           editor.editor.focus();
           editor.source.set('foo', 1);
           const model = editor.model;
-          expect(model.value.text).toBe('{}');
+          expect(model.sharedModel.getSource()).toBe('{}');
           simulate(editor.editorHostNode, 'blur');
-          expect(model.value.text).toBe('{\n    "foo": 1\n}');
+          expect(model.sharedModel.getSource()).toBe('{\n    "foo": 1\n}');
         });
 
         it('should not revert to current data if there was a change', () => {
           editor.source = new ObservableJSON();
-          editor.model.value.text = 'foo';
+          editor.model.sharedModel.setSource('foo');
           editor.source.set('foo', 1);
           const model = editor.model;
-          expect(model.value.text).toBe('foo');
+          expect(model.sharedModel.getSource()).toBe('foo');
           simulate(editor.editorHostNode, 'blur');
-          expect(model.value.text).toBe('foo');
+          expect(model.sharedModel.getSource()).toBe('foo');
           expect(editor.commitButtonNode.hidden).toBe(true);
           expect(editor.revertButtonNode.hidden).toBe(false);
         });
@@ -204,17 +204,19 @@ describe('codeeditor', () => {
 
         it('should revert the current data', () => {
           editor.source = new ObservableJSON();
-          editor.model.value.text = 'foo';
+          editor.model.sharedModel.setSource('foo');
           simulate(editor.revertButtonNode, 'click');
-          expect(editor.model.value.text).toBe('{}');
+          expect(editor.model.sharedModel.getSource()).toBe('{}');
         });
 
         it('should handle programmatic changes', () => {
           editor.source = new ObservableJSON();
-          editor.model.value.text = 'foo';
+          editor.model.sharedModel.setSource('foo');
           editor.source.set('foo', 1);
           simulate(editor.revertButtonNode, 'click');
-          expect(editor.model.value.text).toBe('{\n    "foo": 1\n}');
+          expect(editor.model.sharedModel.getSource()).toBe(
+            '{\n    "foo": 1\n}'
+          );
         });
 
         it('should handle click events on the commit button', () => {
@@ -224,70 +226,76 @@ describe('codeeditor', () => {
 
         it('should bail if it is not valid JSON', () => {
           editor.source = new ObservableJSON();
-          editor.model.value.text = 'foo';
+          editor.model.sharedModel.setSource('foo');
           editor.source.set('foo', 1);
           simulate(editor.commitButtonNode, 'click');
-          expect(editor.model.value.text).toBe('foo');
+          expect(editor.model.sharedModel.getSource()).toBe('foo');
         });
 
         it('should override a key that was set programmatically', () => {
           editor.source = new ObservableJSON();
-          editor.model.value.text = '{"foo": 2}';
+          editor.model.sharedModel.setSource('{"foo": 2}');
           editor.source.set('foo', 1);
           simulate(editor.commitButtonNode, 'click');
-          expect(editor.model.value.text).toBe('{\n    "foo": 2\n}');
+          expect(editor.model.sharedModel.getSource()).toBe(
+            '{\n    "foo": 2\n}'
+          );
         });
 
         it('should allow a programmatic key to update', () => {
           editor.source = new ObservableJSON();
           editor.source.set('foo', 1);
           editor.source.set('bar', 1);
-          editor.model.value.text = '{"foo":1, "bar": 2}';
+          editor.model.sharedModel.setSource('{"foo":1, "bar": 2}');
           editor.source.set('foo', 2);
           simulate(editor.commitButtonNode, 'click');
           const expected = '{\n    "foo": 2,\n    "bar": 2\n}';
-          expect(editor.model.value.text).toBe(expected);
+          expect(editor.model.sharedModel.getSource()).toBe(expected);
         });
 
         it('should allow a key to be added by the user', () => {
           editor.source = new ObservableJSON();
           editor.source.set('foo', 1);
           editor.source.set('bar', 1);
-          editor.model.value.text = '{"foo":1, "bar": 2, "baz": 3}';
+          editor.model.sharedModel.setSource('{"foo":1, "bar": 2, "baz": 3}');
           editor.source.set('foo', 2);
           simulate(editor.commitButtonNode, 'click');
           const value = '{\n    "foo": 2,\n    "bar": 2,\n    "baz": 3\n}';
-          expect(editor.model.value.text).toBe(value);
+          expect(editor.model.sharedModel.getSource()).toBe(value);
         });
 
         it('should allow a key to be removed by the user', () => {
           editor.source = new ObservableJSON();
           editor.source.set('foo', 1);
           editor.source.set('bar', 1);
-          editor.model.value.text = '{"foo": 1}';
+          editor.model.sharedModel.setSource('{"foo": 1}');
           simulate(editor.commitButtonNode, 'click');
-          expect(editor.model.value.text).toBe('{\n    "foo": 1\n}');
+          expect(editor.model.sharedModel.getSource()).toBe(
+            '{\n    "foo": 1\n}'
+          );
         });
 
         it('should allow a key to be removed programmatically that was not set by the user', () => {
           editor.source = new ObservableJSON();
           editor.source.set('foo', 1);
           editor.source.set('bar', 1);
-          editor.model.value.text = '{"foo": 1, "bar": 3}';
+          editor.model.sharedModel.setSource('{"foo": 1, "bar": 3}');
           editor.source.delete('foo');
           simulate(editor.commitButtonNode, 'click');
-          expect(editor.model.value.text).toBe('{\n    "bar": 3\n}');
+          expect(editor.model.sharedModel.getSource()).toBe(
+            '{\n    "bar": 3\n}'
+          );
         });
 
         it('should keep a key that was removed programmatically that was changed by the user', () => {
           editor.source = new ObservableJSON();
           editor.source.set('foo', 1);
           editor.source.set('bar', 1);
-          editor.model.value.text = '{"foo": 2, "bar": 3}';
+          editor.model.sharedModel.setSource('{"foo": 2, "bar": 3}');
           editor.source.set('foo', null);
           simulate(editor.commitButtonNode, 'click');
           const expected = '{\n    "foo": 2,\n    "bar": 3\n}';
-          expect(editor.model.value.text).toBe(expected);
+          expect(editor.model.sharedModel.getSource()).toBe(expected);
         });
       });
     });
@@ -337,24 +345,24 @@ describe('codeeditor', () => {
       it('should update the value', () => {
         editor.source = new ObservableJSON();
         editor.source.set('foo', 1);
-        expect(editor.model.value.text).toBe('{\n    "foo": 1\n}');
+        expect(editor.model.sharedModel.getSource()).toBe('{\n    "foo": 1\n}');
       });
 
       it('should bail if the input is dirty', () => {
         Widget.attach(editor, document.body);
         editor.source = new ObservableJSON();
-        editor.model.value.text = 'ha';
+        editor.model.sharedModel.setSource('ha');
         editor.source.set('foo', 2);
-        expect(editor.model.value.text).toBe('ha');
+        expect(editor.model.sharedModel.getSource()).toBe('ha');
       });
 
       it('should bail if the input is focused', () => {
         Widget.attach(editor, document.body);
-        editor.model.value.text = '{}';
+        editor.model.sharedModel.setSource('{}');
         editor.source = new ObservableJSON();
         editor.editor.focus();
         editor.source.set('foo', 2);
-        expect(editor.model.value.text).toBe('{}');
+        expect(editor.model.sharedModel.getSource()).toBe('{}');
       });
     });
   });

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -44,7 +44,6 @@
     "@jupyterlab/coreutils": "^6.0.0-alpha.2",
     "@jupyterlab/nbformat": "^4.0.0-alpha.2",
     "@jupyterlab/observables": "^5.0.0-alpha.2",
-    "@jupyterlab/shared-models": "^4.0.0-alpha.2",
     "@jupyterlab/statusbar": "^4.0.0-alpha.2",
     "@jupyterlab/translation": "^4.0.0-alpha.2",
     "@jupyterlab/ui-components": "^4.0.0-alpha.17",

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -6,7 +6,7 @@
 
 import { showDialog } from '@jupyterlab/apputils';
 import { CodeEditor } from '@jupyterlab/codeeditor';
-import { ICollaborator, IObservableMap } from '@jupyterlab/observables';
+import { IObservableMap } from '@jupyterlab/observables';
 import {
   ITranslator,
   nullTranslator,
@@ -58,12 +58,12 @@ const READ_ONLY_CLASS = 'jp-mod-readOnly';
 /**
  * The class name for the hover box for collaborator cursors.
  */
-const COLLABORATOR_CURSOR_CLASS = 'jp-CollaboratorCursor';
+//const COLLABORATOR_CURSOR_CLASS = 'jp-CollaboratorCursor';
 
 /**
  * The class name for the hover box for collaborator cursors.
  */
-const COLLABORATOR_HOVER_CLASS = 'jp-CollaboratorCursor-hover';
+//const COLLABORATOR_HOVER_CLASS = 'jp-CollaboratorCursor-hover';
 
 /**
  * The key code for the up arrow key.
@@ -78,7 +78,7 @@ const DOWN_ARROW = 40;
 /**
  * The time that a collaborator name hover persists.
  */
-const HOVER_TIMEOUT = 1000;
+//const HOVER_TIMEOUT = 1000;
 
 /**
  * CodeMirror editor.
@@ -181,7 +181,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
    */
   private _initializeEditorBinding(): void {
     this._yeditorBinding?.destroy();
-    const sharedModel = this.model.ymodel;
+    const sharedModel = this.model.ymodel!;
     const opts = sharedModel.undoManager
       ? { yUndoManager: sharedModel.undoManager }
       : {};
@@ -799,12 +799,6 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
     if (uuid === this._hoverId) {
       this._clearHover();
     }
-    // If we can id the selection to a specific collaborator,
-    // use that information.
-    let collaborator: ICollaborator | undefined;
-    if (this._model.modelDB.collaborators) {
-      collaborator = this._model.modelDB.collaborators.get(uuid);
-    }
 
     // Style each selection for the uuid.
     selections.forEach(selection => {
@@ -825,22 +819,9 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
           forward ? selection.end : selection.start
         );
         let markerOptions: CodeMirror.TextMarkerOptions;
-        if (collaborator) {
-          markerOptions = this._toTextMarkerOptions({
-            ...selection.style,
-            color: collaborator.color
-          });
-        } else {
-          markerOptions = this._toTextMarkerOptions(selection.style);
-        }
+
+        markerOptions = this._toTextMarkerOptions(selection.style);
         markers.push(this.doc.markText(anchor, head, markerOptions));
-      } else if (collaborator) {
-        const caret = this._getCaret(collaborator);
-        markers.push(
-          this.doc.setBookmark(this._toCodeMirrorPosition(selection.end), {
-            widget: caret
-          })
-        );
       }
     });
     this.selectionMarkers[uuid] = markers;
@@ -994,6 +975,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
    * Construct a caret element representing the position
    * of a collaborator's cursor.
    */
+  /* 
   private _getCaret(collaborator: ICollaborator): HTMLElement {
     // FIXME-TRANS: Is this localizable?
     const name = collaborator ? collaborator.displayName : 'Anonymous';
@@ -1033,7 +1015,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
       }, HOVER_TIMEOUT);
     };
     return caret;
-  }
+  } */
 
   /**
    * Check for an out of sync editor.

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -7,7 +7,6 @@
 import { showDialog } from '@jupyterlab/apputils';
 import { CodeEditor } from '@jupyterlab/codeeditor';
 import { ICollaborator, IObservableMap } from '@jupyterlab/observables';
-import * as models from '@jupyterlab/shared-models';
 import {
   ITranslator,
   nullTranslator,
@@ -182,7 +181,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
    */
   private _initializeEditorBinding(): void {
     this._yeditorBinding?.destroy();
-    const sharedModel = this.model.sharedModel as models.IYText;
+    const sharedModel = this.model.ymodel;
     const opts = sharedModel.undoManager
       ? { yUndoManager: sharedModel.undoManager }
       : {};
@@ -366,14 +365,14 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
    * Undo one edit (if any undo events are stored).
    */
   undo(): void {
-    this.model.sharedModel.undo();
+    this.model.undo();
   }
 
   /**
    * Redo one undone edit.
    */
   redo(): void {
-    this.model.sharedModel.redo();
+    this.model.redo();
   }
 
   /**
@@ -1047,7 +1046,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
     this._lastChange = null;
     const editor = this._editor;
     const doc = editor.getDoc();
-    if (doc.getValue() === this._model.sharedModel.getSource()) {
+    if (doc.getValue() === this._model.source) {
       return;
     }
 
@@ -1062,7 +1061,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
     );
     console.warn(
       JSON.stringify({
-        model: this._model.sharedModel.getSource(),
+        model: this._model.source,
         view: doc.getValue(),
         selections: this.getSelections(),
         cursor: this.getCursorPosition(),

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1047,7 +1047,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
     this._lastChange = null;
     const editor = this._editor;
     const doc = editor.getDoc();
-    if (doc.getValue() === this._model.value) {
+    if (doc.getValue() === this._model.sharedModel.getSource()) {
       return;
     }
 
@@ -1062,7 +1062,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
     );
     console.warn(
       JSON.stringify({
-        model: this._model.value,
+        model: this._model.sharedModel.getSource(),
         view: doc.getValue(),
         selections: this.getSelections(),
         cursor: this.getCursorPosition(),

--- a/packages/codemirror/test/editor.spec.ts
+++ b/packages/codemirror/test/editor.spec.ts
@@ -113,7 +113,7 @@ describe('CodeMirrorEditor', () => {
   describe('#lineCount', () => {
     it('should get the number of lines in the editor', () => {
       expect(editor.lineCount).toBe(1);
-      editor.model.value.text = 'foo\nbar\nbaz';
+      editor.model.sharedModel.setSource('foo\nbar\nbaz');
       expect(editor.lineCount).toBe(3);
     });
   });
@@ -187,7 +187,7 @@ describe('CodeMirrorEditor', () => {
 
   describe('#getLine()', () => {
     it('should get a line of text', () => {
-      model.value.text = 'foo\nbar';
+      model.sharedModel.setSource('foo\nbar');
       expect(editor.getLine(0)).toBe('foo');
       expect(editor.getLine(1)).toBe('bar');
       expect(editor.getLine(2)).toBeUndefined();
@@ -196,7 +196,7 @@ describe('CodeMirrorEditor', () => {
 
   describe('#getOffsetAt()', () => {
     it('should get the offset for a given position', () => {
-      model.value.text = 'foo\nbar';
+      model.sharedModel.setSource('foo\nbar');
       let pos = {
         column: 2,
         line: 1
@@ -212,7 +212,7 @@ describe('CodeMirrorEditor', () => {
 
   describe('#getPositionAt()', () => {
     it('should get the position for a given offset', () => {
-      model.value.text = 'foo\nbar';
+      model.sharedModel.setSource('foo\nbar');
       let pos = editor.getPositionAt(6);
       expect(pos.column).toBe(2);
       expect(pos.line).toBe(1);
@@ -224,27 +224,27 @@ describe('CodeMirrorEditor', () => {
 
   describe('#undo()', () => {
     it('should undo one edit', () => {
-      model.value.text = 'foo';
+      model.sharedModel.setSource('foo');
       editor.undo();
-      expect(model.value.text).toBe('');
+      expect(model.sharedModel.getSource()).toBe('');
     });
   });
 
   describe('#redo()', () => {
     it('should redo one undone edit', () => {
-      model.value.text = 'foo';
+      model.sharedModel.setSource('foo');
       editor.undo();
       editor.redo();
-      expect(model.value.text).toBe('foo');
+      expect(model.sharedModel.getSource()).toBe('foo');
     });
   });
 
   describe('#clearHistory()', () => {
     it('should clear the undo history', () => {
-      model.value.text = 'foo';
+      model.sharedModel.setSource('foo');
       editor.clearHistory();
       editor.undo();
-      expect(model.value.text).toBe('foo');
+      expect(model.sharedModel.getSource()).toBe('foo');
     });
   });
 
@@ -328,7 +328,7 @@ describe('CodeMirrorEditor', () => {
 
   describe('#revealPosition()', () => {
     it('should reveal the given position in the editor', () => {
-      model.value.text = TEXT;
+      model.sharedModel.setSource(TEXT);
       editor.revealPosition({ line: 50, column: 0 });
       expect(editor).toBeTruthy();
     });
@@ -336,7 +336,7 @@ describe('CodeMirrorEditor', () => {
 
   describe('#revealSelection()', () => {
     it('should reveal the given selection in the editor', () => {
-      model.value.text = TEXT;
+      model.sharedModel.setSource(TEXT);
       const start = { line: 50, column: 0 };
       const end = { line: 52, column: 0 };
       editor.setSelection({ start, end });
@@ -347,7 +347,7 @@ describe('CodeMirrorEditor', () => {
 
   describe('#getCoordinateForPosition()', () => {
     it('should get the window coordinates given a cursor position', () => {
-      model.value.text = TEXT;
+      model.sharedModel.setSource(TEXT);
       const coord = editor.getCoordinateForPosition({ line: 10, column: 1 });
       if (typeof process !== 'undefined') {
         // eslint-disable-next-line jest/no-conditional-expect
@@ -361,7 +361,7 @@ describe('CodeMirrorEditor', () => {
 
   describe('#getPositionForCoordinate()', () => {
     it('should get the window coordinates given a cursor position', () => {
-      model.value.text = TEXT;
+      model.sharedModel.setSource(TEXT);
       const coord = editor.getCoordinateForPosition({ line: 10, column: 1 });
       const newPos = editor.getPositionForCoordinate(coord)!;
       expect(newPos.line).toBeTruthy();
@@ -371,7 +371,7 @@ describe('CodeMirrorEditor', () => {
 
   describe('#getCursorPosition()', () => {
     it('should get the primary position of the cursor', () => {
-      model.value.text = TEXT;
+      model.sharedModel.setSource(TEXT);
       let pos = editor.getCursorPosition();
       expect(pos.line).toBe(0);
       expect(pos.column).toBe(0);
@@ -385,7 +385,7 @@ describe('CodeMirrorEditor', () => {
 
   describe('#setCursorPosition()', () => {
     it('should set the primary position of the cursor', () => {
-      model.value.text = TEXT;
+      model.sharedModel.setSource(TEXT);
       editor.setCursorPosition({ line: 12, column: 3 });
       const pos = editor.getCursorPosition();
       expect(pos.line).toBe(12);
@@ -403,7 +403,7 @@ describe('CodeMirrorEditor', () => {
 
   describe('#setSelection()', () => {
     it('should set the primary selection of the editor', () => {
-      model.value.text = TEXT;
+      model.sharedModel.setSource(TEXT);
       const start = { line: 50, column: 0 };
       const end = { line: 52, column: 0 };
       editor.setSelection({ start, end });
@@ -412,7 +412,7 @@ describe('CodeMirrorEditor', () => {
     });
 
     it('should remove any secondary cursors', () => {
-      model.value.text = TEXT;
+      model.sharedModel.setSource(TEXT);
       const range0 = {
         start: { line: 50, column: 0 },
         end: { line: 52, column: 0 }
@@ -429,7 +429,7 @@ describe('CodeMirrorEditor', () => {
 
   describe('#getSelections()', () => {
     it('should get the selections for all the cursors', () => {
-      model.value.text = TEXT;
+      model.sharedModel.setSource(TEXT);
       const range0 = {
         start: { line: 50, column: 0 },
         end: { line: 52, column: 0 }
@@ -447,7 +447,7 @@ describe('CodeMirrorEditor', () => {
 
   describe('#setSelections()', () => {
     it('should set the selections for all the cursors', () => {
-      model.value.text = TEXT;
+      model.sharedModel.setSource(TEXT);
       const range0 = {
         start: { line: 50, column: 0 },
         end: { line: 52, column: 0 }
@@ -463,7 +463,7 @@ describe('CodeMirrorEditor', () => {
     });
 
     it('should set a default selection for an empty array', () => {
-      model.value.text = TEXT;
+      model.sharedModel.setSource(TEXT);
       editor.setSelections([]);
       const selection = editor.getSelection();
       expect(selection.start.line).toBe(0);

--- a/packages/codemirror/tsconfig.json
+++ b/packages/codemirror/tsconfig.json
@@ -22,9 +22,6 @@
       "path": "../observables"
     },
     {
-      "path": "../shared-models"
-    },
-    {
       "path": "../statusbar"
     },
     {

--- a/packages/codemirror/tsconfig.test.json
+++ b/packages/codemirror/tsconfig.test.json
@@ -18,9 +18,6 @@
       "path": "../observables"
     },
     {
-      "path": "../shared-models"
-    },
-    {
       "path": "../statusbar"
     },
     {

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -161,7 +161,7 @@ export class CompletionHandler implements IDisposable {
     position: CodeEditor.IPosition
   ): Completer.ITextState {
     return {
-      text: editor.model.value,
+      text: editor.model.sharedModel.getSource(),
       lineHeight: editor.lineHeight,
       charWidth: editor.charWidth,
       line: position.line,
@@ -351,7 +351,7 @@ export class CompletionHandler implements IDisposable {
       return Promise.reject(new Error('No active editor'));
     }
 
-    const text = editor.model.value;
+    const text = editor.model.sharedModel.getSource();
     const offset = Text.jsIndexToCharIndex(editor.getOffsetAt(position), text);
     const pending = ++this._pending;
     const state = this.getState(editor, position);

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -95,7 +95,7 @@ export class CompletionHandler implements IDisposable {
       editor.host.classList.remove(COMPLETER_ENABLED_CLASS);
       editor.host.classList.remove(COMPLETER_ACTIVE_CLASS);
       model.selections.changed.disconnect(this.onSelectionsChanged, this);
-      model.sharedModel.changed.disconnect(this.onTextChanged, this);
+      model.sourceChanged.disconnect(this.onTextChanged, this);
     }
 
     // Reset completer state.
@@ -109,7 +109,7 @@ export class CompletionHandler implements IDisposable {
 
       this._enabled = false;
       model.selections.changed.connect(this.onSelectionsChanged, this);
-      model.sharedModel.changed.connect(this.onTextChanged, this);
+      model.sourceChanged.connect(this.onTextChanged, this);
       // On initial load, manually check the cursor position.
       this.onSelectionsChanged();
     }
@@ -161,7 +161,7 @@ export class CompletionHandler implements IDisposable {
     position: CodeEditor.IPosition
   ): Completer.ITextState {
     return {
-      text: editor.model.sharedModel.getSource(),
+      text: editor.model.source,
       lineHeight: editor.lineHeight,
       charWidth: editor.charWidth,
       line: position.line,
@@ -188,7 +188,7 @@ export class CompletionHandler implements IDisposable {
     const { start, end, value } = patch;
     const cursorBeforeChange = editor.getOffsetAt(editor.getCursorPosition());
     // we need to update the shared model in a single transaction so that the undo manager works as expected
-    editor.model.sharedModel.updateSource(start, end, value);
+    editor.model.updateSource(start, end, value);
     if (cursorBeforeChange <= end && cursorBeforeChange >= start) {
       editor.setCursorPosition(editor.getPositionAt(start + value.length)!);
     }
@@ -351,7 +351,7 @@ export class CompletionHandler implements IDisposable {
       return Promise.reject(new Error('No active editor'));
     }
 
-    const text = editor.model.sharedModel.getSource();
+    const text = editor.model.source;
     const offset = Text.jsIndexToCharIndex(editor.getOffsetAt(position), text);
     const pending = ++this._pending;
     const state = this.getState(editor, position);

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -95,7 +95,7 @@ export class CompletionHandler implements IDisposable {
       editor.host.classList.remove(COMPLETER_ENABLED_CLASS);
       editor.host.classList.remove(COMPLETER_ACTIVE_CLASS);
       model.selections.changed.disconnect(this.onSelectionsChanged, this);
-      model.value.changed.disconnect(this.onTextChanged, this);
+      model.sharedModel.changed.disconnect(this.onTextChanged, this);
     }
 
     // Reset completer state.
@@ -109,7 +109,7 @@ export class CompletionHandler implements IDisposable {
 
       this._enabled = false;
       model.selections.changed.connect(this.onSelectionsChanged, this);
-      model.value.changed.connect(this.onTextChanged, this);
+      model.sharedModel.changed.connect(this.onTextChanged, this);
       // On initial load, manually check the cursor position.
       this.onSelectionsChanged();
     }
@@ -161,7 +161,7 @@ export class CompletionHandler implements IDisposable {
     position: CodeEditor.IPosition
   ): Completer.ITextState {
     return {
-      text: editor.model.value.text,
+      text: editor.model.value,
       lineHeight: editor.lineHeight,
       charWidth: editor.charWidth,
       line: position.line,
@@ -351,7 +351,7 @@ export class CompletionHandler implements IDisposable {
       return Promise.reject(new Error('No active editor'));
     }
 
-    const text = editor.model.value.text;
+    const text = editor.model.value;
     const offset = Text.jsIndexToCharIndex(editor.getOffsetAt(position), text);
     const pending = ++this._pending;
     const state = this.getState(editor, position);

--- a/packages/completer/test/handler.spec.ts
+++ b/packages/completer/test/handler.spec.ts
@@ -177,7 +177,7 @@ describe('@jupyterlab/completer', () => {
         expect(handler.methods).toEqual(
           expect.not.arrayContaining(['onTextChanged'])
         );
-        handler.editor.model.value.text = 'foo';
+        handler.editor.model.sharedModel.setSource('foo');
         expect(handler.methods).toEqual(
           expect.arrayContaining(['onTextChanged'])
         );
@@ -196,11 +196,14 @@ describe('@jupyterlab/completer', () => {
         expect(model.methods).toEqual(
           expect.not.arrayContaining(['handleTextChange'])
         );
-        editor.model.value.text = 'bar';
+        editor.model.sharedModel.setSource('bar');
         editor.setCursorPosition({ line: 0, column: 2 });
         // This signal is emitted (again) because the cursor position that
         // a natural user would create need to be recreated here.
-        (editor.model.value.changed as any).emit({ type: 'set', value: 'bar' });
+        (editor.model.sharedModel.changed as any).emit({
+          type: 'set',
+          value: 'bar'
+        });
         expect(model.methods).toEqual(
           expect.arrayContaining(['handleTextChange'])
         );
@@ -257,12 +260,12 @@ describe('@jupyterlab/completer', () => {
         };
 
         handler.editor = editor;
-        handler.editor.model.value.text = text;
+        handler.editor.model.sharedModel.setSource(text);
         handler.editor.setCursorPosition({ line, column: column + 3 });
         model.original = request;
         model.cursor = { start: column, end: column + 3 };
         (completer.selected as any).emit(patch);
-        expect(handler.editor.model.value.text).toBe(want);
+        expect(handler.editor.model.sharedModel.getSource()).toBe(want);
         expect(handler.editor.getCursorPosition()).toEqual({
           line,
           column: column + 6
@@ -289,14 +292,14 @@ describe('@jupyterlab/completer', () => {
         };
 
         handler.editor = editor;
-        handler.editor.model.value.text = text;
+        handler.editor.model.sharedModel.setSource(text);
         handler.editor.model.sharedModel.clearUndoHistory();
         handler.editor.setCursorPosition({ line, column: column + 3 });
         model.original = request;
         model.cursor = { start: column, end: column + 3 };
         // Make the completion, check its value and cursor position.
         (completer.selected as any).emit(patch);
-        expect(editor.model.value.text).toBe(want);
+        expect(editor.model.sharedModel.getSource()).toBe(want);
         expect(editor.getCursorPosition()).toEqual({
           line,
           column: column + 6
@@ -304,7 +307,7 @@ describe('@jupyterlab/completer', () => {
         console.warn(editor.getCursorPosition());
         // Undo the completion, check its value and cursor position.
         editor.undo();
-        expect(editor.model.value.text).toBe(text);
+        expect(editor.model.sharedModel.getSource()).toBe(text);
         expect(editor.getCursorPosition()).toEqual({
           line,
           column: column + 3
@@ -312,7 +315,7 @@ describe('@jupyterlab/completer', () => {
         console.warn(editor.getCursorPosition());
         // Redo the completion, check its value and cursor position.
         editor.redo();
-        expect(editor.model.value.text).toBe(want);
+        expect(editor.model.sharedModel.getSource()).toBe(want);
         expect(editor.getCursorPosition()).toEqual({
           line,
           column: column + 6
@@ -341,7 +344,7 @@ describe('@jupyterlab/completer', () => {
       };
 
       handler.editor = editor;
-      handler.editor.model.value.text = text;
+      handler.editor.model.sharedModel.setSource(text);
       handler.editor.model.sharedModel.clearUndoHistory();
       handler.editor.setCursorPosition({ line, column });
       model.original = request;
@@ -349,7 +352,7 @@ describe('@jupyterlab/completer', () => {
       model.cursor = { start: offset, end: offset };
       // Make the completion, check its value and cursor position.
       (completer.selected as any).emit(patch);
-      expect(editor.model.value.text).toBe(want);
+      expect(editor.model.sharedModel.getSource()).toBe(want);
       expect(editor.getCursorPosition()).toEqual({
         line,
         column: column + 6

--- a/packages/completer/test/widget.spec.ts
+++ b/packages/completer/test/widget.spec.ts
@@ -243,7 +243,7 @@ describe('completer/widget', () => {
         const model = new CompleterModel();
         let called = false;
 
-        editor.model.value.text = 'a';
+        editor.model.sharedModel.setSource('a');
         panel.node.style.position = 'absolute';
         panel.node.style.top = '0px';
         panel.node.style.left = '0px';
@@ -293,7 +293,7 @@ describe('completer/widget', () => {
         let model = new CompleterModel();
         let called = false;
 
-        editor.model.value.text = 'a';
+        editor.model.sharedModel.setSource('a');
         panel.node.style.position = 'absolute';
         panel.node.style.top = '0px';
         panel.node.style.left = '0px';
@@ -1486,7 +1486,7 @@ describe('completer/widget', () => {
           code.node.style.height = '5000px';
           code.node.style.width = '400px';
           code.node.style.background = 'yellow';
-          editor.model.value.text = text;
+          editor.model.sharedModel.setSource(text);
 
           panel.node.style.background = 'red';
           panel.node.style.height = '2000px';

--- a/packages/console/src/foreign.ts
+++ b/packages/console/src/foreign.ts
@@ -99,7 +99,7 @@ export class ForeignHandler implements IDisposable {
         cell = this._newCell(parentMsgId);
         const model = cell.model;
         model.executionCount = inputMsg.content.execution_count;
-        model.value = inputMsg.content.code;
+        model.sharedModel.setSource(inputMsg.content.code);
         model.trusted = true;
         parent.update();
         return true;

--- a/packages/console/src/foreign.ts
+++ b/packages/console/src/foreign.ts
@@ -99,7 +99,7 @@ export class ForeignHandler implements IDisposable {
         cell = this._newCell(parentMsgId);
         const model = cell.model;
         model.executionCount = inputMsg.content.execution_count;
-        model.value.text = inputMsg.content.code;
+        model.value = inputMsg.content.code;
         model.trusted = true;
         parent.update();
         return true;

--- a/packages/console/src/foreign.ts
+++ b/packages/console/src/foreign.ts
@@ -99,7 +99,7 @@ export class ForeignHandler implements IDisposable {
         cell = this._newCell(parentMsgId);
         const model = cell.model;
         model.executionCount = inputMsg.content.execution_count;
-        model.sharedModel.setSource(inputMsg.content.code);
+        model.source = inputMsg.content.code;
         model.trusted = true;
         parent.update();
         return true;

--- a/packages/console/src/history.ts
+++ b/packages/console/src/history.ts
@@ -251,18 +251,18 @@ export class ConsoleHistory implements IConsoleHistory {
     location: CodeEditor.EdgeLocation
   ): void {
     const model = editor.model;
-    const source = model.value;
+    const source = model.sharedModel.getSource();
 
     if (location === 'top' || location === 'topLine') {
       void this.back(source).then(value => {
         if (this.isDisposed || !value) {
           return;
         }
-        if (model.value === value) {
+        if (model.sharedModel.getSource() === value) {
           return;
         }
         this._setByHistory = true;
-        model.value = value;
+        model.sharedModel.setSource(value);
         let columnPos = 0;
         columnPos = value.indexOf('\n');
         if (columnPos < 0) {
@@ -276,11 +276,11 @@ export class ConsoleHistory implements IConsoleHistory {
           return;
         }
         const text = value || this.placeholder;
-        if (model.value === text) {
+        if (model.sharedModel.getSource() === text) {
           return;
         }
         this._setByHistory = true;
-        model.value = value;
+        model.sharedModel.setSource(value);
         const pos = editor.getPositionAt(text.length);
         if (pos) {
           editor.setCursorPosition(pos);

--- a/packages/console/src/history.ts
+++ b/packages/console/src/history.ts
@@ -98,14 +98,14 @@ export class ConsoleHistory implements IConsoleHistory {
     const prev = this._editor;
     if (prev) {
       prev.edgeRequested.disconnect(this.onEdgeRequest, this);
-      prev.model.sharedModel.changed.disconnect(this.onTextChange, this);
+      prev.model.sourceChanged.disconnect(this.onTextChange, this);
     }
 
     this._editor = value;
 
     if (value) {
       value.edgeRequested.connect(this.onEdgeRequest, this);
-      value.model.sharedModel.changed.connect(this.onTextChange, this);
+      value.model.sourceChanged.connect(this.onTextChange, this);
     }
   }
 
@@ -251,18 +251,18 @@ export class ConsoleHistory implements IConsoleHistory {
     location: CodeEditor.EdgeLocation
   ): void {
     const model = editor.model;
-    const source = model.sharedModel.getSource();
+    const source = model.source;
 
     if (location === 'top' || location === 'topLine') {
       void this.back(source).then(value => {
         if (this.isDisposed || !value) {
           return;
         }
-        if (model.sharedModel.getSource() === value) {
+        if (model.source === value) {
           return;
         }
         this._setByHistory = true;
-        model.sharedModel.setSource(value);
+        model.source = value;
         let columnPos = 0;
         columnPos = value.indexOf('\n');
         if (columnPos < 0) {
@@ -276,11 +276,11 @@ export class ConsoleHistory implements IConsoleHistory {
           return;
         }
         const text = value || this.placeholder;
-        if (model.sharedModel.getSource() === text) {
+        if (model.source === text) {
           return;
         }
         this._setByHistory = true;
-        model.sharedModel.setSource(value);
+        model.source = value;
         const pos = editor.getPositionAt(text.length);
         if (pos) {
           editor.setCursorPosition(pos);

--- a/packages/console/src/history.ts
+++ b/packages/console/src/history.ts
@@ -98,14 +98,14 @@ export class ConsoleHistory implements IConsoleHistory {
     const prev = this._editor;
     if (prev) {
       prev.edgeRequested.disconnect(this.onEdgeRequest, this);
-      prev.model.value.changed.disconnect(this.onTextChange, this);
+      prev.model.sharedModel.changed.disconnect(this.onTextChange, this);
     }
 
     this._editor = value;
 
     if (value) {
       value.edgeRequested.connect(this.onEdgeRequest, this);
-      value.model.value.changed.connect(this.onTextChange, this);
+      value.model.sharedModel.changed.connect(this.onTextChange, this);
     }
   }
 
@@ -251,18 +251,18 @@ export class ConsoleHistory implements IConsoleHistory {
     location: CodeEditor.EdgeLocation
   ): void {
     const model = editor.model;
-    const source = model.value.text;
+    const source = model.value;
 
     if (location === 'top' || location === 'topLine') {
       void this.back(source).then(value => {
         if (this.isDisposed || !value) {
           return;
         }
-        if (model.value.text === value) {
+        if (model.value === value) {
           return;
         }
         this._setByHistory = true;
-        model.value.text = value;
+        model.value = value;
         let columnPos = 0;
         columnPos = value.indexOf('\n');
         if (columnPos < 0) {
@@ -276,11 +276,11 @@ export class ConsoleHistory implements IConsoleHistory {
           return;
         }
         const text = value || this.placeholder;
-        if (model.value.text === text) {
+        if (model.value === text) {
           return;
         }
         this._setByHistory = true;
-        model.value.text = text;
+        model.value = value;
         const pos = editor.getPositionAt(text.length);
         if (pos) {
           editor.setCursorPosition(pos);

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -219,7 +219,7 @@ export class CodeConsole extends Widget {
     }
     // Create the banner.
     const model = this.modelFactory.createRawCell({});
-    model.sharedModel.setSource('...');
+    model.source = '...';
     const banner = (this._banner = new RawCell({
       model,
       contentFactory: this.contentFactory,
@@ -331,7 +331,7 @@ export class CodeConsole extends Widget {
    */
   inject(code: string, metadata: JSONObject = {}): Promise<void> {
     const cell = this.createCodeCell();
-    cell.model.sharedModel.setSource(code);
+    cell.model.source = code;
     for (const key of Object.keys(metadata)) {
       cell.model.metadata.set(key, metadata[key]);
     }
@@ -486,7 +486,7 @@ export class CodeConsole extends Widget {
     });
 
     this._drag.mimeData.setData(JUPYTER_CELL_MIME, selected);
-    const textContent = cellModel.sharedModel.getSource();
+    const textContent = cellModel.source;
     this._drag.mimeData.setData('text/plain', textContent);
 
     this._focusedCell = null;
@@ -645,7 +645,7 @@ export class CodeConsole extends Widget {
    * Execute the code in the current prompt cell.
    */
   private _execute(cell: CodeCell): Promise<void> {
-    const source = cell.model.sharedModel.getSource();
+    const source = cell.model.source;
     this._history.push(source);
     // If the source of the console is just "clear", clear the console as we
     // do in IPython or QtConsole.
@@ -668,7 +668,7 @@ export class CodeConsole extends Widget {
           if (setNextInput) {
             const text = (setNextInput as any).text;
             // Ignore the `replace` value and always set the next cell.
-            cell.model.sharedModel.setSource(text);
+            cell.model.source = text;
           }
         }
       } else if (value && value.content.status === 'error') {
@@ -700,12 +700,10 @@ export class CodeConsole extends Widget {
    */
   private _handleInfo(info: KernelMessage.IInfoReplyMsg['content']): void {
     if (info.status !== 'ok') {
-      this._banner!.model.sharedModel.setSource(
-        'Error in getting kernel banner'
-      );
+      this._banner!.model.source = 'Error in getting kernel banner';
       return;
     }
-    this._banner!.model.sharedModel.setSource(info.banner);
+    this._banner!.model.source = info.banner;
     const lang = info.language_info as nbformat.ILanguageInfoMetadata;
     this._mimetype = this._mimeTypeService.getMimeTypeByLanguage(lang);
     if (this.promptCell) {
@@ -747,7 +745,7 @@ export class CodeConsole extends Widget {
       return Promise.resolve(false);
     }
     const model = promptCell.model;
-    const code = model.sharedModel.getSource();
+    const code = model.source;
     return new Promise<boolean>((resolve, reject) => {
       const timer = setTimeout(() => {
         resolve(true);

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -219,7 +219,7 @@ export class CodeConsole extends Widget {
     }
     // Create the banner.
     const model = this.modelFactory.createRawCell({});
-    model.value = '...';
+    model.sharedModel.setSource('...');
     const banner = (this._banner = new RawCell({
       model,
       contentFactory: this.contentFactory,
@@ -331,7 +331,7 @@ export class CodeConsole extends Widget {
    */
   inject(code: string, metadata: JSONObject = {}): Promise<void> {
     const cell = this.createCodeCell();
-    cell.model.value = code;
+    cell.model.sharedModel.setSource(code);
     for (const key of Object.keys(metadata)) {
       cell.model.metadata.set(key, metadata[key]);
     }
@@ -486,7 +486,7 @@ export class CodeConsole extends Widget {
     });
 
     this._drag.mimeData.setData(JUPYTER_CELL_MIME, selected);
-    const textContent = cellModel.value;
+    const textContent = cellModel.sharedModel.getSource();
     this._drag.mimeData.setData('text/plain', textContent);
 
     this._focusedCell = null;
@@ -645,7 +645,7 @@ export class CodeConsole extends Widget {
    * Execute the code in the current prompt cell.
    */
   private _execute(cell: CodeCell): Promise<void> {
-    const source = cell.model.value;
+    const source = cell.model.sharedModel.getSource();
     this._history.push(source);
     // If the source of the console is just "clear", clear the console as we
     // do in IPython or QtConsole.
@@ -668,7 +668,7 @@ export class CodeConsole extends Widget {
           if (setNextInput) {
             const text = (setNextInput as any).text;
             // Ignore the `replace` value and always set the next cell.
-            cell.model.value = text;
+            cell.model.sharedModel.setSource(text);
           }
         }
       } else if (value && value.content.status === 'error') {
@@ -700,10 +700,12 @@ export class CodeConsole extends Widget {
    */
   private _handleInfo(info: KernelMessage.IInfoReplyMsg['content']): void {
     if (info.status !== 'ok') {
-      this._banner!.model.value = 'Error in getting kernel banner';
+      this._banner!.model.sharedModel.setSource(
+        'Error in getting kernel banner'
+      );
       return;
     }
-    this._banner!.model.value = info.banner;
+    this._banner!.model.sharedModel.setSource(info.banner);
     const lang = info.language_info as nbformat.ILanguageInfoMetadata;
     this._mimetype = this._mimeTypeService.getMimeTypeByLanguage(lang);
     if (this.promptCell) {
@@ -745,7 +747,7 @@ export class CodeConsole extends Widget {
       return Promise.resolve(false);
     }
     const model = promptCell.model;
-    const code = model.value;
+    const code = model.sharedModel.getSource();
     return new Promise<boolean>((resolve, reject) => {
       const timer = setTimeout(() => {
         resolve(true);

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -219,7 +219,7 @@ export class CodeConsole extends Widget {
     }
     // Create the banner.
     const model = this.modelFactory.createRawCell({});
-    model.value.text = '...';
+    model.value = '...';
     const banner = (this._banner = new RawCell({
       model,
       contentFactory: this.contentFactory,
@@ -331,7 +331,7 @@ export class CodeConsole extends Widget {
    */
   inject(code: string, metadata: JSONObject = {}): Promise<void> {
     const cell = this.createCodeCell();
-    cell.model.value.text = code;
+    cell.model.value = code;
     for (const key of Object.keys(metadata)) {
       cell.model.metadata.set(key, metadata[key]);
     }
@@ -486,7 +486,7 @@ export class CodeConsole extends Widget {
     });
 
     this._drag.mimeData.setData(JUPYTER_CELL_MIME, selected);
-    const textContent = cellModel.value.text;
+    const textContent = cellModel.value;
     this._drag.mimeData.setData('text/plain', textContent);
 
     this._focusedCell = null;
@@ -645,7 +645,7 @@ export class CodeConsole extends Widget {
    * Execute the code in the current prompt cell.
    */
   private _execute(cell: CodeCell): Promise<void> {
-    const source = cell.model.value.text;
+    const source = cell.model.value;
     this._history.push(source);
     // If the source of the console is just "clear", clear the console as we
     // do in IPython or QtConsole.
@@ -668,7 +668,7 @@ export class CodeConsole extends Widget {
           if (setNextInput) {
             const text = (setNextInput as any).text;
             // Ignore the `replace` value and always set the next cell.
-            cell.model.value.text = text;
+            cell.model.value = text;
           }
         }
       } else if (value && value.content.status === 'error') {
@@ -700,10 +700,10 @@ export class CodeConsole extends Widget {
    */
   private _handleInfo(info: KernelMessage.IInfoReplyMsg['content']): void {
     if (info.status !== 'ok') {
-      this._banner!.model.value.text = 'Error in getting kernel banner';
+      this._banner!.model.value = 'Error in getting kernel banner';
       return;
     }
-    this._banner!.model.value.text = info.banner;
+    this._banner!.model.value = info.banner;
     const lang = info.language_info as nbformat.ILanguageInfoMetadata;
     this._mimetype = this._mimeTypeService.getMimeTypeByLanguage(lang);
     if (this.promptCell) {
@@ -745,7 +745,7 @@ export class CodeConsole extends Widget {
       return Promise.resolve(false);
     }
     const model = promptCell.model;
-    const code = model.value.text;
+    const code = model.value;
     return new Promise<boolean>((resolve, reject) => {
       const timer = setTimeout(() => {
         resolve(true);

--- a/packages/console/test/history.spec.ts
+++ b/packages/console/test/history.spec.ts
@@ -165,7 +165,7 @@ describe('console/history', () => {
         const host = document.createElement('div');
         const editor = new CodeMirrorEditor({ model, host });
         history.editor = editor;
-        model.value.text = 'foo';
+        model.sharedModel.setSource('foo');
         expect(history.methods).toEqual(
           expect.arrayContaining(['onTextChange'])
         );
@@ -183,13 +183,13 @@ describe('console/history', () => {
         const editor = new CodeMirrorEditor({ model, host });
         history.editor = editor;
         history.push('foo');
-        const promise = signalToPromise(editor.model.value.changed);
+        const promise = signalToPromise(editor.model.sharedModel.changed);
         editor.edgeRequested.emit('top');
         expect(history.methods).toEqual(
           expect.arrayContaining(['onEdgeRequest'])
         );
         await promise;
-        expect(editor.model.value.text).toBe('foo');
+        expect(editor.model.sharedModel.getSource()).toBe('foo');
       });
     });
   });

--- a/packages/console/test/widget.spec.ts
+++ b/packages/console/test/widget.spec.ts
@@ -164,7 +164,7 @@ describe('console/widget', () => {
         expect(widget.cells.length).toBeGreaterThan(0);
         widget.clear();
         expect(widget.cells.length).toBe(0);
-        expect(widget.promptCell!.model.value.text).toBe('');
+        expect(widget.promptCell!.model.sharedModel.getSource()).toBe('');
       });
     });
 
@@ -199,7 +199,7 @@ describe('console/widget', () => {
         const force = false;
         const timeout = 9000;
         Widget.attach(widget, document.body);
-        widget.promptCell!.model.value.text = 'for x in range(5):';
+        widget.promptCell!.model.sharedModel.setSource('for x in range(5):');
         expect(widget.cells.length).toBe(0);
         const session = widget.sessionContext as SessionContext;
         session.kernelPreference = { name: 'ipython' };
@@ -224,16 +224,16 @@ describe('console/widget', () => {
         Widget.attach(widget, document.body);
 
         const model = widget.promptCell!.model;
-        expect(model.value.text).toHaveLength(0);
+        expect(model.sharedModel.getSource()).toHaveLength(0);
         widget.insertLinebreak();
-        expect(model.value.text).toBe('\n');
+        expect(model.sharedModel.getSource()).toBe('\n');
       });
     });
 
     describe('#serialize()', () => {
       it('should serialize the contents of a console', () => {
         Widget.attach(widget, document.body);
-        widget.promptCell!.model.value.text = 'foo';
+        widget.promptCell!.model.sharedModel.setSource('foo');
 
         const serialized = widget.serialize();
         expect(serialized).toHaveLength(1);

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -61,6 +61,7 @@
     "@jupyterlab/observables": "^5.0.0-alpha.2",
     "@jupyterlab/rendermime": "^4.0.0-alpha.2",
     "@jupyterlab/services": "^7.0.0-alpha.2",
+    "@jupyterlab/shared-models": "^4.0.0-alpha.2",
     "@jupyterlab/translation": "^4.0.0-alpha.2",
     "@jupyterlab/ui-components": "^4.0.0-alpha.17",
     "@lumino/algorithm": "^1.9.1",

--- a/packages/debugger/src/dialogs/evaluate.ts
+++ b/packages/debugger/src/dialogs/evaluate.ts
@@ -117,7 +117,7 @@ class EvaluateDialogBody extends Widget implements Dialog.IBodyWidget<string> {
    * Get the text specified by the user
    */
   getValue(): string {
-    return this._prompt.model.sharedModel.getSource();
+    return this._prompt.model.source;
   }
 
   /**

--- a/packages/debugger/src/dialogs/evaluate.ts
+++ b/packages/debugger/src/dialogs/evaluate.ts
@@ -117,7 +117,7 @@ class EvaluateDialogBody extends Widget implements Dialog.IBodyWidget<string> {
    * Get the text specified by the user
    */
   getValue(): string {
-    return this._prompt.model.value;
+    return this._prompt.model.sharedModel.getSource();
   }
 
   /**

--- a/packages/debugger/src/dialogs/evaluate.ts
+++ b/packages/debugger/src/dialogs/evaluate.ts
@@ -117,7 +117,7 @@ class EvaluateDialogBody extends Widget implements Dialog.IBodyWidget<string> {
    * Get the text specified by the user
    */
   getValue(): string {
-    return this._prompt.model.value.text;
+    return this._prompt.model.value;
   }
 
   /**

--- a/packages/debugger/src/handlers/editor.ts
+++ b/packages/debugger/src/handlers/editor.ts
@@ -139,7 +139,7 @@ export class EditorHandler implements IDisposable {
     });
 
     void this._debuggerService.updateBreakpoints(
-      this._editor.model.value,
+      this._editor.model.sharedModel.getSource(),
       breakpoints,
       this._path
     );
@@ -171,7 +171,7 @@ export class EditorHandler implements IDisposable {
     }
 
     void this._debuggerService.updateBreakpoints(
-      this._editor.model.value,
+      this._editor.model.sharedModel.getSource(),
       breakpoints,
       this._path
     );
@@ -218,7 +218,7 @@ export class EditorHandler implements IDisposable {
    * or its path (if it exists).
    */
   private _getBreakpoints(): IDebugger.IBreakpoint[] {
-    const code = this._editor.model.value;
+    const code = this._editor.model.sharedModel.getSource();
     return this._debuggerService.model.breakpoints.getBreakpoints(
       this._path || this._debuggerService.getCodeId(code)
     );

--- a/packages/debugger/src/handlers/editor.ts
+++ b/packages/debugger/src/handlers/editor.ts
@@ -7,7 +7,7 @@ import { CodeMirrorEditor } from '@jupyterlab/codemirror';
 
 import { ActivityMonitor } from '@jupyterlab/coreutils';
 
-import { ISharedText, TextChange } from '@jupyterlab/shared-models';
+import { SourceChange } from '@jupyterlab/shared-models';
 
 import { IDisposable } from '@lumino/disposable';
 
@@ -43,7 +43,7 @@ export class EditorHandler implements IDisposable {
     this._editor = options.editor;
 
     this._editorMonitor = new ActivityMonitor({
-      signal: this._editor.model.sharedModel.changed,
+      signal: this._editor.model.sourceChanged,
       timeout: EDITOR_CHANGED_TIMEOUT
     });
     this._editorMonitor.activityStopped.connect(() => {
@@ -139,7 +139,7 @@ export class EditorHandler implements IDisposable {
     });
 
     void this._debuggerService.updateBreakpoints(
-      this._editor.model.sharedModel.getSource(),
+      this._editor.model.source,
       breakpoints,
       this._path
     );
@@ -171,7 +171,7 @@ export class EditorHandler implements IDisposable {
     }
 
     void this._debuggerService.updateBreakpoints(
-      this._editor.model.sharedModel.getSource(),
+      this._editor.model.source,
       breakpoints,
       this._path
     );
@@ -218,7 +218,7 @@ export class EditorHandler implements IDisposable {
    * or its path (if it exists).
    */
   private _getBreakpoints(): IDebugger.IBreakpoint[] {
-    const code = this._editor.model.sharedModel.getSource();
+    const code = this._editor.model.source;
     return this._debuggerService.model.breakpoints.getBreakpoints(
       this._path || this._debuggerService.getCodeId(code)
     );
@@ -228,7 +228,7 @@ export class EditorHandler implements IDisposable {
   private _path: string;
   private _editor: CodeEditor.IEditor;
   private _debuggerService: IDebugger;
-  private _editorMonitor: ActivityMonitor<ISharedText, TextChange>;
+  private _editorMonitor: ActivityMonitor<CodeEditor.IModel, SourceChange[]>;
 }
 
 /**

--- a/packages/debugger/src/handlers/editor.ts
+++ b/packages/debugger/src/handlers/editor.ts
@@ -7,7 +7,7 @@ import { CodeMirrorEditor } from '@jupyterlab/codemirror';
 
 import { ActivityMonitor } from '@jupyterlab/coreutils';
 
-import { IObservableString } from '@jupyterlab/observables';
+import { ISharedText, TextChange } from '@jupyterlab/shared-models';
 
 import { IDisposable } from '@lumino/disposable';
 
@@ -43,7 +43,7 @@ export class EditorHandler implements IDisposable {
     this._editor = options.editor;
 
     this._editorMonitor = new ActivityMonitor({
-      signal: this._editor.model.value.changed,
+      signal: this._editor.model.sharedModel.changed,
       timeout: EDITOR_CHANGED_TIMEOUT
     });
     this._editorMonitor.activityStopped.connect(() => {
@@ -139,7 +139,7 @@ export class EditorHandler implements IDisposable {
     });
 
     void this._debuggerService.updateBreakpoints(
-      this._editor.model.value.text,
+      this._editor.model.value,
       breakpoints,
       this._path
     );
@@ -171,7 +171,7 @@ export class EditorHandler implements IDisposable {
     }
 
     void this._debuggerService.updateBreakpoints(
-      this._editor.model.value.text,
+      this._editor.model.value,
       breakpoints,
       this._path
     );
@@ -218,7 +218,7 @@ export class EditorHandler implements IDisposable {
    * or its path (if it exists).
    */
   private _getBreakpoints(): IDebugger.IBreakpoint[] {
-    const code = this._editor.model.value.text;
+    const code = this._editor.model.value;
     return this._debuggerService.model.breakpoints.getBreakpoints(
       this._path || this._debuggerService.getCodeId(code)
     );
@@ -228,10 +228,7 @@ export class EditorHandler implements IDisposable {
   private _path: string;
   private _editor: CodeEditor.IEditor;
   private _debuggerService: IDebugger;
-  private _editorMonitor: ActivityMonitor<
-    IObservableString,
-    IObservableString.IChangedArgs
-  >;
+  private _editorMonitor: ActivityMonitor<ISharedText, TextChange>;
 }
 
 /**

--- a/packages/debugger/src/panels/sources/body.ts
+++ b/packages/debugger/src/panels/sources/body.ts
@@ -104,7 +104,7 @@ export class SourcesBody extends Widget {
     const editorMimeType =
       mimeType || this._mimeTypeService.getMimeTypeByFilePath(path ?? '');
 
-    this._editor.model.sharedModel.setSource(content);
+    this._editor.model.source = content;
     this._editor.model.mimeType = editorMimeType;
 
     this._editorHandler = new EditorHandler({

--- a/packages/debugger/src/panels/sources/body.ts
+++ b/packages/debugger/src/panels/sources/body.ts
@@ -104,7 +104,7 @@ export class SourcesBody extends Widget {
     const editorMimeType =
       mimeType || this._mimeTypeService.getMimeTypeByFilePath(path ?? '');
 
-    this._editor.model.value = content;
+    this._editor.model.sharedModel.setSource(content);
     this._editor.model.mimeType = editorMimeType;
 
     this._editorHandler = new EditorHandler({

--- a/packages/debugger/src/panels/sources/body.ts
+++ b/packages/debugger/src/panels/sources/body.ts
@@ -104,7 +104,7 @@ export class SourcesBody extends Widget {
     const editorMimeType =
       mimeType || this._mimeTypeService.getMimeTypeByFilePath(path ?? '');
 
-    this._editor.model.value.text = content;
+    this._editor.model.value = content;
     this._editor.model.mimeType = editorMimeType;
 
     this._editorHandler = new EditorHandler({

--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -514,7 +514,7 @@ export class DebuggerService implements IDebugger, IDisposable {
           path: this._session?.connection?.path ?? '',
           source: id
         });
-        const tmpCells = editorList.map(e => e.model.value.text);
+        const tmpCells = editorList.map(e => e.model.value);
         cells = cells.concat(tmpCells);
       }
     }

--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -514,7 +514,7 @@ export class DebuggerService implements IDebugger, IDisposable {
           path: this._session?.connection?.path ?? '',
           source: id
         });
-        const tmpCells = editorList.map(e => e.model.value);
+        const tmpCells = editorList.map(e => e.model.sharedModel.getSource());
         cells = cells.concat(tmpCells);
       }
     }

--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -514,7 +514,7 @@ export class DebuggerService implements IDebugger, IDisposable {
           path: this._session?.connection?.path ?? '',
           source: id
         });
-        const tmpCells = editorList.map(e => e.model.sharedModel.getSource());
+        const tmpCells = editorList.map(e => e.model.source);
         cells = cells.concat(tmpCells);
       }
     }

--- a/packages/debugger/src/sources.ts
+++ b/packages/debugger/src/sources.ts
@@ -107,7 +107,7 @@ export class DebuggerSources implements IDebugger.ISources {
       const cells = notebookPanel.content.widgets;
       cells.forEach((cell, i) => {
         // check the event is for the correct cell
-        const code = cell.model.sharedModel.getSource();
+        const code = cell.model.source;
         const codeId = this._getCodeId(code, kernel);
         if (!codeId) {
           return;
@@ -153,7 +153,7 @@ export class DebuggerSources implements IDebugger.ISources {
 
       const cells = consoleWidget.console.cells;
       each(cells, cell => {
-        const code = cell.model.sharedModel.getSource();
+        const code = cell.model.source;
         const codeId = this._getCodeId(code, kernel);
         if (!codeId) {
           return;
@@ -195,7 +195,7 @@ export class DebuggerSources implements IDebugger.ISources {
         return;
       }
 
-      const code = editor.model.sharedModel.getSource();
+      const code = editor.model.source;
       const codeId = this._getCodeId(code, kernel);
       if (!codeId) {
         return;
@@ -228,7 +228,7 @@ export class DebuggerSources implements IDebugger.ISources {
         return;
       }
 
-      const code = editor.model.sharedModel.getSource();
+      const code = editor.model.source;
       const codeId = this._getCodeId(code, kernel);
       if (!codeId) {
         return;

--- a/packages/debugger/src/sources.ts
+++ b/packages/debugger/src/sources.ts
@@ -107,7 +107,7 @@ export class DebuggerSources implements IDebugger.ISources {
       const cells = notebookPanel.content.widgets;
       cells.forEach((cell, i) => {
         // check the event is for the correct cell
-        const code = cell.model.value.text;
+        const code = cell.model.value;
         const codeId = this._getCodeId(code, kernel);
         if (!codeId) {
           return;
@@ -153,7 +153,7 @@ export class DebuggerSources implements IDebugger.ISources {
 
       const cells = consoleWidget.console.cells;
       each(cells, cell => {
-        const code = cell.model.value.text;
+        const code = cell.model.value;
         const codeId = this._getCodeId(code, kernel);
         if (!codeId) {
           return;
@@ -195,7 +195,8 @@ export class DebuggerSources implements IDebugger.ISources {
         return;
       }
 
-      const code = editor.model.value.text;
+      //const code = editor.model.value.text;
+      const code = editor.model.value;
       const codeId = this._getCodeId(code, kernel);
       if (!codeId) {
         return;
@@ -228,7 +229,7 @@ export class DebuggerSources implements IDebugger.ISources {
         return;
       }
 
-      const code = editor.model.value.text;
+      const code = editor.model.value;
       const codeId = this._getCodeId(code, kernel);
       if (!codeId) {
         return;

--- a/packages/debugger/src/sources.ts
+++ b/packages/debugger/src/sources.ts
@@ -107,7 +107,7 @@ export class DebuggerSources implements IDebugger.ISources {
       const cells = notebookPanel.content.widgets;
       cells.forEach((cell, i) => {
         // check the event is for the correct cell
-        const code = cell.model.value;
+        const code = cell.model.sharedModel.getSource();
         const codeId = this._getCodeId(code, kernel);
         if (!codeId) {
           return;
@@ -153,7 +153,7 @@ export class DebuggerSources implements IDebugger.ISources {
 
       const cells = consoleWidget.console.cells;
       each(cells, cell => {
-        const code = cell.model.value;
+        const code = cell.model.sharedModel.getSource();
         const codeId = this._getCodeId(code, kernel);
         if (!codeId) {
           return;
@@ -195,8 +195,7 @@ export class DebuggerSources implements IDebugger.ISources {
         return;
       }
 
-      //const code = editor.model.value.text;
-      const code = editor.model.value;
+      const code = editor.model.sharedModel.getSource();
       const codeId = this._getCodeId(code, kernel);
       if (!codeId) {
         return;
@@ -229,7 +228,7 @@ export class DebuggerSources implements IDebugger.ISources {
         return;
       }
 
-      const code = editor.model.value;
+      const code = editor.model.sharedModel.getSource();
       const codeId = this._getCodeId(code, kernel);
       if (!codeId) {
         return;

--- a/packages/debugger/test/debugger.spec.ts
+++ b/packages/debugger/test/debugger.spec.ts
@@ -362,7 +362,7 @@ describe('Debugger', () => {
       const body = sidebar.sources.widgets[0] as SourcesBody;
       const children = toArray(body.children());
       const editor = children[0] as CodeEditorWrapper;
-      expect(editor.model.value.text).toEqual(code);
+      expect(editor.model.sharedModel.getSource()).toEqual(code);
     });
   });
 });

--- a/packages/debugger/tsconfig.json
+++ b/packages/debugger/tsconfig.json
@@ -46,6 +46,9 @@
       "path": "../services"
     },
     {
+      "path": "../shared-models"
+    },
+    {
       "path": "../translation"
     },
     {

--- a/packages/debugger/tsconfig.test.json
+++ b/packages/debugger/tsconfig.test.json
@@ -42,6 +42,9 @@
       "path": "../services"
     },
     {
+      "path": "../shared-models"
+    },
+    {
       "path": "../translation"
     },
     {

--- a/packages/docprovider/src/tokens.ts
+++ b/packages/docprovider/src/tokens.ts
@@ -1,4 +1,4 @@
-import { DocumentChange, YDocument } from '@jupyterlab/shared-models';
+import { IYText } from '@jupyterlab/shared-models';
 import { Token } from '@lumino/coreutils';
 
 /**
@@ -70,6 +70,6 @@ export namespace IDocumentProviderFactory {
     /**
      * The YNotebook.
      */
-    ymodel: YDocument<DocumentChange>;
+    ymodel: IYText;
   }
 }

--- a/packages/docprovider/src/tokens.ts
+++ b/packages/docprovider/src/tokens.ts
@@ -1,4 +1,4 @@
-import { IYText } from '@jupyterlab/shared-models';
+import { IYDocument } from '@jupyterlab/shared-models';
 import { Token } from '@lumino/coreutils';
 
 /**
@@ -70,6 +70,6 @@ export namespace IDocumentProviderFactory {
     /**
      * The YNotebook.
      */
-    ymodel: IYText;
+    ydocument: IYDocument;
   }
 }

--- a/packages/docprovider/src/yprovider.ts
+++ b/packages/docprovider/src/yprovider.ts
@@ -33,9 +33,9 @@ export class WebSocketProviderWithLocks
     super(
       options.url,
       options.contentType + ':' + options.path,
-      options.ymodel.ydoc!,
+      options.ydocument.ydoc,
       {
-        awareness: options.ymodel.awareness!
+        awareness: options.ydocument.awareness
       }
     );
     this._path = options.path;
@@ -84,7 +84,7 @@ export class WebSocketProviderWithLocks
     this._onConnectionStatus = this._onConnectionStatus.bind(this);
     this.on('status', this._onConnectionStatus);
 
-    const awareness = options.ymodel.awareness!;
+    const awareness = options.ydocument.awareness;
     const user = options.user;
     const userChanged = () => {
       const name =

--- a/packages/docprovider/src/yprovider.ts
+++ b/packages/docprovider/src/yprovider.ts
@@ -33,9 +33,9 @@ export class WebSocketProviderWithLocks
     super(
       options.url,
       options.contentType + ':' + options.path,
-      options.ymodel.ydoc,
+      options.ymodel.ydoc!,
       {
-        awareness: options.ymodel.awareness
+        awareness: options.ymodel.awareness!
       }
     );
     this._path = options.path;
@@ -84,7 +84,7 @@ export class WebSocketProviderWithLocks
     this._onConnectionStatus = this._onConnectionStatus.bind(this);
     this.on('status', this._onConnectionStatus);
 
-    const awareness = options.ymodel.awareness;
+    const awareness = options.ymodel.awareness!;
     const user = options.user;
     const userChanged = () => {
       const name =

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -23,7 +23,6 @@ import {
   ServerConnection,
   ServiceManager
 } from '@jupyterlab/services';
-import * as ymodels from '@jupyterlab/shared-models';
 import {
   ITranslator,
   nullTranslator,
@@ -68,8 +67,8 @@ export class Context<
       this._model = this._factory.createNew(lang, undefined, false);
     }
 
-    const ymodel = this._model.sharedModel as ymodels.YDocument<any>; // translate to the concrete Yjs implementation
-    const ydoc = ymodel.ydoc;
+    const ymodel = this._model.ymodel!; // translate to the concrete Yjs implementation
+    const ydoc = ymodel.ydoc!;
     this._ydoc = ydoc;
     this._ycontext = ydoc.getMap('context');
     const docProviderFactory = options.docProviderFactory;
@@ -609,13 +608,8 @@ export class Context<
       content
     };
     try {
-      let value: Contents.IModel;
       await this._manager.ready;
-      if (!model.modelDB.isCollaborative) {
-        value = await this._maybeSave(options);
-      } else {
-        value = await this._manager.contents.save(this._path, options);
-      }
+      const value = await this._maybeSave(options);
       if (this.isDisposed) {
         return;
       }

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -227,7 +227,6 @@ export class Context<
     }
     this._model.dispose();
     this._provider.destroy();
-    this._model.sharedModel.dispose();
     this._ydoc.destroy();
     this._disposed.emit(void 0);
     Signal.clearData(this);

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -67,8 +67,8 @@ export class Context<
       this._model = this._factory.createNew(lang, undefined, false);
     }
 
-    const ymodel = this._model.ymodel!; // translate to the concrete Yjs implementation
-    const ydoc = ymodel.ydoc!;
+    const ydocument = this._model.ydocument!; // translate to the concrete Yjs implementation
+    const ydoc = ydocument.ydoc;
     this._ydoc = ydoc;
     this._ycontext = ydoc.getMap('context');
     const docProviderFactory = options.docProviderFactory;
@@ -76,7 +76,7 @@ export class Context<
       ? docProviderFactory({
           path: this._path,
           contentType: this._factory.contentType,
-          ymodel
+          ydocument
         })
       : new ProviderMock();
 

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -143,12 +143,8 @@ export class DocumentModel
    * @param reinitialize Whether to reinitialize the shared model.
    */
   switchSharedModel(sharedModel: ISharedFile, reinitialize?: boolean): void {
-    // Disconnect from old model
-    //this.sharedModel.changed.disconnect(this.onSharedModelChanged, this);
     // parent class changes the model
     super.switchSharedModel(sharedModel, reinitialize);
-    // connect to new model
-    //this.sharedModel.changed.connect(this.onSharedModelChanged, this);
   }
 
   protected onSharedModelChanged(

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -28,11 +28,8 @@ export class DocumentModel
     this._defaultLang = languagePreference || '';
     const filemodel = new YFile() as ISharedFile;
     this.switchSharedModel(filemodel, true);
-    // Deprecate: triggered when the shared model's source changes
-    //this.value.changed.connect(this.triggerContentChange, this);
 
     (this.sharedModel as YFile).dirty = false;
-    //this.sharedModel.changed.connect(this.onSharedModelChanged, this);
   }
 
   /**

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -32,7 +32,7 @@ export class DocumentModel
     //this.value.changed.connect(this.triggerContentChange, this);
 
     (this.sharedModel as YFile).dirty = false;
-    this.sharedModel.changed.connect(this.onSharedModelChanged, this);
+    //this.sharedModel.changed.connect(this.onSharedModelChanged, this);
   }
 
   /**
@@ -152,11 +152,11 @@ export class DocumentModel
    */
   switchSharedModel(sharedModel: ISharedFile, reinitialize?: boolean): void {
     // Disconnect from old model
-    this.sharedModel.changed.disconnect(this.onSharedModelChanged, this);
+    //this.sharedModel.changed.disconnect(this.onSharedModelChanged, this);
     // parent class changes the model
     super.switchSharedModel(sharedModel, reinitialize);
     // connect to new model
-    this.sharedModel.changed.connect(this.onSharedModelChanged, this);
+    //this.sharedModel.changed.connect(this.onSharedModelChanged, this);
   }
 
   protected onSharedModelChanged(

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -29,13 +29,8 @@ export class DocumentModel
     const filemodel = new YFile() as ISharedFile;
     this.switchSharedModel(filemodel, true);
 
-    (this.sharedModel as YFile).dirty = false;
+    (this._sharedModel as YFile).dirty = false;
   }
-
-  /**
-   * The shared file model.
-   */
-  readonly sharedModel: ISharedFile;
 
   /**
    * A signal emitted when the document content changes.
@@ -55,13 +50,13 @@ export class DocumentModel
    * The dirty state of the document.
    */
   get dirty(): boolean {
-    return this.sharedModel.dirty;
+    return this._sharedModel.dirty;
   }
   set dirty(newValue: boolean) {
     if (newValue === this.dirty) {
       return;
     }
-    (this.sharedModel as YFile).dirty = newValue;
+    (this._sharedModel as YFile).dirty = newValue;
   }
 
   /**
@@ -103,7 +98,7 @@ export class DocumentModel
    * Serialize the model to a string.
    */
   toString(): string {
-    return this.sharedModel.getSource();
+    return this._sharedModel.getSource();
   }
 
   /**
@@ -113,14 +108,14 @@ export class DocumentModel
    * Should emit a [contentChanged] signal.
    */
   fromString(value: string): void {
-    this.sharedModel.setSource(value);
+    this._sharedModel.setSource(value);
   }
 
   /**
    * Serialize the model to JSON.
    */
   toJSON(): PartialJSONValue {
-    return JSON.parse(this.sharedModel.getSource() || 'null');
+    return JSON.parse(this._sharedModel.getSource() || 'null');
   }
 
   /**
@@ -160,6 +155,11 @@ export class DocumentModel
     sender: ISharedFile,
     change: FileChange
   ): void {
+    // Trigger sourceChanged
+    super.onSharedModelChanged(sender, change);
+
+    // TODO: Remove contentChanged in favor of sourceChanged?
+    // Will break a lot of extensions but
     if (change.sourceChange) {
       this.triggerContentChange();
     }
@@ -187,6 +187,8 @@ export class DocumentModel
     this._contentChanged.emit(void 0);
     this.dirty = true;
   }
+
+  protected _sharedModel: ISharedFile;
 
   private _defaultLang = '';
   private _readOnly = false;

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -106,7 +106,7 @@ export class DocumentModel
    * Serialize the model to a string.
    */
   toString(): string {
-    return this.value;
+    return this.sharedModel.getSource();
   }
 
   /**
@@ -116,14 +116,14 @@ export class DocumentModel
    * Should emit a [contentChanged] signal.
    */
   fromString(value: string): void {
-    this.value = value;
+    this.sharedModel.setSource(value);
   }
 
   /**
    * Serialize the model to JSON.
    */
   toJSON(): PartialJSONValue {
-    return JSON.parse(this.value || 'null');
+    return JSON.parse(this.sharedModel.getSource() || 'null');
   }
 
   /**

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -7,7 +7,12 @@ import { Mode } from '@jupyterlab/codemirror';
 import { IChangedArgs, PathExt } from '@jupyterlab/coreutils';
 import { IModelDB } from '@jupyterlab/observables';
 import { Contents } from '@jupyterlab/services';
-import { FileChange, ISharedFile, YFile } from '@jupyterlab/shared-models';
+import {
+  FileChange,
+  ISharedFile,
+  IYDocument,
+  YFile
+} from '@jupyterlab/shared-models';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { PartialJSONValue } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
@@ -92,6 +97,10 @@ export class DocumentModel
    */
   get defaultKernelLanguage(): string {
     return this._defaultLang;
+  }
+
+  get ydocument(): IYDocument {
+    return this._sharedModel as any;
   }
 
   /**

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -10,7 +10,7 @@ import {
 import { IModelDB } from '@jupyterlab/observables';
 import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 import { Contents, Kernel } from '@jupyterlab/services';
-import * as models from '@jupyterlab/shared-models';
+import { IYText } from '@jupyterlab/shared-models';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import {
   fileIcon,
@@ -839,6 +839,8 @@ export namespace DocumentRegistry {
      * The shared notebook model.
      */
     //readonly sharedModel: models.ISharedDocument;
+    readonly ymodel?: IYText;
+
     /**
      * Undo an operation.
      */

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -833,12 +833,12 @@ export namespace DocumentRegistry {
      * Making direct edits to the values stored in the`IModelDB`
      * is not recommended, and may produce unpredictable results.
      */
-    readonly modelDB: IModelDB;
+    //readonly modelDB: IModelDB;
 
     /**
      * The shared notebook model.
      */
-    readonly sharedModel: models.ISharedDocument;
+    //readonly sharedModel: models.ISharedDocument;
 
     /**
      * Serialize the model to a string.
@@ -880,7 +880,7 @@ export namespace DocumentRegistry {
    * The interface for a document model that represents code.
    */
   export interface ICodeModel extends IModel, CodeEditor.IModel {
-    sharedModel: models.ISharedFile;
+    //sharedModel: models.ISharedFile;
   }
 
   /**

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -10,7 +10,7 @@ import {
 import { IModelDB } from '@jupyterlab/observables';
 import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 import { Contents, Kernel } from '@jupyterlab/services';
-import { IYText } from '@jupyterlab/shared-models';
+import { IYDocument } from '@jupyterlab/shared-models';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import {
   fileIcon,
@@ -839,7 +839,7 @@ export namespace DocumentRegistry {
      * The shared notebook model.
      */
     //readonly sharedModel: models.ISharedDocument;
-    readonly ymodel?: IYText;
+    readonly ydocument: IYDocument;
 
     /**
      * Undo an operation.

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -839,6 +839,15 @@ export namespace DocumentRegistry {
      * The shared notebook model.
      */
     //readonly sharedModel: models.ISharedDocument;
+    /**
+     * Undo an operation.
+     */
+    undo(): void;
+
+    /**
+     * Redo an operation.
+     */
+    redo(): void;
 
     /**
      * Serialize the model to a string.

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -535,9 +535,9 @@ export namespace Commands {
           const start = editor.getOffsetAt(selection.start);
           const end = editor.getOffsetAt(selection.end);
 
-          code = editor.model.sharedModel.getSource().substring(start, end);
+          code = editor.model.source.substring(start, end);
         } else if (MarkdownCodeBlocks.isMarkdown(extension)) {
-          const text = editor.model.sharedModel.getSource();
+          const text = editor.model.source;
           const blocks = MarkdownCodeBlocks.findMarkdownCodeBlocks(text);
 
           for (const block of blocks) {
@@ -554,8 +554,8 @@ export namespace Commands {
           code = editor.getLine(selection.start.line);
           const cursor = editor.getCursorPosition();
           if (cursor.line + 1 === editor.lineCount) {
-            const text = editor.model.sharedModel.getSource();
-            editor.model.sharedModel.setSource(text + '\n');
+            const text = editor.model.source;
+            editor.model.source = text + '\n';
           }
           editor.setCursorPosition({
             line: cursor.line + 1,
@@ -587,7 +587,7 @@ export namespace Commands {
 
         let code = '';
         const editor = widget.editor;
-        const text = editor.model.sharedModel.getSource();
+        const text = editor.model.source;
         const path = widget.context.path;
         const extension = PathExt.extname(path);
 
@@ -880,7 +880,7 @@ export namespace Commands {
     const selectionObj = editor.getSelection();
     const start = editor.getOffsetAt(selectionObj.start);
     const end = editor.getOffsetAt(selectionObj.end);
-    const text = editor.model.sharedModel.getSource().substring(start, end);
+    const text = editor.model.source.substring(start, end);
 
     return text;
   }

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -535,9 +535,9 @@ export namespace Commands {
           const start = editor.getOffsetAt(selection.start);
           const end = editor.getOffsetAt(selection.end);
 
-          code = editor.model.value.substring(start, end);
+          code = editor.model.sharedModel.getSource().substring(start, end);
         } else if (MarkdownCodeBlocks.isMarkdown(extension)) {
-          const text = editor.model.value;
+          const text = editor.model.sharedModel.getSource();
           const blocks = MarkdownCodeBlocks.findMarkdownCodeBlocks(text);
 
           for (const block of blocks) {
@@ -554,8 +554,8 @@ export namespace Commands {
           code = editor.getLine(selection.start.line);
           const cursor = editor.getCursorPosition();
           if (cursor.line + 1 === editor.lineCount) {
-            const text = editor.model.value;
-            editor.model.value = text + '\n';
+            const text = editor.model.sharedModel.getSource();
+            editor.model.sharedModel.setSource(text + '\n');
           }
           editor.setCursorPosition({
             line: cursor.line + 1,
@@ -587,7 +587,7 @@ export namespace Commands {
 
         let code = '';
         const editor = widget.editor;
-        const text = editor.model.value;
+        const text = editor.model.sharedModel.getSource();
         const path = widget.context.path;
         const extension = PathExt.extname(path);
 
@@ -880,7 +880,7 @@ export namespace Commands {
     const selectionObj = editor.getSelection();
     const start = editor.getOffsetAt(selectionObj.start);
     const end = editor.getOffsetAt(selectionObj.end);
-    const text = editor.model.value.substring(start, end);
+    const text = editor.model.sharedModel.getSource().substring(start, end);
 
     return text;
   }

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -535,9 +535,9 @@ export namespace Commands {
           const start = editor.getOffsetAt(selection.start);
           const end = editor.getOffsetAt(selection.end);
 
-          code = editor.model.value.text.substring(start, end);
+          code = editor.model.value.substring(start, end);
         } else if (MarkdownCodeBlocks.isMarkdown(extension)) {
-          const { text } = editor.model.value;
+          const text = editor.model.value;
           const blocks = MarkdownCodeBlocks.findMarkdownCodeBlocks(text);
 
           for (const block of blocks) {
@@ -554,8 +554,8 @@ export namespace Commands {
           code = editor.getLine(selection.start.line);
           const cursor = editor.getCursorPosition();
           if (cursor.line + 1 === editor.lineCount) {
-            const text = editor.model.value.text;
-            editor.model.value.text = text + '\n';
+            const text = editor.model.value;
+            editor.model.value = text + '\n';
           }
           editor.setCursorPosition({
             line: cursor.line + 1,
@@ -587,7 +587,7 @@ export namespace Commands {
 
         let code = '';
         const editor = widget.editor;
-        const text = editor.model.value.text;
+        const text = editor.model.value;
         const path = widget.context.path;
         const extension = PathExt.extname(path);
 
@@ -880,7 +880,7 @@ export namespace Commands {
     const selectionObj = editor.getSelection();
     const start = editor.getOffsetAt(selectionObj.start);
     const end = editor.getOffsetAt(selectionObj.end);
-    const text = editor.model.value.text.substring(start, end);
+    const text = editor.model.value.substring(start, end);
 
     return text;
   }

--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -53,7 +53,7 @@ export class FileEditorCodeWrapper extends CodeEditorWrapper {
       this._onContextReady();
     });
 
-    if (context.model.modelDB.isCollaborative) {
+    /* if (context.model.modelDB.isCollaborative) {
       const modelDB = context.model.modelDB;
       void modelDB.connected.then(() => {
         const collaborators = modelDB.collaborators;
@@ -74,7 +74,7 @@ export class FileEditorCodeWrapper extends CodeEditorWrapper {
         // Trigger an initial onCollaboratorsChanged event.
         this._onCollaboratorsChanged();
       });
-    }
+    } */
   }
 
   /**
@@ -132,7 +132,7 @@ export class FileEditorCodeWrapper extends CodeEditorWrapper {
    * Handle a change to the collaborators on the model
    * by updating UI elements associated with them.
    */
-  private _onCollaboratorsChanged(): void {
+  /* private _onCollaboratorsChanged(): void {
     // If there are selections corresponding to non-collaborators,
     // they are stale and should be removed.
     const collaborators = this._context.model.modelDB.collaborators;
@@ -144,7 +144,7 @@ export class FileEditorCodeWrapper extends CodeEditorWrapper {
         this.editor.model.selections.delete(key);
       }
     }
-  }
+  } */
 
   protected _context: DocumentRegistry.Context;
   private _ready = new PromiseDelegate<void>();

--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -48,7 +48,7 @@ export class FileEditorCodeWrapper extends CodeEditorWrapper {
     this.node.dataset[CODE_RUNNER] = 'true';
     this.node.dataset[UNDOER] = 'true';
 
-    editor.model.value.text = context.model.toString();
+    editor.model.value = context.model.toString();
     void context.ready.then(() => {
       this._onContextReady();
     });
@@ -103,7 +103,7 @@ export class FileEditorCodeWrapper extends CodeEditorWrapper {
     const editorModel = editor.model;
 
     // Set the editor model value.
-    editorModel.value.text = contextModel.toString();
+    editorModel.value = contextModel.toString();
 
     // Prevent the initial loading from disk from being in the editor history.
     editor.clearHistory();
@@ -120,11 +120,11 @@ export class FileEditorCodeWrapper extends CodeEditorWrapper {
    */
   private _onContentChanged(): void {
     const editorModel = this.editor.model;
-    const oldValue = editorModel.value.text;
+    const oldValue = editorModel.value;
     const newValue = this._context.model.toString();
 
     if (oldValue !== newValue) {
-      editorModel.value.text = newValue;
+      editorModel.value = newValue;
     }
   }
 

--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -48,7 +48,7 @@ export class FileEditorCodeWrapper extends CodeEditorWrapper {
     this.node.dataset[CODE_RUNNER] = 'true';
     this.node.dataset[UNDOER] = 'true';
 
-    editor.model.sharedModel.setSource(context.model.toString());
+    editor.model.source = context.model.toString();
     void context.ready.then(() => {
       this._onContextReady();
     });
@@ -103,7 +103,7 @@ export class FileEditorCodeWrapper extends CodeEditorWrapper {
     const editorModel = editor.model;
 
     // Set the editor model value.
-    editorModel.sharedModel.setSource(contextModel.toString());
+    editorModel.source = contextModel.toString();
 
     // Prevent the initial loading from disk from being in the editor history.
     editor.clearHistory();
@@ -120,11 +120,11 @@ export class FileEditorCodeWrapper extends CodeEditorWrapper {
    */
   private _onContentChanged(): void {
     const editorModel = this.editor.model;
-    const oldValue = editorModel.sharedModel.getSource();
+    const oldValue = editorModel.source;
     const newValue = this._context.model.toString();
 
     if (oldValue !== newValue) {
-      editorModel.sharedModel.setSource(newValue);
+      editorModel.source = newValue;
     }
   }
 

--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -48,7 +48,7 @@ export class FileEditorCodeWrapper extends CodeEditorWrapper {
     this.node.dataset[CODE_RUNNER] = 'true';
     this.node.dataset[UNDOER] = 'true';
 
-    editor.model.value = context.model.toString();
+    editor.model.sharedModel.setSource(context.model.toString());
     void context.ready.then(() => {
       this._onContextReady();
     });
@@ -103,7 +103,7 @@ export class FileEditorCodeWrapper extends CodeEditorWrapper {
     const editorModel = editor.model;
 
     // Set the editor model value.
-    editorModel.value = contextModel.toString();
+    editorModel.sharedModel.setSource(contextModel.toString());
 
     // Prevent the initial loading from disk from being in the editor history.
     editor.clearHistory();
@@ -120,11 +120,11 @@ export class FileEditorCodeWrapper extends CodeEditorWrapper {
    */
   private _onContentChanged(): void {
     const editorModel = this.editor.model;
-    const oldValue = editorModel.value;
+    const oldValue = editorModel.sharedModel.getSource();
     const newValue = this._context.model.toString();
 
     if (oldValue !== newValue) {
-      editorModel.value = newValue;
+      editorModel.sharedModel.setSource(newValue);
     }
   }
 

--- a/packages/fileeditor/test/widget.spec.ts
+++ b/packages/fileeditor/test/widget.spec.ts
@@ -88,7 +88,7 @@ describe('fileeditorcodewrapper', () => {
         await context.initialize(true);
         await context.ready;
         widget.context.model.fromString('foo');
-        expect(widget.editor.model.value.text).toBe('foo');
+        expect(widget.editor.model.sharedModel.getSource()).toBe('foo');
       });
     });
 
@@ -125,7 +125,7 @@ describe('fileeditorcodewrapper', () => {
         await context.initialize(true);
         await context.ready;
         widget.context.model.fromString('foo');
-        expect(widget.editor.model.value.text).toBe('foo');
+        expect(widget.editor.model.sharedModel.getSource()).toBe('foo');
       });
 
       it('should set the mime type for the path', () => {

--- a/packages/inspector/src/handler.ts
+++ b/packages/inspector/src/handler.ts
@@ -123,7 +123,7 @@ export class InspectionHandler implements IDisposable, IInspector.IInspectable {
     if (!editor) {
       return;
     }
-    const text = customText ? customText : editor.model.value;
+    const text = customText ? customText : editor.model.sharedModel.getSource();
     const position = editor.getCursorPosition();
     const offset = Text.jsIndexToCharIndex(editor.getOffsetAt(position), text);
     const update: IInspector.IInspectorUpdate = { content: null };

--- a/packages/inspector/src/handler.ts
+++ b/packages/inspector/src/handler.ts
@@ -66,7 +66,7 @@ export class InspectionHandler implements IDisposable, IInspector.IInspectable {
       // the active cell
       this.onEditorChange();
       editor.model.selections.changed.connect(this._onChange, this);
-      editor.model.sharedModel.changed.connect(this._onChange, this);
+      editor.model.sourceChanged.connect(this._onChange, this);
     }
   }
 
@@ -123,7 +123,7 @@ export class InspectionHandler implements IDisposable, IInspector.IInspectable {
     if (!editor) {
       return;
     }
-    const text = customText ? customText : editor.model.sharedModel.getSource();
+    const text = customText ? customText : editor.model.source;
     const position = editor.getCursorPosition();
     const offset = Text.jsIndexToCharIndex(editor.getOffsetAt(position), text);
     const update: IInspector.IInspectorUpdate = { content: null };

--- a/packages/inspector/src/handler.ts
+++ b/packages/inspector/src/handler.ts
@@ -66,7 +66,7 @@ export class InspectionHandler implements IDisposable, IInspector.IInspectable {
       // the active cell
       this.onEditorChange();
       editor.model.selections.changed.connect(this._onChange, this);
-      editor.model.value.changed.connect(this._onChange, this);
+      editor.model.sharedModel.changed.connect(this._onChange, this);
     }
   }
 
@@ -123,7 +123,7 @@ export class InspectionHandler implements IDisposable, IInspector.IInspectable {
     if (!editor) {
       return;
     }
-    const text = customText ? customText : editor.model.value.text;
+    const text = customText ? customText : editor.model.value;
     const position = editor.getCursorPosition();
     const offset = Text.jsIndexToCharIndex(editor.getOffsetAt(position), text);
     const update: IInspector.IInspectorUpdate = { content: null };

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1032,11 +1032,11 @@ function activateCodeConsole(
         // Get the selected code from the editor.
         const start = editor.getOffsetAt(selection.start);
         const end = editor.getOffsetAt(selection.end);
-        code = editor.model.value.substring(start, end);
+        code = editor.model.sharedModel.getSource().substring(start, end);
       } else {
         // no selection, find the complete statement around the current line
         const cursor = editor.getCursorPosition();
-        const srcLines = editor.model.value.split('\n');
+        const srcLines = editor.model.sharedModel.getSource().split('\n');
         let curLine = selection.start.line;
         while (
           curLine < editor.lineCount &&

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1032,11 +1032,11 @@ function activateCodeConsole(
         // Get the selected code from the editor.
         const start = editor.getOffsetAt(selection.start);
         const end = editor.getOffsetAt(selection.end);
-        code = editor.model.value.text.substring(start, end);
+        code = editor.model.value.substring(start, end);
       } else {
         // no selection, find the complete statement around the current line
         const cursor = editor.getCursorPosition();
-        const srcLines = editor.model.value.text.split('\n');
+        const srcLines = editor.model.value.split('\n');
         let curLine = selection.start.line;
         while (
           curLine < editor.lineCount &&

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1032,11 +1032,11 @@ function activateCodeConsole(
         // Get the selected code from the editor.
         const start = editor.getOffsetAt(selection.start);
         const end = editor.getOffsetAt(selection.end);
-        code = editor.model.sharedModel.getSource().substring(start, end);
+        code = editor.model.source.substring(start, end);
       } else {
         // no selection, find the complete statement around the current line
         const cursor = editor.getCursorPosition();
-        const srcLines = editor.model.sharedModel.getSource().split('\n');
+        const srcLines = editor.model.source.split('\n');
         let curLine = selection.start.line;
         while (
           curLine < editor.lineCount &&

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -158,7 +158,7 @@ export namespace NotebookActions {
     const child = notebook.widgets[index];
     const editor = child.editor;
     const selections = editor.getSelections();
-    const orig = child.model.value.text;
+    const orig = child.model.value;
 
     const offsets = [0];
 
@@ -192,7 +192,7 @@ export namespace NotebookActions {
       if (i !== clones.length - 1 && clones[i].type === 'code') {
         (clones[i] as ICodeCellModel).outputs.clear();
       }
-      clones[i].value.text = orig
+      clones[i].value = orig
         .slice(offsets[i], offsets[i + 1])
         .replace(/^\n+/, '')
         .replace(/\n+$/, '');
@@ -256,7 +256,7 @@ export namespace NotebookActions {
     // Get the cells to merge.
     notebook.widgets.forEach((child, index) => {
       if (notebook.isSelectedOrActive(child)) {
-        toMerge.push(child.model.value.text);
+        toMerge.push(child.model.value);
         if (index !== active) {
           toDelete.push(child.model);
         }
@@ -281,7 +281,7 @@ export namespace NotebookActions {
         // Otherwise merge with the previous cell.
         const cellModel = cells.get(active - 1);
 
-        toMerge.unshift(cellModel.value.text);
+        toMerge.unshift(cellModel.value);
         toDelete.push(cellModel);
       } else if (mergeAbove === false) {
         // Bail if it is the last cell.
@@ -291,7 +291,7 @@ export namespace NotebookActions {
         // Otherwise merge with the next cell.
         const cellModel = cells.get(active + 1);
 
-        toMerge.push(cellModel.value.text);
+        toMerge.push(cellModel.value);
         toDelete.push(cellModel);
       }
     }
@@ -301,7 +301,7 @@ export namespace NotebookActions {
     // Create a new cell for the source to preserve history.
     const newModel = Private.cloneCell(model, primary.model);
 
-    newModel.value.text = toMerge.join('\n\n');
+    newModel.value = toMerge.join('\n\n');
     if (isCodeCellModel(newModel)) {
       newModel.outputs.clear();
     } else if (isMarkdownCellModel(newModel) || isRawCellModel(newModel)) {
@@ -2096,7 +2096,7 @@ namespace Private {
     const replace = setNextInput.replace;
 
     if (replace) {
-      cell.model.value.text = text;
+      cell.model.value = text;
       return;
     }
 
@@ -2105,7 +2105,7 @@ namespace Private {
     const cells = notebook.model!.cells;
     const index = ArrayExt.firstIndexOf(toArray(cells), cell.model);
 
-    newCell.value.text = text;
+    newCell.value = text;
     if (index === -1) {
       cells.push(newCell);
     } else {
@@ -2280,7 +2280,7 @@ namespace Private {
    */
   export function setMarkdownHeader(cell: ICellModel, level: number): void {
     // Remove existing header or leading white space.
-    let source = cell.value.text;
+    let source = cell.value;
     const regex = /^(#+\s*)|^(\s*)/;
     const newHeader = Array(level + 1).join('#') + ' ';
     const matches = regex.exec(source);
@@ -2288,6 +2288,6 @@ namespace Private {
     if (matches) {
       source = source.slice(matches[0].length);
     }
-    cell.value.text = newHeader + source;
+    cell.value = newHeader + source;
   }
 }

--- a/packages/notebook/src/celllist.ts
+++ b/packages/notebook/src/celllist.ts
@@ -70,7 +70,7 @@ export class CellList implements IObservableUndoableList<ICellModel> {
           change.type === 'move'
         ) {
           const cells = change.newValues.map(cell => {
-            return cell.sharedModel.clone() as any;
+            return cell.cloneSharedModel();
           });
           let insertLocation = change.newIndex;
           if (change.type === 'move' && insertLocation > change.oldIndex) {
@@ -551,7 +551,7 @@ export class CellList implements IObservableUndoableList<ICellModel> {
               break;
           }
           this._cellMap.set(id, cell);
-        } else if (!existingCell.sharedModel.isStandalone) {
+        } else if (!existingCell.isStandalone) {
           this._mutex(() => {
             // it does already exist, probably because it was deleted previously and we introduced it
             // copy it to a fresh codecell instance

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -26,6 +26,7 @@ import {
 import {
   createMutex,
   ISharedNotebook,
+  IYDocument,
   NotebookChange,
   YNotebook
 } from '@jupyterlab/shared-models';
@@ -223,6 +224,10 @@ export class NotebookModel implements INotebookModel {
       'language_info'
     ) as nbformat.ILanguageInfoMetadata;
     return info ? info.name : '';
+  }
+
+  get ydocument(): IYDocument {
+    return this._sharedModel as any;
   }
 
   /**

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -241,6 +241,20 @@ export class NotebookModel implements INotebookModel {
   }
 
   /**
+   * Undo an operation.
+   */
+  undo(): void {
+    this._sharedModel.undo();
+  }
+
+  /**
+   * Redo an operation.
+   */
+  redo(): void {
+    this._sharedModel.redo();
+  }
+
+  /**
    * Serialize the model to a string.
    */
   toString(): string {

--- a/packages/notebook/src/notebooktools.ts
+++ b/packages/notebook/src/notebooktools.ts
@@ -10,11 +10,6 @@ import {
 import * as nbformat from '@jupyterlab/nbformat';
 import { IObservableMap, ObservableJSON } from '@jupyterlab/observables';
 import {
-  CellChange,
-  ISharedBaseCellMetadata,
-  ISharedCell
-} from '@jupyterlab/shared-models';
-import {
   ITranslator,
   nullTranslator,
   TranslationBundle
@@ -460,10 +455,7 @@ export namespace NotebookTools {
         layout.widgets[0].dispose();
       }
       if (this._cellModel && !this._cellModel.isDisposed) {
-        (this._cellModel.sharedModel as ISharedCell).changed.disconnect(
-          this._onValueChanged,
-          this
-        );
+        this._cellModel.sourceChanged.disconnect(this._onValueChanged, this);
         this._cellModel.mimeTypeChanged.disconnect(
           this._onMimeTypeChanged,
           this
@@ -483,10 +475,7 @@ export namespace NotebookTools {
       const factory = activeCell.contentFactory.editorFactory;
 
       const cellModel = (this._cellModel = activeCell.model);
-      (cellModel.sharedModel as ISharedCell).changed.connect(
-        this._onValueChanged,
-        this
-      );
+      cellModel.sourceChanged.connect(this._onValueChanged, this);
       cellModel.mimeTypeChanged.connect(this._onMimeTypeChanged, this);
       this._model.source = cellModel.source.split('\n')[0];
       this._model.mimeType = cellModel.mimeType;
@@ -502,13 +491,8 @@ export namespace NotebookTools {
     /**
      * Handle a change to the current editor value.
      */
-    private _onValueChanged(
-      sender: ISharedCell,
-      changes: CellChange<ISharedBaseCellMetadata>
-    ): void {
-      if (changes.sourceChange) {
-        this._model.source = this._cellModel!.source.split('\n')[0];
-      }
+    private _onValueChanged(): void {
+      this._model.source = this._cellModel!.source.split('\n')[0];
     }
 
     /**

--- a/packages/notebook/src/notebooktools.ts
+++ b/packages/notebook/src/notebooktools.ts
@@ -488,9 +488,7 @@ export namespace NotebookTools {
         this
       );
       cellModel.mimeTypeChanged.connect(this._onMimeTypeChanged, this);
-      this._model.sharedModel.setSource(
-        cellModel.sharedModel.getSource().split('\n')[0]
-      );
+      this._model.source = cellModel.source.split('\n')[0];
       this._model.mimeType = cellModel.mimeType;
 
       const model = this._model;
@@ -509,9 +507,7 @@ export namespace NotebookTools {
       changes: CellChange<ISharedBaseCellMetadata>
     ): void {
       if (changes.sourceChange) {
-        this._model.sharedModel.setSource(
-          this._cellModel!.sharedModel.getSource().split('\n')[0]
-        );
+        this._model.source = this._cellModel!.source.split('\n')[0];
       }
     }
 
@@ -644,9 +640,9 @@ export namespace NotebookTools {
 
     private _update() {
       const cell = this.notebookTools.activeCell;
-      this.editor.model.sharedModel.setSource(
-        cell ? JSON.stringify(cell.model.metadata) : ''
-      );
+      this.editor.model.source = cell
+        ? JSON.stringify(cell.model.metadata)
+        : '';
     }
   }
 

--- a/packages/notebook/src/notebooktools.ts
+++ b/packages/notebook/src/notebooktools.ts
@@ -488,7 +488,9 @@ export namespace NotebookTools {
         this
       );
       cellModel.mimeTypeChanged.connect(this._onMimeTypeChanged, this);
-      this._model.value = cellModel.value.split('\n')[0];
+      this._model.sharedModel.setSource(
+        cellModel.sharedModel.getSource().split('\n')[0]
+      );
       this._model.mimeType = cellModel.mimeType;
 
       const model = this._model;
@@ -507,7 +509,9 @@ export namespace NotebookTools {
       changes: CellChange<ISharedBaseCellMetadata>
     ): void {
       if (changes.sourceChange) {
-        this._model.value = this._cellModel!.value.split('\n')[0];
+        this._model.sharedModel.setSource(
+          this._cellModel!.sharedModel.getSource().split('\n')[0]
+        );
       }
     }
 
@@ -640,7 +644,9 @@ export namespace NotebookTools {
 
     private _update() {
       const cell = this.notebookTools.activeCell;
-      this.editor.model.value = cell ? JSON.stringify(cell.model.metadata) : '';
+      this.editor.model.sharedModel.setSource(
+        cell ? JSON.stringify(cell.model.metadata) : ''
+      );
     }
   }
 

--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -77,7 +77,7 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
       // Set the document edit mode on initial open if it looks like a new document.
       if (this.content.widgets.length === 1) {
         const cellModel = this.content.widgets[0].model;
-        if (cellModel.type === 'code' && cellModel.value.text === '') {
+        if (cellModel.type === 'code' && cellModel.value === '') {
           this.content.mode = 'edit';
         }
       }
@@ -100,7 +100,7 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
       each(cells, cell => {
         if (isMarkdownCellModel(cell)) {
           for (const key of cell.attachments.keys) {
-            if (!cell.value.text.includes(key)) {
+            if (!cell.value.includes(key)) {
               cell.attachments.remove(key);
             }
           }

--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -77,7 +77,10 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
       // Set the document edit mode on initial open if it looks like a new document.
       if (this.content.widgets.length === 1) {
         const cellModel = this.content.widgets[0].model;
-        if (cellModel.type === 'code' && cellModel.value === '') {
+        if (
+          cellModel.type === 'code' &&
+          cellModel.sharedModel.getSource() === ''
+        ) {
           this.content.mode = 'edit';
         }
       }
@@ -100,7 +103,7 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
       each(cells, cell => {
         if (isMarkdownCellModel(cell)) {
           for (const key of cell.attachments.keys) {
-            if (!cell.value.includes(key)) {
+            if (!cell.sharedModel.getSource().includes(key)) {
               cell.attachments.remove(key);
             }
           }

--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -77,10 +77,7 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
       // Set the document edit mode on initial open if it looks like a new document.
       if (this.content.widgets.length === 1) {
         const cellModel = this.content.widgets[0].model;
-        if (
-          cellModel.type === 'code' &&
-          cellModel.sharedModel.getSource() === ''
-        ) {
+        if (cellModel.type === 'code' && cellModel.source === '') {
           this.content.mode = 'edit';
         }
       }
@@ -103,7 +100,7 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
       each(cells, cell => {
         if (isMarkdownCellModel(cell)) {
           for (const key of cell.attachments.keys) {
-            if (!cell.sharedModel.getSource().includes(key)) {
+            if (!cell.source.includes(key)) {
               cell.attachments.remove(key);
             }
           }

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -563,7 +563,7 @@ export class StaticNotebook extends Widget {
         break;
       case 'markdown':
         widget = this._createMarkdownCell(cell as IMarkdownCellModel);
-        if (cell.value.text === '') {
+        if (cell.value === '') {
           (widget as MarkdownCell).rendered = false;
         }
         break;
@@ -2305,7 +2305,7 @@ export class Notebook extends StaticNotebook {
     dragImage = Private.createDragImage(
       selected.length,
       countString,
-      activeCell?.model.value.text.split('\n')[0].slice(0, 26) ?? ''
+      activeCell?.model.value.split('\n')[0].slice(0, 26) ?? ''
     );
 
     // Set up the drag event.
@@ -2323,7 +2323,7 @@ export class Notebook extends StaticNotebook {
     this._drag.mimeData.setData('internal:cells', toMove);
     // Add mimeData for the text content of the selected cells,
     // allowing for drag/drop into plain text fields.
-    const textContent = toMove.map(cell => cell.model.value.text).join('\n');
+    const textContent = toMove.map(cell => cell.model.value).join('\n');
     this._drag.mimeData.setData('text/plain', textContent);
 
     // Remove mousemove and mouseup listeners and start the drag.

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -563,7 +563,7 @@ export class StaticNotebook extends Widget {
         break;
       case 'markdown':
         widget = this._createMarkdownCell(cell as IMarkdownCellModel);
-        if (cell.value === '') {
+        if (cell.sharedModel.getSource() === '') {
           (widget as MarkdownCell).rendered = false;
         }
         break;
@@ -2305,7 +2305,8 @@ export class Notebook extends StaticNotebook {
     dragImage = Private.createDragImage(
       selected.length,
       countString,
-      activeCell?.model.value.split('\n')[0].slice(0, 26) ?? ''
+      activeCell?.model.sharedModel.getSource().split('\n')[0].slice(0, 26) ??
+        ''
     );
 
     // Set up the drag event.
@@ -2323,7 +2324,9 @@ export class Notebook extends StaticNotebook {
     this._drag.mimeData.setData('internal:cells', toMove);
     // Add mimeData for the text content of the selected cells,
     // allowing for drag/drop into plain text fields.
-    const textContent = toMove.map(cell => cell.model.value).join('\n');
+    const textContent = toMove
+      .map(cell => cell.model.sharedModel.getSource())
+      .join('\n');
     this._drag.mimeData.setData('text/plain', textContent);
 
     // Remove mousemove and mouseup listeners and start the drag.

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -563,7 +563,7 @@ export class StaticNotebook extends Widget {
         break;
       case 'markdown':
         widget = this._createMarkdownCell(cell as IMarkdownCellModel);
-        if (cell.sharedModel.getSource() === '') {
+        if (cell.source === '') {
           (widget as MarkdownCell).rendered = false;
         }
         break;
@@ -2305,8 +2305,7 @@ export class Notebook extends StaticNotebook {
     dragImage = Private.createDragImage(
       selected.length,
       countString,
-      activeCell?.model.sharedModel.getSource().split('\n')[0].slice(0, 26) ??
-        ''
+      activeCell?.model.source.split('\n')[0].slice(0, 26) ?? ''
     );
 
     // Set up the drag event.
@@ -2324,9 +2323,7 @@ export class Notebook extends StaticNotebook {
     this._drag.mimeData.setData('internal:cells', toMove);
     // Add mimeData for the text content of the selected cells,
     // allowing for drag/drop into plain text fields.
-    const textContent = toMove
-      .map(cell => cell.model.sharedModel.getSource())
-      .join('\n');
+    const textContent = toMove.map(cell => cell.model.source).join('\n');
     this._drag.mimeData.setData('text/plain', textContent);
 
     // Remove mousemove and mouseup listeners and start the drag.

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -296,7 +296,7 @@ export class StaticNotebook extends Widget {
     const oldValue = this._model;
     this._model = newValue;
 
-    if (oldValue && oldValue.modelDB.isCollaborative) {
+    /* if (oldValue && oldValue.modelDB.isCollaborative) {
       void oldValue.modelDB.connected.then(() => {
         oldValue!.modelDB.collaborators!.changed.disconnect(
           this._onCollaboratorsChanged,
@@ -311,7 +311,7 @@ export class StaticNotebook extends Widget {
           this
         );
       });
-    }
+    } */
 
     // Trigger private, protected, and public changes.
     this._onModelChanged(oldValue, newValue);
@@ -768,7 +768,7 @@ export class StaticNotebook extends Widget {
   /**
    * Handle an update to the collaborators.
    */
-  private _onCollaboratorsChanged(): void {
+  /* private _onCollaboratorsChanged(): void {
     // If there are selections corresponding to non-collaborators,
     // they are stale and should be removed.
     for (let i = 0; i < this.widgets.length; i++) {
@@ -779,7 +779,7 @@ export class StaticNotebook extends Widget {
         }
       }
     }
-  }
+  } */
 
   /**
    * Update editor settings for notebook cells.
@@ -1741,7 +1741,7 @@ export class Notebook extends StaticNotebook {
    * Handle a cell being inserted.
    */
   protected onCellInserted(index: number, cell: Cell): void {
-    if (this.model && this.model.modelDB.isCollaborative) {
+    /* if (this.model && this.model.modelDB.isCollaborative) {
       const modelDB = this.model.modelDB;
       void modelDB.connected.then(() => {
         if (!cell.isDisposed) {
@@ -1754,7 +1754,7 @@ export class Notebook extends StaticNotebook {
           };
         }
       });
-    }
+    } */
     cell.editor.edgeRequested.connect(this._onEdgeRequest, this);
     // If the insertion happened above, increment the active cell
     // index, otherwise it stays the same.

--- a/packages/notebook/test/model.spec.ts
+++ b/packages/notebook/test/model.spec.ts
@@ -76,14 +76,14 @@ describe('@jupyterlab/notebook', () => {
           disableDocumentWideUndoRedo: true
         });
         const cell = model.contentFactory.createCodeCell({});
-        cell.value.text = 'foo';
+        cell.sharedModel.setSource('foo');
         const cellJSON = cell.toJSON();
         model.cells.push(cell);
         model.cells.clearUndo();
         model.cells.remove(model.cells.length - 1);
         model.cells.undo();
         expect(model.cells.length).toBe(1);
-        expect(model.cells.get(0).value.text).toBe('foo');
+        expect(model.cells.get(0).sharedModel.getSource()).toBe('foo');
         // Previous model matches the restored model
         expect(model.cells.get(0).toJSON()).toEqual(cellJSON);
       });
@@ -140,7 +140,7 @@ describe('@jupyterlab/notebook', () => {
           const cell = model.contentFactory.createCodeCell({});
           model.cells.push(cell);
           expect(() => {
-            cell.value.text = 'foo';
+            cell.sharedModel.setSource('foo');
           }).not.toThrow();
         });
 
@@ -161,7 +161,7 @@ describe('@jupyterlab/notebook', () => {
           const cell = model.contentFactory.createCodeCell({});
           model.cells.push(cell);
           model.dirty = false;
-          cell.value.text = 'foo';
+          cell.sharedModel.setSource('foo');
           expect(model.dirty).toBe(true);
         });
       });
@@ -386,7 +386,7 @@ describe('@jupyterlab/notebook', () => {
           disableDocumentWideUndoRedo: true
         });
         const cell = model.contentFactory.createCodeCell({});
-        cell.value.text = 'foo';
+        cell.sharedModel.setSource('foo');
         model.cells.push(cell);
         expect(model.cells.canUndo).toBe(true);
         model.initialize();
@@ -438,18 +438,18 @@ describe('@jupyterlab/notebook', () => {
 
         it('should clone an existing code cell', () => {
           const orig = factory.createCodeCell({});
-          orig.value.text = 'foo';
+          orig.sharedModel.setSource('foo');
           const cell = orig.toJSON();
           const newCell = factory.createCodeCell({ cell });
-          expect(newCell.value.text).toBe('foo');
+          expect(newCell.sharedModel.getSource()).toBe('foo');
         });
 
         it('should clone an existing raw cell', () => {
           const orig = factory.createRawCell({});
-          orig.value.text = 'foo';
+          orig.sharedModel.setSource('foo');
           const cell = orig.toJSON();
           const newCell = factory.createCodeCell({ cell });
-          expect(newCell.value.text).toBe('foo');
+          expect(newCell.sharedModel.getSource()).toBe('foo');
         });
       });
 
@@ -461,18 +461,18 @@ describe('@jupyterlab/notebook', () => {
 
         it('should clone an existing raw cell', () => {
           const orig = factory.createRawCell({});
-          orig.value.text = 'foo';
+          orig.sharedModel.setSource('foo');
           const cell = orig.toJSON();
           const newCell = factory.createRawCell({ cell });
-          expect(newCell.value.text).toBe('foo');
+          expect(newCell.sharedModel.getSource()).toBe('foo');
         });
 
         it('should clone an existing code cell', () => {
           const orig = factory.createCodeCell({});
-          orig.value.text = 'foo';
+          orig.sharedModel.setSource('foo');
           const cell = orig.toJSON();
           const newCell = factory.createRawCell({ cell });
-          expect(newCell.value.text).toBe('foo');
+          expect(newCell.sharedModel.getSource()).toBe('foo');
         });
       });
 
@@ -484,18 +484,18 @@ describe('@jupyterlab/notebook', () => {
 
         it('should clone an existing markdown cell', () => {
           const orig = factory.createMarkdownCell({});
-          orig.value.text = 'foo';
+          orig.sharedModel.setSource('foo');
           const cell = orig.toJSON();
           const newCell = factory.createMarkdownCell({ cell });
-          expect(newCell.value.text).toBe('foo');
+          expect(newCell.sharedModel.getSource()).toBe('foo');
         });
 
         it('should clone an existing raw cell', () => {
           const orig = factory.createRawCell({});
-          orig.value.text = 'foo';
+          orig.sharedModel.setSource('foo');
           const cell = orig.toJSON();
           const newCell = factory.createMarkdownCell({ cell });
-          expect(newCell.value.text).toBe('foo');
+          expect(newCell.sharedModel.getSource()).toBe('foo');
         });
       });
 

--- a/packages/notebook/test/notebooktools.spec.ts
+++ b/packages/notebook/test/notebooktools.spec.ts
@@ -307,11 +307,11 @@ describe('@jupyterlab/notebook', () => {
         });
         notebookTools.addItem({ tool });
         const model = tool.editor.model;
-        expect(JSON.stringify(model.value.text)).toBeTruthy();
+        expect(JSON.stringify(model.sharedModel.getSource())).toBeTruthy();
         const widget = tracker.currentWidget!;
         widget.content.activeCellIndex++;
         widget.content.activeCell!.model.metadata.set('bar', 1);
-        expect(JSON.stringify(model.value.text)).toContain('bar');
+        expect(JSON.stringify(model.sharedModel.getSource())).toContain('bar');
       });
 
       it('should handle a change to the metadata', () => {
@@ -320,10 +320,10 @@ describe('@jupyterlab/notebook', () => {
         });
         notebookTools.addItem({ tool });
         const model = tool.editor.model;
-        const previous = model.value.text;
+        const previous = model.sharedModel.getSource();
         const metadata = notebookTools.activeCell!.model.metadata;
         metadata.set('foo', 1);
-        expect(model.value.text).not.toBe(previous);
+        expect(model.sharedModel.getSource()).not.toBe(previous);
       });
     });
 
@@ -346,15 +346,23 @@ describe('@jupyterlab/notebook', () => {
         });
         notebookTools.addItem({ tool });
         const model = tool.editor.model;
-        expect(JSON.stringify(model.value.text)).toBeTruthy();
+        expect(JSON.stringify(model.sharedModel.getSource())).toBeTruthy();
 
         simulate(panel0.node, 'focus');
-        expect(JSON.stringify(model.value.text)).toContain('panel0');
-        expect(JSON.stringify(model.value.text)).not.toContain('panel1');
+        expect(JSON.stringify(model.sharedModel.getSource())).toContain(
+          'panel0'
+        );
+        expect(JSON.stringify(model.sharedModel.getSource())).not.toContain(
+          'panel1'
+        );
 
         simulate(panel1.node, 'focus');
-        expect(JSON.stringify(model.value.text)).not.toContain('panel0');
-        expect(JSON.stringify(model.value.text)).toContain('panel1');
+        expect(JSON.stringify(model.sharedModel.getSource())).not.toContain(
+          'panel0'
+        );
+        expect(JSON.stringify(model.sharedModel.getSource())).toContain(
+          'panel1'
+        );
       });
 
       it('should handle a change to the metadata', () => {
@@ -364,9 +372,13 @@ describe('@jupyterlab/notebook', () => {
         notebookTools.addItem({ tool });
         const model = tool.editor.model;
         const widget = tracker.currentWidget!;
-        expect(JSON.stringify(model.value.text)).not.toContain('newvalue');
+        expect(JSON.stringify(model.sharedModel.getSource())).not.toContain(
+          'newvalue'
+        );
         widget.content.model!.metadata.set('newvalue', 1);
-        expect(JSON.stringify(model.value.text)).toContain('newvalue');
+        expect(JSON.stringify(model.sharedModel.getSource())).toContain(
+          'newvalue'
+        );
       });
     });
 

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -339,7 +339,7 @@ describe('@jupyter/notebook', () => {
         it('should initially render markdown cells with content', () => {
           const cell1 = widget.model!.contentFactory.createMarkdownCell({});
           const cell2 = widget.model!.contentFactory.createMarkdownCell({});
-          cell1.value.text = '# Hello';
+          cell1.sharedModel.setSource('# Hello');
           widget.model!.cells.push(cell1);
           widget.model!.cells.push(cell2);
           expect(widget.widgets.length).toBe(widget.model!.cells.length);
@@ -734,7 +734,7 @@ describe('@jupyter/notebook', () => {
         Widget.attach(widget, document.body);
         MessageLoop.sendMessage(widget, Widget.Msg.ActivateRequest);
         const cell = widget.model!.contentFactory.createMarkdownCell({});
-        cell.value.text = '# Hello'; // Should be rendered with content.
+        cell.sharedModel.setSource('# Hello'); // Should be rendered with content.
         widget.model!.cells.push(cell);
         const child = widget.widgets[widget.widgets.length - 1] as MarkdownCell;
         expect(child.rendered).toBe(true);
@@ -1212,7 +1212,7 @@ describe('@jupyter/notebook', () => {
 
         it('should preserve "command" mode if in a markdown cell', () => {
           const cell = widget.model!.contentFactory.createMarkdownCell({});
-          cell.value.text = '# Hello'; // Should be rendered with content.
+          cell.sharedModel.setSource('# Hello'); // Should be rendered with content.
           widget.model!.cells.push(cell);
           const count = widget.widgets.length;
           const child = widget.widgets[count - 1] as MarkdownCell;
@@ -1267,7 +1267,7 @@ describe('@jupyter/notebook', () => {
         it('should leave a markdown cell rendered', () => {
           const code = widget.model!.contentFactory.createCodeCell({});
           const md = widget.model!.contentFactory.createMarkdownCell({});
-          md.value.text = '# Hello'; // Should be rendered with content.
+          md.sharedModel.setSource('# Hello'); // Should be rendered with content.
           widget.model!.cells.push(code);
           widget.model!.cells.push(md);
           const count = widget.widgets.length;
@@ -1326,7 +1326,7 @@ describe('@jupyter/notebook', () => {
       describe('dblclick', () => {
         it('should unrender a markdown cell', () => {
           const cell = widget.model!.contentFactory.createMarkdownCell({});
-          cell.value.text = '# Hello'; // Should be rendered with content.
+          cell.sharedModel.setSource('# Hello'); // Should be rendered with content.
           widget.model!.cells.push(cell);
           const child = widget.widgets[
             widget.widgets.length - 1
@@ -1621,9 +1621,9 @@ describe('@jupyter/notebook', () => {
         widget.model!.fromJSON(utils.DEFAULT_CONTENT);
         const cell = widget.widgets[5];
         expect(
-          cell.inputArea.editorWidget.model.value.text.startsWith(
-            'from IPython.display import Latex'
-          )
+          cell.inputArea.editorWidget.model.sharedModel
+            .getSource()
+            .startsWith('from IPython.display import Latex')
         ).toBe(true);
         console.log();
       });

--- a/packages/settingeditor/src/raweditor.ts
+++ b/packages/settingeditor/src/raweditor.ts
@@ -53,7 +53,7 @@ export class RawEditor extends SplitPanel {
       factory: editorFactory
     }));
 
-    defaults.editor.model.value.text = '';
+    defaults.editor.model.value = '';
     defaults.editor.model.mimeType = 'text/javascript';
     defaults.editor.setOption('readOnly', true);
 
@@ -66,7 +66,7 @@ export class RawEditor extends SplitPanel {
 
     user.addClass(USER_CLASS);
     user.editor.model.mimeType = 'text/javascript';
-    user.editor.model.value.changed.connect(this._onTextChanged, this);
+    user.editor.model.sharedModel.changed.connect(this._onTextChanged, this);
 
     // Create and set up an inspector.
     this._inspector = createInspector(
@@ -114,7 +114,7 @@ export class RawEditor extends SplitPanel {
    * Tests whether the settings have been modified and need saving.
    */
   get isDirty(): boolean {
-    return this._user.editor.model.value.text !== this._settings?.raw ?? '';
+    return this._user.editor.model.value !== this._settings?.raw ?? '';
   }
 
   /**
@@ -149,8 +149,8 @@ export class RawEditor extends SplitPanel {
       this._onSettingsChanged();
     } else {
       this._settings = null;
-      defaults.editor.model.value.text = '';
-      user.editor.model.value.text = '';
+      defaults.editor.model.value = '';
+      user.editor.model.value = '';
     }
 
     this.update();
@@ -190,7 +190,7 @@ export class RawEditor extends SplitPanel {
    * Revert the editor back to original settings.
    */
   revert(): void {
-    this._user.editor.model.value.text = this.settings?.raw ?? '';
+    this._user.editor.model.value = this.settings?.raw ?? '';
     this._updateToolbar(false, false);
   }
 
@@ -203,7 +203,7 @@ export class RawEditor extends SplitPanel {
     }
 
     const settings = this._settings;
-    const source = this._user.editor.model.value.text;
+    const source = this._user.editor.model.value;
 
     return settings
       .save(source)
@@ -242,7 +242,7 @@ export class RawEditor extends SplitPanel {
    * Handle text changes in the underlying editor.
    */
   private _onTextChanged(): void {
-    const raw = this._user.editor.model.value.text;
+    const raw = this._user.editor.model.value;
     const settings = this._settings;
 
     this.removeClass(ERROR_CLASS);
@@ -272,8 +272,8 @@ export class RawEditor extends SplitPanel {
     const defaults = this._defaults;
     const user = this._user;
 
-    defaults.editor.model.value.text = settings?.annotatedDefaults() ?? '';
-    user.editor.model.value.text = settings?.raw ?? '';
+    defaults.editor.model.value = settings?.annotatedDefaults() ?? '';
+    user.editor.model.value = settings?.raw ?? '';
   }
 
   private _updateToolbar(revert = this._canRevert, save = this._canSave): void {

--- a/packages/settingeditor/src/raweditor.ts
+++ b/packages/settingeditor/src/raweditor.ts
@@ -53,7 +53,7 @@ export class RawEditor extends SplitPanel {
       factory: editorFactory
     }));
 
-    defaults.editor.model.value = '';
+    defaults.editor.model.sharedModel.setSource('');
     defaults.editor.model.mimeType = 'text/javascript';
     defaults.editor.setOption('readOnly', true);
 
@@ -114,7 +114,10 @@ export class RawEditor extends SplitPanel {
    * Tests whether the settings have been modified and need saving.
    */
   get isDirty(): boolean {
-    return this._user.editor.model.value !== this._settings?.raw ?? '';
+    return (
+      this._user.editor.model.sharedModel.getSource() !== this._settings?.raw ??
+      ''
+    );
   }
 
   /**
@@ -149,8 +152,8 @@ export class RawEditor extends SplitPanel {
       this._onSettingsChanged();
     } else {
       this._settings = null;
-      defaults.editor.model.value = '';
-      user.editor.model.value = '';
+      defaults.editor.model.sharedModel.setSource('');
+      user.editor.model.sharedModel.setSource('');
     }
 
     this.update();
@@ -190,7 +193,7 @@ export class RawEditor extends SplitPanel {
    * Revert the editor back to original settings.
    */
   revert(): void {
-    this._user.editor.model.value = this.settings?.raw ?? '';
+    this._user.editor.model.sharedModel.setSource(this.settings?.raw ?? '');
     this._updateToolbar(false, false);
   }
 
@@ -203,7 +206,7 @@ export class RawEditor extends SplitPanel {
     }
 
     const settings = this._settings;
-    const source = this._user.editor.model.value;
+    const source = this._user.editor.model.sharedModel.getSource();
 
     return settings
       .save(source)
@@ -242,7 +245,7 @@ export class RawEditor extends SplitPanel {
    * Handle text changes in the underlying editor.
    */
   private _onTextChanged(): void {
-    const raw = this._user.editor.model.value;
+    const raw = this._user.editor.model.sharedModel.getSource();
     const settings = this._settings;
 
     this.removeClass(ERROR_CLASS);
@@ -272,8 +275,10 @@ export class RawEditor extends SplitPanel {
     const defaults = this._defaults;
     const user = this._user;
 
-    defaults.editor.model.value = settings?.annotatedDefaults() ?? '';
-    user.editor.model.value = settings?.raw ?? '';
+    defaults.editor.model.sharedModel.setSource(
+      settings?.annotatedDefaults() ?? ''
+    );
+    user.editor.model.sharedModel.setSource(settings?.raw ?? '');
   }
 
   private _updateToolbar(revert = this._canRevert, save = this._canSave): void {

--- a/packages/settingeditor/src/raweditor.ts
+++ b/packages/settingeditor/src/raweditor.ts
@@ -53,7 +53,7 @@ export class RawEditor extends SplitPanel {
       factory: editorFactory
     }));
 
-    defaults.editor.model.sharedModel.setSource('');
+    defaults.editor.model.source = '';
     defaults.editor.model.mimeType = 'text/javascript';
     defaults.editor.setOption('readOnly', true);
 
@@ -66,7 +66,7 @@ export class RawEditor extends SplitPanel {
 
     user.addClass(USER_CLASS);
     user.editor.model.mimeType = 'text/javascript';
-    user.editor.model.sharedModel.changed.connect(this._onTextChanged, this);
+    user.editor.model.sourceChanged.connect(this._onTextChanged, this);
 
     // Create and set up an inspector.
     this._inspector = createInspector(
@@ -114,10 +114,7 @@ export class RawEditor extends SplitPanel {
    * Tests whether the settings have been modified and need saving.
    */
   get isDirty(): boolean {
-    return (
-      this._user.editor.model.sharedModel.getSource() !== this._settings?.raw ??
-      ''
-    );
+    return this._user.editor.model.source !== this._settings?.raw ?? '';
   }
 
   /**
@@ -152,8 +149,8 @@ export class RawEditor extends SplitPanel {
       this._onSettingsChanged();
     } else {
       this._settings = null;
-      defaults.editor.model.sharedModel.setSource('');
-      user.editor.model.sharedModel.setSource('');
+      defaults.editor.model.source = '';
+      user.editor.model.source = '';
     }
 
     this.update();
@@ -193,7 +190,7 @@ export class RawEditor extends SplitPanel {
    * Revert the editor back to original settings.
    */
   revert(): void {
-    this._user.editor.model.sharedModel.setSource(this.settings?.raw ?? '');
+    this._user.editor.model.source = this.settings?.raw ?? '';
     this._updateToolbar(false, false);
   }
 
@@ -206,7 +203,7 @@ export class RawEditor extends SplitPanel {
     }
 
     const settings = this._settings;
-    const source = this._user.editor.model.sharedModel.getSource();
+    const source = this._user.editor.model.source;
 
     return settings
       .save(source)
@@ -245,7 +242,7 @@ export class RawEditor extends SplitPanel {
    * Handle text changes in the underlying editor.
    */
   private _onTextChanged(): void {
-    const raw = this._user.editor.model.sharedModel.getSource();
+    const raw = this._user.editor.model.source;
     const settings = this._settings;
 
     this.removeClass(ERROR_CLASS);
@@ -275,10 +272,8 @@ export class RawEditor extends SplitPanel {
     const defaults = this._defaults;
     const user = this._user;
 
-    defaults.editor.model.sharedModel.setSource(
-      settings?.annotatedDefaults() ?? ''
-    );
-    user.editor.model.sharedModel.setSource(settings?.raw ?? '');
+    defaults.editor.model.source = settings?.annotatedDefaults() ?? '';
+    user.editor.model.source = settings?.raw ?? '';
   }
 
   private _updateToolbar(revert = this._canRevert, save = this._canSave): void {

--- a/packages/shared-models/src/api.ts
+++ b/packages/shared-models/src/api.ts
@@ -464,8 +464,39 @@ export interface ISharedUnrecognizedCell
   toJSON(): nbformat.ICodeCell;
 }
 
+export type SourceChange = {
+  /**
+   * The type of change undergone by the list.
+   */
+  type: 'insert' | 'remove' | 'set';
+
+  /**
+   * The starting index of the change.
+   */
+  start: number;
+
+  /**
+   * The end index of the change.
+   */
+  end: number;
+
+  /**
+   * The value of the change.
+   *
+   * ### Notes
+   * If `ChangeType` is `set`, then
+   * this is the new value of the string.
+   *
+   * If `type` is `insert` this is
+   * the value of the inserted string.
+   *
+   * If `type` is remove this is null.
+   */
+  value: string | null;
+};
+
 export type TextChange = {
-  sourceChange?: Delta<string>;
+  sourceChange?: Array<SourceChange>;
 };
 
 /**
@@ -486,7 +517,7 @@ export type NotebookChange = {
 };
 
 export type FileChange = {
-  sourceChange?: Delta<string>;
+  sourceChange?: Array<SourceChange>;
   contextChange?: MapChange;
   stateChange?: Array<{
     name: string;
@@ -499,7 +530,7 @@ export type FileChange = {
  * Definition of the shared Cell changes.
  */
 export type CellChange<MetadataType> = {
-  sourceChange?: Delta<string>;
+  sourceChange?: Array<SourceChange>;
   outputsChange?: Delta<nbformat.IOutput[]>;
   executionCountChange?: {
     oldValue: number | undefined;

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -17,11 +17,16 @@ const deepCopy = (o: any) => JSON.parse(JSON.stringify(o));
  * Abstract interface to define Shared Models that can be bound to a text editor using any existing
  * Yjs-based editor binding.
  */
-export interface IYText extends models.ISharedText {
+export interface IYModel {
   readonly ysource: Y.Text;
   readonly awareness: Awareness | null;
   readonly undoManager: Y.UndoManager | null;
-  readonly ydoc?: Y.Doc;
+}
+
+export interface IYDocument {
+  readonly awareness: Awareness;
+  readonly undoManager: Y.UndoManager;
+  readonly ydoc: Y.Doc;
 }
 
 export type YCellType = YRawCell | YCodeCell | YMarkdownCell;
@@ -107,7 +112,7 @@ export class YDocument<T> implements models.ISharedDocument {
 
 export class YFile
   extends YDocument<models.FileChange>
-  implements models.ISharedFile, models.ISharedText, IYText {
+  implements models.ISharedFile, models.ISharedText, IYModel {
   constructor() {
     super();
     this.ysource.observe(this._modelObserver);
@@ -233,7 +238,7 @@ export class YFile
  */
 export class YNotebook
   extends YDocument<models.NotebookChange>
-  implements models.ISharedNotebook {
+  implements models.ISharedNotebook, IYDocument {
   constructor(options: ISharedNotebook.IOptions) {
     super();
     this._disableDocumentWideUndoRedo = options.disableDocumentWideUndoRedo;
@@ -537,7 +542,7 @@ export const createStandaloneCell = (
 };
 
 export class YBaseCell<Metadata extends models.ISharedBaseCellMetadata>
-  implements models.ISharedBaseCell<Metadata>, IYText {
+  implements models.ISharedBaseCell<Metadata>, IYModel {
   constructor(ymodel: Y.Map<any>) {
     this.ymodel = ymodel;
     this.ymodel.observeDeep(this._modelObserver);

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -21,6 +21,7 @@ export interface IYText extends models.ISharedText {
   readonly ysource: Y.Text;
   readonly awareness: Awareness | null;
   readonly undoManager: Y.UndoManager | null;
+  readonly ydoc?: Y.Doc;
 }
 
 export type YCellType = YRawCell | YCodeCell | YMarkdownCell;

--- a/packages/toc/src/generators/latex/index.ts
+++ b/packages/toc/src/generators/latex/index.ts
@@ -65,7 +65,7 @@ function isEnabled(editor: IDocumentWidget<FileEditor>) {
  */
 function generate(editor: IDocumentWidget<FileEditor>): IHeading[] {
   // Split the text into lines:
-  let lines = editor.content.model.value.text.split('\n') as Array<any>;
+  let lines = editor.content.model.value.split('\n') as Array<any>;
 
   // Convert the list into "entries" so we can use the line number to scroll the editor upon ToC item click:
   lines = toEntries(lines);

--- a/packages/toc/src/generators/latex/index.ts
+++ b/packages/toc/src/generators/latex/index.ts
@@ -65,7 +65,9 @@ function isEnabled(editor: IDocumentWidget<FileEditor>) {
  */
 function generate(editor: IDocumentWidget<FileEditor>): IHeading[] {
   // Split the text into lines:
-  let lines = editor.content.model.value.split('\n') as Array<any>;
+  let lines = editor.content.model.sharedModel.getSource().split('\n') as Array<
+    any
+  >;
 
   // Convert the list into "entries" so we can use the line number to scroll the editor upon ToC item click:
   lines = toEntries(lines);

--- a/packages/toc/src/generators/latex/index.ts
+++ b/packages/toc/src/generators/latex/index.ts
@@ -65,9 +65,7 @@ function isEnabled(editor: IDocumentWidget<FileEditor>) {
  */
 function generate(editor: IDocumentWidget<FileEditor>): IHeading[] {
   // Split the text into lines:
-  let lines = editor.content.model.sharedModel.getSource().split('\n') as Array<
-    any
-  >;
+  let lines = editor.content.model.source.split('\n') as Array<any>;
 
   // Convert the list into "entries" so we can use the line number to scroll the editor upon ToC item click:
   lines = toEntries(lines);

--- a/packages/toc/src/generators/markdown/index.ts
+++ b/packages/toc/src/generators/markdown/index.ts
@@ -49,12 +49,7 @@ function generate(
   if (options !== undefined) {
     numberingH1 = options.numberingH1;
   }
-  return getHeadings(
-    editor.content.model.value.text,
-    onClick,
-    dict,
-    numberingH1
-  );
+  return getHeadings(editor.content.model.value, onClick, dict, numberingH1);
 
   /**
    * Returns a "click" handler.

--- a/packages/toc/src/generators/markdown/index.ts
+++ b/packages/toc/src/generators/markdown/index.ts
@@ -49,12 +49,7 @@ function generate(
   if (options !== undefined) {
     numberingH1 = options.numberingH1;
   }
-  return getHeadings(
-    editor.content.model.sharedModel.getSource(),
-    onClick,
-    dict,
-    numberingH1
-  );
+  return getHeadings(editor.content.model.source, onClick, dict, numberingH1);
 
   /**
    * Returns a "click" handler.

--- a/packages/toc/src/generators/markdown/index.ts
+++ b/packages/toc/src/generators/markdown/index.ts
@@ -49,7 +49,12 @@ function generate(
   if (options !== undefined) {
     numberingH1 = options.numberingH1;
   }
-  return getHeadings(editor.content.model.value, onClick, dict, numberingH1);
+  return getHeadings(
+    editor.content.model.sharedModel.getSource(),
+    onClick,
+    dict,
+    numberingH1
+  );
 
   /**
    * Returns a "click" handler.

--- a/packages/toc/src/generators/notebook/index.ts
+++ b/packages/toc/src/generators/notebook/index.ts
@@ -206,7 +206,7 @@ class NotebookGenerator implements Registry.IGenerator<NotebookPanel> {
               count ?? (isRunning !== RunningStatus.Idle ? '*' : ' ');
             let executionCount = `[${executionIndicator}]: `;
             let heading = getCodeCellHeading(
-              (model as CodeCellModel).value,
+              (model as CodeCellModel).sharedModel.getSource(),
               onClick,
               executionCount,
               getLastHeadingLevel(headings),
@@ -320,7 +320,7 @@ class NotebookGenerator implements Registry.IGenerator<NotebookPanel> {
               };
             };
             const markdownHeadings = getMarkdownHeadings(
-              model!.value,
+              model!.sharedModel.getSource(),
               onClick,
               dict,
               lastLevel,

--- a/packages/toc/src/generators/notebook/index.ts
+++ b/packages/toc/src/generators/notebook/index.ts
@@ -206,7 +206,7 @@ class NotebookGenerator implements Registry.IGenerator<NotebookPanel> {
               count ?? (isRunning !== RunningStatus.Idle ? '*' : ' ');
             let executionCount = `[${executionIndicator}]: `;
             let heading = getCodeCellHeading(
-              (model as CodeCellModel).value.text,
+              (model as CodeCellModel).value,
               onClick,
               executionCount,
               getLastHeadingLevel(headings),
@@ -320,7 +320,7 @@ class NotebookGenerator implements Registry.IGenerator<NotebookPanel> {
               };
             };
             const markdownHeadings = getMarkdownHeadings(
-              model!.value.text,
+              model!.value,
               onClick,
               dict,
               lastLevel,

--- a/packages/toc/src/generators/notebook/index.ts
+++ b/packages/toc/src/generators/notebook/index.ts
@@ -206,7 +206,7 @@ class NotebookGenerator implements Registry.IGenerator<NotebookPanel> {
               count ?? (isRunning !== RunningStatus.Idle ? '*' : ' ');
             let executionCount = `[${executionIndicator}]: `;
             let heading = getCodeCellHeading(
-              (model as CodeCellModel).sharedModel.getSource(),
+              (model as CodeCellModel).source,
               onClick,
               executionCount,
               getLastHeadingLevel(headings),
@@ -320,7 +320,7 @@ class NotebookGenerator implements Registry.IGenerator<NotebookPanel> {
               };
             };
             const markdownHeadings = getMarkdownHeadings(
-              model!.sharedModel.getSource(),
+              model!.source,
               onClick,
               dict,
               lastLevel,

--- a/packages/toc/src/generators/python/index.ts
+++ b/packages/toc/src/generators/python/index.ts
@@ -16,7 +16,7 @@ import { render } from './render';
  */
 function generate(editor: IDocumentWidget<FileEditor>): IHeading[] {
   // Split the text into lines:
-  let lines = editor.content.model.value.text.split('\n') as Array<any>;
+  let lines = editor.content.model.value.split('\n') as Array<any>;
 
   // Iterate over the lines to get the heading level and text for each line:
   let headings: IHeading[] = [];

--- a/packages/toc/src/generators/python/index.ts
+++ b/packages/toc/src/generators/python/index.ts
@@ -16,7 +16,9 @@ import { render } from './render';
  */
 function generate(editor: IDocumentWidget<FileEditor>): IHeading[] {
   // Split the text into lines:
-  let lines = editor.content.model.value.split('\n') as Array<any>;
+  let lines = editor.content.model.sharedModel.getSource().split('\n') as Array<
+    any
+  >;
 
   // Iterate over the lines to get the heading level and text for each line:
   let headings: IHeading[] = [];

--- a/packages/toc/src/generators/python/index.ts
+++ b/packages/toc/src/generators/python/index.ts
@@ -16,9 +16,7 @@ import { render } from './render';
  */
 function generate(editor: IDocumentWidget<FileEditor>): IHeading[] {
   // Split the text into lines:
-  let lines = editor.content.model.sharedModel.getSource().split('\n') as Array<
-    any
-  >;
+  let lines = editor.content.model.source.split('\n') as Array<any>;
 
   // Iterate over the lines to get the heading level and text for each line:
   let headings: IHeading[] = [];

--- a/packages/tooltip-extension/src/index.ts
+++ b/packages/tooltip-extension/src/index.ts
@@ -283,7 +283,7 @@ namespace Private {
    */
   export function fetch(options: IFetchOptions): Promise<JSONObject> {
     const { detail, editor, kernel } = options;
-    const code = editor.model.value;
+    const code = editor.model.sharedModel.getSource();
     const position = editor.getCursorPosition();
     const offset = Text.jsIndexToCharIndex(editor.getOffsetAt(position), code);
 

--- a/packages/tooltip-extension/src/index.ts
+++ b/packages/tooltip-extension/src/index.ts
@@ -283,7 +283,7 @@ namespace Private {
    */
   export function fetch(options: IFetchOptions): Promise<JSONObject> {
     const { detail, editor, kernel } = options;
-    const code = editor.model.sharedModel.getSource();
+    const code = editor.model.source;
     const position = editor.getCursorPosition();
     const offset = Text.jsIndexToCharIndex(editor.getOffsetAt(position), code);
 

--- a/packages/tooltip-extension/src/index.ts
+++ b/packages/tooltip-extension/src/index.ts
@@ -283,7 +283,7 @@ namespace Private {
    */
   export function fetch(options: IFetchOptions): Promise<JSONObject> {
     const { detail, editor, kernel } = options;
-    const code = editor.model.value.text;
+    const code = editor.model.value;
     const position = editor.getCursorPosition();
     const offset = Text.jsIndexToCharIndex(editor.getOffsetAt(position), code);
 


### PR DESCRIPTION
## References
* #11434
* #11602

## Code changes
Removes `value` from ModelDB to use its counterpart `source` from the shared model:
https://github.com/jupyterlab/jupyterlab/blob/014091f21d00bd1c940105744d945a61a7b23e6a/packages/codeeditor/src/editor.ts#L244-L246
https://github.com/jupyterlab/jupyterlab/blob/014091f21d00bd1c940105744d945a61a7b23e6a/packages/shared-models/src/ymodels.ts#L98

## User-facing changes
N/A

## Backwards-incompatible changes
* Regarding the `IModel`, I removed the property `value`. Now we can interact with the content with:
    * `model.value.changed` -> `model.sourceChanged`
    * `model.value.text` -> `model.source`
    * `model.value.remove` -> `model.source = ""`
    * `model.value.insert` -> `model.updateSource`
