### PR TITLE
Automated Changelog Entry for 3.3.0a2 on 3.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,33 +19,33 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.3.x/CHANGELOG.md'
 ### Enhancements made
 
 - Add startMode setting to define the startup mode [#11881](https://github.com/jupyterlab/jupyterlab/pull/11881) ([@echarles](https://github.com/echarles))
-- Backport PR #11171 on branch 3.3.x (Update variable renderer panels) [#11874](https://github.com/jupyterlab/jupyterlab/pull/11874) ([@fcollonval](https://github.com/fcollonval))
-- Backport PR #10469 on branch 3.3.x (Allow extensions and users to customize easily toolbar items.) [#11873](https://github.com/jupyterlab/jupyterlab/pull/11873) ([@fcollonval](https://github.com/fcollonval))
-- Backport PR #10299 on branch 3.3.x (Add debugger variable renderer based on mime type) [#11871](https://github.com/jupyterlab/jupyterlab/pull/11871) ([@fcollonval](https://github.com/fcollonval))
-- Backport PR #11387 on branch 3.3.x (Add a command to open a file from a URL) [#11870](https://github.com/jupyterlab/jupyterlab/pull/11870) ([@fcollonval](https://github.com/fcollonval))
-- Backport PR #11730 on branch 3.3.x (List workspaces) [#11869](https://github.com/jupyterlab/jupyterlab/pull/11869) ([@fcollonval](https://github.com/fcollonval))
-- Backport PR #11637 on branch 3.3.x (Add closeOnExit terminal option) [#11868](https://github.com/jupyterlab/jupyterlab/pull/11868) ([@fcollonval](https://github.com/fcollonval))
-- Backport PR #11356: Toc running cell indicator [#11804](https://github.com/jupyterlab/jupyterlab/pull/11804) ([@andrewfulton9](https://github.com/andrewfulton9))
+- Update variable renderer panels [#11874](https://github.com/jupyterlab/jupyterlab/pull/11874) ([@fcollonval](https://github.com/fcollonval))
+- Allow extensions and users to customize easily toolbar items [#11873](https://github.com/jupyterlab/jupyterlab/pull/11873) ([@fcollonval](https://github.com/fcollonval))
+- Add debugger variable renderer based on mime type [#11871](https://github.com/jupyterlab/jupyterlab/pull/11871) ([@fcollonval](https://github.com/fcollonval))
+- Add a command to open a file from a URL [#11870](https://github.com/jupyterlab/jupyterlab/pull/11870) ([@fcollonval](https://github.com/fcollonval))
+- List workspaces [#11869](https://github.com/jupyterlab/jupyterlab/pull/11869) ([@fcollonval](https://github.com/fcollonval))
+- Add closeOnExit terminal option [#11868](https://github.com/jupyterlab/jupyterlab/pull/11868) ([@fcollonval](https://github.com/fcollonval))
+- Table of Contents running cell indicator [#11804](https://github.com/jupyterlab/jupyterlab/pull/11804) ([@andrewfulton9](https://github.com/andrewfulton9))
 
 ### Bugs fixed
 
-- Backport PR #11852 on branch 3.3.x (Add percent decoding to username) [#11865](https://github.com/jupyterlab/jupyterlab/pull/11865) ([@fcollonval](https://github.com/fcollonval))
+- Add percent decoding to username [#11865](https://github.com/jupyterlab/jupyterlab/pull/11865) ([@fcollonval](https://github.com/fcollonval))
 - Fix Handling of WebSocket Startup Errors [#11358](https://github.com/jupyterlab/jupyterlab/pull/11358) ([@blink1073](https://github.com/blink1073))
 
 ### Maintenance and upkeep improvements
 
 - Use `maintainer-tools` base setup action [#11595](https://github.com/jupyterlab/jupyterlab/pull/11595) ([@jtpio](https://github.com/jtpio))
-- Backport PR #11646 on branch 3.3.x (Drop testing Python 3.6, test on Python 3.10) [#11867](https://github.com/jupyterlab/jupyterlab/pull/11867) ([@fcollonval](https://github.com/fcollonval))
+- Drop testing Python 3.6, test on Python 3.10 [#11867](https://github.com/jupyterlab/jupyterlab/pull/11867) ([@fcollonval](https://github.com/fcollonval))
 - Drop support for Python 3.6 [#11740](https://github.com/jupyterlab/jupyterlab/pull/11740) ([@jtpio](https://github.com/jtpio))
-- Use the root yarn.lock in staging when making a release. [#11433](https://github.com/jupyterlab/jupyterlab/pull/11433) ([@jasongrout](https://github.com/jasongrout))
+- Use the root yarn.lock in staging when making a release [#11433](https://github.com/jupyterlab/jupyterlab/pull/11433) ([@jasongrout](https://github.com/jasongrout))
 
 ### Documentation improvements
 
-- Backport PR #10469 on branch 3.3.x (Allow extensions and users to customize easily toolbar items.) [#11873](https://github.com/jupyterlab/jupyterlab/pull/11873) ([@fcollonval](https://github.com/fcollonval))
+- Allow extensions and users to customize easily toolbar items [#11873](https://github.com/jupyterlab/jupyterlab/pull/11873) ([@fcollonval](https://github.com/fcollonval))
 
 ### API and Breaking Changes
 
-- Backport PR #11356: Toc running cell indicator [#11804](https://github.com/jupyterlab/jupyterlab/pull/11804) ([@andrewfulton9](https://github.com/andrewfulton9))
+- Table of Contents running cell indicator [#11804](https://github.com/jupyterlab/jupyterlab/pull/11804) ([@andrewfulton9](https://github.com/andrewfulton9))
 
 ### Contributors to this release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,49 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.3.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.3.0a2
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.3.0a1...f6ac33636809f310c0fdbe0b84dd8b73be8a8820))
+
+### Enhancements made
+
+- Add startMode setting to define the startup mode [#11881](https://github.com/jupyterlab/jupyterlab/pull/11881) ([@echarles](https://github.com/echarles))
+- Backport PR #11171 on branch 3.3.x (Update variable renderer panels) [#11874](https://github.com/jupyterlab/jupyterlab/pull/11874) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #10469 on branch 3.3.x (Allow extensions and users to customize easily toolbar items.) [#11873](https://github.com/jupyterlab/jupyterlab/pull/11873) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #10299 on branch 3.3.x (Add debugger variable renderer based on mime type) [#11871](https://github.com/jupyterlab/jupyterlab/pull/11871) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #11387 on branch 3.3.x (Add a command to open a file from a URL) [#11870](https://github.com/jupyterlab/jupyterlab/pull/11870) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #11730 on branch 3.3.x (List workspaces) [#11869](https://github.com/jupyterlab/jupyterlab/pull/11869) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #11637 on branch 3.3.x (Add closeOnExit terminal option) [#11868](https://github.com/jupyterlab/jupyterlab/pull/11868) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #11356: Toc running cell indicator [#11804](https://github.com/jupyterlab/jupyterlab/pull/11804) ([@andrewfulton9](https://github.com/andrewfulton9))
+
+### Bugs fixed
+
+- Backport PR #11852 on branch 3.3.x (Add percent decoding to username) [#11865](https://github.com/jupyterlab/jupyterlab/pull/11865) ([@fcollonval](https://github.com/fcollonval))
+- Fix Handling of WebSocket Startup Errors [#11358](https://github.com/jupyterlab/jupyterlab/pull/11358) ([@blink1073](https://github.com/blink1073))
+
+### Maintenance and upkeep improvements
+
+- Use `maintainer-tools` base setup action [#11595](https://github.com/jupyterlab/jupyterlab/pull/11595) ([@jtpio](https://github.com/jtpio))
+- Backport PR #11646 on branch 3.3.x (Drop testing Python 3.6, test on Python 3.10) [#11867](https://github.com/jupyterlab/jupyterlab/pull/11867) ([@fcollonval](https://github.com/fcollonval))
+- Drop support for Python 3.6 [#11740](https://github.com/jupyterlab/jupyterlab/pull/11740) ([@jtpio](https://github.com/jtpio))
+- Use the root yarn.lock in staging when making a release. [#11433](https://github.com/jupyterlab/jupyterlab/pull/11433) ([@jasongrout](https://github.com/jasongrout))
+
+### Documentation improvements
+
+- Backport PR #10469 on branch 3.3.x (Allow extensions and users to customize easily toolbar items.) [#11873](https://github.com/jupyterlab/jupyterlab/pull/11873) ([@fcollonval](https://github.com/fcollonval))
+
+### API and Breaking Changes
+
+- Backport PR #11356: Toc running cell indicator [#11804](https://github.com/jupyterlab/jupyterlab/pull/11804) ([@andrewfulton9](https://github.com/andrewfulton9))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-01-13&to=2022-01-24&type=c))
+
+[@andrewfulton9](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aandrewfulton9+updated%3A2022-01-13..2022-01-24&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-01-13..2022-01-24&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-01-13..2022-01-24&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2022-01-13..2022-01-24&type=Issues) | [@isabela-pf](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aisabela-pf+updated%3A2022-01-13..2022-01-24&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-01-13..2022-01-24&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-01-13..2022-01-24&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-01-13..2022-01-24&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-01-13..2022-01-24&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-01-13..2022-01-24&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-01-13..2022-01-24&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AZsailer+updated%3A2022-01-13..2022-01-24&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.3.0a1
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.2.5...a5a0075becdbed3491df972794704f8210b5f636))
@@ -48,8 +91,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.3.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2021-12-10&to=2022-01-13&type=c))
 
 [@agoose77](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aagoose77+updated%3A2021-12-10..2022-01-13&type=Issues) | [@andrewfulton9](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aandrewfulton9+updated%3A2021-12-10..2022-01-13&type=Issues) | [@baggiponte](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abaggiponte+updated%3A2021-12-10..2022-01-13&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2021-12-10..2022-01-13&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2021-12-10..2022-01-13&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2021-12-10..2022-01-13&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2021-12-10..2022-01-13&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2021-12-10..2022-01-13&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2021-12-10..2022-01-13&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2021-12-10..2022-01-13&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2021-12-10..2022-01-13&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2021-12-10..2022-01-13&type=Issues) | [@JohanMabille](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AJohanMabille+updated%3A2021-12-10..2022-01-13&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2021-12-10..2022-01-13&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2021-12-10..2022-01-13&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2021-12-10..2022-01-13&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2021-12-10..2022-01-13&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2021-12-10..2022-01-13&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2021-12-10..2022-01-13&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2021-12-10..2022-01-13&type=Issues) | [@schmidi314](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aschmidi314+updated%3A2021-12-10..2022-01-13&type=Issues) | [@telamonian](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atelamonian+updated%3A2021-12-10..2022-01-13&type=Issues) | [@thesinepainter](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Athesinepainter+updated%3A2021-12-10..2022-01-13&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2021-12-10..2022-01-13&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## v3.2
 


### PR DESCRIPTION
Automated Changelog Entry for 3.3.0a2 on 3.3.x
```
Python version: 3.3.0a2
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.3.0-alpha.17
@jupyterlab/buildutils: 3.3.0-alpha.17
@jupyterlab/template: 3.3.0-alpha.17
@jupyterlab/application-top: 3.3.0-alpha.17
@jupyterlab/example-app: 3.3.0-alpha.17
@jupyterlab/example-cell: 3.3.0-alpha.17
@jupyterlab/example-console: 3.3.0-alpha.17
@jupyterlab/example-federated: 2.4.0-alpha.17
@jupyterlab/example-federated-core: 2.4.0-alpha.17
@jupyterlab/example-federated-md: 2.4.0-alpha.17
@jupyterlab/example-federated-middle: 2.4.0-alpha.17
@jupyterlab/example-federated-phosphor: 2.4.0-alpha.17
@jupyterlab/example-filebrowser: 3.3.0-alpha.17
@jupyterlab/example-notebook: 3.3.0-alpha.17
@jupyterlab/example-terminal: 3.3.0-alpha.17
@jupyterlab/galata: 4.2.0-alpha.17
@jupyterlab/mock-extension: 3.3.0-alpha.17
@jupyterlab/mock-consumer: 3.3.0-alpha.17
@jupyterlab/mock-provider: 3.3.0-alpha.17
@jupyterlab/mock-token: 3.3.0-alpha.17
@jupyterlab/application: 3.3.0-alpha.17
@jupyterlab/application-extension: 3.3.0-alpha.17
@jupyterlab/apputils: 3.3.0-alpha.17
@jupyterlab/apputils-extension: 3.3.0-alpha.17
@jupyterlab/attachments: 3.3.0-alpha.17
@jupyterlab/cells: 3.3.0-alpha.17
@jupyterlab/celltags: 3.3.0-alpha.17
@jupyterlab/celltags-extension: 3.3.0-alpha.17
@jupyterlab/codeeditor: 3.3.0-alpha.17
@jupyterlab/codemirror: 3.3.0-alpha.17
@jupyterlab/codemirror-extension: 3.3.0-alpha.17
@jupyterlab/completer: 3.3.0-alpha.17
@jupyterlab/completer-extension: 3.3.0-alpha.17
@jupyterlab/console: 3.3.0-alpha.17
@jupyterlab/console-extension: 3.3.0-alpha.17
@jupyterlab/coreutils: 5.3.0-alpha.17
@jupyterlab/csvviewer: 3.3.0-alpha.17
@jupyterlab/csvviewer-extension: 3.3.0-alpha.17
@jupyterlab/debugger: 3.3.0-alpha.17
@jupyterlab/debugger-extension: 3.3.0-alpha.17
@jupyterlab/docmanager: 3.3.0-alpha.17
@jupyterlab/docmanager-extension: 3.3.0-alpha.17
@jupyterlab/docprovider: 3.3.0-alpha.17
@jupyterlab/docprovider-extension: 3.3.0-alpha.17
@jupyterlab/docregistry: 3.3.0-alpha.17
@jupyterlab/documentsearch: 3.3.0-alpha.17
@jupyterlab/documentsearch-extension: 3.3.0-alpha.17
@jupyterlab/extensionmanager: 3.3.0-alpha.17
@jupyterlab/extensionmanager-extension: 3.3.0-alpha.17
@jupyterlab/filebrowser: 3.3.0-alpha.17
@jupyterlab/filebrowser-extension: 3.3.0-alpha.17
@jupyterlab/fileeditor: 3.3.0-alpha.17
@jupyterlab/fileeditor-extension: 3.3.0-alpha.17
@jupyterlab/help-extension: 3.3.0-alpha.17
@jupyterlab/htmlviewer: 3.3.0-alpha.17
@jupyterlab/htmlviewer-extension: 3.3.0-alpha.17
@jupyterlab/hub-extension: 3.3.0-alpha.17
@jupyterlab/imageviewer: 3.3.0-alpha.17
@jupyterlab/imageviewer-extension: 3.3.0-alpha.17
@jupyterlab/inspector: 3.3.0-alpha.17
@jupyterlab/inspector-extension: 3.3.0-alpha.17
@jupyterlab/javascript-extension: 3.3.0-alpha.17
@jupyterlab/json-extension: 3.3.0-alpha.17
@jupyterlab/launcher: 3.3.0-alpha.17
@jupyterlab/launcher-extension: 3.3.0-alpha.17
@jupyterlab/logconsole: 3.3.0-alpha.17
@jupyterlab/logconsole-extension: 3.3.0-alpha.17
@jupyterlab/mainmenu: 3.3.0-alpha.17
@jupyterlab/mainmenu-extension: 3.3.0-alpha.17
@jupyterlab/markdownviewer: 3.3.0-alpha.17
@jupyterlab/markdownviewer-extension: 3.3.0-alpha.17
@jupyterlab/mathjax2: 3.3.0-alpha.17
@jupyterlab/mathjax2-extension: 3.3.0-alpha.17
@jupyterlab/metapackage: 3.3.0-alpha.17
@jupyterlab/nbconvert-css: 3.3.0-alpha.17
@jupyterlab/nbformat: 3.3.0-alpha.17
@jupyterlab/notebook: 3.3.0-alpha.17
@jupyterlab/notebook-extension: 3.3.0-alpha.17
@jupyterlab/observables: 4.3.0-alpha.17
@jupyterlab/outputarea: 3.3.0-alpha.17
@jupyterlab/pdf-extension: 3.3.0-alpha.17
@jupyterlab/property-inspector: 3.3.0-alpha.17
@jupyterlab/rendermime: 3.3.0-alpha.17
@jupyterlab/rendermime-extension: 3.3.0-alpha.17
@jupyterlab/rendermime-interfaces: 3.3.0-alpha.17
@jupyterlab/running: 3.3.0-alpha.17
@jupyterlab/running-extension: 3.3.0-alpha.17
@jupyterlab/services: 6.3.0-alpha.17
@jupyterlab/example-services-browser: 3.3.0-alpha.17
node-example: 3.3.0-alpha.17
@jupyterlab/example-services-outputarea: 3.3.0-alpha.17
@jupyterlab/settingeditor: 3.3.0-alpha.17
@jupyterlab/settingeditor-extension: 3.3.0-alpha.17
@jupyterlab/settingregistry: 3.3.0-alpha.17
@jupyterlab/shared-models: 3.3.0-alpha.17
@jupyterlab/shortcuts-extension: 3.3.0-alpha.17
@jupyterlab/statedb: 3.3.0-alpha.17
@jupyterlab/statusbar: 3.3.0-alpha.17
@jupyterlab/statusbar-extension: 3.3.0-alpha.17
@jupyterlab/terminal: 3.3.0-alpha.17
@jupyterlab/terminal-extension: 3.3.0-alpha.17
@jupyterlab/theme-dark-extension: 3.3.0-alpha.17
@jupyterlab/theme-light-extension: 3.3.0-alpha.17
@jupyterlab/toc: 5.3.0-alpha.17
@jupyterlab/toc-extension: 5.3.0-alpha.17
@jupyterlab/tooltip: 3.3.0-alpha.17
@jupyterlab/tooltip-extension: 3.3.0-alpha.17
@jupyterlab/translation: 3.3.0-alpha.17
@jupyterlab/translation-extension: 3.3.0-alpha.17
@jupyterlab/ui-components: 3.3.0-alpha.16
@jupyterlab/ui-components-extension: 3.3.0-alpha.17
@jupyterlab/vdom: 3.3.0-alpha.17
@jupyterlab/vdom-extension: 3.3.0-alpha.17
@jupyterlab/vega5-extension: 3.3.0-alpha.17
@jupyterlab/testutils: 3.3.0-alpha.17
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.3.x  |
| Version Spec | next |
| Since | v3.3.0a1 |