### PR TITLE
Fix typos in `@jupyterlab/console-extension` plugins

### DIFF
--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -136,7 +136,7 @@ const factory: JupyterFrontEndPlugin<ConsolePanel.IContentFactory> = {
  * Kernel status indicator.
  */
 const kernelStatus: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlab/console-extensions:kernel-status',
+  id: '@jupyterlab/console-extension:kernel-status',
   activate: (
     app: JupyterFrontEnd,
     tracker: IConsoleTracker,
@@ -162,7 +162,7 @@ const kernelStatus: JupyterFrontEndPlugin<void> = {
  * Cursor position.
  */
 const lineColStatus: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlab/console-extensions:cursor-position',
+  id: '@jupyterlab/console-extension:cursor-position',
   activate: (
     app: JupyterFrontEnd,
     tracker: IConsoleTracker,


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes the name of some plugins added in https://github.com/jupyterlab/jupyterlab/pull/11450

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Rename plugins.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None since https://github.com/jupyterlab/jupyterlab/pull/11450 was a 4.0 change.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
