### PR TITLE
Remove `Install`, `Update` and `Uninstall` buttons from the extension manager UI

### DIFF
--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -282,41 +282,6 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
             {entry.description}
           </div>
           <div className="jp-extensionmanager-entry-buttons">
-            {!entry.installed &&
-              entry.pkg_type == 'source' &&
-              !entry.blockedExtensionsEntry &&
-              !(!entry.allowedExtensionsEntry && listMode === 'allow') &&
-              ListModel.isDisclaimed() && (
-                <Button
-                  onClick={() => props.performAction('install', entry)}
-                  minimal
-                  small
-                >
-                  {trans.__('Install')}
-                </Button>
-              )}
-            {ListModel.entryHasUpdate(entry) &&
-              entry.pkg_type == 'source' &&
-              !entry.blockedExtensionsEntry &&
-              !(!entry.allowedExtensionsEntry && listMode === 'allow') &&
-              ListModel.isDisclaimed() && (
-                <Button
-                  onClick={() => props.performAction('install', entry)}
-                  minimal
-                  small
-                >
-                  {trans.__('Update')}
-                </Button>
-              )}
-            {entry.installed && entry.pkg_type == 'source' && (
-              <Button
-                onClick={() => props.performAction('uninstall', entry)}
-                minimal
-                small
-              >
-                {trans.__('Uninstall')}
-              </Button>
-            )}
             {entry.enabled && entry.pkg_type == 'source' && (
               <Button
                 onClick={() => props.performAction('disable', entry)}

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -282,7 +282,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
             {entry.description}
           </div>
           <div className="jp-extensionmanager-entry-buttons">
-            {entry.enabled && entry.pkg_type == 'source' && (
+            {entry.enabled && (
               <Button
                 onClick={() => props.performAction('disable', entry)}
                 minimal
@@ -291,7 +291,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                 {trans.__('Disable')}
               </Button>
             )}
-            {entry.installed && entry.pkg_type == 'source' && !entry.enabled && (
+            {entry.installed && !entry.enabled && (
               <Button
                 onClick={() => props.performAction('enable', entry)}
                 minimal


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Incremental step towards https://github.com/jupyterlab/jupyterlab/issues/10554 and https://github.com/jupyterlab/jupyterlab/issues/11336.

To improve and unify the user experience around installing extensions, which is at the moment confusing.

And help reduce the number of "JupyterLab failed to build" issues as mentioned in the `<details>` section of https://github.com/jupyterlab/jupyterlab/issues/10554#issue-938314948.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

This PR:

- removes the `Install`, `Update` and `Uninstall` buttons in the extension manager
- makes it possible to `Enable` and `Disable` prebuilt extensions

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

### Before

![image](https://user-images.githubusercontent.com/591645/147494378-7fcaca8c-7308-4237-801f-7a781bc7b7ed.png)

![image](https://user-images.githubusercontent.com/591645/147494359-0a436679-b393-47a3-8a8d-080927032a85.png)


### After

![image](https://user-images.githubusercontent.com/591645/147494278-2e350daf-de4d-45f7-8280-9c3ecaa30646.png)

![image](https://user-images.githubusercontent.com/591645/147494309-4dad94ef-c4d5-4602-b520-d23f4eb036c1.png)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None (UI only)

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
