### PR TITLE
Automated Changelog Entry for 3.3.0rc0 on 3.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,16 +18,16 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.3.x/CHANGELOG.md'
 
 ### Enhancements made
 
-- Backport PR #11963 on branch 3.3.x (Support dynamic toolbar definition) [#12078](https://github.com/jupyterlab/jupyterlab/pull/12078) ([@fcollonval](https://github.com/fcollonval))
-- Backport PR #12030 on branch 3.3.x (Debounce kernel sources filter) [#12068](https://github.com/jupyterlab/jupyterlab/pull/12068) ([@fcollonval](https://github.com/fcollonval))
+- Support dynamic toolbar definition [#12078](https://github.com/jupyterlab/jupyterlab/pull/12078) ([@fcollonval](https://github.com/fcollonval))
+- Debounce kernel sources filter [#12068](https://github.com/jupyterlab/jupyterlab/pull/12068) ([@fcollonval](https://github.com/fcollonval))
 - Settings UI gives an unreadable JSON dump [#12064](https://github.com/jupyterlab/jupyterlab/pull/12064) ([@fcollonval](https://github.com/fcollonval))
-- Backport PR #12045 on branch 3.3.x (Polish settings editor) [#12061](https://github.com/jupyterlab/jupyterlab/pull/12061) ([@fcollonval](https://github.com/fcollonval))
-- show pause on exception button when not available and change caption … [#12005](https://github.com/jupyterlab/jupyterlab/pull/12005) ([@andrewfulton9](https://github.com/andrewfulton9))
+- Polish settings editor [#12061](https://github.com/jupyterlab/jupyterlab/pull/12061) ([@fcollonval](https://github.com/fcollonval))
+- Show pause on exception button when not available [#12005](https://github.com/jupyterlab/jupyterlab/pull/12005) ([@andrewfulton9](https://github.com/andrewfulton9))
 
 ### Bugs fixed
 
 - Handle shutdown error [#12048](https://github.com/jupyterlab/jupyterlab/pull/12048) ([@Zsailer](https://github.com/Zsailer))
-- use path-like comparison in initialize_templates() [#12024](https://github.com/jupyterlab/jupyterlab/pull/12024) ([@kellyyke](https://github.com/kellyyke))
+- use path-like comparison in `initialize_templates()` [#12024](https://github.com/jupyterlab/jupyterlab/pull/12024) ([@kellyyke](https://github.com/kellyyke))
 
 ### Documentation improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,35 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.3.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.3.0rc0
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.3.0b0...3e449cd2cfe0a7f6ac204f66f56f161fba7e0e49))
+
+### Enhancements made
+
+- Backport PR #11963 on branch 3.3.x (Support dynamic toolbar definition) [#12078](https://github.com/jupyterlab/jupyterlab/pull/12078) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #12030 on branch 3.3.x (Debounce kernel sources filter) [#12068](https://github.com/jupyterlab/jupyterlab/pull/12068) ([@fcollonval](https://github.com/fcollonval))
+- Settings UI gives an unreadable JSON dump [#12064](https://github.com/jupyterlab/jupyterlab/pull/12064) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #12045 on branch 3.3.x (Polish settings editor) [#12061](https://github.com/jupyterlab/jupyterlab/pull/12061) ([@fcollonval](https://github.com/fcollonval))
+- show pause on exception button when not available and change caption … [#12005](https://github.com/jupyterlab/jupyterlab/pull/12005) ([@andrewfulton9](https://github.com/andrewfulton9))
+
+### Bugs fixed
+
+- Handle shutdown error [#12048](https://github.com/jupyterlab/jupyterlab/pull/12048) ([@Zsailer](https://github.com/Zsailer))
+- use path-like comparison in initialize_templates() [#12024](https://github.com/jupyterlab/jupyterlab/pull/12024) ([@kellyyke](https://github.com/kellyyke))
+
+### Documentation improvements
+
+- Fix anchors and myst configuration [#12063](https://github.com/jupyterlab/jupyterlab/pull/12063) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-02-10&to=2022-02-18&type=c))
+
+[@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-02-10..2022-02-18&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-02-10..2022-02-18&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-02-10..2022-02-18&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-02-10..2022-02-18&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-02-10..2022-02-18&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-02-10..2022-02-18&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-02-10..2022-02-18&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-02-10..2022-02-18&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-02-10..2022-02-18&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-02-10..2022-02-18&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.3.0b0
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.3.0a3...878dd5d9b03878b5e57e61c4089cc4d9873fa236))
@@ -35,8 +64,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.3.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-02-03&to=2022-02-10&type=c))
 
 [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2022-02-03..2022-02-10&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-02-03..2022-02-10&type=Issues) | [@ErikBjare](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AErikBjare+updated%3A2022-02-03..2022-02-10&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-02-03..2022-02-10&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-02-03..2022-02-10&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-02-03..2022-02-10&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-02-03..2022-02-10&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-02-03..2022-02-10&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-02-03..2022-02-10&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-02-03..2022-02-10&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrungleduc+updated%3A2022-02-03..2022-02-10&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-02-03..2022-02-10&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.3.0a3
 


### PR DESCRIPTION
Automated Changelog Entry for 3.3.0rc0 on 3.3.x
```
Python version: 3.3.0rc0
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.3.0-rc.0
@jupyterlab/buildutils: 3.3.0-rc.0
@jupyterlab/template: 3.3.0-rc.0
@jupyterlab/application-top: 3.3.0-rc.0
@jupyterlab/example-app: 3.3.0-rc.0
@jupyterlab/example-cell: 3.3.0-rc.0
@jupyterlab/example-console: 3.3.0-rc.0
@jupyterlab/example-federated: 2.4.0-rc.0
@jupyterlab/example-federated-core: 2.4.0-rc.0
@jupyterlab/example-federated-md: 2.4.0-rc.0
@jupyterlab/example-federated-middle: 2.4.0-rc.0
@jupyterlab/example-federated-phosphor: 2.4.0-rc.0
@jupyterlab/example-filebrowser: 3.3.0-rc.0
@jupyterlab/example-notebook: 3.3.0-rc.0
@jupyterlab/example-terminal: 3.3.0-rc.0
@jupyterlab/galata: 4.2.0-rc.0
@jupyterlab/mock-extension: 3.3.0-rc.0
@jupyterlab/mock-consumer: 3.3.0-rc.0
@jupyterlab/mock-provider: 3.3.0-rc.0
@jupyterlab/mock-token: 3.3.0-rc.0
@jupyterlab/application: 3.3.0-rc.0
@jupyterlab/application-extension: 3.3.0-rc.0
@jupyterlab/apputils: 3.3.0-rc.0
@jupyterlab/apputils-extension: 3.3.0-rc.0
@jupyterlab/attachments: 3.3.0-rc.0
@jupyterlab/cells: 3.3.0-rc.0
@jupyterlab/celltags: 3.3.0-rc.0
@jupyterlab/celltags-extension: 3.3.0-rc.0
@jupyterlab/codeeditor: 3.3.0-rc.0
@jupyterlab/codemirror: 3.3.0-rc.0
@jupyterlab/codemirror-extension: 3.3.0-rc.0
@jupyterlab/completer: 3.3.0-rc.0
@jupyterlab/completer-extension: 3.3.0-rc.0
@jupyterlab/console: 3.3.0-rc.0
@jupyterlab/console-extension: 3.3.0-rc.0
@jupyterlab/coreutils: 5.3.0-rc.0
@jupyterlab/csvviewer: 3.3.0-rc.0
@jupyterlab/csvviewer-extension: 3.3.0-rc.0
@jupyterlab/debugger: 3.3.0-rc.0
@jupyterlab/debugger-extension: 3.3.0-rc.0
@jupyterlab/docmanager: 3.3.0-rc.0
@jupyterlab/docmanager-extension: 3.3.0-rc.0
@jupyterlab/docprovider: 3.3.0-rc.0
@jupyterlab/docprovider-extension: 3.3.0-rc.0
@jupyterlab/docregistry: 3.3.0-rc.0
@jupyterlab/documentsearch: 3.3.0-rc.0
@jupyterlab/documentsearch-extension: 3.3.0-rc.0
@jupyterlab/extensionmanager: 3.3.0-rc.0
@jupyterlab/extensionmanager-extension: 3.3.0-rc.0
@jupyterlab/filebrowser: 3.3.0-rc.0
@jupyterlab/filebrowser-extension: 3.3.0-rc.0
@jupyterlab/fileeditor: 3.3.0-rc.0
@jupyterlab/fileeditor-extension: 3.3.0-rc.0
@jupyterlab/help-extension: 3.3.0-rc.0
@jupyterlab/htmlviewer: 3.3.0-rc.0
@jupyterlab/htmlviewer-extension: 3.3.0-rc.0
@jupyterlab/hub-extension: 3.3.0-rc.0
@jupyterlab/imageviewer: 3.3.0-rc.0
@jupyterlab/imageviewer-extension: 3.3.0-rc.0
@jupyterlab/inspector: 3.3.0-rc.0
@jupyterlab/inspector-extension: 3.3.0-rc.0
@jupyterlab/javascript-extension: 3.3.0-rc.0
@jupyterlab/json-extension: 3.3.0-rc.0
@jupyterlab/launcher: 3.3.0-rc.0
@jupyterlab/launcher-extension: 3.3.0-rc.0
@jupyterlab/logconsole: 3.3.0-rc.0
@jupyterlab/logconsole-extension: 3.3.0-rc.0
@jupyterlab/mainmenu: 3.3.0-rc.0
@jupyterlab/mainmenu-extension: 3.3.0-rc.0
@jupyterlab/markdownviewer: 3.3.0-rc.0
@jupyterlab/markdownviewer-extension: 3.3.0-rc.0
@jupyterlab/mathjax2: 3.3.0-rc.0
@jupyterlab/mathjax2-extension: 3.3.0-rc.0
@jupyterlab/metapackage: 3.3.0-rc.0
@jupyterlab/nbconvert-css: 3.3.0-rc.0
@jupyterlab/nbformat: 3.3.0-rc.0
@jupyterlab/notebook: 3.3.0-rc.0
@jupyterlab/notebook-extension: 3.3.0-rc.0
@jupyterlab/observables: 4.3.0-rc.0
@jupyterlab/outputarea: 3.3.0-rc.0
@jupyterlab/pdf-extension: 3.3.0-rc.0
@jupyterlab/property-inspector: 3.3.0-rc.0
@jupyterlab/rendermime: 3.3.0-rc.0
@jupyterlab/rendermime-extension: 3.3.0-rc.0
@jupyterlab/rendermime-interfaces: 3.3.0-rc.0
@jupyterlab/running: 3.3.0-rc.0
@jupyterlab/running-extension: 3.3.0-rc.0
@jupyterlab/services: 6.3.0-rc.0
@jupyterlab/example-services-browser: 3.3.0-rc.0
node-example: 3.3.0-rc.0
@jupyterlab/example-services-outputarea: 3.3.0-rc.0
@jupyterlab/settingeditor: 3.3.0-rc.0
@jupyterlab/settingeditor-extension: 3.3.0-rc.0
@jupyterlab/settingregistry: 3.3.0-rc.0
@jupyterlab/shared-models: 3.3.0-rc.0
@jupyterlab/shortcuts-extension: 3.3.0-rc.0
@jupyterlab/statedb: 3.3.0-rc.0
@jupyterlab/statusbar: 3.3.0-rc.0
@jupyterlab/statusbar-extension: 3.3.0-rc.0
@jupyterlab/terminal: 3.3.0-rc.0
@jupyterlab/terminal-extension: 3.3.0-rc.0
@jupyterlab/theme-dark-extension: 3.3.0-rc.0
@jupyterlab/theme-light-extension: 3.3.0-rc.0
@jupyterlab/toc: 5.3.0-rc.0
@jupyterlab/toc-extension: 5.3.0-rc.0
@jupyterlab/tooltip: 3.3.0-rc.0
@jupyterlab/tooltip-extension: 3.3.0-rc.0
@jupyterlab/translation: 3.3.0-rc.0
@jupyterlab/translation-extension: 3.3.0-rc.0
@jupyterlab/ui-components: 3.3.0-rc.0
@jupyterlab/ui-components-extension: 3.3.0-rc.0
@jupyterlab/vdom: 3.3.0-rc.0
@jupyterlab/vdom-extension: 3.3.0-rc.0
@jupyterlab/vega5-extension: 3.3.0-rc.0
@jupyterlab/testutils: 3.3.0-rc.0
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.3.x  |
| Version Spec | release |
| Since | v3.3.0b0 |