### PR TITLE
Add JSX CodeMirror mode

### DIFF
--- a/packages/codemirror/src/mode.ts
+++ b/packages/codemirror/src/mode.ts
@@ -11,6 +11,7 @@ import 'codemirror/mode/clike/clike';
 import 'codemirror/mode/css/css';
 // Bundle other common modes
 import 'codemirror/mode/javascript/javascript';
+import 'codemirror/mode/jsx/jsx';
 import 'codemirror/mode/julia/julia';
 import 'codemirror/mode/markdown/markdown';
 import 'codemirror/mode/meta';


### PR DESCRIPTION
## References

Fixes #11665. I would like to see it backported to 3.x.

## Code changes

Bundle the jsx mode

## User-facing changes

.jsx and .tsx files should be syntax-highlighted

Before:

![Screenshot from 2021-12-11 14-52-56](https://user-images.githubusercontent.com/5832902/145681008-efc6378f-8d24-40f7-b90f-5ea4ff3d1c69.png)

After:

![Screenshot from 2021-12-11 14-53-06](https://user-images.githubusercontent.com/5832902/145681010-1dacd158-6eaf-4c8d-96e5-242b36951001.png)

## Backwards-incompatible changes

None