### PR TITLE
Drop familyName from the ICurrentUser interface

### DIFF
--- a/packages/docprovider/src/yprovider.ts
+++ b/packages/docprovider/src/yprovider.ts
@@ -87,10 +87,7 @@ export class WebSocketProviderWithLocks
     const awareness = options.ymodel.awareness;
     const user = options.user;
     const userChanged = () => {
-      const name =
-        user.familyName !== ''
-          ? `${user.givenName} ${user.familyName}`
-          : user.givenName;
+      const name = user.displayName !== '' ? user.displayName : user.name;
       awareness.setLocalStateField('user', { ...user.toJSON(), name });
     };
     if (user.isReady) {

--- a/packages/user/src/menu.ts
+++ b/packages/user/src/menu.ts
@@ -109,9 +109,7 @@ export class UserMenu extends Menu {
     super(options);
     this._user = options.user;
     const name =
-      this._user.familyName !== ''
-        ? `${this._user.givenName} ${this._user.familyName}`
-        : this._user.givenName;
+      this._user.displayName !== '' ? this._user.displayName : this._user.name;
     this.title.label = this._user.isReady ? name : '';
     this.title.icon = caretDownIcon;
     this.title.iconClass = 'jp-UserMenu-caretDownIcon';
@@ -125,10 +123,7 @@ export class UserMenu extends Menu {
   }
 
   private _updateLabel = (user: ICurrentUser) => {
-    const name =
-      user.familyName !== ''
-        ? `${user.givenName} ${user.familyName}`
-        : user.givenName;
+    const name = user.displayName !== '' ? user.displayName : user.name;
     this.title.label = name;
     this.update();
   };

--- a/packages/user/src/model.ts
+++ b/packages/user/src/model.ts
@@ -6,15 +6,15 @@ import { UUID } from '@lumino/coreutils';
 import * as env from 'lib0/environment';
 
 import { ICurrentUser, IUser, USER } from './tokens';
-import { getAnonymousUserName, getInitials } from './utils';
+import { getAnonymousUserName } from './utils';
 
 /**
  * Default user implementation.
  */
 export class User implements ICurrentUser {
   private _username: string;
-  private _givenName: string;
-  private _familyName: string;
+  private _name: string;
+  private _displayName: string;
   private _initials: string;
   private _color: string;
   private _anonymous: boolean;
@@ -43,15 +43,15 @@ export class User implements ICurrentUser {
   /**
    * User's name.
    */
-  get givenName(): string {
-    return this._givenName;
+  get name(): string {
+    return this._name;
   }
 
   /**
    * User's last name.
    */
-  get familyName(): string {
-    return this._familyName;
+  get displayName(): string {
+    return this._displayName;
   }
 
   /**
@@ -115,8 +115,8 @@ export class User implements ICurrentUser {
    */
   fromJSON(user: IUser.User): void {
     this._username = user.username;
-    this._givenName = user.givenName;
-    this._familyName = user.familyName;
+    this._name = user.name;
+    this._displayName = user.displayName;
     this._initials = user.initials;
     this._color = user.color;
     this._anonymous = user.anonymous;
@@ -130,8 +130,8 @@ export class User implements ICurrentUser {
   toJSON(): IUser.User {
     return {
       username: this._username,
-      givenName: this._givenName,
-      familyName: this._familyName,
+      name: this.name,
+      displayName: this._displayName,
       initials: this._initials,
       color: this._color,
       anonymous: this._anonymous,
@@ -163,8 +163,8 @@ export class User implements ICurrentUser {
       const user = JSON.parse(data);
 
       this._username = user.username as string;
-      this._givenName = name !== '' ? name : (user.givenName as string);
-      this._familyName = name !== '' ? '' : (user.familyName as string);
+      this._name = name !== '' ? '' : (user.name as string);
+      this._displayName = name !== '' ? '' : (user.displayName as string);
       this._initials = user.initials as string;
       this._color = color !== '' ? '#' + color : (user.color as string);
       this._anonymous = user.anonymous as boolean;
@@ -175,10 +175,11 @@ export class User implements ICurrentUser {
       }
     } else {
       // Get random values
+      const anonymousName = getAnonymousUserName();
       this._username = UUID.uuid4();
-      this._givenName = name !== '' ? name : 'Anonymous';
-      this._familyName = name !== '' ? '' : getAnonymousUserName();
-      this._initials = getInitials(this.givenName, this.familyName);
+      this._name = name !== '' ? '' : 'Anonymous ' + anonymousName;
+      this._displayName = this._name;
+      this._initials = `A${anonymousName.substring(0, 1).toLocaleUpperCase()}`;
       this._color =
         '#' + (color !== '' ? color : Private.getRandomColor().slice(1));
       this._anonymous = true;

--- a/packages/user/src/model.ts
+++ b/packages/user/src/model.ts
@@ -164,9 +164,9 @@ export class User implements ICurrentUser {
       const user = JSON.parse(data);
 
       this._username = user.username as string;
-      this._name = name !== '' ? '' : (user.name as string);
-      this._displayName = name !== '' ? '' : (user.displayName as string);
-      this._initials = initials !== '' ? '' : (user.initials as string);
+      this._name = name !== '' ? name : (user.name as string);
+      this._displayName = name !== '' ? name : (user.displayName as string);
+      this._initials = initials !== '' ? initials : (user.initials as string);
       this._color = color !== '' ? '#' + color : (user.color as string);
       this._anonymous = user.anonymous as boolean;
       this._cursor = (user.cursor as IUser.Cursor) || undefined;
@@ -178,11 +178,11 @@ export class User implements ICurrentUser {
       // Get random values
       const anonymousName = getAnonymousUserName();
       this._username = UUID.uuid4();
-      this._name = name !== '' ? '' : 'Anonymous ' + anonymousName;
+      this._name = name !== '' ? name : 'Anonymous ' + anonymousName;
       this._displayName = this._name;
       this._initials =
         initials !== ''
-          ? ''
+          ? initials
           : `A${anonymousName.substring(0, 1).toLocaleUpperCase()}`;
       this._color =
         '#' + (color !== '' ? color : Private.getRandomColor().slice(1));

--- a/packages/user/src/model.ts
+++ b/packages/user/src/model.ts
@@ -156,6 +156,7 @@ export class User implements ICurrentUser {
     // Read username and color from URL
     let name = env.getParam('--username', '');
     let color = env.getParam('--usercolor', '');
+    let initials = env.getParam('--initials', '');
 
     const { localStorage } = window;
     const data = localStorage.getItem(USER);
@@ -165,7 +166,7 @@ export class User implements ICurrentUser {
       this._username = user.username as string;
       this._name = name !== '' ? '' : (user.name as string);
       this._displayName = name !== '' ? '' : (user.displayName as string);
-      this._initials = user.initials as string;
+      this._initials = initials !== '' ? '' : (user.initials as string);
       this._color = color !== '' ? '#' + color : (user.color as string);
       this._anonymous = user.anonymous as boolean;
       this._cursor = (user.cursor as IUser.Cursor) || undefined;
@@ -179,7 +180,10 @@ export class User implements ICurrentUser {
       this._username = UUID.uuid4();
       this._name = name !== '' ? '' : 'Anonymous ' + anonymousName;
       this._displayName = this._name;
-      this._initials = `A${anonymousName.substring(0, 1).toLocaleUpperCase()}`;
+      this._initials =
+        initials !== ''
+          ? ''
+          : `A${anonymousName.substring(0, 1).toLocaleUpperCase()}`;
       this._color =
         '#' + (color !== '' ? color : Private.getRandomColor().slice(1));
       this._anonymous = true;

--- a/packages/user/src/tokens.ts
+++ b/packages/user/src/tokens.ts
@@ -86,12 +86,12 @@ export namespace IUser {
     /**
      * User's name.
      */
-    readonly givenName: string;
+    readonly name: string;
 
     /**
      * User's last name.
      */
-    readonly familyName: string;
+    readonly displayName: string;
 
     /**
      * User's name initials.

--- a/packages/user/src/utils.ts
+++ b/packages/user/src/utils.ts
@@ -131,23 +131,3 @@ export const moonsOfJupyter = [
  */
 export const getAnonymousUserName = (): string =>
   moonsOfJupyter[Math.floor(Math.random() * moonsOfJupyter.length)];
-
-/**
- * Extract the initials from the name of the user.
- */
-export const getInitials = (name: string, familyName?: string): string => {
-  let initials = '';
-  const tmpName = name.split(' ');
-  const tmpFamilyName = familyName ? familyName.split(' ') : [];
-
-  if (tmpName.length > 0) {
-    initials += tmpName[0].substring(0, 1).toLocaleUpperCase();
-  }
-  if (tmpFamilyName.length > 0) {
-    initials += tmpFamilyName[0].substring(0, 1).toLocaleUpperCase();
-  } else if (tmpName.length > 1) {
-    initials += tmpName[1].substring(0, 1).toLocaleUpperCase();
-  }
-
-  return initials;
-};


### PR DESCRIPTION
This PR implements the solution commented by @ellisonbg in https://github.com/jupyterlab/jupyterlab/issues/11657#issuecomment-996338877

## References
Solves #11657 

## Code changes
Changed `givenName` and `familyName` to `name` and `displayName`. Also removed the `getInitials` function instead, for the default anonymous user's name for example "Anonymous Metis" the initials are calculated as "AM", If users manually change their names they will have to introduce the initials.

## User-facing changes


## Backwards-incompatible changes

