### PR TITLE
Fix installed extensions in the extension manager

### DIFF
--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -832,7 +832,7 @@ risks or contain malicious code that runs on your machine.`)}
             listMode={model.listMode}
             viewType={'installed'}
             entries={
-              model.searchResult.length > 0
+              model.query && model.searchResult.length > 0
                 ? model.installed.filter(
                     entry => model.searchResult.indexOf(entry) > -1
                   )

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -832,7 +832,7 @@ risks or contain malicious code that runs on your machine.`)}
             listMode={model.listMode}
             viewType={'installed'}
             entries={
-              model.query && model.searchResult.length > 0
+              model.query?.trim() && model.searchResult.length > 0
                 ? model.installed.filter(
                     entry => model.searchResult.indexOf(entry) > -1
                   )


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/12233

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/7423

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Fixes the logic to list installed extensions in the extension manager.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

With the following prebuilt extensions installed and JupyterLab dev mode started with `--extensions-in-dev-mode`:

```bash
$ jupyter labextension list
JupyterLab v4.0.0a22
PREFIX/share/jupyter/labextensions
        @jupyter-widgets/jupyterlab-manager v3.1.0 enabled  X (python, jupyterlab_widgets)
        @jupyterlab/geojson-extension v3.2.0 enabled  X (python, jupyterlab-geojson)
```

#### Before

![image](https://user-images.githubusercontent.com/591645/159036342-a9d594d6-389e-41ac-be64-92cba72a77eb.png)


#### After

![image](https://user-images.githubusercontent.com/591645/159036270-df8e27ee-ab5d-4608-8cf6-b086d66df968.png)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
