### PR TITLE
Fix handling of disabled extensions

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1152,6 +1152,8 @@ class _AppHandler(object):
         page_config = get_page_config(labextensions_path, app_settings_dir=app_settings_dir, logger=self.logger)
 
         disabled = page_config.get('disabledExtensions', {})
+        # handle disabledExtensions specified as a list (jupyterlab_server < 2.10)
+        # see https://github.com/jupyterlab/jupyterlab_server/pull/192 for more info
         if isinstance(disabled, list):
             disabled = { extension: True for extension in disabled }
 

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -602,8 +602,6 @@ class _AppHandler(object):
         # Do this last since it relies on other attributes
         self.info = self._get_app_info()
 
-
-
     def install_extension(self, extension, existing=None, pin=None):
         """Install an extension package into JupyterLab.
 
@@ -1153,7 +1151,11 @@ class _AppHandler(object):
 
         page_config = get_page_config(labextensions_path, app_settings_dir=app_settings_dir, logger=self.logger)
 
-        info['disabled'] = page_config.get('disabledExtensions', [])
+        disabled = page_config.get('disabledExtensions', {})
+        if isinstance(disabled, list):
+            disabled = { extension: True for extension in disabled }
+
+        info['disabled'] = disabled
 
         disabled_core = []
         for key in info['core_extensions']:

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -2238,7 +2238,7 @@ def _is_disabled(name, disabled={}):
     """Test whether the package is disabled.
     """
     for pattern, value in disabled.items():
-        # skip packages explicitely marked as disabled
+        # skip packages explicitly marked as not disabled
         if value == False:
             continue
         if name == pattern:

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -2234,9 +2234,10 @@ def _compare_ranges(spec1, spec2, drop_prerelease1=False, drop_prerelease2=False
     return return_value
 
 
-def _is_disabled(name, disabled={}):
+def _is_disabled(name, disabled=None):
     """Test whether the package is disabled.
     """
+    disabled = disabled or {}
     for pattern, value in disabled.items():
         # skip packages explicitly marked as not disabled
         if value == False:

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -2230,10 +2230,13 @@ def _compare_ranges(spec1, spec2, drop_prerelease1=False, drop_prerelease2=False
     return return_value
 
 
-def _is_disabled(name, disabled=[]):
+def _is_disabled(name, disabled={}):
     """Test whether the package is disabled.
     """
-    for pattern in disabled:
+    for pattern, value in disabled.items():
+        # skip packages explicitely marked as disabled
+        if value == False:
+            continue
         if name == pattern:
             return True
         if re.compile(pattern).match(name) is not None:

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -543,15 +543,15 @@ class TestExtension(AppHandlerTest):
         assert disable_extension(self.pkg_names['extension'], app_options=options) is True
         info = get_app_info(app_options=options)
         name = self.pkg_names['extension']
-        assert name in info['disabled']
+        assert info['disabled'].get(name) is True
         assert not check_extension(name, app_options=options)
         assert check_extension(name, installed=True, app_options=options)
         assert disable_extension('@jupyterlab/notebook-extension', app_options=options) is True
         info = get_app_info(app_options=options)
-        assert '@jupyterlab/notebook-extension' in info['disabled']
+        assert info['disabled'].get('@jupyterlab/notebook-extension') is True
         assert not check_extension('@jupyterlab/notebook-extension', app_options=options)
         assert check_extension('@jupyterlab/notebook-extension', installed=True, app_options=options)
-        assert name in info['disabled']
+        assert info['disabled'].get(name) is True
         assert not check_extension(name, app_options=options)
         assert check_extension(name, installed=True, app_options=options)
 

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -563,7 +563,7 @@ class TestExtension(AppHandlerTest):
         info = get_app_info(app_options=options)
         assert '@jupyterlab/notebook-extension' not in info['disabled']
         name = self.pkg_names['extension']
-        assert name not in info['disabled']
+        assert info['disabled'].get(name, False) is False
         assert check_extension(name, app_options=options)
         assert disable_extension('@jupyterlab/notebook-extension', app_options=options) is True
         assert check_extension(name, app_options=options)

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     packaging
     tornado>=6.1.0
     jupyter_core
-    jupyterlab_server~=2.9.0
+    jupyterlab_server~=2.3
     jupyter_server~=1.4
     nbclassic~=0.2
     jinja2>=2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     packaging
     tornado>=6.1.0
     jupyter_core
-    jupyterlab_server~=2.3
+    jupyterlab_server~=2.9.0
     jupyter_server~=1.4
     nbclassic~=0.2
     jinja2>=2.1


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Attempt at fixing #11743 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Fix handling of disabled extensions when they are explicitly set to `false`:

```json
{
  "@jupyterlab/mock-extension": false
}
```

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Should fix issues with `disabledExtensions` when using `jupyterlab_server>=2.10`.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
