### PR TITLE
Document search debounce time via setting

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -39,6 +39,9 @@ bumped their major version (following semver convention):
    ``@jupyterlab/toc:plugin`` renamed ``@jupyterlab/toc-extension:registry``
    This may impact application configuration (for instance if the plugin was disabled).
    The namespace ``TableOfContentsRegistry`` has been renamed ``ITableOfContentsRegistry``.
+- ``@jupyterlab/documentsearch`` from 3.x to 4.x
+   ``@jupyterlab/documentsearch:plugin`` renamed ``@jupyterlab/documentsearch-extension:plugin``
+   This may impact application configuration (for instance if the plugin was disabled).
 - ``@jupyterlab/console`` from 3.x to 4.x
    The type of ``IConsoleHistory.sessionContext`` has been updated to ``ISessionContext | null`` instead of ``ISessionContext``.
    This might break the compilation of plugins accessing the ``sessionContext`` from a ``ConsoleHistory``,

--- a/examples/notebook/src/commands.ts
+++ b/examples/notebook/src/commands.ts
@@ -88,7 +88,7 @@ export const SetupCommands = (
         return;
       }
       const provider = new NotebookSearchProvider();
-      searchInstance = new SearchInstance(nbWidget, provider);
+      searchInstance = new SearchInstance(nbWidget, 500, provider);
       searchInstance.disposed.connect(() => {
         searchInstance = undefined;
         // find next and previous are now not enabled

--- a/examples/notebook/src/commands.ts
+++ b/examples/notebook/src/commands.ts
@@ -88,7 +88,7 @@ export const SetupCommands = (
         return;
       }
       const provider = new NotebookSearchProvider();
-      searchInstance = new SearchInstance(nbWidget, 500, provider);
+      searchInstance = new SearchInstance(nbWidget, provider, 500);
       searchInstance.disposed.connect(() => {
         searchInstance = undefined;
         // find next and previous are now not enabled

--- a/packages/documentsearch-extension/package.json
+++ b/packages/documentsearch-extension/package.json
@@ -36,6 +36,7 @@
     "@jupyterlab/application": "^4.0.0-alpha.5",
     "@jupyterlab/apputils": "^4.0.0-alpha.5",
     "@jupyterlab/documentsearch": "^4.0.0-alpha.5",
+    "@jupyterlab/settingregistry": "^4.0.0-alpha.5",
     "@jupyterlab/translation": "^4.0.0-alpha.5",
     "@lumino/widgets": "^1.31.1"
   },

--- a/packages/documentsearch-extension/schema/plugin.json
+++ b/packages/documentsearch-extension/schema/plugin.json
@@ -50,10 +50,10 @@
   "properties": {
     "searchDebounceTime": {
       "title": "Search debounce time (ms)",
-      "description": "The debounce time in milliseconds applied to the search input field",
+      "description": "The debounce time in milliseconds applied to the search input field. The already opened input fileds will not be updated if you change that value",
       "type": "number",
       "default": 500,
-      "exclusiveMinimum": 0
+      "minimum": 0
     }
   },
   "additionalProperties": false,

--- a/packages/documentsearch-extension/schema/plugin.json
+++ b/packages/documentsearch-extension/schema/plugin.json
@@ -52,7 +52,8 @@
       "title": "Search debounce time (ms)",
       "description": "The debounce time in milliseconds applied to the search input field",
       "type": "number",
-      "default": 500
+      "default": 500,
+      "exclusiveMinimum": 0
     }
   },
   "additionalProperties": false,

--- a/packages/documentsearch-extension/schema/plugin.json
+++ b/packages/documentsearch-extension/schema/plugin.json
@@ -47,7 +47,14 @@
       "selector": ".jp-mod-searchable"
     }
   ],
-  "properties": {},
+  "properties": {
+    "searchDebounceTime": {
+      "title": "Search debounce time (ms)",
+      "description": "The debounce time in milliseconds applied to the search input field",
+      "type": "number",
+      "default": 500
+    }
+  },
   "additionalProperties": false,
   "type": "object"
 }

