### PR TITLE
Share execution count, nbformat and metadata

### DIFF
--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -632,10 +632,12 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
     const trusted = this.trusted;
     const cell = options.cell as nbformat.ICodeCell;
     let outputs: nbformat.IOutput[] = [];
+    let execution_count: number | null = null;
     const executionCount = this.modelDB.createValue('executionCount');
     if (!executionCount.get()) {
       if (cell && cell.cell_type === 'code') {
-        executionCount.set(cell.execution_count || null);
+        execution_count = cell.execution_count || null;
+        executionCount.set(execution_count);
         outputs = cell.outputs ?? [];
         // If execution count is not null presume the input code was the latest executed
         // TODO load from the notebook file when the dirty state is stored in it
@@ -654,6 +656,7 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
     globalModelDBMutex(() => {
       const sharedCell = this.sharedModel as models.ISharedCodeCell;
       sharedCell.setOutputs(outputs);
+      sharedCell.execution_count = execution_count;
     });
     this._outputs = factory.createOutputArea({ trusted, values: outputs });
     this._outputs.changed.connect(this.onGenericChange, this);

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -112,10 +112,7 @@ export class NotebookModel implements INotebookModel {
     metadata.changed.connect(this._onMetadataChanged, this);
     this._deletedCells = [];
 
-    (this.sharedModel as models.YNotebook).dirty = false;
     this.sharedModel.changed.connect(this._onStateChanged, this);
-    (this.sharedModel as models.YNotebook).nbformat = this._nbformat;
-    (this.sharedModel as models.YNotebook).nbformat_minor = this._nbformatMinor;
   }
   /**
    * A signal emitted when the document content changes.

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -33,8 +33,6 @@ import { JSONObject, ReadonlyPartialJSONValue, UUID } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 import { CellList } from './celllist';
 
-const UNSHARED_KEYS = ['kernelspec', 'language_info'];
-
 /**
  * The definition of a model object for a notebook widget.
  */
@@ -116,6 +114,8 @@ export class NotebookModel implements INotebookModel {
 
     (this.sharedModel as models.YNotebook).dirty = false;
     this.sharedModel.changed.connect(this._onStateChanged, this);
+    (this.sharedModel as models.YNotebook).nbformat = this._nbformat;
+    (this.sharedModel as models.YNotebook).nbformat_minor = this._nbformatMinor;
   }
   /**
    * A signal emitted when the document content changes.
@@ -447,11 +447,9 @@ close the notebook without saving it.`,
     metadata: IObservableJSON,
     change: IObservableMap.IChangedArgs<ReadonlyPartialJSONValue | undefined>
   ): void {
-    if (!UNSHARED_KEYS.includes(change.key)) {
-      this._modelDBMutex(() => {
-        this.sharedModel.updateMetadata(metadata.toJSON());
-      });
-    }
+    this._modelDBMutex(() => {
+      this.sharedModel.updateMetadata(metadata.toJSON());
+    });
     this.triggerContentChange();
   }
 


### PR DESCRIPTION
## References

#11599

## Code changes

When we save a notebook from the back-end using `y-py`, we will need data that is currently not set in the shared model e.g. when a notebook is loaded.
- Populate every cell shared model with `execution_count` when a notebook is loaded.
- Populate the notebook shared model with `nbformat` and `nbformat_minor` when a notebook is created/loaded, and with `metadata` whenever it changes. For `metadata`, we didn't share `kernelspec` and `language_info`, I'm not sure why.

## User-facing changes

None

## Backwards-incompatible changes

None