### PR TITLE
Triage documentation

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -61,7 +61,7 @@ Submitting a Pull Request Contribution
 
 Generally, an issue should be opened describing a piece of proposed work
 and the issues it solves before a pull request is opened. A triager will 
-ensure that your issue it meets our definition of ready before we can merge
+ensure that your issue meets our definition of ready before we can merge
 any pull requests that relate to it.
 
 Issue Management

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -117,7 +117,7 @@ For a **bug**:
 * Description, preferably including screen shots
 * Steps to reproduce
 * Expected behavior
-* Context: OS, browser, JupyterLab version, relevant output
+* Context, such as OS, browser, JupyterLab version, and output or log excerpts
 
 For a **feature request**:
 

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -137,7 +137,7 @@ furthers the goals of the Jupyter project.
 * The issue represents work that one developer can commit to owning, even if 
   they collaborate with other developers for feedback. Excessively large issues 
   should be split into multiple issues, each triaged individually, or into 
-  `team-compass <https://github.com/jupyterlab/team-compass>` issues to discuss
+  `team-compass <https://github.com/jupyterlab/team-compass>`__ issues to discuss
   more substantive changes.
 
 Labels Used by Triagers

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -60,9 +60,9 @@ Submitting a Pull Request Contribution
 --------------------------------------
 
 Generally, an issue should be opened describing a piece of proposed work
-and the issues it solves before a pull request is opened. Your issue should 
-go through a brief triage process to ensure that it meets our definition 
-of ready before we merge any pull requests that relate to it.
+and the issues it solves before a pull request is opened. A triager will 
+ensure that your issue it meets our definition of ready before we can merge
+any pull requests that relate to it.
 
 Issue Management
 ^^^^^^^^^^^^^^^^
@@ -83,8 +83,8 @@ bot <https://github.com/apps/lock>`__ will lock the issue. If additional
 discussion is desired, or if the pull request doesn't fully address the
 locked issue, please open a new issue referencing the locked issue.
 
-New issues are subject to triage. A developer will triage your new issue 
-by doing the following:
+New issues are subject to triage. A developer with triage permissions 
+(a *triager*) will do the following:
 
 1. Read the issue
 2. Search the existing issues and mark it as a duplicate if necessary
@@ -92,12 +92,18 @@ by doing the following:
 4. If the issue is ready to be worked on, assign it to a milestone
 5. Apply appropriate labels to the issue (see examples below)
 
-You may start to work on your issue as soon as you file it. Please 
+A developer may start to work on an issue as soon as it is filed. Please 
 work with a triager if they have any questions about your issue so that 
 your changes can be merged in without delay.
 
 Definition of Ready
 ^^^^^^^^^^^^^^^^^^^
+
+One of the main goals of triage is to get issues into a state where they
+are **ready** for someone to work on. Once a triager is satisfies that an 
+issue meets the definition below, they will remove the ``status:Needs Triage``
+label from it. We will not merge a pull request for an issue that still 
+needs triage.
 
 **All requested information, where applicable, is provided.** From the 
 templates in JupyterLab’s issues:
@@ -133,8 +139,7 @@ furthers the goals of the Jupyter project.
 Labels Used by Triagers
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-A bot applies the ``status: Needs Triage`` label to all new bugs and 
-enhancement requests as they are filed.
+All new bugs and enhancement requests have the ``status: Needs Triage`` label.
 
 On a regular basis, Jupyter contributors (triage reviewers or triagers)
 review JupyterLab issues tagged

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -60,14 +60,21 @@ Submitting a Pull Request Contribution
 --------------------------------------
 
 Generally, an issue should be opened describing a piece of proposed work
-and the issues it solves before a pull request is opened.
+and the issues it solves before a pull request is opened. Your issue should 
+go through a brief triage process to ensure that it meets our definition 
+of ready before we merge any pull requests that relate to it.
 
 Issue Management
 ^^^^^^^^^^^^^^^^
 
 Opening an issue lets community members participate in the design
 discussion, makes others aware of work being done, and sets the stage
