### PR TITLE
Use Black 22.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         exclude: .bumpversion.cfg
 
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         args: ["--line-length", "100"]


### PR DESCRIPTION
## References

See https://github.com/jupyterlab/jupyterlab/pull/11599#issuecomment-1081279222.

## Code changes

Use Black 22.3.0 for formatting.

## User-facing changes

None.

## Backwards-incompatible changes

None.