### PR TITLE
Remove the `watch` dependency from the examples

### DIFF
--- a/examples/app/package.json
+++ b/examples/app/package.json
@@ -57,7 +57,6 @@
     "svg-url-loader": "~6.0.0",
     "to-string-loader": "^1.1.6",
     "url-loader": "~4.1.0",
-    "watch": "~1.0.2",
     "webpack": "^5.55.1",
     "webpack-cli": "^4.8.0",
     "whatwg-fetch": "^3.0.0"

--- a/examples/cell/package.json
+++ b/examples/cell/package.json
@@ -31,7 +31,6 @@
     "svg-url-loader": "~6.0.0",
     "typescript": "~4.5.2",
     "url-loader": "~4.1.0",
-    "watch": "~1.0.2",
     "webpack": "^5.55.1",
     "webpack-cli": "^4.8.0",
     "whatwg-fetch": "^3.0.0"

--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -29,7 +29,6 @@
     "style-loader": "~2.0.0",
     "typescript": "~4.5.2",
     "url-loader": "~4.1.0",
-    "watch": "~1.0.2",
     "webpack": "^5.55.1",
     "webpack-cli": "^4.8.0",
     "whatwg-fetch": "^3.0.0"

--- a/examples/federated/core_package/package.json
+++ b/examples/federated/core_package/package.json
@@ -167,7 +167,6 @@
     "svg-url-loader": "~6.0.0",
     "to-string-loader": "^1.1.6",
     "url-loader": "~4.1.0",
-    "watch": "~1.0.2",
     "webpack": "^5.55.1",
     "webpack-cli": "^4.8.0",
     "webpack-merge": "^5.8.0",

--- a/examples/filebrowser/package.json
+++ b/examples/filebrowser/package.json
@@ -35,7 +35,6 @@
     "svg-url-loader": "~6.0.0",
     "typescript": "~4.5.2",
     "url-loader": "~4.1.0",
-    "watch": "~1.0.2",
     "webpack": "^5.55.1",
     "webpack-cli": "^4.8.0",
     "whatwg-fetch": "^3.0.0"

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -35,7 +35,6 @@
     "svg-url-loader": "~6.0.0",
     "typescript": "~4.5.2",
     "url-loader": "~4.1.0",
-    "watch": "~1.0.2",
     "webpack": "^5.55.1",
     "webpack-cli": "^4.8.0",
     "whatwg-fetch": "^3.0.0"

--- a/examples/terminal/package.json
+++ b/examples/terminal/package.json
@@ -25,7 +25,6 @@
     "svg-url-loader": "~6.0.0",
     "typescript": "~4.5.2",
     "url-loader": "~4.1.0",
-    "watch": "~1.0.2",
     "webpack": "^5.55.1",
     "webpack-cli": "^4.8.0",
     "whatwg-fetch": "^3.0.0"

--- a/packages/extensionmanager-extension/examples/listings/package.json
+++ b/packages/extensionmanager-extension/examples/listings/package.json
@@ -54,7 +54,6 @@
     "style-loader": "~2.0.0",
     "svg-url-loader": "~6.0.0",
     "url-loader": "~4.1.0",
-    "watch": "~1.0.2",
     "webpack": "^4.41.1",
     "webpack-cli": "^4.1.0",
     "whatwg-fetch": "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6129,13 +6129,6 @@ events@^3.2.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
-exec-sh@^0.2.0:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.2.tgz#2a5e7ffcbd7d0ba2755bdecb16e5a427dfbdec36"
-  integrity sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==
-  dependencies:
-    merge "^1.2.0"
-
 exec-sh@^0.3.2:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.6.tgz#ff264f9e325519a60cb5e273692943483cca63bc"
@@ -9473,11 +9466,6 @@ merge2@^1.2.3, merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
-
-merge@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
-  integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
 
 metaviewport-parser@0.2.0:
   version "0.2.0"
@@ -13929,14 +13917,6 @@ walker@^1.0.7, walker@~1.0.5:
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
-
-watch@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/watch/-/watch-1.0.2.tgz#340a717bde765726fa0aa07d721e0147a551df0c"
-  integrity sha1-NApxe952Vyb6CqB9ch4BR6VR3ww=
-  dependencies:
-    exec-sh "^0.2.0"
-    minimist "^1.2.0"
 
 watchpack@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

The `watch` dependency currently in most of the `examples` folders doesn't seem to be used anymore.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Remove `watch` from the dependencies. This cleans up the `yarn.lock` a bit.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
