### PR TITLE
Removing early bail out in ToC widget update

### DIFF
--- a/packages/toc/src/toc.tsx
+++ b/packages/toc/src/toc.tsx
@@ -122,11 +122,6 @@ export class TableOfContents extends Widget {
    * @param msg - message
    */
   protected onUpdateRequest(msg: Message): void {
-    if (this.isHidden) {
-      // Bail early
-      return;
-    }
-
     let title = this._trans.__('Table of Contents');
     if (this._current) {
       this._headings = this._current.generator.generate(


### PR DESCRIPTION
## References

Fixes #11709 

## Code changes

Removing early bail out in ToC widget update to trigger rendering of notebook header numbering also if ToC widget is hidden.

## User-facing changes

Headings now numbered correctly.

## Backwards-incompatible changes

none
