### PR TITLE
renderCellOnIdle improvements

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -603,15 +603,28 @@ export class StaticNotebook extends Widget {
       this.onCellInserted(index, widget);
     }
 
+    this._scheduleCellRenderOnIdle();
+  }
+
+  private _scheduleCellRenderOnIdle() {
     if (this._observer && this.notebookConfig.renderCellOnIdle) {
       const renderPlaceholderCells = this._renderPlaceholderCells.bind(this);
       (window as any).requestIdleCallback(renderPlaceholderCells, {
-        timeout: 1000
+        timeout: 60000
       });
     }
   }
 
   private _renderPlaceholderCells(deadline: any) {
+    const timeRemaining = deadline.timeRemaining();
+
+    // In case this got triggered because of timeout or when there are screen updates (https://w3c.github.io/requestidlecallback/#idle-periods),
+    // avoiding the render and rescheduling the place holder cell rendering.
+    if (deadline.didTimeout || timeRemaining < 50) {
+      this._scheduleCellRenderOnIdle();
+      return;
+    }
+
     if (
       this._renderedCellsCount < this._cellsArray.length &&
       this._renderedCellsCount >=
@@ -623,6 +636,11 @@ export class StaticNotebook extends Widget {
   }
 
   private _renderPlaceholderCell(cell: Cell, index: number) {
+    // We don't have cancel mechanism for scheduled requestIdleCallback(renderPlaceholderCells),
+    // adding defensive check for layout in case tab is closed.
+    if (!this.layout) {
+      return;
+    }
     const pl = this.layout as PanelLayout;
     pl.removeWidgetAt(index);
     pl.insertWidget(index, cell);


### PR DESCRIPTION
Currently on page load, all placeholder cells' widget are being rendered immediately irrespective of whether user is interacting with UI or not.

This is because currently on every cell's widget (numberCellsToRenderDirectly) insert, there is a requestIdleCallback registered to render a placeholder cells' widget (which is enabled when observer is present) and its timeout is specified as 1 second. On page load, initial cells' widget (numberCellsToRenderDirectly) gets rendered and each of them will trigger a renderPlaceholderCells in a short span and given all of them have timeout: 1000 ms, they are going to render almost together and more over it is not using idle time left which means even if 100 cells are queued then irrespective of idle time left (which is generally <50ms during active rendering) it will try to render all the 100 cells which might hinder actual user interaction.
For each scheduled place holder cell's widget rendered it will register more callbacks which is making all the cells to render as soon as page loads making the numberCellsToRenderDirectly setting not so useful.

For large notebooks this causes user experience degradation (like tab switch being slow) as browser is busy rendering all the cells.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
https://github.com/jupyterlab/jupyterlab/issues/9757
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
To fix this I have tried rendering place holder cell's widget during [full idle frames](https://w3c.github.io/requestidlecallback/#idle-periods) (deadline.timeRemaining() will be 50) i.e., when there are no UI updates/user inputs queued. Increased timeout to avoid lot of cells getting idle callback at closer intervals and in case of timeout (meaning it couldn't find real idle time) instead of trying to render placeholder cell's widget, rescheduling to find another idle period.

These changes fixes sluggish UI for large notebooks.

Below is the benchmark report for [generated-1000cells-0.9ratio-2loc.ipynb](https://github.com/jupyterlab/benchmarks/blob/master/examples/from-script/generated-1000cells-0.9ratio-2loc.ipynb) notebook with 1K cells.

![image](https://user-images.githubusercontent.com/22656114/156692850-9945f5a1-0d90-44c3-83e8-3a725c12942b.png)

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
