### PR TITLE
Remove Yjs room locks

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -17,6 +17,11 @@ API breaking changes
 Here is a list of JupyterLab npm packages that encountered API changes and therefore have
 bumped their major version (following semver convention):
 
+- ``@jupyterlab/docprovider`` from 3.x to 4.x
+   ``WebSocketProviderWithLocks`` has been renamed to ``WebSocketProvider``.
+   ``acquireLock`` and ``releaseLock`` have been removed from ``IDocumentProvider``.
+   ``renameAck`` is not optional anymore in ``IDocumentProvider``.
+   The ``renameAck`` property is
 - ``@jupyterlab/completer`` from 3.x to 4.x
    Major version bumped following the removal of ``ICompletionManager`` token and the replacement
    of ``ICompletableAttributes`` interface by ``ICompletionProvider``. To create a completer provider

--- a/jupyterlab/handlers/yjs_echo_ws.py
+++ b/jupyterlab/handlers/yjs_echo_ws.py
@@ -3,7 +3,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import time
 import uuid
 from enum import IntEnum
 

--- a/packages/docprovider-extension/src/index.ts
+++ b/packages/docprovider-extension/src/index.ts
@@ -14,7 +14,7 @@ import {
   IDocumentProvider,
   IDocumentProviderFactory,
   ProviderMock,
-  WebSocketProviderWithLocks
+  WebSocketProvider
 } from '@jupyterlab/docprovider';
 import { ICurrentUser } from '@jupyterlab/user';
 import { ServerConnection } from '@jupyterlab/services';
