### PR TITLE
Fix plugin id for the toolbar registry plugin

### DIFF
--- a/packages/apputils-extension/src/toolbarregistryplugin.ts
+++ b/packages/apputils-extension/src/toolbarregistryplugin.ts
@@ -12,7 +12,7 @@ import {
  * The default toolbar registry.
  */
 export const toolbarRegistry: JupyterFrontEndPlugin<IToolbarWidgetRegistry> = {
-  id: '@jupyter/apputils-extension:toolbar-registry',
+  id: '@jupyterlab/apputils-extension:toolbar-registry',
   autoStart: true,
   provides: IToolbarWidgetRegistry,
   activate: (app: JupyterFrontEnd) => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

For consistency with the other `@jupyterlab` plugins.

Noticed when updating RetroLab to the latest `@jupyterlab` packages: https://github.com/jupyterlab/retrolab/pull/319

## Code changes

Rename plugin id.

## User-facing changes

None

## Backwards-incompatible changes

None (4.0 still in alpha cycle)