### PR TITLE
Fix state restoration in the notebook extension

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1328,53 +1328,54 @@ function activateNotebookHandler(
     ? settingRegistry.load(trackerPlugin.id)
     : Promise.reject(new Error(`No setting registry for ${trackerPlugin.id}`));
 
+  fetchSettings
+    .then(settings => {
+      updateConfig(settings);
+      settings.changed.connect(() => {
+        updateConfig(settings);
+      });
+      commands.addCommand(CommandIDs.autoClosingBrackets, {
+        execute: args => {
+          const codeConfig = settings.get('codeCellConfig')
+            .composite as JSONObject;
+          const markdownConfig = settings.get('markdownCellConfig')
+            .composite as JSONObject;
+          const rawConfig = settings.get('rawCellConfig')
+            .composite as JSONObject;
+
+          const anyToggled =
+            codeConfig.autoClosingBrackets ||
+            markdownConfig.autoClosingBrackets ||
+            rawConfig.autoClosingBrackets;
+          const toggled = !!(args['force'] ?? !anyToggled);
+          [
+            codeConfig.autoClosingBrackets,
+            markdownConfig.autoClosingBrackets,
+            rawConfig.autoClosingBrackets
+          ] = [toggled, toggled, toggled];
+
+          void settings.set('codeCellConfig', codeConfig);
+          void settings.set('markdownCellConfig', markdownConfig);
+          void settings.set('rawCellConfig', rawConfig);
+        },
+        label: trans.__('Auto Close Brackets for All Notebook Cell Types'),
+        isToggled: () =>
+          ['codeCellConfig', 'markdownCellConfig', 'rawCellConfig'].some(
+            x => (settings.get(x).composite as JSONObject).autoClosingBrackets
+          )
+      });
+    })
+    .catch((reason: Error) => {
+      console.warn(reason.message);
+      updateTracker({
+        editorConfig: factory.editorConfig,
+        notebookConfig: factory.notebookConfig,
+        kernelShutdown: factory.shutdownOnClose
+      });
+    });
+
   // Handle state restoration.
   if (restorer) {
-    fetchSettings
-      .then(settings => {
-        updateConfig(settings);
-        settings.changed.connect(() => {
-          updateConfig(settings);
-        });
-        commands.addCommand(CommandIDs.autoClosingBrackets, {
-          execute: args => {
-            const codeConfig = settings.get('codeCellConfig')
-              .composite as JSONObject;
-            const markdownConfig = settings.get('markdownCellConfig')
-              .composite as JSONObject;
-            const rawConfig = settings.get('rawCellConfig')
-              .composite as JSONObject;
-
-            const anyToggled =
-              codeConfig.autoClosingBrackets ||
-              markdownConfig.autoClosingBrackets ||
-              rawConfig.autoClosingBrackets;
-            const toggled = !!(args['force'] ?? !anyToggled);
-            [
-              codeConfig.autoClosingBrackets,
-              markdownConfig.autoClosingBrackets,
-              rawConfig.autoClosingBrackets
-            ] = [toggled, toggled, toggled];
-
-            void settings.set('codeCellConfig', codeConfig);
-            void settings.set('markdownCellConfig', markdownConfig);
-            void settings.set('rawCellConfig', rawConfig);
-          },
-          label: trans.__('Auto Close Brackets for All Notebook Cell Types'),
-          isToggled: () =>
-            ['codeCellConfig', 'markdownCellConfig', 'rawCellConfig'].some(
-              x => (settings.get(x).composite as JSONObject).autoClosingBrackets
-            )
-        });
-      })
-      .catch((reason: Error) => {
-        console.warn(reason.message);
-        updateTracker({
-          editorConfig: factory.editorConfig,
-          notebookConfig: factory.notebookConfig,
-          kernelShutdown: factory.shutdownOnClose
-        });
-      });
     void restorer.restore(tracker, {
       command: 'docmanager:open',
       args: panel => ({ path: panel.context.path, factory: FACTORY }),


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

As reported in https://github.com/jupyterlab/retrolab/issues/358, where some commands are not available in downstream applications like RetroLab since they don't include a `ILayoutRestorer`.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Fix the guard checking if the `restorer` is available, so it only surrounds the relevant logic.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Should fix some behavior in downstream applications reusing `@jupyterlab/notebook-extension:tracker` as is.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
