### PR TITLE
Use y-py 0.3.0

### DIFF
--- a/jupyterlab/handlers/ydoc.py
+++ b/jupyterlab/handlers/ydoc.py
@@ -21,8 +21,7 @@ class YFile(YBaseDoc):
 
     @property
     def source(self):
-        with self._ydoc.begin_transaction() as t:
-            return self._ysource.to_string(t)
+        return str(self._ysource)
 
 
 class YNotebook(YBaseDoc):
@@ -34,10 +33,9 @@ class YNotebook(YBaseDoc):
 
     @property
     def source(self):
-        with self._ydoc.begin_transaction() as t:
-            cells = self._ycells.to_json(t)
-            meta = self._ymeta.to_json(t)
-            state = self._ystate.to_json(t)
+        cells = self._ycells.to_json()
+        meta = self._ymeta.to_json()
+        state = self._ystate.to_json()
         for cell in cells:
             if "execution_count" in cell:
                 execution_count = cell["execution_count"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     jupyter_server>=1.15.6,<2
     notebook_shim>=0.1
     jinja2>=3.0.3
-    y-py==0.3.0
+    y-py>=0.3.0,<0.4.0
 
 [options.extras_require]
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     jupyter_server>=1.15.6,<2
     notebook_shim>=0.1
     jinja2>=3.0.3
-    y-py>=0.2.3,<1
+    y-py==0.3.0
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
## References

Supersedes #12320.

## Code changes

Require `y-py==0.3.0` and use its new API.

## User-facing changes

None.

## Backwards-incompatible changes

None.