### PR TITLE
Debounce kernel sources filter

### DIFF
--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -69,6 +69,7 @@
     "@lumino/datagrid": "^0.35.1",
     "@lumino/disposable": "^1.10.1",
     "@lumino/messaging": "^1.10.1",
+    "@lumino/polling": "^1.10.0",
     "@lumino/signaling": "^1.10.1",
     "@lumino/widgets": "^1.31.1",
     "@vscode/debugprotocol": "^1.51.0",

--- a/packages/debugger/src/panels/kernelSources/filter.tsx
+++ b/packages/debugger/src/panels/kernelSources/filter.tsx
@@ -3,7 +3,7 @@
 
 import { InputGroup, ReactWidget, UseSignal } from '@jupyterlab/ui-components';
 
-import React, { useState } from 'react';
+import React from 'react';
 
 import { IDebugger } from '../../tokens';
 
@@ -15,21 +15,16 @@ export interface IFilterBoxProps {
 }
 
 const FilterBox = (props: IFilterBoxProps) => {
-  const [filter, setFilter] = useState('');
-  props.model.filterChanged.connect((_, filter) => {
-    setFilter(filter);
-  });
   const onFilterChange = (e: any) => {
     const filter = (e.target as HTMLInputElement).value;
     props.model.filter = filter;
-    setFilter(filter);
   };
   return (
     <InputGroup
       type="text"
       onChange={onFilterChange}
       placeholder="Filter the kernel sources"
-      value={filter}
+      value={props.model.filter}
     />
   );
 };
@@ -40,8 +35,8 @@ const FilterBox = (props: IFilterBoxProps) => {
 export const KernelSourcesFilter = (props: IFilterBoxProps): ReactWidget => {
   return ReactWidget.create(
     <UseSignal
-      signal={props.model.changed}
-      initialArgs={props.model.kernelSources}
+      signal={props.model.filterChanged}
+      initialArgs={props.model.filter}
     >
       {model => <FilterBox model={props.model} />}
     </UseSignal>

--- a/packages/debugger/src/panels/kernelSources/filter.tsx
+++ b/packages/debugger/src/panels/kernelSources/filter.tsx
@@ -3,7 +3,7 @@
 
 import { InputGroup, ReactWidget, UseSignal } from '@jupyterlab/ui-components';
 
-import React from 'react';
+import React, { useState } from 'react';
 
 import { IDebugger } from '../../tokens';
 
@@ -12,24 +12,24 @@ import { IDebugger } from '../../tokens';
  */
 export interface IFilterBoxProps {
   model: IDebugger.Model.IKernelSources;
-  onFilterChange?: (e: any) => void;
 }
 
 const FilterBox = (props: IFilterBoxProps) => {
-  /**
-   * Handler for search input changes.
-  const handleChange = (e: React.FormEvent<HTMLElement>) => {
-    const target = e.target as HTMLInputElement;
-    setFilter(target.value);
-    props.model.filter = target.value;
+  const [filter, setFilter] = useState('');
+  props.model.filterChanged.connect((_, filter) => {
+    setFilter(filter);
+  });
+  const onFilterChange = (e: any) => {
+    const filter = (e.target as HTMLInputElement).value;
+    props.model.filter = filter;
+    setFilter(filter);
   };
-  */
   return (
     <InputGroup
       type="text"
-      onChange={props.onFilterChange}
+      onChange={onFilterChange}
       placeholder="Filter the kernel sources"
-      value={props.model.filter}
+      value={filter}
     />
   );
 };
@@ -43,14 +43,7 @@ export const KernelSourcesFilter = (props: IFilterBoxProps): ReactWidget => {
       signal={props.model.changed}
       initialArgs={props.model.kernelSources}
     >
-      {model => (
-        <FilterBox
-          model={props.model}
-          onFilterChange={(e: any) => {
-            props.model.filter = (e.target as HTMLInputElement).value;
-          }}
-        />
-      )}
+      {model => <FilterBox model={props.model} />}
     </UseSignal>
   );
 };

--- a/packages/debugger/src/panels/kernelSources/model.ts
+++ b/packages/debugger/src/panels/kernelSources/model.ts
@@ -23,7 +23,7 @@ const compare = (a: IDebugger.KernelSource, b: IDebugger.KernelSource) => {
 export class KernelSourcesModel implements IDebugger.Model.IKernelSources {
   constructor() {
     this.refresh = this.refresh.bind(this);
-    this._debouncer = new Debouncer(this.refresh, 1000);
+    this._debouncer = new Debouncer(this.refresh, 500);
   }
 
   /**

--- a/packages/debugger/src/panels/kernelSources/model.ts
+++ b/packages/debugger/src/panels/kernelSources/model.ts
@@ -39,7 +39,7 @@ export class KernelSourcesModel implements IDebugger.Model.IKernelSources {
   set filter(filter: string) {
     this._filter = filter;
     this._filterChanged.emit(filter);
-    this._debouncer.invoke();
+    void this._debouncer.invoke();
   }
 
   /**

--- a/packages/debugger/src/tokens.ts
+++ b/packages/debugger/src/tokens.ts
@@ -934,6 +934,11 @@ export namespace IDebugger {
       >;
 
       /**
+       * Signal emitted when the kernel sources filter has changed.
+       */
+      readonly filterChanged: ISignal<IDebugger.Model.IKernelSources, string>;
+
+      /**
        * Signal emitted when a kernel source has be opened in the main area.
        */
       readonly kernelSourceOpened: ISignal<


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/12029

## Code changes

Add a debouncer that update the kernelsources after a filter change with a 1 second latency on inactivity.

## User-facing changes

![Untitled4](https://user-images.githubusercontent.com/226720/153133008-97d2a1a6-fee3-413a-8504-4ba436eed40e.gif)


## Backwards-incompatible changes

None.
