### PR TITLE
Fixes Ctrl+Shift+ArrowLeft/Right shortcuts edit mode

### DIFF
--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -519,7 +519,7 @@
     {
       "command": "notebook:move-cursor-heading-above-or-collapse",
       "keys": ["ArrowLeft"],
-      "selector": ".jp-Notebook:focus"
+      "selector": ".jp-Notebook.jp-mod-commandMode"
     },
     {
       "command": "notebook:move-cursor-heading-below-or-expand",

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -524,7 +524,7 @@
     {
       "command": "notebook:move-cursor-heading-below-or-expand",
       "keys": ["ArrowRight"],
-      "selector": ".jp-Notebook:focus"
+      "selector": ".jp-Notebook.jp-mod-commandMode"
     },
     {
       "command": "notebook:insert-heading-above",
@@ -539,12 +539,12 @@
     {
       "command": "notebook:collapse-all-headings",
       "keys": ["Ctrl Shift ArrowLeft"],
-      "selector": ".jp-Notebook"
+      "selector": ".jp-Notebook.jp-mod-commandMode"
     },
     {
       "command": "notebook:expand-all-headings",
       "keys": ["Ctrl Shift ArrowRight"],
-      "selector": ".jp-Notebook"
+      "selector": ".jp-Notebook.jp-mod-commandMode"
     },
     {
       "command": "notebook:paste-cell-below",


### PR DESCRIPTION
## References

Fixes #11817

## Code changes

Changed selectors in default keyboard shortcuts.

## User-facing changes

only the bugfix

## Backwards-incompatible changes

none
