### PR TITLE
Remove use of ipython_genutils

### DIFF
--- a/jupyterlab/federated_labextensions.py
+++ b/jupyterlab/federated_labextensions.py
@@ -20,7 +20,6 @@ from jupyter_core.paths import (
     jupyter_data_dir, SYSTEM_JUPYTER_PATH, ENV_JUPYTER_PATH,
 )
 from jupyter_core.utils import ensure_dir_exists
-from ipython_genutils.py3compat import cast_unicode_py2
 from jupyterlab_server.config import get_federated_extensions
 from jupyter_server.extension.serverextension import ArgumentConflict
 
@@ -81,11 +80,8 @@ def develop_labextension(path, symlink=True, overwrite=False,
     if isinstance(path, (list, tuple)):
         raise TypeError("path must be a string pointing to a single extension to install; call this function multiple times to install multiple extensions")
 
-    path = cast_unicode_py2(path)
-
     if not destination:
         destination = basename(normpath(path))
-    destination = cast_unicode_py2(destination)
 
     full_dest = normpath(pjoin(labext, destination))
     if overwrite and os.path.lexists(full_dest):


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Avoids having an implicit dependency. cf https://github.com/jupyter/nbconvert/issues/1725
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Removes unnecessary use of `ipython_genutils` for Python 2 compatibility.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Avoid installation errors due to missing dependencies.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
