### PR TITLE
Use shields.io badge for Gitpod editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@
 [![GitHub](https://img.shields.io/badge/issue_tracking-github-blue.svg)](https://github.com/jupyterlab/jupyterlab/issues)
 [![Discourse](https://img.shields.io/badge/help_forum-discourse-blue.svg)](https://discourse.jupyter.org/c/jupyterlab)
 [![Gitter](https://img.shields.io/badge/social_chat-gitter-blue.svg)](https://gitter.im/jupyterlab/jupyterlab)
+[![Gitpod](https://img.shields.io/badge/gitpod_editor-open-blue.svg)](https://gitpod.io/#https://github.com/jupyterlab/jupyterlab)
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab/jupyterlab-demo/7390762294552deb550b486928646705bbb24333?urlpath=lab/tree/demo)
-
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/jupyterlab/jupyterlab)
 
 An extensible environment for interactive and reproducible computing, based on the
 Jupyter Notebook and Architecture. [Currently ready for users.](https://blog.jupyter.org/jupyterlab-is-ready-for-users-5a6f039b8906)

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -91,9 +91,17 @@ the label ``foo`` and ``bar baz`` to an issue, comment
 
 Contributing from within the browser
 ------------------------------------
-Using the https://github.com web interface - documented
-`here <https://docs.github.com/en/free-pro-team@latest/github>`__ - you
-can create and propose a change purely within your browser.
+
+Contributing to JupyterLab codebase is also possible without setting up
+a local environment, directly from the Web browser:
+
+-  Gitpod integration is enabled, however it is not actively maintained,
+-  GitHub's built-in editor is suitable for contributing very small fixes,
+-  more advanced ``github.dev`` editor can be accessed by pressing the dot
+   (``.``) key while in the JupyterLab GitHub repository,
+-  `jupyterlab-playground <https://github.com/jupyterlab/jupyterlab-plugin-playground>`__,
+   allows to prototype JupyterLab extensions from within JupyterLab and
+   can be run without installation in the browser using Binder.
 
 Using `Binder <https://mybinder.org>`__, you can test the current master branch and your
 changes within the browser as well. We recommend you have at least 8 GB of RAM for this.
@@ -307,21 +315,6 @@ function to get a ``Promise`` for a ``requestAnimationFrame``. We
 sometimes have to set a sentinel value inside a ``Promise`` and then
 check that the sentinel was set if we need a promise to run without
 blocking.
-
-Alternatives To Local Development Environment
-"""""""""""""""""""""""""""""""""""""""""""""
-
-Contributing to JupyterLab codebase without setting up a local development
-environment is also possible using a number of options, often allowing
-to contribute directly from the Web browser:
-
--  Gitpod integration is enabled, however it is not actively maintained,
--  GitHub's built-in editor is suitable for contributing very small fixes,
--  more advanced ``github.dev`` editor can be accessed by pressing the dot
-   (``.``) key while in the JupyterLab GitHub repository,
--  `jupyterlab-playground <https://github.com/jupyterlab/jupyterlab-plugin-playground>`__,
-   allows to prototype JupyterLab extensions from within JupyterLab and
-   can be run without installation in the browser using Binder.
 
 Internationalization
 --------------------

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -97,7 +97,9 @@ a local environment, directly from the Web browser:
 
 -  `Gitpod <https://www.gitpod.io/>`__ integration is enabled,
    however it is not actively maintained,
--  GitHub's built-in editor is suitable for contributing very small fixes,
+-  GitHub's
+   `built-in editor <https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files>`__
+   is suitable for contributing very small fixes,
 -  more advanced `github.dev <https://docs.github.com/en/codespaces/the-githubdev-web-based-editor>`__
    editor can be accessed by pressing the dot (``.``) key while in the JupyterLab GitHub repository,
 -  `jupyterlab-playground <https://github.com/jupyterlab/jupyterlab-plugin-playground>`__,
@@ -186,10 +188,10 @@ Notes:
    Python 3.0+ version of ``pip`` or ``pip3 install -e .`` command to
    install JupyterLab from the forked repository.
 -  If you see an error that says ``Call to 'pkg-config pixman-1 --libs'
-   returned exit status 127 while in binding.gyp`` while running the 
+   returned exit status 127 while in binding.gyp`` while running the
    ``pip install`` command above, you may be missing packages required
    by ``canvas``. On macOS with Homebrew, you can add these packages by
-   running 
+   running
    ``brew install pkg-config cairo pango libpng jpeg giflib librsvg``.
 -  The ``jlpm`` command is a JupyterLab-provided, locked version of the
    `yarn <https://yarnpkg.com/en>`__ package manager. If you have
@@ -323,7 +325,7 @@ Internationalization
 Translatable strings update
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The translatable strings update cannot occur on patch release. They 
+The translatable strings update cannot occur on patch release. They
 must be delayed on minor or major versions.
 
 Performance Testing
@@ -559,40 +561,40 @@ Visual Regression and UI Tests
 ------------------------------
 
 As part of JupyterLab CI workflows, UI tests are run with visual regression checks.
-`Galata <https://github.com/jupyterlab/jupyterlab/tree/master/galata>`__ is used for UI 
-testing. Galata provides `Playwright <https://playwright.dev>`__ helpers to control and 
+`Galata <https://github.com/jupyterlab/jupyterlab/tree/master/galata>`__ is used for UI
+testing. Galata provides `Playwright <https://playwright.dev>`__ helpers to control and
 inspect JupyterLab UI programmatically.
 
-UI tests are run for each commit into JupyterLab project in PRs or direct commits. Code 
-changes can sometimes cause UI tests to fail for various reasons. After each test run, 
-Galata generates a user friendly test result report which can be used to inspect failing 
-UI tests. Result report shows the failure reason, call-stack up to the failure and 
-detailed information on visual regression issues. For visual regression errors, reference 
-image and test capture image, along with diff image generated during comparison are 
-provided in the report. You can use these information to debug failing tests. Galata test 
-report can be downloaded from GitHub Actions page for a UI test run. Test artifact is 
-named ``galata-report`` and once you extract it, you can access the report by launching 
-a server to serve the files ``python -m http.server -d <path-to-extracted-report>``. 
+UI tests are run for each commit into JupyterLab project in PRs or direct commits. Code
+changes can sometimes cause UI tests to fail for various reasons. After each test run,
+Galata generates a user friendly test result report which can be used to inspect failing
+UI tests. Result report shows the failure reason, call-stack up to the failure and
+detailed information on visual regression issues. For visual regression errors, reference
+image and test capture image, along with diff image generated during comparison are
+provided in the report. You can use these information to debug failing tests. Galata test
+report can be downloaded from GitHub Actions page for a UI test run. Test artifact is
+named ``galata-report`` and once you extract it, you can access the report by launching
+a server to serve the files ``python -m http.server -d <path-to-extracted-report>``.
 Then open *http://localhost:8000* with your web browser.
 
 Main reasons for UI test failures are:
 
 1. **A visual regression caused by code changes**:
 
-   Sometimes unintentional UI changes are introduced by modifications to project source 
-   code. Goal of visual regression testing is to detect this kind of UI changes. If your 
-   PR / commit is causing visual regression, then debug and fix the regression caused. 
+   Sometimes unintentional UI changes are introduced by modifications to project source
+   code. Goal of visual regression testing is to detect this kind of UI changes. If your
+   PR / commit is causing visual regression, then debug and fix the regression caused.
    You can locally run and debug the UI tests to fix the visual regression. To debug your
-   test, you may run ``PWDEBUG=1 jlpm playwright test <path-to-test-file>``. Once you 
+   test, you may run ``PWDEBUG=1 jlpm playwright test <path-to-test-file>``. Once you
    have a fix, you can push the change to your GitHub branch and test with GitHub actions.
 
 2. **An intended update to user interface**:
 
    If your code change is introducing an update to UI which causes existing UI Tests to
    fail, then you will need to update reference image(s) for the failing tests. In order
-   to do that, go to GitHub Actions page for the failed test and download test 
-   artifacts ``galata-test-assets``. It will contain test captures. You can 
-   copy the capture for the failed test suffixed with *actual* and paste it into reference 
+   to do that, go to GitHub Actions page for the failed test and download test
+   artifacts ``galata-test-assets``. It will contain test captures. You can
+   copy the capture for the failed test suffixed with *actual* and paste it into reference
    screenshots directory in JupyterLab source code, replacing the failing test's reference
    capture. Reference captures are located in directories named as the test files with the
    suffix ``-snapshots`` in JupyterLab source code.

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -308,6 +308,21 @@ sometimes have to set a sentinel value inside a ``Promise`` and then
 check that the sentinel was set if we need a promise to run without
 blocking.
 
+Alternatives To Local Development Environment
+"""""""""""""""""""""""""""""""""""""""""""""
+
+Contributing to JupyterLab codebase without setting up a local development
+environment is also possible using a number of options, often allowing
+to contribute directly from the Web browser:
+
+-  Gitpod integration is enabled, however it is not actively maintained,
+-  GitHub's built-in editor is suitable for contributing very small fixes,
+-  more advanced ``github.dev`` editor can be accessed by pressing the dot
+   (``.``) key while in the JupyterLab GitHub repository,
+-  `jupyterlab-playground <https://github.com/jupyterlab/jupyterlab-plugin-playground>`__,
+   allows to prototype JupyterLab extensions from within JupyterLab and
+   can be run without installation in the browser using Binder.
+
 Internationalization
 --------------------
 

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -95,10 +95,11 @@ Contributing from within the browser
 Contributing to JupyterLab codebase is also possible without setting up
 a local environment, directly from the Web browser:
 
--  Gitpod integration is enabled, however it is not actively maintained,
+-  `Gitpod <https://www.gitpod.io/>`__ integration is enabled,
+   however it is not actively maintained,
 -  GitHub's built-in editor is suitable for contributing very small fixes,
--  more advanced ``github.dev`` editor can be accessed by pressing the dot
-   (``.``) key while in the JupyterLab GitHub repository,
+-  more advanced `github.dev <https://docs.github.com/en/codespaces/the-githubdev-web-based-editor>`__
+   editor can be accessed by pressing the dot (``.``) key while in the JupyterLab GitHub repository,
 -  `jupyterlab-playground <https://github.com/jupyterlab/jupyterlab-plugin-playground>`__,
    allows to prototype JupyterLab extensions from within JupyterLab and
    can be run without installation in the browser using Binder.


### PR DESCRIPTION
## References

Based on discussions during meetings earlier this year and https://github.com/jupyterlab/jupyterlab/issues/9928#issuecomment-954899877 and some discussions on [gitter](https://gitter.im/jupyterlab/jupyterlab?at=61c2dab64024f534f2d1c532) I think it could be better to de-emphasise the Gitpod button (or maybe even remove it?); while we cannot be certain if it is not actively used by anyone, better alternatives (which do not require authorizing GitHub access for a third-party) now exist (`.`).

I am opening this PR with the possibly less controversial harmonization proposal, but if you think that it should be removed altogether please feel welcome to suggest it in the review and we could discuss on the next meeting.

Edit: The documentation was updated to clarify that Gitpod integration is not actively maintained, and describe other options. I replaced generic and outdated `https://docs.github.com/en/free-pro-team@latest/github` link.

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None
