### PR TITLE
Add note about `async`, `await` and `Promises` in the extension tutorial

### DIFF
--- a/docs/source/extension/extension_tutorial.rst
+++ b/docs/source/extension/extension_tutorial.rst
@@ -457,6 +457,16 @@ And update the ``activate`` method to be ``async`` since we are now using
 
         activate: async (app: JupyterFrontEnd, palette: ICommandPalette) =>
 
+.. note::
+
+    If you are new to JavaScript and TypeScript and want to learn more about the ``async``
+    and ``await`` keywords and ``Promises``, you can check out the following tutorial on MDN:
+    https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Promises
+
+    Be sure to also refer to the other resources in the
+    `See Also <https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Promises#see_also>`_
+    for more materials.
+
 Rebuild your extension if necessary (``jlpm run build``), refresh your browser
 tab, and run the *Random Astronomy Picture* command again. You should now see a
 picture in the panel when it opens (if that random date had a picture and not a

--- a/docs/source/extension/extension_tutorial.rst
+++ b/docs/source/extension/extension_tutorial.rst
@@ -460,8 +460,7 @@ And update the ``activate`` method to be ``async`` since we are now using
 .. note::
 
     If you are new to JavaScript / TypeScript and want to learn more about ``async``, ``await``,
-    and ``Promises``, you can check out the following tutorial on MDN:
-    https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Promises
+    and ``Promises``, you can check out the following `tutorial on MDN <https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Promises>`_
 
     Be sure to also refer to the other resources in the
     `See Also <https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Promises#see_also>`_

--- a/docs/source/extension/extension_tutorial.rst
+++ b/docs/source/extension/extension_tutorial.rst
@@ -459,13 +459,13 @@ And update the ``activate`` method to be ``async`` since we are now using
 
 .. note::
 
-    If you are new to JavaScript and TypeScript and want to learn more about the ``async``
-    and ``await`` keywords and ``Promises``, you can check out the following tutorial on MDN:
+    If you are new to JavaScript / TypeScript and want to learn more about ``async``, ``await``,
+    and ``Promises``, you can check out the following tutorial on MDN:
     https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Promises
 
     Be sure to also refer to the other resources in the
     `See Also <https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Promises#see_also>`_
-    for more materials.
+    section for more materials.
 
 Rebuild your extension if necessary (``jlpm run build``), refresh your browser
 tab, and run the *Random Astronomy Picture* command again. You should now see a


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/4352

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Documentation changes.

Incremental improvement to welcome new extension authors even more, by linking to resources about Promises and `async` / `await`.

This also prepares the ground for extension authors who might want to write extensions for Notebook v7.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None for users.

For extension authors the tutorial has been updated:

![image](https://user-images.githubusercontent.com/591645/157912160-98a62ef5-49ef-46e2-b9a1-d190a43e7027.png)

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
