### PR TITLE
Fix formatting in extension migration docs

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -32,16 +32,17 @@ bumped their major version (following semver convention):
    See https://github.com/jupyterlab/jupyterlab/pull/11537 for more details.
 - ``@jupyterlab/toc:plugin`` renamed ``@jupyterlab/toc-extension:registry``
    This may impact application configuration (for instance if the plugin was disabled).
-- As a result of the update to TypeScript 4.5, a couple of interfaces have had their definitions changed.
-   The ``anchor`` parameter of ``HoverBox.IOptions` is now a ``DOMRect` instead of ``ClientRect``.
-   The ``CodeEditor.ICoordinate`` interface now extends ``DOMRectReadOnly`` instead of ``JSONObject, ClientRect``.
 - ``@jupyterlab/notebook`` from 3.x to 4.x
    The ``NotebookPanel._onSave`` method is now ``private``.
 - ``@jupyterlab/shared-models`` from 3.x to 4.x
-  The ``createCellFromType`` function has been renamed to ``createCellModelFromSharedType``
+   The ``createCellFromType`` function has been renamed to ``createCellModelFromSharedType``
 - ``@jupyterlab/buildutils`` from 3.x to 4.x
-  The ``create-theme`` script has been removed. If you want to create a new theme extension, you
-  should use the `Theme Cookiecutter <https://github.com/jupyterlab/theme-cookiecutter>`_ instead.
+   The ``create-theme`` script has been removed. If you want to create a new theme extension, you
+   should use the `Theme Cookiecutter <https://github.com/jupyterlab/theme-cookiecutter>`_ instead.
+- TypeScript 4.5 update
+   As a result of the update to TypeScript 4.5, a couple of interfaces have had their definitions changed.
+   The ``anchor`` parameter of ``HoverBox.IOptions` is now a ``DOMRect` instead of ``ClientRect``.
+   The ``CodeEditor.ICoordinate`` interface now extends ``DOMRectReadOnly`` instead of ``JSONObject, ClientRect``.
 
 JupyterLab 3.0 to 3.1
 ---------------------

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -41,7 +41,7 @@ bumped their major version (following semver convention):
    should use the `Theme Cookiecutter <https://github.com/jupyterlab/theme-cookiecutter>`_ instead.
 - TypeScript 4.5 update
    As a result of the update to TypeScript 4.5, a couple of interfaces have had their definitions changed.
-   The ``anchor`` parameter of ``HoverBox.IOptions` is now a ``DOMRect` instead of ``ClientRect``.
+   The ``anchor`` parameter of ``HoverBox.IOptions`` is now a ``DOMRect`` instead of ``ClientRect``.
    The ``CodeEditor.ICoordinate`` interface now extends ``DOMRectReadOnly`` instead of ``JSONObject, ClientRect``.
 
 JupyterLab 3.0 to 3.1


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Follow-up to the recent edits to the 3.x -> 4.x extension migration guide.


## User-facing changes

None for end users

For extension authors:

### Before

![image](https://user-images.githubusercontent.com/591645/146403043-41f25e99-69ed-4c6e-8ae8-23031f81a167.png)

### After

![image](https://user-images.githubusercontent.com/591645/146403367-a9dee74e-750d-4c1b-8b5b-7ba7fb2f7c3c.png)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
