### PR TITLE
use path comparison instead of string comparisons

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -550,11 +550,11 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
 
     def initialize_templates(self):
         # Determine which model to run JupyterLab
-        if self.core_mode or self.app_dir.startswith(HERE):
+        if self.core_mode or HERE == os.path.commonpath([self.app_dir, HERE]):
             self.core_mode = True
             self.log.info('Running JupyterLab in core mode')
 
-        if self.dev_mode or self.app_dir.startswith(DEV_DIR):
+        if self.dev_mode or DEV_DIR == os.path.commonpath([self.app_dir, DEV_DIR]):
             self.dev_mode = True
             self.log.info('Running JupyterLab in dev mode')
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
https://github.com/jupyterlab/jupyterlab/issues/11850

## Code changes
Use path comparisons between `HERE` and `app.self_dir` in `initialize_templates()`

## User-facing changes
None

## Backwards-incompatible changes
None