### PR TITLE
Remove border from user menu when is empty

### DIFF
--- a/packages/user/src/menu.ts
+++ b/packages/user/src/menu.ts
@@ -120,7 +120,6 @@ export class UserMenu extends Menu {
     this.title.icon = caretDownIcon;
     this.title.iconClass = 'jp-UserMenu-caretDownIcon';
     this.title.dataset = { empty: 'true' };
-    //this.dataset.empty = 'true';
     this._user.ready.connect(this._updateLabel);
     this._user.changed.connect(this._updateLabel);
   }
@@ -152,7 +151,6 @@ export class UserMenu extends Menu {
    * The index will be clamped to the bounds of the items.
    */
   insertItem(index: number, options: Menu.IItemOptions): Menu.IItem {
-    //this.dataset.empty = 'false';
     this.title.dataset = { ...this.title.dataset, empty: 'false' };
     return super.insertItem(index, options);
   }
@@ -168,7 +166,6 @@ export class UserMenu extends Menu {
   removeItemAt(index: number): void {
     super.removeItemAt(index);
     if (this.items.length === 0) {
-      //this.dataset.empty = 'true';
       this.title.dataset = { ...this.title.dataset, empty: 'true' };
     }
   }
@@ -178,7 +175,6 @@ export class UserMenu extends Menu {
    */
   clearItems(): void {
     super.clearItems();
-    //this.dataset.empty = 'true';
     this.title.dataset = { ...this.title.dataset, empty: 'true' };
   }
 }

--- a/packages/user/src/menu.ts
+++ b/packages/user/src/menu.ts
@@ -35,20 +35,15 @@ export class RendererUserMenu extends MenuBar.Renderer {
     let dataset = this.createItemDataset(data);
     let aria = this.createItemARIA(data);
 
-    if ('empty' in dataset && dataset.empty === 'true') {
-      return h.li(
-        { className, dataset, tabindex: '0', onfocus: data.onfocus, ...aria },
-        this._createUserIcon(),
-        this.renderLabel(data)
-      );
-    } else {
-      return h.li(
-        { className, dataset, tabindex: '0', onfocus: data.onfocus, ...aria },
-        this._createUserIcon(),
-        this.renderLabel(data),
-        this.renderIcon(data)
-      );
+    const children = [this._createUserIcon(), this.renderLabel(data)];
+    if (dataset.empty !== 'true') {
+      children.push(this.renderIcon(data));
     }
+
+    return h.li(
+      { className, dataset, tabindex: '0', onfocus: data.onfocus, ...aria },
+      ...children
+    );
   }
 
   /**

--- a/packages/user/src/menu.ts
+++ b/packages/user/src/menu.ts
@@ -120,7 +120,7 @@ export class UserMenu extends Menu {
     this.title.icon = caretDownIcon;
     this.title.iconClass = 'jp-UserMenu-caretDownIcon';
     this.title.dataset = { empty: 'true' };
-    this.dataset.empty = 'true';
+    //this.dataset.empty = 'true';
     this._user.ready.connect(this._updateLabel);
     this._user.changed.connect(this._updateLabel);
   }
@@ -152,7 +152,7 @@ export class UserMenu extends Menu {
    * The index will be clamped to the bounds of the items.
    */
   insertItem(index: number, options: Menu.IItemOptions): Menu.IItem {
-    this.dataset.empty = 'false';
+    //this.dataset.empty = 'false';
     this.title.dataset = { ...this.title.dataset, empty: 'false' };
     return super.insertItem(index, options);
   }
@@ -168,7 +168,7 @@ export class UserMenu extends Menu {
   removeItemAt(index: number): void {
     super.removeItemAt(index);
     if (this.items.length === 0) {
-      this.dataset.empty = 'true';
+      //this.dataset.empty = 'true';
       this.title.dataset = { ...this.title.dataset, empty: 'true' };
     }
   }
@@ -178,7 +178,7 @@ export class UserMenu extends Menu {
    */
   clearItems(): void {
     super.clearItems();
-    this.dataset.empty = 'true';
+    //this.dataset.empty = 'true';
     this.title.dataset = { ...this.title.dataset, empty: 'true' };
   }
 }

--- a/packages/user/src/menu.ts
+++ b/packages/user/src/menu.ts
@@ -34,12 +34,21 @@ export class RendererUserMenu extends MenuBar.Renderer {
     let className = this.createItemClass(data);
     let dataset = this.createItemDataset(data);
     let aria = this.createItemARIA(data);
-    return h.li(
-      { className, dataset, tabindex: '0', onfocus: data.onfocus, ...aria },
-      this._createUserIcon(),
-      this.renderLabel(data),
-      this.renderIcon(data)
-    );
+
+    if ('empty' in dataset && dataset.empty === 'true') {
+      return h.li(
+        { className, dataset, tabindex: '0', onfocus: data.onfocus, ...aria },
+        this._createUserIcon(),
+        this.renderLabel(data)
+      );
+    } else {
+      return h.li(
+        { className, dataset, tabindex: '0', onfocus: data.onfocus, ...aria },
+        this._createUserIcon(),
+        this.renderLabel(data),
+        this.renderIcon(data)
+      );
+    }
   }
 
   /**
@@ -115,6 +124,8 @@ export class UserMenu extends Menu {
     this.title.label = this._user.isReady ? name : '';
     this.title.icon = caretDownIcon;
     this.title.iconClass = 'jp-UserMenu-caretDownIcon';
+    this.title.dataset = { empty: 'true' };
+    this.dataset.empty = 'true';
     this._user.ready.connect(this._updateLabel);
     this._user.changed.connect(this._updateLabel);
   }
@@ -132,6 +143,49 @@ export class UserMenu extends Menu {
     this.title.label = name;
     this.update();
   };
+
+  /**
+   * Insert a menu item into the menu at the specified index.
+   *
+   * @param index - The index at which to insert the item.
+   *
+   * @param options - The options for creating the menu item.
+   *
+   * @returns The menu item added to the menu.
+   *
+   * #### Notes
+   * The index will be clamped to the bounds of the items.
+   */
+  insertItem(index: number, options: Menu.IItemOptions): Menu.IItem {
+    this.dataset.empty = 'false';
+    this.title.dataset = { ...this.title.dataset, empty: 'false' };
+    return super.insertItem(index, options);
+  }
+
+  /**
+   * Remove the item at a given index from the menu.
+   *
+   * @param index - The index of the item to remove.
+   *
+   * #### Notes
+   * This is a no-op if the index is out of range.
+   */
+  removeItemAt(index: number): void {
+    super.removeItemAt(index);
+    if (this.items.length === 0) {
+      this.dataset.empty = 'true';
+      this.title.dataset = { ...this.title.dataset, empty: 'true' };
+    }
+  }
+
+  /**
+   * Remove all menu items from the menu.
+   */
+  clearItems(): void {
+    super.clearItems();
+    this.dataset.empty = 'true';
+    this.title.dataset = { ...this.title.dataset, empty: 'true' };
+  }
 }
 
 /**

--- a/packages/user/style/menu.css
+++ b/packages/user/style/menu.css
@@ -3,8 +3,23 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
+.lm-MenuBar-item[data-empty='true'],
+.p-MenuBar-item[data-empty='true'] {
+  border: none !important;
+}
+
+.lm-MenuBar-item[data-empty='true']:hover,
+.p-MenuBar-item[data-empty='true']:hover {
+  background: none !important;
+}
+
+.lm-MenuBar-menu[data-empty='true'],
+.p-MenuBar-menu[data-empty='true'] {
+  border: none !important;
+}
+
 .jp-MenuBar-label {
-  margin-left: 25px;
+  margin-left: 30px;
 }
 
 .jp-MenuBar-anonymousIcon span {

--- a/packages/user/style/menu.css
+++ b/packages/user/style/menu.css
@@ -5,15 +5,17 @@
 
 .lm-MenuBar-item[data-empty='true'] {
   border: none !important;
+  /* Ensure the menu won't be displayed if there are no items */
+  pointer-events: none;
 }
 
 .lm-MenuBar-item[data-empty='true']:hover {
   background: none !important;
 }
 
-.lm-MenuBar-menu[data-empty='true'] {
+/* .lm-MenuBar-menu[data-empty='true'] {
   border: none !important;
-}
+} */
 
 .jp-MenuBar-label {
   margin-left: 30px;

--- a/packages/user/style/menu.css
+++ b/packages/user/style/menu.css
@@ -3,18 +3,15 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-.lm-MenuBar-item[data-empty='true'],
-.p-MenuBar-item[data-empty='true'] {
+.lm-MenuBar-item[data-empty='true'] {
   border: none !important;
 }
 
-.lm-MenuBar-item[data-empty='true']:hover,
-.p-MenuBar-item[data-empty='true']:hover {
+.lm-MenuBar-item[data-empty='true']:hover {
   background: none !important;
 }
 
-.lm-MenuBar-menu[data-empty='true'],
-.p-MenuBar-menu[data-empty='true'] {
+.lm-MenuBar-menu[data-empty='true'] {
   border: none !important;
 }
 

--- a/packages/user/style/menu.css
+++ b/packages/user/style/menu.css
@@ -13,10 +13,6 @@
   background: none !important;
 }
 
-/* .lm-MenuBar-menu[data-empty='true'] {
-  border: none !important;
-} */
-
 .jp-MenuBar-label {
   margin-left: 30px;
 }


### PR DESCRIPTION
Follow-up for https://github.com/jupyterlab/jupyterlab/pull/11443#issuecomment-989664692

## References
#11443

## Code changes
Added a data attribute to the title when the menu is empty and remove the border from CSS.
I also removed the caret down from the widget when the menu is empty.

## User-facing changes

## Backwards-incompatible changes

Screencast:

https://user-images.githubusercontent.com/26092748/145483961-f7743758-94ca-4aea-8151-f6ff9a6aa323.mp4



cc @krassowski 