### PR TITLE
Settings UI gives an unreadable JSON dump

### DIFF
--- a/packages/settingeditor/src/SettingsFormEditor.tsx
+++ b/packages/settingeditor/src/SettingsFormEditor.tsx
@@ -22,6 +22,11 @@ import React from 'react';
 import { PluginList } from './pluginlist';
 
 /**
+ * Indentation to use when saving the settings as JSON document.
+ */
+const JSON_INDENTATION = 4;
+
+/**
  * Namespace for a React component that prepares the settings for a
  * given plugin to be rendered in the FormEditor.
  */
@@ -257,7 +262,7 @@ export class SettingsFormEditor extends React.Component<
       return;
     }
     this.props.settings
-      .save(JSON.stringify(this.state.formData))
+      .save(JSON.stringify(this.state.formData, undefined, JSON_INDENTATION))
       .then(() => {
         this.props.updateDirtyState(false);
         this.setState({ isModified: this.props.settings.isModified });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #12057

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Save form data to JSON using 4 spaces indentation.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Settings displayed in the raw JSON editor are indented after saved from the settings editor.
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A