### PR TITLE
Update `NotebookApp` to `ServerApp` in the contributing docs

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -479,7 +479,7 @@ Then, start JupyterLab using the dev build:
 
 .. code:: bash
 
-   jupyter lab --dev-mode --NotebookApp.token=''  --no-browser
+   jupyter lab --dev-mode --ServerApp.token=''  --no-browser
 
 Now run Lighthouse against this local server and show the results:
 
@@ -540,7 +540,7 @@ the results:
 .. code:: bash
 
    jlpm build:dev
-   jupyter lab --dev --NotebookApp.token='' --no-browser
+   jupyter lab --dev --ServerApp.token='' --no-browser
 
    # in new window
    jlpm run lighthouse --output json --output-path normal.json
@@ -550,7 +550,7 @@ Then rebuild with the production build and retest:
 .. code:: bash
 
    jlpm run build:dev:prod
-   jupyter lab --dev --NotebookApp.token='' --no-browser
+   jupyter lab --dev --ServerApp.token='' --no-browser
 
    # in new window
    jlpm run lighthouse --output json --output-path prod.json


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Minor cleanup, since JupyterLab 4.0 and the current master branch to not install `notebook` by default anymore.

## Code changes

Update some references of `NotebookApp` to `ServerApp` in the contributing documentation.

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
