### PR TITLE
Fix changelog link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 ---
 
+<!-- The line below is MyST syntax for creating a reference to changelog -->
+(changelog)=
+
 # JupyterLab Changelog
 
 ## 4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 ---
 
 <!-- The line below is MyST syntax for creating a reference to changelog -->
+
 (changelog)=
 
 # JupyterLab Changelog


### PR DESCRIPTION
## References

The changelog link in https://jupyterlab.readthedocs.io/en/stable/getting_started/overview.html#jupyterlab-releases currently leads to https://docs.python.org/3/whatsnew/changelog.html#changelog because there is no reference target in our docs.

## Code changes

Introduce MyST reference target.

## User-facing changes

Links to changelog in docs work

Before:
![Screenshot from 2021-12-12 14-01-37](https://user-images.githubusercontent.com/5832902/145715511-2468cecc-6792-454d-934e-88287cb131db.png)

After:
![Screenshot from 2021-12-12 14-02-05](https://user-images.githubusercontent.com/5832902/145715522-fb054cac-dd54-49c8-abd9-fcc8bce057c6.png)

## Backwards-incompatible changes

None