### PR TITLE
Handle shutdown error

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -763,6 +763,9 @@ export class SessionContext implements ISessionContext {
    */
   private async _shutdownSession(): Promise<void> {
     const session = this._session;
+    // Capture starting values in case an error is raised.
+    const isTerminating = this._isTerminating;
+    const isReady = this._isReady;
     this._isTerminating = true;
     this._isReady = false;
     this._statusChanged.emit('terminating');
@@ -784,17 +787,17 @@ export class SessionContext implements ISessionContext {
         newValue: null
       });
     } catch (err) {
-      this._isTerminating = false;
-      this._isReady = true;
+      this._isTerminating = isTerminating;
+      this._isReady = isReady;
       const status = session?.kernel?.status;
       if (status === undefined) {
-        this._statusChanged.emit('unknown')
+        this._statusChanged.emit('unknown');
       } else {
         this._statusChanged.emit(status);
       }
       throw err;
     }
-    return
+    return;
   }
 
   /**
@@ -1403,8 +1406,9 @@ namespace Private {
 
     const body = document.createElement('div');
     const text = document.createElement('label');
-    text.textContent = `${trans.__('Select kernel for:')} "${sessionContext.name
-      }"`;
+    text.textContent = `${trans.__('Select kernel for:')} "${
+      sessionContext.name
+    }"`;
     body.appendChild(text);
 
     const options = getKernelSearch(sessionContext);
@@ -1469,12 +1473,12 @@ namespace Private {
       const specName = matches[0];
       console.warn(
         'No exact match found for ' +
-        specName +
-        ', using kernel ' +
-        specName +
-        ' that matches ' +
-        'language=' +
-        language
+          specName +
+          ', using kernel ' +
+          specName +
+          ' that matches ' +
+          'language=' +
+          language
       );
       return specName;
     }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

Fixes https://github.com/jupyterlab/jupyterlab/issues/12042

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Catch errors raised when attempting to shutdown a kernel through the SessionContext interface. If an error is raised, the SessionContext is reset back to its original status. 

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

This won't affect most users. This really becomes important in a remote kernel context, where kernel shutdown failures are more common.

Specifically, if [pending kernels](https://jupyter-client.readthedocs.io/en/stable/pending-kernels.html) are enabled, an [error is raised when a "pending kernel" is shutdown](https://github.com/jupyter/jupyter_client/blob/10decd25308c306b6005cbf271b96493824a83e8/jupyter_client/multikernelmanager.py#L260-L261). Without this change, the UI shows that the kernel is terminating when it's actually in a pending state.

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None 

This change should be backported to 3.3.x branch.