### PR TITLE
Revert "Restore accidentally removed ToC context menu"

### DIFF
--- a/packages/toc-extension/src/index.ts
+++ b/packages/toc-extension/src/index.ts
@@ -125,11 +125,6 @@ async function activateTOC(
     label: trans.__('Run Cell(s)')
   });
 
-  app.contextMenu.addItem({
-    selector: '.jp-tocItem',
-    command: CommandIDs.runCells
-  });
-
   if (restorer) {
     // Add the ToC widget to the application restorer:
     restorer.add(toc, '@jupyterlab/toc:plugin');


### PR DESCRIPTION
Reverts jupyterlab/jupyterlab#11617

In fact the trouble is the plugin name of the toc that does not respect JupyterLab pattern => the settings containing the menus definition are not loaded.