### PR TITLE
Specifying print CSS rules for notebooks

### DIFF
--- a/packages/cells/style/collapser.css
+++ b/packages/cells/style/collapser.css
@@ -23,3 +23,19 @@
   top: 0px;
   bottom: 0px;
 }
+
+/*-----------------------------------------------------------------------------
+| Printing
+|----------------------------------------------------------------------------*/
+
+/*
+Hiding collapsers in print mode.
+
+Note: input and output wrappers have "display: block" propery in print mode.
+*/
+
+@media print {
+  .jp-Collapser {
+    display: none;
+  }
+}

--- a/packages/cells/style/widget.css
+++ b/packages/cells/style/widget.css
@@ -142,3 +142,19 @@ is a consequence of the showHiddenCellsButton option in Notebook Settings)*/
 .jp-showHiddenCellsButton {
   display: none;
 }
+
+/*-----------------------------------------------------------------------------
+| Printing
+|----------------------------------------------------------------------------*/
+
+/*
+Using block instead of flex to allow the use of the break-inside CSS property for
+cell outputs.
+*/
+
+@media print {
+  .jp-Cell-inputWrapper,
+  .jp-Cell-outputWrapper {
+    display: block;
+  }
+}

--- a/packages/outputarea/style/base.css
+++ b/packages/outputarea/style/base.css
@@ -222,3 +222,13 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
 .jp-LinkedOutputView .jp-OutputArea-output:only-child {
   height: 100%;
 }
+
+/*-----------------------------------------------------------------------------
+| Printing
+|----------------------------------------------------------------------------*/
+
+@media print {
+  .jp-OutputArea-child {
+    break-inside: avoid-page;
+  }
+}


### PR DESCRIPTION
## References

This CSS change is meant to prevent page breaks in the middle of outputs when printing notebooks (webpdf export in nbconvert).

## Code changes

Adding `@media print` CSS rules to:

 - hide collapsers
 - display the input wrappers and output wrapper with `display: block` (because flex prevents the use of `break-inside` CSS property in inner HTML).
 - set the `break-inside` property to `avoid-page` for `jp-OutputArea-child` elements.

## Screenshots (Before | After)

<img width="134" alt="before" src="https://user-images.githubusercontent.com/2397974/145302305-e30a5387-860e-417a-911e-155187a8bf45.png"> <img width="134" alt="after" src="https://user-images.githubusercontent.com/2397974/145302317-a9a237a7-62e1-4add-91ec-b7a8b8dd01f1.png">





