### PR TITLE
Add additional `Accel Enter` keyboard shortcuts for the `notebook:run-cell` command

### DIFF
--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -558,12 +558,12 @@
     },
     {
       "command": "notebook:run-cell",
-      "keys": ["Ctrl Enter"],
+      "keys": ["Accel Enter"],
       "selector": ".jp-Notebook:focus"
     },
     {
       "command": "notebook:run-cell",
-      "keys": ["Ctrl Enter"],
+      "keys": ["Accel Enter"],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -558,6 +558,16 @@
     },
     {
       "command": "notebook:run-cell",
+      "keys": ["Ctrl Enter"],
+      "selector": ".jp-Notebook:focus"
+    },
+    {
+      "command": "notebook:run-cell",
+      "keys": ["Ctrl Enter"],
+      "selector": ".jp-Notebook.jp-mod-editMode"
+    },
+    {
+      "command": "notebook:run-cell",
       "keys": ["Accel Enter"],
       "selector": ".jp-Notebook:focus"
     },


### PR DESCRIPTION


## References

This was reported in https://github.com/jupyterlab/retrolab/issues/329 by @yuvipanda and @papajohn.

## Code changes

Add an additional keyboard shortcut for the `notebook:run-cell` command so it also supports <kbd>Accel Enter</kbd> in addition to <kbd>Ctrl Enter</kbd>.

For reference the Lumino documentation says:

> The supported modifiers are: `Accel`, `Alt`, `Cmd`, `Ctrl`, and
> `Shift`. The `Accel` modifier is translated to `Cmd` on Mac and
> `Ctrl` on all other platforms. The `Cmd` modifier is ignored on
> non-Mac platforms.

From: https://github.com/jupyterlab/lumino/blob/66b9df5ecc8f22e203a96df8a252956e8c8a9263/packages/commands/src/index.ts#L942-L945

## User-facing changes

Mac users should be able to use <kbd>Cmd Enter</kbd> to execute a cell without advancing.

## Backwards-incompatible changes

None

