### PR TITLE
Add a note to command line option that collaborative mode is experimental

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -431,7 +431,7 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
     )
     flags['collaborative'] = (
         {'LabApp': {'collaborative': True}},
-        "Whether to enable collaborative mode."
+        "Whether to enable collaborative mode (experimental)."
     )
 
     subcommands = dict(
@@ -492,7 +492,7 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
         help="Whether to expose the global app instance to browser via window.jupyterlab")
 
     collaborative = Bool(False, config=True,
-        help="Whether to enable collaborative mode.")
+        help="Whether to enable collaborative mode (experimental).")
 
     @default('app_dir')
     def _default_app_dir(self):


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References


This is a follow-up PR to #12171 and #12154.


## Code changes

Adds a note to the command line options for real-time collaboration that the feature is experimental.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
