### PR TITLE
Opening keyboard shortcuts UI result in "destruction" of shortcut settings

### DIFF
--- a/packages/settingregistry/src/settingregistry.ts
+++ b/packages/settingregistry/src/settingregistry.ts
@@ -1162,13 +1162,15 @@ export namespace SettingRegistry {
     });
 
     // Return all the shortcuts that should be registered
-    return user
-      .concat(defaults)
-      .filter(shortcut => !shortcut.disabled)
-      // Fix shortcuts comparison in rjsf Form to avoid polluting the user settings
-      .map(shortcut => {
-        return { args: {}, ...shortcut };
-      });
+    return (
+      user
+        .concat(defaults)
+        .filter(shortcut => !shortcut.disabled)
+        // Fix shortcuts comparison in rjsf Form to avoid polluting the user settings
+        .map(shortcut => {
+          return { args: {}, ...shortcut };
+        })
+    );
   }
 
   /**

--- a/packages/settingregistry/src/settingregistry.ts
+++ b/packages/settingregistry/src/settingregistry.ts
@@ -1162,7 +1162,13 @@ export namespace SettingRegistry {
     });
 
     // Return all the shortcuts that should be registered
-    return user.concat(defaults).filter(shortcut => !shortcut.disabled);
+    return user
+      .concat(defaults)
+      .filter(shortcut => !shortcut.disabled)
+      // Fix shortcuts comparison in rjsf Form to avoid polluting the user settings
+      .map(shortcut => {
+        return { args: {}, ...shortcut };
+      });
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #12056
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
react-json-schema-form `Form` component is internally checking for discrepancy between the settings provided and the default built from the schema (see [that line](https://github.com/rjsf-team/react-jsonschema-form/blob/a6d1c32102d534fc1ba155dcb04173c80560dc4a/packages/core/src/components/Form.js#L38)). The trouble for shortcut arises because of `args` that is an optional argument of type object. So within the `Form` component, `args` will always exist when building from the schema. The workaround here is to define a default empty `args` on all shortcuts when transforming them.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
No more settings changes when the user open the shortcut settings panel.
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A