### PR TITLE
Clear breakpoints when disposing an editor

### DIFF
--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -716,7 +716,7 @@ const main: JupyterFrontEndPlugin<void> = {
     shell.add(sidebar, 'right');
 
     commands.addCommand(CommandIDs.showPanel, {
-      label: translator.load('jupyterlab').__('Debugger Panel'),
+      label: trans.__('Debugger Panel'),
       execute: () => {
         shell.activateById(sidebar.id);
       }
@@ -781,12 +781,12 @@ const main: JupyterFrontEndPlugin<void> = {
               if (editor instanceof CodeMirrorEditor) {
                 (editor as CodeMirrorEditor).scrollIntoViewCentered({
                   line: (breakpoint.line as number) - 1,
-                  ch: breakpoint.column || 0
+                  ch: breakpoint.column ?? 0
                 });
               } else {
                 editor.revealPosition({
                   line: (breakpoint.line as number) - 1,
-                  column: breakpoint.column || 0
+                  column: breakpoint.column ?? 0
                 });
               }
             });

--- a/packages/debugger/src/handlers/editor.ts
+++ b/packages/debugger/src/handlers/editor.ts
@@ -83,10 +83,16 @@ export class EditorHandler implements IDisposable {
     if (this.isDisposed) {
       return;
     }
+    this.isDisposed = true;
     this._editorMonitor.dispose();
     this._clearEditor();
-    this.isDisposed = true;
     Signal.clearData(this);
+    // Clear breakpoints
+    this._debuggerService.updateBreakpoints(
+      this._editor.model.value.text,
+      [],
+      this._path
+    );
   }
 
   /**
@@ -133,7 +139,7 @@ export class EditorHandler implements IDisposable {
 
     const breakpoints = this._getBreakpointsFromEditor().map(lineInfo => {
       return Private.createBreakpoint(
-        this._debuggerService.session?.connection?.name || '',
+        this._debuggerService.session?.connection?.name ?? '',
         lineInfo.line + 1
       );
     });

--- a/packages/debugger/src/handlers/editor.ts
+++ b/packages/debugger/src/handlers/editor.ts
@@ -88,11 +88,11 @@ export class EditorHandler implements IDisposable {
     this._clearEditor();
     Signal.clearData(this);
     // Clear breakpoints
-    this._debuggerService.updateBreakpoints(
-      this._editor.model.value.text,
-      [],
-      this._path
-    );
+    this._debuggerService
+      .updateBreakpoints(this._editor.model.value.text, [], this._path)
+      .catch(reason => {
+        console.error(`Fail to clear breakpoints:\n${reason}`);
+      });
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Partialy address #11467
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
When disposing an editor handler, the associated breakpoints are cleared.

Minor changes:
- Fix usage of translation
- Use non-nullish operator instead of or operator

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

This clear the breakpoints when a cell is cut or deleted.

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A