### PR TITLE
Encourage new contributors to send draft PR over asking for permission

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -17,7 +17,12 @@ or `help
 wanted <https://github.com/jupyterlab/jupyterlab/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22>`__
 that we believe are good examples of small, self-contained changes. We
 encourage those that are new to the code base to implement and/or ask
-questions about these issues.
+questions about these issues. You are not required to ask for a permission
+to work on such issue, but if you do and do not get a reply within 48 hours
+please assume that no one else is working on it (even if someone previously
+volunteered) and open a pull request with proposed implementation.
+If you are not certain about the implementation, using draft pull requests is encouraged.
+
 
 If you believe you’ve found a security vulnerability in JupyterLab or
 any Jupyter project, please report it to security@ipython.org. If you


### PR DESCRIPTION
## References

This addresses part of the discussion from our September meeting https://github.com/jupyterlab/team-compass/issues/128#issuecomment-910424790. We see a number of questions on GitHub issues which come down to "Can I contribute to this issue?" or "Is anyone already working on this?"; the former is easy to answer but sometimes goes unnoticed, and the latter is difficult to answer. I thought it might be helpful to let potential new contributors know that we do not require asking for permission if an issue is labeled "good first issue" and that no reply = no one is working on it.

I did not explicitly mention that we will not be assigning issues routinely - it could be good to add it here if we can find a good language.

CC @jasongrout

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None