### PR TITLE
Add `closeOnExit` terminal option

### DIFF
--- a/packages/services/src/terminal/manager.ts
+++ b/packages/services/src/terminal/manager.ts
@@ -113,11 +113,9 @@ export class TerminalManager extends BaseManager implements Terminal.IManager {
   /*
    * Connect to a running terminal.
    *
-   * @param name - The name of the target terminal.
-   *
    * @param options - The options used to connect to the terminal.
    *
-   * @returns A promise that resolves to the new terminal connection instance.
+   * @returns The new terminal connection instance.
    *
    * #### Notes
    * The manager `serverSettings` will be used.
@@ -166,14 +164,16 @@ export class TerminalManager extends BaseManager implements Terminal.IManager {
   /**
    * Create a new terminal session.
    *
-   * @returns A promise that resolves with the terminal instance.
+   * @param name - The name of the target terminal.
+   *
+   * @returns A promise that resolves with the terminal connection instance.
    *
    * #### Notes
    * The manager `serverSettings` will be used unless overridden in the
    * options.
    */
-  async startNew(): Promise<Terminal.ITerminalConnection> {
-    const model = await startNew(this.serverSettings);
+  async startNew(name?: string): Promise<Terminal.ITerminalConnection> {
+    const model = await startNew(this.serverSettings, name);
     await this.refreshRunning();
     return this.connectTo({ model });
   }
@@ -323,7 +323,7 @@ export namespace TerminalManager {
      * Create a new terminal session - throw an error since it is not supported.
      *
      */
-    async startNew(): Promise<Terminal.ITerminalConnection> {
+    async startNew(name?: string): Promise<Terminal.ITerminalConnection> {
       return Promise.reject(
         new Error('Not implemented in no-op Terminal Manager')
       );

--- a/packages/services/src/terminal/manager.ts
+++ b/packages/services/src/terminal/manager.ts
@@ -173,9 +173,9 @@ export class TerminalManager extends BaseManager implements Terminal.IManager {
    * options.
    */
   async startNew(
-    options?: Omit<Terminal.ITerminalConnection.IOptions, 'serverSettings'>
+    options?: Terminal.ITerminal.IOptions
   ): Promise<Terminal.ITerminalConnection> {
-    const model = await startNew(this.serverSettings, options?.model.name);
+    const model = await startNew(this.serverSettings, options?.name);
     await this.refreshRunning();
     return this.connectTo({ model });
   }
@@ -326,7 +326,7 @@ export namespace TerminalManager {
      *
      */
     async startNew(
-      options?: Omit<Terminal.ITerminalConnection.IOptions, 'serverSettings'>
+      options?: Terminal.ITerminal.IOptions
     ): Promise<Terminal.ITerminalConnection> {
       return Promise.reject(
         new Error('Not implemented in no-op Terminal Manager')

--- a/packages/services/src/terminal/manager.ts
+++ b/packages/services/src/terminal/manager.ts
@@ -164,7 +164,7 @@ export class TerminalManager extends BaseManager implements Terminal.IManager {
   /**
    * Create a new terminal session.
    *
-   * @param name - The name of the target terminal.
+   * @param options - The options used to create the terminal.
    *
    * @returns A promise that resolves with the terminal connection instance.
    *
@@ -172,8 +172,10 @@ export class TerminalManager extends BaseManager implements Terminal.IManager {
    * The manager `serverSettings` will be used unless overridden in the
    * options.
    */
-  async startNew(name?: string): Promise<Terminal.ITerminalConnection> {
-    const model = await startNew(this.serverSettings, name);
+  async startNew(
+    options?: Omit<Terminal.ITerminalConnection.IOptions, 'serverSettings'>
+  ): Promise<Terminal.ITerminalConnection> {
+    const model = await startNew(this.serverSettings, options?.model.name);
     await this.refreshRunning();
     return this.connectTo({ model });
   }
@@ -323,7 +325,9 @@ export namespace TerminalManager {
      * Create a new terminal session - throw an error since it is not supported.
      *
      */
-    async startNew(name?: string): Promise<Terminal.ITerminalConnection> {
+    async startNew(
+      options?: Omit<Terminal.ITerminalConnection.IOptions, 'serverSettings'>
+    ): Promise<Terminal.ITerminalConnection> {
       return Promise.reject(
         new Error('Not implemented in no-op Terminal Manager')
       );

--- a/packages/services/src/terminal/restapi.ts
+++ b/packages/services/src/terminal/restapi.ts
@@ -30,16 +30,22 @@ export interface IModel {
 /**
  * Start a new terminal session.
  *
- * @param options - The session options to use.
+ * @param settings - The server settings to use.
  *
- * @returns A promise that resolves with the session instance.
+ * @param name - The name of the target terminal.
+ *
+ * @returns A promise that resolves with the session model.
  */
 export async function startNew(
-  settings: ServerConnection.ISettings = ServerConnection.makeSettings()
+  settings: ServerConnection.ISettings = ServerConnection.makeSettings(),
+  name?: string
 ): Promise<IModel> {
   Private.errorIfNotAvailable();
   const url = URLExt.join(settings.baseUrl, TERMINAL_SERVICE_URL);
-  const init = { method: 'POST' };
+  const init = {
+    method: 'POST',
+    body: JSON.stringify({ name })
+  };
 
   const response = await ServerConnection.makeRequest(url, init, settings);
   if (response.status !== 200) {

--- a/packages/services/src/terminal/terminal.ts
+++ b/packages/services/src/terminal/terminal.ts
@@ -145,14 +145,16 @@ export interface IManager extends IBaseManager {
   /**
    * Create a new terminal session.
    *
-   * @param name - The name of the target terminal.
+   * @param options - The options used to create the terminal.
    *
    * @returns A promise that resolves with the terminal connection instance.
    *
    * #### Notes
    * The manager `serverSettings` will be always be used.
    */
-  startNew(name?: string): Promise<ITerminalConnection>;
+  startNew(
+    options?: Omit<ITerminalConnection.IOptions, 'serverSettings'>
+  ): Promise<ITerminalConnection>;
 
   /*
    * Connect to a running session.

--- a/packages/services/src/terminal/terminal.ts
+++ b/packages/services/src/terminal/terminal.ts
@@ -145,23 +145,21 @@ export interface IManager extends IBaseManager {
   /**
    * Create a new terminal session.
    *
-   * @param options - The options used to create the session.
+   * @param name - The name of the target terminal.
    *
-   * @returns A promise that resolves with the terminal instance.
+   * @returns A promise that resolves with the terminal connection instance.
    *
    * #### Notes
    * The manager `serverSettings` will be always be used.
    */
-  startNew(
-    options?: ITerminalConnection.IOptions
-  ): Promise<ITerminalConnection>;
+  startNew(name?: string): Promise<ITerminalConnection>;
 
   /*
    * Connect to a running session.
    *
-   * @param name - The name of the target session.
+   * @param options - The options used to connect to the terminal.
    *
-   * @returns A promise that resolves with the new session instance.
+   * @returns The new terminal connection instance.
    */
   connectTo(
     options: Omit<ITerminalConnection.IOptions, 'serverSettings'>

--- a/packages/services/src/terminal/terminal.ts
+++ b/packages/services/src/terminal/terminal.ts
@@ -16,6 +16,15 @@ import { IManager as IBaseManager } from '../basemanager';
 import { IModel, isAvailable } from './restapi';
 export { IModel, isAvailable };
 
+export namespace ITerminal {
+  export interface IOptions {
+    /**
+     * Terminal name.
+     */
+    name: string;
+  }
+}
+
 /**
  * An interface for a terminal session.
  */
@@ -152,9 +161,7 @@ export interface IManager extends IBaseManager {
    * #### Notes
    * The manager `serverSettings` will be always be used.
    */
-  startNew(
-    options?: Omit<ITerminalConnection.IOptions, 'serverSettings'>
-  ): Promise<ITerminalConnection>;
+  startNew(options?: ITerminal.IOptions): Promise<ITerminalConnection>;
 
   /*
    * Connect to a running session.

--- a/packages/terminal-extension/schema/plugin.json
+++ b/packages/terminal-extension/schema/plugin.json
@@ -81,9 +81,9 @@
       "type": "boolean",
       "default": false
     },
-    "disposeOnExit": {
-      "title": "Dispose on exit",
-      "description": "Dispose the widget when exiting the terminal.",
+    "closeOnExit": {
+      "title": "Close on exit",
+      "description": "Close the widget when exiting the terminal.",
       "type": "boolean",
       "default": true
     },

--- a/packages/terminal-extension/schema/plugin.json
+++ b/packages/terminal-extension/schema/plugin.json
@@ -81,6 +81,12 @@
       "type": "boolean",
       "default": false
     },
+    "disposeOnExit": {
+      "title": "Dispose on exit",
+      "description": "Dispose the widget when exiting the terminal.",
+      "type": "boolean",
+      "default": true
+    },
     "pasteWithCtrlV": {
       "title": "Paste with Ctrl+V",
       "description": "Enable pasting with Ctrl+V.  This can be disabled to use Ctrl+V in the vi editor, for instance.  This setting has no effect on macOS, where Cmd+V is available",

--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -356,9 +356,7 @@ export function addCommands(
         } else {
           // we are restoring a terminal widget but the corresponding terminal was closed
           // let's start a new terminal with the original name
-          session = await serviceManager.terminals.startNew({
-            model: { name }
-          });
+          session = await serviceManager.terminals.startNew({ name });
         }
       } else {
         // we are creating a new terminal widget with a new terminal

--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -356,7 +356,9 @@ export function addCommands(
         } else {
           // we are restoring a terminal widget but the corresponding terminal was closed
           // let's start a new terminal with the original name
-          session = await serviceManager.terminals.startNew(name);
+          session = await serviceManager.terminals.startNew({
+            model: { name }
+          });
         }
       } else {
         // we are creating a new terminal widget with a new terminal

--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -19,7 +19,7 @@ import {
 import { ILauncher } from '@jupyterlab/launcher';
 import { IMainMenu } from '@jupyterlab/mainmenu';
 import { IRunningSessionManagers, IRunningSessions } from '@jupyterlab/running';
-import { Terminal } from '@jupyterlab/services';
+import { Terminal, TerminalAPI } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { ITerminal, ITerminalTracker } from '@jupyterlab/terminal';
 // Name-only import so as to not trigger inclusion in main bundle
@@ -346,9 +346,23 @@ export function addCommands(
 
       const name = args['name'] as string;
 
-      const session = await (name
-        ? serviceManager.terminals.connectTo({ model: { name } })
-        : serviceManager.terminals.startNew());
+      let session;
+      if (name) {
+        const models = await TerminalAPI.listRunning();
+        if (models.map(d => d.name).includes(name)) {
+          // we are restoring a terminal widget and the corresponding terminal exists
+          // let's connect to it
+          session = serviceManager.terminals.connectTo({ model: { name } });
+        } else {
+          // we are restoring a terminal widget but the corresponding terminal was closed
+          // let's start a new terminal with the original name
+          session = await serviceManager.terminals.startNew(name);
+        }
+      } else {
+        // we are creating a new terminal widget with a new terminal
+        // let the server choose the terminal name
+        session = await serviceManager.terminals.startNew();
+      }
 
       const term = new Terminal(session, options, translator);
 

--- a/packages/terminal/src/tokens.ts
+++ b/packages/terminal/src/tokens.ts
@@ -83,9 +83,9 @@ export namespace ITerminal {
     shutdownOnClose: boolean;
 
     /**
-     * Whether to dispose the widget when exiting a terminal or not.
+     * Whether to close the widget when exiting a terminal or not.
      */
-    disposeOnExit: boolean;
+    closeOnExit: boolean;
 
     /**
      * Whether to blink the cursor.  Can only be set at startup.
@@ -130,7 +130,7 @@ export namespace ITerminal {
     lineHeight: 1.0,
     scrollback: 1000,
     shutdownOnClose: false,
-    disposeOnExit: true,
+    closeOnExit: true,
     cursorBlink: true,
     initialCommand: '',
     screenReaderMode: false, // False by default, can cause scrollbar mouse interaction issues.

--- a/packages/terminal/src/tokens.ts
+++ b/packages/terminal/src/tokens.ts
@@ -83,6 +83,11 @@ export namespace ITerminal {
     shutdownOnClose: boolean;
 
     /**
+     * Whether to dispose the widget when exiting a terminal or not.
+     */
+    disposeOnExit: boolean;
+
+    /**
      * Whether to blink the cursor.  Can only be set at startup.
      */
     cursorBlink: boolean;
@@ -125,6 +130,7 @@ export namespace ITerminal {
     lineHeight: 1.0,
     scrollback: 1000,
     shutdownOnClose: false,
+    disposeOnExit: true,
     cursorBlink: true,
     initialCommand: '',
     screenReaderMode: false, // False by default, can cause scrollbar mouse interaction issues.

--- a/packages/terminal/src/widget.ts
+++ b/packages/terminal/src/widget.ts
@@ -71,7 +71,9 @@ export class Terminal extends Widget implements ITerminal.ITerminal {
     this.title.label = this._trans.__('Terminal');
 
     session.messageReceived.connect(this._onMessage, this);
-    session.disposed.connect(this.dispose, this);
+    if (this.getOption('closeOnExit')) {
+      session.disposed.connect(this.dispose, this);
+    }
 
     if (session.connectionStatus === 'connected') {
       this._initialConnection();
@@ -148,7 +150,7 @@ export class Terminal extends Widget implements ITerminal.ITerminal {
 
     switch (option) {
       case 'shutdownOnClose': // Do not transmit to XTerm
-      case 'disposeOnExit': // Do not transmit to XTerm
+      case 'closeOnExit': // Do not transmit to XTerm
         break;
       case 'theme':
         this._term.setOption(
@@ -177,10 +179,8 @@ export class Terminal extends Widget implements ITerminal.ITerminal {
         });
       }
     }
-    if (this.getOption('disposeOnExit')) {
-      this._term.dispose();
-      super.dispose();
-    }
+    this._term.dispose();
+    super.dispose();
   }
 
   /**

--- a/packages/terminal/src/widget.ts
+++ b/packages/terminal/src/widget.ts
@@ -148,6 +148,7 @@ export class Terminal extends Widget implements ITerminal.ITerminal {
 
     switch (option) {
       case 'shutdownOnClose': // Do not transmit to XTerm
+      case 'disposeOnExit': // Do not transmit to XTerm
         break;
       case 'theme':
         this._term.setOption(

--- a/packages/terminal/src/widget.ts
+++ b/packages/terminal/src/widget.ts
@@ -71,14 +71,11 @@ export class Terminal extends Widget implements ITerminal.ITerminal {
     this.title.label = this._trans.__('Terminal');
 
     session.messageReceived.connect(this._onMessage, this);
-    session.disposed.connect(
-      () => {
-        if (this.getOption('closeOnExit')) {
-          this.dispose();
-        }
-      },
-      this
-    );
+    session.disposed.connect(() => {
+      if (this.getOption('closeOnExit')) {
+        this.dispose();
+      }
+    }, this);
 
     if (session.connectionStatus === 'connected') {
       this._initialConnection();

--- a/packages/terminal/src/widget.ts
+++ b/packages/terminal/src/widget.ts
@@ -71,9 +71,14 @@ export class Terminal extends Widget implements ITerminal.ITerminal {
     this.title.label = this._trans.__('Terminal');
 
     session.messageReceived.connect(this._onMessage, this);
-    if (this.getOption('closeOnExit')) {
-      session.disposed.connect(this.dispose, this);
-    }
+    session.disposed.connect(
+      () => {
+        if (this.getOption('closeOnExit')) {
+          this.dispose();
+        }
+      },
+      this
+    );
 
     if (session.connectionStatus === 'connected') {
       this._initialConnection();

--- a/packages/terminal/src/widget.ts
+++ b/packages/terminal/src/widget.ts
@@ -176,8 +176,10 @@ export class Terminal extends Widget implements ITerminal.ITerminal {
         });
       }
     }
-    this._term.dispose();
-    super.dispose();
+    if (this.getOption('disposeOnExit')) {
+      this._term.dispose();
+      super.dispose();
+    }
   }
 
   /**


### PR DESCRIPTION
## References

https://github.com/jupyterlab/retrolab/issues/299

## Code changes

This PR adds a new `closeOnExit` option for terminals, which defaults to `true`. If set to `false`, the terminal widget won't be disposed when exiting the terminal, which is similar to the classic notebook behavior.

## User-facing changes

No change when set to `true` (which is the default). When set to `false`, the widget is not disposed:

![image](https://user-images.githubusercontent.com/4711805/145202024-9427c9db-7126-4d3a-be4d-40e87eac3c83.png)

## Backwards-incompatible changes

None