### PR TITLE
Add percent decoding to `username` & `initials`

### DIFF
--- a/packages/user/src/model.ts
+++ b/packages/user/src/model.ts
@@ -153,10 +153,10 @@ export class User implements ICurrentUser {
    * the user as anonymous if doesn't exists.
    */
   private _fetchUser(): void {
-    // Read username and color from URL
-    let name = env.getParam('--username', '');
+    // Read username, color and initials from URL
+    let name = decodeURIComponent(env.getParam('--username', ''));
     let color = env.getParam('--usercolor', '');
-    let initials = env.getParam('--initials', '');
+    let initials = decodeURIComponent(env.getParam('--initials', ''));
 
     const { localStorage } = window;
     const data = localStorage.getItem(USER);


### PR DESCRIPTION
## References
See this issue - [#11820](https://github.com/jupyterlab/jupyterlab/issues/11820).

## Code changes
- Added the function `decodeURIComponent` at the definition of `name`.
- Applied samely to `initials`.
- Edited comments.