### PR TITLE
Update link to `jupyterlab-some-package` in docs

### DIFF
--- a/docs/source/extension/internationalization.rst
+++ b/docs/source/extension/internationalization.rst
@@ -4,7 +4,7 @@ Internationalization and Localization
 To internationalize your extension, the following tasks are required:
 
 .. note::
-    
+
     Please read carefully the :ref:`internationalization-rules` as they are strong constraints for internationalization to work.
 
 1. Add the token ``ITranslator`` from ``@jupyterlab/translation`` package to your plugin dependencies.
@@ -47,7 +47,7 @@ You could also look at the following pull requests on the
 4. Create and publish the translation for your extension.
 
 There are two options: you can either add your extension to the JupyterLab `language packs <https://github.com/jupyterlab/language-packs/#adding-a-new-extension>`_
-or you can create a python package to distribute your extension translation (see `test example <https://github.com/jupyterlab/jupyterlab_server/tree/master/jupyterlab_server/tests/translations/jupyterlab-some-package>`_).
+or you can create a python package to distribute your extension translation (see `test example <https://github.com/jupyterlab/jupyterlab_server/tree/main/tests/translations/jupyterlab-some-package>`_).
 
 
 Settings translation


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This should help fix the failing link check running on CI, as seen in https://github.com/jupyterlab/jupyterlab/runs/5614948983?check_suite_focus=true

```
F                                                                        [100%]
=================================== FAILURES ===================================
_ /home/runner/work/jupyterlab/jupyterlab/.jupyter_releaser_checkout/docs/source/extension/internationalization.rst: https://github.com/jupyterlab/jupyterlab_server/tree/master/jupyterlab_server/tests/translations/jupyterlab-some-package _
https://github.com/jupyterlab/jupyterlab_server/tree/master/jupyterlab_server/tests/translations/jupyterlab-some-package: 404: Not Found
```

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update link in documentation.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
