### PR TITLE
Mentions pip3 for macOS users in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you use [conda](https://docs.conda.io/en/latest/), [mamba](https://mamba.read
   ```shell
   pip install jupyterlab
   ```
-  If installing using `pip install --user`, you must add the user-level `bin` directory to your `PATH` environment variable in order to launch `jupyter lab`. If you are using a Unix derivative (FreeBSD, GNU / Linux, OS X), you can achieve this by using `export PATH="$HOME/.local/bin:$PATH"` command.
+  If installing using `pip install --user`, you must add the user-level `bin` directory to your `PATH` environment variable in order to launch `jupyter lab`. If you are using a Unix derivative (FreeBSD, GNU/Linux, macOS), you can achieve this by using `export PATH="$HOME/.local/bin:$PATH"` command. If you are using a macOS version that comes with Python 2, run `pip3` instead of `pip`.
 
 For more detailed instructions, consult the [installation guide](http://jupyterlab.readthedocs.io/en/latest/getting_started/installation.html). Project installation instructions from the git sources are available in the [contributor documentation](CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you use [conda](https://docs.conda.io/en/latest/), [mamba](https://mamba.read
   ```shell
   pip install jupyterlab
   ```
-  If installing using `pip install --user`, you must add the user-level `bin` directory to your `PATH` environment variable in order to launch `jupyter lab`. If you are using a Unix derivative (FreeBSD, GNU/Linux, macOS), you can achieve this by using `export PATH="$HOME/.local/bin:$PATH"` command. If you are using a macOS version that comes with Python 2, run `pip3` instead of `pip`.
+  If installing using `pip install --user`, you must add the user-level `bin` directory to your `PATH` environment variable in order to launch `jupyter lab`. If you are using a Unix derivative (e.g., FreeBSD, GNU/Linux, macOS), you can do this by running `export PATH="$HOME/.local/bin:$PATH"`. If you are using a macOS version that comes with Python 2, run `pip3` instead of `pip`.
 
 For more detailed instructions, consult the [installation guide](http://jupyterlab.readthedocs.io/en/latest/getting_started/installation.html). Project installation instructions from the git sources are available in the [contributor documentation](CONTRIBUTING.md).
 

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -32,11 +32,13 @@ If you use ``pip``, you can install it with:
 
     pip install jupyterlab
 
+If you are using a macOS version that comes with Python 2, run ``pip3``
+instead of ``pip``.
 
 If installing using ``pip install --user``, you must add the user-level
 ``bin`` directory to your ``PATH`` environment variable in order to launch
-``jupyter lab``. If you are using a Unix derivative (FreeBSD, GNU / Linux, 
-macOS), you can achieve this by using ``export PATH="$HOME/.local/bin:$PATH"`` command.
+``jupyter lab``. If you are using a Unix derivative (FreeBSD, GNU/Linux, 
+macOS), you can do this by running ``export PATH="$HOME/.local/bin:$PATH"``.
 
 pipenv
 ------


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

To address #11815, this change modifies the README and installation instructions to direct macOS users to run `pip3` instead of `pip`. This applies to any system which comes with Python 2.7, including macOS Monterey (12.0).

This change does not modify the web site, also mentioned in this issue.

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Documentation changes only

## User-facing changes

Modifies README and installation documentation only

## Backwards-incompatible changes

None.
