### PR TITLE
Automated Changelog Entry for 3.2.6 on 3.2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,16 +23,16 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 
 ### Bugs fixed
 
-- [3.2.x] Manual backport: Restore compact notebook layout on mobile (#11762) [#11778](https://github.com/jupyterlab/jupyterlab/pull/11778) ([@jtpio](https://github.com/jtpio))
+- Restore compact notebook layout on mobile [#11778](https://github.com/jupyterlab/jupyterlab/pull/11778) ([@jtpio](https://github.com/jtpio))
 - Ensure browser attributes are set in plugin adding it [#11758](https://github.com/jupyterlab/jupyterlab/pull/11758) ([@fcollonval](https://github.com/fcollonval))
 - Fix handling of disabled extensions [#11744](https://github.com/jupyterlab/jupyterlab/pull/11744) ([@jtpio](https://github.com/jtpio))
-- updates debugger icon css to work with white panel background [#11688](https://github.com/jupyterlab/jupyterlab/pull/11688) ([@andrewfulton9](https://github.com/andrewfulton9))
+- Update debugger icon css to work with white panel background [#11688](https://github.com/jupyterlab/jupyterlab/pull/11688) ([@andrewfulton9](https://github.com/andrewfulton9))
 - Ensure the dialog does not close if you drag outside by mistake [#11673](https://github.com/jupyterlab/jupyterlab/pull/11673) ([@echarles](https://github.com/echarles))
 - Add JSX CodeMirror mode [#11666](https://github.com/jupyterlab/jupyterlab/pull/11666) ([@krassowski](https://github.com/krassowski))
 
 ### Maintenance and upkeep improvements
 
-- Revert "Backport/3.2.x/11608 Toggle side-by-side rendering for current notebook" [#11793](https://github.com/jupyterlab/jupyterlab/pull/11793) ([@fcollonval](https://github.com/fcollonval))
+- Revert "Toggle side-by-side rendering for current notebook" [#11793](https://github.com/jupyterlab/jupyterlab/pull/11793) ([@fcollonval](https://github.com/fcollonval))
 - Fix integrity failure on CI [#11770](https://github.com/jupyterlab/jupyterlab/pull/11770) ([@jtpio](https://github.com/jtpio))
 
 ### Documentation improvements
@@ -44,7 +44,7 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 
 ### Other merged PRs
 
-- Backport/3.2.x/11608 Toggle side-by-side rendering for current notebook [#11718](https://github.com/jupyterlab/jupyterlab/pull/11718) ([@echarles](https://github.com/echarles))
+- Toggle side-by-side rendering for current notebook [#11718](https://github.com/jupyterlab/jupyterlab/pull/11718) ([@echarles](https://github.com/echarles))
 
 ### Contributors to this release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,48 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.2.6
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.2.5...ebce458c5e55126a7cbd5082f669446269007a34))
+
+### Enhancements made
+
+- Add JSX CodeMirror mode [#11666](https://github.com/jupyterlab/jupyterlab/pull/11666) ([@krassowski](https://github.com/krassowski))
+- Remove leading slash from console path [#11626](https://github.com/jupyterlab/jupyterlab/pull/11626) ([@davidbrochart](https://github.com/davidbrochart))
+
+### Bugs fixed
+
+- [3.2.x] Manual backport: Restore compact notebook layout on mobile (#11762) [#11778](https://github.com/jupyterlab/jupyterlab/pull/11778) ([@jtpio](https://github.com/jtpio))
+- Ensure browser attributes are set in plugin adding it [#11758](https://github.com/jupyterlab/jupyterlab/pull/11758) ([@fcollonval](https://github.com/fcollonval))
+- Fix handling of disabled extensions [#11744](https://github.com/jupyterlab/jupyterlab/pull/11744) ([@jtpio](https://github.com/jtpio))
+- updates debugger icon css to work with white panel background [#11688](https://github.com/jupyterlab/jupyterlab/pull/11688) ([@andrewfulton9](https://github.com/andrewfulton9))
+- Ensure the dialog does not close if you drag outside by mistake [#11673](https://github.com/jupyterlab/jupyterlab/pull/11673) ([@echarles](https://github.com/echarles))
+- Add JSX CodeMirror mode [#11666](https://github.com/jupyterlab/jupyterlab/pull/11666) ([@krassowski](https://github.com/krassowski))
+
+### Maintenance and upkeep improvements
+
+- Revert "Backport/3.2.x/11608 Toggle side-by-side rendering for current notebook" [#11793](https://github.com/jupyterlab/jupyterlab/pull/11793) ([@fcollonval](https://github.com/fcollonval))
+- Fix integrity failure on CI [#11770](https://github.com/jupyterlab/jupyterlab/pull/11770) ([@jtpio](https://github.com/jtpio))
+
+### Documentation improvements
+
+- Triage documentation [#11661](https://github.com/jupyterlab/jupyterlab/pull/11661) ([@jweill-aws](https://github.com/jweill-aws))
+- Add text on how to run it in a dir other than home [#11761](https://github.com/jupyterlab/jupyterlab/pull/11761) ([@TheOtherRealm](https://github.com/TheOtherRealm))
+- Encourage new contributors to send draft PR over asking for permission [#11746](https://github.com/jupyterlab/jupyterlab/pull/11746) ([@krassowski](https://github.com/krassowski))
+- Fix changelog link [#11668](https://github.com/jupyterlab/jupyterlab/pull/11668) ([@krassowski](https://github.com/krassowski))
+
+### Other merged PRs
+
+- Backport/3.2.x/11608 Toggle side-by-side rendering for current notebook [#11718](https://github.com/jupyterlab/jupyterlab/pull/11718) ([@echarles](https://github.com/echarles))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-12-10&to=2022-01-07&type=c))
+
+[@andrewfulton9](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aandrewfulton9+updated%3A2021-12-10..2022-01-07&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2021-12-10..2022-01-07&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2021-12-10..2022-01-07&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-12-10..2022-01-07&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2021-12-10..2022-01-07&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-12-10..2022-01-07&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-12-10..2022-01-07&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2021-12-10..2022-01-07&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-12-10..2022-01-07&type=Issues) | [@JohanMabille](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AJohanMabille+updated%3A2021-12-10..2022-01-07&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-12-10..2022-01-07&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-12-10..2022-01-07&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-12-10..2022-01-07&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-12-10..2022-01-07&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-12-10..2022-01-07&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-12-10..2022-01-07&type=Issues) | [@schmidi314](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aschmidi314+updated%3A2021-12-10..2022-01-07&type=Issues) | [@TheOtherRealm](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ATheOtherRealm+updated%3A2021-12-10..2022-01-07&type=Issues) | [@thesinepainter](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Athesinepainter+updated%3A2021-12-10..2022-01-07&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-12-10..2022-01-07&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.2.5
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.2.4...97b8069f014c51f584c86165ec0aff8c98be99cb))
@@ -58,8 +100,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-11-17&to=2021-12-10&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-11-17..2021-12-10&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2021-11-17..2021-12-10&type=Issues) | [@dmonad](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Admonad+updated%3A2021-11-17..2021-12-10&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-11-17..2021-12-10&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2021-11-17..2021-12-10&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-11-17..2021-12-10&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-11-17..2021-12-10&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2021-11-17..2021-12-10&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-11-17..2021-12-10&type=Issues) | [@jess-x](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajess-x+updated%3A2021-11-17..2021-12-10&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-11-17..2021-12-10&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-11-17..2021-12-10&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-11-17..2021-12-10&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2021-11-17..2021-12-10&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-11-17..2021-12-10&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-11-17..2021-12-10&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-11-17..2021-12-10&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrungleduc+updated%3A2021-11-17..2021-12-10&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-11-17..2021-12-10&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.2.4
 


### PR DESCRIPTION
Automated Changelog Entry for 3.2.6 on 3.2.x
```
Python version: 3.2.6
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.2.6
@jupyterlab/buildutils: 3.2.6
@jupyterlab/template: 3.2.6
@jupyterlab/application-top: 3.2.6
@jupyterlab/example-app: 3.2.6
@jupyterlab/example-cell: 3.2.6
@jupyterlab/example-console: 3.2.6
@jupyterlab/example-federated: 2.3.6
@jupyterlab/example-federated-core: 2.3.6
@jupyterlab/example-federated-md: 2.3.6
@jupyterlab/example-federated-middle: 2.3.6
@jupyterlab/example-federated-phosphor: 2.3.6
@jupyterlab/example-filebrowser: 3.2.6
@jupyterlab/example-notebook: 3.2.6
@jupyterlab/example-terminal: 3.2.6
@jupyterlab/galata: 4.1.3
@jupyterlab/mock-extension: 3.2.6
@jupyterlab/mock-consumer: 3.2.6
@jupyterlab/mock-provider: 3.2.6
@jupyterlab/mock-token: 3.2.6
@jupyterlab/application: 3.2.6
@jupyterlab/application-extension: 3.2.6
@jupyterlab/apputils: 3.2.6
@jupyterlab/apputils-extension: 3.2.6
@jupyterlab/attachments: 3.2.6
@jupyterlab/cells: 3.2.6
@jupyterlab/celltags: 3.2.6
@jupyterlab/celltags-extension: 3.2.6
@jupyterlab/codeeditor: 3.2.6
@jupyterlab/codemirror: 3.2.6
@jupyterlab/codemirror-extension: 3.2.6
@jupyterlab/completer: 3.2.6
@jupyterlab/completer-extension: 3.2.6
@jupyterlab/console: 3.2.6
@jupyterlab/console-extension: 3.2.6
@jupyterlab/coreutils: 5.2.6
@jupyterlab/csvviewer: 3.2.6
@jupyterlab/csvviewer-extension: 3.2.6
@jupyterlab/debugger: 3.2.6
@jupyterlab/debugger-extension: 3.2.6
@jupyterlab/docmanager: 3.2.6
@jupyterlab/docmanager-extension: 3.2.6
@jupyterlab/docprovider: 3.2.6
@jupyterlab/docprovider-extension: 3.2.6
@jupyterlab/docregistry: 3.2.6
@jupyterlab/documentsearch: 3.2.6
@jupyterlab/documentsearch-extension: 3.2.6
@jupyterlab/extensionmanager: 3.2.6
@jupyterlab/extensionmanager-extension: 3.2.6
@jupyterlab/filebrowser: 3.2.6
@jupyterlab/filebrowser-extension: 3.2.6
@jupyterlab/fileeditor: 3.2.6
@jupyterlab/fileeditor-extension: 3.2.6
@jupyterlab/help-extension: 3.2.6
@jupyterlab/htmlviewer: 3.2.6
@jupyterlab/htmlviewer-extension: 3.2.6
@jupyterlab/hub-extension: 3.2.6
@jupyterlab/imageviewer: 3.2.6
@jupyterlab/imageviewer-extension: 3.2.6
@jupyterlab/inspector: 3.2.6
@jupyterlab/inspector-extension: 3.2.6
@jupyterlab/javascript-extension: 3.2.6
@jupyterlab/json-extension: 3.2.6
@jupyterlab/launcher: 3.2.6
@jupyterlab/launcher-extension: 3.2.6
@jupyterlab/logconsole: 3.2.6
@jupyterlab/logconsole-extension: 3.2.6
@jupyterlab/mainmenu: 3.2.6
@jupyterlab/mainmenu-extension: 3.2.6
@jupyterlab/markdownviewer: 3.2.6
@jupyterlab/markdownviewer-extension: 3.2.6
@jupyterlab/mathjax2: 3.2.6
@jupyterlab/mathjax2-extension: 3.2.6
@jupyterlab/metapackage: 3.2.6
@jupyterlab/nbconvert-css: 3.2.6
@jupyterlab/nbformat: 3.2.6
@jupyterlab/notebook: 3.2.6
@jupyterlab/notebook-extension: 3.2.6
@jupyterlab/observables: 4.2.6
@jupyterlab/outputarea: 3.2.6
@jupyterlab/pdf-extension: 3.2.6
@jupyterlab/property-inspector: 3.2.6
@jupyterlab/rendermime: 3.2.6
@jupyterlab/rendermime-extension: 3.2.6
@jupyterlab/rendermime-interfaces: 3.2.6
@jupyterlab/running: 3.2.6
@jupyterlab/running-extension: 3.2.6
@jupyterlab/services: 6.2.6
@jupyterlab/example-services-browser: 3.2.6
node-example: 3.2.6
@jupyterlab/example-services-outputarea: 3.2.6
@jupyterlab/settingeditor: 3.2.6
@jupyterlab/settingeditor-extension: 3.2.6
@jupyterlab/settingregistry: 3.2.6
@jupyterlab/shared-models: 3.2.6
@jupyterlab/shortcuts-extension: 3.2.6
@jupyterlab/statedb: 3.2.6
@jupyterlab/statusbar: 3.2.6
@jupyterlab/statusbar-extension: 3.2.6
@jupyterlab/terminal: 3.2.6
@jupyterlab/terminal-extension: 3.2.6
@jupyterlab/theme-dark-extension: 3.2.6
@jupyterlab/theme-light-extension: 3.2.6
@jupyterlab/toc: 5.2.6
@jupyterlab/toc-extension: 5.2.6
@jupyterlab/tooltip: 3.2.6
@jupyterlab/tooltip-extension: 3.2.6
@jupyterlab/translation: 3.2.6
@jupyterlab/translation-extension: 3.2.6
@jupyterlab/ui-components: 3.2.6
@jupyterlab/ui-components-extension: 3.2.6
@jupyterlab/vdom: 3.2.6
@jupyterlab/vdom-extension: 3.2.6
@jupyterlab/vega5-extension: 3.2.6
@jupyterlab/testutils: 3.2.6
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.2.x  |
| Version Spec | next |
| Since | v3.2.5 |