### PR TITLE
Update completer part 3

### DIFF
--- a/packages/completer-extension/src/index.ts
+++ b/packages/completer-extension/src/index.ts
@@ -68,6 +68,8 @@ const manager: JupyterFrontEndPlugin<ICompletionProviderManager> = {
         .filter(val => val[1] >= 0 && availableProviders.includes(val[0]))
         .sort(([, rank1], [, rank2]) => rank2 - rank1)
         .map(item => item[0]);
+        console.log('activate', sortedProviders );
+        
       manager.activateProvider(sortedProviders);
     };
 

--- a/packages/completer-extension/src/index.ts
+++ b/packages/completer-extension/src/index.ts
@@ -71,27 +71,31 @@ const manager: JupyterFrontEndPlugin<ICompletionProviderManager> = {
       manager.activateProvider(sortedProviders);
     };
 
-    app.restored.then(() => {
-      const availableProviders = [...manager.getProviders().keys()];
-      settings.transform(COMPLETION_MANAGER_PLUGIN, {
-        fetch: plugin => {
-          const schema = plugin.schema.properties!;
-          const defaultValue: { [key: string]: number } = {};
-          availableProviders.forEach((item, index) => {
-            defaultValue[item] = (index + 1) * 100;
-          });
-          schema[AVAILABLE_PROVIDERS]['default'] = defaultValue;
-          return plugin;
-        }
-      });
-      const settingsPromise = settings.load(COMPLETION_MANAGER_PLUGIN);
-      settingsPromise.then(settingValues => {
-        updateSetting(settingValues, availableProviders);
-        settingValues.changed.connect(newSettings => {
-          updateSetting(newSettings, availableProviders);
+    app.restored
+      .then(() => {
+        const availableProviders = [...manager.getProviders().keys()];
+        settings.transform(COMPLETION_MANAGER_PLUGIN, {
+          fetch: plugin => {
+            const schema = plugin.schema.properties!;
+            const defaultValue: { [key: string]: number } = {};
+            availableProviders.forEach((item, index) => {
+              defaultValue[item] = (index + 1) * 100;
+            });
+            schema[AVAILABLE_PROVIDERS]['default'] = defaultValue;
+            return plugin;
+          }
         });
-      });
-    });
+        const settingsPromise = settings.load(COMPLETION_MANAGER_PLUGIN);
+        settingsPromise
+          .then(settingValues => {
+            updateSetting(settingValues, availableProviders);
+            settingValues.changed.connect(newSettings => {
+              updateSetting(newSettings, availableProviders);
+            });
+          })
+          .catch(console.error);
+      })
+      .catch(console.error);
 
     if (editorRegistry) {
       editorRegistry.addRenderer('availableProviders', (props: FieldProps) => {

--- a/packages/completer-extension/src/index.ts
+++ b/packages/completer-extension/src/index.ts
@@ -68,8 +68,6 @@ const manager: JupyterFrontEndPlugin<ICompletionProviderManager> = {
         .filter(val => val[1] >= 0 && availableProviders.includes(val[0]))
         .sort(([, rank1], [, rank2]) => rank2 - rank1)
         .map(item => item[0]);
-        console.log('activate', sortedProviders );
-        
       manager.activateProvider(sortedProviders);
     };
 

--- a/packages/completer-extension/src/renderer.tsx
+++ b/packages/completer-extension/src/renderer.tsx
@@ -40,7 +40,7 @@ export function renderAvailableProviders(props: FieldProps): JSX.Element {
       [key]: parseInt(e.target.value)
     };
 
-    settings.set(AVAILABLE_PROVIDERS, newValue);
+    settings.set(AVAILABLE_PROVIDERS, newValue).catch(console.error);
 
     setValue(newValue);
   };

--- a/packages/completer/src/manager.ts
+++ b/packages/completer/src/manager.ts
@@ -25,13 +25,13 @@ export class CompletionProviderManager implements ICompletionProviderManager {
   constructor() {
     this._providers = new Map();
     this._panelHandlers = new Map();
-    this._providersActivated = new Signal<ICompletionProviderManager, void>(
+    this._activeProvidersChanged = new Signal<ICompletionProviderManager, void>(
       this
     );
   }
 
-  get providersActivated(): ISignal<ICompletionProviderManager, void> {
-    return this._providersActivated;
+  get activeProvidersChanged(): ISignal<ICompletionProviderManager, void> {
+    return this._activeProvidersChanged;
   }
 
   /**
@@ -102,7 +102,7 @@ export class CompletionProviderManager implements ICompletionProviderManager {
       this._activeProviders.add(KERNEL_PROVIDER_ID);
       this._activeProviders.add(CONTEXT_PROVIDER_ID);
     }
-    this._providersActivated.emit();
+    this._activeProvidersChanged.emit();
   }
 
   /**
@@ -216,6 +216,7 @@ export class CompletionProviderManager implements ICompletionProviderManager {
     }
 
     const completer = new Completer({ model, renderer });
+    completer.showDocsPanel = this._showDoc;
     completer.hide();
     Widget.attach(completer, document.body);
     const connectorProxy = await this.generateConnectorProxy(completerContext);
@@ -260,8 +261,8 @@ export class CompletionProviderManager implements ICompletionProviderManager {
   private _autoCompletion: boolean;
 
   /**
-   * Signal emitted when all providers are registered.
+   * Signal emitted when active providers list is changed.
    *
    */
-  private _providersActivated: Signal<ICompletionProviderManager, void>;
+  private _activeProvidersChanged: Signal<ICompletionProviderManager, void>;
 }

--- a/packages/completer/src/manager.ts
+++ b/packages/completer/src/manager.ts
@@ -30,6 +30,9 @@ export class CompletionProviderManager implements ICompletionProviderManager {
     );
   }
 
+  /**
+   * Signal emitted when active providers list is changed.
+   */
   get activeProvidersChanged(): ISignal<ICompletionProviderManager, void> {
     return this._activeProvidersChanged;
   }
@@ -260,9 +263,5 @@ export class CompletionProviderManager implements ICompletionProviderManager {
    */
   private _autoCompletion: boolean;
 
-  /**
-   * Signal emitted when active providers list is changed.
-   *
-   */
   private _activeProvidersChanged: Signal<ICompletionProviderManager, void>;
 }

--- a/packages/completer/src/manager.ts
+++ b/packages/completer/src/manager.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import { ISignal, Signal } from '@lumino/signaling';
 import { Widget } from '@lumino/widgets';
 import { ConnectorProxy } from './connectorproxy';
 import { CONTEXT_PROVIDER_ID } from './default/contextprovider';
@@ -24,6 +25,11 @@ export class CompletionProviderManager implements ICompletionProviderManager {
   constructor() {
     this._providers = new Map();
     this._panelHandlers = new Map();
+    this._providersActivated = new Signal<ICompletionProviderManager, void>(this)
+  }
+
+  get providersActivated(): ISignal<ICompletionProviderManager, void> {
+    return this._providersActivated
   }
 
   /**
@@ -94,6 +100,7 @@ export class CompletionProviderManager implements ICompletionProviderManager {
       this._activeProviders.add(KERNEL_PROVIDER_ID);
       this._activeProviders.add(CONTEXT_PROVIDER_ID);
     }
+    this._providersActivated.emit()
   }
 
   /**
@@ -196,7 +203,8 @@ export class CompletionProviderManager implements ICompletionProviderManager {
     if (!renderer) {
       renderer = Completer.defaultRenderer;
     }
-
+    console.log('using', renderer, firstProvider);
+    
     const model = new CompleterModel();
     const completer = new Completer({ model, renderer });
     completer.hide();
@@ -241,4 +249,10 @@ export class CompletionProviderManager implements ICompletionProviderManager {
    * Flag to enable/disable continuous hinting.
    */
   private _autoCompletion: boolean;
+
+  /**
+   * Signal emitted when all providers are registered.
+   *
+   */
+   private _providersActivated: Signal<ICompletionProviderManager, void>
 }

--- a/packages/completer/src/tokens.ts
+++ b/packages/completer/src/tokens.ts
@@ -141,10 +141,10 @@ export interface ICompletionProviderManager {
   updateCompleter(newCompleterContext: ICompletionContext): Promise<void>;
 
   /**
-   * Signal emitted when all providers are registered.
+   * Signal emitted when active providers list is changed.
    *
    */
-  providersActivated: ISignal<ICompletionProviderManager, void>;
+  activeProvidersChanged: ISignal<ICompletionProviderManager, void>;
 }
 
 export interface IConnectorProxy {

--- a/packages/completer/src/tokens.ts
+++ b/packages/completer/src/tokens.ts
@@ -71,6 +71,7 @@ export interface ICompletionProvider<
    * If it is not provided, the default model will be used.
    *
    * @param context - additional information about context of completion request
+   * @returns The completer model
    */
   modelFactory?(context: ICompletionContext): Promise<Completer.IModel>;
 
@@ -142,7 +143,6 @@ export interface ICompletionProviderManager {
 
   /**
    * Signal emitted when active providers list is changed.
-   *
    */
   activeProvidersChanged: ISignal<ICompletionProviderManager, void>;
 }

--- a/packages/completer/src/tokens.ts
+++ b/packages/completer/src/tokens.ts
@@ -5,6 +5,7 @@ import { CodeEditor } from '@jupyterlab/codeeditor';
 import { IObservableString } from '@jupyterlab/observables';
 import { Session } from '@jupyterlab/services';
 import { Token } from '@lumino/coreutils';
+import { ISignal } from '@lumino/signaling';
 import { Widget } from '@lumino/widgets';
 import { CompletionHandler } from './handler';
 import { Completer } from './widget';
@@ -130,6 +131,12 @@ export interface ICompletionProviderManager {
    * @param newCompleterContext - The completion context.
    */
   updateCompleter(newCompleterContext: ICompletionContext): Promise<void>;
+
+  /**
+   * Signal emitted when all providers are registered.
+   *
+   */
+  providersActivated: ISignal<ICompletionProviderManager, void>
 }
 
 export interface IConnectorProxy {

--- a/packages/completer/src/tokens.ts
+++ b/packages/completer/src/tokens.ts
@@ -44,6 +44,11 @@ export interface ICompletionProvider<
   readonly identifier: string;
 
   /**
+   * Renderer for provider's completions (optional).
+   */
+  readonly renderer?: Completer.IRenderer | null;
+
+  /**
    * Is completion provider applicable to specified context?
    * @param request - the completion request text and details
    * @param context - additional information about context of completion request
@@ -62,9 +67,12 @@ export interface ICompletionProvider<
   ): Promise<CompletionHandler.ICompletionItemsReply<T>>;
 
   /**
-   * Renderer for provider's completions (optional).
+   * This method is called to customize the model of a completer widget.
+   * If it is not provided, the default model will be used.
+   *
+   * @param context - additional information about context of completion request
    */
-  readonly renderer: Completer.IRenderer | null | undefined;
+  modelFactory?(context: ICompletionContext): Promise<Completer.IModel>;
 
   /**
    * Given an incomplete (unresolved) completion item, resolve it by adding
@@ -136,7 +144,7 @@ export interface ICompletionProviderManager {
    * Signal emitted when all providers are registered.
    *
    */
-  providersActivated: ISignal<ICompletionProviderManager, void>
+  providersActivated: ISignal<ICompletionProviderManager, void>;
 }
 
 export interface IConnectorProxy {

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -977,7 +977,7 @@ export namespace Completer {
       const sanitizer = { sanitize: (dirty: string) => dirty };
       const source = activeItem.documentation || '';
 
-      renderText({ host, sanitizer, source });
+      renderText({ host, sanitizer, source }).catch(console.error);
       return host;
     }
 

--- a/packages/completer/test/manager.spec.ts
+++ b/packages/completer/test/manager.spec.ts
@@ -4,6 +4,8 @@
 import { ISessionContext, SessionContext } from '@jupyterlab/apputils';
 import { Cell, CellModel } from '@jupyterlab/cells';
 import {
+  Completer,
+  CompleterModel,
   CompletionHandler,
   CompletionProviderManager,
   ConnectorProxy,
@@ -39,6 +41,9 @@ function contextFactory(): Context<INotebookModel> {
   });
   return context;
 }
+
+class CustomCompleterModel extends CompleterModel {}
+
 class FooCompletionProvider implements ICompletionProvider {
   identifier: string = SAMPLE_PROVIDER_ID;
   renderer = null;
@@ -57,6 +62,10 @@ class FooCompletionProvider implements ICompletionProvider {
   }
   async isApplicable(context: ICompletionContext): Promise<boolean> {
     return true;
+  }
+
+  async modelFactory(context: ICompletionContext): Promise<Completer.IModel> {
+    return new CustomCompleterModel();
   }
 }
 
@@ -139,8 +148,19 @@ describe('completer/manager', () => {
 
     describe('#generateHandler()', () => {
       it('should create a handler with connector proxy', async () => {
-        const handler = await manager['generateHandler']({});
+        const handler = (await manager['generateHandler'](
+          {}
+        )) as CompletionHandler;
         expect(handler).toBeInstanceOf(CompletionHandler);
+      });
+
+      it('should create a handler with a custom model', async () => {
+        manager.registerProvider(new FooCompletionProvider());
+        manager.activateProvider([SAMPLE_PROVIDER_ID]);
+        const handler = (await manager['generateHandler'](
+          {}
+        )) as CompletionHandler;
+        expect(handler.completer.model).toBeInstanceOf(CustomCompleterModel);
       });
     });
 

--- a/packages/completer/test/manager.spec.ts
+++ b/packages/completer/test/manager.spec.ts
@@ -187,7 +187,7 @@ describe('completer/manager', () => {
           widget
         };
         const handler = manager['_panelHandlers'].get(widget.id);
-        manager.updateCompleter(newCompleterContext);
+        manager.updateCompleter(newCompleterContext).catch(console.error);
         expect(handler.editor).toBe(newCompleterContext.editor);
       });
     });

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -899,8 +899,7 @@ function activateConsoleCompleterService(
     keys: ['Enter'],
     selector: '.jp-ConsolePanel .jp-mod-completer-active'
   });
-
-  consoles.widgetAdded.connect(async (_, consolePanel) => {
+  const updateCompleter = async (_: any, consolePanel: ConsolePanel) => {
     const completerContext = {
       editor: consolePanel.console.promptCell?.editor ?? null,
       session: consolePanel.console.sessionContext.session,
@@ -923,5 +922,11 @@ function activateConsoleCompleterService(
       };
       manager.updateCompleter(newContext);
     });
-  });
+  }
+  manager.providersActivated.connect(()=> {
+    if(consoles.currentWidget){
+      updateCompleter(undefined, consoles.currentWidget).catch(e => console.error(e))
+    }
+    consoles.widgetAdded.connect(updateCompleter);
+  })
 }

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -906,13 +906,13 @@ function activateConsoleCompleterService(
       widget: consolePanel
     };
     await manager.updateCompleter(completerContext);
-    consolePanel.console.promptCellCreated.connect((console, cell) => {
+    consolePanel.console.promptCellCreated.connect((codeConsole, cell) => {
       const newContext = {
         editor: cell.editor,
-        session: console.sessionContext.session,
+        session: codeConsole.sessionContext.session,
         widget: consolePanel
       };
-      manager.updateCompleter(newContext);
+      manager.updateCompleter(newContext).catch(console.error);
     });
     consolePanel.console.sessionContext.sessionChanged.connect(() => {
       const newContext = {
@@ -920,15 +920,13 @@ function activateConsoleCompleterService(
         session: consolePanel.console.sessionContext.session,
         widget: consolePanel
       };
-      manager.updateCompleter(newContext);
+      manager.updateCompleter(newContext).catch(console.error);
     });
   };
-  manager.providersActivated.connect(() => {
-    if (consoles.currentWidget) {
-      updateCompleter(undefined, consoles.currentWidget).catch(e =>
-        console.error(e)
-      );
-    }
-    consoles.widgetAdded.connect(updateCompleter);
+  consoles.widgetAdded.connect(updateCompleter);
+  manager.activeProvidersChanged.connect(() => {
+    consoles.forEach(consoleWidget => {
+      updateCompleter(undefined, consoleWidget).catch(e => console.error(e));
+    });
   });
 }

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -922,11 +922,13 @@ function activateConsoleCompleterService(
       };
       manager.updateCompleter(newContext);
     });
-  }
-  manager.providersActivated.connect(()=> {
-    if(consoles.currentWidget){
-      updateCompleter(undefined, consoles.currentWidget).catch(e => console.error(e))
+  };
+  manager.providersActivated.connect(() => {
+    if (consoles.currentWidget) {
+      updateCompleter(undefined, consoles.currentWidget).catch(e =>
+        console.error(e)
+      );
     }
     consoles.widgetAdded.connect(updateCompleter);
-  })
+  });
 }

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1631,7 +1631,10 @@ function activateNotebookCompleterService(
     keys: ['Enter'],
     selector: '.jp-Notebook .jp-mod-completer-active'
   });
