### PR TITLE
Add argument `searchText` and `replaceText` to search and replace commands

### DIFF
--- a/galata/test/jupyterlab/search.test.ts
+++ b/galata/test/jupyterlab/search.test.ts
@@ -1,0 +1,63 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+import { test } from '@jupyterlab/galata';
+import { expect } from '@playwright/test';
+
+const DEFAULT_NAME = 'untitled.txt';
+
+const TEST_FILE_CONTENT = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam urna
+libero, dictum a egestas non, placerat vel neque. In imperdiet iaculis fermentum.
+Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia
+Curae; Cras augue tortor, tristique vitae varius nec, dictum eu lectus. Pellentesque
+id eleifend eros. In non odio in lorem iaculis sollicitudin. In faucibus ante ut
+arcu fringilla interdum. Maecenas elit nulla, imperdiet nec blandit et, consequat
+ut elit.`;
+
+test('Search with a text', async ({ page }) => {
+  const searchText = 'ipsum';
+  await page.menu.clickMenuItem('File>New>Text File');
+
+  await page.waitForSelector(`[role="main"] >> text=${DEFAULT_NAME}`);
+
+  await page.fill('[role="main"] >> textarea', TEST_FILE_CONTENT);
+
+  await page.evaluate(async searchText => {
+    await window.jupyterapp.commands.execute('documentsearch:start', {
+      searchText
+    });
+  }, searchText);
+
+  expect(
+    await page.locator('input.jp-DocumentSearch-input').inputValue()
+  ).toEqual(searchText);
+});
+
+test('Search with a text and replacement', async ({ page }) => {
+  const searchText = 'ipsum';
+  const replaceText = 'banana';
+  await page.menu.clickMenuItem('File>New>Text File');
+
+  await page.waitForSelector(`[role="main"] >> text=${DEFAULT_NAME}`);
+
+  await page.fill('[role="main"] >> textarea', TEST_FILE_CONTENT);
+
+  await page.evaluate(
+    async ([searchText, replaceText]) => {
+      await window.jupyterapp.commands.execute(
+        'documentsearch:startWithReplace',
+        {
+          searchText,
+          replaceText
+        }
+      );
+    },
+    [searchText, replaceText]
+  );
+
+  expect(
+    await page.locator('input.jp-DocumentSearch-input').inputValue()
+  ).toEqual(searchText);
+  expect(
+    await page.locator('input.jp-DocumentSearch-replace-entry').inputValue()
+  ).toEqual(replaceText);
+});

--- a/packages/documentsearch-extension/src/index.ts
+++ b/packages/documentsearch-extension/src/index.ts
@@ -165,9 +165,13 @@ const extension: JupyterFrontEndPlugin<ISearchProviderRegistry> = {
     app.commands.addCommand(startCommand, {
       label: trans.__('Find…'),
       isEnabled: currentWidgetHasSearchProvider,
-      execute: () => {
+      execute: args => {
         const searchInstance = getCurrentWidgetSearchInstance();
         if (searchInstance) {
+          const searchText = args['searchText'] as string;
+          if (searchText) {
+            searchInstance.setSearchText(searchText);
+          }
           searchInstance.focusInput();
         }
       }
@@ -176,9 +180,17 @@ const extension: JupyterFrontEndPlugin<ISearchProviderRegistry> = {
     app.commands.addCommand(startReplaceCommand, {
       label: trans.__('Find and Replace…'),
       isEnabled: currentWidgetHasSearchProvider,
-      execute: () => {
+      execute: args => {
         const searchInstance = getCurrentWidgetSearchInstance();
         if (searchInstance) {
+          const searchText = args['searchText'] as string;
+          if (searchText) {
+            searchInstance.setSearchText(searchText);
+          }
+          const replaceText = args['replaceText'] as string;
+          if (replaceText) {
+            searchInstance.setReplaceText(replaceText);
+          }
           searchInstance.showReplace();
           searchInstance.focusInput();
         }

--- a/packages/documentsearch/src/searchinstance.ts
+++ b/packages/documentsearch/src/searchinstance.ts
@@ -103,6 +103,24 @@ export class SearchInstance implements IDisposable {
   }
 
   /**
+   * Set the search text
+   *
+   * It does not trigger a view update.
+   */
+  setSearchText(search: string): void {
+    this._displayState.searchText = search;
+  }
+
+  /**
+   * Set the replace text
+   *
+   * It does not trigger a view update.
+   */
+  setReplaceText(replace: string): void {
+    this._displayState.replaceText = replace;
+  }
+
+  /**
    * If there is a replace box, show it.
    */
   showReplace(): void {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Trying to add action to start a search in a document from an external extension is not easy as calling the go to line command.

Ref https://github.com/jupyterlab-contrib/search-replace/issues/22
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Add `setSearchText` and `setReplaceText` to `SearchInstance`
Add arguments `searchText` to command search
Add arguments `searchText` and `replaceText` to command search and replace

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A