### PR TITLE
overrides.json definition takes precedence

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -1091,7 +1091,7 @@ namespace Private {
      */
     function populate(schema: ISettingRegistry.ISchema) {
       loaded = {};
-      schema.properties!.contextMenu.default = Object.keys(registry.plugins)
+      const pluginDefaults = Object.keys(registry.plugins)
         .map(plugin => {
           const items =
             registry.plugins[plugin]!.schema['jupyter.lab.menus']?.context ??
@@ -1099,17 +1099,24 @@ namespace Private {
           loaded[plugin] = items;
           return items;
         })
-        .concat([
-          schema['jupyter.lab.menus']?.context ?? [],
-          schema.properties!.contextMenu.default as any[]
-        ])
+        .concat([schema['jupyter.lab.menus']?.context ?? []])
         .reduceRight(
           (
             acc: ISettingRegistry.IContextMenuItem[],
             val: ISettingRegistry.IContextMenuItem[]
           ) => SettingRegistry.reconcileItems(acc, val, true),
           []
-        )! // flatten one level
+        )!;
+
+      // Apply default value as last step to take into account overrides.json
+      // The standard default being [] as the plugin must use `jupyter.lab.menus.context`
+      // to define their default value.
+      schema.properties!.contextMenu.default = SettingRegistry.reconcileItems(
+        pluginDefaults,
+        schema.properties!.contextMenu.default as any[],
+        true
+      )!
+        // flatten one level
         .sort((a, b) => (a.rank ?? Infinity) - (b.rank ?? Infinity));
     }
 

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -790,21 +790,28 @@ namespace Private {
      */
     function populate(schema: ISettingRegistry.ISchema) {
       loaded = {};
-      schema.properties!.menus.default = Object.keys(registry.plugins)
+      const pluginDefaults = Object.keys(registry.plugins)
         .map(plugin => {
           const menus =
             registry.plugins[plugin]!.schema['jupyter.lab.menus']?.main ?? [];
           loaded[plugin] = menus;
           return menus;
         })
-        .concat([
-          schema['jupyter.lab.menus']?.main ?? [],
-          schema.properties!.menus.default as any[]
-        ])
+        .concat([schema['jupyter.lab.menus']?.main ?? []])
         .reduceRight(
           (acc, val) => SettingRegistry.reconcileMenus(acc, val, true),
-          []
-        ) // flatten one level
+          schema.properties!.menus.default as any[]
+        );
+
+      // Apply default value as last step to take into account overrides.json
+      // The standard default being [] as the plugin must use `jupyter.lab.menus.main`
+      // to define their default value.
+      schema.properties!.menus.default = SettingRegistry.reconcileMenus(
+        pluginDefaults,
+        schema.properties!.menus.default as any[],
+        true
+      )
+        // flatten one level
         .sort((a, b) => (a.rank ?? Infinity) - (b.rank ?? Infinity));
     }
 


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fix bug discovered in https://github.com/jupyterlab/jupyterlab/issues/10343#issuecomment-985370344
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Apply the default settings (empty by default but could come from overrides.json) at the latest stage to build menus and toolbars; so that they take precedence.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Rank will correctly be overriden
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A