### PR TITLE
Fix settings with `null` default not getting marked as modified

### DIFF
--- a/packages/settingregistry/src/settingregistry.ts
+++ b/packages/settingregistry/src/settingregistry.ts
@@ -728,9 +728,7 @@ export class Settings implements ISettingRegistry.ISettings {
       const defaultValue = this.default(key);
       if (
         value === undefined ||
-        value === null ||
         defaultValue === undefined ||
-        defaultValue === null ||
         JSONExt.deepEqual(value, JSONExt.emptyObject) ||
         JSONExt.deepEqual(value, JSONExt.emptyArray)
       ) {


### PR DESCRIPTION
## References

Fixes #12092.

## Code changes

Remove lines which were ignoring `null` so that changes in setting if the user-set value, or the default values is `null` are recognised as modifications.

## User-facing changes

Settings UI properly marks sections with modified settings when only fields with `null` where modified (such as Markdown Viewer → Line Width).

| Before (`Restore to Defaults` not shown, even though settings were modified) | After (shown correctly) |
| --- | --- |
| ![Screenshot from 2022-03-20 02-05-55](https://user-images.githubusercontent.com/5832902/159144912-44b800ae-3e7d-40d5-aef9-c8eab59697e8.png) | ![Screenshot from 2022-03-20 02-06-23](https://user-images.githubusercontent.com/5832902/159144910-6cf13ed0-1d3c-4ad9-90a3-9fd4012c8397.png) |

## Backwards-incompatible changes

None.