### PR TITLE
Automated Changelog Entry for 3.3.0a1 on 3.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,8 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.3.x/CHANGELOG.md'
 
 ### Enhancements made
 
-- Backport PR #11816: Mentions pip3 for macOS users in docs [#11848](https://github.com/jupyterlab/jupyterlab/pull/11848) ([@jweill-aws](https://github.com/jweill-aws))
 - Fix overlapped shadow for scrolling output cell [#11785](https://github.com/jupyterlab/jupyterlab/pull/11785) ([@thesinepainter](https://github.com/thesinepainter))
-- Backport on 3.3.x: Toggle side-by-side rendering for current notebook (#11793) [#11794](https://github.com/jupyterlab/jupyterlab/pull/11794) ([@fcollonval](https://github.com/fcollonval))
+- Toggle side-by-side rendering for current notebook [#11794](https://github.com/jupyterlab/jupyterlab/pull/11794) ([@fcollonval](https://github.com/fcollonval))
 
 ### Bugs fixed
 
@@ -29,18 +28,18 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.3.x/CHANGELOG.md'
 
 ### Maintenance and upkeep improvements
 
-- [3.3.x] Backport PR #11844: Update reference snapshot for the completer UI test [#11846](https://github.com/jupyterlab/jupyterlab/pull/11846) ([@jtpio](https://github.com/jtpio))
-- [3.3.x] Bump version for the 3.3 prerelease [#11810](https://github.com/jupyterlab/jupyterlab/pull/11810) ([@jtpio](https://github.com/jtpio))
+- Update reference snapshot for the completer UI test [#11846](https://github.com/jupyterlab/jupyterlab/pull/11846) ([@jtpio](https://github.com/jtpio))
+- Bump version for the 3.3 prerelease [#11810](https://github.com/jupyterlab/jupyterlab/pull/11810) ([@jtpio](https://github.com/jtpio))
 
 ### Documentation improvements
 
-- Backport PR #11816: Mentions pip3 for macOS users in docs [#11848](https://github.com/jupyterlab/jupyterlab/pull/11848) ([@jweill-aws](https://github.com/jweill-aws))
-- Backport PR #11837: `3.1.19` Changelog Entry [#11842](https://github.com/jupyterlab/jupyterlab/pull/11842) ([@jtpio](https://github.com/jtpio))
+- Mention pip3 for macOS users in docs [#11848](https://github.com/jupyterlab/jupyterlab/pull/11848) ([@jweill-aws](https://github.com/jweill-aws))
+- Add `3.1.x` Changelog Entries [#11842](https://github.com/jupyterlab/jupyterlab/pull/11842) ([@jtpio](https://github.com/jtpio))
 - Give conda instructions for the pixman pkg-config error. [#11829](https://github.com/jupyterlab/jupyterlab/pull/11829) ([@jasongrout](https://github.com/jasongrout))
 
 ### API and Breaking Changes
 
-- Backport on 3.3.x: Toggle side-by-side rendering for current notebook (#11793) [#11794](https://github.com/jupyterlab/jupyterlab/pull/11794) ([@fcollonval](https://github.com/fcollonval))
+- Toggle side-by-side rendering for current notebook [#11794](https://github.com/jupyterlab/jupyterlab/pull/11794) ([@fcollonval](https://github.com/fcollonval))
 
 ### Other merged PRs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,46 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.3.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.3.0a1
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.2.5...a5a0075becdbed3491df972794704f8210b5f636))
+
+### Enhancements made
+
+- Backport PR #11816: Mentions pip3 for macOS users in docs [#11848](https://github.com/jupyterlab/jupyterlab/pull/11848) ([@jweill-aws](https://github.com/jweill-aws))
+- Fix overlapped shadow for scrolling output cell [#11785](https://github.com/jupyterlab/jupyterlab/pull/11785) ([@thesinepainter](https://github.com/thesinepainter))
+- Backport on 3.3.x: Toggle side-by-side rendering for current notebook (#11793) [#11794](https://github.com/jupyterlab/jupyterlab/pull/11794) ([@fcollonval](https://github.com/fcollonval))
+
+### Bugs fixed
+
+- Specify an output hash function for Galata [#11830](https://github.com/jupyterlab/jupyterlab/pull/11830) ([@jasongrout](https://github.com/jasongrout))
+- Preserve breakpoint gutter when cells are moved. [#11766](https://github.com/jupyterlab/jupyterlab/pull/11766) ([@fcollonval](https://github.com/fcollonval))
+
+### Maintenance and upkeep improvements
+
+- [3.3.x] Backport PR #11844: Update reference snapshot for the completer UI test [#11846](https://github.com/jupyterlab/jupyterlab/pull/11846) ([@jtpio](https://github.com/jtpio))
+- [3.3.x] Bump version for the 3.3 prerelease [#11810](https://github.com/jupyterlab/jupyterlab/pull/11810) ([@jtpio](https://github.com/jtpio))
+
+### Documentation improvements
+
+- Backport PR #11816: Mentions pip3 for macOS users in docs [#11848](https://github.com/jupyterlab/jupyterlab/pull/11848) ([@jweill-aws](https://github.com/jweill-aws))
+- Backport PR #11837: `3.1.19` Changelog Entry [#11842](https://github.com/jupyterlab/jupyterlab/pull/11842) ([@jtpio](https://github.com/jtpio))
+- Give conda instructions for the pixman pkg-config error. [#11829](https://github.com/jupyterlab/jupyterlab/pull/11829) ([@jasongrout](https://github.com/jasongrout))
+
+### API and Breaking Changes
+
+- Backport on 3.3.x: Toggle side-by-side rendering for current notebook (#11793) [#11794](https://github.com/jupyterlab/jupyterlab/pull/11794) ([@fcollonval](https://github.com/fcollonval))
+
+### Other merged PRs
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-12-10&to=2022-01-13&type=c))
+
+[@agoose77](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aagoose77+updated%3A2021-12-10..2022-01-13&type=Issues) | [@andrewfulton9](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aandrewfulton9+updated%3A2021-12-10..2022-01-13&type=Issues) | [@baggiponte](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abaggiponte+updated%3A2021-12-10..2022-01-13&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-12-10..2022-01-13&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2021-12-10..2022-01-13&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2021-12-10..2022-01-13&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-12-10..2022-01-13&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2021-12-10..2022-01-13&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-12-10..2022-01-13&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-12-10..2022-01-13&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2021-12-10..2022-01-13&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-12-10..2022-01-13&type=Issues) | [@JohanMabille](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AJohanMabille+updated%3A2021-12-10..2022-01-13&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-12-10..2022-01-13&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-12-10..2022-01-13&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-12-10..2022-01-13&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2021-12-10..2022-01-13&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-12-10..2022-01-13&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-12-10..2022-01-13&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-12-10..2022-01-13&type=Issues) | [@schmidi314](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aschmidi314+updated%3A2021-12-10..2022-01-13&type=Issues) | [@telamonian](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atelamonian+updated%3A2021-12-10..2022-01-13&type=Issues) | [@thesinepainter](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Athesinepainter+updated%3A2021-12-10..2022-01-13&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-12-10..2022-01-13&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## v3.2
 
 ## 3.2.7
@@ -104,8 +144,6 @@ No merged PRs
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-11-17&to=2021-12-10&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-11-17..2021-12-10&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2021-11-17..2021-12-10&type=Issues) | [@dmonad](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Admonad+updated%3A2021-11-17..2021-12-10&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-11-17..2021-12-10&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2021-11-17..2021-12-10&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-11-17..2021-12-10&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-11-17..2021-12-10&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2021-11-17..2021-12-10&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-11-17..2021-12-10&type=Issues) | [@jess-x](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajess-x+updated%3A2021-11-17..2021-12-10&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-11-17..2021-12-10&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-11-17..2021-12-10&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-11-17..2021-12-10&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2021-11-17..2021-12-10&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-11-17..2021-12-10&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-11-17..2021-12-10&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-11-17..2021-12-10&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrungleduc+updated%3A2021-11-17..2021-12-10&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-11-17..2021-12-10&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.2.4
 


### PR DESCRIPTION
Automated Changelog Entry for 3.3.0a1 on 3.3.x
```
Python version: 3.3.0a1
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.3.0-alpha.16
@jupyterlab/buildutils: 3.3.0-alpha.16
@jupyterlab/template: 3.3.0-alpha.16
@jupyterlab/application-top: 3.3.0-alpha.16
@jupyterlab/example-app: 3.3.0-alpha.16
@jupyterlab/example-cell: 3.3.0-alpha.16
@jupyterlab/example-console: 3.3.0-alpha.16
@jupyterlab/example-federated: 2.4.0-alpha.16
@jupyterlab/example-federated-core: 2.4.0-alpha.16
@jupyterlab/example-federated-md: 2.4.0-alpha.16
@jupyterlab/example-federated-middle: 2.4.0-alpha.16
@jupyterlab/example-federated-phosphor: 2.4.0-alpha.16
@jupyterlab/example-filebrowser: 3.3.0-alpha.16
@jupyterlab/example-notebook: 3.3.0-alpha.16
@jupyterlab/example-terminal: 3.3.0-alpha.16
@jupyterlab/galata: 4.2.0-alpha.16
@jupyterlab/mock-extension: 3.3.0-alpha.16
@jupyterlab/mock-consumer: 3.3.0-alpha.16
@jupyterlab/mock-provider: 3.3.0-alpha.16
@jupyterlab/mock-token: 3.3.0-alpha.16
@jupyterlab/application: 3.3.0-alpha.16
@jupyterlab/application-extension: 3.3.0-alpha.16
@jupyterlab/apputils: 3.3.0-alpha.16
@jupyterlab/apputils-extension: 3.3.0-alpha.16
@jupyterlab/attachments: 3.3.0-alpha.16
@jupyterlab/cells: 3.3.0-alpha.16
@jupyterlab/celltags: 3.3.0-alpha.16
@jupyterlab/celltags-extension: 3.3.0-alpha.16
@jupyterlab/codeeditor: 3.3.0-alpha.16
@jupyterlab/codemirror: 3.3.0-alpha.16
@jupyterlab/codemirror-extension: 3.3.0-alpha.16
@jupyterlab/completer: 3.3.0-alpha.16
@jupyterlab/completer-extension: 3.3.0-alpha.16
@jupyterlab/console: 3.3.0-alpha.16
@jupyterlab/console-extension: 3.3.0-alpha.16
@jupyterlab/coreutils: 5.3.0-alpha.16
@jupyterlab/csvviewer: 3.3.0-alpha.16
@jupyterlab/csvviewer-extension: 3.3.0-alpha.16
@jupyterlab/debugger: 3.3.0-alpha.16
@jupyterlab/debugger-extension: 3.3.0-alpha.16
@jupyterlab/docmanager: 3.3.0-alpha.16
@jupyterlab/docmanager-extension: 3.3.0-alpha.16
@jupyterlab/docprovider: 3.3.0-alpha.16
@jupyterlab/docprovider-extension: 3.3.0-alpha.16
@jupyterlab/docregistry: 3.3.0-alpha.16
@jupyterlab/documentsearch: 3.3.0-alpha.16
@jupyterlab/documentsearch-extension: 3.3.0-alpha.16
@jupyterlab/extensionmanager: 3.3.0-alpha.16
@jupyterlab/extensionmanager-extension: 3.3.0-alpha.16
@jupyterlab/filebrowser: 3.3.0-alpha.16
@jupyterlab/filebrowser-extension: 3.3.0-alpha.16
@jupyterlab/fileeditor: 3.3.0-alpha.16
@jupyterlab/fileeditor-extension: 3.3.0-alpha.16
@jupyterlab/help-extension: 3.3.0-alpha.16
@jupyterlab/htmlviewer: 3.3.0-alpha.16
@jupyterlab/htmlviewer-extension: 3.3.0-alpha.16
@jupyterlab/hub-extension: 3.3.0-alpha.16
@jupyterlab/imageviewer: 3.3.0-alpha.16
@jupyterlab/imageviewer-extension: 3.3.0-alpha.16
@jupyterlab/inspector: 3.3.0-alpha.16
@jupyterlab/inspector-extension: 3.3.0-alpha.16
@jupyterlab/javascript-extension: 3.3.0-alpha.16
@jupyterlab/json-extension: 3.3.0-alpha.16
@jupyterlab/launcher: 3.3.0-alpha.16
@jupyterlab/launcher-extension: 3.3.0-alpha.16
@jupyterlab/logconsole: 3.3.0-alpha.16
@jupyterlab/logconsole-extension: 3.3.0-alpha.16
@jupyterlab/mainmenu: 3.3.0-alpha.16
@jupyterlab/mainmenu-extension: 3.3.0-alpha.16
@jupyterlab/markdownviewer: 3.3.0-alpha.16
@jupyterlab/markdownviewer-extension: 3.3.0-alpha.16
@jupyterlab/mathjax2: 3.3.0-alpha.16
@jupyterlab/mathjax2-extension: 3.3.0-alpha.16
@jupyterlab/metapackage: 3.3.0-alpha.16
@jupyterlab/nbconvert-css: 3.3.0-alpha.16
@jupyterlab/nbformat: 3.3.0-alpha.16
@jupyterlab/notebook: 3.3.0-alpha.16
@jupyterlab/notebook-extension: 3.3.0-alpha.16
@jupyterlab/observables: 4.3.0-alpha.16
@jupyterlab/outputarea: 3.3.0-alpha.16
@jupyterlab/pdf-extension: 3.3.0-alpha.16
@jupyterlab/property-inspector: 3.3.0-alpha.16
@jupyterlab/rendermime: 3.3.0-alpha.16
@jupyterlab/rendermime-extension: 3.3.0-alpha.16
@jupyterlab/rendermime-interfaces: 3.3.0-alpha.16
@jupyterlab/running: 3.3.0-alpha.16
@jupyterlab/running-extension: 3.3.0-alpha.16
@jupyterlab/services: 6.3.0-alpha.16
@jupyterlab/example-services-browser: 3.3.0-alpha.16
node-example: 3.3.0-alpha.16
@jupyterlab/example-services-outputarea: 3.3.0-alpha.16
@jupyterlab/settingeditor: 3.3.0-alpha.16
@jupyterlab/settingeditor-extension: 3.3.0-alpha.16
@jupyterlab/settingregistry: 3.3.0-alpha.16
@jupyterlab/shared-models: 3.3.0-alpha.16
@jupyterlab/shortcuts-extension: 3.3.0-alpha.16
@jupyterlab/statedb: 3.3.0-alpha.16
@jupyterlab/statusbar: 3.3.0-alpha.16
@jupyterlab/statusbar-extension: 3.3.0-alpha.16
@jupyterlab/terminal: 3.3.0-alpha.16
@jupyterlab/terminal-extension: 3.3.0-alpha.16
@jupyterlab/theme-dark-extension: 3.3.0-alpha.16
@jupyterlab/theme-light-extension: 3.3.0-alpha.16
@jupyterlab/toc: 5.3.0-alpha.16
@jupyterlab/toc-extension: 5.3.0-alpha.16
@jupyterlab/tooltip: 3.3.0-alpha.16
@jupyterlab/tooltip-extension: 3.3.0-alpha.16
@jupyterlab/translation: 3.3.0-alpha.16
@jupyterlab/translation-extension: 3.3.0-alpha.16
@jupyterlab/ui-components: 3.3.0-alpha.15
@jupyterlab/ui-components-extension: 3.3.0-alpha.16
@jupyterlab/vdom: 3.3.0-alpha.16
@jupyterlab/vdom-extension: 3.3.0-alpha.16
@jupyterlab/vega5-extension: 3.3.0-alpha.16
@jupyterlab/testutils: 3.3.0-alpha.16
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.3.x  |
| Version Spec | next |
| Since | v3.2.5 |