### PR TITLE
fix(docprovider): fix issue with empty notebook

### DIFF
--- a/packages/docprovider/src/yprovider.ts
+++ b/packages/docprovider/src/yprovider.ts
@@ -70,9 +70,7 @@ export class WebSocketProviderWithLocks
       const initialContent = decoding.readTailAsUint8Array(decoder);
       // Apply data from server
       if (initialContent.byteLength > 0) {
-        setTimeout(() => {
-          Y.applyUpdate(this.doc, initialContent);
-        }, 0);
+        Y.applyUpdate(this.doc, initialContent);
       }
       const initialContentRequest = this._initialContentRequest;
       this._initialContentRequest = null;


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/10962

## Code changes

The response of the initialContent request was only applied after the promise callbacks for the promise that is resolved on line 80. 

So the original order is:
1. Request received
2. Promise resolved
3. Triggering the [save](https://github.com/jupyterlab/jupyterlab/blob/90ff82bb9023be8d09b895d8e8eedac45f82eba7/packages/docregistry/src/context.ts#L264-L270) (if there is any data in the intialContent) (and the [first thing this does](https://github.com/jupyterlab/jupyterlab/blob/90ff82bb9023be8d09b895d8e8eedac45f82eba7/packages/docregistry/src/context.ts#L597-L605) is getting the content as known at that time)
4. Updated applied in the setTimeout

By dropping the setTimeout, we first apply the initialContent before we resolve the `_initialContentRequest`.

Which basically means that IF there is data in the intialContent, a save happens of the current state without the actual initial content applied. Basically relying on the fact that before [initialize](https://github.com/jupyterlab/jupyterlab/blob/90ff82bb9023be8d09b895d8e8eedac45f82eba7/packages/docregistry/src/context.ts#L262) is called, the sync is already started and hopefully finished, if however it isn't, the notebook ends up being saved as an empty notebook without cells and if multiple people are joining at the same time, this update is also propagated over RTC

You can replicate by dropping / delaying some of the yjs sync messages on the client and then refreshing 2 different clients at almost the same time.
```typescript
    const originalHandler = this.messageHandlers[0];
    this.messageHandlers[0] = (
      encoder,
      decoder,
      provider,
      emitSynced,
      messageType,
    ) => {
      const type = decoding.peekVarInt(decoder);
      if (type === 2) {
        // drop updates
        return;
      }
      if (type === 1) {
        // make applying syncstep 2 slow
        setTimeout(() => {
          originalHandler(encoder, decoder, provider, emitSynced, messageType);

          if (encoding.length(encoder) > 1) {
            this.ws?.send(encoding.toUint8Array(encoder));
          }
        }, 2000);
      } else {
        // normal syncstep 1
        originalHandler(encoder, decoder, provider, emitSynced, messageType);
      }
    };
```

## User-facing changes

None other than no empty notebooks

## Backwards-incompatible changes

None
