### PR TITLE
Move the top area spacer to a different plugin

### DIFF
--- a/docs/source/extension/extension_points.rst
+++ b/docs/source/extension/extension_points.rst
@@ -424,7 +424,7 @@ declaring default keyboard shortcuts for a command:
 
 Shortcuts added to the settings system will be editable by users.
 
-From Jupyterlab version 3.1 onwards, it is possible to execute multiple commands with a single shortcut. 
+From Jupyterlab version 3.1 onwards, it is possible to execute multiple commands with a single shortcut.
 This requires you to define a keyboard shortcut for ``apputils:run-all-enabled`` command:
 
 .. code:: json
@@ -445,9 +445,9 @@ This requires you to define a keyboard shortcut for ``apputils:run-all-enabled``
       "selector": "body"
     }
 
-In this example ``my-command-1`` and ``my-command-2`` are passed in ``args`` 
+In this example ``my-command-1`` and ``my-command-2`` are passed in ``args``
 of ``apputils:run-all-enabled`` command as ``commands`` list.
-You can optionally pass the command arguemnts of ``my-command-1`` and ``my-command-2`` in ``args`` 
+You can optionally pass the command arguemnts of ``my-command-1`` and ``my-command-2`` in ``args``
 of ``apputils:run-all-enabled`` command as ``args`` list.
 
 Launcher
@@ -487,6 +487,23 @@ In JupyterLab, the application shell consists of:
 -  A ``bottom`` area for things like status bars.
 -  A ``header`` area for custom elements.
 
+Top Area
+^^^^^^^^
+
+The top area is intended to host most persistent user interface elements that span the whole session of a user.
+JupyterLab adds a user dropdown to that area when started in ``collaborative`` mode.
+
+You can use a numeric rank to control the ordering of top area widgets:
+
+.. code:: typescript
+
+  app.shell.add(widget, 'top', { rank: 100 });
+
+JupyterLab adds a spacer widget to the top area at rank ``900`` by default.
+You can then use the following guidelines to place your items:
+
+* ``rank <= 900`` to place items to the left side of the top area
+* ``rank > 900`` to place items to the right side of the top area
 
 Left/Right Areas
 ^^^^^^^^^^^^^^^^
@@ -776,20 +793,20 @@ bar. A typical example is the notebook toolbar as in the snippet below:
      let toolbarFactory:
        | ((widget: NotebookPanel) => DocumentRegistry.IToolbarItem[])
        | undefined;
-   
+
      // Register notebook toolbar specific widgets
      if (toolbarRegistry) {
        toolbarRegistry.registerFactory<NotebookPanel>(FACTORY, 'cellType', panel =>
          ToolbarItems.createCellTypeItem(panel, translator)
        );
-       
+
        toolbarRegistry.registerFactory<NotebookPanel>(
          FACTORY,
          'kernelStatus',
          panel => Toolbar.createKernelStatusItem(panel.sessionContext, translator)
        );
-       // etc... 
-     
+       // etc...
+
        if (settingRegistry) {
          // Create the factory
          toolbarFactory = createToolbarFactory(
@@ -803,7 +820,7 @@ bar. A typical example is the notebook toolbar as in the snippet below:
          );
        }
      }
-   
+
      const factory = new NotebookWidgetFactory({
        name: FACTORY,
        fileTypes: ['notebook'],
@@ -815,7 +832,7 @@ bar. A typical example is the notebook toolbar as in the snippet below:
      });
      app.docRegistry.addWidgetFactory(factory);
 
-The registry ``registerFactory`` method allows an extension to provide special widget for a unique pair 
+The registry ``registerFactory`` method allows an extension to provide special widget for a unique pair
 (factory name, toolbar item name). Then the helper ``createToolbarFactory`` can be used to extract the
 toolbar definition from the settings and build the factory to pass to the widget factory.
 
@@ -823,11 +840,11 @@ The default toolbar items can be defined across multiple extensions by providing
 mapping. For example for the notebook panel:
 
 .. code:: js
- 
+
    "jupyter.lab.toolbars": {
      "Notebook": [ // Factory name
        // Item with non-default widget - it must be registered within an extension
-       { 
+       {
          "name": "save", // Unique toolbar item name
          "rank": 10 // Item rank
        },

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -1047,6 +1047,20 @@ const JupyterLogo: JupyterFrontEndPlugin<void> = {
 };
 
 /**
+ * A plugin that adds a spacer widget to the top area.
+ */
+const topSpacer: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlab/application-extension:top-spacer',
+  autoStart: true,
+  requires: [ILabShell],
+  activate: (app: JupyterFrontEnd, shell: ILabShell) => {
+    const spacer = new Widget();
+    spacer.id = 'jp-topbar-spacer';
+    shell.add(spacer, 'top', { rank: 900 });
+  }
+};
+
+/**
  * Export the plugins as default.
  */
 const plugins: JupyterFrontEndPlugin<any>[] = [
@@ -1064,7 +1078,8 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   info,
   paths,
   propertyInspector,
-  JupyterLogo
+  JupyterLogo,
+  topSpacer
 ];
 
 export default plugins;

--- a/packages/application-extension/style/base.css
+++ b/packages/application-extension/style/base.css
@@ -7,3 +7,8 @@
 #jp-MainLogo {
   width: calc(var(--jp-private-sidebar-tab-width) + var(--jp-border-width));
 }
+
+#jp-topbar-spacer {
+  flex-grow: 1;
+  flex-shrink: 1;
+}

--- a/packages/user-extension/src/index.ts
+++ b/packages/user-extension/src/index.ts
@@ -17,7 +17,7 @@ import {
   User,
   UserMenu
 } from '@jupyterlab/user';
-import { Menu, MenuBar, Widget } from '@lumino/widgets';
+import { Menu, MenuBar } from '@lumino/widgets';
 
 /**
  * Jupyter plugin providing the ICurrentUser.
@@ -62,10 +62,6 @@ const menuBarPlugin: JupyterFrontEndPlugin<void> = {
     if (PageConfig.getOption('collaborative') !== 'true') {
       return;
     }
-
-    const spacer = new Widget();
-    spacer.id = 'jp-topbar-spacer';
-    shell.add(spacer, 'top', { rank: 900 });
 
     const menuBar = new MenuBar({
       forceItemsPosition: {

--- a/packages/user-extension/style/base.css
+++ b/packages/user-extension/style/base.css
@@ -2,8 +2,3 @@
 | Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
-
-#jp-topbar-spacer {
-  flex-grow: 1;
-  flex-shrink: 1;
-}


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/11443 tracked in https://github.com/jupyterlab/jupyterlab/issues/11589.

This PR moves the spacer widget in the top area to a separate plugin in `@jupyterlab/application-extension`.

## Code changes

Move the `#jp-topbar-spacer` to a different plugin.

This is the simplest "fix" for #11589. With this, we should also document how to position widgets to the left (rank < 900) or to the right (rank > 900) of the spacer.

However we could also consider doing some more elaborate, such as reusing the `Toolbar` API so it's easier to position elements. Similar to the notebook toolbar. This could then also be made configurable via the settings.
Not sure yet whether we want to do this to fully fix #11589. If so this could be done as a separate PR.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
