### PR TITLE
Make use of current user id for YJS room

### DIFF
--- a/jupyterlab/handlers/user.py
+++ b/jupyterlab/handlers/user.py
@@ -1,0 +1,26 @@
+from jupyter_server.base.handlers import APIHandler
+import json
+
+
+class CurrentUserHandler(APIHandler):
+    """A Handler returning the current user information"""
+
+    @web.authenticated
+    @gen.coroutine
+    def get(self):
+        """GET query returns info on the current user"""
+        yield json.dumps({
+            'name': 'Victor Hugo'
+        })
+
+class ConnectedUsersHandler(APIHandler):
+    """A Handler returning the list of connected users"""
+
+    @web.authenticated
+    @gen.coroutine
+    def get(self):
+        """GET query returns the list of connected users"""
+        yield json.dumps([])
+
+# The path for lab extensions handler.
+extensions_handler_path = r"/lab/api/extensions"

--- a/jupyterlab/handlers/yjs_echo_ws.py
+++ b/jupyterlab/handlers/yjs_echo_ws.py
@@ -3,7 +3,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import uuid
 import time
 
 from tornado.ioloop import IOLoop
@@ -52,11 +51,11 @@ class YjsEchoWebSocket(WebSocketHandler, JupyterHandler):
             raise web.HTTPError(403)
         return await super().get(*args, **kwargs)
 
-    def open(self, guid):
-        #print("[YJSEchoWS]: open", guid)
+    def open(self, room_id):
+        #print("[YJSEchoWS]: open", room_id)
         cls = self.__class__
-        self.id = str(uuid.uuid4())
-        self.room_id = guid
+        self.id = self.get_current_user()
+        self.room_id = room_id
         room = cls.rooms.get(self.room_id)
         if room is None:
             room = YjsRoom()


### PR DESCRIPTION
- Rename `guid` parameter to `room_id` since it is not a guid, but rather a string of the form `notebook:Untitled.ipynb`
- Reuse user id for the id of the user in the YJS room.