-  const updateCompleter =  async (_: INotebookTracker | undefined, notebook: NotebookPanel) => {
+  const updateCompleter = async (
+    _: INotebookTracker | undefined,
+    notebook: NotebookPanel
+  ) => {
     const completerContext = {
       editor: notebook.content.activeCell?.editor ?? null,
       session: notebook.sessionContext.session,
@@ -1654,13 +1657,15 @@ function activateNotebookCompleterService(
       };
       manager.updateCompleter(newCompleterContext);
     });
-  } 
-  manager.providersActivated.connect(()=> {
-    if(notebooks.currentWidget){
-      updateCompleter(undefined, notebooks.currentWidget).catch(e => console.error(e))
+  };
+  manager.providersActivated.connect(() => {
+    if (notebooks.currentWidget) {
+      updateCompleter(undefined, notebooks.currentWidget).catch(e =>
+        console.error(e)
+      );
     }
     notebooks.widgetAdded.connect(updateCompleter);
-  })
+  });
 }
 
 // Get the current widget and activate unless the args specify otherwise.

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1631,8 +1631,7 @@ function activateNotebookCompleterService(
     keys: ['Enter'],
     selector: '.jp-Notebook .jp-mod-completer-active'
   });
-
-  notebooks.widgetAdded.connect(async (_, notebook) => {
+  const updateCompleter =  async (_: INotebookTracker | undefined, notebook: NotebookPanel) => {
     const completerContext = {
       editor: notebook.content.activeCell?.editor ?? null,
       session: notebook.sessionContext.session,
@@ -1655,7 +1654,13 @@ function activateNotebookCompleterService(
       };
       manager.updateCompleter(newCompleterContext);
     });
-  });
+  } 
+  manager.providersActivated.connect(()=> {
+    if(notebooks.currentWidget){
+      updateCompleter(undefined, notebooks.currentWidget).catch(e => console.error(e))
+    }
+    notebooks.widgetAdded.connect(updateCompleter);
+  })
 }
 
 // Get the current widget and activate unless the args specify otherwise.

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1647,7 +1647,7 @@ function activateNotebookCompleterService(
         session: notebook.sessionContext.session,
         widget: notebook
       };
