### PR TITLE
Automated Changelog Entry for 4.0.0a23 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,66 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 4.0.0a23
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v4.0.0a22...6a5e1d47e1bc0d40d3850ad8aae1b32079846a0c))
+
+### Enhancements made
+
+- Remove Yjs room locks [#12288](https://github.com/jupyterlab/jupyterlab/pull/12288) ([@davidbrochart](https://github.com/davidbrochart))
+- Adds preferKernel option to JupyterLab code [#12260](https://github.com/jupyterlab/jupyterlab/pull/12260) ([@jweill-aws](https://github.com/jweill-aws))
+- Customize the file browser toolbar via the settings [#12281](https://github.com/jupyterlab/jupyterlab/pull/12281) ([@fcollonval](https://github.com/fcollonval))
+- Show kernel name on restart to avoid data loss on misclick [#12241](https://github.com/jupyterlab/jupyterlab/pull/12241) ([@krassowski](https://github.com/krassowski))
+- Ignore auto-generated `.ipynb_checkpoints` directories [#12239](https://github.com/jupyterlab/jupyterlab/pull/12239) ([@krassowski](https://github.com/krassowski))
+- Add aria progressbar role and data-status for testing in extensions [#12238](https://github.com/jupyterlab/jupyterlab/pull/12238) ([@krassowski](https://github.com/krassowski))
+- Add a "New Tab" button that opens the launcher [#12195](https://github.com/jupyterlab/jupyterlab/pull/12195) ([@ajbozarth](https://github.com/ajbozarth))
+- add "Toggle Contextual Help" command [#12091](https://github.com/jupyterlab/jupyterlab/pull/12091) ([@Josh0823](https://github.com/Josh0823))
+- Save document from the backend using y-py [#11599](https://github.com/jupyterlab/jupyterlab/pull/11599) ([@davidbrochart](https://github.com/davidbrochart))
+
+### Bugs fixed
+
+- Use Black 22.3.0 [#12285](https://github.com/jupyterlab/jupyterlab/pull/12285) ([@davidbrochart](https://github.com/davidbrochart))
+- Allow linear and radial gradient [#12276](https://github.com/jupyterlab/jupyterlab/pull/12276) ([@krassowski](https://github.com/krassowski))
+- Use css variable for font size. [#12255](https://github.com/jupyterlab/jupyterlab/pull/12255) ([@Carreau](https://github.com/Carreau))
+- Don't rely on search results to filter installed extension [#12249](https://github.com/jupyterlab/jupyterlab/pull/12249) ([@fcollonval](https://github.com/fcollonval))
+- Fix settings with `null` default not getting marked as modified [#12240](https://github.com/jupyterlab/jupyterlab/pull/12240) ([@krassowski](https://github.com/krassowski))
+- fixes directory not found error when preferred_dir is set [#12220](https://github.com/jupyterlab/jupyterlab/pull/12220) ([@andrewfulton9](https://github.com/andrewfulton9))
+- Filter settings with `app.hasPlugin()` [#11938](https://github.com/jupyterlab/jupyterlab/pull/11938) ([@jtpio](https://github.com/jtpio))
+
+### Maintenance and upkeep improvements
+
+- Fix usage of pre-commit-ci [#12304](https://github.com/jupyterlab/jupyterlab/pull/12304) ([@blink1073](https://github.com/blink1073))
+- Fix documentation snapshots [#12301](https://github.com/jupyterlab/jupyterlab/pull/12301) ([@fcollonval](https://github.com/fcollonval))
+- Add flake8 rules and update files [#12291](https://github.com/jupyterlab/jupyterlab/pull/12291) ([@blink1073](https://github.com/blink1073))
+- Add git-blame-ignore-revs file [#12290](https://github.com/jupyterlab/jupyterlab/pull/12290) ([@blink1073](https://github.com/blink1073))
+- Use pre-commit [#12279](https://github.com/jupyterlab/jupyterlab/pull/12279) ([@blink1073](https://github.com/blink1073))
+- Bump minimist from 1.2.5 to 1.2.6 [#12266](https://github.com/jupyterlab/jupyterlab/pull/12266) ([@dependabot](https://github.com/dependabot))
+- Stop using py.test [#12262](https://github.com/jupyterlab/jupyterlab/pull/12262) ([@fcollonval](https://github.com/fcollonval))
+- Re-align version for `@jupyterlab/markedparser-extension` [#12247](https://github.com/jupyterlab/jupyterlab/pull/12247) ([@jtpio](https://github.com/jtpio))
+- Make `IStatusBar` optional in the plugin providing `IPositionModel` [#12232](https://github.com/jupyterlab/jupyterlab/pull/12232) ([@jtpio](https://github.com/jtpio))
+
+### Documentation improvements
+
+- Update `NotebookApp` to `ServerApp` in the contributing docs [#12309](https://github.com/jupyterlab/jupyterlab/pull/12309) ([@jtpio](https://github.com/jtpio))
+- Remove Yjs room locks [#12288](https://github.com/jupyterlab/jupyterlab/pull/12288) ([@davidbrochart](https://github.com/davidbrochart))
+- Customize the file browser toolbar via the settings [#12281](https://github.com/jupyterlab/jupyterlab/pull/12281) ([@fcollonval](https://github.com/fcollonval))
+- Use pre-commit [#12279](https://github.com/jupyterlab/jupyterlab/pull/12279) ([@blink1073](https://github.com/blink1073))
+- Stop using py.test [#12262](https://github.com/jupyterlab/jupyterlab/pull/12262) ([@fcollonval](https://github.com/fcollonval))
+- Update links to create new issues in README.md [#12257](https://github.com/jupyterlab/jupyterlab/pull/12257) ([@jtpio](https://github.com/jtpio))
+- Update link to `jupyterlab-some-package` in docs [#12248](https://github.com/jupyterlab/jupyterlab/pull/12248) ([@jtpio](https://github.com/jtpio))
+
+### API and Breaking Changes
+
+- Remove Yjs room locks [#12288](https://github.com/jupyterlab/jupyterlab/pull/12288) ([@davidbrochart](https://github.com/davidbrochart))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-03-18&to=2022-03-31&type=c))
+
+[@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2022-03-18..2022-03-31&type=Issues) | [@aiqc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aaiqc+updated%3A2022-03-18..2022-03-31&type=Issues) | [@ajbozarth](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aajbozarth+updated%3A2022-03-18..2022-03-31&type=Issues) | [@andrewfulton9](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aandrewfulton9+updated%3A2022-03-18..2022-03-31&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-03-18..2022-03-31&type=Issues) | [@Carreau](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ACarreau+updated%3A2022-03-18..2022-03-31&type=Issues) | [@damianavila](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adamianavila+updated%3A2022-03-18..2022-03-31&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2022-03-18..2022-03-31&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adependabot+updated%3A2022-03-18..2022-03-31&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-03-18..2022-03-31&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-03-18..2022-03-31&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-03-18..2022-03-31&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2022-03-18..2022-03-31&type=Issues) | [@Josh0823](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AJosh0823+updated%3A2022-03-18..2022-03-31&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-03-18..2022-03-31&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-03-18..2022-03-31&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-03-18..2022-03-31&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-03-18..2022-03-31&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-03-18..2022-03-31&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-03-18..2022-03-31&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 4.0.0a22
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v4.0.0a21...0040f2649c77af0251b8c8f73aea91c26c3960c5))
@@ -36,8 +96,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-03-11&to=2022-03-18&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-03-11..2022-03-18&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-03-11..2022-03-18&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-03-11..2022-03-18&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-03-11..2022-03-18&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-03-11..2022-03-18&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2022-03-11..2022-03-18&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 4.0.0a21
 


### PR DESCRIPTION
Automated Changelog Entry for 4.0.0a23 on master
```
Python version: 4.0.0a23
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 4.0.0-alpha.8
@jupyterlab/buildutils: 4.0.0-alpha.8
@jupyterlab/template: 4.0.0-alpha.8
@jupyterlab/application-top: 4.0.0-alpha.8
@jupyterlab/example-app: 4.0.0-alpha.8
@jupyterlab/example-cell: 4.0.0-alpha.8
@jupyterlab/example-console: 4.0.0-alpha.8
@jupyterlab/example-federated: 3.0.0-alpha.8
@jupyterlab/example-federated-core: 3.0.0-alpha.8
@jupyterlab/example-federated-md: 3.0.0-alpha.8
@jupyterlab/example-federated-middle: 3.0.0-alpha.8
@jupyterlab/example-federated-phosphor: 3.0.0-alpha.8
@jupyterlab/example-filebrowser: 4.0.0-alpha.8
@jupyterlab/example-notebook: 4.0.0-alpha.8
@jupyterlab/example-terminal: 4.0.0-alpha.8
@jupyterlab/galata: 5.0.0-alpha.8
@jupyterlab/mock-extension: 4.0.0-alpha.8
@jupyterlab/mock-consumer: 4.0.0-alpha.8
@jupyterlab/mock-provider: 4.0.0-alpha.8
@jupyterlab/mock-token: 4.0.0-alpha.8
@jupyterlab/application: 4.0.0-alpha.8
@jupyterlab/application-extension: 4.0.0-alpha.8
@jupyterlab/apputils: 4.0.0-alpha.8
@jupyterlab/apputils-extension: 4.0.0-alpha.8
@jupyterlab/attachments: 4.0.0-alpha.8
@jupyterlab/cells: 4.0.0-alpha.8
@jupyterlab/celltags: 4.0.0-alpha.8
@jupyterlab/celltags-extension: 4.0.0-alpha.8
@jupyterlab/codeeditor: 4.0.0-alpha.8
@jupyterlab/codemirror: 4.0.0-alpha.8
@jupyterlab/codemirror-extension: 4.0.0-alpha.8
@jupyterlab/completer: 4.0.0-alpha.8
@jupyterlab/completer-extension: 4.0.0-alpha.8
@jupyterlab/console: 4.0.0-alpha.8
@jupyterlab/console-extension: 4.0.0-alpha.8
@jupyterlab/coreutils: 6.0.0-alpha.8
@jupyterlab/csvviewer: 4.0.0-alpha.8
@jupyterlab/csvviewer-extension: 4.0.0-alpha.8
@jupyterlab/debugger: 4.0.0-alpha.8
@jupyterlab/debugger-extension: 4.0.0-alpha.8
@jupyterlab/docmanager: 4.0.0-alpha.8
@jupyterlab/docmanager-extension: 4.0.0-alpha.8
@jupyterlab/docprovider: 4.0.0-alpha.8
@jupyterlab/docprovider-extension: 4.0.0-alpha.8
@jupyterlab/docregistry: 4.0.0-alpha.8
@jupyterlab/documentsearch: 4.0.0-alpha.8
@jupyterlab/documentsearch-extension: 4.0.0-alpha.8
@jupyterlab/extensionmanager: 4.0.0-alpha.8
@jupyterlab/extensionmanager-extension: 4.0.0-alpha.8
@jupyterlab/filebrowser: 4.0.0-alpha.8
@jupyterlab/filebrowser-extension: 4.0.0-alpha.8
@jupyterlab/fileeditor: 4.0.0-alpha.8
@jupyterlab/fileeditor-extension: 4.0.0-alpha.8
@jupyterlab/help-extension: 4.0.0-alpha.8
@jupyterlab/htmlviewer: 4.0.0-alpha.8
@jupyterlab/htmlviewer-extension: 4.0.0-alpha.8
@jupyterlab/hub-extension: 4.0.0-alpha.8
@jupyterlab/imageviewer: 4.0.0-alpha.8
@jupyterlab/imageviewer-extension: 4.0.0-alpha.8
@jupyterlab/inspector: 4.0.0-alpha.8
@jupyterlab/inspector-extension: 4.0.0-alpha.8
@jupyterlab/javascript-extension: 4.0.0-alpha.8
@jupyterlab/json-extension: 4.0.0-alpha.8
@jupyterlab/launcher: 4.0.0-alpha.8
@jupyterlab/launcher-extension: 4.0.0-alpha.8
@jupyterlab/logconsole: 4.0.0-alpha.8
@jupyterlab/logconsole-extension: 4.0.0-alpha.8
@jupyterlab/mainmenu: 4.0.0-alpha.8
@jupyterlab/mainmenu-extension: 4.0.0-alpha.8
@jupyterlab/markdownviewer: 4.0.0-alpha.8
@jupyterlab/markdownviewer-extension: 4.0.0-alpha.8
@jupyterlab/markedparser-extension: 4.0.0-alpha.8
@jupyterlab/mathjax2: 4.0.0-alpha.8
@jupyterlab/mathjax2-extension: 4.0.0-alpha.8
@jupyterlab/metapackage: 4.0.0-alpha.8
@jupyterlab/nbconvert-css: 4.0.0-alpha.8
@jupyterlab/nbformat: 4.0.0-alpha.8
@jupyterlab/notebook: 4.0.0-alpha.8
@jupyterlab/notebook-extension: 4.0.0-alpha.8
@jupyterlab/observables: 5.0.0-alpha.8
@jupyterlab/outputarea: 4.0.0-alpha.8
@jupyterlab/pdf-extension: 4.0.0-alpha.8
@jupyterlab/property-inspector: 4.0.0-alpha.8
@jupyterlab/rendermime: 4.0.0-alpha.8
@jupyterlab/rendermime-extension: 4.0.0-alpha.8
@jupyterlab/rendermime-interfaces: 4.0.0-alpha.8
@jupyterlab/running: 4.0.0-alpha.8
@jupyterlab/running-extension: 4.0.0-alpha.8
@jupyterlab/services: 7.0.0-alpha.8
@jupyterlab/example-services-browser: 4.0.0-alpha.8
node-example: 4.0.0-alpha.8
@jupyterlab/example-services-outputarea: 4.0.0-alpha.8
@jupyterlab/settingeditor: 4.0.0-alpha.8
@jupyterlab/settingeditor-extension: 4.0.0-alpha.8
@jupyterlab/settingregistry: 4.0.0-alpha.8
@jupyterlab/shared-models: 4.0.0-alpha.8
@jupyterlab/shortcuts-extension: 4.0.0-alpha.8
@jupyterlab/statedb: 4.0.0-alpha.8
@jupyterlab/statusbar: 4.0.0-alpha.8
@jupyterlab/statusbar-extension: 4.0.0-alpha.8
@jupyterlab/terminal: 4.0.0-alpha.8
@jupyterlab/terminal-extension: 4.0.0-alpha.8
@jupyterlab/theme-dark-extension: 4.0.0-alpha.8
@jupyterlab/theme-light-extension: 4.0.0-alpha.8
@jupyterlab/toc: 6.0.0-alpha.8
@jupyterlab/toc-extension: 6.0.0-alpha.8
@jupyterlab/tooltip: 4.0.0-alpha.8
@jupyterlab/tooltip-extension: 4.0.0-alpha.8
@jupyterlab/translation: 4.0.0-alpha.8
@jupyterlab/translation-extension: 4.0.0-alpha.8
@jupyterlab/ui-components: 4.0.0-alpha.23
@jupyterlab/ui-components-extension: 4.0.0-alpha.8
@jupyterlab/user: 4.0.0-alpha.8
@jupyterlab/user-extension: 4.0.0-alpha.8
@jupyterlab/vdom: 4.0.0-alpha.8
@jupyterlab/vdom-extension: 4.0.0-alpha.8
@jupyterlab/vega5-extension: 4.0.0-alpha.8
@jupyterlab/testutils: 4.0.0-alpha.8
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | master  |
| Version Spec | next |
| Since | v4.0.0a22 |