--- a/packages/documentsearch-extension/schema/plugin.json
+++ b/packages/documentsearch-extension/schema/plugin.json
@@ -50,7 +50,7 @@
   "properties": {
     "searchDebounceTime": {
       "title": "Search debounce time (ms)",
-      "description": "The debounce time in milliseconds applied to the search input field. The already opened input fileds will not be updated if you change that value",
+      "description": "The debounce time in milliseconds applied to the search input field. The already opened input files will not be updated if you change that value",
       "type": "number",
       "default": 500,
       "minimum": 0

--- a/packages/documentsearch-extension/src/index.ts
+++ b/packages/documentsearch-extension/src/index.ts
@@ -107,11 +107,8 @@ const extension: JupyterFrontEndPlugin<ISearchProviderRegistry> = {
     if (settingRegistry) {
       const loadSettings = settingRegistry.load(extension.id);
       const updateSettings = (settings: ISettingRegistry.ISettings): void => {
-        const searchDebounceTimeSetting = settings.get('searchDebounceTime')
+        searchDebounceTime = settings.get('searchDebounceTime')
           .composite as number;
-        if (searchDebounceTime) {
-          searchDebounceTime = searchDebounceTimeSetting;
-        }
       };
 
       Promise.all([loadSettings, app.restored])

--- a/packages/documentsearch-extension/tsconfig.json
+++ b/packages/documentsearch-extension/tsconfig.json
@@ -16,6 +16,9 @@
       "path": "../documentsearch"
     },
     {
+      "path": "../settingregistry"
+    },
+    {
       "path": "../translation"
     }
   ]

--- a/packages/documentsearch/src/searchinstance.ts
+++ b/packages/documentsearch/src/searchinstance.ts
@@ -17,6 +17,7 @@ export class SearchInstance implements IDisposable {
   constructor(
     widget: Widget,
     searchProvider: ISearchProvider,
+    searchDebounceTime: number,
     translator?: ITranslator
   ) {
     this.translator = translator || nullTranslator;
@@ -39,6 +40,7 @@ export class SearchInstance implements IDisposable {
       onEndSearch: this.dispose.bind(this),
       isReadOnly: this._activeProvider.isReadOnly,
       hasOutputs: this._activeProvider.hasOutputs || false,
+      searchDebounceTime: searchDebounceTime,
       translator: this.translator
     });
 

--- a/packages/documentsearch/src/searchoverlay.tsx
+++ b/packages/documentsearch/src/searchoverlay.tsx
@@ -361,6 +361,7 @@ interface ISearchOverlayProps {
   onReplaceAll: (t: string) => void;
   isReadOnly: boolean;
   hasOutputs: boolean;
+  searchDebounceTime: number;
   translator?: ITranslator;
 }
 
@@ -373,6 +374,9 @@ class SearchOverlay extends React.Component<
     this.translator = props.translator || nullTranslator;
     this.state = props.overlayState;
     this.replaceEntryRef = React.createRef();
+    this._debouncedStartSearch = new Debouncer(() => {
+      this._executeSearch(true, this.state.searchText);
+    }, props.searchDebounceTime);
     this._toggleSearchOutput = this._toggleSearchOutput.bind(this);
     this._toggleSearchSelectedCells = this._toggleSearchSelectedCells.bind(
       this
@@ -636,9 +640,7 @@ class SearchOverlay extends React.Component<
   protected translator: ITranslator;
   private replaceEntryRef: React.RefObject<ReplaceEntry>;
 
-  private _debouncedStartSearch = new Debouncer(() => {
-    this._executeSearch(true, this.state.searchText);
-  }, 500);
+  private _debouncedStartSearch: Debouncer;
 }
 
 export function createSearchOverlay(
@@ -657,6 +659,7 @@ export function createSearchOverlay(
     onEndSearch,
     isReadOnly,
     hasOutputs,
+    searchDebounceTime,
     translator
   } = options;
   const widget = ReactWidget.create(
@@ -675,6 +678,7 @@ export function createSearchOverlay(
             overlayState={args!}
             isReadOnly={isReadOnly}
             hasOutputs={hasOutputs}
+            searchDebounceTime={searchDebounceTime}
             translator={translator}
           />
         );
@@ -699,6 +703,7 @@ namespace createSearchOverlay {
     onReplaceAll: (t: string) => void;
     isReadOnly: boolean;
     hasOutputs: boolean;
+    searchDebounceTime: number;
     translator?: ITranslator;
   }
 }


### PR DESCRIPTION
## References

Mitigates https://github.com/jupyterlab/jupyterlab/issues/11876

## Code changes

A setting `searchDebounceTime` is added in the `documentsearch-extension`

## User-facing changes

The use can configure the debounce time to e.g. a large value and use `Enter` to trigger the search in the document when he wants. This mitigates performance issue while searching in large documents.

## Backwards-incompatible changes

@fcollonval Once merged, I'd like to backport this in 3.3.x if still time. Regarding backwards compatibly, it is not clear to me:

- I had to change the id of the documentsearch-extension from `'@jupyterlab/documentsearch:plugin',` to  `'@jupyterlab/documentsearch-extension:plugin',` - This is needed to load the plugin.json.
- For now, I propagate the `searchDebounceTime` value to some object constructor and mandatory attributed. It is not clear to me what `Backwards compatible` is. If it is the extension point only, this is backwards compatible. If any object constructor or method signature is changed, then this is not backwards compatible. I can make it backwards compatible providing default values in the changed constructors. WDYT?
