### PR TITLE
Do not load CSS of disabled federated extensions

### DIFF
--- a/dev_mode/index.js
+++ b/dev_mode/index.js
@@ -80,7 +80,8 @@ export async function main() {
       queuedFederated.push(data.name);
       federatedMimeExtensionPromises.push(createModule(data.name, data.mimeExtension));
     }
-    if (data.style) {
+
+    if (data.style && !PageConfig.Extension.isDisabled(data.name)) {
       federatedStylePromises.push(createModule(data.name, data.style));
     }
   });

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -152,6 +152,8 @@ Extension Development Changes
 - The ``webpack`` dependency in ``@jupyterlab/builder`` has been updated to ``5.72`` (or newer). Base rules have been updated to use the
   `Asset Modules <https://webpack.js.org/guides/asset-modules>`_ instead of the previous ``file-loader``, ``raw-loader`` and ``url-loader``.
   This might affect third-party extensions if they were relying on specific behaviors from these loaders.
+- In JupyterLab 3.x, the CSS for a _disabled_ prebuilt extensions would still be loaded on the page.
+  This is no longer the case in JupyterLab 4.0.
 
 JupyterLab 3.0 to 3.1
 ---------------------


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #11728

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Check for `PageConfig.Extension.isDisabled(data.name))` before loading the styles coming from federated extensions.
- [x] Document this behavior?

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

For example with a federated extension that adds the following CSS:

```css
#jp-topbar-spacer {
  background: blue;
}
```

**Before**

![image](https://user-images.githubusercontent.com/591645/151797973-e33237e9-4fc4-4032-8c6e-faeb0188dd0d.png)

**After**

![image](https://user-images.githubusercontent.com/591645/151799023-a343e980-8045-47a4-a110-472b7c7f61ae.png)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

This is a change of behavior that some deployments that have been depending on.

A new entry in this section of the docs could then be useful for reference purposes: https://jupyterlab.readthedocs.io/en/latest/extension/extension_migration.html#extension-development-changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