@@ -38,7 +38,7 @@ const docProviderPlugin: JupyterFrontEndPlugin<IDocumentProviderFactory> = {
       options: IDocumentProviderFactory.IOptions
     ): IDocumentProvider => {
       return collaborative
-        ? new WebSocketProviderWithLocks({
+        ? new WebSocketProvider({
             ...options,
             url,
             user

--- a/packages/docprovider/src/tokens.ts
+++ b/packages/docprovider/src/tokens.ts
@@ -24,9 +24,8 @@ export interface IDocumentProvider {
 
   /**
    * Returns a Promise that resolves when renaming is ackownledged.
-   * TODO: make it non-optional in JupyterLab 4.0
    */
-  readonly renameAck?: Promise<boolean>;
+  readonly renameAck: Promise<boolean>;
 
   /**
    * This should be called by the docregistry when the file has been renamed to update the websocket connection url

--- a/packages/docprovider/src/tokens.ts
+++ b/packages/docprovider/src/tokens.ts
@@ -23,19 +23,6 @@ export interface IDocumentProvider {
   putInitializedState(): void;
 
   /**
-   * Acquire a lock.
-   * Returns a Promise that resolves to the lock number.
-   */
-  acquireLock(): Promise<number>;
-
-  /**
-   * Release a lock.
-   *
-   * @param lock The lock to release.
-   */
-  releaseLock(lock: number): void;
-
-  /**
    * Returns a Promise that resolves when renaming is ackownledged.
    * TODO: make it non-optional in JupyterLab 4.0
    */

--- a/packages/docprovider/src/yprovider.ts
+++ b/packages/docprovider/src/yprovider.ts
@@ -7,7 +7,7 @@ import { ICurrentUser } from '@jupyterlab/user';
 import { PromiseDelegate } from '@lumino/coreutils';
 import * as decoding from 'lib0/decoding';
 import * as encoding from 'lib0/encoding';
-import { WebsocketProvider } from 'y-websocket';
+import { WebsocketProvider as YWebsocketProvider } from 'y-websocket';
 import * as Y from 'yjs';
 import { IDocumentProvider, IDocumentProviderFactory } from './tokens';
 
@@ -21,15 +21,15 @@ import { IDocumentProvider, IDocumentProviderFactory } from './tokens';
  * We specify custom messages that the server can interpret. For reference please look in yjs_ws_server.
  *
  */
-export class WebSocketProviderWithLocks
-  extends WebsocketProvider
+export class WebSocketProvider
+  extends YWebsocketProvider
   implements IDocumentProvider {
   /**
-   * Construct a new WebSocketProviderWithLocks
+   * Construct a new WebSocketProvider
    *
-   * @param options The instantiation options for a WebSocketProviderWithLocks
+   * @param options The instantiation options for a WebSocketProvider
    */
-  constructor(options: WebSocketProviderWithLocks.IOptions) {
+  constructor(options: WebSocketProvider.IOptions) {
     super(
       options.url,
       options.contentType + ':' + options.path,
@@ -42,24 +42,8 @@ export class WebSocketProviderWithLocks
     this._contentType = options.contentType;
     this._serverUrl = options.url;
 
-    // Message handler that confirms when a lock has been acquired
-    this.messageHandlers[127] = (
-      encoder,
-      decoder,
-      provider,
-      emitSynced,
-      messageType
-    ) => {
-      // acquired lock
-      const timestamp = decoding.readUint32(decoder);
-      const lockRequest = this._currentLockRequest;
-      this._currentLockRequest = null;
-      if (lockRequest) {
-        lockRequest.resolve(timestamp);
-      }
-    };
     // Message handler that receives the initial content
-    this.messageHandlers[125] = (
+    this.messageHandlers[127] = (
       encoder,
       decoder,
       provider,
@@ -79,7 +63,7 @@ export class WebSocketProviderWithLocks
       }
     };
     // Message handler that receives the rename acknowledge
-    this.messageHandlers[123] = (
+    this.messageHandlers[125] = (
       encoder,
       decoder,
       provider,
@@ -116,7 +100,7 @@ export class WebSocketProviderWithLocks
       this._path = newPath;
       const encoder = encoding.createEncoder();
       this._renameAck = new PromiseDelegate<boolean>();
-      encoding.write(encoder, 123);
+      encoding.write(encoder, 125);
       // writing a utf8 string to the encoder
       const escapedPath = unescape(
         encodeURIComponent(this._contentType + ':' + newPath)
@@ -147,7 +131,7 @@ export class WebSocketProviderWithLocks
     }
 
     this._initialContentRequest = new PromiseDelegate<boolean>();
-    this._sendMessage(new Uint8Array([125]));
+    this._sendMessage(new Uint8Array([127]));
 
     // Resolve with true if the server doesn't respond for some reason.
     // In case of a connection problem, we don't want the user to re-initialize the window.
@@ -162,55 +146,10 @@ export class WebSocketProviderWithLocks
    */
   putInitializedState(): void {
     const encoder = encoding.createEncoder();
-    encoding.writeVarUint(encoder, 124);
+    encoding.writeVarUint(encoder, 126);
     encoding.writeUint8Array(encoder, Y.encodeStateAsUpdate(this.doc));
     this._sendMessage(encoding.toUint8Array(encoder));
     this._isInitialized = true;
-  }
-
-  /**
-   * Acquire a lock.
-   * Returns a Promise that resolves to the lock number.
-   */
-  acquireLock(): Promise<number> {
-    if (this._currentLockRequest) {
-      return this._currentLockRequest.promise;
-    }
-    this._sendMessage(new Uint8Array([127]));
-    // try to acquire lock in regular interval
-    if (this._requestLockInterval) {
-      clearInterval(this._requestLockInterval);
-    }
-    this._requestLockInterval = setInterval(() => {
-      if (this.wsconnected) {
-        // try to acquire lock
-        this._sendMessage(new Uint8Array([127]));
-      }
-    }, 500);
-    let resolve: any, reject: any;
-    const promise: Promise<number> = new Promise((_resolve, _reject) => {
-      resolve = _resolve;
-      reject = _reject;
-    });
-    this._currentLockRequest = { promise, resolve, reject };
-    return promise;
-  }
-
-  /**
-   * Release a lock.
-   *
-   * @param lock The lock to release.
-   */
-  releaseLock(lock: number): void {
-    const encoder = encoding.createEncoder();
-    // reply with release lock
-    encoding.writeVarUint(encoder, 126);
-    encoding.writeUint32(encoder, lock);
-    // releasing lock
-    this._sendMessage(encoding.toUint8Array(encoder));
-    if (this._requestLockInterval) {
-      clearInterval(this._requestLockInterval);
-    }
   }
 
   /**
@@ -241,12 +180,10 @@ export class WebSocketProviderWithLocks
     status: 'connected' | 'disconnected';
   }): Promise<void> {
     if (this._isInitialized && status.status === 'connected') {
-      const lock = await this.acquireLock();
       const contentIsInitialized = await this.requestInitialContent();
       if (!contentIsInitialized) {
         this.putInitializedState();
       }
-      this.releaseLock(lock);
     }
   }
 
@@ -254,22 +191,16 @@ export class WebSocketProviderWithLocks
   private _contentType: string;
   private _serverUrl: string;
   private _isInitialized: boolean;
-  private _requestLockInterval: number;
-  private _currentLockRequest: {
-    promise: Promise<number>;
-    resolve: (lock: number) => void;
-    reject: () => void;
-  } | null = null;
   private _initialContentRequest: PromiseDelegate<boolean> | null = null;
   private _renameAck: PromiseDelegate<boolean>;
 }
 
 /**
- * A namespace for WebSocketProviderWithLocks statics.
+ * A namespace for WebSocketProvider statics.
  */
-export namespace WebSocketProviderWithLocks {
+export namespace WebSocketProvider {
   /**
-   * The instantiation options for a WebSocketProviderWithLocks.
+   * The instantiation options for a WebSocketProvider.
    */
   export interface IOptions extends IDocumentProviderFactory.IOptions {
     /**

--- a/packages/docprovider/test/yprovider.spec.ts
+++ b/packages/docprovider/test/yprovider.spec.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { WebSocketProviderWithLocks } from '../src';
+import { WebSocketProvider } from '../src';
 
 describe('@jupyterlab/docprovider', () => {
   describe('docprovider', () => {
     it('should have a type', () => {
-      expect(WebSocketProviderWithLocks).not.toBeUndefined();
+      expect(WebSocketProvider).not.toBeUndefined();
     });
   });
 });

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -261,7 +261,6 @@ export class Context<
    * @returns a promise that resolves upon initialization.
    */
   async initialize(isNew: boolean): Promise<void> {
-    const lock = await this._provider.acquireLock();
     const contentIsInitialized = await this._provider.requestInitialContent();
     let promise;
     if (isNew || contentIsInitialized) {
@@ -269,17 +268,11 @@ export class Context<
     } else {
       promise = this._revert();
     }
-    // make sure that the lock is released after the above operations are completed.
-    const finally_ = () => {
-      this._provider.releaseLock(lock);
-    };
     // if save/revert completed successfully, we set the initialized content in the rtc server.
-    promise
-      .then(() => {
-        this._provider.putInitializedState();
-        this._model.initialize();
-      })
-      .then(finally_, finally_);
+    promise = promise.then(() => {
+      this._provider.putInitializedState();
+      this._model.initialize();
+    });
     return promise;
   }
 
@@ -300,20 +293,13 @@ export class Context<
    * Save the document contents to disk.
    */
   async save(): Promise<void> {
-    const [lock] = await Promise.all([
-      this._provider.acquireLock(),
-      this.ready
-    ]);
+    await this.ready;
     let promise: Promise<void>;
     promise = this._save();
     // if save completed successfully, we set the initialized content in the rtc server.
     promise = promise.then(() => {
       this._provider.putInitializedState();
     });
-    const finally_ = () => {
-      this._provider.releaseLock(lock);
-    };
-    promise.then(finally_, finally_);
     return await promise;
   }
 
@@ -372,15 +358,8 @@ export class Context<
    * Revert the document contents to disk contents.
    */
   async revert(): Promise<void> {
-    const [lock] = await Promise.all([
-      this._provider.acquireLock(),
-      this.ready
-    ]);
+    await this.ready;
     const promise = this._revert();
-    const finally_ = () => {
-      this._provider.releaseLock(lock);
-    };
-    promise.then(finally_, finally_);
     return await promise;
   }
 


### PR DESCRIPTION
## Code changes

Remove the Yjs room locks.

## User-facing changes

None

## Backwards-incompatible changes

Rename `WebSocketProviderWithLocks` to `WebSocketProvider` in `@jupyterlab/docprovider`.