### PR TITLE
update status to unkown when kernel is shutdown from running kernels tab

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -562,7 +562,7 @@ export class SessionContext implements ISessionContext {
     }
 
     if (this._pendingKernelName === this.noKernelName) {
-      return 'idle';
+      return 'unknown';
     }
 
     if (!kernel && this._pendingKernelName) {

--- a/packages/apputils/test/sessioncontext.spec.ts
+++ b/packages/apputils/test/sessioncontext.spec.ts
@@ -370,10 +370,10 @@ describe('@jupyterlab/apputils', () => {
         expect(sessionContext.kernelDisplayStatus).toBe('initializing');
       });
 
-      it('should be "idle" if there is no current kernel', async () => {
+      it('should be "unknown" if there is no current kernel', async () => {
         await sessionContext.initialize();
         await sessionContext.shutdown();
-        expect(sessionContext.kernelDisplayStatus).toBe('idle');
+        expect(sessionContext.kernelDisplayStatus).toBe('unknown');
       });
     });
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

fixes https://github.com/jupyterlab/jupyterlab/issues/11984

## Code changes
This PR updates status of the kernel to unknown when the shutdown operation is invoked from running kernels tab. This behavior is similar to the shutdown operation invoked from kernel menu
