### PR TITLE
Make INotebookTracker parameter mandatory in TOC extension, as it had been

### DIFF
--- a/packages/toc-extension/src/index.ts
+++ b/packages/toc-extension/src/index.ts
@@ -62,11 +62,11 @@ async function activateTOC(
   docmanager: IDocumentManager,
   rendermime: IRenderMimeRegistry,
   translator: ITranslator,
+  notebookTracker: INotebookTracker,
   editorTracker?: IEditorTracker,
   restorer?: ILayoutRestorer,
   labShell?: ILabShell,
   markdownViewerTracker?: IMarkdownViewerTracker,
-  notebookTracker?: INotebookTracker,
   settingRegistry?: ISettingRegistry
 ): Promise<ITableOfContentsRegistry> {
   const trans = translator.load('jupyterlab');
@@ -91,10 +91,6 @@ async function activateTOC(
 
   app.commands.addCommand(CommandIDs.runCells, {
     execute: args => {
-      if (!notebookTracker) {
-        return null;
-      }
-
       const panel = notebookTracker.currentWidget;
       if (panel == null) {
         return;
@@ -153,16 +149,14 @@ async function activateTOC(
   }
 
   // Create a notebook generator:
-  if (notebookTracker) {
-    const notebookGenerator = createNotebookGenerator(
-      notebookTracker,
-      toc,
-      rendermime.sanitizer,
-      translator,
-      settings
-    );
-    registry.add(notebookGenerator);
-  }
+  const notebookGenerator = createNotebookGenerator(
+    notebookTracker,
+    toc,
+    rendermime.sanitizer,
+    translator,
+    settings
+  );
+  registry.add(notebookGenerator);
 
   // Create a Markdown generator:
   if (editorTracker) {
@@ -235,13 +229,17 @@ const extension: JupyterFrontEndPlugin<ITableOfContentsRegistry> = {
   id: '@jupyterlab/toc-extension:registry',
   autoStart: true,
   provides: ITableOfContentsRegistry,
-  requires: [IDocumentManager, IRenderMimeRegistry, ITranslator],
+  requires: [
+    IDocumentManager,
+    IRenderMimeRegistry,
+    ITranslator,
+    INotebookTracker
+  ],
   optional: [
     IEditorTracker,
     ILayoutRestorer,
     ILabShell,
     IMarkdownViewerTracker,
-    INotebookTracker,
     ISettingRegistry
   ],
   activate: activateTOC


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Affects issue #11663. A partial rollback of changes made in #11445.

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Reinstates `INotebookTracker` as a mandatory parameter in the TOC extension, as without a notebook tracker, the TOC extension displays nothing.

## User-facing changes

Required to make TOC extension functional in RetroLab. Should have no effect on JupyterLab.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
