### PR TITLE
Remove duplicated shortcuts

### DIFF
--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -558,16 +558,14 @@
     },
     {
       "command": "notebook:run-cell",
-      "linuxKeys": ["Ctrl Enter"],
-      "macKeys": ["Cmd Enter", "Ctrl Enter"],
-      "winKeys": ["Ctrl Enter"],
+      "keys": ["Ctrl Enter"],
+      "macKeys": ["Ctrl Enter", "Cmd Enter"],
       "selector": ".jp-Notebook:focus"
     },
     {
       "command": "notebook:run-cell",
-      "linuxKeys": ["Ctrl Enter"],
-      "macKeys": ["Cmd Enter", "Ctrl Enter"],
-      "winKeys": ["Ctrl Enter"],
+      "keys": ["Ctrl Enter"],
+      "macKeys": ["Ctrl Enter", "Cmd Enter"],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -558,12 +558,12 @@
     },
     {
       "command": "notebook:run-cell",
-      "keys": ["Accel Enter"],
+      "keys": ["Accel Enter", "Ctrl Enter"],
       "selector": ".jp-Notebook:focus"
     },
     {
       "command": "notebook:run-cell",
-      "keys": ["Accel Enter"],
+      "keys": ["Accel Enter", "Ctrl Enter"],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -558,22 +558,24 @@
     },
     {
       "command": "notebook:run-cell",
-      "keys": ["Ctrl Enter"],
+      "macKeys": ["Ctrl Enter"],
+      "keys": [],
       "selector": ".jp-Notebook:focus"
     },
     {
       "command": "notebook:run-cell",
-      "keys": ["Cmd Enter"],
-      "selector": ".jp-Notebook:focus"
-    },
-    {
-      "command": "notebook:run-cell",
-      "keys": ["Ctrl Enter"],
+      "macKeys": ["Ctrl Enter"],
+      "keys": [],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {
       "command": "notebook:run-cell",
-      "keys": ["Cmd Enter"],
+      "keys": ["Accel Enter"],
+      "selector": ".jp-Notebook:focus"
+    },
+    {
+      "command": "notebook:run-cell",
+      "keys": ["Accel Enter"],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -559,13 +559,21 @@
     {
       "command": "notebook:run-cell",
       "keys": ["Ctrl Enter"],
-      "macKeys": ["Ctrl Enter", "Cmd Enter"],
+      "selector": ".jp-Notebook:focus"
+    },
+    {
+      "command": "notebook:run-cell",
+      "keys": ["Cmd Enter"],
       "selector": ".jp-Notebook:focus"
     },
     {
       "command": "notebook:run-cell",
       "keys": ["Ctrl Enter"],
-      "macKeys": ["Ctrl Enter", "Cmd Enter"],
+      "selector": ".jp-Notebook.jp-mod-editMode"
+    },
+    {
+      "command": "notebook:run-cell",
+      "keys": ["Cmd Enter"],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -558,16 +558,6 @@
     },
     {
       "command": "notebook:run-cell",
-      "keys": ["Ctrl Enter"],
-      "selector": ".jp-Notebook:focus"
-    },
-    {
-      "command": "notebook:run-cell",
-      "keys": ["Ctrl Enter"],
-      "selector": ".jp-Notebook.jp-mod-editMode"
-    },
-    {
-      "command": "notebook:run-cell",
       "keys": ["Accel Enter"],
       "selector": ".jp-Notebook:focus"
     },

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -558,12 +558,16 @@
     },
     {
       "command": "notebook:run-cell",
-      "keys": ["Accel Enter", "Ctrl Enter"],
+      "linuxKeys": ["Ctrl Enter"],
+      "macKeys": ["Cmd Enter", "Ctrl Enter"],
+      "winKeys": ["Ctrl Enter"],
       "selector": ".jp-Notebook:focus"
     },
     {
       "command": "notebook:run-cell",
-      "keys": ["Accel Enter", "Ctrl Enter"],
+      "linuxKeys": ["Ctrl Enter"],
+      "macKeys": ["Cmd Enter", "Ctrl Enter"],
+      "winKeys": ["Ctrl Enter"],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {

--- a/packages/settingeditor-extension/schema/plugin.json
+++ b/packages/settingeditor-extension/schema/plugin.json
@@ -9,12 +9,6 @@
       "selector": "body"
     },
     {
-      "command": "settingeditor:open-json",
-      "args": {},
-      "keys": ["Shift Accel ,"],
-      "selector": "body"
-    },
-    {
       "command": "settingeditor:save",
       "args": {},
       "keys": ["Accel S"],

--- a/packages/settingregistry/src/plugin-schema.json
+++ b/packages/settingregistry/src/plugin-schema.json
@@ -212,11 +212,34 @@
         },
         "keys": {
           "title": "The key sequence for the binding",
+          "description": "The key shortcut like `Accel A` or the sequence of shortcuts to press like [`Accel A`, `B`]",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "macKeys": {
+          "title": "The key sequence for the binding on macOS",
+          "description": "The key shortcut like `Cmd A` or the sequence of shortcuts to press like [`Cmd A`, `B`]",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "winKeys": {
+          "title": "The key sequence for the binding on Windows",
           "description": "The key shortcut like `Ctrl A` or the sequence of shortcuts to press like [`Ctrl A`, `B`]",
           "items": {
             "type": "string"
           },
-          "minItems": 1,
+          "type": "array"
+        },
+        "linuxKeys": {
+          "title": "The key sequence for the binding on Linux",
+          "description": "The key shortcut like `Ctrl A` or the sequence of shortcuts to press like [`Ctrl A`, `B`]",
+          "items": {
+            "type": "string"
+          },
           "type": "array"
         },
         "selector": {

--- a/packages/settingregistry/src/plugin-schema.json
+++ b/packages/settingregistry/src/plugin-schema.json
@@ -197,16 +197,22 @@
     "shortcut": {
       "properties": {
         "args": {
+          "title": "The arguments for the command",
           "type": "object"
         },
         "command": {
+          "title": "The command id",
+          "description": "The command executed when the binding is matched.",
           "type": "string"
         },
         "disabled": {
+          "description": "Whether this shortcut is disabled or not.",
           "type": "boolean",
           "default": false
         },
         "keys": {
+          "title": "The key sequence for the binding",
+          "description": "The key shortcut like `Ctrl A` or the sequence of shortcuts to press like [`Ctrl A`, `B`]",
           "items": {
             "type": "string"
           },
@@ -214,6 +220,7 @@
           "type": "array"
         },
         "selector": {
+          "title": "CSS selector",
           "type": "string"
         }
       },

--- a/packages/settingregistry/src/tokens.ts
+++ b/packages/settingregistry/src/tokens.ts
@@ -592,7 +592,12 @@ export namespace ISettingRegistry {
     disabled?: boolean;
 
     /**
-     * The key combination of the shortcut.
+     * The key sequence of the shortcut.
+     *
+     * ### Notes
+     *
+     * If this is a list like `[Ctrl A, B]`, the user needs to press
+     * `Ctrl A` followed by `B` to trigger the shortcuts.
      */
     keys: string[];
 

--- a/packages/settingregistry/src/tokens.ts
+++ b/packages/settingregistry/src/tokens.ts
@@ -596,7 +596,7 @@ export namespace ISettingRegistry {
      *
      * ### Notes
      *
-     * If this is a list like `[Ctrl A, B]`, the user needs to press
+     * If this is a list like `['Ctrl A', 'B']`, the user needs to press
      * `Ctrl A` followed by `B` to trigger the shortcuts.
      */
     keys: string[];

--- a/packages/shortcuts-extension/.vscode/launch.json
+++ b/packages/shortcuts-extension/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Attach to jest",
+            // Usage:
+            // Open the parent directory in VSCode
+            // Run `jlpm test:debug:watch` in a terminal
+            // Run this debugging task
+            "port": 9229
+        }
+    ]
+}

--- a/packages/shortcuts-extension/babel.config.js
+++ b/packages/shortcuts-extension/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@jupyterlab/testutils/lib/babel.config');

--- a/packages/shortcuts-extension/jest.config.js
+++ b/packages/shortcuts-extension/jest.config.js
@@ -1,0 +1,2 @@
+const func = require('@jupyterlab/testutils/lib/jest-config');
+module.exports = func(__dirname);

--- a/packages/shortcuts-extension/package.json
+++ b/packages/shortcuts-extension/package.json
@@ -30,8 +30,13 @@
   ],
   "scripts": {
     "build": "tsc -b",
+    "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
+    "test": "jest",
+    "test:cov": "jest --collect-coverage",
+    "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
+    "test:debug:watch": "node --inspect-brk node_modules/.bin/jest --runInBand --watch",
     "watch": "tsc -b --watch"
   },
   "dependencies": {
@@ -50,7 +55,11 @@
     "typestyle": "^2.0.4"
   },
   "devDependencies": {
+    "@jupyterlab/testutils": "^4.0.0-alpha.5",
+    "@types/jest": "^26.0.10",
+    "jest": "^26.4.2",
     "rimraf": "~3.0.0",
+    "ts-jest": "^26.3.0",
     "typedoc": "~0.22.10",
     "typescript": "~4.5.2"
   },

--- a/packages/shortcuts-extension/test/shortcuts.spec.ts
+++ b/packages/shortcuts-extension/test/shortcuts.spec.ts
@@ -81,9 +81,12 @@ describe('@jupyterlab/shortcut-extension', () => {
 
       await settingRegistry.load(bar.id);
 
-      plugin.default.activate({
-        commands: new CommandRegistry()
-      } as any, settingRegistry)
+      plugin.default.activate(
+        {
+          commands: new CommandRegistry()
+        } as any,
+        settingRegistry
+      );
 
       const settings = await settingRegistry.load(plugin.default.id);
       const shortcuts = (await settings.get('shortcuts')
@@ -146,9 +149,12 @@ describe('@jupyterlab/shortcut-extension', () => {
 
       await settingRegistry.load(bar.id);
 
-      plugin.default.activate({
-        commands: new CommandRegistry()
-      } as any, settingRegistry)
+      plugin.default.activate(
+        {
+          commands: new CommandRegistry()
+        } as any,
+        settingRegistry
+      );
 
       const settings = await settingRegistry.load(plugin.default.id);
       const shortcuts = (await settings.get('shortcuts')

--- a/packages/shortcuts-extension/test/shortcuts.spec.ts
+++ b/packages/shortcuts-extension/test/shortcuts.spec.ts
@@ -1,0 +1,160 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { ISettingRegistry, SettingRegistry } from '@jupyterlab/settingregistry';
+import * as plugin from '@jupyterlab/shortcuts-extension';
+import { IDataConnector } from '@jupyterlab/statedb';
+import { CommandRegistry } from '@lumino/commands';
+import { Platform } from '@lumino/domutils';
+import pluginSchema from '../schema/shortcuts.json';
+
+describe('@jupyterlab/shortcut-extension', () => {
+  const pluginId = 'test-plugin:settings';
+
+  let dummySettings: ISettingRegistry.IPlugin;
+
+  beforeEach(() => {
+    dummySettings = {
+      data: {
+        composite: {},
+        user: {}
+      },
+      id: plugin.default.id,
+      raw: '{}',
+      schema: pluginSchema as any,
+      version: 'test'
+    };
+  });
+
+  describe('shorcuts list', () => {
+    it('should ignored Cmd on non-Mac platform', async () => {
+      const bar: ISettingRegistry.IPlugin = {
+        data: {
+          composite: {},
+          user: {}
+        },
+        id: pluginId,
+        raw: '{}',
+        schema: {
+          'jupyter.lab.shortcuts': [
+            {
+              command: 'notebook:run-cell',
+              keys: ['Ctrl Enter'],
+              selector: '.jp-Notebook.jp-mod-editMode'
+            },
+            {
+              command: 'notebook:run-cell',
+              keys: ['Cmd Enter'],
+              selector: '.jp-Notebook.jp-mod-editMode'
+            }
+          ],
+          type: 'object'
+        },
+        version: 'test'
+      };
+
+      const connector: IDataConnector<
+        ISettingRegistry.IPlugin,
+        string,
+        string,
+        string
+      > = {
+        fetch: jest.fn().mockImplementation((id: string) => {
+          switch (id) {
+            case bar.id:
+              return bar;
+            case plugin.default.id:
+              return dummySettings;
+            default:
+              return {};
+          }
+        }),
+        list: jest.fn(),
+        save: jest.fn(),
+        remove: jest.fn()
+      };
+
+      const settingRegistry = new SettingRegistry({
+        connector,
+        timeout: Infinity
+      });
+
+      await settingRegistry.load(bar.id);
+
+      plugin.default.activate({
+        commands: new CommandRegistry()
+      } as any, settingRegistry)
+
+      const settings = await settingRegistry.load(plugin.default.id);
+      const shortcuts = (await settings.get('shortcuts')
+        .composite) as ISettingRegistry.IShortcut[];
+
+      expect(shortcuts).toHaveLength(Platform.IS_MAC ? 2 : 1);
+    });
+
+    it('should ignore colliding shortcuts', async () => {
+      const pluginId = 'test-plugin:settings';
+      const bar: ISettingRegistry.IPlugin = {
+        data: {
+          composite: {},
+          user: {}
+        },
+        id: pluginId,
+        raw: '{}',
+        schema: {
+          'jupyter.lab.shortcuts': [
+            {
+              command: 'notebook:run-cell',
+              keys: ['Accel Enter'],
+              selector: '.jp-Notebook.jp-mod-editMode'
+            },
+            {
+              command: 'another-colliding-command',
+              keys: ['Accel Enter'],
+              selector: '.jp-Notebook.jp-mod-editMode'
+            }
+          ],
+          type: 'object'
+        },
+        version: 'test'
+      };
+
+      const connector: IDataConnector<
+        ISettingRegistry.IPlugin,
+        string,
+        string,
+        string
+      > = {
+        fetch: jest.fn().mockImplementation((id: string) => {
+          switch (id) {
+            case bar.id:
+              return bar;
+            case plugin.default.id:
+              return dummySettings;
+            default:
+              return {};
+          }
+        }),
+        list: jest.fn(),
+        save: jest.fn(),
+        remove: jest.fn()
+      };
+
+      const settingRegistry = new SettingRegistry({
+        connector
+      });
+
+      await settingRegistry.load(bar.id);
+
+      plugin.default.activate({
+        commands: new CommandRegistry()
+      } as any, settingRegistry)
+
+      const settings = await settingRegistry.load(plugin.default.id);
+      const shortcuts = (await settings.get('shortcuts')
+        .composite) as ISettingRegistry.IShortcut[];
+
+      expect(shortcuts).toHaveLength(1);
+    });
+  });
+});

--- a/packages/shortcuts-extension/tsconfig.test.json
+++ b/packages/shortcuts-extension/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfigbase.test",
+  "include": ["src/*", "test/*"],
+  "references": [
+    {
+      "path": "."
+    },
+    {
+      "path": "../../testutils"
+    }
+  ]
+}

--- a/packages/shortcuts-extension/tsconfig.test.json
+++ b/packages/shortcuts-extension/tsconfig.test.json
@@ -3,6 +3,18 @@
   "include": ["src/*", "test/*"],
   "references": [
     {
+      "path": "../application"
+    },
+    {
+      "path": "../settingregistry"
+    },
+    {
+      "path": "../translation"
+    },
+    {
+      "path": "../ui-components"
+    },
+    {
       "path": "."
     },
     {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #12103
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Remove shortcut for JSON editor (it was ignored as already defined).
Convert `Accel Enter` shortcut to `Cmd Enter` to run cells (this will be available only on MacOS)
Ignore shortcuts that contains explicitly `Cmd` on non-MacOS platforms. This will avoid creating unwanted shortcuts. Otherwise the `Cmd Enter` is converted to `Enter` shortcut on Windows and Linux.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
`Cmd Enter` and `Ctrl Enter` should work on Mac OS.
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A