### PR TITLE
Make `ILayoutRestorer` optional in the extension tutorial

### DIFF
--- a/docs/source/extension/extension_tutorial.rst
+++ b/docs/source/extension/extension_tutorial.rst
@@ -820,7 +820,7 @@ Finally, rewrite the ``activate`` function so that it:
 
 1. Declares a widget variable, but does not create an instance
    immediately.
-2. Adds the global ``LayoutRestorer`` as the thid parameter of the ``activate`` function.
+2. Adds the global ``LayoutRestorer`` as the third parameter of the ``activate`` function.
    This parameter is declared as ``ILayoutRestorer | null`` since the token is specified as ``optional``.
 3. Constructs a ``WidgetTracker`` and tells the ``ILayoutRestorer``
    to use it to save/restore panel state.

--- a/docs/source/extension/extension_tutorial.rst
+++ b/docs/source/extension/extension_tutorial.rst
@@ -792,30 +792,41 @@ entire list of import statements looks like the following:
     import { Widget } from '@lumino/widgets';
 
 Then add the ``ILayoutRestorer`` interface to the ``JupyterFrontEndPlugin``
-definition. This addition passes the global ``LayoutRestorer`` as the
+definition as ``optional``. This addition passes the global ``LayoutRestorer`` as the
 third parameter of the ``activate`` function.
 
 .. code-block:: typescript
-    :emphasize-lines: 4
+    :emphasize-lines: 5
 
     const extension: JupyterFrontEndPlugin<void> = {
       id: 'jupyterlab_apod',
       autoStart: true,
-      requires: [ICommandPalette, ILayoutRestorer],
+      requires: [ICommandPalette],
+      optional: [ILayoutRestorer],
       activate: activate
     };
+
+Here ``ILayoutRestorer`` is specified as an ``optional`` token, as the corresponding might
+not be available in a customized JupyterLab distribution that does not provide layout restoration
+functionalities. Having it ``optional`` make a nice to have, and enable your extension to be loaded
+in more JupyterLab based applications.
+
+You can learn more about ``requires`` and ``optional`` in the :ref:`tokens` section
+of the Extension Developer Guide.
 
 Finally, rewrite the ``activate`` function so that it:
 
 1. Declares a widget variable, but does not create an instance
    immediately.
-2. Constructs a ``WidgetTracker`` and tells the ``ILayoutRestorer``
+2. Add the global ``LayoutRestorer`` as the thid parameter of the ``activate`` function.
+   This parameter is declared as ``ILayoutRestorer | null`` since the token is specified as ``optional``.
+3. Constructs a ``WidgetTracker`` and tells the ``ILayoutRestorer``
    to use it to save/restore panel state.
-3. Creates, tracks, shows, and refreshes the widget panel appropriately.
+4. Creates, tracks, shows, and refreshes the widget panel appropriately.
 
 .. code-block:: typescript
 
-    function activate(app: JupyterFrontEnd, palette: ICommandPalette, restorer: ILayoutRestorer) {
+    function activate(app: JupyterFrontEnd, palette: ICommandPalette, restorer: ILayoutRestorer | null) {
       console.log('JupyterLab extension jupyterlab_apod is activated!');
 
       // Declare a widget variable
@@ -857,10 +868,12 @@ Finally, rewrite the ``activate`` function so that it:
       let tracker = new WidgetTracker<MainAreaWidget<APODWidget>>({
         namespace: 'apod'
       });
-      restorer.restore(tracker, {
-        command,
-        name: () => 'apod'
-      });
+      if (restorer) {
+        restorer.restore(tracker, {
+          command,
+          name: () => 'apod'
+        });
+      }
     }
 
 Rebuild your extension one last time and refresh your browser tab.

--- a/docs/source/extension/extension_tutorial.rst
+++ b/docs/source/extension/extension_tutorial.rst
@@ -806,19 +806,21 @@ third parameter of the ``activate`` function.
       activate: activate
     };
 
-Here ``ILayoutRestorer`` is specified as an ``optional`` token, as the corresponding might
+Here ``ILayoutRestorer`` is specified as an ``optional`` token, as the corresponding service might
 not be available in a customized JupyterLab distribution that does not provide layout restoration
-functionalities. Having it ``optional`` make a nice to have, and enable your extension to be loaded
+functionalities. Having it ``optional`` make it a nice to have, and enable your extension to be loaded
 in more JupyterLab based applications.
 
-You can learn more about ``requires`` and ``optional`` in the :ref:`tokens` section
-of the Extension Developer Guide.
+.. note::
+
+    You can learn more about ``requires`` and ``optional`` in the :ref:`tokens` section
+    of the Extension Developer Guide.
 
 Finally, rewrite the ``activate`` function so that it:
 
 1. Declares a widget variable, but does not create an instance
    immediately.
-2. Add the global ``LayoutRestorer`` as the thid parameter of the ``activate`` function.
+2. Adds the global ``LayoutRestorer`` as the thid parameter of the ``activate`` function.
    This parameter is declared as ``ILayoutRestorer | null`` since the token is specified as ``optional``.
 3. Constructs a ``WidgetTracker`` and tells the ``ILayoutRestorer``
    to use it to save/restore panel state.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/11611.

The motivation here is to make extension authors more aware of the `optional` field of the plugin definition, so they can build extensions that can be used in more JupyterLab based applications by default.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Documentation changes.

- Make `ILayoutRestorer` an `optional` to cover `optional` in the extension tutorial
- Keep `ICommandPaletter` as `requires` to also cover tokens specified as `requires`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None for end users.

Documentation changes can be previewed on RTD: https://jupyterlab--11677.org.readthedocs.build/en/11677/extension/extension_tutorial.html

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
