### PR TITLE
[WIP] cell-based undo manager.

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -121,7 +121,7 @@
     "@lumino/widgets": "^1.30.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "yjs": "^13.5.17"
+    "yjs": "next"
   },
   "dependencies": {
     "@jupyterlab/application": "~3.3.0-alpha.15",

--- a/jupyterlab/staging/package.json
+++ b/jupyterlab/staging/package.json
@@ -121,7 +121,7 @@
     "@lumino/widgets": "^1.28.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "yjs": "^13.5.17"
+    "yjs": "next"
   },
   "dependencies": {
     "@jupyterlab/application": "~3.3.0-alpha.15",

--- a/packages/docprovider/package.json
+++ b/packages/docprovider/package.json
@@ -42,7 +42,7 @@
     "@lumino/coreutils": "^1.11.1",
     "lib0": "^0.2.42",
     "y-websocket": "^1.3.15",
-    "yjs": "^13.5.17"
+    "yjs": "next"
   },
   "devDependencies": {
     "@jupyterlab/testutils": "^3.3.0-alpha.15",

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -59,7 +59,7 @@
     "@lumino/messaging": "^1.10.1",
     "@lumino/signaling": "^1.10.1",
     "@lumino/widgets": "^1.30.0",
-    "yjs": "^13.5.17"
+    "yjs": "next"
   },
   "devDependencies": {
     "@jupyterlab/testutils": "^3.3.0-alpha.15",

--- a/packages/notebook/src/celllist.ts
+++ b/packages/notebook/src/celllist.ts
@@ -64,29 +64,31 @@ export class CellList implements IObservableUndoableList<ICellModel> {
             change.oldIndex + change.oldValues.length
           );
         }
-        if (
-          change.type === 'set' ||
-          change.type === 'add' ||
-          change.type === 'move'
-        ) {
+        if (change.type === 'move') {
+          const moveLen = change.oldValues.length;
+          const adaptionIncrease =
+            change.oldIndex < change.newIndex ? moveLen : 0;
+          if (moveLen === 1) {
+            nbmodel.moveCell(
+              change.oldIndex,
+              change.newIndex + adaptionIncrease
+            );
+          } else {
+            nbmodel.moveCells(
+              change.oldIndex,
+              change.oldIndex + moveLen,
+              change.newIndex + adaptionIncrease
+            );
+          }
+        } else if (change.type === 'set' || change.type === 'add') {
           const cells = change.newValues.map(cell => {
             return cell.sharedModel.clone() as any;
           });
           let insertLocation = change.newIndex;
-          if (change.type === 'move' && insertLocation > change.oldIndex) {
-            insertLocation += change.oldValues.length;
-          }
           nbmodel.insertCells(insertLocation, cells);
           change.newValues.forEach((cell, index) => {
             cell.switchSharedModel(cells[index], false);
           });
-        }
-        if (change.type === 'move') {
-          let from = change.oldIndex;
-          if (from >= change.newIndex) {
-            from += change.oldValues.length;
-          }
-          nbmodel.deleteCellRange(from, from + change.oldValues.length);
         }
       });
     });

--- a/packages/shared-models/package.json
+++ b/packages/shared-models/package.json
@@ -42,7 +42,7 @@
     "@lumino/disposable": "^1.10.1",
     "@lumino/signaling": "^1.10.1",
     "y-protocols": "^1.0.5",
