### PR TITLE
Fix contrast in dark theme of settings editor

### DIFF
--- a/packages/settingeditor/style/base.css
+++ b/packages/settingeditor/style/base.css
@@ -108,6 +108,7 @@
   margin: 10px;
   border-bottom: var(--jp-border-width) solid var(--jp-border-color2);
   border-top: var(--jp-border-width) solid var(--jp-border-color2);
+  color: var(--jp-content-font-color1);
 }
 
 .jp-PluginList .jp-SelectedIndicator {

--- a/packages/ui-components/style/icons/toolbar/launch.svg
+++ b/packages/ui-components/style/icons/toolbar/launch.svg
@@ -1,12 +1,6 @@
-<svg id="icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
-  <defs>
-    <style>
-      .cls-1 {
-        fill: none;
-      }
-    </style>
-  </defs>
-  <path d="M26,28H6a2.0027,2.0027,0,0,1-2-2V6A2.0027,2.0027,0,0,1,6,4H16V6H6V26H26V16h2V26A2.0027,2.0027,0,0,1,26,28Z"/>
-  <polygon points="20 2 20 4 26.586 4 18 12.586 19.414 14 28 5.414 28 12 30 12 30 2 20 2"/>
-  <rect id="_Transparent_Rectangle_" data-name="&lt;Transparent Rectangle&gt;" class="cls-1" width="32" height="32"/>
+<svg viewBox="0 0 32 32" width="32" xmlns="http://www.w3.org/2000/svg">
+  <g class="jp-icon3 jp-icon-selectable" fill="#616161">
+    <path d="M26,28H6a2.0027,2.0027,0,0,1-2-2V6A2.0027,2.0027,0,0,1,6,4H16V6H6V26H26V16h2V26A2.0027,2.0027,0,0,1,26,28Z"/>
+    <polygon points="20 2 20 4 26.586 4 18 12.586 19.414 14 28 5.414 28 12 30 12 30 2 20 2"/>
+  </g>
 </svg>


### PR DESCRIPTION
## References

Addresses some points from https://github.com/jupyterlab/jupyterlab/issues/11988#issuecomment-1029502096

## Code changes

Harmonize SVG code of newly added icon, add explicit color rule.

## User-facing changes

### Dark theme

Before:
![Screenshot from 2022-02-03 23-45-27](https://user-images.githubusercontent.com/5832902/152448027-fa75bb1a-501d-4907-bff9-21357a23def8.png)

After:

![Screenshot from 2022-02-03 23-40-24](https://user-images.githubusercontent.com/5832902/152447978-1f5e92c8-c1e9-4980-aea0-299525852822.png)

(Note: the font did not change, the "before" screenshots is just from 3.3 branch hence the stronger color in "Code Console settings" and slightly different font).

### Light theme

Before:

![Screenshot from 2022-02-03 23-40-57](https://user-images.githubusercontent.com/5832902/152447903-894b3b1d-fb58-461a-9c8b-0b3c1f3ac153.png)

After:

![Screenshot from 2022-02-03 23-41-04](https://user-images.githubusercontent.com/5832902/152447901-81c88b15-489c-4a9c-a530-337466bdf8c2.png)

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
