### PR TITLE
Stop using py.test

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -15,7 +15,7 @@ pytest_plugins = [
 
 def pytest_addoption(parser):
     """
-    Adds flags for py.test.
+    Adds flags for pytest.
 
     This is called by the pytest API
     """

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -898,7 +898,7 @@ To test the docs run:
 
 .. code:: bash
 
-   py.test --check-links -k .md . || py.test --check-links -k .md --lf .
+   python -m pytest --check-links -k .md . || python -m pytest --check-links -k .md --lf .
 
 The Read the Docs pages can be built using ``make``:
 

--- a/scripts/ci_script.ps1
+++ b/scripts/ci_script.ps1
@@ -11,7 +11,7 @@ if ($Env:GROUP -eq "python") {
     if ($LASTEXITCODE -ne 0) { throw "Command failed. See above errors for details" }
 
     # Run the python tests
-    py.test
+    python -m pytest
     if ($LASTEXITCODE -ne 0) { throw "Command failed. See above errors for details" }
 }
 

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -14,7 +14,7 @@ fi
 if [[ $GROUP == python ]]; then
     jupyter lab build --debug
     # Run the python tests
-    py.test
+    python -m pytest
 fi
 
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
MacOS CI failure due to not found `py.test`
Example: https://github.com/jupyterlab/jupyterlab/runs/5657563889?check_suite_focus=true
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Use pytest instead of `py.test` in CI script and documentation.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A