### PR TITLE
Fix semantic wrap words command

### DIFF
--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -591,7 +591,7 @@ export function createViewMenu(
     CommandIDs.wordWrap,
     createSemanticCommand(
       app,
-      menu.editorViewers.toggleMatchBrackets,
+      menu.editorViewers.toggleWordWrap,
       {
         label: trans.__('Wrap Words')
       },


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
When opening a text file, the view menu will have duplicated entries for _Match Brackets_ and none for _Wrap Words_.
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Correctly use the `menu.editorViewers.toggleWordWrap` semantic command to create the view menu entry _Wrap Words_.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Correctly display the wrap words status in the text editor
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A