### PR TITLE
Explicitly specifies triageLabel parameter

### DIFF
--- a/.github/jupyterlab-probot.yml
+++ b/.github/jupyterlab-probot.yml
@@ -1,2 +1,3 @@
 binderUrlSuffix: "?urlpath=lab-dev"
 addBinderLink: true
+triageLabel: "status:Needs Triage"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Addresses #11911 by explicitly specifying the triageLabel option.

Right now this option has a default value in `jupyterlab-probot`, but I plan to remove this default value.

## Code changes

Affects `jupyterlab-probot` config only.

## User-facing changes

None

## Backwards-incompatible changes

None