### PR TITLE
[ALT] Show the kernel sources as a debugger tab and allow the user to break in kernel sources

### DIFF
--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -820,6 +820,7 @@ const main: JupyterFrontEndPlugin<void> = {
 
       model.callstack.currentFrameChanged.connect(onCurrentFrameChanged);
       model.sources.currentSourceOpened.connect(onCurrentSourceOpened);
+      model.kernelSources.currentSourceOpened.connect(onCurrentSourceOpened);
       model.breakpoints.clicked.connect(async (_, breakpoint) => {
         const path = breakpoint.source?.path;
         const source = await service.getSource({

--- a/packages/debugger/src/model.ts
+++ b/packages/debugger/src/model.ts
@@ -11,6 +11,8 @@ import { CallstackModel } from './panels/callstack/model';
 
 import { SourcesModel } from './panels/sources/model';
 
+import { KernelSourcesModel } from './panels/kernelSources/model';
+
 import { VariablesModel } from './panels/variables/model';
 
 /**
@@ -25,6 +27,9 @@ export class DebuggerModel implements IDebugger.Model.IService {
     this.callstack = new CallstackModel();
     this.variables = new VariablesModel();
     this.sources = new SourcesModel({
+      currentFrameChanged: this.callstack.currentFrameChanged
+    });
+    this.kernelSources = new KernelSourcesModel({
       currentFrameChanged: this.callstack.currentFrameChanged
     });
   }
@@ -48,6 +53,11 @@ export class DebuggerModel implements IDebugger.Model.IService {
    * The sources model.
    */
   readonly sources: SourcesModel;
+
+  /**
+   * The sources model.
+   */
+  readonly kernelSources: KernelSourcesModel;
 
   /**
    * A signal emitted when the debugger widget is disposed.

--- a/packages/debugger/src/panels/kernelSources/body.ts
+++ b/packages/debugger/src/panels/kernelSources/body.ts
@@ -1,0 +1,215 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  CodeEditorWrapper,
+  IEditorMimeTypeService,
+  IEditorServices
+} from '@jupyterlab/codeeditor';
+
+import { viewBreakpointIcon } from '../../icons';
+
+import { ToolbarButton } from '@jupyterlab/ui-components';
+
+import { Kernel, KernelMessage } from '@jupyterlab/services';
+
+import { Signal } from '@lumino/signaling';
+
+import { PanelLayout, Widget } from '@lumino/widgets';
+
+import { Debugger } from '../..';
+
+import { EditorHandler } from '../../handlers/editor';
+
+import { IDebugger } from '../../tokens';
+
+/**
+ * The body for a Sources Panel.
+ */
+export class KernelSourcesBody extends Widget {
+  /**
+   * Instantiate a new Body for the SourcesBody widget.
+   *
+   * @param options The instantiation options for a SourcesBody.
+   */
+  constructor(options: KernelSourcesBody.IOptions) {
+    super();
+    this._model = options.model;
+    this._debuggerService = options.service;
+    this._mimeTypeService = options.editorServices.mimeTypeService;
+
+    const factory = new Debugger.ReadOnlyEditorFactory({
+      editorServices: options.editorServices
+    });
+
+    const layout = new PanelLayout();
+    this.layout = layout;
+    this.addClass('jp-DebuggerKernelSources-body');
+
+    this._editor = factory.createNewEditor({
+      content: '',
+      mimeType: '',
+      path: ''
+    });
+    this._editor.hide();
+
+    this._model.currentFrameChanged.connect(async (_, frame) => {
+      if (!frame) {
+        this._clearEditor();
+        return;
+      }
+      const kernel = this._debuggerService.session?.connection
+        ?.kernel as Kernel.IKernelConnection;
+      kernel.registerCommTarget(
+        'get_sources',
+        (comm: Kernel.IComm, commOpen: KernelMessage.ICommOpenMsg) => {
+          comm.onMsg = msg => {
+            const data = JSON.parse(msg.content.data as any);
+            Object.entries(data).forEach(entry => {
+              const [key, value] = entry;
+              const button = new ToolbarButton({
+                icon: viewBreakpointIcon,
+                onClick: (): void => {
+                  this._debuggerService
+                    .getSource({
+                      sourceReference: 0,
+                      path: value as string
+                    })
+                    .then(source => {
+                      console.log('---', source);
+                      this._model.currentSource = source;
+                      this._model.open();
+                    });
+                },
+                label: key,
+                tooltip: value as string
+              });
+              layout.addWidget(button);
+            });
+          };
+        }
+      );
+      const code = `
+import sys, re, json
+from ipykernel.comm import Comm
+comm = Comm(target_name="get_sources")
+# help('modules')
+modules = [sys.modules[name] for name in sys.modules]
+mods = {}
+for module in modules:
+    m = str(module)
+    if ".py'" in m:
+        x = re.findall(r"'(.*?)'", m)
+        mods[x[0]] = x[1]
+
+j = json.dumps(mods)
+print(j)
+comm.send(data=str(j))
+comm.close(data="closing comm")
+`;
+      kernel.requestExecute({
+        code
+      });
+
+      void this._showSource(frame);
+    });
+  }
+
+  /**
+   * Dispose the sources body widget.
+   */
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this._editorHandler?.dispose();
+    Signal.clearData(this);
+    super.dispose();
+  }
+
+  /**
+   * Clear the content of the source read-only editor.
+   */
+  private _clearEditor(): void {
+    this._model.currentSource = null;
+    this._editor.hide();
+  }
+
+  /**
+   * Show the content of the source for the given frame.
+   *
+   * @param frame The current frame.
+   */
+  private async _showSource(frame: IDebugger.IStackFrame): Promise<void> {
+    const path = frame.source?.path;
+    const source = await this._debuggerService.getSource({
+      sourceReference: 0,
+      path
+    });
+
+    if (!source?.content) {
+      this._clearEditor();
+      return;
+    }
+
+    if (this._editorHandler) {
+      this._editorHandler.dispose();
+    }
+
+    const { content, mimeType } = source;
+    const editorMimeType =
+      mimeType || this._mimeTypeService.getMimeTypeByFilePath(path ?? '');
+
+    this._editor.model.value.text = content;
+    this._editor.model.mimeType = editorMimeType;
+
+    this._editorHandler = new EditorHandler({
+      debuggerService: this._debuggerService,
+      editor: this._editor.editor,
+      path
+    });
+
+    this._model.currentSource = {
+      content,
+      mimeType: editorMimeType,
+      path: path ?? ''
+    };
+
+    requestAnimationFrame(() => {
+      EditorHandler.showCurrentLine(this._editor.editor, frame.line);
+    });
+
+    this._editor.show();
+  }
+
+  private _model: IDebugger.Model.ISources;
+  private _editor: CodeEditorWrapper;
+  private _editorHandler: EditorHandler;
+  private _debuggerService: IDebugger;
+  private _mimeTypeService: IEditorMimeTypeService;
+}
+
+/**
+ * A namespace for SourcesBody `statics`.
+ */
+export namespace KernelSourcesBody {
+  /**
+   * Instantiation options for `Breakpoints`.
+   */
+  export interface IOptions {
+    /**
+     * The debug service.
+     */
+    service: IDebugger;
+
+    /**
+     * The sources model.
+     */
+    model: IDebugger.Model.ISources;
+
+    /**
+     * The editor services used to create new read-only editors.
+     */
+    editorServices: IEditorServices;
+  }
+}

--- a/packages/debugger/src/panels/kernelSources/index.tsx
+++ b/packages/debugger/src/panels/kernelSources/index.tsx
@@ -1,0 +1,79 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+import { IEditorServices } from '@jupyterlab/codeeditor';
+import { ITranslator, nullTranslator } from '@jupyterlab/translation';
+import { PanelWithToolbar } from '@jupyterlab/ui-components';
+import { IDebugger } from '../../tokens';
+import { KernelSourcesBody } from './body';
+// import { KernelSourcePathComponent } from './sourcepath';
+// import { ReactWidget } from '@jupyterlab/ui-components';
+// import React from 'react';
+
+/**
+ * A Panel that shows a preview of the source code while debugging.
+ */
+export class KernelSources extends PanelWithToolbar {
+  /**
+   * Instantiate a new Sources preview Panel.
+   *
+   * @param options The Sources instantiation options.
+   */
+  constructor(options: KernelSources.IOptions) {
+    super();
+    const { model, service, editorServices } = options;
+    const trans = (options.translator ?? nullTranslator).load('jupyterlab');
+    this.title.label = trans.__('Kernel Sources');
+
+    this.toolbar.addClass('jp-DebuggerKernelSources-header');
+    const body = new KernelSourcesBody({
+      service,
+      model,
+      editorServices
+    });
+    /*
+    const button = new ToolbarButton({
+      icon: viewBreakpointIcon,
+      onClick: (): void => model.open(),
+      label: '/Users/echarles/miniconda3/envs/datalayer/lib/python3.8/os.py',
+      tooltip: '/Users/echarles/miniconda3/envs/datalayer/lib/python3.8/os.py'
+    });
+    this.addWidget(button);
+    */
+    this.addClass('jp-DebuggerKernelSources-header');
+    this.addWidget(body);
+    this.addClass('jp-DebuggerKenelSources');
+  }
+}
+
+/**
+ * A namespace for `Sources` statics.
+ */
+export namespace KernelSources {
+  /**
+   * The options used to create a Sources.
+   */
+  export interface IOptions {
+    /**
+     * The debugger service.
+     */
+    service: IDebugger;
+
+    /**
+     * The model for the sources.
+     */
+    model: IDebugger.Model.ISources;
+
+    /**
+     * The editor services used to create new read-only editors.
+     */
+    editorServices: IEditorServices;
+
+    /**
+     * The application language translator
+     */
+    translator?: ITranslator;
+  }
+}

--- a/packages/debugger/src/panels/kernelSources/model.ts
+++ b/packages/debugger/src/panels/kernelSources/model.ts
@@ -1,0 +1,100 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { ISignal, Signal } from '@lumino/signaling';
+
+import { IDebugger } from '../../tokens';
+
+/**
+ * The model to keep track of the current source being displayed.
+ */
+export class KernelSourcesModel implements IDebugger.Model.ISources {
+  /**
+   * Instantiate a new Sources.Model
+   *
+   * @param options The Sources.Model instantiation options.
+   */
+  constructor(options: KernelSourcesModel.IOptions) {
+    this.currentFrameChanged = options.currentFrameChanged;
+  }
+
+  /**
+   * Signal emitted when the current frame changes.
+   */
+  readonly currentFrameChanged: ISignal<
+    IDebugger.Model.ICallstack,
+    IDebugger.IStackFrame | null
+  >;
+
+  /**
+   * Signal emitted when a source should be open in the main area.
+   */
+  get currentSourceOpened(): ISignal<
+    KernelSourcesModel,
+    IDebugger.Source | null
+  > {
+    return this._currentSourceOpened;
+  }
+
+  /**
+   * Signal emitted when the current source changes.
+   */
+  get currentSourceChanged(): ISignal<
+    KernelSourcesModel,
+    IDebugger.Source | null
+  > {
+    return this._currentSourceChanged;
+  }
+
+  /**
+   * Return the current source.
+   */
+  get currentSource(): IDebugger.Source | null {
+    return this._currentSource;
+  }
+
+  /**
+   * Set the current source.
+   *
+   * @param source The source to set as the current source.
+   */
+  set currentSource(source: IDebugger.Source | null) {
+    this._currentSource = source;
+    this._currentSourceChanged.emit(source);
+  }
+
+  /**
+   * Open a source in the main area.
+   */
+  open(): void {
+    this._currentSourceOpened.emit(this._currentSource);
+  }
+
+  private _currentSource: IDebugger.Source | null;
+  private _currentSourceOpened = new Signal<
+    KernelSourcesModel,
+    IDebugger.Source | null
+  >(this);
+  private _currentSourceChanged = new Signal<
+    KernelSourcesModel,
+    IDebugger.Source | null
+  >(this);
+}
+
+/**
+ * A namespace for SourcesModel `statics`.
+ */
+export namespace KernelSourcesModel {
+  /**
+   * The options used to initialize a SourcesModel object.
+   */
+  export interface IOptions {
+    /**
+     * Signal emitted when the current frame changes.
+     */
+    currentFrameChanged: ISignal<
+      IDebugger.Model.ICallstack,
+      IDebugger.IStackFrame | null
+    >;
+  }
+}

--- a/packages/debugger/src/panels/kernelSources/sourcepath.tsx
+++ b/packages/debugger/src/panels/kernelSources/sourcepath.tsx
@@ -1,0 +1,28 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { UseSignal } from '@jupyterlab/ui-components';
+import React from 'react';
+import { IDebugger } from '../../tokens';
+
+/**
+ * A React component to display the path to a source.
+ *
+ * @param {object} props The component props.
+ * @param props.model The model for the sources.
+ */
+export const KernelSourcePathComponent = ({
+  model
+}: {
+  model: IDebugger.Model.ISources;
+}): JSX.Element => {
+  return (
+    <UseSignal signal={model.currentSourceChanged} initialSender={model}>
+      {(model): JSX.Element => (
+        <span onClick={(): void => model?.open()}>
+          {model?.currentSource?.path ?? ''}
+        </span>
+      )}
+    </UseSignal>
+  );
+};

--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -839,7 +839,6 @@ export class DebuggerService implements IDebugger, IDisposable {
     breakpoints: Map<string, IDebugger.IBreakpoint[]>
   ): Promise<void> {
     for (const [source, points] of breakpoints) {
-      console.log(source);
       await this._setBreakpoints(
         points
           .filter(({ line }) => typeof line === 'number')

--- a/packages/debugger/src/sidebar.ts
+++ b/packages/debugger/src/sidebar.ts
@@ -17,6 +17,8 @@ import { Callstack as CallstackPanel } from './panels/callstack';
 
 import { Sources as SourcesPanel } from './panels/sources';
 
+import { KernelSources as KernelSourcesPanel } from './panels/kernelSources';
+
 import { Variables as VariablesPanel } from './panels/variables';
 
 import { IDebugger } from './tokens';
@@ -72,6 +74,13 @@ export class DebuggerSidebar extends SidePanel implements IDebugger.ISidebar {
       translator
     });
 
+    this.kernelSources = new KernelSourcesPanel({
+      model: model.kernelSources,
+      service,
+      editorServices,
+      translator
+    });
+
     const header = new DebuggerSidebar.Header();
 
     this.header.addWidget(header);
@@ -85,6 +94,7 @@ export class DebuggerSidebar extends SidePanel implements IDebugger.ISidebar {
     this.addWidget(this.callstack);
     this.addWidget(this.breakpoints);
     this.addWidget(this.sources);
+    this.addWidget(this.kernelSources);
   }
 
   /**
@@ -106,6 +116,8 @@ export class DebuggerSidebar extends SidePanel implements IDebugger.ISidebar {
    * The sources widget.
    */
   readonly sources: SourcesPanel;
+
+  readonly kernelSources: KernelSourcesPanel;
 }
 
 /**

--- a/packages/debugger/src/tokens.ts
+++ b/packages/debugger/src/tokens.ts
@@ -803,6 +803,11 @@ export namespace IDebugger {
       readonly sources: ISources;
 
       /**
+       * The kernel sources UI model.
+       */
+      readonly kernelSources: ISources;
+
+      /**
        * The set of threads in stopped state.
        */
       stoppedThreads: Set<number>;

--- a/packages/debugger/style/base.css
+++ b/packages/debugger/style/base.css
@@ -6,6 +6,7 @@
 @import './callstack.css';
 @import './editor.css';
 @import './icons.css';
+@import './kernelSources.css';
 @import './sidebar.css';
 @import './sources.css';
 @import './variables.css';

--- a/packages/debugger/style/kernelSources.css
+++ b/packages/debugger/style/kernelSources.css
@@ -1,0 +1,32 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+.jp-DebuggerKernelSources {
+  min-height: 50px;
+  margin-top: 3px;
+}
+
+[data-jp-debugger='true'].jp-Editor .jp-mod-readOnly {
+  background: var(--jp-layout-color2);
+  height: 100%;
+}
+
+.jp-DebuggerKernelSources-body [data-jp-debugger='true'].jp-Editor {
+  height: 100%;
+}
+
+.jp-DebuggerKernelSources-body {
+  height: 100%;
+  overflow-y: auto;
+}
+
+.jp-DebuggerKernelSources-header > div > span {
+  overflow: hidden;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--jp-ui-font-size0);
+  color: var(--jp-ui-font-color1);
+}


### PR DESCRIPTION
Alternative implementation of https://github.com/jupyterlab/jupyterlab/pull/11566

This PR uses a `Comm` to get the kernel sources.