### PR TITLE
Enforcing fonts for galata

### DIFF
--- a/galata/src/galata.ts
+++ b/galata/src/galata.ts
@@ -32,6 +32,9 @@ export namespace galata {
       codeCellConfig: { cursorBlinkRate: 0 },
       markdownCellConfig: { cursorBlinkRate: 0 },
       rawCellConfig: { cursorBlinkRate: 0 }
+    },
+    '@jupyterlab/apputils-extension:themes': {
+      overrides: { 'content-font-family': 'DejaVu Sans' }
     }
   };
 


### PR DESCRIPTION
Trying to make fonts consistent over different Linux systems, including the github test.

Testing the github galata tests...
--> This commit should not affect the github workflow.

## References

See discussion in #11615

## Code changes

* Only in galata tests

## User-facing changes

None

## Backwards-incompatible changes

None
