### PR TITLE
Specify an output hash function for Galata

### DIFF
--- a/galata/webpack.config.js
+++ b/galata/webpack.config.js
@@ -11,7 +11,8 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, 'lib/lib-inpage'),
     filename: 'inpage.js',
-    publicPath: '/'
+    publicPath: '/',
+    hashFunction: 'sha256'
   },
   resolve: {
     extensions: ['.ts', '.js']


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This is an analogous change to 1198d56160f26f54fda9022a4a6f21411fcd6c87 (https://github.com/jupyterlab/jupyterlab/pull/11234). 

## Code changes

Without this change, I am seeing an error from webpack like the following:

```
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
```

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
