### PR TITLE
Move the file browser upload button to a separate plugin so it can be disabled

### DIFF
--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -22,7 +22,6 @@ import { PanelLayout, Widget } from '@lumino/widgets';
 import { BreadCrumbs } from './crumbs';
 import { DirListing } from './listing';
 import { FilterFileBrowserModel } from './model';
-import { Uploader } from './upload';
 
 /**
  * The class name added to file browsers.
@@ -92,7 +91,6 @@ export class FileBrowser extends Widget {
       },
       tooltip: this._trans.__('New Folder')
     });
-    const uploader = new Uploader({ model, translator: this.translator });
 
     const refresher = new ToolbarButton({
       icon: refreshIcon,
@@ -103,7 +101,6 @@ export class FileBrowser extends Widget {
     });
 
     this.toolbar.addItem('newFolder', newFolder);
-    this.toolbar.addItem('upload', uploader);
     this.toolbar.addItem('refresher', refresher);
 
     this.listing = this.createDirListing({


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/10405

Should also help with https://github.com/jupyter/notebook/issues/5770

However this does not prevent dragging and dropping files to the listing to perform an upload.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Move the file upload button to a separate plugin so it can be disabled with:

```
jupyter labextension disable @jupyterlab/filebrowser-extension:file-upload-button
```

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

After running:

```
jupyter labextension disable @jupyterlab/filebrowser-extension:file-upload-button
```

**Before**

![image](https://user-images.githubusercontent.com/591645/160101433-5720f40f-79b9-44f8-b7e3-0a65f013c1c0.png)


**After**

![image](https://user-images.githubusercontent.com/591645/160101312-ac33e66b-2c0b-41a3-a107-59c1d2c17a6e.png)


## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
