### PR TITLE
show pause on exception button when not available and change caption …

### DIFF
--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -721,19 +721,21 @@ const main: JupyterFrontEndPlugin<void> = {
     });
 
     commands.addCommand(CommandIDs.pause, {
-      label: service.isPausingOnExceptions
-        ? trans.__('Disable pausing on exceptions')
-        : trans.__('Enable pausing on exceptions'),
-      caption: trans.__('Enable / Disable pausing on exceptions'),
+      label: trans.__('Enable / Disable pausing on exceptions'),
+      caption: () =>
+        service.isStarted
+          ? service.pauseOnExceptionsIsValid()
+            ? service.isPausingOnExceptions
+              ? trans.__('Disable pausing on exceptions')
+              : trans.__('Enable pausing on exceptions')
+            : trans.__('Kernel does not support pausing on exceptions.')
+          : trans.__('Enable / Disable pausing on exceptions'),
       className: 'jp-PauseOnExceptions',
       icon: Debugger.Icons.pauseOnExceptionsIcon,
       isToggled: () => {
         return service.isPausingOnExceptions;
       },
       isEnabled: () => {
-        return !!service.isStarted;
-      },
-      isVisible: () => {
         return service.pauseOnExceptionsIsValid();
       },
       execute: async () => {


### PR DESCRIPTION
…to reflect status

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #11965
Closes #11970
<!-- Note any other pull requests that address this issue and how this pull request is different. -->
I used PR #11970 as my basis for this.
## Code changes

<!-- Describe the code changes and how they address the issue. -->
changes the caption for the pause_on_exception to reflect if a kernel does not support pausing.
## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
the caption for pause is changed depending on the kernel and debugger extension state.
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
