### PR TITLE
Remove theme cookiecutter from the docs

### DIFF
--- a/docs/source/extension/extension_dev.rst
+++ b/docs/source/extension/extension_dev.rst
@@ -45,7 +45,6 @@ We provide several cookiecutters to create JupyterLab extensions:
 - `extension-cookiecutter-ts <https://github.com/jupyterlab/extension-cookiecutter-ts>`_: Create a JupyterLab extension in TypeScript
 - `extension-cookiecutter-js <https://github.com/jupyterlab/extension-cookiecutter-js>`_: Create a JupyterLab extension in JavaScript
 - `mimerender-cookiecutter-ts <https://github.com/jupyterlab/mimerender-cookiecutter-ts>`_: Create a MIME Renderer JupyterLab extension in TypeScript
-- `theme-cookiecutter <https://github.com/jupyterlab/theme-cookiecutter>`_: Create a theme extension for JupyterLab
 
 API Reference Documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/extension/extension_tutorial.rst
+++ b/docs/source/extension/extension_tutorial.rst
@@ -104,14 +104,19 @@ are using to fetch pictures).
 
 ::
 
+    Select kind:
+    1 - frontend
+    2 - server
+    3 - theme
+    Choose from 1, 2, 3 [1]: 1
     author_name []: Your Name
     author_email []: your@name.org
-    python_name [myextension]: jupyterlab_apod
     labextension_name [myextension]: jupyterlab_apod
+    python_name [myextension]: jupyterlab_apod
     project_short_description [A JupyterLab extension.]: Show a random NASA Astronomy Picture of the Day in a JupyterLab panel
-    has_server_extension [n]: n
+    has_settings [n]: n
     has_binder [n]: y
-    repository [https://github.com/my_name/myextension]: https://github.com/my_name/jupyterlab_apod
+    repository [https://github.com/github_username/myextension]: https://github.com/github_username/jupyterlab_apod
 
 Note: if not using a repository, leave the repository field blank. You can come
 back and edit the repository field in the ``package.json`` file later.
@@ -127,8 +132,8 @@ You should see a list like the following.
 
 ::
 
-    LICENSE          README.md        jupyterlab_apod/ pyproject.toml   src/             tsconfig.json
-    MANIFEST.in      install.json     package.json     setup.py         style/
+    binder          CHANGELOG.md  install.json  jupyterlab_apod  LICENSE   MANIFEST.in   package.json
+    pyproject.toml  README.md     RELEASE.md    setup.py         src       style         tsconfig.json
 
 Commit what you have to git
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #11908

## Code changes

Documentation changes:

- [x] Remove the theme cookiecutter from the list of cookiecutters
- [x] Update the extension tutorial to reflect the new prompts

## User-facing changes

Update the docs for extension authors.

![image](https://user-images.githubusercontent.com/591645/150978267-5c343918-2e61-4a82-a442-39ea7f77ff50.png)


## Backwards-incompatible changes

None