### PR TITLE
Simplify galata import by proxying `expect`

### DIFF
--- a/galata/README.md
+++ b/galata/README.md
@@ -35,8 +35,7 @@ module.exports = require('@jupyterlab/galata/lib/playwright-config');
 Create `ui-tests/foo.spec.ts` to define your test.
 
 ```typescript
-import { test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, test } from '@jupyterlab/galata';
 
 test.describe('Notebook Tests', () => {
   test('Create New Notebook', async ({ page, tmpPath }) => {

--- a/galata/src/index.ts
+++ b/galata/src/index.ts
@@ -6,6 +6,11 @@
  * @module galata
  */
 
+/**
+ * Export expect from playwright to simplify the import in tests
+ */
+export { expect } from '@playwright/test';
+
 export * from './benchmarkReporter';
 export * from './galata';
 export * from './global';

--- a/galata/test/documentation/debugger.test.ts
+++ b/galata/test/documentation/debugger.test.ts
@@ -1,8 +1,12 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { galata, IJupyterLabPageFixture, test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import {
+  expect,
+  galata,
+  IJupyterLabPageFixture,
+  test
+} from '@jupyterlab/galata';
 import {
   generateCaptureArea,
   positionMouse,

--- a/galata/test/documentation/export_notebook.test.ts
+++ b/galata/test/documentation/export_notebook.test.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { galata, test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, galata, test } from '@jupyterlab/galata';
 import { generateCaptureArea, setLeftSidebarWidth } from './utils';
 
 test.use({

--- a/galata/test/documentation/extension_manager.test.ts
+++ b/galata/test/documentation/extension_manager.test.ts
@@ -1,8 +1,12 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { galata, IJupyterLabPageFixture, test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import {
+  expect,
+  galata,
+  IJupyterLabPageFixture,
+  test
+} from '@jupyterlab/galata';
 import { generateCaptureArea, setLeftSidebarWidth } from './utils';
 
 test.use({

--- a/galata/test/documentation/general.test.ts
+++ b/galata/test/documentation/general.test.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { galata, test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, galata, test } from '@jupyterlab/galata';
 import {
   generateArrow,
   generateCaptureArea,

--- a/galata/test/documentation/internationalization.test.ts
+++ b/galata/test/documentation/internationalization.test.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { galata, test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, galata, test } from '@jupyterlab/galata';
 import { generateCaptureArea, setLeftSidebarWidth } from './utils';
 
 test.use({

--- a/galata/test/galata/benchmarkReporter.spec.ts
+++ b/galata/test/galata/benchmarkReporter.spec.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, test } from '@jupyterlab/galata';
 import { TestResult } from '@playwright/test/reporter';
 import BenchmarkReporter, {
   benchmark,

--- a/galata/test/galata/contents.spec.ts
+++ b/galata/test/galata/contents.spec.ts
@@ -4,8 +4,7 @@
 
 import * as path from 'path';
 
-import { test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, test } from '@jupyterlab/galata';
 
 test.describe('Contents API Tests', () => {
   test('Upload directory to server', async ({ page, tmpPath }) => {

--- a/galata/test/galata/fixture.spec.ts
+++ b/galata/test/galata/fixture.spec.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { expect } from '@playwright/test';
-import { JupyterLabPage, test } from '@jupyterlab/galata';
+import { expect, JupyterLabPage, test } from '@jupyterlab/galata';
 
 test.describe('page', () => {
   test('should return a JupyterLabPage', ({ page }) => {

--- a/galata/test/galata/jupyterlabpage.spec.ts
+++ b/galata/test/galata/jupyterlabpage.spec.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { test } from '@jupyterlab/galata';
-import { expect, test as playwrightTest } from '@playwright/test';
+import { expect, test } from '@jupyterlab/galata';
+import { test as playwrightTest } from '@playwright/test';
 
 test.describe('appPath', () => {
   const APP_PATH = '/retro';

--- a/galata/test/galata/notebook.spec.ts
+++ b/galata/test/galata/notebook.spec.ts
@@ -4,8 +4,7 @@
 
 import * as path from 'path';
 
-import { test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, test } from '@jupyterlab/galata';
 
 test.describe('Notebook Tests', () => {
   test('Create New Notebook', async ({ page, tmpPath }) => {

--- a/galata/test/galata/test.spec.ts
+++ b/galata/test/galata/test.spec.ts
@@ -2,8 +2,7 @@
 // Copyright (c) Bloomberg Finance LP.
 // Distributed under the terms of the Modified BSD License.
 
-import { test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, test } from '@jupyterlab/galata';
 
 test('should display the launcher', async ({ page }) => {
   expect(await page.waitForSelector(page.launcherSelector)).toBeTruthy();

--- a/galata/test/jupyterlab/collapsible-headings.test.ts
+++ b/galata/test/jupyterlab/collapsible-headings.test.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { IJupyterLabPageFixture, test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, IJupyterLabPageFixture, test } from '@jupyterlab/galata';
 
 const fileName = 'notebook.ipynb';
 

--- a/galata/test/jupyterlab/completer.test.ts
+++ b/galata/test/jupyterlab/completer.test.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, test } from '@jupyterlab/galata';
 
 const fileName = 'notebook.ipynb';
 const COMPLETER_SELECTOR = '.jp-Completer';

--- a/galata/test/jupyterlab/contextmenu.test.ts
+++ b/galata/test/jupyterlab/contextmenu.test.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { galata, test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, galata, test } from '@jupyterlab/galata';
 
 import * as path from 'path';
 

--- a/galata/test/jupyterlab/debugger.test.ts
+++ b/galata/test/jupyterlab/debugger.test.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-import { IJupyterLabPageFixture, test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, IJupyterLabPageFixture, test } from '@jupyterlab/galata';
 import * as path from 'path';
 
 async function openNotebook(page: IJupyterLabPageFixture, tmpPath, fileName) {

--- a/galata/test/jupyterlab/general.test.ts
+++ b/galata/test/jupyterlab/general.test.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, test } from '@jupyterlab/galata';
 
 test.describe('General Tests', () => {
   test('Launch Screen', async ({ page }) => {

--- a/galata/test/jupyterlab/menus.test.ts
+++ b/galata/test/jupyterlab/menus.test.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, test } from '@jupyterlab/galata';
 
 const menuPaths = [
   'File',

--- a/galata/test/jupyterlab/notebook-create.test.ts
+++ b/galata/test/jupyterlab/notebook-create.test.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { IJupyterLabPageFixture, test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, IJupyterLabPageFixture, test } from '@jupyterlab/galata';
 
 const fileName = 'notebook.ipynb';
 

--- a/galata/test/jupyterlab/notebook-edit.test.ts
+++ b/galata/test/jupyterlab/notebook-edit.test.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { IJupyterLabPageFixture, test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, IJupyterLabPageFixture, test } from '@jupyterlab/galata';
 
 const fileName = 'notebook.ipynb';
 

--- a/galata/test/jupyterlab/notebook-markdown.test.ts
+++ b/galata/test/jupyterlab/notebook-markdown.test.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { IJupyterLabPageFixture, test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, IJupyterLabPageFixture, test } from '@jupyterlab/galata';
 import * as path from 'path';
 
 const fileName = 'markdown_notebook.ipynb';

--- a/galata/test/jupyterlab/notebook-mobile.test.ts
+++ b/galata/test/jupyterlab/notebook-mobile.test.ts
@@ -1,9 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { test } from '@jupyterlab/galata';
-
-import { expect } from '@playwright/test';
+import { expect, test } from '@jupyterlab/galata';
 
 const fileName = 'notebook.ipynb';
 

--- a/galata/test/jupyterlab/notebook-run.test.ts
+++ b/galata/test/jupyterlab/notebook-run.test.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { galata, test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, galata, test } from '@jupyterlab/galata';
 import * as path from 'path';
 
 const fileName = 'simple_notebook.ipynb';

--- a/galata/test/jupyterlab/notebook-toolbar.test.ts
+++ b/galata/test/jupyterlab/notebook-toolbar.test.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { IJupyterLabPageFixture, test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, IJupyterLabPageFixture, test } from '@jupyterlab/galata';
 
 const fileName = 'notebook.ipynb';
 

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { galata, test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, galata, test } from '@jupyterlab/galata';
 
 const sidebarIds: galata.SidebarTabId[] = [
   'filebrowser',

--- a/galata/test/jupyterlab/terminal.test.ts
+++ b/galata/test/jupyterlab/terminal.test.ts
@@ -1,5 +1,4 @@
-import { test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, test } from '@jupyterlab/galata';
 
 const TERMINAL_SELECTOR = '.jp-Terminal';
 const TERMINAL_THEME_ATTRIBUTE = 'data-term-theme';

--- a/galata/test/jupyterlab/texteditor.test.ts
+++ b/galata/test/jupyterlab/texteditor.test.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, test } from '@jupyterlab/galata';
 
 const DEFAULT_NAME = 'untitled.txt';
 

--- a/galata/test/jupyterlab/toc-running.test.ts
+++ b/galata/test/jupyterlab/toc-running.test.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, test } from '@jupyterlab/galata';
 
 test.describe('ToC Running indicator', () => {
   test.beforeEach(async ({ page }) => {

--- a/galata/test/jupyterlab/toc.test.ts
+++ b/galata/test/jupyterlab/toc.test.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { galata, test } from '@jupyterlab/galata';
-import { expect } from '@playwright/test';
+import { expect, galata, test } from '@jupyterlab/galata';
 import * as path from 'path';
 
 const fileName = 'toc_notebook.ipynb';

--- a/galata/test/jupyterlab/workspace.test.ts
+++ b/galata/test/jupyterlab/workspace.test.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { galata, test } from '@jupyterlab/galata';
-import { expect, Page } from '@playwright/test';
+import { expect, galata, test } from '@jupyterlab/galata';
+import { Page } from '@playwright/test';
 import * as path from 'path';
 
 const nbFile = 'simple_notebook.ipynb';

--- a/packages/apputils/test/commandpalette.spec.ts
+++ b/packages/apputils/test/commandpalette.spec.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-// import { expect } from 'chai';
-
 import { ModalCommandPalette } from '@jupyterlab/apputils';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { CommandPaletteSvg, paletteIcon } from '@jupyterlab/ui-components';

--- a/packages/apputils/test/dialog.spec.tsx
+++ b/packages/apputils/test/dialog.spec.tsx
@@ -2,8 +2,6 @@
 
 // Distributed under the terms of the Modified BSD License.
 
-// import { expect } from 'chai';
-
 import { Dialog, showDialog } from '@jupyterlab/apputils';
 import {
   acceptDialog,


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Export `expect` from `@playwright/test` in `@jupyterlab/galata`. So it simplifies definig integration tests by importing

`import { expect, test } from '@jupyterlab/galata';`

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A