### PR TITLE
fix run cells breaking on non-header markdown cells

### DIFF
--- a/packages/toc-extension/src/index.ts
+++ b/packages/toc-extension/src/index.ts
@@ -111,7 +111,11 @@ async function activateTOC(
         let level = activeCell.headingInfo.level;
         for (let i = cells.indexOf(activeCell) + 1; i < cells.length; i++) {
           const cell = cells[i];
-          if (cell instanceof MarkdownCell && cell.headingInfo.level <= level) {
+          if (
+            cell instanceof MarkdownCell &&
+            cell.headingInfo.level <= level &&
+            cell.headingInfo.level > -1
+          ) {
             break;
           }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #12026
If this could be backported to 3.3.x, that would be great too.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
in the toc-extension `runCells` command, the logic of when to break out of a loop running each code cell is amended so that the loop is not broken if `MarkdownCell.headingInfo.level` is equal to -1 (markdown cell is not a header)

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Now code cells under a ToC section are run after runCells is called even if they are under a non-header markdown cell
<!-- Describe any visual or user interaction changes and how they address the issue. -->
![chrome-capture (5)](https://user-images.githubusercontent.com/13774419/153062256-76e2cf94-196c-4f94-a920-92a781572d64.gif)

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None that I am aware