### PR TITLE
Make `IStatusBar` optional in the plugin providing `IPositionModel`

### DIFF
--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -123,14 +123,14 @@ export const editorSyntaxStatus: JupyterFrontEndPlugin<void> = {
 export const lineColItem: JupyterFrontEndPlugin<IPositionModel> = {
   id: '@jupyterlab/codemirror-extension:line-col-status',
   autoStart: true,
-  requires: [IStatusBar, ITranslator],
-  optional: [ILabShell],
+  requires: [ITranslator],
+  optional: [ILabShell, IStatusBar],
   provides: IPositionModel,
   activate: (
     app: JupyterFrontEnd,
-    statusBar: IStatusBar,
     translator: ITranslator,
-    labShell: ILabShell | null
+    labShell: ILabShell | null,
+    statusBar: IStatusBar | null
   ): IPositionModel => {
     const item = new LineCol(translator);
 
@@ -138,13 +138,15 @@ export const lineColItem: JupyterFrontEndPlugin<IPositionModel> = {
       (widget: Widget | null) => CodeEditor.IEditor | null
     >();
 
-    // Add the status item to the status bar.
-    statusBar.registerStatusItem(lineColItem.id, {
-      item,
-      align: 'right',
-      rank: 2,
-      isActive: () => !!item.model.editor
-    });
+    if (statusBar) {
+      // Add the status item to the status bar.
+      statusBar.registerStatusItem(lineColItem.id, {
+        item,
+        align: 'right',
+        rank: 2,
+        isActive: () => !!item.model.editor
+      });
+    }
 
     const addEditorProvider = (
       provider: (widget: Widget | null) => CodeEditor.IEditor | null


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Noticed when updating to the latest lab packages for Notebook v7: https://github.com/jupyter/notebook/pull/6314



<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

The definition of `IPositionModel` doesn't indicate anything related to the status bar:

https://github.com/jupyterlab/jupyterlab/blob/d33de1537004414bd2242661a4797d53d2e699cd/packages/codeeditor/src/tokens.ts#L32-L57

But the plugin definition of the plugin providing `IPositionModel` still requires `IStatusBar`.

It looks like these two should be independent. Or that `IStatusBar` should at least be `optional`, if some other plugins want to require `IPositionModel`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None for lab users.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
