### PR TITLE
Add legacy editor to same palette category

### DIFF
--- a/packages/settingeditor-extension/src/index.ts
+++ b/packages/settingeditor-extension/src/index.ts
@@ -273,7 +273,7 @@ function activateJSON(
   });
   if (palette) {
     palette.addItem({
-      category: trans.__('Advanced Settings Editor'),
+      category: trans.__('Settings'),
       command: CommandIDs.openJSON
     });
   }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Follow up of #11079

The command for the legacy editor was not added in the same palette editor
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Use the same _Settings_ category for the palette
## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Opening the advanced settings editor will not be the first item in the command palette.
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A