### PR TITLE
Fix `OSTYPE` check in `ci_install.sh`

### DIFF
--- a/buildutils/src/local-repository.ts
+++ b/buildutils/src/local-repository.ts
@@ -32,10 +32,10 @@ async function startLocalRegistry(out_dir: string, port = DEFAULT_PORT) {
 
   // Get current registry values
   let prev_npm = utils.run('npm config get registry', { stdio: 'pipe' }, true);
-  let prev_yarn = '';
+  let prev_jlpm = '';
   try {
-    prev_yarn = utils.run(
-      'yarn config get npmRegistryServer',
+    prev_jlpm = utils.run(
+      'jlpm config get npmRegistryServer',
       { stdio: 'pipe' },
       true
     );
@@ -45,8 +45,8 @@ async function startLocalRegistry(out_dir: string, port = DEFAULT_PORT) {
   if (!prev_npm || prev_npm.indexOf('0.0.0.0') !== -1) {
     prev_npm = 'https://registry.npmjs.org/';
   }
-  if (prev_yarn.indexOf('0.0.0.0') !== -1) {
-    prev_yarn = '';
+  if (prev_jlpm.indexOf('0.0.0.0') !== -1) {
+    prev_jlpm = '';
   }
 
   // write the config file
@@ -126,7 +126,7 @@ packages:
   const info_file = path.join(out_dir, 'info.json');
   const data = {
     prev_npm,
-    prev_yarn,
+    prev_jlpm,
     pid: subproc.pid
   };
   utils.writeJSONFile(info_file, data);
@@ -140,13 +140,13 @@ packages:
     local_registry
   ]);
   try {
-    child_process.execFileSync('yarn', [
+    child_process.execFileSync('jlpm', [
       'config',
       'set',
       'npmRegistryServer',
       local_registry
     ]);
-    child_process.execFileSync('yarn', [
+    child_process.execFileSync('jlpm', [
       'config',
       'set',
       'unsafeHttpWhitelist',
@@ -154,7 +154,7 @@ packages:
       '["0.0.0.0"]'
     ]);
   } catch (e) {
-    // yarn not available
+    // jlpm not available
   }
 
   // Log in using cli and temp credentials
@@ -238,17 +238,17 @@ async function stopLocalRegistry(out_dir: string) {
   } else {
     child_process.execSync(`npm config rm registry`);
   }
-  if (data.prev_yarn) {
+  if (data.prev_jlpm) {
     child_process.execSync(
-      `yarn config set npmRegistryServer ${data.prev_yarn}`
+      `jlpm config set npmRegistryServer ${data.prev_jlpm}`
     );
-    child_process.execSync(`yarn config unset unsafeHttpWhitelist`);
+    child_process.execSync(`jlpm config unset unsafeHttpWhitelist`);
   } else {
     try {
-      child_process.execSync(`yarn config unset npmRegistryServer`);
-      child_process.execSync(`yarn config unset unsafeHttpWhitelist`);
+      child_process.execSync(`jlpm config unset npmRegistryServer`);
+      child_process.execSync(`jlpm config unset unsafeHttpWhitelist`);
     } catch (e) {
-      // yarn not available
+      // jlpm not available
     }
   }
 }

--- a/buildutils/src/publish.ts
+++ b/buildutils/src/publish.ts
@@ -44,6 +44,7 @@ commander
 
       if (!options.dryRun) {
         // Make sure we are logged in.
+        utils.run('npm whoami');
         if (utils.checkStatus('npm whoami') !== 0) {
           console.error('Please run `npm login`');
           process.exit(1);

--- a/buildutils/src/publish.ts
+++ b/buildutils/src/publish.ts
@@ -44,7 +44,6 @@ commander
 
       if (!options.dryRun) {
         // Make sure we are logged in.
-        utils.run('npm whoami');
         if (utils.checkStatus('npm whoami') !== 0) {
           console.error('Please run `npm login`');
           process.exit(1);

--- a/scripts/ci_install.sh
+++ b/scripts/ci_install.sh
@@ -31,7 +31,6 @@ pip install -q --upgrade pip --user
 pip --version
 # Show a verbose install if the install fails, for debugging
 pip install -e ".[dev,test]" || pip install -v -e ".[dev,test]"
-yarn --version
 node -p process.versions
 jlpm config
 

--- a/scripts/ci_install.sh
+++ b/scripts/ci_install.sh
@@ -14,7 +14,7 @@ export YARN_ENABLE_INLINE_BUILDS=1
 
 # Building should work without yarn installed globally, so uninstall the
 # global yarn installed by default.
-if [ $OSTYPE == "Linux" ]; then
+if [ $OSTYPE == "linux-gnu" ]; then
     sudo rm -rf $(which yarn)
     ! yarn
 fi


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

As noticed in https://github.com/jupyterlab/jupyterlab/pull/11770#issuecomment-1003129065, the check against `$OSTYPE` in the `ci_install.sh` script doesn't seem to be hit at the moment.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update CI install script to see if this has any affect on the CI checks.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