-for a fruitful community interaction. A pull request should reference
+for a fruitful community interaction. When you open a new bug or 
+enhancement request, please provide all the requested information 
+in the issue template 
+so that a responder will be able to triage your bug without delay.
+
+A pull request should reference
 the issue it is addressing. Once the pull request is merged, the issue
 related to it will also be closed. If there is additional discussion
 around implementation the issue may be re-opened. Once 30 days have
@@ -76,8 +83,78 @@ bot <https://github.com/apps/lock>`__ will lock the issue. If additional
 discussion is desired, or if the pull request doesn't fully address the
 locked issue, please open a new issue referencing the locked issue.
 
-Tag Issues with Labels
-^^^^^^^^^^^^^^^^^^^^^^
+New issues are subject to triage. A developer will triage your new issue 
+by doing the following:
+
+1. Read the item
+2. Search the existing issues and mark it as a duplicate if necessary
+3. If additional information is required, add a comment requesting it
+4. If the item is ready to be worked on, assign it to a milestone
+5. Apply appropriate labels to the item (see examples below)
+
+You may start to work on your issue as soon as you file it. Please 
+work with a triager if they have any questions about your issue so that 
+your changes can be merged in without delay.
+
+Definition of Ready
+^^^^^^^^^^^^^^^^^^^
+
+**All requested information, where applicable, is provided.** From the 
+templates in JupyterLab’s issues:
+
+For a **bug**:
+
+* Description, preferably including screen shots
+* Steps to reproduce
+* Expected behavior
+* Context: OS, browser, JupyterLab version, relevant output
+
+For a **feature request**:
+
+* Description of the problem
+* Description of the proposed solution
+* Additional context
+
+**The item should represent real, relevant, feasible work**. In short, if a 
+knowledgeable person were to be assigned this item, they would be able to
+complete it with a reasonable amount of effort and assistance, and it
+furthers the goals of the Jupyter project.
+
+* Issues should be unique; triage is the best time to identify duplicates.
+* Bugs represent valid expectations for use of Jupyter products and services.
+* Expectations for security, performance, accessibility, and localization match
+  generally-accepted norms in the community that uses Jupyter products.
+* The item represents work that one developer can commit to owning, even if 
+  they collaborate with other developers for feedback. Excessively large items 
+  should be split into multiple items, each triaged individually, or into 
+  `team-compass <https://github.com/jupyterlab/team-compass>` items to discuss
+  more substantive changes.
+
+Labels Used by Triagers
+^^^^^^^^^^^^^^^^^^^^^^^
+
+A bot applies the ``status: Needs Triage`` label to all new bugs and 
+enhancement requests as they are filed.
+
+On a regular basis, Jupyter contributors (triage reviewers or triagers)
+review JupyterLab items tagged
+with ``status: Needs Triage``, starting with the oldest, and determine 
+whether they meet the definition of ready.
+
+Once triaged, if the item is ready, the reviewer removes the 
+``status: Needs Triage`` label; no additional label is required. If there 
+is not enough information in the item as filed, the triage reviewer applies
+the ``status: Needs Info`` label and leaves ``status: Needs Triage`` in place.
+If an item has remained in ``status: Needs Info`` for more than 14 days 
+without any follow-up communication, the reviewer should apply 
+``status: Blocked``. A blocked item should be closed after another 14 days
+pass without a reply that unblocks it.
+
+Our expectation is that every new item should be examined within a week of
+its creation.
+
+Tagging Issues with Labels
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Users without the commit rights to the JupyterLab repository can tag
 issues with labels using the ``@meeseeksdev`` bot. For example: To apply

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -105,6 +105,10 @@ issue meets the definition below, they will remove the ``status:Needs Triage``
 label from it. We will not merge a pull request for an issue that still 
 needs triage.
 
+Triagers should also ensure that the issue has appropriate labels that 
+describe it, such as labels with the ``pkg:`` prefix for issues that 
+affect one or more packages.
+
 **All requested information, where applicable, is provided.** From the 
 templates in JupyterLab’s issues:
 

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -100,7 +100,7 @@ Definition of Ready
 ^^^^^^^^^^^^^^^^^^^
 
 One of the main goals of triage is to get issues into a state where they
