### PR TITLE
Drop support for `externalExtensions`

### DIFF
--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -413,11 +413,7 @@ function ensureJupyterlab(): string[] {
   corePackage.jupyterlab.extensions = {};
   corePackage.jupyterlab.mimeExtensions = {};
   corePackage.jupyterlab.linkedPackages = {};
-  // start with known external dependencies
-  corePackage.dependencies = Object.assign(
-    {},
-    corePackage.jupyterlab.externalExtensions
-  );
+  corePackage.dependencies = {};
   corePackage.resolutions = {};
 
   const singletonPackages: string[] = corePackage.jupyterlab.singletonPackages;

--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -255,7 +255,6 @@
       "@jupyterlab/pdf-extension": "",
       "@jupyterlab/vega5-extension": ""
     },
-    "externalExtensions": {},
     "buildDir": "./static",
     "outputDir": ".",
     "singletonPackages": [

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -21,21 +21,7 @@ const packageData = require('./package.json');
 
 // Handle the extensions.
 const jlab = packageData.jupyterlab;
-const { extensions, mimeExtensions, externalExtensions } = jlab;
-
-// Add external extensions to the extensions/mimeExtensions data as
-// appropriate
-for (const pkg in externalExtensions) {
-  const {
-    jupyterlab: { extension, mimeExtension }
-  } = require(`${pkg}/package.json`);
-  if (extension !== undefined) {
-    extensions[pkg] = extension === true ? '' : extension;
-  }
-  if (mimeExtension !== undefined) {
-    mimeExtensions[pkg] = mimeExtension === true ? '' : mimeExtension;
-  }
-}
+const { extensions, mimeExtensions } = jlab;
 
 // Deduplicated list of extension package names.
 const extensionPackages = [

--- a/docs/source/extension/extension_dev.rst
+++ b/docs/source/extension/extension_dev.rst
@@ -700,24 +700,6 @@ not enabled in our build configuration. To build a compatible package set
 ``output.libraryTarget`` to ``"commonjs2"`` in your Webpack configuration.
 (see `this <https://github.com/saulshanabrook/jupyterlab-webpack>`__ example repo).
 
-Another option to try out your extension with a local version of JupyterLab is to add it to the
-list of locally installed packages and to have JupyterLab register your extension when it starts up.
-
-You can do this by adding your extension to the ``jupyterlab.externalExtensions`` key
-in the ``dev_mode/package.json`` file. It should be a mapping
-of extension name to version, just like in ``dependencies``. Then run ``jlpm run integrity``
-and these extensions should be added automatically to the ``dependencies`` and pulled in.
-
-When you then run ``jlpm run build && jupyter lab --dev`` or ``jupyter lab --dev --watch`` this extension
-will be loaded by default. For example, this is how you can add the Jupyter Widgets
-extensions:
-
-::
-
-    "externalExtensions": {
-      "@jupyter-widgets/jupyterlab-manager": "2.0.0"
-    },
-
 If you publish your extension on ``npm.org``, users will be able to install
 it as simply ``jupyter labextension install <foo>``, where ``<foo>`` is
 the name of the published ``npm`` package. You can alternatively provide a

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -43,6 +43,14 @@ bumped their major version (following semver convention):
   The ``create-theme`` script has been removed. If you want to create a new theme extension, you
   should use the `Theme Cookiecutter <https://github.com/jupyterlab/theme-cookiecutter>`_ instead.
 
+Extension Development Changes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- The ``externalExtensions`` field in the ``dev_mode/package.json`` file corresponding to the ``@jupyterlab/application-top``
+  ``private`` package has now been removed in ``4.0``. If you were using this field to develop source extensions against
+  a development build of JupyterLab, you should instead switch to the federated extensions system (via the ``--extensions-in-dev-mode`` flag)
+  or to using the ``--splice-source`` option. See :ref:`prebuilt_dev_workflow` and :ref:`source_dev_workflow` for more information.
+
 JupyterLab 3.0 to 3.1
 ---------------------
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

As we try to encourage folks to use federated extensions (https://github.com/jupyterlab/jupyterlab/issues/11336), we should limit the options for installing and using source extensions in a dev build of JupyterLab.

The recommended alternative would be to use `--extensions-in-dev-mode` to enable federated extensions: https://jupyterlab.readthedocs.io/en/stable/extension/extension_dev.html?#developing-a-prebuilt-extension

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/11685

## Code changes

`externalExtensions` is currently documented in the Extension Developer Guide: https://jupyterlab.readthedocs.io/en/stable/extension/extension_dev.html?#development-workflow-for-source-extensions

- [x] Remove support for `externalExtensions`, which consisted in manually editing `dev_mode/package.json` to include local extensions in a dev build.
- [x] Document the change in case some were relying on this behavior

## User-facing changes

None

## Backwards-incompatible changes

Remove `externalExtensions` from `@jupyterlab/application-top`.

Probably not a real breaking change since this was meant for development purposes.