-    "yjs": "^13.5.17"
+    "yjs": "next"
   },
   "devDependencies": {
     "@jupyterlab/testutils": "^3.3.0-alpha.15",

--- a/packages/shared-models/src/api.ts
+++ b/packages/shared-models/src/api.ts
@@ -194,6 +194,16 @@ export interface ISharedNotebook extends ISharedDocument {
   moveCell(fromIndex: number, toIndex: number): void;
 
   /**
+   * Move a range of cells.
+   *
+   * @param start: start-position for the cells to move
+   * @param end: end-position for the cells to move
+   *
+   * @param toIndex: New position of the cell.
+   */
+  moveCells(start: number, end: number, toIndex: number): void;
+
+  /**
    * Remove a cell.
    *
    * @param index: Index of the cell to remove.

--- a/yarn.lock
+++ b/yarn.lock
@@ -11653,6 +11653,13 @@ lib0@^0.2.31, lib0@^0.2.42:
   dependencies:
     isomorphic.js "^0.2.4"
 
+lib0@^0.2.43:
+  version "0.2.43"
+  resolved "https://registry.yarnpkg.com/lib0/-/lib0-0.2.43.tgz#1c2ed1fb2e9fe136e92abef7ca56875f2ee66b07"
+  integrity sha512-MJ1KLoz5p3gljIUBfdjjNuL/wlWHHK6+DrcIRhzSRLvtAu1XNdRtRGATYM51KSTI0P2nxJZFQM8rwCH6ga9KUw==
+  dependencies:
+    isomorphic.js "^0.2.4"
+
 libnpmaccess@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/libnpmaccess/-/libnpmaccess-4.0.3.tgz#dfb0e5b0a53c315a2610d300e46b4ddeb66e7eec"
@@ -18533,12 +18540,12 @@ yazl@^2.5.1:
   dependencies:
     buffer-crc32 "~0.2.3"
 
-yjs@^13.5.17:
-  version "13.5.17"
-  resolved "https://registry.yarnpkg.com/yjs/-/yjs-13.5.17.tgz#888830e015cce709f3413f78cfdcf3c2176d4b0a"
-  integrity sha512-EeroWadB+/SlGuNwXaIjo75QlTlCjst3U/dLqhTkqwIXeCGl/nRTbQev+iYgWZVskD1eTCvaDc2FdrGdpKq32A==
+yjs@next:
+  version "13.6.0-2"
+  resolved "https://registry.yarnpkg.com/yjs/-/yjs-13.6.0-2.tgz#670e812d01877eb7232414adfe713f4519a93040"
+  integrity sha512-3+1DHp9vlC1We/gdWExMh7sx/5MmggTnmc+l/O513zy4RC5N4Qia7r0TVx4aJAPwT1XFph8/MfzJI0lfUe0pBA==
   dependencies:
-    lib0 "^0.2.42"
+    lib0 "^0.2.43"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
We switched to a global undo-redo manager for Jupyter notebooks when we integrated shared editing. This lead to some frustration for several users that were used to the local (cell-based) undo manager. https://github.com/jupyterlab/jupyterlab/issues/10791

#10949  aims to revert back to the old behavior by disabling the current collaborative undo manager so that CodeMirror's native undo manager is used. However, when the collaborative undo manager is disabled, you will be able to undo changes from remote users. Aside from that, it seems that disabling the collaborative undo manager leads to some problems (https://github.com/jupyterlab/jupyterlab/issues/11556). 

I've been working on a move feature in Yjs for quite some time now. It allows us to move cells (or ranges of cells) from one place to another while keeping the associated undo-manager to that cell. The undo-history will be retained even when a cell is moved from one place to another. 

In short, this PR implements a proper cell-based undo manager in JupyterLab. In ticket #10791 it was mentioned that switching to a global undo manager was a breaking change. So we should probably make this behavior the default again.

I also would like to add a flag "globalUndo" flag that will replace the current experimental feature "disableDocumentWideUndoRedo".

This PR closes #10949, #11556, & https://github.com/jupyterlab/jupyterlab/issues/10791#issuecomment-943552144 

## Code changes

Currently, when we move a cell from one place to another, we delete the old cell in shared-model and copy it to a new position. This PR uses the new move feature in Yjs to move the cell. This retains the editing history for that cell.

## User-facing changes

Switching back to a local undo manager. 

## Backwards-incompatible changes

This change is backward compatible, but not forward compatible. The PR implements a new feature in shared-model. Old versions of shared-model don't understand the move-semantics in Yjs and won't be able to read the Yjs content. However, I don't think that this will be a problem since there is no reason to use two different versions of shared-model in the same project.

---------

This PR is still in an experimental state. It uses a prerelease of Yjs that still has some known bugs (It's unlikely that you will catch them). I want to invite others to use this PR and give feedback.

@tonyfast 



