### PR TITLE
Remove leading slash from console path

### DIFF
--- a/packages/console/src/panel.ts
+++ b/packages/console/src/panel.ts
@@ -55,7 +55,9 @@ export class ConsolePanel extends MainAreaWidget<Panel> {
       options.contentFactory || ConsolePanel.defaultContentFactory);
     const count = Private.count++;
     if (!path) {
-      path = `${basePath || ''}/console-${count}-${UUID.uuid4()}`;
+      path = `${
+        basePath ? basePath + '/' : ''
+      }console-${count}-${UUID.uuid4()}`;
     }
 
     sessionContext = this._sessionContext =

--- a/packages/console/src/panel.ts
+++ b/packages/console/src/panel.ts
@@ -8,7 +8,7 @@ import {
   sessionContextDialogs
 } from '@jupyterlab/apputils';
 import { IEditorMimeTypeService } from '@jupyterlab/codeeditor';
-import { PathExt, Time } from '@jupyterlab/coreutils';
+import { PathExt, Time, URLExt } from '@jupyterlab/coreutils';
 import {
   IRenderMimeRegistry,
   RenderMimeRegistry
@@ -55,9 +55,7 @@ export class ConsolePanel extends MainAreaWidget<Panel> {
       options.contentFactory || ConsolePanel.defaultContentFactory);
     const count = Private.count++;
     if (!path) {
-      path = `${
-        basePath ? basePath + '/' : ''
-      }console-${count}-${UUID.uuid4()}`;
+      path = URLExt.join(basePath || '', `console-${count}-${UUID.uuid4()}`);
     }
 
     sessionContext = this._sessionContext =


### PR DESCRIPTION
## References

https://github.com/jupyterlab/retrolab/issues/300

## Code changes

This change ensures that a console path doesn't start with `/`, otherwise this leads to the console URL having a double slash e.g. in RetroLab:
```
http://localhost:8888/retro/consoles//console-1-33a9d4ee-3873-4611-9edd-c1ff7afee29e
```

## User-facing changes

None

## Backwards-incompatible changes

None