### PR TITLE
Support dynamic toolbar definition

### DIFF
--- a/packages/apputils/src/toolbar/factory.ts
+++ b/packages/apputils/src/toolbar/factory.ts
@@ -272,9 +272,7 @@ export function createToolbarFactory(
           );
           break;
         case 'remove':
-          change.oldValues.forEach(() =>
-            toolbar.remove(change.oldIndex)
-          );
+          change.oldValues.forEach(() => toolbar.remove(change.oldIndex));
           break;
         case 'set':
           change.newValues.forEach(item =>

--- a/packages/apputils/src/toolbar/factory.ts
+++ b/packages/apputils/src/toolbar/factory.ts
@@ -40,6 +40,8 @@ async function displayInformation(trans: TranslationBundle): Promise<void> {
 /**
  * Set the toolbar definition by accumulating all settings definition.
  *
+ * The list will be populated only with the enabled items.
+ *
  * @param toolbarItems Observable list to populate
  * @param registry Application settings registry
  * @param factoryName Widget factory name that needs a toolbar
@@ -208,7 +210,7 @@ async function setToolbarItems(
     // name cannot be inserted (it will be a no-op). But that could happen
     // if the settings are changing the items order.
     toolbarItems.clear();
-    toolbarItems.pushAll(newItems);
+    toolbarItems.pushAll(newItems.filter(item => !item.disabled));
   };
 
   // Initialize the toolbar

--- a/packages/apputils/test/toolbar.spec.ts
+++ b/packages/apputils/test/toolbar.spec.ts
@@ -252,7 +252,13 @@ describe('@jupyterlab/apputils', () => {
                 rank: 20
               },
               { name: 'spacer', type: 'spacer', rank: 100 },
-              { name: 'cut', command: 'notebook:cut-cell', rank: 21 }
+              { name: 'cut', command: 'notebook:cut-cell', rank: 21 },
+              {
+                name: 'clear-all',
+                command: 'notebook:clear-all-cell-outputs',
+                rank: 60,
+                disabled: true
+              }
             ]
           },
           'jupyter.lab.transform': true,
@@ -309,6 +315,9 @@ describe('@jupyterlab/apputils', () => {
 
       const items = factory(new Widget());
       expect(items).toHaveLength(3);
+      expect(items.get(0).name).toEqual('insert');
+      expect(items.get(1).name).toEqual('cut');
+      expect(items.get(2).name).toEqual('spacer');
     });
 
     it('should update the toolbar items with late settings load', async () => {
@@ -328,7 +337,12 @@ describe('@jupyterlab/apputils', () => {
         schema: {
           'jupyter.lab.toolbars': {
             dummyFactory: [
-              { name: 'cut', command: 'notebook:cut-cell', rank: 21 }
+              { name: 'cut', command: 'notebook:cut-cell', rank: 21 },
+              { name: 'insert', rank: 40 },
+              {
+                name: 'clear-all',
+                disabled: true
+              }
             ]
           },
           type: 'object'
@@ -349,6 +363,11 @@ describe('@jupyterlab/apputils', () => {
                 name: 'insert',
                 command: 'notebook:insert-cell-below',
                 rank: 20
+              },
+              {
+                name: 'clear-all',
+                command: 'notebook:clear-all-cell-outputs',
+                rank: 60
               }
             ]
           },
@@ -409,6 +428,8 @@ describe('@jupyterlab/apputils', () => {
 
       const items = factory(new Widget());
       expect(items).toHaveLength(2);
+      expect(items.get(0).name).toEqual('cut');
+      expect(items.get(1).name).toEqual('insert');
     });
   });
 });

--- a/packages/apputils/test/toolbar.spec.ts
+++ b/packages/apputils/test/toolbar.spec.ts
@@ -307,7 +307,7 @@ describe('@jupyterlab/apputils', () => {
       // factory in `createToolbarFactory`
       await Promise.resolve();
 
-      const items = factory(null as any);
+      const items = factory(new Widget());
       expect(items).toHaveLength(3);
     });
 
@@ -407,7 +407,7 @@ describe('@jupyterlab/apputils', () => {
       await Promise.resolve();
       await settingRegistry.load(foo.id);
 
-      const items = factory(null as any);
+      const items = factory(new Widget());
       expect(items).toHaveLength(2);
     });
   });

--- a/packages/csvviewer-extension/package.json
+++ b/packages/csvviewer-extension/package.json
@@ -43,6 +43,7 @@
     "@jupyterlab/docregistry": "^4.0.0-alpha.4",
     "@jupyterlab/documentsearch": "^4.0.0-alpha.4",
     "@jupyterlab/mainmenu": "^4.0.0-alpha.4",
+    "@jupyterlab/observables": "^5.0.0-alpha.4",
     "@jupyterlab/settingregistry": "^4.0.0-alpha.4",
     "@jupyterlab/translation": "^4.0.0-alpha.4",
     "@lumino/datagrid": "^0.35.1",

--- a/packages/csvviewer-extension/src/index.ts
+++ b/packages/csvviewer-extension/src/index.ts
@@ -27,6 +27,7 @@ import {
 import { DocumentRegistry, IDocumentWidget } from '@jupyterlab/docregistry';
 import { ISearchProviderRegistry } from '@jupyterlab/documentsearch';
 import { IMainMenu } from '@jupyterlab/mainmenu';
+import { IObservableList } from '@jupyterlab/observables';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { ITranslator } from '@jupyterlab/translation';
 import { DataGrid } from '@lumino/datagrid';
@@ -98,7 +99,9 @@ function activateCsv(
 ): void {
   const { commands, shell } = app;
   let toolbarFactory:
-    | ((widget: IDocumentWidget<CSVViewer>) => DocumentRegistry.IToolbarItem[])
+    | ((
+        widget: IDocumentWidget<CSVViewer>
+      ) => IObservableList<DocumentRegistry.IToolbarItem>)
     | undefined;
 
   if (toolbarRegistry) {
@@ -240,7 +243,9 @@ function activateTsv(
 ): void {
   const { commands, shell } = app;
   let toolbarFactory:
-    | ((widget: IDocumentWidget<CSVViewer>) => DocumentRegistry.IToolbarItem[])
+    | ((
+        widget: IDocumentWidget<CSVViewer>
+      ) => IObservableList<DocumentRegistry.IToolbarItem>)
     | undefined;
 
   if (toolbarRegistry) {

--- a/packages/csvviewer-extension/tsconfig.json
+++ b/packages/csvviewer-extension/tsconfig.json
@@ -25,6 +25,9 @@
       "path": "../mainmenu"
     },
     {
+      "path": "../observables"
+    },
+    {
       "path": "../settingregistry"
     },
     {

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -5,10 +5,11 @@ import { MainAreaWidget } from '@jupyterlab/apputils';
 import { CodeEditor } from '@jupyterlab/codeeditor';
 import { Mode } from '@jupyterlab/codemirror';
 import { IChangedArgs, PathExt } from '@jupyterlab/coreutils';
-import { IModelDB } from '@jupyterlab/observables';
+import { IModelDB, IObservableList } from '@jupyterlab/observables';
 import { Contents } from '@jupyterlab/services';
 import * as models from '@jupyterlab/shared-models';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
+import { findIndex, toArray } from '@lumino/algorithm';
 import { PartialJSONValue } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 import { Title, Widget } from '@lumino/widgets';
@@ -428,15 +429,84 @@ export abstract class ABCWidgetFactory<
     const widget = this.createNewWidget(context, source);
 
     // Add toolbar items
-    let items: DocumentRegistry.IToolbarItem[];
-    if (this._toolbarFactory) {
-      items = this._toolbarFactory(widget);
+    const items:
+      | DocumentRegistry.IToolbarItem[]
+      | IObservableList<DocumentRegistry.IToolbarItem> = (
+      this._toolbarFactory ?? this.defaultToolbarFactory
+    )(widget);
+
+    if (Array.isArray(items)) {
+      items.forEach(({ name, widget: item }) => {
+        widget.toolbar.addItem(name, item);
+      });
     } else {
-      items = this.defaultToolbarFactory(widget);
+      const updateToolbar = (
+        list: IObservableList<DocumentRegistry.IToolbarItem>,
+        changes: IObservableList.IChangedArgs<DocumentRegistry.IToolbarItem>
+      ) => {
+        switch (changes.type) {
+          case 'add':
+            changes.newValues.forEach((item, index) => {
+              widget.toolbar.insertItem(
+                changes.newIndex + index,
+                item.name,
+                item.widget
+              );
+            });
+            break;
+          case 'move':
+            changes.oldValues.forEach(item => {
+              item.widget.parent = null;
+            });
+            changes.newValues.forEach((item, index) => {
+              widget.toolbar.insertItem(
+                changes.newIndex + index,
+                item.name,
+                item.widget
+              );
+            });
+            break;
+          case 'remove':
+            changes.oldValues.forEach(item => {
+              item.widget.parent = null;
+            });
+            break;
+          case 'set':
+            changes.oldValues.forEach(item => {
+              item.widget.parent = null;
+            });
+
+            changes.newValues.forEach((item, index) => {
+              const existingIndex = findIndex(
+                widget.toolbar.names(),
+                name => item.name === name
+              );
+              if (existingIndex >= 0) {
+                toArray(widget.toolbar.children())[existingIndex].parent = null;
+              }
+
+              widget.toolbar.insertItem(
+                changes.newIndex + index,
+                item.name,
+                item.widget
+              );
+            });
+            break;
+        }
+      };
+
+      updateToolbar(items, {
+        newIndex: 0,
+        newValues: toArray(items),
+        oldIndex: 0,
+        oldValues: [],
+        type: 'add'
+      });
+      items.changed.connect(updateToolbar);
+      widget.disposed.connect(() => {
+        items.changed.disconnect(updateToolbar);
+      });
     }
-    items.forEach(({ name, widget: item }) => {
-      widget.toolbar.addItem(name, item);
-    });
 
     // Emit widget created signal
     this._widgetCreated.emit(widget);
@@ -460,7 +530,11 @@ export abstract class ABCWidgetFactory<
   }
 
   private _toolbarFactory:
-    | ((widget: T) => DocumentRegistry.IToolbarItem[])
+    | ((
+        widget: T
+      ) =>
+        | DocumentRegistry.IToolbarItem[]
+        | IObservableList<DocumentRegistry.IToolbarItem>)
     | undefined;
   private _isDisposed = false;
   private _translator: ITranslator;

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -432,7 +432,7 @@ export abstract class ABCWidgetFactory<
     const items:
       | DocumentRegistry.IToolbarItem[]
       | IObservableList<DocumentRegistry.IToolbarItem> = (
-      this._toolbarFactory ?? this.defaultToolbarFactory
+      this._toolbarFactory?.bind(this) ?? this.defaultToolbarFactory.bind(this)
     )(widget);
 
     if (Array.isArray(items)) {

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -7,7 +7,7 @@ import {
   IChangedArgs as IChangedArgsGeneric,
   PathExt
 } from '@jupyterlab/coreutils';
-import { IModelDB } from '@jupyterlab/observables';
+import { IModelDB, IObservableList } from '@jupyterlab/observables';
 import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 import { Contents, Kernel } from '@jupyterlab/services';
 import * as models from '@jupyterlab/shared-models';
@@ -1111,7 +1111,11 @@ export namespace DocumentRegistry {
     /**
      * A function producing toolbar widgets, overriding the default toolbar widgets.
      */
-    readonly toolbarFactory?: (widget: T) => DocumentRegistry.IToolbarItem[];
+    readonly toolbarFactory?: (
+      widget: T
+    ) =>
+      | DocumentRegistry.IToolbarItem[]
+      | IObservableList<DocumentRegistry.IToolbarItem>;
   }
 
   /**

--- a/packages/fileeditor-extension/package.json
+++ b/packages/fileeditor-extension/package.json
@@ -48,6 +48,7 @@
     "@jupyterlab/fileeditor": "^4.0.0-alpha.4",
     "@jupyterlab/launcher": "^4.0.0-alpha.4",
     "@jupyterlab/mainmenu": "^4.0.0-alpha.4",
+    "@jupyterlab/observables": "^5.0.0-alpha.4",
     "@jupyterlab/settingregistry": "^4.0.0-alpha.4",
     "@jupyterlab/statusbar": "^4.0.0-alpha.4",
     "@jupyterlab/translation": "^4.0.0-alpha.4",

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -33,6 +33,7 @@ import {
 } from '@jupyterlab/fileeditor';
 import { ILauncher } from '@jupyterlab/launcher';
 import { IMainMenu } from '@jupyterlab/mainmenu';
+import { IObservableList } from '@jupyterlab/observables';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IStatusBar } from '@jupyterlab/statusbar';
 import { ITranslator } from '@jupyterlab/translation';
@@ -193,7 +194,9 @@ function activate(
   const trans = translator.load('jupyterlab');
   const namespace = 'editor';
   let toolbarFactory:
-    | ((widget: IDocumentWidget<FileEditor>) => DocumentRegistry.IToolbarItem[])
+    | ((
+        widget: IDocumentWidget<FileEditor>
+      ) => IObservableList<DocumentRegistry.IToolbarItem>)
     | undefined;
 
   if (toolbarRegistry) {

--- a/packages/fileeditor-extension/tsconfig.json
+++ b/packages/fileeditor-extension/tsconfig.json
@@ -40,6 +40,9 @@
       "path": "../mainmenu"
     },
     {
+      "path": "../observables"
+    },
+    {
       "path": "../settingregistry"
     },
     {

--- a/packages/htmlviewer-extension/package.json
+++ b/packages/htmlviewer-extension/package.json
@@ -38,6 +38,7 @@
     "@jupyterlab/apputils": "^4.0.0-alpha.4",
     "@jupyterlab/docregistry": "^4.0.0-alpha.4",
     "@jupyterlab/htmlviewer": "^4.0.0-alpha.4",
+    "@jupyterlab/observables": "^5.0.0-alpha.4",
     "@jupyterlab/settingregistry": "^4.0.0-alpha.4",
     "@jupyterlab/translation": "^4.0.0-alpha.4",
     "@jupyterlab/ui-components": "^4.0.0-alpha.19"

--- a/packages/htmlviewer-extension/src/index.tsx
+++ b/packages/htmlviewer-extension/src/index.tsx
@@ -25,6 +25,7 @@ import {
   IHTMLViewerTracker,
   ToolbarItems
 } from '@jupyterlab/htmlviewer';
+import { IObservableList } from '@jupyterlab/observables';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { ITranslator } from '@jupyterlab/translation';
 import { html5Icon } from '@jupyterlab/ui-components';
@@ -70,7 +71,7 @@ function activateHTMLViewer(
   toolbarRegistry: IToolbarWidgetRegistry | null
 ): IHTMLViewerTracker {
   let toolbarFactory:
-    | ((widget: HTMLViewer) => DocumentRegistry.IToolbarItem[])
+    | ((widget: HTMLViewer) => IObservableList<DocumentRegistry.IToolbarItem>)
     | undefined;
   const trans = translator.load('jupyterlab');
 

--- a/packages/htmlviewer-extension/tsconfig.json
+++ b/packages/htmlviewer-extension/tsconfig.json
@@ -19,6 +19,9 @@
       "path": "../htmlviewer"
     },
     {
+      "path": "../observables"
+    },
+    {
       "path": "../settingregistry"
     },
     {

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -903,7 +903,11 @@ function activateWidgetFactory(
 ): NotebookWidgetFactory.IFactory {
   const { commands } = app;
   let toolbarFactory:
-    | ((widget: NotebookPanel) => DocumentRegistry.IToolbarItem[])
+    | ((
+        widget: NotebookPanel
+      ) =>
+        | DocumentRegistry.IToolbarItem[]
+        | IObservableList<DocumentRegistry.IToolbarItem>)
     | undefined;
 
   // Register notebook toolbar widgets

--- a/packages/rendermime-interfaces/src/index.ts
+++ b/packages/rendermime-interfaces/src/index.ts
@@ -72,7 +72,13 @@ export namespace IRenderMime {
    * A toolbar item.
    */
   export interface IToolbarItem {
+    /**
+     * Item name
+     */
     name: string;
+    /**
+     * Toolbar widget
+     */
     widget: Widget;
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
This addresses mainly the error seen in
https://github.com/jupyterlab/retrolab/pull/319#issuecomment-1017371450

it also allows to change the toolbar definitions from the settings without reloading
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
The toolbar factory for document widget factory can return either a list of toolbar items or an observable list. When an observable list is returned, the toolbar is updated accordingly.

The toolbar definition built using the settings are returning an observable list.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Toolbar definitions can be changed without reloading.

> When changing the definition, toolbar items not added through the settings (like the debug button) won't be positioned as expected - a reload will be needed for that.

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A