-are **ready** for someone to work on. Once a triager is satisfies that an 
+are **ready** for someone to work on. Once a triager is satisfied that an 
 issue meets the definition below, they will remove the ``status:Needs Triage``
 label from it. We will not merge a pull request for an issue that still 
 needs triage.

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -86,11 +86,11 @@ locked issue, please open a new issue referencing the locked issue.
 New issues are subject to triage. A developer will triage your new issue 
 by doing the following:
 
-1. Read the item
+1. Read the issue
 2. Search the existing issues and mark it as a duplicate if necessary
 3. If additional information is required, add a comment requesting it
-4. If the item is ready to be worked on, assign it to a milestone
-5. Apply appropriate labels to the item (see examples below)
+4. If the issue is ready to be worked on, assign it to a milestone
+5. Apply appropriate labels to the issue (see examples below)
 
 You may start to work on your issue as soon as you file it. Please 
 work with a triager if they have any questions about your issue so that 
@@ -115,8 +115,8 @@ For a **feature request**:
 * Description of the proposed solution
 * Additional context
 
-**The item should represent real, relevant, feasible work**. In short, if a 
-knowledgeable person were to be assigned this item, they would be able to
+**The issue should represent real, relevant, feasible work**. In short, if a 
+knowledgeable person were to be assigned this issue, they would be able to
 complete it with a reasonable amount of effort and assistance, and it
 furthers the goals of the Jupyter project.
 
@@ -124,10 +124,10 @@ furthers the goals of the Jupyter project.
 * Bugs represent valid expectations for use of Jupyter products and services.
 * Expectations for security, performance, accessibility, and localization match
   generally-accepted norms in the community that uses Jupyter products.
-* The item represents work that one developer can commit to owning, even if 
-  they collaborate with other developers for feedback. Excessively large items 
-  should be split into multiple items, each triaged individually, or into 
-  `team-compass <https://github.com/jupyterlab/team-compass>` items to discuss
+* The issue represents work that one developer can commit to owning, even if 
+  they collaborate with other developers for feedback. Excessively large issues 
+  should be split into multiple issues, each triaged individually, or into 
+  `team-compass <https://github.com/jupyterlab/team-compass>` issues to discuss
   more substantive changes.
 
 Labels Used by Triagers
@@ -137,20 +137,20 @@ A bot applies the ``status: Needs Triage`` label to all new bugs and
 enhancement requests as they are filed.
 
 On a regular basis, Jupyter contributors (triage reviewers or triagers)
-review JupyterLab items tagged
+review JupyterLab issues tagged
 with ``status: Needs Triage``, starting with the oldest, and determine 
 whether they meet the definition of ready.
 
-Once triaged, if the item is ready, the reviewer removes the 
+Once triaged, if the issue is ready, the reviewer removes the 
 ``status: Needs Triage`` label; no additional label is required. If there 
-is not enough information in the item as filed, the triage reviewer applies
+is not enough information in the issue as filed, the triage reviewer applies
 the ``status: Needs Info`` label and leaves ``status: Needs Triage`` in place.
-If an item has remained in ``status: Needs Info`` for more than 14 days 
+If an issue has remained in ``status: Needs Info`` for more than 14 days 
 without any follow-up communication, the reviewer should apply 
-``status: Blocked``. A blocked item should be closed after another 14 days
+``status: Blocked``. A blocked issue should be closed after another 14 days
 pass without a reply that unblocks it.
 
-Our expectation is that every new item should be examined within a week of
+Our expectation is that every new issue should be examined within a week of
 its creation.
 
 Tagging Issues with Labels


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This change concerns #11660.

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Documentation changes, migrated from https://github.com/jupyterlab/team-compass/pull/134, to address the definition of ready and the triage process.

## User-facing changes

None directly related, although I will also need to add an automation to apply a label to all new issues before closing #11660.

## Backwards-incompatible changes

None.