### PR TITLE
Remove trailing slash from translations request

### DIFF
--- a/packages/translation/src/server.ts
+++ b/packages/translation/src/server.ts
@@ -26,7 +26,7 @@ export async function requestTranslationsAPI<T>(
   // Make request to Jupyter API
   const settings = serverSettings ?? ServerConnection.makeSettings();
   translationsUrl =
-    translationsUrl || `${settings.appUrl}/${TRANSLATIONS_SETTINGS_URL}/`;
+    translationsUrl || `${settings.appUrl}/${TRANSLATIONS_SETTINGS_URL}`;
   const requestUrl = URLExt.join(settings.baseUrl, translationsUrl, locale);
   let response: Response;
   try {


### PR DESCRIPTION
Fixes #11780

## Code changes

This PR removes the trailing slash in `GET /lab/api/translations/`.

## User-facing changes

None

## Backwards-incompatible changes

None