### PR TITLE
Restore accidentally removed ToC context menu

### DIFF
--- a/packages/toc-extension/src/index.ts
+++ b/packages/toc-extension/src/index.ts
@@ -125,6 +125,11 @@ async function activateTOC(
     label: trans.__('Run Cell(s)')
   });
 
+  app.contextMenu.addItem({
+    selector: '.jp-tocItem',
+    command: CommandIDs.runCells
+  });
+
   if (restorer) {
     // Add the ToC widget to the application restorer:
     restorer.add(toc, '@jupyterlab/toc:plugin');


### PR DESCRIPTION
## References

Fixes #11584. This PR is targeting 3.2.x branch because the code was only removed in manual backport.

## Code changes

Restores code accidentally removed in #11421. 

## User-facing changes

Context menu opens again in table of contents

## Backwards-incompatible changes

None