### PR TITLE
Add spacer widget via `app.shell` instead of `ILabShell`

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -1052,11 +1052,10 @@ const JupyterLogo: JupyterFrontEndPlugin<void> = {
 const topSpacer: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/application-extension:top-spacer',
   autoStart: true,
-  requires: [ILabShell],
-  activate: (app: JupyterFrontEnd, shell: ILabShell) => {
+  activate: (app: JupyterFrontEnd) => {
     const spacer = new Widget();
     spacer.id = 'jp-topbar-spacer';
-    shell.add(spacer, 'top', { rank: 900 });
+    app.shell.add(spacer, 'top', { rank: 900 });
   }
 };
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/11654

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

The `@jupyterlab/application-extension:top-spacer` plugin should not require a `ILabShell`, so it can be reused in downstream distributions.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
