### PR TITLE
Fix misaligned icon and checkbox of setting editor

### DIFF
--- a/packages/settingeditor/style/base.css
+++ b/packages/settingeditor/style/base.css
@@ -135,6 +135,7 @@
 
 .jp-PluginList button span {
   color: var(--jp-content-font-color1);
+  line-height: var(--jp-cell-collapser-min-height);
 }
 
 .jp-FormComponent li span {
@@ -226,8 +227,16 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
   color: var(--jp-content-font-color0);
 }
 
+.jp-SettingsPanel fieldset input[type='checkbox'] {
+  position: relative;
+  top: 2px;
+}
+
 .jp-SettingsPanel .checkbox label {
   cursor: pointer;
+}
+.jp-SettingsPanel .checkbox label:not(:first-child) {
+  margin: 0.5em;
 }
 
 .jp-SettingsPanel button[type='submit'] {
@@ -348,6 +357,7 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
   color: var(--jp-ui-font-color1);
   font-weight: 200;
   margin: 1em;
+  line-height: var(--jp-content-font-size3);
 }
 
 .jp-SettingsPanel p {


### PR DESCRIPTION

## Code changes
Update styles of `span` and `checkbox` in setting editor
## User-facing changes
- Icon before 
![icon-before](https://user-images.githubusercontent.com/4451292/152130539-9d67077f-1607-4270-9a78-9212418c99b9.png)
- Icon after 
![icon-after](https://user-images.githubusercontent.com/4451292/152130620-8becbde0-c254-40e7-8bcf-4a9205847e22.png)
- Checkbox before
![checkbox-before](https://user-images.githubusercontent.com/4451292/152130548-f80e3a4e-7bf4-4a96-b6d4-e13ab623d3b5.png)
- Checkbox after
![checkbox-after](https://user-images.githubusercontent.com/4451292/152130690-7c98ef1c-9439-4fc5-bed7-ae35c57efa91.png)

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
