### PR TITLE
Customize the file browser toolbar via the settings

### DIFF
--- a/docs/source/extension/extension_points.rst
+++ b/docs/source/extension/extension_points.rst
@@ -780,7 +780,7 @@ Toolbar Registry
 
 JupyterLab provides an infrastructure to define and customize toolbar widgets
 from the settings, which is similar to that defining the context menu and the main menu
-bar. 
+bar.
 
 Document Widgets
 ^^^^^^^^^^^^^^^^
@@ -943,7 +943,7 @@ Here is an example for enabling that definition on a widget:
        (browser: FileBrowser) =>
          new Uploader({ model: browser.model, translator })
      );
- 
+
      // - Link the widget toolbar and its definition from the settings
      setToolbar(
        browser,

--- a/docs/source/extension/extension_points.rst
+++ b/docs/source/extension/extension_points.rst
@@ -916,13 +916,13 @@ And the toolbar item must follow this definition:
 Generic Widget with Toolbar
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The logic explain in the previous paragraph can be used to customize any widgets with a toolbar.
+The logic detailed in the previous section can be used to customize any widgets with a toolbar.
 
 The additional keys used in ``jupyter.lab.toolbars`` settings attributes are:
 
 - ``FileBrowser``: Default file browser panel toolbar items
 
-To create the toolbar items from that definition on a widget would can use a logic like the following:
+Here is an example for enabling that definition on a widget:
 
 .. code:: typescript
 
@@ -936,7 +936,7 @@ To create the toolbar items from that definition on a widget would can use a log
      const browser = new FileBrowser();
 
      // Toolbar
-     // - Define a customized toolbar item
+     // - Define a custom toolbar item
      toolbarRegistry.registerFactory(
        'FileBrowser', // Factory name
        'uploader',

--- a/docs/source/extension/extension_points.rst
+++ b/docs/source/extension/extension_points.rst
@@ -778,9 +778,14 @@ When the ``labStatus`` busy state changes, we update the text content of the
 Toolbar Registry
 ----------------
 
-JupyterLab provides an infrastructure to define and customize toolbar widgets of ``DocumentWidget`` s
+JupyterLab provides an infrastructure to define and customize toolbar widgets
 from the settings, which is similar to that defining the context menu and the main menu
-bar. A typical example is the notebook toolbar as in the snippet below:
+bar. 
+
+Document Widgets
+^^^^^^^^^^^^^^^^
+
+A typical example is the notebook toolbar as in the snippet below:
 
 .. code:: typescript
 
@@ -907,6 +912,49 @@ And the toolbar item must follow this definition:
 
 .. literalinclude:: ../snippets/packages/settingregistry/src/toolbarItem.json
    :language: json
+
+Generic Widget with Toolbar
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The logic explain in the previous paragraph can be used to customize any widgets with a toolbar.
+
+The additional keys used in ``jupyter.lab.toolbars`` settings attributes are:
+
+- ``FileBrowser``: Default file browser panel toolbar items
+
+To create the toolbar items from that definition on a widget would can use a logic like the following:
+
+.. code:: typescript
+
+   function activatePlugin(
+     app: JupyterFrontEnd,
+     // ...
+     toolbarRegistry: IToolbarWidgetRegistry,
+     settingRegistry: ISettingRegistry
+   ): void {
+
+     const browser = new FileBrowser();
+
+     // Toolbar
+     // - Define a customized toolbar item
+     toolbarRegistry.registerFactory(
+       'FileBrowser', // Factory name
+       'uploader',
+       (browser: FileBrowser) =>
+         new Uploader({ model: browser.model, translator })
+     );
+ 
+     // - Link the widget toolbar and its definition from the settings
+     setToolbar(
+       browser,
+       createToolbarFactory(
+         toolbarRegistry,
+         settings,
+         'FileBrowser', // Factory name
+         plugin.id,
+         translator
+       )
+     );
 
 .. _widget-tracker:
 

--- a/packages/apputils/src/index.ts
+++ b/packages/apputils/src/index.ts
@@ -51,7 +51,8 @@ export * from './tokens';
 export {
   ToolbarWidgetRegistry,
   createDefaultFactory,
-  createToolbarFactory
+  createToolbarFactory,
+  setToolbar
 } from './toolbar';
 export * from './widgettracker';
 export * from './windowresolver';

--- a/packages/apputils/src/toolbar/factory.ts
+++ b/packages/apputils/src/toolbar/factory.ts
@@ -1,7 +1,8 @@
 import { IObservableList, ObservableList } from '@jupyterlab/observables';
 import { ISettingRegistry, SettingRegistry } from '@jupyterlab/settingregistry';
 import { ITranslator, TranslationBundle } from '@jupyterlab/translation';
-import { toArray } from '@lumino/algorithm';
+import { Toolbar } from '@jupyterlab/ui-components';
+import { findIndex, toArray } from '@lumino/algorithm';
 import { JSONExt, PartialJSONObject } from '@lumino/coreutils';
 import { Widget } from '@lumino/widgets';
 import { Dialog, showDialog } from '../dialog';
@@ -227,7 +228,7 @@ async function setToolbarItems(
  * @param pluginId Settings plugin id
  * @param translator Translator
  * @param propertyId Toolbar definition key in the settings plugin
- * @returns List of toolbar widgets
+ * @returns List of toolbar widgets factory
  */
 export function createToolbarFactory(
   toolbarRegistry: IToolbarWidgetRegistry,
@@ -303,4 +304,99 @@ export function createToolbarFactory(
 
     return toolbar;
   };
+}
+
+/**
+ * Set the toolbar items of a widget from a factory
+ *
+ * @param widget Widget with the toolbar to set
+ * @param factory Toolbar items factory
+ */
+export function setToolbar(
+  widget: Toolbar.IWidgetToolbar,
+  factory: (
+    widget: Widget
+  ) =>
+    | IObservableList<ToolbarRegistry.IToolbarItem>
+    | ToolbarRegistry.IToolbarItem[]
+): void {
+  if (!widget.toolbar) {
+    console.log(`Widget ${widget.id} has no 'toolbar'.`);
+    return;
+  }
+  const items = factory(widget);
+
+  if (Array.isArray(items)) {
+    items.forEach(({ name, widget: item }) => {
+      widget.toolbar!.addItem(name, item);
+    });
+  } else {
+    const updateToolbar = (
+      list: IObservableList<ToolbarRegistry.IToolbarItem>,
+      changes: IObservableList.IChangedArgs<ToolbarRegistry.IToolbarItem>
+    ) => {
+      switch (changes.type) {
+        case 'add':
+          changes.newValues.forEach((item, index) => {
+            widget.toolbar!.insertItem(
+              changes.newIndex + index,
+              item.name,
+              item.widget
+            );
+          });
+          break;
+        case 'move':
+          changes.oldValues.forEach(item => {
+            item.widget.parent = null;
+          });
+          changes.newValues.forEach((item, index) => {
+            widget.toolbar!.insertItem(
+              changes.newIndex + index,
+              item.name,
+              item.widget
+            );
+          });
+          break;
+        case 'remove':
+          changes.oldValues.forEach(item => {
+            item.widget.parent = null;
+          });
+          break;
+        case 'set':
+          changes.oldValues.forEach(item => {
+            item.widget.parent = null;
+          });
+
+          changes.newValues.forEach((item, index) => {
+            const existingIndex = findIndex(
+              widget.toolbar!.names(),
+              name => item.name === name
+            );
+            if (existingIndex >= 0) {
+              toArray(widget.toolbar!.children())[existingIndex].parent = null;
+            }
+
+            widget.toolbar!.insertItem(
+              changes.newIndex + index,
+              item.name,
+              item.widget
+            );
+          });
+          break;
+      }
+    };
+
+    updateToolbar(items, {
+      newIndex: 0,
+      newValues: toArray(items),
+      oldIndex: 0,
+      oldValues: [],
+      type: 'add'
+    });
+
+    items.changed.connect(updateToolbar);
+    widget.disposed.connect(() => {
+      items.changed.disconnect(updateToolbar);
+    });
+  }
 }

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -428,7 +428,10 @@ export abstract class ABCWidgetFactory<
     const widget = this.createNewWidget(context, source);
 
     // Add toolbar
-    setToolbar(widget, this._toolbarFactory ?? this.defaultToolbarFactory);
+    setToolbar(
+      widget,
+      this._toolbarFactory ?? this.defaultToolbarFactory.bind(this)
+    );
 
     // Emit widget created signal
     this._widgetCreated.emit(widget);

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { MainAreaWidget } from '@jupyterlab/apputils';
+import { MainAreaWidget, setToolbar } from '@jupyterlab/apputils';
 import { CodeEditor } from '@jupyterlab/codeeditor';
 import { Mode } from '@jupyterlab/codemirror';
 import { IChangedArgs, PathExt } from '@jupyterlab/coreutils';
@@ -9,7 +9,6 @@ import { IModelDB, IObservableList } from '@jupyterlab/observables';
 import { Contents } from '@jupyterlab/services';
 import * as models from '@jupyterlab/shared-models';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
-import { findIndex, toArray } from '@lumino/algorithm';
 import { PartialJSONValue } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 import { Title, Widget } from '@lumino/widgets';
@@ -428,85 +427,8 @@ export abstract class ABCWidgetFactory<
     // Create the new widget
     const widget = this.createNewWidget(context, source);
 
-    // Add toolbar items
-    const items:
-      | DocumentRegistry.IToolbarItem[]
-      | IObservableList<DocumentRegistry.IToolbarItem> = (
-      this._toolbarFactory?.bind(this) ?? this.defaultToolbarFactory.bind(this)
-    )(widget);
-
-    if (Array.isArray(items)) {
-      items.forEach(({ name, widget: item }) => {
-        widget.toolbar.addItem(name, item);
-      });
-    } else {
-      const updateToolbar = (
-        list: IObservableList<DocumentRegistry.IToolbarItem>,
-        changes: IObservableList.IChangedArgs<DocumentRegistry.IToolbarItem>
-      ) => {
-        switch (changes.type) {
-          case 'add':
-            changes.newValues.forEach((item, index) => {
-              widget.toolbar.insertItem(
-                changes.newIndex + index,
-                item.name,
-                item.widget
-              );
-            });
-            break;
-          case 'move':
-            changes.oldValues.forEach(item => {
-              item.widget.parent = null;
-            });
-            changes.newValues.forEach((item, index) => {
-              widget.toolbar.insertItem(
-                changes.newIndex + index,
-                item.name,
-                item.widget
-              );
-            });
-            break;
-          case 'remove':
-            changes.oldValues.forEach(item => {
-              item.widget.parent = null;
-            });
-            break;
-          case 'set':
-            changes.oldValues.forEach(item => {
-              item.widget.parent = null;
-            });
-
-            changes.newValues.forEach((item, index) => {
-              const existingIndex = findIndex(
-                widget.toolbar.names(),
-                name => item.name === name
-              );
-              if (existingIndex >= 0) {
-                toArray(widget.toolbar.children())[existingIndex].parent = null;
-              }
-
-              widget.toolbar.insertItem(
-                changes.newIndex + index,
-                item.name,
-                item.widget
-              );
-            });
-            break;
-        }
-      };
-
-      updateToolbar(items, {
-        newIndex: 0,
-        newValues: toArray(items),
-        oldIndex: 0,
-        oldValues: [],
-        type: 'add'
-      });
-      items.changed.connect(updateToolbar);
-      widget.disposed.connect(() => {
-        items.changed.disconnect(updateToolbar);
-      });
-    }
+    // Add toolbar
+    setToolbar(widget, this._toolbarFactory ?? this.defaultToolbarFactory);
 
     // Emit widget created signal
     this._widgetCreated.emit(widget);

--- a/packages/filebrowser-extension/schema/widget.json
+++ b/packages/filebrowser-extension/schema/widget.json
@@ -1,0 +1,82 @@
+{
+  "title": "File Browser Widget",
+  "description": "File Browser widget settings.",
+  "jupyter.lab.toolbars": {
+    "FileBrowser": [
+      {
+        "name": "new-launcher",
+        "command": "filebrowser:create-main-launcher",
+        "rank": 1
+      },
+      {
+        "name": "new-directory",
+        "command": "filebrowser:create-new-directory",
+        "rank": 10
+      },
+      { "name": "uploader", "rank": 20 },
+      { "name": "refresh", "command": "filebrowser:refresh", "rank": 30 }
+    ]
+  },
+  "jupyter.lab.transform": true,
+  "properties": {
+    "toolbar": {
+      "title": "File browser toolbar items",
+      "description": "Note: To disable a toolbar item,\ncopy it to User Preferences and add the\n\"disabled\" key. The following example will disable the uploader button:\n{\n  \"toolbar\": [\n    {\n      \"name\": \"uploader\",\n      \"disabled\": true\n    }\n  ]\n}\n\nToolbar description:",
+      "items": {
+        "$ref": "#/definitions/toolbarItem"
+      },
+      "type": "array",
+      "default": []
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "definitions": {
+    "toolbarItem": {
+      "properties": {
+        "name": {
+          "title": "Unique name",
+          "type": "string"
+        },
+        "args": {
+          "title": "Command arguments",
+          "type": "object"
+        },
+        "command": {
+          "title": "Command id",
+          "type": "string",
+          "default": ""
+        },
+        "disabled": {
+          "title": "Whether the item is ignored or not",
+          "type": "boolean",
+          "default": false
+        },
+        "icon": {
+          "title": "Item icon id",
+          "description": "If defined, it will override the command icon",
+          "type": "string"
+        },
+        "label": {
+          "title": "Item label",
+          "description": "If defined, it will override the command label",
+          "type": "string"
+        },
+        "type": {
+          "title": "Item type",
+          "type": "string",
+          "enum": ["command", "spacer"]
+        },
+        "rank": {
+          "title": "Item rank",
+          "type": "number",
+          "minimum": 0,
+          "default": 50
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -1125,7 +1125,7 @@ function addCommands(
 
   commands.addCommand(CommandIDs.createLauncher, {
     label: trans.__('New Launcher'),
-    icon: addIcon,
+    icon: args => (args.toolbar ? addIcon : undefined),
     execute: (args: JSONObject) => {
       if (commands.hasCommand('launcher:create')) {
         return Private.createLauncher(commands, browser, args);

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -16,9 +16,12 @@ import {
 } from '@jupyterlab/application';
 import {
   Clipboard,
+  createToolbarFactory,
   ICommandPalette,
   InputDialog,
+  IToolbarWidgetRegistry,
   MainAreaWidget,
+  setToolbar,
   showErrorMessage,
   WidgetTracker
 } from '@jupyterlab/apputils';
@@ -29,7 +32,8 @@ import {
   FileBrowser,
   FileUploadStatus,
   FilterFileBrowserModel,
-  IFileBrowserFactory
+  IFileBrowserFactory,
+  Uploader
 } from '@jupyterlab/filebrowser';
 import { Launcher } from '@jupyterlab/launcher';
 import { Contents } from '@jupyterlab/services';
@@ -50,14 +54,16 @@ import {
   markdownIcon,
   newFolderIcon,
   pasteIcon,
+  refreshIcon,
   stopIcon,
-  textEditorIcon,
-  ToolbarButton
+  textEditorIcon
 } from '@jupyterlab/ui-components';
 import { find, IIterator, map, reduce, toArray } from '@lumino/algorithm';
 import { CommandRegistry } from '@lumino/commands';
 import { ContextMenu } from '@lumino/widgets';
 import { JSONObject } from '@lumino/coreutils';
+
+const FILE_BROWSER_FACTORY = 'FileBrowser';
 
 /**
  * The command IDs used by the file browser plugin.
@@ -100,6 +106,8 @@ namespace CommandIDs {
   export const createNewFile = 'filebrowser:create-new-file';
 
   export const createNewMarkdownFile = 'filebrowser:create-new-markdown-file';
+
+  export const refresh = 'filebrowser:refresh';
 
   export const rename = 'filebrowser:rename';
 
@@ -375,12 +383,21 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
  */
 const browserWidget: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/filebrowser-extension:widget',
-  requires: [IDocumentManager, IFileBrowserFactory, ITranslator, ILabShell],
+  requires: [
+    IDocumentManager,
+    IFileBrowserFactory,
+    ISettingRegistry,
+    IToolbarWidgetRegistry,
+    ITranslator,
+    ILabShell
+  ],
   autoStart: true,
   activate: (
     app: JupyterFrontEnd,
     docManager: IDocumentManager,
     factory: IFileBrowserFactory,
+    settings: ISettingRegistry,
+    toolbarRegistry: IToolbarWidgetRegistry,
     translator: ITranslator,
     labShell: ILabShell
   ): void => {
@@ -392,6 +409,25 @@ const browserWidget: JupyterFrontEndPlugin<void> = {
     browser.node.setAttribute('role', 'region');
     browser.node.setAttribute('aria-label', trans.__('File Browser Section'));
     browser.title.icon = folderIcon;
+
+    // Toolbar
+    toolbarRegistry.registerFactory(
+      FILE_BROWSER_FACTORY,
+      'uploader',
+      (browser: FileBrowser) =>
+        new Uploader({ model: browser.model, translator })
+    );
+
+    setToolbar(
+      browser,
+      createToolbarFactory(
+        toolbarRegistry,
+        settings,
+        FILE_BROWSER_FACTORY,
+        browserWidget.id,
+        translator
+      )
+    );
 
     labShell.add(browser, 'left', { rank: 100 });
 
@@ -664,37 +700,6 @@ export const fileUploadStatus: JupyterFrontEndPlugin<void> = {
         activeStateChanged: item.model.stateChanged
       }
     );
-  }
-};
-
-/**
- * A plugin to add a launcher button to the file browser toolbar
- */
-export const launcherToolbarButton: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlab/filebrowser-extension:launcher-toolbar-button',
-  autoStart: true,
-  requires: [IFileBrowserFactory, ITranslator],
-  activate: (
-    app: JupyterFrontEnd,
-    factory: IFileBrowserFactory,
-    translator: ITranslator
-  ) => {
-    const { commands } = app;
-    const trans = translator.load('jupyterlab');
-    const { defaultBrowser: browser } = factory;
-
-    // Add a launcher toolbar item.
-    const launcher = new ToolbarButton({
-      icon: addIcon,
-      onClick: () => {
-        if (commands.hasCommand('launcher:create')) {
-          return Private.createLauncher(commands, browser);
-        }
-      },
-      tooltip: trans.__('New Launcher'),
-      actualOnClick: true
-    });
-    browser.toolbar.insertItem(0, 'launch', launcher);
   }
 };
 
@@ -1049,6 +1054,19 @@ function addCommands(
     label: trans.__('New Markdown File')
   });
 
+  commands.addCommand(CommandIDs.refresh, {
+    execute: args => {
+      const widget = tracker.currentWidget;
+
+      if (widget) {
+        return widget.model.refresh();
+      }
+    },
+    icon: refreshIcon.bindprops({ stylesheet: 'menuItem' }),
+    caption: trans.__('Refresh the file browser.'),
+    label: trans.__('Refresh File List')
+  });
+
   commands.addCommand(CommandIDs.rename, {
     execute: args => {
       const widget = tracker.currentWidget;
@@ -1107,8 +1125,12 @@ function addCommands(
 
   commands.addCommand(CommandIDs.createLauncher, {
     label: trans.__('New Launcher'),
-    execute: (args: JSONObject) =>
-      Private.createLauncher(commands, browser, args)
+    icon: addIcon,
+    execute: (args: JSONObject) => {
+      if (commands.hasCommand('launcher:create')) {
+        return Private.createLauncher(commands, browser, args);
+      }
+    }
   });
 
   if (settingRegistry) {
@@ -1316,7 +1338,6 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   fileUploadStatus,
   downloadPlugin,
   browserWidget,
-  launcherToolbarButton,
   openWithPlugin,
   openBrowserTabPlugin,
   openUrlPlugin

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -4,30 +4,27 @@
 import { showErrorMessage } from '@jupyterlab/apputils';
 import { IDocumentManager } from '@jupyterlab/docmanager';
 import { Contents, ServerConnection } from '@jupyterlab/services';
-import {
-  ITranslator,
-  nullTranslator,
-  TranslationBundle
-} from '@jupyterlab/translation';
+import { ITranslator } from '@jupyterlab/translation';
 import {
   FilenameSearcher,
-  newFolderIcon,
   ReactWidget,
-  refreshIcon,
-  Toolbar,
-  ToolbarButton
+  SidePanel
 } from '@jupyterlab/ui-components';
 import { IIterator } from '@lumino/algorithm';
-import { PanelLayout, Widget } from '@lumino/widgets';
+import { Panel } from '@lumino/widgets';
 import { BreadCrumbs } from './crumbs';
 import { DirListing } from './listing';
 import { FilterFileBrowserModel } from './model';
-import { Uploader } from './upload';
 
 /**
  * The class name added to file browsers.
  */
 const FILE_BROWSER_CLASS = 'jp-FileBrowser';
+
+/**
+ * The class name added to file browser panel (gather filter, breadcrumbs and listing).
+ */
+const FILE_BROWSER_PANEL_CLASS = 'jp-FileBrowser-Panel';
 
 /**
  * The class name added to the filebrowser crumbs node.
@@ -56,15 +53,16 @@ const LISTING_CLASS = 'jp-FileBrowser-listing';
  * and presents itself as a flat list of files and directories with
  * breadcrumbs.
  */
-export class FileBrowser extends Widget {
+export class FileBrowser extends SidePanel {
   /**
    * Construct a new file browser.
    *
    * @param options - The file browser options.
    */
   constructor(options: FileBrowser.IOptions) {
-    super();
+    super({ content: new Panel(), translator: options.translator });
     this.addClass(FILE_BROWSER_CLASS);
+    this.toolbar.addClass(TOOLBAR_CLASS);
     this.id = options.id;
 
     const model = (this.model = options.model);
@@ -72,45 +70,31 @@ export class FileBrowser extends Widget {
     const translator = this.translator;
 
     model.connectionFailure.connect(this._onConnectionFailure, this);
-    this.translator = options.translator || nullTranslator;
     this._manager = model.manager;
-    this._trans = this.translator.load('jupyterlab');
-    this.crumbs = new BreadCrumbs({ model, translator });
-    this.toolbar = new Toolbar<Widget>();
+
     // a11y
     this.toolbar.node.setAttribute('role', 'navigation');
     this.toolbar.node.setAttribute(
       'aria-label',
       this._trans.__('file browser')
     );
+
     this._directoryPending = false;
 
-    const newFolder = new ToolbarButton({
-      icon: newFolderIcon,
-      onClick: () => {
-        this.createNewDirectory();
-      },
-      tooltip: this._trans.__('New Folder')
-    });
-    const uploader = new Uploader({ model, translator: this.translator });
+    // File browser widgets container
+    this.mainPanel = new Panel();
+    this.mainPanel.addClass(FILE_BROWSER_PANEL_CLASS);
+    this.mainPanel.title.label = this._trans.__('File Browser');
 
-    const refresher = new ToolbarButton({
-      icon: refreshIcon,
-      onClick: () => {
-        void model.refresh();
-      },
-      tooltip: this._trans.__('Refresh File List')
-    });
-
-    this.toolbar.addItem('newFolder', newFolder);
-    this.toolbar.addItem('upload', uploader);
-    this.toolbar.addItem('refresher', refresher);
+    this.crumbs = new BreadCrumbs({ model, translator });
+    this.crumbs.addClass(CRUMBS_CLASS);
 
     this.listing = this.createDirListing({
       model,
       renderer,
       translator: this.translator
     });
+    this.listing.addClass(LISTING_CLASS);
 
     this._filenameSearcher = FilenameSearcher({
       updateFilter: (filterFn: (item: string) => boolean) => {
@@ -121,17 +105,13 @@ export class FileBrowser extends Widget {
       useFuzzyFilter: this._useFuzzyFilter,
       placeholder: this._trans.__('Filter files by name')
     });
-
-    this.crumbs.addClass(CRUMBS_CLASS);
-    this.toolbar.addClass(TOOLBAR_CLASS);
     this._filenameSearcher.addClass(FILTERBOX_CLASS);
-    this.listing.addClass(LISTING_CLASS);
 
-    this.layout = new PanelLayout();
-    this.layout.addWidget(this.toolbar);
-    this.layout.addWidget(this._filenameSearcher);
-    this.layout.addWidget(this.crumbs);
-    this.layout.addWidget(this.listing);
+    this.mainPanel.addWidget(this._filenameSearcher);
+    this.mainPanel.addWidget(this.crumbs);
+    this.mainPanel.addWidget(this.listing);
+
+    this.addWidget(this.mainPanel);
 
     if (options.restore !== false) {
       void model.restore(this.id);
@@ -142,16 +122,6 @@ export class FileBrowser extends Widget {
    * The model used by the file browser.
    */
   readonly model: FilterFileBrowserModel;
-
-  /**
-   * The toolbar used by the file browser.
-   */
-  readonly toolbar: Toolbar<Widget>;
-
-  /**
-   * Override Widget.layout with a more specific PanelLayout type.
-   */
-  layout: PanelLayout;
 
   /**
    * Whether to show active file in file browser
@@ -186,6 +156,10 @@ export class FileBrowser extends Widget {
   set useFuzzyFilter(value: boolean) {
     this._useFuzzyFilter = value;
 
+    // Detach and dispose the current widget
+    this._filenameSearcher.parent = null;
+    this._filenameSearcher.dispose();
+
     this._filenameSearcher = FilenameSearcher({
       updateFilter: (filterFn: (item: string) => boolean) => {
         this.listing.model.setFilter(value => {
@@ -198,13 +172,7 @@ export class FileBrowser extends Widget {
     });
     this._filenameSearcher.addClass(FILTERBOX_CLASS);
 
-    this.layout.removeWidget(this._filenameSearcher);
-    this.layout.removeWidget(this.crumbs);
-    this.layout.removeWidget(this.listing);
-
-    this.layout.addWidget(this._filenameSearcher);
-    this.layout.addWidget(this.crumbs);
-    this.layout.addWidget(this.listing);
+    this.mainPanel.insertWidget(0, this._filenameSearcher);
   }
 
   /**
@@ -426,7 +394,8 @@ export class FileBrowser extends Widget {
 
   protected listing: DirListing;
   protected crumbs: BreadCrumbs;
-  private _trans: TranslationBundle;
+  protected mainPanel: Panel;
+
   private _filenameSearcher: ReactWidget;
   private _manager: IDocumentManager;
   private _directoryPending: boolean;

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -4,7 +4,7 @@
 import { showErrorMessage } from '@jupyterlab/apputils';
 import { IDocumentManager } from '@jupyterlab/docmanager';
 import { Contents, ServerConnection } from '@jupyterlab/services';
-import { ITranslator } from '@jupyterlab/translation';
+import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import {
   FilenameSearcher,
   ReactWidget,
@@ -64,10 +64,10 @@ export class FileBrowser extends SidePanel {
     this.addClass(FILE_BROWSER_CLASS);
     this.toolbar.addClass(TOOLBAR_CLASS);
     this.id = options.id;
+    const translator = (this.translator = options.translator ?? nullTranslator);
 
     const model = (this.model = options.model);
     const renderer = options.renderer;
-    const translator = this.translator;
 
     model.connectionFailure.connect(this._onConnectionFailure, this);
     this._manager = model.manager;
@@ -92,7 +92,7 @@ export class FileBrowser extends SidePanel {
     this.listing = this.createDirListing({
       model,
       renderer,
-      translator: this.translator
+      translator
     });
     this.listing.addClass(LISTING_CLASS);
 

--- a/packages/filebrowser/src/opendialog.ts
+++ b/packages/filebrowser/src/opendialog.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { Dialog } from '@jupyterlab/apputils';
+import { Dialog, setToolbar, ToolbarButton } from '@jupyterlab/apputils';
 import { PathExt } from '@jupyterlab/coreutils';
 import { IDocumentManager } from '@jupyterlab/docmanager';
 import { Contents } from '@jupyterlab/services';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
+import { newFolderIcon, refreshIcon } from '@jupyterlab/ui-components';
 import { toArray } from '@lumino/algorithm';
 import { PanelLayout, Widget } from '@lumino/widgets';
 import { FileBrowser } from './browser';
@@ -124,7 +125,8 @@ class OpenDialog
     translator?: ITranslator
   ) {
     super();
-    translator = translator || nullTranslator;
+    translator = translator ?? nullTranslator;
+    const trans = translator.load('jupyterlab');
     this.addClass(OPEN_DIALOG_CLASS);
 
     this._browser = Private.createFilteredFileBrowser(
@@ -134,6 +136,35 @@ class OpenDialog
       {},
       translator
     );
+
+    // Add toolbar items
+    setToolbar(this._browser, (browser: FileBrowser) => [
+      {
+        name: 'new-folder',
+        widget: new ToolbarButton({
+          icon: newFolderIcon,
+          onClick: () => {
+            browser.createNewDirectory();
+          },
+          tooltip: trans.__('New Folder')
+        })
+      },
+      {
+        name: 'refresher',
+        widget: new ToolbarButton({
+          icon: refreshIcon,
+          onClick: () => {
+            browser.model.refresh().catch(reason => {
+              console.error(
+                'Failed to refresh file browser in open dialog.',
+                reason
+              );
+            });
+          },
+          tooltip: trans.__('Refresh File List')
+        })
+      }
+    ]);
 
     // Build the sub widgets
     const layout = new PanelLayout();

--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -33,7 +33,6 @@
 
 .jp-FileBrowser-Panel {
   flex: 1 1 auto;
-
   display: flex;
   flex-direction: column;
 }

--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -17,15 +17,9 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-.jp-FileBrowser {
+.jp-FileBrowser .jp-SidePanel-content {
   display: flex;
   flex-direction: column;
-  color: var(--jp-ui-font-color1);
-  background: var(--jp-layout-color1);
-
-  /* This is needed so that all font sizing of children done in ems is
-   * relative to this base size */
-  font-size: var(--jp-ui-font-size1);
 }
 
 .jp-FileBrowser-toolbar.jp-Toolbar {
@@ -35,6 +29,13 @@
   box-shadow: none;
   padding: 0;
   justify-content: flex-start;
+}
+
+.jp-FileBrowser-Panel {
+  flex: 1 1 auto;
+
+  display: flex;
+  flex-direction: column;
 }
 
 .jp-BreadCrumbs {
@@ -66,32 +67,29 @@
 | Buttons
 |----------------------------------------------------------------------------*/
 
-.jp-FileBrowser-toolbar.jp-Toolbar .jp-Toolbar-item {
+.jp-FileBrowser-toolbar > .jp-Toolbar-item {
   flex: 0 0 auto;
   padding-left: 0;
   padding-right: 2px;
 }
 
-.jp-FileBrowser-toolbar.jp-Toolbar .jp-ToolbarButtonComponent {
+.jp-FileBrowser-toolbar > .jp-Toolbar-item .jp-ToolbarButtonComponent {
   width: 40px;
 }
 
-.jp-FileBrowser-toolbar.jp-Toolbar
-  .jp-Toolbar-item:first-child
-  .jp-ToolbarButtonComponent {
+.jp-FileBrowser-toolbar
+  .jp-ToolbarButtonComponent[data-command='filebrowser:create-main-launcher'] {
   width: 72px;
   background: var(--jp-brand-color1);
 }
 
-.jp-FileBrowser-toolbar.jp-Toolbar
-  .jp-Toolbar-item:first-child
-  .jp-ToolbarButtonComponent:focus-visible {
+.jp-FileBrowser-toolbar
+  .jp-ToolbarButtonComponent[data-command='filebrowser:create-main-launcher']:focus-visible {
   background-color: var(--jp-accept-color-active, var(--jp-brand-color0));
 }
 
-.jp-FileBrowser-toolbar.jp-Toolbar
-  .jp-Toolbar-item:first-child
-  .jp-ToolbarButtonComponent
+.jp-FileBrowser-toolbar
+  .jp-ToolbarButtonComponent[data-command='filebrowser:create-main-launcher']
   .jp-icon3 {
   fill: var(--jp-layout-color1);
 }
@@ -116,6 +114,10 @@
   padding: 0;
   flex: 0 0 auto;
   margin: 8px 12px 0;
+}
+
+.jp-FileBrowser .lm-AccordionPanel > h3:first-child {
+  display: none;
 }
 
 /*-----------------------------------------------------------------------------

--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -577,6 +577,10 @@ export namespace ToolbarButtonComponent {
    */
   export interface IProps {
     className?: string;
+    /**
+     * Data set of the button
+     */
+    dataset?: DOMStringMap;
     label?: string;
     icon?: LabIcon.IMaybeResolvable;
     iconClass?: string;
@@ -656,6 +660,7 @@ export function ToolbarButtonComponent(
       }
       aria-pressed={props.pressed}
       aria-disabled={props.enabled === false}
+      {...props.dataset}
       disabled={props.enabled === false}
       onClick={props.actualOnClick ?? false ? handleClick : undefined}
       onMouseDown={
@@ -1071,6 +1076,7 @@ namespace Private {
 
     return {
       className,
+      dataset: { 'data-command': options.id },
       icon,
       iconClass,
       tooltip,


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #12196
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
- New settings for `@jupyterlab/filebrowser-extension:widget` to define the browser toolbar definition
- Remove plugin to isolate create launcher button
- Use `SidePanel` as base widget for the filebrowser - it will ease adding widget to it. But use a `Panel` as default content widget and not a `AccordionPanel` to avoid displaying the file browser title
- Add a wrapper widget around the filter, the crumbs and the listing
- Add a `data-command=<id>` to toolbar button to allow CSS selection
- Create a new command refresh file browser
- Make create new launcher command homogeneous with the removed add launcher button plugin

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A

> The widgets hierarchy has changed due to the introduction of a wrapper around the filter, the crumb and the listing.