### PR TITLE
Automated Changelog Entry for 3.1.19 on 3.1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.1.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.1.19
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.1.18...90ed111b152665357b069cf4a42590fe07d630e8))
+
+### Bugs fixed
+
+- Added handling of '\r' ended files [#11310](https://github.com/jupyterlab/jupyterlab/pull/11310) ([@lucabarcelos](https://github.com/lucabarcelos))
+
+### Maintenance and upkeep improvements
+
+- Pass version spec as an input [#11322](https://github.com/jupyterlab/jupyterlab/pull/11322) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-10-07&to=2022-01-12&type=c))
+
+[@agoose77](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aagoose77+updated%3A2021-10-07..2022-01-12&type=Issues) | [@andrewfulton9](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aandrewfulton9+updated%3A2021-10-07..2022-01-12&type=Issues) | [@baggiponte](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abaggiponte+updated%3A2021-10-07..2022-01-12&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-10-07..2022-01-12&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2021-10-07..2022-01-12&type=Issues) | [@Carreau](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ACarreau+updated%3A2021-10-07..2022-01-12&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2021-10-07..2022-01-12&type=Issues) | [@dmonad](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Admonad+updated%3A2021-10-07..2022-01-12&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-10-07..2022-01-12&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2021-10-07..2022-01-12&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-10-07..2022-01-12&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-10-07..2022-01-12&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2021-10-07..2022-01-12&type=Issues) | [@isabela-pf](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aisabela-pf+updated%3A2021-10-07..2022-01-12&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-10-07..2022-01-12&type=Issues) | [@jess-x](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajess-x+updated%3A2021-10-07..2022-01-12&type=Issues) | [@JohanMabille](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AJohanMabille+updated%3A2021-10-07..2022-01-12&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-10-07..2022-01-12&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-10-07..2022-01-12&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-10-07..2022-01-12&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2021-10-07..2022-01-12&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-10-07..2022-01-12&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-10-07..2022-01-12&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-10-07..2022-01-12&type=Issues) | [@schmidi314](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aschmidi314+updated%3A2021-10-07..2022-01-12&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASylvainCorlay+updated%3A2021-10-07..2022-01-12&type=Issues) | [@telamonian](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atelamonian+updated%3A2021-10-07..2022-01-12&type=Issues) | [@thesinepainter](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Athesinepainter+updated%3A2021-10-07..2022-01-12&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrungleduc+updated%3A2021-10-07..2022-01-12&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-10-07..2022-01-12&type=Issues) | [@williamstein](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awilliamstein+updated%3A2021-10-07..2022-01-12&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ayuvipanda+updated%3A2021-10-07..2022-01-12&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AZsailer+updated%3A2021-10-07..2022-01-12&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.1.18
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.1.17...c6dc40f16ea6fd1b5a58167dec6ed066de3304a9))
@@ -21,8 +41,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.1.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-10-05&to=2021-10-07&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-10-05..2021-10-07&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-10-05..2021-10-07&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-10-05..2021-10-07&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.1.17
 


### PR DESCRIPTION
Automated Changelog Entry for 3.1.19 on 3.1.x
```
Python version: 3.1.19
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.1.19
@jupyterlab/buildutils: 3.1.19
@jupyterlab/template: 3.1.18
@jupyterlab/application-top: 3.1.19
@jupyterlab/example-app: 3.1.19
@jupyterlab/example-cell: 3.1.18
@jupyterlab/example-console: 3.1.18
@jupyterlab/example-federated: 2.2.18
@jupyterlab/example-federated-core: 2.2.19
@jupyterlab/example-federated-md: 2.2.19
@jupyterlab/example-federated-middle: 2.2.19
@jupyterlab/example-federated-phosphor: 2.2.19
@jupyterlab/example-filebrowser: 3.1.18
@jupyterlab/example-notebook: 3.1.18
@jupyterlab/example-terminal: 3.1.18
@jupyterlab/mock-extension: 3.1.19
@jupyterlab/mock-consumer: 3.1.19
@jupyterlab/mock-provider: 3.1.19
@jupyterlab/mock-token: 3.1.18
@jupyterlab/application: 3.1.18
@jupyterlab/application-extension: 3.1.18
@jupyterlab/apputils: 3.1.18
@jupyterlab/apputils-extension: 3.1.19
@jupyterlab/attachments: 3.1.18
@jupyterlab/cells: 3.1.18
@jupyterlab/celltags: 3.1.18
@jupyterlab/celltags-extension: 3.1.18
@jupyterlab/codeeditor: 3.1.18
@jupyterlab/codemirror: 3.1.18
@jupyterlab/codemirror-extension: 3.1.18
@jupyterlab/completer: 3.1.18
@jupyterlab/completer-extension: 3.1.18
@jupyterlab/console: 3.1.18
@jupyterlab/console-extension: 3.1.18
@jupyterlab/coreutils: 5.1.18
@jupyterlab/csvviewer: 3.1.18
@jupyterlab/csvviewer-extension: 3.1.18
@jupyterlab/debugger: 3.1.18
@jupyterlab/debugger-extension: 3.1.18
@jupyterlab/docmanager: 3.1.18
@jupyterlab/docmanager-extension: 3.1.18
@jupyterlab/docprovider: 3.1.18
@jupyterlab/docprovider-extension: 3.1.18
@jupyterlab/docregistry: 3.1.18
@jupyterlab/documentsearch: 3.1.18
@jupyterlab/documentsearch-extension: 3.1.18
@jupyterlab/extensionmanager: 3.1.18
@jupyterlab/extensionmanager-extension: 3.1.18
@jupyterlab/filebrowser: 3.1.18
@jupyterlab/filebrowser-extension: 3.1.18
@jupyterlab/fileeditor: 3.1.18
@jupyterlab/fileeditor-extension: 3.1.18
@jupyterlab/help-extension: 3.1.18
@jupyterlab/htmlviewer: 3.1.18
@jupyterlab/htmlviewer-extension: 3.1.18
@jupyterlab/hub-extension: 3.1.18
@jupyterlab/imageviewer: 3.1.18
@jupyterlab/imageviewer-extension: 3.1.18
@jupyterlab/inspector: 3.1.18
@jupyterlab/inspector-extension: 3.1.18
@jupyterlab/javascript-extension: 3.1.19
@jupyterlab/json-extension: 3.1.19
@jupyterlab/launcher: 3.1.18
@jupyterlab/launcher-extension: 3.1.18
@jupyterlab/logconsole: 3.1.18
@jupyterlab/logconsole-extension: 3.1.18
@jupyterlab/mainmenu: 3.1.18
@jupyterlab/mainmenu-extension: 3.1.18
@jupyterlab/markdownviewer: 3.1.18
@jupyterlab/markdownviewer-extension: 3.1.18
@jupyterlab/mathjax2: 3.1.18
@jupyterlab/mathjax2-extension: 3.1.18
@jupyterlab/metapackage: 3.1.19
@jupyterlab/nbconvert-css: 3.1.18
@jupyterlab/nbformat: 3.1.18
@jupyterlab/notebook: 3.1.18
@jupyterlab/notebook-extension: 3.1.18
@jupyterlab/observables: 4.1.18
@jupyterlab/outputarea: 3.1.18
@jupyterlab/pdf-extension: 3.1.18
@jupyterlab/property-inspector: 3.1.18
@jupyterlab/rendermime: 3.1.18
@jupyterlab/rendermime-extension: 3.1.18
@jupyterlab/rendermime-interfaces: 3.1.18
@jupyterlab/running: 3.1.18
@jupyterlab/running-extension: 3.1.18
@jupyterlab/services: 6.1.18
@jupyterlab/example-services-browser: 3.1.18
node-example: 3.1.18
@jupyterlab/example-services-outputarea: 3.1.18
@jupyterlab/settingeditor: 3.1.18
@jupyterlab/settingeditor-extension: 3.1.18
@jupyterlab/settingregistry: 3.1.18
@jupyterlab/shared-models: 3.1.18
@jupyterlab/shortcuts-extension: 3.1.18
@jupyterlab/statedb: 3.1.18
@jupyterlab/statusbar: 3.1.18
@jupyterlab/statusbar-extension: 3.1.18
@jupyterlab/terminal: 3.1.18
@jupyterlab/terminal-extension: 3.1.18
@jupyterlab/theme-dark-extension: 3.1.18
@jupyterlab/theme-light-extension: 3.1.18
@jupyterlab/toc: 5.1.18
@jupyterlab/toc-extension: 5.1.18
@jupyterlab/tooltip: 3.1.18
@jupyterlab/tooltip-extension: 3.1.18
@jupyterlab/translation: 3.1.18
@jupyterlab/translation-extension: 3.1.18
@jupyterlab/ui-components: 3.1.18
@jupyterlab/ui-components-extension: 3.1.18
@jupyterlab/vdom: 3.1.19
@jupyterlab/vdom-extension: 3.1.19
@jupyterlab/vega5-extension: 3.1.19
@jupyterlab/testutils: 3.1.18
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.1.x  |
| Version Spec | next |
| Since | v3.1.18 |