### PR TITLE
Automated Changelog Entry for 3.2.7 on 3.2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.2.7
+
+No merged PRs
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.2.6
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.2.5...ebce458c5e55126a7cbd5082f669446269007a34))
@@ -51,8 +57,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-12-10&to=2022-01-07&type=c))
 
 [@andrewfulton9](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aandrewfulton9+updated%3A2021-12-10..2022-01-07&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2021-12-10..2022-01-07&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2021-12-10..2022-01-07&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-12-10..2022-01-07&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2021-12-10..2022-01-07&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-12-10..2022-01-07&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-12-10..2022-01-07&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2021-12-10..2022-01-07&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-12-10..2022-01-07&type=Issues) | [@JohanMabille](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AJohanMabille+updated%3A2021-12-10..2022-01-07&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-12-10..2022-01-07&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-12-10..2022-01-07&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-12-10..2022-01-07&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-12-10..2022-01-07&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-12-10..2022-01-07&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-12-10..2022-01-07&type=Issues) | [@schmidi314](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aschmidi314+updated%3A2021-12-10..2022-01-07&type=Issues) | [@TheOtherRealm](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ATheOtherRealm+updated%3A2021-12-10..2022-01-07&type=Issues) | [@thesinepainter](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Athesinepainter+updated%3A2021-12-10..2022-01-07&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-12-10..2022-01-07&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.2.5
 


### PR DESCRIPTION
Automated Changelog Entry for 3.2.7 on 3.2.x
```
Python version: 3.2.7
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.2.7
@jupyterlab/buildutils: 3.2.7
@jupyterlab/template: 3.2.7
@jupyterlab/application-top: 3.2.7
@jupyterlab/example-app: 3.2.7
@jupyterlab/example-cell: 3.2.7
@jupyterlab/example-console: 3.2.7
@jupyterlab/example-federated: 2.3.7
@jupyterlab/example-federated-core: 2.3.7
@jupyterlab/example-federated-md: 2.3.7
@jupyterlab/example-federated-middle: 2.3.7
@jupyterlab/example-federated-phosphor: 2.3.7
@jupyterlab/example-filebrowser: 3.2.7
@jupyterlab/example-notebook: 3.2.7
@jupyterlab/example-terminal: 3.2.7
@jupyterlab/galata: 4.1.4
@jupyterlab/mock-extension: 3.2.7
@jupyterlab/mock-consumer: 3.2.7
@jupyterlab/mock-provider: 3.2.7
@jupyterlab/mock-token: 3.2.7
@jupyterlab/application: 3.2.7
@jupyterlab/application-extension: 3.2.7
@jupyterlab/apputils: 3.2.7
@jupyterlab/apputils-extension: 3.2.7
@jupyterlab/attachments: 3.2.7
@jupyterlab/cells: 3.2.7
@jupyterlab/celltags: 3.2.7
@jupyterlab/celltags-extension: 3.2.7
@jupyterlab/codeeditor: 3.2.7
@jupyterlab/codemirror: 3.2.7
@jupyterlab/codemirror-extension: 3.2.7
@jupyterlab/completer: 3.2.7
@jupyterlab/completer-extension: 3.2.7
@jupyterlab/console: 3.2.7
@jupyterlab/console-extension: 3.2.7
@jupyterlab/coreutils: 5.2.7
@jupyterlab/csvviewer: 3.2.7
@jupyterlab/csvviewer-extension: 3.2.7
@jupyterlab/debugger: 3.2.7
@jupyterlab/debugger-extension: 3.2.7
@jupyterlab/docmanager: 3.2.7
@jupyterlab/docmanager-extension: 3.2.7
@jupyterlab/docprovider: 3.2.7
@jupyterlab/docprovider-extension: 3.2.7
@jupyterlab/docregistry: 3.2.7
@jupyterlab/documentsearch: 3.2.7
@jupyterlab/documentsearch-extension: 3.2.7
@jupyterlab/extensionmanager: 3.2.7
@jupyterlab/extensionmanager-extension: 3.2.7
@jupyterlab/filebrowser: 3.2.7
@jupyterlab/filebrowser-extension: 3.2.7
@jupyterlab/fileeditor: 3.2.7
@jupyterlab/fileeditor-extension: 3.2.7
@jupyterlab/help-extension: 3.2.7
@jupyterlab/htmlviewer: 3.2.7
@jupyterlab/htmlviewer-extension: 3.2.7
@jupyterlab/hub-extension: 3.2.7
@jupyterlab/imageviewer: 3.2.7
@jupyterlab/imageviewer-extension: 3.2.7
@jupyterlab/inspector: 3.2.7
@jupyterlab/inspector-extension: 3.2.7
@jupyterlab/javascript-extension: 3.2.7
@jupyterlab/json-extension: 3.2.7
@jupyterlab/launcher: 3.2.7
@jupyterlab/launcher-extension: 3.2.7
@jupyterlab/logconsole: 3.2.7
@jupyterlab/logconsole-extension: 3.2.7
@jupyterlab/mainmenu: 3.2.7
@jupyterlab/mainmenu-extension: 3.2.7
@jupyterlab/markdownviewer: 3.2.7
@jupyterlab/markdownviewer-extension: 3.2.7
@jupyterlab/mathjax2: 3.2.7
@jupyterlab/mathjax2-extension: 3.2.7
@jupyterlab/metapackage: 3.2.7
@jupyterlab/nbconvert-css: 3.2.7
@jupyterlab/nbformat: 3.2.7
@jupyterlab/notebook: 3.2.7
@jupyterlab/notebook-extension: 3.2.7
@jupyterlab/observables: 4.2.7
@jupyterlab/outputarea: 3.2.7
@jupyterlab/pdf-extension: 3.2.7
@jupyterlab/property-inspector: 3.2.7
@jupyterlab/rendermime: 3.2.7
@jupyterlab/rendermime-extension: 3.2.7
@jupyterlab/rendermime-interfaces: 3.2.7
@jupyterlab/running: 3.2.7
@jupyterlab/running-extension: 3.2.7
@jupyterlab/services: 6.2.7
@jupyterlab/example-services-browser: 3.2.7
node-example: 3.2.7
@jupyterlab/example-services-outputarea: 3.2.7
@jupyterlab/settingeditor: 3.2.7
@jupyterlab/settingeditor-extension: 3.2.7
@jupyterlab/settingregistry: 3.2.7
@jupyterlab/shared-models: 3.2.7
@jupyterlab/shortcuts-extension: 3.2.7
@jupyterlab/statedb: 3.2.7
@jupyterlab/statusbar: 3.2.7
@jupyterlab/statusbar-extension: 3.2.7
@jupyterlab/terminal: 3.2.7
@jupyterlab/terminal-extension: 3.2.7
@jupyterlab/theme-dark-extension: 3.2.7
@jupyterlab/theme-light-extension: 3.2.7
@jupyterlab/toc: 5.2.7
@jupyterlab/toc-extension: 5.2.7
@jupyterlab/tooltip: 3.2.7
@jupyterlab/tooltip-extension: 3.2.7
@jupyterlab/translation: 3.2.7
@jupyterlab/translation-extension: 3.2.7
@jupyterlab/ui-components: 3.2.7
@jupyterlab/ui-components-extension: 3.2.7
@jupyterlab/vdom: 3.2.7
@jupyterlab/vdom-extension: 3.2.7
@jupyterlab/vega5-extension: 3.2.7
@jupyterlab/testutils: 3.2.7
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.2.x  |
| Version Spec | next |
| Since | v3.2.6 |