### PR TITLE
simplify validateMimeValue regex

### DIFF
--- a/packages/nbformat/src/index.ts
+++ b/packages/nbformat/src/index.ts
@@ -102,7 +102,7 @@ export function validateMimeValue(
   value: MultilineString | PartialJSONObject
 ): boolean {
   // Check if "application/json" or "application/foo+json"
-  const jsonTest = /^application\/(.*?)+\+json$/;
+  const jsonTest = /^application\/.+\+json$/;
   const isJSONType = type === 'application/json' || jsonTest.test(type);
 
   const isString = (x: any) => {


### PR DESCRIPTION
The previous regex with an unused group had weird behavior, taking as long as a minute to match pathological strings with lots of `+` in them. I believe it had to do with arbitrary repeats of a capturing group that could match any substring.

Not a big deal, since this function doesn't appear to be used anywhere (should it be removed?), and doesn't have an issue with any reasonable input.

credit @r0hansh who found the issue.


## Code changes

Simplify regex in nbformat.validateMimeValue to improve performance.


## User-facing changes

None, except more stable performance of nbformat.validateMimeValue.

## Backwards-incompatible changes

None.

<details>
<summary> sample test</summary>



```javascript
const groupPat = /^application\/(.*?)+\+json$/;
const newPat = /^application\/.+\+json$/;
var t1 = (t2 = t3 = 0);
var i = 0;
while (t3 - t1 < 10000) {
  i += 1;

  var mime = `application/x${"+".repeat(i)}+`;
  console.log(`${i} '+'s`);
  var t1 = Date.now();
  var match1 = groupPat.test(mime);
  var t2 = Date.now();
  var match2 = newPat.test(mime);
  var t3 = Date.now();
  console.log(`before: ${t2 - t1}ms`);
  console.log(`after: ${t3 - t2}ms`);
}
```

which gives:

```
1 '+'s
before: 0ms
after: 0ms
2 '+'s
before: 0ms
after: 0ms
3 '+'s
before: 0ms
after: 0ms
4 '+'s
before: 0ms
after: 0ms
5 '+'s
before: 0ms
after: 0ms
6 '+'s
before: 0ms
after: 0ms
7 '+'s
before: 0ms
after: 0ms
8 '+'s
before: 0ms
after: 0ms
9 '+'s
before: 0ms
after: 0ms
10 '+'s
before: 0ms
after: 0ms
11 '+'s
before: 0ms
after: 0ms
12 '+'s
before: 1ms
after: 0ms
13 '+'s
before: 1ms
after: 0ms
14 '+'s
before: 3ms
after: 0ms
15 '+'s
before: 4ms
after: 0ms
16 '+'s
before: 15ms
after: 0ms
17 '+'s
before: 22ms
after: 0ms
18 '+'s
before: 48ms
after: 0ms
19 '+'s
before: 84ms
after: 0ms
20 '+'s
before: 137ms
after: 0ms
21 '+'s
before: 268ms
after: 0ms
22 '+'s
before: 528ms
after: 0ms
23 '+'s
before: 1047ms
after: 0ms
24 '+'s
before: 2137ms
after: 0ms
25 '+'s
before: 4182ms
after: 0ms
26 '+'s
before: 8342ms
after: 0ms
27 '+'s
before: 18762ms
after: 0ms
```

</details>