### PR TITLE
Enable scrolling tabs in tab bar in main area

### DIFF
--- a/packages/application-extension/schema/shell.json
+++ b/packages/application-extension/schema/shell.json
@@ -14,6 +14,12 @@
       "title": "Start mode: ``, `single`or `multiple`",
       "description": "The mode under which JupyterLab should start. If empty, the mode will be imposed by the URL",
       "default": ""
+    },
+    "tabScrolling": {
+      "type": "boolean",
+      "title": "Tab scrolling",
+      "description": "Whether to enable scrolling of tabs when they overflow.",
+      "default": true
     }
   },
   "additionalProperties": false,

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -116,6 +116,8 @@ export namespace ILabShell {
      * for the transform action.
      */
     hiddenMode: 'display' | 'scale';
+
+    tabScrolling: boolean;
   }
 
   /**
@@ -287,7 +289,8 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     const vsplitPanel = (this._vsplitPanel = new Private.RestorableSplitPanel());
     const dockPanel = (this._dockPanel = new DockPanelSvg({
       hiddenMode: Widget.HiddenMode.Scale,
-      translator: options?.translator
+      translator: options?.translator,
+      tabScrollingEnabled: true
     }));
     MessageLoop.installMessageHook(dockPanel, this._dockChildHook);
 
@@ -1107,6 +1110,10 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
         config.hiddenMode === 'display'
           ? Widget.HiddenMode.Display
           : Widget.HiddenMode.Scale;
+    }
+    if (typeof config.tabScrolling !== 'undefined') {
+      console.log(config.tabScrolling);
+      this._dockPanel.tabScrollingEnabled = config.tabScrolling;
     }
   }
 

--- a/packages/application/style/tabs.css
+++ b/packages/application/style/tabs.css
@@ -12,6 +12,7 @@
   --jp-private-horizontal-tab-height: 24px;
   --jp-private-horizontal-tab-width: 216px;
   --jp-private-horizontal-tab-active-top-border: 2px;
+  --jp-horizontal-min-tab-width: 120px;
 }
 
 /*-----------------------------------------------------------------------------
@@ -37,8 +38,8 @@
   min-width: 80px;
 }
 
-.lm-DockPanel-tabBar > .lm-TabBar-content,
-.lm-TabPanel-tabBar > .lm-TabBar-content {
+.lm-DockPanel-tabBar > .lm-TabBar-wrapper > .lm-TabBar-content,
+.lm-TabPanel-tabBar > .lm-TabBar-wrapper > .lm-TabBar-content {
   align-items: flex-end;
   min-width: 0;
   min-height: 0;
@@ -51,7 +52,7 @@
   min-height: calc(
     var(--jp-private-horizontal-tab-height) + var(--jp-border-width)
   );
-  min-width: 0;
+  min-width: var(--jp-horizontal-min-tab-width);
   margin-left: calc(-1 * var(--jp-border-width));
   line-height: var(--jp-private-horizontal-tab-height);
   padding: 0 8px;
@@ -168,4 +169,20 @@
   min-width: var(--jp-private-horizontal-tab-width);
   padding: 0 10px;
   transform: translateX(-40%) translateY(-58%);
+}
+
+.lm-TabBar[data-orientation='horizontal'] > .lm-TabBar-wrapper::after {
+  background: linear-gradient(
+    to right,
+    rgba(0, 0, 0, 0),
+    var(--jp-border-color0)
+  );
+}
+
+.lm-TabBar[data-orientation='horizontal'] > .lm-TabBar-wrapper::before {
+  background: linear-gradient(
+    to left,
+    rgba(0, 0, 0, 0),
+    var(--jp-border-color0)
+  );
 }

--- a/packages/ui-components/src/icon/widgets/tabbarsvg.ts
+++ b/packages/ui-components/src/icon/widgets/tabbarsvg.ts
@@ -5,7 +5,12 @@ import { hpass, VirtualElement } from '@lumino/virtualdom';
 import { DockPanel, TabBar, TabPanel, Widget } from '@lumino/widgets';
 import { LabIconStyle } from '../../style';
 import { classes } from '../../utils';
-import { addIcon, closeIcon } from '../iconimports';
+import {
+  addIcon,
+  caretLeftIcon,
+  caretRightIcon,
+  closeIcon
+} from '../iconimports';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 
 /**
@@ -27,6 +32,15 @@ export class TabBarSvg<T> extends TabBar<T> {
     addIcon.element({
       container: this.addButtonNode,
       title: trans.__('New Launcher')
+    });
+    const isHorizontal = this.orientation == 'horizontal';
+    caretLeftIcon.element({
+      container: this.scrollBeforeButtonNode,
+      title: isHorizontal ? trans.__('Scroll left') : trans.__('Scroll top')
+    });
+    caretRightIcon.element({
+      container: this.scrollAfterButtonNode,
+      title: isHorizontal ? trans.__('Scroll right') : trans.__('Scroll bottom')
     });
   }
 }

--- a/packages/ui-components/style/tabbar.css
+++ b/packages/ui-components/style/tabbar.css
@@ -3,20 +3,16 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-.lm-TabBar .lm-TabBar-addButton {
+.lm-TabBar .lm-TabBar-button {
   align-items: center;
   display: flex;
   padding: 4px;
-  margin-right: 1px;
+  margin: 0 1px;
   background-color: var(--jp-layout-color2);
 }
 
-.lm-TabBar .lm-TabBar-addButton:hover {
+.lm-TabBar .lm-TabBar-button:hover {
   background-color: var(--jp-layout-color1);
-}
-
-.lm-DockPanel-tabBar .lm-TabBar-tab {
-  width: var(--jp-private-horizontal-tab-width);
 }
 
 .lm-DockPanel-tabBar .lm-TabBar-content {


### PR DESCRIPTION
## References

Fixes #10305, depends on https://github.com/jupyterlab/lumino/pull/297

TODO:
- [ ] decide on the minimum tab width or make it into a setting
- [ ] maybe reduce the scroll buttons
- [ ] add active and pressed style to the buttons

## Code changes

Adds a setting allowing to enable scrolling of tabs.

## User-facing changes

Users can scroll:
- by pressing the arrow buttons at the ends of tabs list (which only show up if the tab bar overflows)
- by using browser built-in scrolling (e.g. <kbd>Shift</kbd> + mouse wheel; shift needed as this is left-right scrolling)
- when dragging tabs by hovering over the arrow buttons

![scrollbar](https://user-images.githubusercontent.com/5832902/160303846-be561034-e8c9-407a-9558-a035093ccaa9.gif)

## Backwards-incompatible changes

None