### PR TITLE
Parse settings as JSON 5 in services

### DIFF
--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -55,6 +55,7 @@
     "@lumino/disposable": "^1.10.1",
     "@lumino/polling": "^1.9.1",
     "@lumino/signaling": "^1.10.1",
+    "json5": "^2.1.1",
     "node-fetch": "^2.6.0",
     "ws": "^7.4.6"
   },

--- a/packages/services/src/setting/index.ts
+++ b/packages/services/src/setting/index.ts
@@ -7,6 +7,8 @@ import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
 import { DataConnector } from '@jupyterlab/statedb';
 
+import * as json5 from 'json5';
+
 import { ServerConnection } from '../serverconnection';
 
 /**
@@ -60,7 +62,8 @@ export class SettingManager extends DataConnector<
     }
 
     // Assert what type the server response is returning.
-    return response.json() as Promise<ISettingRegistry.IPlugin>;
+    const content = await response.text();
+    return json5.parse(content) as ISettingRegistry.IPlugin;
   }
 
   /**
@@ -80,7 +83,8 @@ export class SettingManager extends DataConnector<
       throw new ResponseError(response);
     }
 
-    const json = await response.json();
+    const content = await response.text();
+    const json = json5.parse(content);
     const values: ISettingRegistry.IPlugin[] =
       json?.['settings']?.map((plugin: ISettingRegistry.IPlugin) => {
         plugin.data = { composite: {}, user: {} };


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes https://github.com/jupyterlab/jupyterlab_server/issues/217
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Parse response from in settings service as JSON 5 not standard JSON.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Settings can be JSON 5 - in particular `Infinity` can now be used.
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A