### PR TITLE
Log error on open document widget.

### DIFF
--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -592,6 +592,7 @@ export class DocumentManager implements IDocumentManager {
 
     // If the initial opening of the context fails, dispose of the widget.
     ready.catch(err => {
+      console.error(err)
       widget.close();
     });
 

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -592,7 +592,10 @@ export class DocumentManager implements IDocumentManager {
 
     // If the initial opening of the context fails, dispose of the widget.
     ready.catch(err => {
-      console.error(err)
+      console.error(
+        `Failed to initialize the context with '${factory.name}' for ${path}`,
+        err
+      );
       widget.close();
     });
 


### PR DESCRIPTION
## References

On document opening, the widget is disposed if the context initialization fails.  Since no error is logged, debugging the issue from the external extension is very hard.

## Code changes
Log the error in the try-catch block.

## User-facing changes
N/A

## Backwards-incompatible changes

N/A
