### PR TITLE
Default is no virtual rendering + Relax virtual notebook rendering and ensure no structural change until rendering is completed

### DIFF
--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -856,7 +856,7 @@
       "title": "Number of cells to render directly",
       "description": "Define the number of cells to render directly when virtual notebook intersection observer is available",
       "type": "number",
-      "default": 20
+      "default": 99999
     },
     "renderCellOnIdle": {
       "title": "Render cell on browser idle time",

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -858,6 +858,12 @@
       "type": "number",
       "default": 99999
     },
+    "remainingTimeBeforeRescheduling": {
+      "title": "Remaining time in milliseconds before virtual notebook rendering is rescheduled",
+      "description": "Define the remaining time in milliseconds before virtual notebook rendering is rescheduled. Set 0 if you want to disable any rescheduling",
+      "type": "number",
+      "default": 50
+    },
     "renderCellOnIdle": {
       "title": "Render cell on browser idle time",
       "description": "Defines if the placeholder cells should be rendered when the browser is idle",

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1461,6 +1461,9 @@ function activateNotebookHandler(
       recordTiming: settings.get('recordTiming').composite as boolean,
       numberCellsToRenderDirectly: settings.get('numberCellsToRenderDirectly')
         .composite as number,
+      remainingTimeBeforeRescheduling: settings.get(
+        'remainingTimeBeforeRescheduling'
+      ).composite as number,
       renderCellOnIdle: settings.get('renderCellOnIdle').composite as boolean,
       observedTopMargin: settings.get('observedTopMargin').composite as string,
       observedBottomMargin: settings.get('observedBottomMargin')

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2000,12 +2000,21 @@ namespace Private {
     activeCell: Cell | null;
   }
 
-  export function isNotebookRendered(notebook: Notebook): boolean {
+  export function isNotebookRendered(
+    notebook: Notebook,
+    translator?: ITranslator
+  ): boolean {
+    translator = translator || nullTranslator;
+    const trans = translator.load('jupyterlab');
+
     if (notebook.remainingCellToRenderCount !== 0) {
       showDialog({
-        body: `Notebook is still rendering and has for now ${notebook.remainingCellToRenderCount} remaining cells to render.
+        body: trans.__(
+          `Notebook is still rendering and has for now (%1) remaining cells to render.
 
 Please wait for the complete rendering before invoking that action.`,
+          notebook.remainingCellToRenderCount
+        ),
         buttons: [Dialog.okButton({ label: 'Ok' })]
       }).catch(reason => {
         console.error(

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2015,7 +2015,7 @@ namespace Private {
 Please wait for the complete rendering before invoking that action.`,
           notebook.remainingCellToRenderCount
         ),
-        buttons: [Dialog.okButton({ label: 'Ok' })]
+        buttons: [Dialog.okButton({ label: trans.__('Ok') })]
       }).catch(reason => {
         console.error(
           'An error occurred when displaying notebook rendering warning',

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2000,9 +2000,7 @@ namespace Private {
     activeCell: Cell | null;
   }
 
-  export function isNotebookRendered(
-    notebook: Notebook,
-  ): boolean {
+  export function isNotebookRendered(notebook: Notebook): boolean {
     const translator = notebook.translator;
     const trans = translator.load('jupyterlab');
 

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2003,7 +2003,7 @@ namespace Private {
   export function isNotebookRendered(
     notebook: Notebook,
   ): boolean {
-    translator = notebook.translator;
+    const translator = notebook.translator;
     const trans = translator.load('jupyterlab');
 
     if (notebook.remainingCellToRenderCount !== 0) {

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2002,9 +2002,8 @@ namespace Private {
 
   export function isNotebookRendered(
     notebook: Notebook,
-    translator?: ITranslator
   ): boolean {
-    translator = translator || nullTranslator;
+    translator = notebook.translator;
     const trans = translator.load('jupyterlab');
 
     if (notebook.remainingCellToRenderCount !== 0) {

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -149,6 +149,9 @@ export namespace NotebookActions {
       return;
     }
 
+    if (!Private.isNotebookRendered(notebook)) {
+      return;
+    }
     const state = Private.getState(notebook);
 
     notebook.deselectAll();
@@ -244,6 +247,9 @@ export namespace NotebookActions {
       return;
     }
 
+    if (!Private.isNotebookRendered(notebook)) {
+      return;
+    }
     const state = Private.getState(notebook);
     const toMerge: string[] = [];
     const toDelete: ICellModel[] = [];
@@ -340,6 +346,9 @@ export namespace NotebookActions {
       return;
     }
 
+    if (!Private.isNotebookRendered(notebook)) {
+      return;
+    }
     const state = Private.getState(notebook);
 
     Private.deleteCells(notebook);
@@ -362,6 +371,9 @@ export namespace NotebookActions {
       return;
     }
 
+    if (!Private.isNotebookRendered(notebook)) {
+      return;
+    }
     const state = Private.getState(notebook);
     const model = notebook.model;
     const cell = model.contentFactory.createCell(
@@ -394,6 +406,9 @@ export namespace NotebookActions {
       return;
     }
 
+    if (!Private.isNotebookRendered(notebook)) {
+      return;
+    }
     const state = Private.getState(notebook);
     const model = notebook.model;
     const cell = model.contentFactory.createCell(
@@ -419,6 +434,9 @@ export namespace NotebookActions {
       return;
     }
 
+    if (!Private.isNotebookRendered(notebook)) {
+      return;
+    }
     const state = Private.getState(notebook);
     const cells = notebook.model.cells;
     const widgets = notebook.widgets;
@@ -450,6 +468,9 @@ export namespace NotebookActions {
       return;
     }
 
+    if (!Private.isNotebookRendered(notebook)) {
+      return;
+    }
     const state = Private.getState(notebook);
     const cells = notebook.model.cells;
     const widgets = notebook.widgets;
@@ -594,6 +615,9 @@ export namespace NotebookActions {
       return Promise.resolve(false);
     }
 
+    if (!Private.isNotebookRendered(notebook)) {
+      return Promise.resolve(false);
+    }
     const state = Private.getState(notebook);
     const promise = Private.runSelected(notebook, sessionContext);
     const model = notebook.model;
@@ -1066,6 +1090,9 @@ export namespace NotebookActions {
    * A new code cell is added if all cells are cut.
    */
   export function cut(notebook: Notebook): void {
+    if (!Private.isNotebookRendered(notebook)) {
+      return;
+    }
     Private.copyOrCut(notebook, true);
   }
 
@@ -1089,6 +1116,10 @@ export namespace NotebookActions {
     mode: 'below' | 'above' | 'replace' = 'below'
   ): void {
     if (!notebook.model || !notebook.activeCell) {
+      return;
+    }
+
+    if (!Private.isNotebookRendered(notebook)) {
       return;
     }
 
@@ -1189,6 +1220,9 @@ export namespace NotebookActions {
       return;
     }
 
+    if (!Private.isNotebookRendered(notebook)) {
+      return;
+    }
     const state = Private.getState(notebook);
 
     notebook.mode = 'command';
@@ -1964,6 +1998,19 @@ namespace Private {
      * The active cell before the action.
      */
     activeCell: Cell | null;
+  }
+
+  export function isNotebookRendered(notebook: Notebook): boolean {
+    if (notebook.cellsToRender.size !== 0) {
+      showDialog({
+        body: `Notebook is still rendering and has for now ${notebook.cellsToRender.size} remaining cells to render.
+
+Please wait for the complete rendering before invoking that action.`,
+        buttons: [Dialog.okButton({ label: 'Ok' })]
+      }).then(() => undefined);
+      return false;
+    }
+    return true;
   }
 
   /**

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2007,7 +2007,12 @@ namespace Private {
 
 Please wait for the complete rendering before invoking that action.`,
         buttons: [Dialog.okButton({ label: 'Ok' })]
-      }).catch((reason) => { console.error('An error occurred when displaying notebook rendering warning', reason); });
+      }).catch(reason => {
+        console.error(
+          'An error occurred when displaying notebook rendering warning',
+          reason
+        );
+      });
       return false;
     }
     return true;

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2001,9 +2001,9 @@ namespace Private {
   }
 
   export function isNotebookRendered(notebook: Notebook): boolean {
-    if (notebook.cellsToRender.size !== 0) {
+    if (notebook.remainingCellToRenderCount !== 0) {
       showDialog({
-        body: `Notebook is still rendering and has for now ${notebook.cellsToRender.size} remaining cells to render.
+        body: `Notebook is still rendering and has for now ${notebook.remainingCellToRenderCount} remaining cells to render.
 
 Please wait for the complete rendering before invoking that action.`,
         buttons: [Dialog.okButton({ label: 'Ok' })]

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2007,7 +2007,7 @@ namespace Private {
 
 Please wait for the complete rendering before invoking that action.`,
         buttons: [Dialog.okButton({ label: 'Ok' })]
-      }).then(() => undefined);
+      }).catch((reason) => { console.error('An error occurred when displaying notebook rendering warning', reason); });
       return false;
     }
     return true;

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -605,7 +605,11 @@ export class StaticNotebook extends Widget {
   }
 
   private _scheduleCellRenderOnIdle() {
-    if (this._observer && this.notebookConfig.renderCellOnIdle) {
+    if (
+      this._observer &&
+      this.notebookConfig.renderCellOnIdle &&
+      !this.isDisposed
+    ) {
       const renderPlaceholderCells = this._renderPlaceholderCells.bind(this);
       (window as any).requestIdleCallback(renderPlaceholderCells, {
         timeout: 3000

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -856,8 +856,8 @@ export class StaticNotebook extends Widget {
     this._renderedCellsCount++;
   }
 
-  public get cellsToRender(): Map<string, { index: number; cell: Cell }> {
-    return this._toRenderMap;
+  public get remainingCellToRenderCount(): number {
+    return this._toRenderMap.size;
   }
 
   private _editorConfig = StaticNotebook.defaultEditorConfig;

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -600,6 +600,7 @@ export class StaticNotebook extends Widget {
       // We have no intersection observer, or we insert, or we are below
       // the number of cells to render directly, so we render directly.
       layout.insertWidget(index, widget);
+      this.onCellInserted(index, widget);
       this._incrementRenderedCount();
     }
     this._scheduleCellRenderOnIdle();

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -601,8 +601,8 @@ export class StaticNotebook extends Widget {
       // the number of cells to render directly, so we render directly.
       layout.insertWidget(index, widget);
       this._incrementRenderedCount();
-      this._scheduleCellRenderOnIdle();
     }
+    this._scheduleCellRenderOnIdle();
   }
 
   private _scheduleCellRenderOnIdle() {
@@ -611,13 +611,15 @@ export class StaticNotebook extends Widget {
       this.notebookConfig.renderCellOnIdle &&
       !this.isDisposed
     ) {
-      const renderPlaceholderCells = this._renderPlaceholderCells.bind(this);
-      this._idleCallBack = (window as any).requestIdleCallback(
-        renderPlaceholderCells,
-        {
-          timeout: 3000
-        }
-      );
+      if (!this._idleCallBack) {
+        const renderPlaceholderCells = this._renderPlaceholderCells.bind(this);
+        this._idleCallBack = (window as any).requestIdleCallback(
+          renderPlaceholderCells,
+          {
+            timeout: 3000
+          }
+        );
+      }
     }
   }
 
@@ -632,10 +634,11 @@ export class StaticNotebook extends Widget {
       ) {
         if (this._idleCallBack) {
           window.cancelIdleCallback(this._idleCallBack);
+          this._idleCallBack = null;
         }
+        this._scheduleCellRenderOnIdle();
       }
     }
-    this._scheduleCellRenderOnIdle();
 
     if (
       this._renderedCellsCount < this._cellsArray.length &&

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -39,6 +39,7 @@ const notebookConfig = {
   defaultCell: 'code' as nbformat.CellType,
   recordTiming: false,
   numberCellsToRenderDirectly: 2,
+  remainingTimeBeforeRescheduling: 50,
   renderCellOnIdle: true,
   observedTopMargin: '1000px',
   observedBottomMargin: '1000px',

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -38,7 +38,7 @@ const notebookConfig = {
   scrollPastEnd: true,
   defaultCell: 'code' as nbformat.CellType,
   recordTiming: false,
-  numberCellsToRenderDirectly: 2,
+  numberCellsToRenderDirectly: 9999,
   remainingTimeBeforeRescheduling: 50,
   renderCellOnIdle: true,
   observedTopMargin: '1000px',


### PR DESCRIPTION
## References

Continuation of https://github.com/jupyterlab/jupyterlab/pull/12166 PR done by @rtrg

Closes https://github.com/jupyterlab/jupyterlab/pull/12166

## Code changes

The rendering virtual notebook rendering of the cells is rescheduled if no idle time can be found by the browser.
The notebook actions which change the structure of the notebook are disabled and an information message is shown to the user.
To ensure user is not impacted, the default setting for the cells to be rendered directly is set to a high number (99999) so that this feature will be an opt-in.

## User-facing changes

![Untitled4](https://user-images.githubusercontent.com/226720/159513944-7a437d16-2db1-482a-ac1d-ecf9eefc8e69.gif)

## Backwards-incompatible changes

None.