### PR TITLE
Ensure the dialog does not close if you drag outside by mistake

### DIFF
--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -97,6 +97,7 @@ export class Dialog<T> extends Widget {
         return renderer.createButtonNode(button);
       })
     );
+    this._lastMouseDownInDialog = false;
 
     const layout = (this.layout = new PanelLayout());
     const content = new Panel();
@@ -206,9 +207,13 @@ export class Dialog<T> extends Widget {
    * not be called directly by user code.
    */
   handleEvent(event: Event): void {
+    console.log('---', event);
     switch (event.type) {
       case 'keydown':
         this._evtKeydown(event as KeyboardEvent);
+        break;
+      case 'mousedown':
+        this._evtMouseDown(event as MouseEvent);
         break;
       case 'click':
         this._evtClick(event as MouseEvent);
@@ -233,6 +238,7 @@ export class Dialog<T> extends Widget {
     node.addEventListener('keydown', this, true);
     node.addEventListener('contextmenu', this, true);
     node.addEventListener('click', this, true);
+    document.addEventListener('mousedown', this, true);
     document.addEventListener('focus', this, true);
     this._first = Private.findFirstFocusable(this.node);
     this._original = document.activeElement as HTMLElement;
@@ -256,6 +262,7 @@ export class Dialog<T> extends Widget {
     node.removeEventListener('contextmenu', this, true);
     node.removeEventListener('click', this, true);
     document.removeEventListener('focus', this, true);
+    document.removeEventListener('mousedown', this, true);
     this._original.focus();
   }
 
@@ -281,7 +288,7 @@ export class Dialog<T> extends Widget {
     if (!content.contains(event.target as HTMLElement)) {
       event.stopPropagation();
       event.preventDefault();
-      if (this._hasClose) {
+      if (this._hasClose && !this._lastMouseDownInDialog) {
         this.reject();
       }
       return;
@@ -391,6 +398,19 @@ export class Dialog<T> extends Widget {
   }
 
   /**
+   * Handle the `'mousedown'` event for the widget.
+   *
+   * @param event - The DOM event sent to the widget
+   */
+  protected _evtMouseDown(event: MouseEvent): void {
+    const content = this.node.getElementsByClassName(
+      'jp-Dialog-content'
+    )[0] as HTMLElement;
+    const target = event.target as HTMLElement;
+    this._lastMouseDownInDialog = content.contains(target as HTMLElement);
+  }
+
+  /**
    * Resolve a button item.
    */
   private _resolve(button: Dialog.IButton): void {
@@ -425,6 +445,7 @@ export class Dialog<T> extends Widget {
   private _host: HTMLElement;
   private _hasClose: boolean;
   private _body: Dialog.Body<T>;
+  private _lastMouseDownInDialog: boolean;
   private _focusNodeSelector: string | undefined = '';
 }
 

--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -207,7 +207,6 @@ export class Dialog<T> extends Widget {
    * not be called directly by user code.
    */
   handleEvent(event: Event): void {
-    console.log('---', event);
     switch (event.type) {
       case 'keydown':
         this._evtKeydown(event as KeyboardEvent);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/11672

## Code changes

Add internal state in Dialog class to identify where the last mousedown occured.

## User-facing changes

Before

![before](https://user-images.githubusercontent.com/226720/145791795-d9cb9ec4-bf1b-4fd0-ba02-094070da4432.gif)

After

![after](https://user-images.githubusercontent.com/226720/145791818-51043ee0-93d8-4f3d-adc3-8975ff29a352.gif)

## Backwards-incompatible changes

None
