### PR TITLE
Parse URL parameters in user model

### DIFF
--- a/packages/user/package.json
+++ b/packages/user/package.json
@@ -47,8 +47,7 @@
     "@lumino/coreutils": "^1.12.0",
     "@lumino/signaling": "^1.10.1",
     "@lumino/virtualdom": "^1.14.1",
-    "@lumino/widgets": "^1.31.1",
-    "lib0": "^0.2.42"
+    "@lumino/widgets": "^1.31.1"
   },
   "devDependencies": {
     "@jupyterlab/testutils": "^4.0.0-alpha.4",

--- a/packages/user/src/model.ts
+++ b/packages/user/src/model.ts
@@ -3,7 +3,6 @@
 
 import { ISignal, Signal } from '@lumino/signaling';
 import { UUID } from '@lumino/coreutils';
-import * as env from 'lib0/environment';
 
 import { ICurrentUser, IUser, USER } from './tokens';
 import { getAnonymousUserName } from './utils';
@@ -154,9 +153,10 @@ export class User implements ICurrentUser {
    */
   private _fetchUser(): void {
     // Read username, color and initials from URL
-    let name = decodeURIComponent(env.getParam('--username', ''));
-    let color = env.getParam('--usercolor', '');
-    let initials = decodeURIComponent(env.getParam('--initials', ''));
+    const urlParams = new URLSearchParams(location.search);
+    let name = urlParams.get('username') || '';
+    let color = urlParams.get('usercolor') || '';
+    let initials = urlParams.get('initials') || '';
 
     const { localStorage } = window;
     const data = localStorage.getItem(USER);


### PR DESCRIPTION
Parse URL parameters without lib0 as suggested by @krassowski here: https://github.com/jupyterlab/jupyterlab/pull/11852#issuecomment-1011994165

## References
follow-up #11852

## Code changes
Removes lib0 from the user package.

## User-facing changes

## Backwards-incompatible changes
