### PR TITLE
Fix for kernel reconnect

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -28,7 +28,7 @@ import { Dialog, showDialog } from './dialog';
  * #### Notes
  * The current session connection is `.session`, the current session's kernel
  * connection is `.session.kernel`. For convenience, we proxy several kernel
- * connection and and session connection signals up to the session context so
+ * connection and session connection signals up to the session context so
  * that you do not have to manage slots as sessions and kernels change. For
  * example, to act on whatever the current kernel's iopubMessage signal is
  * producing, connect to the session context `.iopubMessage` signal.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #11534. 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
<!-- Describe the code changes and how they address the issue. -->
Added a reconnect for `getKernelModel`, so for network failures it will be called again until the connection works or the server responds with a "dead" kernel response.

## User-facing changes
<!-- Describe any visual or user interaction changes and how they address the issue. -->
For long running kernel tasks, if network connection is dropped and then resumes, JupyterLab will be able to auto-reconnect  with the kernel and resume the output of the task.
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None
