### PR TITLE
Ensure browser attributes are set in plugin adding it

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -154,8 +154,6 @@ const browser: JupyterFrontEndPlugin<void> = {
   ): Promise<void> => {
     const trans = translator.load('jupyterlab');
     const browser = factory.defaultBrowser;
-    browser.node.setAttribute('role', 'region');
-    browser.node.setAttribute('aria-label', trans.__('File Browser Section'));
 
     // Let the application restorer track the primary file browser (that is
     // automatically created) for restoration of application state (e.g. setting
@@ -175,7 +173,6 @@ const browser: JupyterFrontEndPlugin<void> = {
 
     addCommands(app, factory, translator, settingRegistry, commandPalette);
 
-    browser.title.icon = folderIcon;
     // Show the current file browser shortcut in its title.
     const updateBrowserTitle = () => {
       const binding = find(
@@ -388,6 +385,13 @@ const browserWidget: JupyterFrontEndPlugin<void> = {
   ): void => {
     const { commands } = app;
     const { defaultBrowser: browser, tracker } = factory;
+    const trans = translator.load('jupyterlab');
+
+    // Set attributes when adding the browser to the UI
+    browser.node.setAttribute('role', 'region');
+    browser.node.setAttribute('aria-label', trans.__('File Browser Section'));
+    browser.title.icon = folderIcon;
+
     labShell.add(browser, 'left', { rank: 100 });
 
     commands.addCommand(CommandIDs.showBrowser, {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #11343
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Set browser attributes in the plugin adding it to the shell.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Correctly render the filebrowser icon
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A