### PR TITLE
Improve toggled button styles in debugger.

### DIFF
--- a/packages/debugger/style/icons.css
+++ b/packages/debugger/style/icons.css
@@ -24,5 +24,5 @@ button.jp-Button.jp-mod-minimal.jp-TreeView.jp-TableView {
 
 .jp-ViewModeSelected .jp-Button .jp-icon3[fill],
 .jp-PauseOnExceptions.lm-mod-toggled .jp-icon3[fill] {
-  fill: var(--jp-layout-color2);
+  fill: var(--jp-layout-color1);
 }

--- a/packages/debugger/style/icons.css
+++ b/packages/debugger/style/icons.css
@@ -12,26 +12,17 @@ button.jp-Button.jp-mod-minimal.jp-TreeView.jp-TableView {
   width: 35px;
 }
 
-button.jp-Button.jp-mod-minimal.jp-TreeView:hover {
-  cursor: pointer;
-  background-color: var(--jp-layout-color2);
+.jp-ViewModeSelected .jp-Button,
+.jp-PauseOnExceptions.lm-mod-toggled {
+  background-color: var(--jp-inverse-layout-color3);
 }
 
-button.jp-Button.jp-mod-minimal.jp-TableView:hover {
-  cursor: pointer;
-  background-color: var(--jp-layout-color2);
+.jp-ViewModeSelected .jp-Button:hover,
+.jp-PauseOnExceptions.lm-mod-toggled:hover {
+  background-color: var(--jp-inverse-layout-color4);
 }
 
-.jp-ViewModeSelected {
-  background-color: var(--jp-layout-color2);
-}
-
-/* Pause on exceptions */
-button.jp-Button.jp-mod-minimal.jp-PauseOnExceptions:hover {
-  cursor: pointer;
-  background-color: var(--jp-layout-color2);
-}
-
-button.jp-Button.jp-PauseOnExceptions.lm-mod-toggled {
-  background-color: var(--jp-layout-color2);
+.jp-ViewModeSelected .jp-Button .jp-icon3[fill],
+.jp-PauseOnExceptions.lm-mod-toggled .jp-icon3[fill] {
+  fill: var(--jp-layout-color2);
 }


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #12109
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

When toggled switch to inverse layout color - the change was applied to the variable view toggled buttons group too for consistency.

<!-- Describe any visual or user interaction changes and how they address the issue. -->
| before | after |
| --- | --- |
| ![pause-style](https://user-images.githubusercontent.com/8435071/155488778-375ef736-0ede-47d0-83c4-3723667a5366.gif) | ![pause-style-new](https://user-images.githubusercontent.com/8435071/155488798-d70d3e5a-b153-4d92-a4c1-e8f6fd74d489.gif) |
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A