### PR TITLE
[wip] update setuptools build dependency, clean up install dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires=["jupyter_packaging>=0.9,<2", "setuptools>=58.1"]
+requires=["jupyter_packaging>=0.9,<2", "pyrsistent!=0.18.1"]
 build-backend = "jupyter_packaging.build_api"
 
 [license]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires=["jupyter_packaging>=0.9,<2"]
+requires=["jupyter_packaging>=0.9,<2", "setuptools>=58.1"]
 build-backend = "jupyter_packaging.build_api"
 
 [license]

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,17 +32,28 @@ packages = find:
 python_requires = >=3.7
 install_requires =
     ipython
+    jinja2>=2.1
+    jupyter_core
+    jupyter_server~=1.4
+    jupyterlab_server~=2.10
+    nbclassic~=0.2
     packaging
     tornado>=6.1.0
-    jupyter_core
-    jupyterlab_server~=2.10
-    jupyter_server~=1.4
-    nbclassic~=0.2
-    jinja2>=2.1
 
 [options.extras_require]
-test = coverage; pytest>=6.0; pytest-cov; pytest-console-scripts; pytest-check-links>=0.5; jupyterlab_server[test]~=2.2; requests; requests_cache; virtualenv; check-manifest
-ui-tests = build
+test =
+    check-manifest
+    coverage
+    jupyterlab_server[test]~=2.2
+    pytest-check-links>=0.5
+    pytest-console-scripts
+    pytest-cov
+    pytest>=6.0
+    requests
+    requests_cache
+    virtualenv
+ui-tests =
+    build
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
## References

- maybe fixes #11933

## Code changes

- [x] adds a minimum pin to setuptools in `build-system`
  - bumped to a week after the changes related to the linked issue from #11933
- [x] splits and sorts the extras and dependencies a la #11944 (will remove from there)
  - still not _actually_ relevant, but better than over there

## User-facing changes

- n/a

## Backwards-incompatible changes

- n/a