### PR TITLE
Split caption for pausing on exceptions

### DIFF
--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -721,12 +721,14 @@ const main: JupyterFrontEndPlugin<void> = {
     });
 
     commands.addCommand(CommandIDs.pause, {
-      label: () => service.isPausingOnExceptions
-        ? trans.__('Disable pausing on exceptions')
-        : trans.__('Enable pausing on exceptions'),
-      caption: () => service.isPausingOnExceptions
-        ? trans.__('Disable pausing on exceptions')
-        : trans.__('Enable pausing on exceptions'),
+      label: () =>
+        service.isPausingOnExceptions
+          ? trans.__('Disable pausing on exceptions')
+          : trans.__('Enable pausing on exceptions'),
+      caption: () =>
+        service.isPausingOnExceptions
+          ? trans.__('Disable pausing on exceptions')
+          : trans.__('Enable pausing on exceptions'),
       className: 'jp-PauseOnExceptions',
       icon: Debugger.Icons.pauseOnExceptionsIcon,
       isToggled: () => {

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -721,10 +721,12 @@ const main: JupyterFrontEndPlugin<void> = {
     });
 
     commands.addCommand(CommandIDs.pause, {
-      label: service.isPausingOnExceptions
+      label: () => service.isPausingOnExceptions
         ? trans.__('Disable pausing on exceptions')
         : trans.__('Enable pausing on exceptions'),
-      caption: trans.__('Enable / Disable pausing on exceptions'),
+      caption: () => service.isPausingOnExceptions
+        ? trans.__('Disable pausing on exceptions')
+        : trans.__('Enable pausing on exceptions'),
       className: 'jp-PauseOnExceptions',
       icon: Debugger.Icons.pauseOnExceptionsIcon,
       isToggled: () => {

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -721,14 +721,11 @@ const main: JupyterFrontEndPlugin<void> = {
     });
 
     commands.addCommand(CommandIDs.pause, {
-      label: () =>
-        service.isPausingOnExceptions
-          ? trans.__('Disable pausing on exceptions')
-          : trans.__('Enable pausing on exceptions'),
+      label: trans.__('Pause on exceptions'),
       caption: () =>
         service.isPausingOnExceptions
-          ? trans.__('Disable pausing on exceptions')
-          : trans.__('Enable pausing on exceptions'),
+          ? trans.__('Disable pause on exceptions')
+          : trans.__('Enable pause on exceptions'),
       className: 'jp-PauseOnExceptions',
       icon: Debugger.Icons.pauseOnExceptionsIcon,
       isToggled: () => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
https://github.com/jupyterlab/jupyterlab/pull/11752#issuecomment-1026010018
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Split the caption to highlight the status of the toggleable command
use function for label and caption so it gets properly updated when the command state changes

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Caption is clarified on the command status
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A