### PR TITLE
Polish settings editor

### DIFF
--- a/packages/codemirror-extension/schema/commands.json
+++ b/packages/codemirror-extension/schema/commands.json
@@ -207,24 +207,32 @@
         }
       ],
       "title": "Style Active Line",
-      "description": "Value is boolean, or { nonEmpty: boolean }",
+      "description": "Highlight active line. Value is boolean, or { nonEmpty: boolean }.",
       "default": false
     },
     "styleSelectedText": {
       "type": "boolean",
       "title": "Style Selected Text",
-      "description": "Value is boolean",
       "default": true
     },
     "selectionPointer": {
-      "oneOf": [{ "type": "boolean" }, { "type": "string" }],
+      "oneOf": [
+        {
+          "type": "boolean",
+          "title": "Use default"
+        },
+        {
+          "type": "string",
+          "title": "Cursor pointer name"
+        }
+      ],
       "title": "Selection Pointer",
-      "description": "Value is boolean or string, e.g. 'pointer'",
+      "description": "Control the mouse cursor appearance when hovering over the selection. Value is boolean or string, e.g. 'pointer'.",
       "default": false
     },
     "lineWiseCopyCut": {
       "type": ["boolean"],
-      "title": "Ctrl-C",
+      "title": "Line-wise Ctrl-C",
       "description": "When enabled, which is the default, doing copy or cut when there is no selection will copy or cut the whole lines that have cursors on them.",
       "default": true
     }

--- a/packages/console-extension/schema/tracker.json
+++ b/packages/console-extension/schema/tracker.json
@@ -107,7 +107,7 @@
         },
         "cursorBlinkRate": {
           "type": "number",
-          "title": "Cursor blinking rate",
+          "title": "Cursor Blinking Rate",
           "description": "Half-period in milliseconds used for cursor blinking. The default blink rate is 530ms. By setting this to zero, blinking can be disabled. A negative value hides the cursor entirely."
         },
         "fontFamily": {
@@ -126,7 +126,7 @@
         },
         "lineNumbers": {
           "type": "boolean",
-          "title": "Line Numbers"
+          "title": "Show Line Numbers"
         },
         "lineWrap": {
           "type": "string",
@@ -135,7 +135,7 @@
         },
         "matchBrackets": {
           "type": "boolean",
-          "title": "match"
+          "title": "Match Brackets"
         },
         "readOnly": {
           "type": "boolean",
@@ -165,7 +165,9 @@
           "title": "Code Folding"
         },
         "lineWiseCopyCut": {
-          "type": "boolean"
+          "type": "boolean",
+          "title": "Line-wise Ctrl-C",
+          "description": "When enabled, which is the default, doing copy or cut when there is no selection will copy or cut the whole lines that have cursors on them."
         }
       },
       "additionalProperties": false,

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -649,73 +649,89 @@
       "properties": {
         "autoClosingBrackets": {
           "type": "boolean",
-          "default": false
+          "default": false,
+          "title": "Auto Closing Brackets"
         },
         "cursorBlinkRate": {
           "type": "number",
-          "title": "Cursor blinking rate",
+          "title": "Cursor Blinking Rate",
           "description": "Half-period in milliseconds used for cursor blinking. The default blink rate is 530ms. By setting this to zero, blinking can be disabled. A negative value hides the cursor entirely.",
           "default": 530
         },
         "fontFamily": {
           "type": ["string", "null"],
-          "default": null
+          "default": null,
+          "title": "Font Family"
         },
         "fontSize": {
           "type": ["integer", "null"],
           "minimum": 1,
           "maximum": 100,
-          "default": null
+          "default": null,
+          "title": "Font Size"
         },
         "lineHeight": {
           "type": ["number", "null"],
-          "default": null
+          "default": null,
+          "title": "Line Height"
         },
         "lineNumbers": {
           "type": "boolean",
-          "default": false
+          "default": false,
+          "title": "Show Line Numbers"
         },
         "lineWrap": {
           "type": "string",
-          "enum": ["off", "on", "wordWrapColumn", "bounded"]
+          "enum": ["off", "on", "wordWrapColumn", "bounded"],
+          "title": "Line Wrap"
         },
         "matchBrackets": {
-          "type": "boolean"
+          "type": "boolean",
+          "title": "Match Brackets"
         },
         "readOnly": {
           "type": "boolean",
-          "default": false
+          "default": false,
+          "title": "Read Only"
         },
         "insertSpaces": {
           "type": "boolean",
-          "default": true
+          "default": true,
+          "title": "Insert Spaces"
         },
         "tabSize": {
           "type": "number",
-          "default": 4
+          "default": 4,
+          "title": "Tab Size"
         },
         "wordWrapColumn": {
           "type": "integer",
-          "default": 80
+          "default": 80,
+          "title": "Word Wrap Column"
         },
         "rulers": {
           "type": "array",
           "items": {
             "type": "number"
           },
+          "title": "Rulers",
           "default": []
         },
         "codeFolding": {
           "type": "boolean",
-          "default": false
+          "default": false,
+          "title": "Code Folding"
         },
         "lineWiseCopyCut": {
           "type": "boolean",
-          "default": true
+          "default": true,
+          "title": "Line-wise Ctrl-C",
+          "description": "When enabled, which is the default, doing copy or cut when there is no selection will copy or cut the whole lines that have cursors on them."
         },
         "showTrailingSpace": {
           "type": "boolean",
-          "default": false
+          "default": false,
+          "title": "Show Trailing Space"
         }
       },
       "additionalProperties": false,
