### PR TITLE
Automated Changelog Entry for 3.2.8 on 3.2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,26 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.2.8
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.2.7...b2402e5b9e0db0416b5f0e5ac29c9104a69f0c83))
+
+### Maintenance and upkeep improvements
+
+- Use the root yarn.lock in staging when making a release. [#11433](https://github.com/jupyterlab/jupyterlab/pull/11433) ([@jasongrout](https://github.com/jasongrout))
+- [3.2.x] Backport PR #11844: Update reference snapshot for the completer UI test [#11847](https://github.com/jupyterlab/jupyterlab/pull/11847) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-01-12&to=2022-01-13&type=c))
+
+[@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-01-12..2022-01-13&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2022-01-12..2022-01-13&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-01-12..2022-01-13&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-01-12..2022-01-13&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-01-12..2022-01-13&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-01-12..2022-01-13&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.2.7
 
 No merged PRs
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.2.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 ### Maintenance and upkeep improvements
 
 - Use the root yarn.lock in staging when making a release. [#11433](https://github.com/jupyterlab/jupyterlab/pull/11433) ([@jasongrout](https://github.com/jasongrout))
-- [3.2.x] Backport PR #11844: Update reference snapshot for the completer UI test [#11847](https://github.com/jupyterlab/jupyterlab/pull/11847) ([@jtpio](https://github.com/jtpio))
+- Update reference snapshot for the completer UI test [#11847](https://github.com/jupyterlab/jupyterlab/pull/11847) ([@jtpio](https://github.com/jtpio))
 
 ### Contributors to this release
 


### PR DESCRIPTION
Automated Changelog Entry for 3.2.8 on 3.2.x
```
Python version: 3.2.8
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.2.8
@jupyterlab/buildutils: 3.2.8
@jupyterlab/template: 3.2.8
@jupyterlab/application-top: 3.2.8
@jupyterlab/example-app: 3.2.8
@jupyterlab/example-cell: 3.2.8
@jupyterlab/example-console: 3.2.8
@jupyterlab/example-federated: 2.3.8
@jupyterlab/example-federated-core: 2.3.8
@jupyterlab/example-federated-md: 2.3.8
@jupyterlab/example-federated-middle: 2.3.8
@jupyterlab/example-federated-phosphor: 2.3.8
@jupyterlab/example-filebrowser: 3.2.8
@jupyterlab/example-notebook: 3.2.8
@jupyterlab/example-terminal: 3.2.8
@jupyterlab/galata: 4.1.5
@jupyterlab/mock-extension: 3.2.8
@jupyterlab/mock-consumer: 3.2.8
@jupyterlab/mock-provider: 3.2.8
@jupyterlab/mock-token: 3.2.8
@jupyterlab/application: 3.2.8
@jupyterlab/application-extension: 3.2.8
@jupyterlab/apputils: 3.2.8
@jupyterlab/apputils-extension: 3.2.8
@jupyterlab/attachments: 3.2.8
@jupyterlab/cells: 3.2.8
@jupyterlab/celltags: 3.2.8
@jupyterlab/celltags-extension: 3.2.8
@jupyterlab/codeeditor: 3.2.8
@jupyterlab/codemirror: 3.2.8
@jupyterlab/codemirror-extension: 3.2.8
@jupyterlab/completer: 3.2.8
@jupyterlab/completer-extension: 3.2.8
@jupyterlab/console: 3.2.8
@jupyterlab/console-extension: 3.2.8
@jupyterlab/coreutils: 5.2.8
@jupyterlab/csvviewer: 3.2.8
@jupyterlab/csvviewer-extension: 3.2.8
@jupyterlab/debugger: 3.2.8
@jupyterlab/debugger-extension: 3.2.8
@jupyterlab/docmanager: 3.2.8
@jupyterlab/docmanager-extension: 3.2.8
@jupyterlab/docprovider: 3.2.8
@jupyterlab/docprovider-extension: 3.2.8
@jupyterlab/docregistry: 3.2.8
@jupyterlab/documentsearch: 3.2.8
@jupyterlab/documentsearch-extension: 3.2.8
@jupyterlab/extensionmanager: 3.2.8
@jupyterlab/extensionmanager-extension: 3.2.8
@jupyterlab/filebrowser: 3.2.8
@jupyterlab/filebrowser-extension: 3.2.8
@jupyterlab/fileeditor: 3.2.8
@jupyterlab/fileeditor-extension: 3.2.8
@jupyterlab/help-extension: 3.2.8
@jupyterlab/htmlviewer: 3.2.8
@jupyterlab/htmlviewer-extension: 3.2.8
@jupyterlab/hub-extension: 3.2.8
@jupyterlab/imageviewer: 3.2.8
@jupyterlab/imageviewer-extension: 3.2.8
@jupyterlab/inspector: 3.2.8
@jupyterlab/inspector-extension: 3.2.8
@jupyterlab/javascript-extension: 3.2.8
@jupyterlab/json-extension: 3.2.8
@jupyterlab/launcher: 3.2.8
@jupyterlab/launcher-extension: 3.2.8
@jupyterlab/logconsole: 3.2.8
@jupyterlab/logconsole-extension: 3.2.8
@jupyterlab/mainmenu: 3.2.8
@jupyterlab/mainmenu-extension: 3.2.8
@jupyterlab/markdownviewer: 3.2.8
@jupyterlab/markdownviewer-extension: 3.2.8
@jupyterlab/mathjax2: 3.2.8
@jupyterlab/mathjax2-extension: 3.2.8
@jupyterlab/metapackage: 3.2.8
@jupyterlab/nbconvert-css: 3.2.8
@jupyterlab/nbformat: 3.2.8
@jupyterlab/notebook: 3.2.8
@jupyterlab/notebook-extension: 3.2.8
@jupyterlab/observables: 4.2.8
@jupyterlab/outputarea: 3.2.8
@jupyterlab/pdf-extension: 3.2.8
@jupyterlab/property-inspector: 3.2.8
@jupyterlab/rendermime: 3.2.8
@jupyterlab/rendermime-extension: 3.2.8
@jupyterlab/rendermime-interfaces: 3.2.8
@jupyterlab/running: 3.2.8
@jupyterlab/running-extension: 3.2.8
@jupyterlab/services: 6.2.8
@jupyterlab/example-services-browser: 3.2.8
node-example: 3.2.8
@jupyterlab/example-services-outputarea: 3.2.8
@jupyterlab/settingeditor: 3.2.8
@jupyterlab/settingeditor-extension: 3.2.8
@jupyterlab/settingregistry: 3.2.8
@jupyterlab/shared-models: 3.2.8
@jupyterlab/shortcuts-extension: 3.2.8
@jupyterlab/statedb: 3.2.8
@jupyterlab/statusbar: 3.2.8
@jupyterlab/statusbar-extension: 3.2.8
@jupyterlab/terminal: 3.2.8
@jupyterlab/terminal-extension: 3.2.8
@jupyterlab/theme-dark-extension: 3.2.8
@jupyterlab/theme-light-extension: 3.2.8
@jupyterlab/toc: 5.2.8
@jupyterlab/toc-extension: 5.2.8
@jupyterlab/tooltip: 3.2.8
@jupyterlab/tooltip-extension: 3.2.8
@jupyterlab/translation: 3.2.8
@jupyterlab/translation-extension: 3.2.8
@jupyterlab/ui-components: 3.2.8
@jupyterlab/ui-components-extension: 3.2.8
@jupyterlab/vdom: 3.2.8
@jupyterlab/vdom-extension: 3.2.8
@jupyterlab/vega5-extension: 3.2.8
@jupyterlab/testutils: 3.2.8
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.2.x  |
| Version Spec | next |
| Since | v3.2.7 |