### PR TITLE
Show kernel name on restart to avoid data loss on misclick

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -1353,7 +1353,8 @@ export const sessionContextDialogs: ISessionContext.IDialogs = {
     const result = await showDialog({
       title: trans.__('Restart Kernel?'),
       body: trans.__(
-        'Do you want to restart the current kernel? All variables will be lost.'
+        'Do you want to restart the kernel of %1? All variables will be lost.',
+        sessionContext.name
       ),
       buttons: [Dialog.cancelButton(), restartBtn]
     });


### PR DESCRIPTION
## References

A simple solution to #11716.

## Code changes

Update text in the modal to show the name of the kernel that is getting restarted.

Grammar suggestions welcome.

## User-facing changes

| Before | After |
| --- | --- |
|  ![image](https://user-images.githubusercontent.com/5832902/159145601-3e8b7c92-1298-40c6-b1b9-2e8bf655afcd.png) | ![Screenshot from 2022-03-20 02-35-42](https://user-images.githubusercontent.com/5832902/159145594-1fb7e436-aa32-44a2-8fd3-49ffcd71a1a7.png) |


## Backwards-incompatible changes

Changes translated string so should not be backported to already released 3.3.x.