### PR TITLE
Correct the set item logic of `CodeCellModel.onModelDBOutputsChange`

### DIFF
--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -827,7 +827,7 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
           const newValues = event.newValues.map(output => output.toJSON());
           codeCell.updateOutputs(
             event.oldIndex,
-            event.oldValues.length,
+            event.oldIndex + newValues.length,
             newValues
           );
           break;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
close  #12131 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- Correct the index value of items in `CodeCellModel.onModelDBOutputsChange`
-  Add tests for  `CodeCellModel.onModelDBOutputsChange`


## User-facing changes
N/A
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
N/A
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
