### PR TITLE
ensure a single modal is opened in case of time conflict savings

### DIFF
--- a/packages/docmanager/src/savehandler.ts
+++ b/packages/docmanager/src/savehandler.ts
@@ -135,7 +135,10 @@ export class SaveHandler implements IDisposable {
       .catch(err => {
         // If the user canceled the save, do nothing.
         // FIXME-TRANS: Is this affected by localization?
-        if (err.message === 'Cancel') {
+        if (
+          err.message === 'Cancel' ||
+          err.message === 'Modal is already displayed'
+        ) {
           return;
         }
         // Otherwise, log the error.

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -808,6 +808,11 @@ export class Context<
         `while the current file seems to have been saved ` +
         `${tDisk}`
     );
+    if (this._timeConflictModalIsOpen) {
+      return new Promise(() => {
+        return;
+      });
+    }
     const body = this._trans.__(
       `"%1" has changed on disk since the last time it was opened or saved.
 Do you want to overwrite the file on disk with the version open here,
@@ -818,11 +823,13 @@ or load the version on disk (revert)?`,
     const overwriteBtn = Dialog.warnButton({
       label: this._trans.__('Overwrite')
     });
+    this._timeConflictModalIsOpen = true;
     return showDialog({
       title: this._trans.__('File Changed'),
       body,
       buttons: [Dialog.cancelButton(), revertBtn, overwriteBtn]
     }).then(result => {
+      this._timeConflictModalIsOpen = false;
       if (this.isDisposed) {
         return Promise.reject(new Error('Disposed'));
       }
@@ -906,6 +913,7 @@ or load the version on disk (revert)?`,
   private _ydoc: Y.Doc;
   private _ycontext: Y.Map<string>;
   private _lastModifiedCheckMargin = 500;
+  private _timeConflictModalIsOpen = false;
 }
 
 /**

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -634,7 +634,10 @@ export class Context<
       // If the save has been canceled by the user,
       // throw the error so that whoever called save()
       // can decide what to do.
-      if (err.message === 'Cancel') {
+      if (
+        err.message === 'Cancel' ||
+        err.message === 'Modal is already displayed'
+      ) {
         throw err;
       }
 

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -809,9 +809,7 @@ export class Context<
         `${tDisk}`
     );
     if (this._timeConflictModalIsOpen) {
-      return new Promise(() => {
-        return;
-      });
+      return Promise.reject(new Error('Modal is already displayed'));
     }
     const body = this._trans.__(
       `"%1" has changed on disk since the last time it was opened or saved.


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/11700

## Code changes

Add a `timeConflictModalIsOpen` flag in the context.

## User-facing changes

Only one modal is opened and they don't stack anymore as described on https://github.com/jupyterlab/jupyterlab/issues/11700#issue-1081421554

## Backwards-incompatible changes

None.