@@ -859,8 +875,8 @@
       "default": "1000px"
     },
     "maxNumberOutputs": {
-      "title": "The maximum number of output cells to be rendered in the output area. Set to 0 to have the complete display.",
-      "description": "Defines the maximum number of output cells to be rendered in the output area for cells with many outputs. The output area will have a head and the remaining outputs will be trimmed and not displayed unless the user clicks on the information message.",
+      "title": "The maximum number of output cells to be rendered in the output area.",
+      "description": "Defines the maximum number of output cells to be rendered in the output area for cells with many outputs. The output area will have a head and the remaining outputs will be trimmed and not displayed unless the user clicks on the information message. Set to 0 to have the complete display.",
       "type": "number",
       "default": 50
     },

--- a/packages/settingeditor/src/SettingsFormEditor.tsx
+++ b/packages/settingeditor/src/SettingsFormEditor.tsx
@@ -311,11 +311,17 @@ export class SettingsFormEditor extends React.Component<
             this.props.onSelect(this.props.settings.id);
           }}
         >
-          <div className="jp-SettingsTitle">
-            <icon.react tag="span" elementPosition="center" />
-            <h2> {this.props.settings.schema.title} </h2>
-            <h3> {this.props.settings.schema.description} </h3>
-          </div>
+          <header className="jp-SettingsTitle">
+            <icon.react
+              tag="span"
+              elementPosition="center"
+              className="jp-SettingsTitle-caret"
+            />
+            <h2>{this.props.settings.schema.title}</h2>
+            <div className="jp-SettingsHeader-description">
+              {this.props.settings.schema.description}
+            </div>
+          </header>
           {this.state.isModified && (
             <button className="jp-RestoreButton" onClick={this.reset}>
               {trans.__('Restore to Defaults')}

--- a/packages/settingeditor/src/SettingsFormEditor.tsx
+++ b/packages/settingeditor/src/SettingsFormEditor.tsx
@@ -198,11 +198,18 @@ const CustomTemplate = (props: FieldTemplateProps) => {
     !schema.properties &&
     schema.type !== 'array' &&
     !JSONExt.deepEqual(formData, defaultValue);
+  const isRoot = schemaId === '';
+
+  const needsDescription =
+    !isRoot &&
+    schema.type != 'object' &&
+    id !=
+      'jp-SettingsEditor-@jupyterlab/shortcuts-extension:shortcuts_shortcuts';
 
   return (
     <div
       className={`form-group ${
-        (displayLabel || schema.type === 'boolean') && 'small-field'
+        displayLabel || schema.type === 'boolean' ? 'small-field' : ''
       }`}
     >
       {
@@ -213,11 +220,24 @@ const CustomTemplate = (props: FieldTemplateProps) => {
         // Shows a red indicator for fields that have validation errors
         rawErrors && <div className="jp-modifiedIndicator jp-errorIndicator" />
       }
-      <div>
-        {displayLabel && schemaId !== '' && <h3> {label} </h3>}
-        <div className={`${schemaId === '' ? 'root' : 'inputFieldWrapper'}`}>
+      <div className="jp-FormGroup-content">
+        {displayLabel && !isRoot && label && (
+          <h3 className="jp-FormGroup-fieldLabel">{label}</h3>
+        )}
+        <div
+          className={`${
+            isRoot
+              ? 'root'
+              : schema.type === 'object'
+              ? 'objectFieldWrapper'
+              : 'inputFieldWrapper'
+          }`}
+        >
           {children}
         </div>
+        {schema.description && needsDescription && (
+          <div className="jp-FormGroup-description">{schema.description}</div>
+        )}
         <div className="validationErrors">{errors}</div>
       </div>
     </div>

--- a/packages/settingeditor/style/base.css
+++ b/packages/settingeditor/style/base.css
@@ -10,6 +10,7 @@
   --jp-private-settingeditor-row-height: 16px;
   --jp-private-settingeditor-toolbar-height: 28px;
   --jp-private-settingeditor-type-width: 75px;
+  --jp-private-settingeditor-modifier-indent: 5px;
 }
 
 .jp-SettingsPanel,
@@ -231,13 +232,25 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
 .jp-SettingsPanel fieldset input[type='checkbox'] {
   position: relative;
   top: 2px;
+  margin-left: 0;
+}
+
+/** copy of `input.jp-mod-styled:focus` style */
+.jp-SettingsPanel fieldset input:focus {
+  border: var(--jp-border-width) solid var(--md-blue-500);
+  box-shadow: inset 0 0 4px var(--md-blue-300);
 }
 
 .jp-SettingsPanel .checkbox label {
   cursor: pointer;
 }
-.jp-SettingsPanel .checkbox label:not(:first-child) {
-  margin: 0.5em;
+
+.jp-SettingsPanel .checkbox .field-description {
+  /* Disable default description field for checkbox:
+   because other widgets do not have description fields,
+   we add descriptions to each widget on the field level.
+  */
+  display: none;
 }
 
 .jp-SettingsPanel button[type='submit'] {
@@ -245,22 +258,33 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
 }
 
 .jp-SettingsPanel .form-group {
-  padding: 0 16px 16px 5px;
+  padding: 8px 8px 8px var(--jp-private-settingeditor-modifier-indent);
   display: flex;
   margin-top: 5px;
+}
+
+.jp-SettingsPanel .jp-FormGroup-content {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.jp-SettingsPanel .jp-FormGroup-description {
+  flex-basis: 100%;
+  padding: 4px 7px;
 }
 
 .jp-SettingsPanel #root__description {
   display: none;
 }
 
-.jp-SettingsPanel .checkbox {
-  padding-top: 20px;
-}
-
 .jp-SettingsPanel fieldset {
   border: none;
   padding: 0;
+}
+
+.jp-SettingsPanel fieldset:not(:first-child) {
+  margin-left: 7px;
 }
 
 .jp-SettingsPanel .jp-SaveSettingsBanner {
@@ -339,6 +363,15 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
   margin: 4px;
 }
 
+.jp-SettingsPanel .field-array-of-string .array-item {
+  /* Display `jp-ArrayOperations` buttons side-by-side with content except
+    for small screens where flex-wrap will place them one below the other.
+  */
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
 .jp-SettingsPanel .root > fieldset > legend {
   display: none;
 }
@@ -361,18 +394,18 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
   line-height: var(--jp-content-font-size3);
 }
 
-.jp-SettingsPanel p {
-  font-size: var(--jp-content-font-size1);
-  margin: 0.5em;
-}
-
 .jp-SettingsPanel legend {
   font-size: var(--jp-content-font-size2);
   color: var(--jp-ui-font-color0);
   flex-basis: 100%;
-  padding: 0.5em;
+  padding: 4px 0;
   font-weight: var(--jp-content-header-font-weight);
   border-bottom: 1px solid var(--jp-border-color2);
+}
+
+.jp-SettingsPanel .field-description {
+  padding: 4px 0;
+  white-space: pre-wrap;
 }
 
 .jp-SettingsPanel .jp-SettingsTitle {
@@ -383,6 +416,7 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
 
 .jp-SettingsPanel .jp-SettingsTitle-caret {
   width: 2em;
+  flex-shrink: 0;
 }
 
 .jp-SettingsForm {
@@ -422,14 +456,15 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
   width: 5px;
   background-color: var(--jp-brand-color2);
   margin-top: 0;
-  margin-bottom: -16px;
-  margin-left: -5px;
+  margin-left: calc(var(--jp-private-settingeditor-modifier-indent) * -1);
+  flex-shrink: 0;
 }
 
-.jp-SettingsPanel .form-group h3 {
+.jp-SettingsPanel .jp-FormGroup-fieldLabel {
   font-size: var(--jp-content-font-size1);
-  font-weight: 500;
-  margin-left: 7px;
+  font-weight: normal;
+  margin: 0px 0px 0px 7px;
+  min-width: 120px;
 }
 
 .jp-SettingsPanel .inputFieldWrapper {

--- a/packages/settingeditor/style/base.css
+++ b/packages/settingeditor/style/base.css
@@ -362,12 +362,12 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
 }
 
 .jp-SettingsPanel p {
-  font-size: var(--jp-content-font-size2);
+  font-size: var(--jp-content-font-size1);
   margin: 0.5em;
 }
 
 .jp-SettingsPanel legend {
-  font-size: var(--jp-content-font-size3);
+  font-size: var(--jp-content-font-size2);
   color: var(--jp-ui-font-color0);
   flex-basis: 100%;
   padding: 0.5em;

--- a/packages/settingeditor/style/base.css
+++ b/packages/settingeditor/style/base.css
@@ -353,7 +353,7 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
   margin: 1em;
 }
 
-.jp-SettingsPanel .jp-SettingsHeader h3 {
+.jp-SettingsPanel .jp-SettingsHeader-description {
   font-size: var(--jp-content-font-size2);
   color: var(--jp-ui-font-color1);
   font-weight: 200;
@@ -381,7 +381,7 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
   padding-left: 1em;
 }
 
-.jp-SettingsPanel .jp-SettingsTitle span {
+.jp-SettingsPanel .jp-SettingsTitle-caret {
   width: 2em;
 }
 

--- a/packages/settingeditor/style/base.css
+++ b/packages/settingeditor/style/base.css
@@ -426,8 +426,7 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
   margin-left: -5px;
 }
 
-.jp-SettingsPanel .form-group h3,
-.jp-SettingsPanel .form-group p#field-description {
+.jp-SettingsPanel .form-group h3 {
   font-size: var(--jp-content-font-size1);
   font-weight: 500;
   margin-left: 7px;

--- a/packages/settingeditor/style/base.css
+++ b/packages/settingeditor/style/base.css
@@ -227,6 +227,7 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
   padding: 6px 8px;
   background: none;
   color: var(--jp-content-font-color0);
+  height: inherit;
 }
 
 .jp-SettingsPanel fieldset input[type='checkbox'] {
@@ -258,15 +259,28 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
 }
 
 .jp-SettingsPanel .form-group {
-  padding: 8px 8px 8px var(--jp-private-settingeditor-modifier-indent);
   display: flex;
+  padding: 4px 8px 4px var(--jp-private-settingeditor-modifier-indent);
   margin-top: 5px;
+}
+
+.jp-SettingsPanel .jp-objectFieldWrapper .form-group {
+  padding: 2px 8px 2px var(--jp-private-settingeditor-modifier-indent);
+  margin-top: 2px;
+}
+
+.jp-ArrayOperations {
+  margin-left: 8px;
 }
 
 .jp-SettingsPanel .jp-FormGroup-content {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
+}
+
+.jp-SettingsPanel .jp-FormGroup-contentItem {
+  margin-left: 7px;
 }
 
 .jp-SettingsPanel .jp-FormGroup-description {
@@ -311,25 +325,18 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
 .jp-SettingsPanel .form-group.small-field:hover {
   background: var(--jp-border-color3);
 }
-.jp-SettingsPanel .array-item button {
-  color: var(--jp-brand-color2);
-  background-color: var(--jp-layout-color2);
+
+.jp-SettingsPanel button.jp-mod-styled {
   cursor: pointer;
-  margin: 2px;
-  padding: 5px;
-  border: none;
-}
-.jp-SettingsPanel .array-item button:disabled {
-  color: var(--jp-brand-color3);
-  background-color: var(--jp-layout-color1);
-  cursor: not-allowed;
 }
 
-.jp-SettingsPanel .array-item button,
-.jp-SettingsPanel button.array-item-add {
-  box-shadow: none;
-  border: none;
-  padding: 10px;
+.jp-SettingsPanel button.jp-mod-styled:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.jp-SettingsPanel .array-item button {
+  margin: 2px;
 }
 
 .jp-openJSONSettingsEditor {
@@ -372,10 +379,10 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
   flex-wrap: wrap;
 }
 
-.jp-SettingsPanel .root > fieldset > legend {
+.jp-SettingsPanel .jp-root > fieldset > legend {
   display: none;
 }
-.jp-SettingsPanel .root > fieldset > p {
+.jp-SettingsPanel .jp-root > fieldset > p {
   display: none;
 }
 
@@ -463,12 +470,7 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
 .jp-SettingsPanel .jp-FormGroup-fieldLabel {
   font-size: var(--jp-content-font-size1);
   font-weight: normal;
-  margin: 0px 0px 0px 7px;
   min-width: 120px;
-}
-
-.jp-SettingsPanel .inputFieldWrapper {
-  margin-left: 7px;
 }
 
 .jp-SettingsPanel .jp-modifiedIndicator.jp-errorIndicator {


### PR DESCRIPTION
## References

Addresses major part of #11988.

## Code changes

Major bug fixes and usability fixes:
- fix object settings (Sidebar, Document Manager, +extensions like jupyterlab-lsp, eb9e0b4865588d49c1fa5e9783cdd51bb430b09c):
   - fix lack of ability to change key names
   - fix lack of ability to remove properties
   - fix button for adding properties lacking text and style
- fix all fields other than checkbox missing descriptions (e0fe70a5b65a6d7808d618c986c357baf5be00d8)
- add titles and descriptions to schema of some settings which were appearing as uninformative code-names

Styles:
- fix accordion/collapser icon getting shrunk on small screens for sections with longer titles
- fix contrast of buttons by using the native JupyterLab classes (eb9e0b4865588d49c1fa5e9783cdd51bb430b09c)
- make settings layout more compact:
  - by matching font size to hierarchy level (733693c205b5ac9780bf0f1c0928b3f7b26f5ac7)
  - by reducing padding, margins and displaying buttons next to items in arrays (e0fe70a5b65a6d7808d618c986c357baf5be00d8)

Accessibility fixes:
   - do not use `h3` as a description of `h2` (a6761d7bbe6254f22e392c0934ab740ff5bd0802)
   - fix lack of focus outline indicator by coping the native JupyterLab style (ideally we would find a way to just add appropriate class name to input fields which get created by rjsf)

## User-facing changes

<details>

### Sidebar customization is now possible

| Before | After |
|---|---|
| ![Screenshot from 2022-02-14 03-16-02](https://user-images.githubusercontent.com/5832902/153794284-0a309a18-d07a-4b0f-8f9f-602418508df5.png)  |  ![Screenshot from 2022-02-14 03-13-57](https://user-images.githubusercontent.com/5832902/153794304-b73d7184-b185-4a93-937c-12918aea0ba7.png) |

### Default viewers customization is now possible, newlines in descriptions are kept

| Before | After |
|---|---|
| ![Screenshot from 2022-02-14 03-22-40](https://user-images.githubusercontent.com/5832902/153794866-735d1998-8186-4507-a517-4c7209b592f2.png) | ![Screenshot from 2022-02-14 03-22-33](https://user-images.githubusercontent.com/5832902/153794868-60b0eb6e-424c-4eb7-8bce-c0f6b0de6ff7.png) |


### Descriptions are now shown for input fields

| Before | After |
|---|---|
| ![Screenshot from 2022-02-14 03-18-48](https://user-images.githubusercontent.com/5832902/153794530-335cd7dd-0d27-487c-b496-710b6b048db7.png) | ![Screenshot from 2022-02-14 03-13-34](https://user-images.githubusercontent.com/5832902/153794453-e517bed3-9a11-463a-9e55-b0c3b2987394.png) |

### Array template uses space to the left if available (and JupyterLab button styles)

| Before | After |
|---|---|
| ![Screenshot from 2022-02-14 03-20-38](https://user-images.githubusercontent.com/5832902/153794695-3d087a75-b66e-4887-9776-b076fb733fdc.png) | ![Screenshot from 2022-02-14 03-20-50](https://user-images.githubusercontent.com/5832902/153794692-1e74fdd7-bfe7-41ad-91bb-2ee10fd882bc.png) |

</details>

## Backwards-incompatible changes

None.