### PR TITLE
DOCS: Remove custom icon link template

### DIFF
--- a/docs/source/_templates/jupyter-website-icon.html
+++ b/docs/source/_templates/jupyter-website-icon.html
@@ -1,4 +1,0 @@
-<a class="nav-link jupyter-nav-logo" href="https://jupyter.org" rel="noopener" target="_blank" title="Jupyter Website">
-  <img src="{{ pathto('_static/logo-icon.png', 1) }}" />
-  <label class="sr-only">jupyter.org</label>
-</a>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -175,6 +175,12 @@ html_favicon = "_static/logo-icon.png"
 html_theme_options = {
     "icon_links": [
         {
+            "name": "jupyter.org",
+            "url": "https://jupyter.org",
+            "icon": "_static/jupyter_logo.svg",
+            "type": "local",
+        },
+        {
             "name": "GitHub",
             "url": "https://github.com/jupyterlab/jupyterlab",
             "icon": "fab fa-github-square",
@@ -192,7 +198,7 @@ html_theme_options = {
     ],
     "use_edit_page_button": True,
     "navbar_align": "left",
-    "navbar_end": ["jupyter-website-icon.html", "navbar-icon-links.html", "search-field.html"],
+    "navbar_end": ["navbar-icon-links.html", "search-field.html"],
     "footer_items": ["copyright.html"],
 }
 


### PR DESCRIPTION
Follow up to #11803 - I upstreamed the ability to add custom SVG icons and it was included in the latest pydata theme release, so this removes our custom code and re-uses the theme's built-in functionality 🎉 

(note that because these docs install from `conda-forge`, this PR shouldn't be merged until the pydata theme version is bumped on conda forge as well)