### PR TITLE
fixes directory not found error when preferred_dir is set

### DIFF
--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -378,6 +378,10 @@ export class FileBrowserModel implements IDisposable {
       }
 
       const path = (value as ReadonlyJSONObject)['path'] as string;
+      // need to return to root path if preferred dir is set
+      if (path) {
+        await this.cd('/');
+      }
       const localPath = manager.services.contents.localPath(path);
 
       await manager.services.contents.get(path);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
https://github.com/jupyterlab/jupyterlab/issues/12111
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Made change to filebrowser `FileBrowserModel.restore` so that if it is restoring a path from a previous session, it cds to the root directory before restoring the path. This fixes the directory not found error thrown when `preferred_dir` was set and the user was restoring a previous session with a sub-folder of the `preferred_dir`.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
User will no longer get a directory not found error when restoring a previous session in a sub-folder of their set `preferred_dir`.

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None that I am aware.
