### PR TITLE
Adjust z-index of execution progress tooltip

### DIFF
--- a/packages/apputils/style/toolbar.css
+++ b/packages/apputils/style/toolbar.css
@@ -20,7 +20,7 @@
   background: var(--jp-toolbar-background);
   min-height: var(--jp-toolbar-micro-height);
   padding: 2px;
-  z-index: 1;
+  z-index: 8;
   overflow-x: hidden;
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #11972

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
z-index of the search bar is 7
https://github.com/jupyterlab/jupyterlab/blob/f995e5d8be9a31b40fc08d8a210ec32bc849b0bf/packages/documentsearch/style/base.css#L19
and tooltip was 1
https://github.com/jupyterlab/jupyterlab/blob/f995e5d8be9a31b40fc08d8a210ec32bc849b0bf/packages/apputils/style/toolbar.css#L23

This was causing the search bar to overshadow the tooltip so changed the z-index of tooltip to 8 so that it stays on top
```diff
-  z-index: 1;
+  z-index: 8;
```
## User-facing changes

### Before
![image](https://user-images.githubusercontent.com/67158080/152070272-2773a71e-29b9-4bbf-a477-6446dfbba7bd.png)
### After
![image](https://user-images.githubusercontent.com/67158080/152070397-c6be7b0a-ed84-4f10-9abd-9993910a889a.png)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
