### PR TITLE
Automated Changelog Entry for 3.3.0a3 on 3.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,34 +19,34 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.3.x/CHANGELOG.md'
 ### Enhancements made
 
 - Fix for kernel reconnect [#11952](https://github.com/jupyterlab/jupyterlab/pull/11952) ([@3coins](https://github.com/3coins))
-- Backport PR #11079 on branch 3.3.x (Add settings UI) [#11977](https://github.com/jupyterlab/jupyterlab/pull/11977) ([@fcollonval](https://github.com/fcollonval))
-- Backport PR #11566 on branch 3.3.x (Show the kernel sources as a debugger tab and allow the user to break in kernel sources) [#11954](https://github.com/jupyterlab/jupyterlab/pull/11954) ([@echarles](https://github.com/echarles))
-- Backport PR #10956 on branch 3.3.x (Enable not showing editor for read-only Markdown cells) [#11950](https://github.com/jupyterlab/jupyterlab/pull/11950) ([@fcollonval](https://github.com/fcollonval))
+- Add settings UI [#11977](https://github.com/jupyterlab/jupyterlab/pull/11977) ([@fcollonval](https://github.com/fcollonval))
+- Show the kernel sources as a debugger tab and allow the user to break in kernel sources [#11954](https://github.com/jupyterlab/jupyterlab/pull/11954) ([@echarles](https://github.com/echarles))
+- Enable not showing editor for read-only Markdown cells [#11950](https://github.com/jupyterlab/jupyterlab/pull/11950) ([@fcollonval](https://github.com/fcollonval))
 - Add side-by-side margin override in the notebookConfig [#11880](https://github.com/jupyterlab/jupyterlab/pull/11880) ([@echarles](https://github.com/echarles))
 - Add additional `Accel Enter` keyboard shortcuts for the `notebook:run-cell` command [#11942](https://github.com/jupyterlab/jupyterlab/pull/11942) ([@jtpio](https://github.com/jtpio))
-- Backport PR #10730 on branch 3.3.x (Add execution progress indicator) [#11941](https://github.com/jupyterlab/jupyterlab/pull/11941) ([@trungleduc](https://github.com/trungleduc))
+- Add execution progress indicator [#11941](https://github.com/jupyterlab/jupyterlab/pull/11941) ([@trungleduc](https://github.com/trungleduc))
 - Allow to link factory to file type when adding it [#11540](https://github.com/jupyterlab/jupyterlab/pull/11540) ([@fcollonval](https://github.com/fcollonval))
-- Backport PR #11752: Pause on exception [#11923](https://github.com/jupyterlab/jupyterlab/pull/11923) ([@andrewfulton9](https://github.com/andrewfulton9))
-- Backport PR #11658 on branch 3.3.x (Increase color contrast in input boxes) [#11922](https://github.com/jupyterlab/jupyterlab/pull/11922) ([@fcollonval](https://github.com/fcollonval))
+- Pause on exception [#11923](https://github.com/jupyterlab/jupyterlab/pull/11923) ([@andrewfulton9](https://github.com/andrewfulton9))
+- Increase color contrast in input boxes [#11922](https://github.com/jupyterlab/jupyterlab/pull/11922) ([@fcollonval](https://github.com/fcollonval))
 
 ### Bugs fixed
 
-- overrides.json definition takes precedence [#11610](https://github.com/jupyterlab/jupyterlab/pull/11610) ([@fcollonval](https://github.com/fcollonval))
+- Overrides.json definition takes precedence [#11610](https://github.com/jupyterlab/jupyterlab/pull/11610) ([@fcollonval](https://github.com/fcollonval))
 - Adjust z-index of execution progress tooltip [#11973](https://github.com/jupyterlab/jupyterlab/pull/11973) ([@Sync271](https://github.com/Sync271))
-- [Backport to 3.3.x] Fix the debug modules model #11967 [#11968](https://github.com/jupyterlab/jupyterlab/pull/11968) ([@echarles](https://github.com/echarles))
+- Fix the debug modules model #11967 [#11968](https://github.com/jupyterlab/jupyterlab/pull/11968) ([@echarles](https://github.com/echarles))
 - Fix autocomplete in console [#11949](https://github.com/jupyterlab/jupyterlab/pull/11949) ([@fcollonval](https://github.com/fcollonval))
-- fix(docprovider): fix issue with empty notebook [#11901](https://github.com/jupyterlab/jupyterlab/pull/11901) ([@entropitor](https://github.com/entropitor))
-- ensure a single modal is opened in case of time conflict savings [#11883](https://github.com/jupyterlab/jupyterlab/pull/11883) ([@echarles](https://github.com/echarles))
+- Fix issue with empty notebook [#11901](https://github.com/jupyterlab/jupyterlab/pull/11901) ([@entropitor](https://github.com/entropitor))
+- Ensure a single modal is opened in case of time conflict savings [#11883](https://github.com/jupyterlab/jupyterlab/pull/11883) ([@echarles](https://github.com/echarles))
 - Restore line number state when stopping debugger [#11768](https://github.com/jupyterlab/jupyterlab/pull/11768) ([@fcollonval](https://github.com/fcollonval))
 
 ### Maintenance and upkeep improvements
 
 - Update vscode-debugprotocol to @vscode/debugprotocol [#11953](https://github.com/jupyterlab/jupyterlab/pull/11953) ([@fcollonval](https://github.com/fcollonval))
-- Partly backport PR #11388 on branch 3.3.x (Add update galata snapshot step) [#11927](https://github.com/jupyterlab/jupyterlab/pull/11927) ([@fcollonval](https://github.com/fcollonval))
+- Add update galata snapshot step [#11927](https://github.com/jupyterlab/jupyterlab/pull/11927) ([@fcollonval](https://github.com/fcollonval))
 
 ### Documentation improvements
 
-- Backport PR #11499 on branch 3.3.x (Update screenshots and text for user interface docs) [#11982](https://github.com/jupyterlab/jupyterlab/pull/11982) ([@fcollonval](https://github.com/fcollonval))
+- Update screenshots and text for user interface docs [#11982](https://github.com/jupyterlab/jupyterlab/pull/11982) ([@fcollonval](https://github.com/fcollonval))
 - Update several extensions readme files to delete old content. [#11947](https://github.com/jupyterlab/jupyterlab/pull/11947) ([@jasongrout](https://github.com/jasongrout))
 - Remove theme cookiecutter from the docs [#11928](https://github.com/jupyterlab/jupyterlab/pull/11928) ([@jtpio](https://github.com/jtpio))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,52 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.3.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.3.0a3
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.3.0a2...843120368a8a6d98db23373a716e3575ce5b5d5e))
+
+### Enhancements made
+
+- Fix for kernel reconnect [#11952](https://github.com/jupyterlab/jupyterlab/pull/11952) ([@3coins](https://github.com/3coins))
+- Backport PR #11079 on branch 3.3.x (Add settings UI) [#11977](https://github.com/jupyterlab/jupyterlab/pull/11977) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #11566 on branch 3.3.x (Show the kernel sources as a debugger tab and allow the user to break in kernel sources) [#11954](https://github.com/jupyterlab/jupyterlab/pull/11954) ([@echarles](https://github.com/echarles))
+- Backport PR #10956 on branch 3.3.x (Enable not showing editor for read-only Markdown cells) [#11950](https://github.com/jupyterlab/jupyterlab/pull/11950) ([@fcollonval](https://github.com/fcollonval))
+- Add side-by-side margin override in the notebookConfig [#11880](https://github.com/jupyterlab/jupyterlab/pull/11880) ([@echarles](https://github.com/echarles))
+- Add additional `Accel Enter` keyboard shortcuts for the `notebook:run-cell` command [#11942](https://github.com/jupyterlab/jupyterlab/pull/11942) ([@jtpio](https://github.com/jtpio))
+- Backport PR #10730 on branch 3.3.x (Add execution progress indicator) [#11941](https://github.com/jupyterlab/jupyterlab/pull/11941) ([@trungleduc](https://github.com/trungleduc))
+- Allow to link factory to file type when adding it [#11540](https://github.com/jupyterlab/jupyterlab/pull/11540) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #11752: Pause on exception [#11923](https://github.com/jupyterlab/jupyterlab/pull/11923) ([@andrewfulton9](https://github.com/andrewfulton9))
+- Backport PR #11658 on branch 3.3.x (Increase color contrast in input boxes) [#11922](https://github.com/jupyterlab/jupyterlab/pull/11922) ([@fcollonval](https://github.com/fcollonval))
+
+### Bugs fixed
+
+- overrides.json definition takes precedence [#11610](https://github.com/jupyterlab/jupyterlab/pull/11610) ([@fcollonval](https://github.com/fcollonval))
+- Adjust z-index of execution progress tooltip [#11973](https://github.com/jupyterlab/jupyterlab/pull/11973) ([@Sync271](https://github.com/Sync271))
+- [Backport to 3.3.x] Fix the debug modules model #11967 [#11968](https://github.com/jupyterlab/jupyterlab/pull/11968) ([@echarles](https://github.com/echarles))
+- Fix autocomplete in console [#11949](https://github.com/jupyterlab/jupyterlab/pull/11949) ([@fcollonval](https://github.com/fcollonval))
+- fix(docprovider): fix issue with empty notebook [#11901](https://github.com/jupyterlab/jupyterlab/pull/11901) ([@entropitor](https://github.com/entropitor))
+- ensure a single modal is opened in case of time conflict savings [#11883](https://github.com/jupyterlab/jupyterlab/pull/11883) ([@echarles](https://github.com/echarles))
+- Restore line number state when stopping debugger [#11768](https://github.com/jupyterlab/jupyterlab/pull/11768) ([@fcollonval](https://github.com/fcollonval))
+
+### Maintenance and upkeep improvements
+
+- Update vscode-debugprotocol to @vscode/debugprotocol [#11953](https://github.com/jupyterlab/jupyterlab/pull/11953) ([@fcollonval](https://github.com/fcollonval))
+- Partly backport PR #11388 on branch 3.3.x (Add update galata snapshot step) [#11927](https://github.com/jupyterlab/jupyterlab/pull/11927) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+- Backport PR #11499 on branch 3.3.x (Update screenshots and text for user interface docs) [#11982](https://github.com/jupyterlab/jupyterlab/pull/11982) ([@fcollonval](https://github.com/fcollonval))
+- Update several extensions readme files to delete old content. [#11947](https://github.com/jupyterlab/jupyterlab/pull/11947) ([@jasongrout](https://github.com/jasongrout))
+- Remove theme cookiecutter from the docs [#11928](https://github.com/jupyterlab/jupyterlab/pull/11928) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-01-24&to=2022-02-03&type=c))
+
+[@andrewfulton9](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aandrewfulton9+updated%3A2022-01-24..2022-02-03&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-01-24..2022-02-03&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2022-01-24..2022-02-03&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-01-24..2022-02-03&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-01-24..2022-02-03&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-01-24..2022-02-03&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2022-01-24..2022-02-03&type=Issues) | [@isabela-pf](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aisabela-pf+updated%3A2022-01-24..2022-02-03&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-01-24..2022-02-03&type=Issues) | [@JohanMabille](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AJohanMabille+updated%3A2022-01-24..2022-02-03&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-01-24..2022-02-03&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2022-01-24..2022-02-03&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-01-24..2022-02-03&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-01-24..2022-02-03&type=Issues) | [@marthacryan](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Amarthacryan+updated%3A2022-01-24..2022-02-03&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-01-24..2022-02-03&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-01-24..2022-02-03&type=Issues) | [@mlucool](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Amlucool+updated%3A2022-01-24..2022-02-03&type=Issues) | [@Sync271](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASync271+updated%3A2022-01-24..2022-02-03&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrungleduc+updated%3A2022-01-24..2022-02-03&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-01-24..2022-02-03&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ayuvipanda+updated%3A2022-01-24..2022-02-03&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.3.0a2
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.3.0a1...f6ac33636809f310c0fdbe0b84dd8b73be8a8820))
@@ -52,8 +98,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.3.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-01-13&to=2022-01-24&type=c))
 
 [@andrewfulton9](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aandrewfulton9+updated%3A2022-01-13..2022-01-24&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-01-13..2022-01-24&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-01-13..2022-01-24&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2022-01-13..2022-01-24&type=Issues) | [@isabela-pf](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aisabela-pf+updated%3A2022-01-13..2022-01-24&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-01-13..2022-01-24&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-01-13..2022-01-24&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-01-13..2022-01-24&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-01-13..2022-01-24&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-01-13..2022-01-24&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-01-13..2022-01-24&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AZsailer+updated%3A2022-01-13..2022-01-24&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.3.0a1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.3.x/CHANGELOG.md'
 ### Bugs fixed
 
 - Overrides.json definition takes precedence [#11610](https://github.com/jupyterlab/jupyterlab/pull/11610) ([@fcollonval](https://github.com/fcollonval))
-- Adjust z-index of execution progress tooltip [#11973](https://github.com/jupyterlab/jupyterlab/pull/11973) ([@Sync271](https://github.com/Sync271))
+- Adjust `z-index` of execution progress tooltip [#11973](https://github.com/jupyterlab/jupyterlab/pull/11973) ([@Sync271](https://github.com/Sync271))
 - Fix the debug modules model #11967 [#11968](https://github.com/jupyterlab/jupyterlab/pull/11968) ([@echarles](https://github.com/echarles))
 - Fix autocomplete in console [#11949](https://github.com/jupyterlab/jupyterlab/pull/11949) ([@fcollonval](https://github.com/fcollonval))
 - Fix issue with empty notebook [#11901](https://github.com/jupyterlab/jupyterlab/pull/11901) ([@entropitor](https://github.com/entropitor))
@@ -41,7 +41,7 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.3.x/CHANGELOG.md'
 
 ### Maintenance and upkeep improvements
 
-- Update vscode-debugprotocol to @vscode/debugprotocol [#11953](https://github.com/jupyterlab/jupyterlab/pull/11953) ([@fcollonval](https://github.com/fcollonval))
+- Update `vscode-debugprotocol` to `@vscode/debugprotocol` [#11953](https://github.com/jupyterlab/jupyterlab/pull/11953) ([@fcollonval](https://github.com/fcollonval))
 - Add update galata snapshot step [#11927](https://github.com/jupyterlab/jupyterlab/pull/11927) ([@fcollonval](https://github.com/fcollonval))
 
 ### Documentation improvements


### PR DESCRIPTION
Automated Changelog Entry for 3.3.0a3 on 3.3.x
```
Python version: 3.3.0a3
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.3.0-alpha.18
@jupyterlab/buildutils: 3.3.0-alpha.18
@jupyterlab/template: 3.3.0-alpha.18
@jupyterlab/application-top: 3.3.0-alpha.18
@jupyterlab/example-app: 3.3.0-alpha.18
@jupyterlab/example-cell: 3.3.0-alpha.18
@jupyterlab/example-console: 3.3.0-alpha.18
@jupyterlab/example-federated: 2.4.0-alpha.18
@jupyterlab/example-federated-core: 2.4.0-alpha.18
@jupyterlab/example-federated-md: 2.4.0-alpha.18
@jupyterlab/example-federated-middle: 2.4.0-alpha.18
@jupyterlab/example-federated-phosphor: 2.4.0-alpha.18
@jupyterlab/example-filebrowser: 3.3.0-alpha.18
@jupyterlab/example-notebook: 3.3.0-alpha.18
@jupyterlab/example-terminal: 3.3.0-alpha.18
@jupyterlab/galata: 4.2.0-alpha.18
@jupyterlab/mock-extension: 3.3.0-alpha.18
@jupyterlab/mock-consumer: 3.3.0-alpha.18
@jupyterlab/mock-provider: 3.3.0-alpha.18
@jupyterlab/mock-token: 3.3.0-alpha.18
@jupyterlab/application: 3.3.0-alpha.18
@jupyterlab/application-extension: 3.3.0-alpha.18
@jupyterlab/apputils: 3.3.0-alpha.18
@jupyterlab/apputils-extension: 3.3.0-alpha.18
@jupyterlab/attachments: 3.3.0-alpha.18
@jupyterlab/cells: 3.3.0-alpha.18
@jupyterlab/celltags: 3.3.0-alpha.18
@jupyterlab/celltags-extension: 3.3.0-alpha.18
@jupyterlab/codeeditor: 3.3.0-alpha.18
@jupyterlab/codemirror: 3.3.0-alpha.18
@jupyterlab/codemirror-extension: 3.3.0-alpha.18
@jupyterlab/completer: 3.3.0-alpha.18
@jupyterlab/completer-extension: 3.3.0-alpha.18
@jupyterlab/console: 3.3.0-alpha.18
@jupyterlab/console-extension: 3.3.0-alpha.18
@jupyterlab/coreutils: 5.3.0-alpha.18
@jupyterlab/csvviewer: 3.3.0-alpha.18
@jupyterlab/csvviewer-extension: 3.3.0-alpha.18
@jupyterlab/debugger: 3.3.0-alpha.18
@jupyterlab/debugger-extension: 3.3.0-alpha.18
@jupyterlab/docmanager: 3.3.0-alpha.18
@jupyterlab/docmanager-extension: 3.3.0-alpha.18
@jupyterlab/docprovider: 3.3.0-alpha.18
@jupyterlab/docprovider-extension: 3.3.0-alpha.18
@jupyterlab/docregistry: 3.3.0-alpha.18
@jupyterlab/documentsearch: 3.3.0-alpha.18
@jupyterlab/documentsearch-extension: 3.3.0-alpha.18
@jupyterlab/extensionmanager: 3.3.0-alpha.18
@jupyterlab/extensionmanager-extension: 3.3.0-alpha.18
@jupyterlab/filebrowser: 3.3.0-alpha.18
@jupyterlab/filebrowser-extension: 3.3.0-alpha.18
@jupyterlab/fileeditor: 3.3.0-alpha.18
@jupyterlab/fileeditor-extension: 3.3.0-alpha.18
@jupyterlab/help-extension: 3.3.0-alpha.18
@jupyterlab/htmlviewer: 3.3.0-alpha.18
@jupyterlab/htmlviewer-extension: 3.3.0-alpha.18
@jupyterlab/hub-extension: 3.3.0-alpha.18
@jupyterlab/imageviewer: 3.3.0-alpha.18
@jupyterlab/imageviewer-extension: 3.3.0-alpha.18
@jupyterlab/inspector: 3.3.0-alpha.18
@jupyterlab/inspector-extension: 3.3.0-alpha.18
@jupyterlab/javascript-extension: 3.3.0-alpha.18
@jupyterlab/json-extension: 3.3.0-alpha.18
@jupyterlab/launcher: 3.3.0-alpha.18
@jupyterlab/launcher-extension: 3.3.0-alpha.18
@jupyterlab/logconsole: 3.3.0-alpha.18
@jupyterlab/logconsole-extension: 3.3.0-alpha.18
@jupyterlab/mainmenu: 3.3.0-alpha.18
@jupyterlab/mainmenu-extension: 3.3.0-alpha.18
@jupyterlab/markdownviewer: 3.3.0-alpha.18
@jupyterlab/markdownviewer-extension: 3.3.0-alpha.18
@jupyterlab/mathjax2: 3.3.0-alpha.18
@jupyterlab/mathjax2-extension: 3.3.0-alpha.18
@jupyterlab/metapackage: 3.3.0-alpha.18
@jupyterlab/nbconvert-css: 3.3.0-alpha.18
@jupyterlab/nbformat: 3.3.0-alpha.18
@jupyterlab/notebook: 3.3.0-alpha.18
@jupyterlab/notebook-extension: 3.3.0-alpha.18
@jupyterlab/observables: 4.3.0-alpha.18
@jupyterlab/outputarea: 3.3.0-alpha.18
@jupyterlab/pdf-extension: 3.3.0-alpha.18
@jupyterlab/property-inspector: 3.3.0-alpha.18
@jupyterlab/rendermime: 3.3.0-alpha.18
@jupyterlab/rendermime-extension: 3.3.0-alpha.18
@jupyterlab/rendermime-interfaces: 3.3.0-alpha.18
@jupyterlab/running: 3.3.0-alpha.18
@jupyterlab/running-extension: 3.3.0-alpha.18
@jupyterlab/services: 6.3.0-alpha.18
@jupyterlab/example-services-browser: 3.3.0-alpha.18
node-example: 3.3.0-alpha.18
@jupyterlab/example-services-outputarea: 3.3.0-alpha.18
@jupyterlab/settingeditor: 3.3.0-alpha.18
@jupyterlab/settingeditor-extension: 3.3.0-alpha.18
@jupyterlab/settingregistry: 3.3.0-alpha.18
@jupyterlab/shared-models: 3.3.0-alpha.18
@jupyterlab/shortcuts-extension: 3.3.0-alpha.18
@jupyterlab/statedb: 3.3.0-alpha.18
@jupyterlab/statusbar: 3.3.0-alpha.18
@jupyterlab/statusbar-extension: 3.3.0-alpha.18
@jupyterlab/terminal: 3.3.0-alpha.18
@jupyterlab/terminal-extension: 3.3.0-alpha.18
@jupyterlab/theme-dark-extension: 3.3.0-alpha.18
@jupyterlab/theme-light-extension: 3.3.0-alpha.18
@jupyterlab/toc: 5.3.0-alpha.18
@jupyterlab/toc-extension: 5.3.0-alpha.18
@jupyterlab/tooltip: 3.3.0-alpha.18
@jupyterlab/tooltip-extension: 3.3.0-alpha.18
@jupyterlab/translation: 3.3.0-alpha.18
@jupyterlab/translation-extension: 3.3.0-alpha.18
@jupyterlab/ui-components: 3.3.0-alpha.17
@jupyterlab/ui-components-extension: 3.3.0-alpha.18
@jupyterlab/vdom: 3.3.0-alpha.18
@jupyterlab/vdom-extension: 3.3.0-alpha.18
@jupyterlab/vega5-extension: 3.3.0-alpha.18
@jupyterlab/testutils: 3.3.0-alpha.18
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.3.x  |
| Version Spec | next |
| Since | v3.3.0a2 |