### PR TITLE
add "Toggle Contextual Help" command

### DIFF
--- a/packages/inspector-extension/schema/inspector.json
+++ b/packages/inspector-extension/schema/inspector.json
@@ -24,7 +24,7 @@
   },
   "jupyter.lab.shortcuts": [
     {
-      "command": "inspector:open",
+      "command": "inspector:toggle",
       "keys": ["Accel I"],
       "selector": "body"
     }

--- a/packages/inspector-extension/schema/inspector.json
+++ b/packages/inspector-extension/schema/inspector.json
@@ -31,7 +31,7 @@
     {
       "command": "inspector:close",
       "keys": ["Accel I"],
-      "selector": ".jp-Inspector"
+      "selector": "body[data-jp-inspector='open']"
     }
   ],
   "properties": {},

--- a/packages/inspector-extension/schema/inspector.json
+++ b/packages/inspector-extension/schema/inspector.json
@@ -24,9 +24,14 @@
   },
   "jupyter.lab.shortcuts": [
     {
-      "command": "inspector:toggle",
+      "command": "inspector:open",
       "keys": ["Accel I"],
       "selector": "body"
+    },
+    {
+      "command": "inspector:close",
+      "keys": ["Accel I"],
+      "selector": ".jp-Inspector"
     }
   ],
   "properties": {},

--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -33,6 +33,7 @@ import { inspectorIcon } from '@jupyterlab/ui-components';
  */
 namespace CommandIDs {
   export const open = 'inspector:open';
+  export const close = 'inspector:close';
   export const toggle = 'inspector:toggle';
 }
 
@@ -90,6 +91,7 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
     }
 
     // Add inspector:open command to registry.
+    const showLabel = trans.__('Show Contextual Help');
     commands.addCommand(CommandIDs.open, {
       caption,
       isEnabled: () =>
@@ -97,7 +99,7 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
         inspector.isDisposed ||
         !inspector.isAttached ||
         !inspector.isVisible,
-      label: trans.__('Show Contextual Help'),
+      label: showLabel,
       icon: args => (args.isLauncher ? inspectorIcon : undefined),
       execute: args => {
         const text = args && (args.text as string);
@@ -109,11 +111,22 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
       }
     });
 
+    // Add inspector:close command to registry.
+    const closeLabel = trans.__('Hide Contextual Help');
+    commands.addCommand(CommandIDs.close, {
+      caption,
+      isEnabled: () => isInspectorOpen(),
+      label: closeLabel,
+      icon: args => (args.isLauncher ? inspectorIcon : undefined),
+      execute: () => inspector.dispose()
+    });
+
     // Add inspector:toggle command to registry.
-    const label = trans.__('Toggle Contextual Help');
+    const toggleLabel = trans.__('Show Contextual Help');
     commands.addCommand(CommandIDs.toggle, {
       caption,
-      label,
+      label: toggleLabel,
+      isToggled: () => isInspectorOpen(),
       execute: args => {
         if (isInspectorOpen()) {
           inspector.dispose();
@@ -131,7 +144,7 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
 
     // Add toggle command to command palette if possible.
     if (palette) {
-      palette.addItem({ command: CommandIDs.toggle, category: label });
+      palette.addItem({ command: CommandIDs.toggle, category: toggleLabel });
     }
 
     // Handle state restoration.

--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -97,7 +97,7 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
         inspector.isDisposed ||
         !inspector.isAttached ||
         !inspector.isVisible,
-      label: () => trans.__('Show Contextual Help'),
+      label: trans.__('Show Contextual Help'),
       icon: args => (args.isLauncher ? inspectorIcon : undefined),
       execute: args => {
         const text = args && (args.text as string);
@@ -129,7 +129,7 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
       launcher.add({ command: CommandIDs.open, args: { isLauncher: true } });
     }
 
-    // Add toggle command to command palette is possible.
+    // Add toggle command to command palette if possible.
     if (palette) {
       palette.addItem({ command: CommandIDs.toggle, category: label });
     }

--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -54,7 +54,9 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
   ): IInspector => {
     const trans = translator.load('jupyterlab');
     const { commands, shell } = app;
-    const caption = trans.__('Live updating code documentation from the active kernel');
+    const caption = trans.__(
+      'Live updating code documentation from the active kernel'
+    );
     const openedLabel = trans.__('Contextual Help');
     const namespace = 'inspector';
     const tracker = new WidgetTracker<MainAreaWidget<InspectorPanel>>({
@@ -64,7 +66,7 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
     function isInspectorOpen() {
       return inspector && !inspector.isDisposed;
     }
-  
+
     let source: IInspector.IInspectable | null = null;
     let inspector: MainAreaWidget<InspectorPanel>;
     function openInspector(args: string): MainAreaWidget<InspectorPanel> {
@@ -90,7 +92,7 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
     // Add inspector:open command to registry.
     commands.addCommand(CommandIDs.open, {
       caption,
-      isEnabled: () => 
+      isEnabled: () =>
         !inspector ||
         inspector.isDisposed ||
         !inspector.isAttached ||
@@ -112,11 +114,11 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
     commands.addCommand(CommandIDs.toggle, {
       caption,
       label,
-      execute: (args) => {
+      execute: args => {
         if (isInspectorOpen()) {
-          inspector.dispose()
+          inspector.dispose();
         } else {
-          const text = args && (args.text as string)
+          const text = args && (args.text as string);
           openInspector(text);
         }
       }
@@ -134,7 +136,10 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
 
     // Handle state restoration.
     if (restorer) {
-      void restorer.restore(tracker, { command: CommandIDs.toggle, name: () => 'inspector' });
+      void restorer.restore(tracker, {
+        command: CommandIDs.toggle,
+        name: () => 'inspector'
+      });
     }
 
     // Create a proxy to pass the `source` to the current inspector.

--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -60,6 +60,7 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
     );
     const openedLabel = trans.__('Contextual Help');
     const namespace = 'inspector';
+    const datasetKey = 'jpInspector';
     const tracker = new WidgetTracker<MainAreaWidget<InspectorPanel>>({
       namespace
     });
@@ -87,7 +88,12 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
         shell.add(inspector, 'main', { activate: false, mode: 'split-right' });
       }
       shell.activateById(inspector.id);
+      document.body.dataset[datasetKey] = 'open';
       return inspector;
+    }
+    function closeInspector(): void {
+      inspector.dispose();
+      delete document.body.dataset[datasetKey];
     }
 
     // Add inspector:open command to registry.
@@ -118,7 +124,7 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
       isEnabled: () => isInspectorOpen(),
       label: closeLabel,
       icon: args => (args.isLauncher ? inspectorIcon : undefined),
-      execute: () => inspector.dispose()
+      execute: () => closeInspector()
     });
 
     // Add inspector:toggle command to registry.
@@ -129,7 +135,7 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
       isToggled: () => isInspectorOpen(),
       execute: args => {
         if (isInspectorOpen()) {
-          inspector.dispose();
+          closeInspector();
         } else {
           const text = args && (args.text as string);
           openInspector(text);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Addresses #12021

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Adds a new inspector:toggle command that will toggle whether the Contextual Help tab is shown or not. This command is used for the keyboard shortcut and added to the command palette, while the original inspector:open command continues to be used for the launcher. This was suggested by @krassowski in #12021.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
[Accel I] can now be used to open and close the Contextual Help tab, whereas before it could only open the tab.

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
