### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ classifiers =
 zip_safe = False
 include_package_data = True
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     ipython
     packaging


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Second part of https://github.com/jupyterlab/jupyterlab/pull/11646

Fixes https://github.com/jupyterlab/jupyterlab/issues/11645

Python 3.6 EOL is today (`2021-12-23`).

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Bump to `python_requires = >=3.7`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

JupyterLab 4.0 (and maybe 3.3 if this gets backported later) will not be installable with Python 3.6.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
