### PR TITLE
Add side-by-side margin override in the notebookConfig

### DIFF
--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -904,6 +904,18 @@
       "description": "Global setting to define the rendering layout in notebooks. 'default' or 'side-by-side' are supported.",
       "type": "string",
       "default": "default"
+    },
+    "sideBySideLeftMarginOverride": {
+      "title": "Side-by-side left margin override",
+      "description": "Side-by-side left margin override.",
+      "type": "string",
+      "default": "10px"
+    },
+    "sideBySideRightMarginOverride": {
+      "title": "Side-by-side right margin override",
+      "description": "Side-by-side right margin override.",
+      "type": "string",
+      "default": "10px"
     }
   },
   "additionalProperties": false,

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -282,6 +282,11 @@ const FORMAT_EXCLUDE = ['notebook', 'python', 'custom'];
 const PANEL_SETTINGS = '@jupyterlab/notebook-extension:panel';
 
 /**
+ * The id to use on the style tag for the side by side margins.
+ */
+const SIDE_BY_SIDE_STYLE_ID = 'jp-NotebookExtension-sideBySideMargins';
+
+/**
  * The notebook widget tracker provider.
  */
 const trackerPlugin: JupyterFrontEndPlugin<INotebookTracker> = {
@@ -1376,13 +1381,18 @@ function activateNotebookHandler(
         'sideBySideRightMarginOverride'
       ).composite as string
     };
-    document.head.insertAdjacentHTML(
-      'beforeend',
-      `<style>.jp-mod-sideBySide.jp-Notebook .jp-Notebook-cell { 
+    const sideBySideMarginStyle = `.jp-mod-sideBySide.jp-Notebook .jp-Notebook-cell { 
       margin-left: ${factory.notebookConfig.sideBySideLeftMarginOverride} !important;
-      margin-right: ${factory.notebookConfig.sideBySideRightMarginOverride} !important;
-    }</style>`
-    );
+      margin-right: ${factory.notebookConfig.sideBySideRightMarginOverride} !important;`;
+    const sideBySideMarginTag = document.getElementById(SIDE_BY_SIDE_STYLE_ID);
+    if (sideBySideMarginTag) {
+      sideBySideMarginTag.innerText = sideBySideMarginStyle;
+    } else {
+      document.head.insertAdjacentHTML(
+        'beforeend',
+        `<style id="${SIDE_BY_SIDE_STYLE_ID}">${sideBySideMarginStyle}}</style>`
+      );
+    }
     factory.shutdownOnClose = settings.get('kernelShutdown')
       .composite as boolean;
 

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1383,10 +1383,10 @@ function activateNotebookHandler(
     };
     const sideBySideMarginStyle = `.jp-mod-sideBySide.jp-Notebook .jp-Notebook-cell { 
       margin-left: ${factory.notebookConfig.sideBySideLeftMarginOverride} !important;
-      margin-right: ${factory.notebookConfig.sideBySideRightMarginOverride} !important;`;
+      margin-right: ${factory.notebookConfig.sideBySideRightMarginOverride} !important;`
     const sideBySideMarginTag = document.getElementById(SIDE_BY_SIDE_STYLE_ID);
     if (sideBySideMarginTag) {
-      sideBySideMarginTag.innerText = sideBySideMarginStyle;
+      sideBySideMarginTag.innerText = sideBySideMarginStyle;  
     } else {
       document.head.insertAdjacentHTML(
         'beforeend',

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1369,8 +1369,20 @@ function activateNotebookHandler(
       ).composite as boolean,
       renderingLayout: settings.get('renderingLayout').composite as
         | 'default'
-        | 'side-by-side'
+        | 'side-by-side',
+      sideBySideLeftMarginOverride: settings.get('sideBySideLeftMarginOverride')
+        .composite as string,
+      sideBySideRightMarginOverride: settings.get(
+        'sideBySideRightMarginOverride'
+      ).composite as string
     };
+    document.head.insertAdjacentHTML(
+      'beforeend',
+      `<style>.jp-mod-sideBySide.jp-Notebook .jp-Notebook-cell { 
+      margin-left: ${factory.notebookConfig.sideBySideLeftMarginOverride} !important;
+      margin-right: ${factory.notebookConfig.sideBySideRightMarginOverride} !important;
+    }</style>`
+    );
     factory.shutdownOnClose = settings.get('kernelShutdown')
       .composite as boolean;
 

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1383,10 +1383,10 @@ function activateNotebookHandler(
     };
     const sideBySideMarginStyle = `.jp-mod-sideBySide.jp-Notebook .jp-Notebook-cell { 
       margin-left: ${factory.notebookConfig.sideBySideLeftMarginOverride} !important;
-      margin-right: ${factory.notebookConfig.sideBySideRightMarginOverride} !important;`
+      margin-right: ${factory.notebookConfig.sideBySideRightMarginOverride} !important;`;
     const sideBySideMarginTag = document.getElementById(SIDE_BY_SIDE_STYLE_ID);
     if (sideBySideMarginTag) {
-      sideBySideMarginTag.innerText = sideBySideMarginStyle;  
+      sideBySideMarginTag.innerText = sideBySideMarginStyle;
     } else {
       document.head.insertAdjacentHTML(
         'beforeend',

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1028,6 +1028,16 @@ export namespace StaticNotebook {
      * Defines the rendering layout to use.
      */
     renderingLayout: RenderingLayout;
+
+    /**
+     * Override the side-by-side left margin.
+     */
+    sideBySideLeftMarginOverride: string;
+
+    /**
+     * Override the side-by-side right margin.
+     */
+    sideBySideRightMarginOverride: string;
   }
 
   /**
@@ -1044,7 +1054,9 @@ export namespace StaticNotebook {
     observedBottomMargin: '1000px',
     maxNumberOutputs: 50,
     disableDocumentWideUndoRedo: false,
-    renderingLayout: 'default'
+    renderingLayout: 'default',
+    sideBySideLeftMarginOverride: '10px',
+    sideBySideRightMarginOverride: '10px'
   };
 
   /**

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -44,7 +44,9 @@ const notebookConfig = {
   observedBottomMargin: '1000px',
   maxNumberOutputs: 50,
   disableDocumentWideUndoRedo: true,
-  renderingLayout: 'default' as 'default' | 'side-by-side'
+  renderingLayout: 'default' as 'default' | 'side-by-side',
+  sideBySideLeftMarginOverride: '10px',
+  sideBySideRightMarginOverride: '10px'
 };
 
 const options: Notebook.IOptions = {


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/11719

## Code changes

Add 2 settings in the notebookConfig

- sideBySideLeftMarginOverride
- sideBySideRightMarginOverride

## User-facing changes

The user can define its own margins when rendering in side-by-side.

## Backwards-incompatible changes

None.
