### PR TITLE
Fix sdist editable install and add tests

### DIFF
--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -77,7 +77,7 @@ jobs:
           name: ${{ matrix.group }} ${{ github.run_number }}
           path: ./build/${{ matrix.group }}_output
 
-  test_miniumum_verisons:
+  test_minimum_versions:
     name: Test Minimum Versions
     timeout-minutes: 30
     runs-on: ubuntu-latest

--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -87,6 +87,8 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         with:
           python_version: "3.7"
+      - name: Update Setuptools
+        run: python -m pip install -U setuptools
       - name: Install miniumum versions
         uses: jupyterlab/maintainer-tools/.github/actions/install-minimums@v1
       - name: Install dependencies

--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -76,3 +76,65 @@ jobs:
         with:
           name: ${{ matrix.group }} ${{ github.run_number }}
           path: ./build/${{ matrix.group }}_output
+
+  test_miniumum_verisons:
+    name: Test Minimum Versions
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          python_version: "3.7"
+      - name: Install miniumum versions
+        uses: jupyterlab/maintainer-tools/.github/actions/install-minimums@v1
+      - name: Install dependencies
+        run: |
+          bash ./scripts/ci_install.sh
+      - name: Run the unit tests
+        run: pytest -vv || pytest -vv --lf
+
+  make_sdist:
+    name: Make SDist
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v2
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Install dependencies
+        run: |
+          bash ./scripts/ci_install.sh
+      - name: Build SDist
+        run: |
+          pip install build
+          python -m build --sdist
+      - uses: actions/upload-artifact@v2
+        with:
+          name: "sdist"
+          path: dist/*.tar.gz
+
+  test_sdist:
+    runs-on: ubuntu-latest
+    needs: [make_sdist]
+    name: Install from SDist and Test
+    timeout-minutes: 20
+    steps:
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Download sdist
+        uses: actions/download-artifact@v2
+      - name: Install From SDist
+        run: |
+          set -ex
+          cd sdist
+          mkdir test
+          tar --strip-components=1 -zxvf *.tar.gz -C ./test
+          cd test
+          pip install -e .[test]
+          pip install pytest-github-actions-annotate-failures
+      - name: Run Test
+        run: |
+          cd sdist/test
+          pytest -vv || pytest -vv --lf

--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -87,8 +87,6 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         with:
           python_version: "3.7"
-      - name: Update Setuptools
-        run: python -m pip install -U setuptools
       - name: Install miniumum versions
         uses: jupyterlab/maintainer-tools/.github/actions/install-minimums@v1
       - name: Install dependencies

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ include pyproject.toml
 include setup.py
 include setup.cfg
 include conftest.py
+include scripts/ensure-buildutils.js
 
 # Documentation
 graft docs

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,7 +5,6 @@ include pyproject.toml
 include setup.py
 include setup.cfg
 include conftest.py
-include scripts/ensure-buildutils.js
 
 # Documentation
 graft docs

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -21,7 +21,7 @@ import pytest
 from jupyter_core import paths
 from jupyterlab import commands
 from jupyterlab.commands import (
-    AppOptions, _compare_ranges, _test_overlap,
+    DEV_DIR, AppOptions, _compare_ranges, _test_overlap,
     build, build_check, check_extension,
     disable_extension, enable_extension,
     get_app_info, install_extension, link_package,
@@ -448,6 +448,7 @@ class TestExtension(AppHandlerTest):
         assert self.pkg_names['extension'] in data
 
     @pytest.mark.slow
+    @pytest.mark.skipif(not os.path.exists(DEV_DIR), reason="Not in git checkout")
     def test_build_splice_packages(self):
         app_options = AppOptions(splice_source=True)
         assert install_extension(self.mock_extension) is True

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,8 +35,8 @@ install_requires =
     packaging
     tornado>=6.1.0
     jupyter_core
-    jupyterlab_server~=2.10
-    jupyter_server~=1.4
+    jupyterlab_server>=2.10
+    jupyter_server>=1.4
     notebook_shim>=0.1
     jinja2>=2.11.1
 
@@ -64,7 +64,7 @@ docs-screenshots =
 test =
     check-manifest
     coverage
-    jupyterlab_server[test]~=2.2
+    jupyterlab_server[test]>=2.10
     pytest>=6.0
     pytest-check-links>=0.5
     pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     jupyterlab_server>=2.10
     jupyter_server>=1.8
     notebook_shim>=0.1
-    jinja2>=2.11.3
+    jinja2>=3.0.3
 
 [options.extras_require]
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     jupyterlab_server>=2.10
     jupyter_server>=1.8
     notebook_shim>=0.1
-    jinja2>=2.11.1
+    jinja2>=2.11.3
 
 [options.extras_require]
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     jupyterlab_server~=2.10
     jupyter_server~=1.4
     notebook_shim>=0.1
-    jinja2>=2.1
+    jinja2>=2.11.1
 
 [options.extras_require]
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     tornado>=6.1.0
     jupyter_core
     jupyterlab_server>=2.10
-    jupyter_server>=1.4
+    jupyter_server>=1.8
     notebook_shim>=0.1
     jinja2>=2.11.1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,8 +35,8 @@ install_requires =
     packaging
     tornado>=6.1.0
     jupyter_core
-    jupyterlab_server>=2.10
-    jupyter_server>=1.8
+    jupyterlab_server~=2.10
+    jupyter_server~=1.8
     notebook_shim>=0.1
     jinja2>=3.0.3
 
@@ -64,7 +64,7 @@ docs-screenshots =
 test =
     check-manifest
     coverage
-    jupyterlab_server[test]>=2.10
+    jupyterlab_server[test]~=2.10
     pytest>=6.0
     pytest-check-links>=0.5
     pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -48,12 +48,11 @@ try:
 
     npm = ['node', pjoin(HERE, NAME, 'staging', 'yarn.js')]
     # In develop mode, just run yarn, unless this is an sdist.
-    force = True
-    if not os.path.exists(os.path.join(HERE, 'buildutils')):
-        force = False
-    builder = npm_builder(build_cmd=None, npm=npm, force=force)
-    cmdclass = wrap_installers(post_develop=builder, post_dist=post_dist, ensured_targets=ensured_targets)
-
+    if os.path.exists(os.path.join(HERE, 'buildutils')):
+        builder = npm_builder(build_cmd=None, npm=npm, force=True)
+        cmdclass = wrap_installers(post_develop=builder, post_dist=post_dist, ensured_targets=ensured_targets)
+    else:
+        cmdclass = wrap_installers(post_dist=post_dist, ensured_targets=ensured_targets)
 
     setup_args = dict(
         cmdclass=cmdclass,

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,11 @@ try:
     from jupyter_packaging import wrap_installers, npm_builder, get_data_files
 
     npm = ['node', pjoin(HERE, NAME, 'staging', 'yarn.js')]
-    # In develop mode, just run yarn
-    builder = npm_builder(build_cmd=None, npm=npm, force=True)
+    # In develop mode, just run yarn, unless this is an sdist.
+    force = True
+    if not os.path.exists(os.path.join(HERE, 'buildutils')):
+        force = False
+    builder = npm_builder(build_cmd=None, npm=npm, force=force)
     cmdclass = wrap_installers(post_develop=builder, post_dist=post_dist, ensured_targets=ensured_targets)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
In the `maintainer-tools` [downstream test action](https://github.com/jupyterlab/maintainer-tools#test-downstream-libraries) we install in editable mode from an sdist by default.  In JupyterLab this was breaking because `scripts/ensure-buildutils.js` was not in the sdist, but really we shouldn't be running node at all.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Cleans up installing from sdist and adds a test for the sdist, as well as a test with the minimum supported dependencies using the new action from `maintainer-tools`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Can now install in editable mode from an sdist.
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
