### PR TITLE
Inline `expected_http_error` function from `jupyterlab_server.tests`

### DIFF
--- a/jupyterlab/tests/test_build_api.py
+++ b/jupyterlab/tests/test_build_api.py
@@ -6,7 +6,28 @@ from tempfile import TemporaryDirectory
 
 import pytest
 import tornado
-from jupyterlab_server.tests.utils import expected_http_error
+
+
+def expected_http_error(error, expected_code, expected_message=None):
+    """Check that the error matches the expected output error."""
+    e = error.value
+    if isinstance(e, tornado.web.HTTPError):
+        if expected_code != e.status_code:
+            return False
+        if expected_message is not None and expected_message != str(e):
+            return False
+        return True
+    elif any([
+        isinstance(e, tornado.httpclient.HTTPClientError),
+        isinstance(e, tornado.httpclient.HTTPError)
+    ]):
+        if expected_code != e.code:
+            return False
+        if expected_message:
+            message = json.loads(e.response.body.decode())['message']
+            if expected_message != message:
+                return False
+        return True
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This should help fix some of the failing CI checks on `master`.

See https://github.com/jupyterlab/jupyterlab_server/pull/243#issuecomment-1069676233 for more context.

Example run where the CI checks are failing with the latest commit on `master`: https://github.com/jupyterlab/jupyterlab/runs/5583340091?check_suite_focus=true

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Drop dependency on `jupyterlab_server.tests`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
