### PR TITLE
Preserve breakpoint gutter when cells are moved.

### DIFF
--- a/packages/debugger/src/handlers/editor.ts
+++ b/packages/debugger/src/handlers/editor.ts
@@ -93,7 +93,7 @@ export class EditorHandler implements IDisposable {
    * Refresh the breakpoints display
    */
   refreshBreakpoints(): void {
-    this._addBreakpointsToEditor()
+    this._addBreakpointsToEditor();
   }
 
   /**

--- a/packages/debugger/src/handlers/editor.ts
+++ b/packages/debugger/src/handlers/editor.ts
@@ -90,6 +90,13 @@ export class EditorHandler implements IDisposable {
   }
 
   /**
+   * Refresh the breakpoints display
+   */
+  refreshBreakpoints(): void {
+    this._addBreakpointsToEditor()
+  }
+
+  /**
    * Setup the editor.
    */
   private _setupEditor(): void {

--- a/packages/debugger/src/handlers/notebook.ts
+++ b/packages/debugger/src/handlers/notebook.ts
@@ -1,9 +1,14 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { Cell, CodeCell } from '@jupyterlab/cells';
+import { Cell, CodeCell, ICellModel } from '@jupyterlab/cells';
 
-import { IObservableMap, ObservableMap } from '@jupyterlab/observables';
+import {
+  IObservableList,
+  IObservableMap,
+  IObservableUndoableList,
+  ObservableMap
+} from '@jupyterlab/observables';
 
 import { Notebook, NotebookPanel } from '@jupyterlab/notebook';
 
@@ -57,10 +62,19 @@ export class NotebookHandler implements IDisposable {
   /**
    * Handle a notebook cells changed event.
    */
-  private _onCellsChanged(): void {
+  private _onCellsChanged(
+    cells?: IObservableUndoableList<ICellModel>,
+    changes?: IObservableList.IChangedArgs<ICellModel>
+  ): void {
     this._notebookPanel.content.widgets.forEach(cell =>
       this._addEditorHandler(cell)
     );
+
+    if (changes?.type === 'move') {
+      for (const cell of changes.newValues) {
+        this._cellMap.get(cell.id)?.refreshBreakpoints();
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #11765
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Refresh gutter on cell moved

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Breakpoint are correctly displayed when cell is moved

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A