### PR TITLE
Automated Changelog Entry for 3.2.5 on 3.2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,53 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.2.5
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.2.4...97b8069f014c51f584c86165ec0aff8c98be99cb))
+
+### Enhancements made
+
+- Tweak CSS for scrolled outputs [#11478](https://github.com/jupyterlab/jupyterlab/pull/11478) ([@jtpio](https://github.com/jtpio))
+- Add side-by-side rendering as global setting [#11533](https://github.com/jupyterlab/jupyterlab/pull/11533) ([@jess-x](https://github.com/jess-x))
+
+### Bugs fixed
+
+- Backport PR #11622 on branch 3.2.x (Fix menu items for toc) [#11634](https://github.com/jupyterlab/jupyterlab/pull/11634) ([@fcollonval](https://github.com/fcollonval))
+- Restore accidentally removed ToC context menu [#11617](https://github.com/jupyterlab/jupyterlab/pull/11617) ([@krassowski](https://github.com/krassowski))
+- Increase notebook-cell margin in side-by-side mode [#11539](https://github.com/jupyterlab/jupyterlab/pull/11539) ([@jess-x](https://github.com/jess-x))
+- Support file type extension with upper case [#11526](https://github.com/jupyterlab/jupyterlab/pull/11526) ([@fcollonval](https://github.com/fcollonval))
+- Sync dirty property between clients [#11525](https://github.com/jupyterlab/jupyterlab/pull/11525) ([@hbcarlos](https://github.com/hbcarlos))
+- Fix markdown benchmark snapshot [#11575](https://github.com/jupyterlab/jupyterlab/pull/11575) ([@fcollonval](https://github.com/fcollonval))
+- Cell YModel: Fix setAttachment method [#11529](https://github.com/jupyterlab/jupyterlab/pull/11529) ([@martinRenou](https://github.com/martinRenou))
+- Allow cross-file anchors with leading number [#11517](https://github.com/jupyterlab/jupyterlab/pull/11517) ([@loichuder](https://github.com/loichuder))
+- Update ModelDB metadata when switching the shared model [#11493](https://github.com/jupyterlab/jupyterlab/pull/11493) ([@hbcarlos](https://github.com/hbcarlos))
+- Backport PR #11505 on branch 3.2.x (Connecting toggleCollapsedSignal to handler right at creation of Mark…) [#11514](https://github.com/jupyterlab/jupyterlab/pull/11514) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #11510 on branch 3.2.x (Update sanitize-html pin to 3.5.3) [#11513](https://github.com/jupyterlab/jupyterlab/pull/11513) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #11457 on branch 3.2.x (Only show the head of the outputs and ensure iopub outputs are correctly displayed) [#11502](https://github.com/jupyterlab/jupyterlab/pull/11502) ([@fcollonval](https://github.com/fcollonval))
+- Fix Tex highlights affecting Markdown with standalone `$` [#11488](https://github.com/jupyterlab/jupyterlab/pull/11488) ([@krassowski](https://github.com/krassowski))
+- Fix malformed fenced code block Markdown rendering [#11479](https://github.com/jupyterlab/jupyterlab/pull/11479) ([@krassowski](https://github.com/krassowski))
+
+### Maintenance and upkeep improvements
+
+- "Backport PR #11580 on branch 3.2.x (Explicitly build JupyterLab in dev-mode)" [#11585](https://github.com/jupyterlab/jupyterlab/pull/11585) ([@fcollonval](https://github.com/fcollonval))
+- Fix markdown benchmark snapshot [#11575](https://github.com/jupyterlab/jupyterlab/pull/11575) ([@fcollonval](https://github.com/fcollonval))
+- postcss 8.4.0 breaks integrity 2 CI test [#11552](https://github.com/jupyterlab/jupyterlab/pull/11552) ([@fcollonval](https://github.com/fcollonval))
+- Bump tmpl from 1.0.4 to 1.0.5 [#11512](https://github.com/jupyterlab/jupyterlab/pull/11512) ([@dependabot[bot]](https://github.com/apps/dependabot))
+- Backport PR #11507 on branch 3.2.x (Increase notebook markdown test robustness) [#11524](https://github.com/jupyterlab/jupyterlab/pull/11524) ([@fcollonval](https://github.com/fcollonval))
+- Bump semver-regex from 3.1.2 to 3.1.3 [#11511](https://github.com/jupyterlab/jupyterlab/pull/11511) ([@dependabot[bot]](https://github.com/apps/dependabot))
+- Run UI test on 3.2.x push [#11521](https://github.com/jupyterlab/jupyterlab/pull/11521) ([@fcollonval](https://github.com/fcollonval))
+- Enforce labels on PRs [#11496](https://github.com/jupyterlab/jupyterlab/pull/11496) ([@blink1073](https://github.com/blink1073))
+
+- Missing parenthesis [#11590](https://github.com/jupyterlab/jupyterlab/pull/11590) ([@davidbrochart](https://github.com/davidbrochart))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-11-17&to=2021-12-10&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-11-17..2021-12-10&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2021-11-17..2021-12-10&type=Issues) | [@dmonad](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Admonad+updated%3A2021-11-17..2021-12-10&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-11-17..2021-12-10&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2021-11-17..2021-12-10&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-11-17..2021-12-10&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-11-17..2021-12-10&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2021-11-17..2021-12-10&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-11-17..2021-12-10&type=Issues) | [@jess-x](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajess-x+updated%3A2021-11-17..2021-12-10&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-11-17..2021-12-10&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-11-17..2021-12-10&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-11-17..2021-12-10&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2021-11-17..2021-12-10&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-11-17..2021-12-10&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-11-17..2021-12-10&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-11-17..2021-12-10&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrungleduc+updated%3A2021-11-17..2021-12-10&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-11-17..2021-12-10&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.2.4
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.2.3...3bf36235a2521944b2b0b034e7986630ee83de18))
@@ -36,8 +83,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-11-11&to=2021-11-17&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-11-11..2021-11-17&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-11-11..2021-11-17&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-11-11..2021-11-17&type=Issues) | [@isabela-pf](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aisabela-pf+updated%3A2021-11-11..2021-11-17&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-11-11..2021-11-17&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-11-11..2021-11-17&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-11-11..2021-11-17&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-11-11..2021-11-17&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-11-11..2021-11-17&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-11-11..2021-11-17&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-11-11..2021-11-17&type=Issues) | [@williamstein](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awilliamstein+updated%3A2021-11-11..2021-11-17&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 
 ### Bugs fixed
 
-- Backport PR #11622 on branch 3.2.x (Fix menu items for toc) [#11634](https://github.com/jupyterlab/jupyterlab/pull/11634) ([@fcollonval](https://github.com/fcollonval))
+- Fix menu items for toc [#11634](https://github.com/jupyterlab/jupyterlab/pull/11634) ([@fcollonval](https://github.com/fcollonval))
 - Restore accidentally removed ToC context menu [#11617](https://github.com/jupyterlab/jupyterlab/pull/11617) ([@krassowski](https://github.com/krassowski))
 - Increase notebook-cell margin in side-by-side mode [#11539](https://github.com/jupyterlab/jupyterlab/pull/11539) ([@jess-x](https://github.com/jess-x))
 - Support file type extension with upper case [#11526](https://github.com/jupyterlab/jupyterlab/pull/11526) ([@fcollonval](https://github.com/fcollonval))
@@ -28,22 +28,24 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 - Cell YModel: Fix setAttachment method [#11529](https://github.com/jupyterlab/jupyterlab/pull/11529) ([@martinRenou](https://github.com/martinRenou))
 - Allow cross-file anchors with leading number [#11517](https://github.com/jupyterlab/jupyterlab/pull/11517) ([@loichuder](https://github.com/loichuder))
 - Update ModelDB metadata when switching the shared model [#11493](https://github.com/jupyterlab/jupyterlab/pull/11493) ([@hbcarlos](https://github.com/hbcarlos))
-- Backport PR #11505 on branch 3.2.x (Connecting toggleCollapsedSignal to handler right at creation of Mark…) [#11514](https://github.com/jupyterlab/jupyterlab/pull/11514) ([@fcollonval](https://github.com/fcollonval))
-- Backport PR #11510 on branch 3.2.x (Update sanitize-html pin to 3.5.3) [#11513](https://github.com/jupyterlab/jupyterlab/pull/11513) ([@fcollonval](https://github.com/fcollonval))
-- Backport PR #11457 on branch 3.2.x (Only show the head of the outputs and ensure iopub outputs are correctly displayed) [#11502](https://github.com/jupyterlab/jupyterlab/pull/11502) ([@fcollonval](https://github.com/fcollonval))
+- Connecting `toggleCollapsedSignal` to handler right at creation of Markdown [#11514](https://github.com/jupyterlab/jupyterlab/pull/11514) ([@fcollonval](https://github.com/fcollonval))
+- Update `sanitize-html` pin to 3.5.3 [#11513](https://github.com/jupyterlab/jupyterlab/pull/11513) ([@fcollonval](https://github.com/fcollonval))
+- Only show the head of the outputs and ensure iopub outputs are correctly displayed [#11502](https://github.com/jupyterlab/jupyterlab/pull/11502) ([@fcollonval](https://github.com/fcollonval))
 - Fix Tex highlights affecting Markdown with standalone `$` [#11488](https://github.com/jupyterlab/jupyterlab/pull/11488) ([@krassowski](https://github.com/krassowski))
 - Fix malformed fenced code block Markdown rendering [#11479](https://github.com/jupyterlab/jupyterlab/pull/11479) ([@krassowski](https://github.com/krassowski))
 
 ### Maintenance and upkeep improvements
 
-- "Backport PR #11580 on branch 3.2.x (Explicitly build JupyterLab in dev-mode)" [#11585](https://github.com/jupyterlab/jupyterlab/pull/11585) ([@fcollonval](https://github.com/fcollonval))
+- Explicitly build JupyterLab in dev-mode [#11585](https://github.com/jupyterlab/jupyterlab/pull/11585) ([@fcollonval](https://github.com/fcollonval))
 - Fix markdown benchmark snapshot [#11575](https://github.com/jupyterlab/jupyterlab/pull/11575) ([@fcollonval](https://github.com/fcollonval))
 - postcss 8.4.0 breaks integrity 2 CI test [#11552](https://github.com/jupyterlab/jupyterlab/pull/11552) ([@fcollonval](https://github.com/fcollonval))
 - Bump tmpl from 1.0.4 to 1.0.5 [#11512](https://github.com/jupyterlab/jupyterlab/pull/11512) ([@dependabot[bot]](https://github.com/apps/dependabot))
-- Backport PR #11507 on branch 3.2.x (Increase notebook markdown test robustness) [#11524](https://github.com/jupyterlab/jupyterlab/pull/11524) ([@fcollonval](https://github.com/fcollonval))
+- Increase notebook markdown test robustness [#11524](https://github.com/jupyterlab/jupyterlab/pull/11524) ([@fcollonval](https://github.com/fcollonval))
 - Bump semver-regex from 3.1.2 to 3.1.3 [#11511](https://github.com/jupyterlab/jupyterlab/pull/11511) ([@dependabot[bot]](https://github.com/apps/dependabot))
 - Run UI test on 3.2.x push [#11521](https://github.com/jupyterlab/jupyterlab/pull/11521) ([@fcollonval](https://github.com/fcollonval))
 - Enforce labels on PRs [#11496](https://github.com/jupyterlab/jupyterlab/pull/11496) ([@blink1073](https://github.com/blink1073))
+
+### Documentation
 
 - Missing parenthesis [#11590](https://github.com/jupyterlab/jupyterlab/pull/11590) ([@davidbrochart](https://github.com/davidbrochart))
 


### PR DESCRIPTION
Automated Changelog Entry for 3.2.5 on 3.2.x
```
Python version: 3.2.5
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/application-top: 3.2.5
@jupyterlab/example-cell: 3.2.5
@jupyterlab/example-console: 3.2.5
@jupyterlab/example-filebrowser: 3.2.5
@jupyterlab/example-terminal: 3.2.5
@jupyterlab/example-app: 3.2.5
@jupyterlab/example-federated: 2.3.5
@jupyterlab/example-notebook: 3.2.5
@jupyterlab/example-federated-middle: 2.3.5
@jupyterlab/example-federated-md: 2.3.5
@jupyterlab/example-federated-core: 2.3.5
@jupyterlab/example-federated-phosphor: 2.3.5
@jupyterlab/application-extension: 3.2.5
@jupyterlab/extensionmanager: 3.2.5
@jupyterlab/documentsearch-extension: 3.2.5
@jupyterlab/terminal-extension: 3.2.5
@jupyterlab/mathjax2: 3.2.5
@jupyterlab/theme-light-extension: 3.2.5
@jupyterlab/celltags-extension: 3.2.5
@jupyterlab/property-inspector: 3.2.5
@jupyterlab/nbformat: 3.2.5
@jupyterlab/codeeditor: 3.2.5
@jupyterlab/vega5-extension: 3.2.5
@jupyterlab/htmlviewer: 3.2.5
@jupyterlab/codemirror-extension: 3.2.5
@jupyterlab/toc-extension: 5.2.5
@jupyterlab/settingeditor: 3.2.5
@jupyterlab/statedb: 3.2.5
@jupyterlab/apputils: 3.2.5
@jupyterlab/console: 3.2.5
@jupyterlab/extensionmanager-extension: 3.2.5
@jupyterlab/vdom: 3.2.5
@jupyterlab/debugger-extension: 3.2.5
@jupyterlab/mathjax2-extension: 3.2.5
@jupyterlab/tooltip-extension: 3.2.5
@jupyterlab/coreutils: 5.2.5
@jupyterlab/ui-components: 3.2.5
@jupyterlab/launcher: 3.2.5
@jupyterlab/javascript-extension: 3.2.5
@jupyterlab/inspector: 3.2.5
@jupyterlab/csvviewer-extension: 3.2.5
@jupyterlab/fileeditor-extension: 3.2.5
@jupyterlab/imageviewer-extension: 3.2.5
@jupyterlab/mainmenu: 3.2.5
@jupyterlab/filebrowser: 3.2.5
@jupyterlab/metapackage: 3.2.5
@jupyterlab/observables: 4.2.5
@jupyterlab/running-extension: 3.2.5
@jupyterlab/markdownviewer-extension: 3.2.5
@jupyterlab/docprovider-extension: 3.2.5
@jupyterlab/ui-components-extension: 3.2.5
@jupyterlab/vdom-extension: 3.2.5
@jupyterlab/docmanager-extension: 3.2.5
@jupyterlab/debugger: 3.2.5
@jupyterlab/theme-dark-extension: 3.2.5
@jupyterlab/docmanager: 3.2.5
@jupyterlab/attachments: 3.2.5
@jupyterlab/notebook-extension: 3.2.5
@jupyterlab/cells: 3.2.5
@jupyterlab/rendermime-interfaces: 3.2.5
@jupyterlab/celltags: 3.2.5
@jupyterlab/statusbar-extension: 3.2.5
@jupyterlab/logconsole-extension: 3.2.5
@jupyterlab/shortcuts-extension: 3.2.5
@jupyterlab/help-extension: 3.2.5
@jupyterlab/filebrowser-extension: 3.2.5
@jupyterlab/statusbar: 3.2.5
@jupyterlab/fileeditor: 3.2.5
@jupyterlab/inspector-extension: 3.2.5
@jupyterlab/logconsole: 3.2.5
@jupyterlab/completer-extension: 3.2.5
@jupyterlab/console-extension: 3.2.5
@jupyterlab/nbconvert-css: 3.2.5
@jupyterlab/running: 3.2.5
@jupyterlab/markdownviewer: 3.2.5
@jupyterlab/application: 3.2.5
@jupyterlab/toc: 5.2.5
@jupyterlab/htmlviewer-extension: 3.2.5
@jupyterlab/docregistry: 3.2.5
@jupyterlab/translation-extension: 3.2.5
@jupyterlab/apputils-extension: 3.2.5
@jupyterlab/docprovider: 3.2.5
@jupyterlab/mainmenu-extension: 3.2.5
@jupyterlab/terminal: 3.2.5
@jupyterlab/settingregistry: 3.2.5
@jupyterlab/settingeditor-extension: 3.2.5
@jupyterlab/translation: 3.2.5
@jupyterlab/imageviewer: 3.2.5
@jupyterlab/services: 6.2.5
@jupyterlab/tooltip: 3.2.5
@jupyterlab/outputarea: 3.2.5
@jupyterlab/launcher-extension: 3.2.5
@jupyterlab/json-extension: 3.2.5
@jupyterlab/pdf-extension: 3.2.5
@jupyterlab/documentsearch: 3.2.5
@jupyterlab/shared-models: 3.2.5
@jupyterlab/notebook: 3.2.5
@jupyterlab/csvviewer: 3.2.5
@jupyterlab/rendermime-extension: 3.2.5
@jupyterlab/rendermime: 3.2.5
@jupyterlab/codemirror: 3.2.5
@jupyterlab/hub-extension: 3.2.5
@jupyterlab/completer: 3.2.5
node-example: 3.2.5
@jupyterlab/example-services-browser: 3.2.5
@jupyterlab/example-services-outputarea: 3.2.5
@jupyterlab/builder: 3.2.5
@jupyterlab/buildutils: 3.2.5
@jupyterlab/template: 3.2.5
@jupyterlab/galata: 4.1.2
@jupyterlab/testutils: 3.2.5
@jupyterlab/mock-extension: 3.2.5
@jupyterlab/mock-consumer: 3.2.5
@jupyterlab/mock-token: 3.2.5
@jupyterlab/mock-provider: 3.2.5
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.2.x  |
| Version Spec | next |
| Since | v3.2.4 |