### PR TITLE
updates debugger icon css to work with white panel background

### DIFF
--- a/packages/debugger/style/icons.css
+++ b/packages/debugger/style/icons.css
@@ -14,14 +14,14 @@ button.jp-Button.jp-mod-minimal.jp-TreeView.jp-TableView {
 
 button.jp-Button.jp-mod-minimal.jp-TreeView:hover {
   cursor: pointer;
-  background-color: var(--jp-layout-color1);
+  background-color: var(--jp-layout-color2);
 }
 
 button.jp-Button.jp-mod-minimal.jp-TableView:hover {
   cursor: pointer;
-  background-color: var(--jp-layout-color1);
+  background-color: var(--jp-layout-color2);
 }
 
 .jp-ViewModeSelected {
-  background-color: var(--jp-layout-color1);
+  background-color: var(--jp-layout-color2);
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

Fixes debugger icon styling raised in #11656 

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

changes hover and jp-ViewModeSelected background-color tags in debugger icon.css from `--jp-layout-color1` to `--jp-layout-color2` so icons that are hovered over or selected show up as grey on the white panel background
## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

Allows hovered over of selected icons in the debugger to show up with a grey background against the white panel

<!-- For visual changes, include before and after screenshots here. -->
![chrome-capture (2)](https://user-images.githubusercontent.com/13774419/146026597-afb12416-3336-4fa9-b71e-007fa697b084.gif)

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
