### PR TITLE
Restore line number state when stopping debugger

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -238,7 +238,7 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
 
     // Editor settings
     if (options.editorConfig) {
-      this.editor.setOptions({...options.editorConfig});
+      this.editor.setOptions({ ...options.editorConfig });
     }
 
     model.metadata.changed.connect(this.onMetadataChanged, this);

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -238,13 +238,7 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
 
     // Editor settings
     if (options.editorConfig) {
-      let editorOptions: any = {};
-      Object.keys(options.editorConfig).forEach(
-        (key: keyof CodeEditor.IConfig) => {
-          editorOptions[key] = options.editorConfig?.[key] ?? null;
-        }
-      );
-      this.editor.setOptions(editorOptions);
+      this.editor.setOptions({...options.editorConfig} ?? {});
     }
 
     model.metadata.changed.connect(this.onMetadataChanged, this);

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -238,7 +238,7 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
 
     // Editor settings
     if (options.editorConfig) {
-      this.editor.setOptions({...options.editorConfig} ?? {});
+      this.editor.setOptions({...options.editorConfig});
     }
 
     model.metadata.changed.connect(this.onMetadataChanged, this);

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -548,7 +548,7 @@ export namespace CodeEditor {
     /**
      * Set config options for the editor.
      */
-    setOptions<K extends keyof IConfig>(options: IConfigOptions<K>[]): void;
+    setOptions(options: Partial<IConfig>): void;
 
     /**
      * Returns the content for the given line number.
@@ -818,13 +818,6 @@ export namespace CodeEditor {
   };
 
   /**
-   * The options used to set several options at once with setOptions.
-   */
-  export interface IConfigOptions<K extends keyof IConfig> {
-    K: IConfig[K];
-  }
-
-  /**
    * The options used to initialize an editor.
    */
   export interface IOptions {
@@ -861,7 +854,11 @@ export namespace CodeEditor {
 
   export namespace Model {
     export interface IOptions {
+      /**
+       * A unique identifier for the model.
+       */
       id?: string;
+
       /**
        * The initial value of the model.
        */

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -799,22 +799,22 @@ export namespace CodeEditor {
    * The default configuration options for an editor.
    */
   export const defaultConfig: IConfig = {
+    autoClosingBrackets: false,
+    codeFolding: false,
     cursorBlinkRate: 530,
     fontFamily: null,
     fontSize: null,
+    handlePaste: true,
+    insertSpaces: true,
     lineHeight: null,
     lineNumbers: false,
     lineWrap: 'on',
-    wordWrapColumn: 80,
+    matchBrackets: true,
     readOnly: false,
     tabSize: 4,
-    insertSpaces: true,
-    matchBrackets: true,
-    autoClosingBrackets: false,
-    handlePaste: true,
     rulers: [],
-    codeFolding: false,
-    showTrailingSpace: false
+    showTrailingSpace: false,
+    wordWrapColumn: 80
   };
 
   /**

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -351,14 +351,13 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
    * the costly update at the end, and not after every option
    * is set.
    */
-  setOptions<K extends keyof CodeMirrorEditor.IConfig>(
-    options: CodeMirrorEditor.IConfigOptions<K>[]
-  ): void {
+  setOptions(options: Partial<CodeMirrorEditor.IConfig>): void {
     const editor = this._editor;
     editor.startOperation();
-    for (let key in options) {
+    for (const key in options) {
+      const k = key as keyof CodeMirrorEditor.IConfig;
       editor.operation(() => {
-        this.setOption(key as any, options[key]);
+        this.setOption(k, options[k]);
       });
     }
     editor.endOperation();
@@ -1368,13 +1367,6 @@ export namespace CodeMirrorEditor {
     foldGutter: false,
     handlePaste: true
   };
-
-  /**
-   * The options used to set several options at once with setOptions.
-   */
-  export interface IConfigOptions<K extends keyof IConfig> {
-    K: IConfig[K];
-  }
 
   /**
    * Add a command to CodeMirror.

--- a/packages/debugger/src/handlers/editor.ts
+++ b/packages/debugger/src/handlers/editor.ts
@@ -72,6 +72,13 @@ export class EditorHandler implements IDisposable {
   }
 
   /**
+   * The editor
+   */
+  get editor(): CodeEditor.IEditor {
+    return this._editor;
+  }
+
+  /**
    * Whether the handler is disposed.
    */
   isDisposed: boolean;

--- a/packages/debugger/src/handlers/file.ts
+++ b/packages/debugger/src/handlers/file.ts
@@ -26,6 +26,7 @@ export class FileHandler implements IDisposable {
     this._debuggerService = options.debuggerService;
     this._fileEditor = options.widget.content;
 
+    this._hasLineNumber = this._fileEditor.editor.getOption('lineNumbers');
     this._editorHandler = new EditorHandler({
       debuggerService: this._debuggerService,
       editor: this._fileEditor.editor
@@ -46,12 +47,17 @@ export class FileHandler implements IDisposable {
     }
     this.isDisposed = true;
     this._editorHandler?.dispose();
+    // Restore editor options
+    this._editorHandler?.editor.setOptions({
+      lineNumbers: this._hasLineNumber
+    });
     Signal.clearData(this);
   }
 
   private _fileEditor: FileEditor;
   private _debuggerService: IDebugger;
   private _editorHandler: EditorHandler;
+  private _hasLineNumber: boolean;
 }
 
 /**

--- a/packages/debugger/src/handlers/notebook.ts
+++ b/packages/debugger/src/handlers/notebook.ts
@@ -52,7 +52,9 @@ export class NotebookHandler implements IDisposable {
     this._cellMap.values().forEach(handler => {
       handler.dispose();
       // Ensure to restore notebook editor settings
-      handler.editor.setOptions({...this._notebookPanel.content.editorConfig.code})
+      handler.editor.setOptions({
+        ...this._notebookPanel.content.editorConfig.code
+      });
     });
     this._cellMap.dispose();
     Signal.clearData(this);

--- a/packages/debugger/src/handlers/notebook.ts
+++ b/packages/debugger/src/handlers/notebook.ts
@@ -49,7 +49,11 @@ export class NotebookHandler implements IDisposable {
       return;
     }
     this.isDisposed = true;
-    this._cellMap.values().forEach(handler => handler.dispose());
+    this._cellMap.values().forEach(handler => {
+      handler.dispose();
+      // Ensure to restore notebook editor settings
+      handler.editor.setOptions({...this._notebookPanel.content.editorConfig.code})
+    });
     this._cellMap.dispose();
     Signal.clearData(this);
   }

--- a/packages/fileeditor-extension/schema/plugin.json
+++ b/packages/fileeditor-extension/schema/plugin.json
@@ -166,6 +166,7 @@
         "matchBrackets": true,
         "readOnly": false,
         "rulers": [],
+        "showTrailingSpace": false,
         "tabSize": 4,
         "wordWrapColumn": 80
       }

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -111,19 +111,20 @@ export const FACTORY = 'Editor';
 
 const userSettings = [
   'autoClosingBrackets',
+  'codeFolding',
   'cursorBlinkRate',
   'fontFamily',
   'fontSize',
+  'insertSpaces',
   'lineHeight',
   'lineNumbers',
   'lineWrap',
   'matchBrackets',
   'readOnly',
-  'insertSpaces',
-  'tabSize',
-  'wordWrapColumn',
   'rulers',
-  'codeFolding'
+  'showTrailingSpace',
+  'tabSize',
+  'wordWrapColumn'
 ];
 
 function filterUserSettings(config: CodeEditor.IConfig): CodeEditor.IConfig {

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -208,7 +208,7 @@ export namespace Commands {
    */
   export function updateWidget(widget: FileEditor): void {
     const editor = widget.editor;
-    editor.setOptions({...config});
+    editor.setOptions({ ...config });
   }
 
   /**

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -207,11 +207,7 @@ export namespace Commands {
    */
   export function updateWidget(widget: FileEditor): void {
     const editor = widget.editor;
-    let editorOptions: any = {};
-    Object.keys(config).forEach((key: keyof CodeEditor.IConfig) => {
-      editorOptions[key] = config[key];
-    });
-    editor.setOptions(editorOptions);
+    editor.setOptions({...config});
   }
 
   /**

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -787,7 +787,7 @@ export class StaticNotebook extends Widget {
   private _updateEditorConfig() {
     for (let i = 0; i < this.widgets.length; i++) {
       const cell = this.widgets[i];
-      let config: Partial<CodeEditor.IConfig>;
+      let config: Partial<CodeEditor.IConfig> = {};
       switch (cell.model.type) {
         case 'code':
           config = this._editorConfig.code;
@@ -799,11 +799,7 @@ export class StaticNotebook extends Widget {
           config = this._editorConfig.raw;
           break;
       }
-      let editorOptions: any = {};
-      Object.keys(config).forEach((key: keyof CodeEditor.IConfig) => {
-        editorOptions[key] = config[key] ?? null;
-      });
-      cell.editor.setOptions(editorOptions);
+      cell.editor.setOptions({ ...config });
       cell.editor.refresh();
     }
   }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #9675
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Restore the editor configuration when the widget handler is disposed.

Simplify the code to `setOptions` of code editor.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Line number are maintain when stopping the debugger if they were displayed.
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A