-      manager.updateCompleter(newCompleterContext);
+      manager.updateCompleter(newCompleterContext).catch(console.error);
     });
     notebook.sessionContext.sessionChanged.connect(() => {
       const newCompleterContext = {
@@ -1655,16 +1655,14 @@ function activateNotebookCompleterService(
         session: notebook.sessionContext.session,
         widget: notebook
       };
-      manager.updateCompleter(newCompleterContext);
+      manager.updateCompleter(newCompleterContext).catch(console.error);
     });
   };
-  manager.providersActivated.connect(() => {
-    if (notebooks.currentWidget) {
-      updateCompleter(undefined, notebooks.currentWidget).catch(e =>
-        console.error(e)
-      );
-    }
-    notebooks.widgetAdded.connect(updateCompleter);
+  notebooks.widgetAdded.connect(updateCompleter);
+  manager.activeProvidersChanged.connect(() => {
+    notebooks.forEach(panel => {
+      updateCompleter(undefined, panel).catch(e => console.error(e));
+    });
   });
 }
 


### PR DESCRIPTION
## References

This PR allows completer providers to customize the completer widget model and fixes an issue of activating completer before all providers are registered.

## Code changes

- Add a new signal (`providersActivated`), that is emitted when all providers are registered.
- Add an optional `modelFactory` method to the provider interface.

## User-facing changes

N/A

## Backwards-incompatible changes

N/A
