### PR TITLE
Pin exact version of y-py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     jupyter_server>=1.15.6,<2
     notebook_shim>=0.1
     jinja2>=3.0.3
-    y-py>=0.2.3,<1
+    y-py==0.2.3
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
## References

[y-py](https://github.com/y-crdt/ypy) is still in development, and we should expect the API to break at every release until we reach v1.0.0. Next release won't be backward-compatible for sure.

## Code changes

Pin exact version of y-py until it reaches v1.0.0.

## User-facing changes

None.

## Backwards-incompatible changes

None.