### PR TITLE
Experiment sending the complete_request message on the control channel.

### DIFF
--- a/packages/completer/src/kernelconnector.ts
+++ b/packages/completer/src/kernelconnector.ts
@@ -42,7 +42,7 @@ export class KernelConnector extends DataConnector<
       cursor_pos: request.offset
     };
 
-    const msg = await kernel.requestComplete(contents);
+    const msg = await kernel.requestCompleteControl(contents);
     const response = msg.content;
 
     if (response.status !== 'ok') {

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -221,7 +221,7 @@ export interface IKernelConnection extends IObservableDisposable {
   requestKernelInfo(): Promise<KernelMessage.IInfoReplyMsg | undefined>;
 
   /**
-   * Send a `complete_request` message.
+   * Send a `complete_request` message on the shell channel.
    *
    * @param content - The content of the request.
    *
@@ -236,6 +236,23 @@ export interface IKernelConnection extends IObservableDisposable {
   requestComplete(
     content: KernelMessage.ICompleteRequestMsg['content']
   ): Promise<KernelMessage.ICompleteReplyMsg>;
+
+  /**
+   * Send a `complete_request` message on the control channel.
+   *
+   * @param content - The content of the request.
+   *
+   * @returns A promise that resolves with the response message.
+   *
+   * #### Notes
+   * See [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html#completion).
+   *
+   * Fulfills with the `complete_reply` content when the control reply is
+   * received and validated.
+   */
+   requestCompleteControl(
+    content: KernelMessage.ICompleteRequestControlMsg['content']
+  ): Promise<KernelMessage.ICompleteReplyControlMsg>;
 
   /**
    * Send an `inspect_request` message.

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -48,6 +48,12 @@ export function createMessage<T extends ICompleteReplyMsg>(
 export function createMessage<T extends ICompleteRequestMsg>(
   options: IOptions<T>
 ): T;
+export function createMessage<T extends ICompleteReplyControlMsg>(
+  options: IOptions<T>
+): T;
+export function createMessage<T extends ICompleteRequestControlMsg>(
+  options: IOptions<T>
+): T;
 export function createMessage<T extends IDisplayDataMsg>(
   options: IOptions<T>
 ): T;
@@ -183,7 +189,11 @@ export type ShellMessageType =
  * kernel message specification. As such, debug message types are *NOT*
  * considered part of the public API, and may change without notice.
  */
-export type ControlMessageType = 'debug_request' | 'debug_reply';
+export type ControlMessageType =
+  | 'debug_request'
+  | 'debug_reply'
+  | 'complete_reply'
+  | 'complete_request';
 
 /**
  * IOPub message types.
@@ -364,6 +374,8 @@ export type Message =
   | ICommOpenMsg<'shell'>
   | ICompleteReplyMsg
   | ICompleteRequestMsg
+  | ICompleteReplyControlMsg
+  | ICompleteRequestControlMsg
   | IDisplayDataMsg
   | IErrorMsg
   | IExecuteInputMsg
@@ -821,6 +833,33 @@ interface ICompleteReply extends IReplyOkContent {
  * **See also:** [[ICompleteRequest]], [[IKernel.complete]]
  */
 export interface ICompleteReplyMsg extends IShellMessage<'complete_reply'> {
+  parent_header: IHeader<'complete_request'>;
+  content: ReplyContent<ICompleteReply>;
+}
+
+
+/**
+ * A  `'complete_request'` message on the `'control'` channel.
+ *
+ * See [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html#completion).
+ *
+ * **See also:** [[ICompleteReplyControlMsg]], [[IKernel.complete]]
+ */
+ export interface ICompleteRequestControlMsg extends IControlMessage<'complete_request'> {
+  content: {
+    code: string;
+    cursor_pos: number;
+  };
+}
+
+/**
+ * A `'complete_reply'` message on the `'control'` channel.
+ *
+ * See [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html#completion).
+ *
+ * **See also:** [[ICompleteRequestControl]], [[IKernel.complete]]
+ */
+export interface ICompleteReplyControlMsg extends IControlMessage<'complete_reply'> {
   parent_header: IHeader<'complete_request'>;
   content: ReplyContent<ICompleteReply>;
 }


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

With ipykernel 6.0 or later, this enables the complete request to be processed in parallel with execution, so we can still get completions while the kernel is busy.

This is an experiment to see if we can improve autocomplete responsiveness. Luckily, it seems that ipykernel accepts any shell message on the control channel, so this should work with any ipykernel version 6 or later. The messaging spec implies that sending completion requests to the control channel is not officially supported.

## User-facing changes

In one cell, execute a sleep, like: `import time; time.sleep(20)`

Immediately after that, while it is still busy, try doing autocomplete (like `pri<tab>`). The autocomplete should work.



## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
