### PR TITLE
Automated Changelog Entry for 4.0.0a22 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,33 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 4.0.0a22
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v4.0.0a21...0040f2649c77af0251b8c8f73aea91c26c3960c5))
+
+### Bugs fixed
+
+- Fix state restoration in the notebook extension [#12218](https://github.com/jupyterlab/jupyterlab/pull/12218) ([@jtpio](https://github.com/jtpio))
+- Fix sdist editable install and add tests [#12208](https://github.com/jupyterlab/jupyterlab/pull/12208) ([@blink1073](https://github.com/blink1073))
+- Remove use of ipython_genutils [#12202](https://github.com/jupyterlab/jupyterlab/pull/12202) ([@blink1073](https://github.com/blink1073))
+
+### Maintenance and upkeep improvements
+
+- Inline `expected_http_error` function from `jupyterlab_server.tests` [#12228](https://github.com/jupyterlab/jupyterlab/pull/12228) ([@jtpio](https://github.com/jtpio))
+
+### Documentation improvements
+
+- Update command in Performance Testing to use the right option [#12215](https://github.com/jupyterlab/jupyterlab/pull/12215) ([@jweill-aws](https://github.com/jweill-aws))
+- Add note about `async`, `await` and `Promises` in the extension tutorial [#12199](https://github.com/jupyterlab/jupyterlab/pull/12199) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-03-11&to=2022-03-18&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-03-11..2022-03-18&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-03-11..2022-03-18&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-03-11..2022-03-18&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-03-11..2022-03-18&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-03-11..2022-03-18&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2022-03-11..2022-03-18&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 4.0.0a21
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v4.0.0a20...d7f1704307c2e345f247e1a411bdbae50f2a5708))
@@ -54,8 +81,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-02-24&to=2022-03-11&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-02-24..2022-03-11&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2022-02-24..2022-03-11&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adependabot+updated%3A2022-02-24..2022-03-11&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-02-24..2022-03-11&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2022-02-24..2022-03-11&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-02-24..2022-03-11&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-02-24..2022-03-11&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2022-02-24..2022-03-11&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-02-24..2022-03-11&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-02-24..2022-03-11&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-02-24..2022-03-11&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-02-24..2022-03-11&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AmartinRenou+updated%3A2022-02-24..2022-03-11&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-02-24..2022-03-11&type=Issues) | [@sparanoid](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Asparanoid+updated%3A2022-02-24..2022-03-11&type=Issues) | [@tkrabel-db](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atkrabel-db+updated%3A2022-02-24..2022-03-11&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrungleduc+updated%3A2022-02-24..2022-03-11&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-02-24..2022-03-11&type=Issues) | [@yangql176](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ayangql176+updated%3A2022-02-24..2022-03-11&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 4.0.0a20
 


### PR DESCRIPTION
Automated Changelog Entry for 4.0.0a22 on master
```
Python version: 4.0.0a22
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 4.0.0-alpha.7
@jupyterlab/buildutils: 4.0.0-alpha.7
@jupyterlab/template: 4.0.0-alpha.7
@jupyterlab/application-top: 4.0.0-alpha.7
@jupyterlab/example-app: 4.0.0-alpha.7
@jupyterlab/example-cell: 4.0.0-alpha.7
@jupyterlab/example-console: 4.0.0-alpha.7
@jupyterlab/example-federated: 3.0.0-alpha.7
@jupyterlab/example-federated-core: 3.0.0-alpha.7
@jupyterlab/example-federated-md: 3.0.0-alpha.7
@jupyterlab/example-federated-middle: 3.0.0-alpha.7
@jupyterlab/example-federated-phosphor: 3.0.0-alpha.7
@jupyterlab/example-filebrowser: 4.0.0-alpha.7
@jupyterlab/example-notebook: 4.0.0-alpha.7
@jupyterlab/example-terminal: 4.0.0-alpha.7
@jupyterlab/galata: 5.0.0-alpha.7
@jupyterlab/mock-extension: 4.0.0-alpha.7
@jupyterlab/mock-consumer: 4.0.0-alpha.7
@jupyterlab/mock-provider: 4.0.0-alpha.7
@jupyterlab/mock-token: 4.0.0-alpha.7
@jupyterlab/application: 4.0.0-alpha.7
@jupyterlab/application-extension: 4.0.0-alpha.7
@jupyterlab/apputils: 4.0.0-alpha.7
@jupyterlab/apputils-extension: 4.0.0-alpha.7
@jupyterlab/attachments: 4.0.0-alpha.7
@jupyterlab/cells: 4.0.0-alpha.7
@jupyterlab/celltags: 4.0.0-alpha.7
@jupyterlab/celltags-extension: 4.0.0-alpha.7
@jupyterlab/codeeditor: 4.0.0-alpha.7
@jupyterlab/codemirror: 4.0.0-alpha.7
@jupyterlab/codemirror-extension: 4.0.0-alpha.7
@jupyterlab/completer: 4.0.0-alpha.7
@jupyterlab/completer-extension: 4.0.0-alpha.7
@jupyterlab/console: 4.0.0-alpha.7
@jupyterlab/console-extension: 4.0.0-alpha.7
@jupyterlab/coreutils: 6.0.0-alpha.7
@jupyterlab/csvviewer: 4.0.0-alpha.7
@jupyterlab/csvviewer-extension: 4.0.0-alpha.7
@jupyterlab/debugger: 4.0.0-alpha.7
@jupyterlab/debugger-extension: 4.0.0-alpha.7
@jupyterlab/docmanager: 4.0.0-alpha.7
@jupyterlab/docmanager-extension: 4.0.0-alpha.7
@jupyterlab/docprovider: 4.0.0-alpha.7
@jupyterlab/docprovider-extension: 4.0.0-alpha.7
@jupyterlab/docregistry: 4.0.0-alpha.7
@jupyterlab/documentsearch: 4.0.0-alpha.7
@jupyterlab/documentsearch-extension: 4.0.0-alpha.7
@jupyterlab/extensionmanager: 4.0.0-alpha.7
@jupyterlab/extensionmanager-extension: 4.0.0-alpha.7
@jupyterlab/filebrowser: 4.0.0-alpha.7
@jupyterlab/filebrowser-extension: 4.0.0-alpha.7
@jupyterlab/fileeditor: 4.0.0-alpha.7
@jupyterlab/fileeditor-extension: 4.0.0-alpha.7
@jupyterlab/help-extension: 4.0.0-alpha.7
@jupyterlab/htmlviewer: 4.0.0-alpha.7
@jupyterlab/htmlviewer-extension: 4.0.0-alpha.7
@jupyterlab/hub-extension: 4.0.0-alpha.7
@jupyterlab/imageviewer: 4.0.0-alpha.7
@jupyterlab/imageviewer-extension: 4.0.0-alpha.7
@jupyterlab/inspector: 4.0.0-alpha.7
@jupyterlab/inspector-extension: 4.0.0-alpha.7
@jupyterlab/javascript-extension: 4.0.0-alpha.7
@jupyterlab/json-extension: 4.0.0-alpha.7
@jupyterlab/launcher: 4.0.0-alpha.7
@jupyterlab/launcher-extension: 4.0.0-alpha.7
@jupyterlab/logconsole: 4.0.0-alpha.7
@jupyterlab/logconsole-extension: 4.0.0-alpha.7
@jupyterlab/mainmenu: 4.0.0-alpha.7
@jupyterlab/mainmenu-extension: 4.0.0-alpha.7
@jupyterlab/markdownviewer: 4.0.0-alpha.7
@jupyterlab/markdownviewer-extension: 4.0.0-alpha.7
@jupyterlab/markedparser-extension: 4.0.0-alpha.6
@jupyterlab/mathjax2: 4.0.0-alpha.7
@jupyterlab/mathjax2-extension: 4.0.0-alpha.7
@jupyterlab/metapackage: 4.0.0-alpha.7
@jupyterlab/nbconvert-css: 4.0.0-alpha.7
@jupyterlab/nbformat: 4.0.0-alpha.7
@jupyterlab/notebook: 4.0.0-alpha.7
@jupyterlab/notebook-extension: 4.0.0-alpha.7
@jupyterlab/observables: 5.0.0-alpha.7
@jupyterlab/outputarea: 4.0.0-alpha.7
@jupyterlab/pdf-extension: 4.0.0-alpha.7
@jupyterlab/property-inspector: 4.0.0-alpha.7
@jupyterlab/rendermime: 4.0.0-alpha.7
@jupyterlab/rendermime-extension: 4.0.0-alpha.7
@jupyterlab/rendermime-interfaces: 4.0.0-alpha.7
@jupyterlab/running: 4.0.0-alpha.7
@jupyterlab/running-extension: 4.0.0-alpha.7
@jupyterlab/services: 7.0.0-alpha.7
@jupyterlab/example-services-browser: 4.0.0-alpha.7
node-example: 4.0.0-alpha.7
@jupyterlab/example-services-outputarea: 4.0.0-alpha.7
@jupyterlab/settingeditor: 4.0.0-alpha.7
@jupyterlab/settingeditor-extension: 4.0.0-alpha.7
@jupyterlab/settingregistry: 4.0.0-alpha.7
@jupyterlab/shared-models: 4.0.0-alpha.7
@jupyterlab/shortcuts-extension: 4.0.0-alpha.7
@jupyterlab/statedb: 4.0.0-alpha.7
@jupyterlab/statusbar: 4.0.0-alpha.7
@jupyterlab/statusbar-extension: 4.0.0-alpha.7
@jupyterlab/terminal: 4.0.0-alpha.7
@jupyterlab/terminal-extension: 4.0.0-alpha.7
@jupyterlab/theme-dark-extension: 4.0.0-alpha.7
@jupyterlab/theme-light-extension: 4.0.0-alpha.7
@jupyterlab/toc: 6.0.0-alpha.7
@jupyterlab/toc-extension: 6.0.0-alpha.7
@jupyterlab/tooltip: 4.0.0-alpha.7
@jupyterlab/tooltip-extension: 4.0.0-alpha.7
@jupyterlab/translation: 4.0.0-alpha.7
@jupyterlab/translation-extension: 4.0.0-alpha.7
@jupyterlab/ui-components: 4.0.0-alpha.22
@jupyterlab/ui-components-extension: 4.0.0-alpha.7
@jupyterlab/user: 4.0.0-alpha.7
@jupyterlab/user-extension: 4.0.0-alpha.7
@jupyterlab/vdom: 4.0.0-alpha.7
@jupyterlab/vdom-extension: 4.0.0-alpha.7
@jupyterlab/vega5-extension: 4.0.0-alpha.7
@jupyterlab/testutils: 4.0.0-alpha.7
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | master  |
| Version Spec | next |
| Since | v4.0.0a21 |