### PR TITLE
Automated Changelog Entry for 3.3.0 on 3.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,43 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.3.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.3.0
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.3.0rc0...6e484f89df73e09c29e8608e5eca88fa48cc4267))
+
+### Enhancements made
+
+- Backport PR #12097 on branch 3.3.x (Document search debounce time via setting) [#12121](https://github.com/jupyterlab/jupyterlab/pull/12121) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #12110 on branch 3.3.x (Improve toggled button styles in debugger.) [#12120](https://github.com/jupyterlab/jupyterlab/pull/12120) ([@fcollonval](https://github.com/fcollonval))
+
+### Bugs fixed
+
+- Build UMD module for @jupyterlab/services [#12141](https://github.com/jupyterlab/jupyterlab/pull/12141) ([@fcollonval](https://github.com/fcollonval))
+- Fix broken link in docs [#12138](https://github.com/jupyterlab/jupyterlab/pull/12138) ([@jweill-aws](https://github.com/jweill-aws))
+-  fix: Select kernal text(when open a no kernal .ipynb file)is not translated correctly  (#12133) [#12135](https://github.com/jupyterlab/jupyterlab/pull/12135) ([@yangql176](https://github.com/yangql176))
+- Opening keyboard shortcuts UI result in "destruction" of shortcut settings [#12112](https://github.com/jupyterlab/jupyterlab/pull/12112) ([@fcollonval](https://github.com/fcollonval))
+- Fix error rendering in Advanced Settings Editor [#12107](https://github.com/jupyterlab/jupyterlab/pull/12107) ([@krassowski](https://github.com/krassowski))
+- Fix json schema for kernel status settings [#11451](https://github.com/jupyterlab/jupyterlab/pull/11451) ([@fcollonval](https://github.com/fcollonval))
+- Remove toolbar factory setting trick in the tests [#12096](https://github.com/jupyterlab/jupyterlab/pull/12096) ([@jtpio](https://github.com/jtpio))
+- Log error on open document widget. [#12080](https://github.com/jupyterlab/jupyterlab/pull/12080) ([@trungleduc](https://github.com/trungleduc))
+- update status to unkown when kernel is shutdown from running kernels tab [#12083](https://github.com/jupyterlab/jupyterlab/pull/12083) ([@akshaychitneni](https://github.com/akshaychitneni))
+
+### Maintenance and upkeep improvements
+
+- Backport PR #12046 on branch 3.3.x (Parse URL parameters in user model) [#12065](https://github.com/jupyterlab/jupyterlab/pull/12065) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+- Fix broken link in docs [#12138](https://github.com/jupyterlab/jupyterlab/pull/12138) ([@jweill-aws](https://github.com/jweill-aws))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-02-18&to=2022-03-02&type=c))
+
+[@Carreau](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ACarreau+updated%3A2022-02-18..2022-03-02&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2022-02-18..2022-03-02&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-02-18..2022-03-02&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-02-18..2022-03-02&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-02-18..2022-03-02&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-02-18..2022-03-02&type=Issues) | [@JohanMabille](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AJohanMabille+updated%3A2022-02-18..2022-03-02&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-02-18..2022-03-02&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-02-18..2022-03-02&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2022-02-18..2022-03-02&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-02-18..2022-03-02&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-02-18..2022-03-02&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-02-18..2022-03-02&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AZsailer+updated%3A2022-02-18..2022-03-02&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.3.0rc0
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.3.0b0...3e449cd2cfe0a7f6ac204f66f56f161fba7e0e49))
@@ -38,8 +75,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.3.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-02-10&to=2022-02-18&type=c))
 
 [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-02-10..2022-02-18&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-02-10..2022-02-18&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-02-10..2022-02-18&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-02-10..2022-02-18&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-02-10..2022-02-18&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-02-10..2022-02-18&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-02-10..2022-02-18&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-02-10..2022-02-18&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-02-10..2022-02-18&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-02-10..2022-02-18&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.3.0b0
 


### PR DESCRIPTION
Automated Changelog Entry for 3.3.0 on 3.3.x
```
Python version: 3.3.0
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.3.0
@jupyterlab/buildutils: 3.3.0
@jupyterlab/template: 3.3.0
@jupyterlab/application-top: 3.3.0
@jupyterlab/example-app: 3.3.0
@jupyterlab/example-cell: 3.3.0
@jupyterlab/example-console: 3.3.0
@jupyterlab/example-federated: 2.4.0
@jupyterlab/example-federated-core: 2.4.0
@jupyterlab/example-federated-md: 2.4.0
@jupyterlab/example-federated-middle: 2.4.0
@jupyterlab/example-federated-phosphor: 2.4.0
@jupyterlab/example-filebrowser: 3.3.0
@jupyterlab/example-notebook: 3.3.0
@jupyterlab/example-terminal: 3.3.0
@jupyterlab/galata: 4.2.0
@jupyterlab/mock-extension: 3.3.0
@jupyterlab/mock-consumer: 3.3.0
@jupyterlab/mock-provider: 3.3.0
@jupyterlab/mock-token: 3.3.0
@jupyterlab/application: 3.3.0
@jupyterlab/application-extension: 3.3.0
@jupyterlab/apputils: 3.3.0
@jupyterlab/apputils-extension: 3.3.0
@jupyterlab/attachments: 3.3.0
@jupyterlab/cells: 3.3.0
@jupyterlab/celltags: 3.3.0
@jupyterlab/celltags-extension: 3.3.0
@jupyterlab/codeeditor: 3.3.0
@jupyterlab/codemirror: 3.3.0
@jupyterlab/codemirror-extension: 3.3.0
@jupyterlab/completer: 3.3.0
@jupyterlab/completer-extension: 3.3.0
@jupyterlab/console: 3.3.0
@jupyterlab/console-extension: 3.3.0
@jupyterlab/coreutils: 5.3.0
@jupyterlab/csvviewer: 3.3.0
@jupyterlab/csvviewer-extension: 3.3.0
@jupyterlab/debugger: 3.3.0
@jupyterlab/debugger-extension: 3.3.0
@jupyterlab/docmanager: 3.3.0
@jupyterlab/docmanager-extension: 3.3.0
@jupyterlab/docprovider: 3.3.0
@jupyterlab/docprovider-extension: 3.3.0
@jupyterlab/docregistry: 3.3.0
@jupyterlab/documentsearch: 3.3.0
@jupyterlab/documentsearch-extension: 3.3.0
@jupyterlab/extensionmanager: 3.3.0
@jupyterlab/extensionmanager-extension: 3.3.0
@jupyterlab/filebrowser: 3.3.0
@jupyterlab/filebrowser-extension: 3.3.0
@jupyterlab/fileeditor: 3.3.0
@jupyterlab/fileeditor-extension: 3.3.0
@jupyterlab/help-extension: 3.3.0
@jupyterlab/htmlviewer: 3.3.0
@jupyterlab/htmlviewer-extension: 3.3.0
@jupyterlab/hub-extension: 3.3.0
@jupyterlab/imageviewer: 3.3.0
@jupyterlab/imageviewer-extension: 3.3.0
@jupyterlab/inspector: 3.3.0
@jupyterlab/inspector-extension: 3.3.0
@jupyterlab/javascript-extension: 3.3.0
@jupyterlab/json-extension: 3.3.0
@jupyterlab/launcher: 3.3.0
@jupyterlab/launcher-extension: 3.3.0
@jupyterlab/logconsole: 3.3.0
@jupyterlab/logconsole-extension: 3.3.0
@jupyterlab/mainmenu: 3.3.0
@jupyterlab/mainmenu-extension: 3.3.0
@jupyterlab/markdownviewer: 3.3.0
@jupyterlab/markdownviewer-extension: 3.3.0
@jupyterlab/mathjax2: 3.3.0
@jupyterlab/mathjax2-extension: 3.3.0
@jupyterlab/metapackage: 3.3.0
@jupyterlab/nbconvert-css: 3.3.0
@jupyterlab/nbformat: 3.3.0
@jupyterlab/notebook: 3.3.0
@jupyterlab/notebook-extension: 3.3.0
@jupyterlab/observables: 4.3.0
@jupyterlab/outputarea: 3.3.0
@jupyterlab/pdf-extension: 3.3.0
@jupyterlab/property-inspector: 3.3.0
@jupyterlab/rendermime: 3.3.0
@jupyterlab/rendermime-extension: 3.3.0
@jupyterlab/rendermime-interfaces: 3.3.0
@jupyterlab/running: 3.3.0
@jupyterlab/running-extension: 3.3.0
@jupyterlab/services: 6.3.0
@jupyterlab/example-services-browser: 3.3.0
node-example: 3.3.0
@jupyterlab/example-services-outputarea: 3.3.0
@jupyterlab/settingeditor: 3.3.0
@jupyterlab/settingeditor-extension: 3.3.0
@jupyterlab/settingregistry: 3.3.0
@jupyterlab/shared-models: 3.3.0
@jupyterlab/shortcuts-extension: 3.3.0
@jupyterlab/statedb: 3.3.0
@jupyterlab/statusbar: 3.3.0
@jupyterlab/statusbar-extension: 3.3.0
@jupyterlab/terminal: 3.3.0
@jupyterlab/terminal-extension: 3.3.0
@jupyterlab/theme-dark-extension: 3.3.0
@jupyterlab/theme-light-extension: 3.3.0
@jupyterlab/toc: 5.3.0
@jupyterlab/toc-extension: 5.3.0
@jupyterlab/tooltip: 3.3.0
@jupyterlab/tooltip-extension: 3.3.0
@jupyterlab/translation: 3.3.0
@jupyterlab/translation-extension: 3.3.0
@jupyterlab/ui-components: 3.3.0
@jupyterlab/ui-components-extension: 3.3.0
@jupyterlab/vdom: 3.3.0
@jupyterlab/vdom-extension: 3.3.0
@jupyterlab/vega5-extension: 3.3.0
@jupyterlab/testutils: 3.3.0
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.3.x  |
| Version Spec | release |
| Since | v3.3.0rc0 |