### PR TITLE
Add scroll bar for horizontally overflowing, unshrinkable outputs

### DIFF
--- a/packages/outputarea/style/base.css
+++ b/packages/outputarea/style/base.css
@@ -22,6 +22,7 @@
 .jp-OutputArea-child {
   display: flex;
   flex-direction: row;
+  overflow-x: auto;
 }
 
 body[data-format='mobile'] .jp-OutputArea-child {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #12070

## Code changes

`.jp-OutputArea-child` overflow `auto` instead of `hidden`.

## User-facing changes

Adds a horizontal scroll bar for the case that horizontal overflow occurs.
![image](https://user-images.githubusercontent.com/847751/154505403-b1562e2a-46c1-4e8b-b4d7-af539cd84dce.png)

In the general case of no overflow, no visual changes are present.

![image](https://user-images.githubusercontent.com/847751/154505786-d1ecddb9-4c86-4016-8828-4762c67ee50d.png)

If output scrolling is enabled, the horizontal scrollbar will appear only once scrolled to the bottom (as it is in a different place in the DOM).

![image](https://user-images.githubusercontent.com/847751/154506093-a07b8833-8096-401e-a596-a7f16e13aa16.png)
![image](https://user-images.githubusercontent.com/847751/154506140-862668a5-c690-4b93-b2f0-bb68e7ca8f75.png)


## Backwards-incompatible changes

None.
