### PR TITLE
Add aria progressbar role and data-status for testing in extensions

### DIFF
--- a/packages/notebook/src/executionindicator.tsx
+++ b/packages/notebook/src/executionindicator.tsx
@@ -77,6 +77,7 @@ export function ExecutionIndicatorComponent(
     <div
       className={'jp-Notebook-ExecutionIndicator'}
       title={showProgress ? '' : titleFactory(kernelStatuses[status])}
+      data-status={status}
     >
       {circle}
       <div

--- a/packages/statusbar/src/components/progressBar.tsx
+++ b/packages/statusbar/src/components/progressBar.tsx
@@ -32,10 +32,16 @@ export namespace ProgressBar {
  * A functional tsx component for a progress bar.
  */
 export function ProgressBar(props: ProgressBar.IProps): JSX.Element {
-  const { width, ...rest } = props;
+  const { width, percentage, ...rest } = props;
   return (
-    <div className={'jp-Statusbar-ProgressBar-progress-bar'}>
-      <Filler {...rest} contentWidth={width} />
+    <div
+      className={'jp-Statusbar-ProgressBar-progress-bar'}
+      role="progressbar"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={percentage}
+    >
+      <Filler {...{ percentage, ...rest }} contentWidth={width} />
     </div>
   );
 }

--- a/packages/statusbar/src/components/progressCircle.tsx
+++ b/packages/statusbar/src/components/progressCircle.tsx
@@ -34,7 +34,13 @@ export function ProgressCircle(props: ProgressCircle.IProps): JSX.Element {
     return shape;
   };
   return (
-    <div className={'jp-Statusbar-ProgressCircle'}>
+    <div
+      className={'jp-Statusbar-ProgressCircle'}
+      role="progressbar"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={props.progress}
+    >
       <svg viewBox="0 0 250 250">
         <circle
           cx="125"


### PR DESCRIPTION
## References

Fixes #12174

## Code changes

- exposes kernel status in DOM as a data attribute for easier downstream testing
- adds aria attributes for progress bar

## User-facing changes

Screen reader users may notice the progress updates being read out depending on the screen reader and it settings.

## Backwards-incompatible changes

None