### PR TITLE
Automated Changelog Entry for 3.2.9 on 3.2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,33 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.2.9
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.2.8...dbfc96a51c872288f16b7340398bf99a3df14b1f))
+
+### Bugs fixed
+
+- Backport PR #11610 on branch 3.2.x (overrides.json definition takes precedence) [#11980](https://github.com/jupyterlab/jupyterlab/pull/11980) ([@fcollonval](https://github.com/fcollonval))
+- Fix autocomplete in console [#11949](https://github.com/jupyterlab/jupyterlab/pull/11949) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #11852 on branch 3.3.x (Add percent decoding to username) [#11865](https://github.com/jupyterlab/jupyterlab/pull/11865) ([@fcollonval](https://github.com/fcollonval))
+
+### Maintenance and upkeep improvements
+
+- Use `maintainer-tools` base setup action [#11595](https://github.com/jupyterlab/jupyterlab/pull/11595) ([@jtpio](https://github.com/jtpio))
+- Drop testing Python 3.6, test on Python 3.10 [#11646](https://github.com/jupyterlab/jupyterlab/pull/11646) ([@jtpio](https://github.com/jtpio))
+
+### Documentation improvements
+
+- Backport PR #11499 on branch 3.2.x (Update screenshots and text for user interface docs) [#11981](https://github.com/jupyterlab/jupyterlab/pull/11981) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-01-13&to=2022-02-04&type=c))
+
+[@andrewfulton9](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aandrewfulton9+updated%3A2022-01-13..2022-02-04&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-01-13..2022-02-04&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2022-01-13..2022-02-04&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-01-13..2022-02-04&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-01-13..2022-02-04&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-01-13..2022-02-04&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2022-01-13..2022-02-04&type=Issues) | [@isabela-pf](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aisabela-pf+updated%3A2022-01-13..2022-02-04&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-01-13..2022-02-04&type=Issues) | [@JohanMabille](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AJohanMabille+updated%3A2022-01-13..2022-02-04&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-01-13..2022-02-04&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2022-01-13..2022-02-04&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-01-13..2022-02-04&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-01-13..2022-02-04&type=Issues) | [@marthacryan](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Amarthacryan+updated%3A2022-01-13..2022-02-04&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-01-13..2022-02-04&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-01-13..2022-02-04&type=Issues) | [@mlucool](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Amlucool+updated%3A2022-01-13..2022-02-04&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-01-13..2022-02-04&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ayuvipanda+updated%3A2022-01-13..2022-02-04&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AZsailer+updated%3A2022-01-13..2022-02-04&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.2.8
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.2.7...b2402e5b9e0db0416b5f0e5ac29c9104a69f0c83))
@@ -26,8 +53,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-01-12&to=2022-01-13&type=c))
 
 [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-01-12..2022-01-13&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2022-01-12..2022-01-13&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-01-12..2022-01-13&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-01-12..2022-01-13&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-01-12..2022-01-13&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-01-12..2022-01-13&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.2.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 
 ### Bugs fixed
 
-- Backport PR #11610 on branch 3.2.x (overrides.json definition takes precedence) [#11980](https://github.com/jupyterlab/jupyterlab/pull/11980) ([@fcollonval](https://github.com/fcollonval))
+- overrides.json definition takes precedence [#11980](https://github.com/jupyterlab/jupyterlab/pull/11980) ([@fcollonval](https://github.com/fcollonval))
 - Fix autocomplete in console [#11949](https://github.com/jupyterlab/jupyterlab/pull/11949) ([@fcollonval](https://github.com/fcollonval))
-- Backport PR #11852 on branch 3.3.x (Add percent decoding to username) [#11865](https://github.com/jupyterlab/jupyterlab/pull/11865) ([@fcollonval](https://github.com/fcollonval))
+- Add percent decoding to username [#11865](https://github.com/jupyterlab/jupyterlab/pull/11865) ([@fcollonval](https://github.com/fcollonval))
 
 ### Maintenance and upkeep improvements
 
@@ -29,7 +29,7 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.2.x/CHANGELOG.md'
 
 ### Documentation improvements
 
-- Backport PR #11499 on branch 3.2.x (Update screenshots and text for user interface docs) [#11981](https://github.com/jupyterlab/jupyterlab/pull/11981) ([@fcollonval](https://github.com/fcollonval))
+- Update screenshots and text for user interface docs [#11981](https://github.com/jupyterlab/jupyterlab/pull/11981) ([@fcollonval](https://github.com/fcollonval))
 
 ### Contributors to this release
 


### PR DESCRIPTION
Automated Changelog Entry for 3.2.9 on 3.2.x
```
Python version: 3.2.9
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.2.9
@jupyterlab/buildutils: 3.2.9
@jupyterlab/template: 3.2.9
@jupyterlab/application-top: 3.2.9
@jupyterlab/example-app: 3.2.9
@jupyterlab/example-cell: 3.2.9
@jupyterlab/example-console: 3.2.9
@jupyterlab/example-federated: 2.3.9
@jupyterlab/example-federated-core: 2.3.9
@jupyterlab/example-federated-md: 2.3.9
@jupyterlab/example-federated-middle: 2.3.9
@jupyterlab/example-federated-phosphor: 2.3.9
@jupyterlab/example-filebrowser: 3.2.9
@jupyterlab/example-notebook: 3.2.9
@jupyterlab/example-terminal: 3.2.9
@jupyterlab/galata: 4.1.6
@jupyterlab/mock-extension: 3.2.9
@jupyterlab/mock-consumer: 3.2.9
@jupyterlab/mock-provider: 3.2.9
@jupyterlab/mock-token: 3.2.9
@jupyterlab/application: 3.2.9
@jupyterlab/application-extension: 3.2.9
@jupyterlab/apputils: 3.2.9
@jupyterlab/apputils-extension: 3.2.9
@jupyterlab/attachments: 3.2.9
@jupyterlab/cells: 3.2.9
@jupyterlab/celltags: 3.2.9
@jupyterlab/celltags-extension: 3.2.9
@jupyterlab/codeeditor: 3.2.9
@jupyterlab/codemirror: 3.2.9
@jupyterlab/codemirror-extension: 3.2.9
@jupyterlab/completer: 3.2.9
@jupyterlab/completer-extension: 3.2.9
@jupyterlab/console: 3.2.9
@jupyterlab/console-extension: 3.2.9
@jupyterlab/coreutils: 5.2.9
@jupyterlab/csvviewer: 3.2.9
@jupyterlab/csvviewer-extension: 3.2.9
@jupyterlab/debugger: 3.2.9
@jupyterlab/debugger-extension: 3.2.9
@jupyterlab/docmanager: 3.2.9
@jupyterlab/docmanager-extension: 3.2.9
@jupyterlab/docprovider: 3.2.9
@jupyterlab/docprovider-extension: 3.2.9
@jupyterlab/docregistry: 3.2.9
@jupyterlab/documentsearch: 3.2.9
@jupyterlab/documentsearch-extension: 3.2.9
@jupyterlab/extensionmanager: 3.2.9
@jupyterlab/extensionmanager-extension: 3.2.9
@jupyterlab/filebrowser: 3.2.9
@jupyterlab/filebrowser-extension: 3.2.9
@jupyterlab/fileeditor: 3.2.9
@jupyterlab/fileeditor-extension: 3.2.9
@jupyterlab/help-extension: 3.2.9
@jupyterlab/htmlviewer: 3.2.9
@jupyterlab/htmlviewer-extension: 3.2.9
@jupyterlab/hub-extension: 3.2.9
@jupyterlab/imageviewer: 3.2.9
@jupyterlab/imageviewer-extension: 3.2.9
@jupyterlab/inspector: 3.2.9
@jupyterlab/inspector-extension: 3.2.9
@jupyterlab/javascript-extension: 3.2.9
@jupyterlab/json-extension: 3.2.9
@jupyterlab/launcher: 3.2.9
@jupyterlab/launcher-extension: 3.2.9
@jupyterlab/logconsole: 3.2.9
@jupyterlab/logconsole-extension: 3.2.9
@jupyterlab/mainmenu: 3.2.9
@jupyterlab/mainmenu-extension: 3.2.9
@jupyterlab/markdownviewer: 3.2.9
@jupyterlab/markdownviewer-extension: 3.2.9
@jupyterlab/mathjax2: 3.2.9
@jupyterlab/mathjax2-extension: 3.2.9
@jupyterlab/metapackage: 3.2.9
@jupyterlab/nbconvert-css: 3.2.9
@jupyterlab/nbformat: 3.2.9
@jupyterlab/notebook: 3.2.9
@jupyterlab/notebook-extension: 3.2.9
@jupyterlab/observables: 4.2.9
@jupyterlab/outputarea: 3.2.9
@jupyterlab/pdf-extension: 3.2.9
@jupyterlab/property-inspector: 3.2.9
@jupyterlab/rendermime: 3.2.9
@jupyterlab/rendermime-extension: 3.2.9
@jupyterlab/rendermime-interfaces: 3.2.9
@jupyterlab/running: 3.2.9
@jupyterlab/running-extension: 3.2.9
@jupyterlab/services: 6.2.9
@jupyterlab/example-services-browser: 3.2.9
node-example: 3.2.9
@jupyterlab/example-services-outputarea: 3.2.9
@jupyterlab/settingeditor: 3.2.9
@jupyterlab/settingeditor-extension: 3.2.9
@jupyterlab/settingregistry: 3.2.9
@jupyterlab/shared-models: 3.2.9
@jupyterlab/shortcuts-extension: 3.2.9
@jupyterlab/statedb: 3.2.9
@jupyterlab/statusbar: 3.2.9
@jupyterlab/statusbar-extension: 3.2.9
@jupyterlab/terminal: 3.2.9
@jupyterlab/terminal-extension: 3.2.9
@jupyterlab/theme-dark-extension: 3.2.9
@jupyterlab/theme-light-extension: 3.2.9
@jupyterlab/toc: 5.2.9
@jupyterlab/toc-extension: 5.2.9
@jupyterlab/tooltip: 3.2.9
@jupyterlab/tooltip-extension: 3.2.9
@jupyterlab/translation: 3.2.9
@jupyterlab/translation-extension: 3.2.9
@jupyterlab/ui-components: 3.2.9
@jupyterlab/ui-components-extension: 3.2.9
@jupyterlab/vdom: 3.2.9
@jupyterlab/vdom-extension: 3.2.9
@jupyterlab/vega5-extension: 3.2.9
@jupyterlab/testutils: 3.2.9
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.2.x  |
| Version Spec | next |
| Since | v3.2.8 |