### PR TITLE
Update command in Performance Testing to use the right option

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -456,7 +456,7 @@ Then, start JupyterLab using the dev build:
 
 .. code:: bash
 
-   jupyter lab --dev --NotebookApp.token=''  --no-browser
+   jupyter lab --dev-mode --NotebookApp.token=''  --no-browser
 
 Now run Lighthouse against this local server and show the results:
 


### PR DESCRIPTION
Uses `--dev-mode` instead of `--dev` in the command line to run the dev build.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Partial fix for #12216.

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

None.

## User-facing changes

Doc changes only.

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None.
