### PR TITLE
Remove cell id before saving the notebook

### DIFF
--- a/jupyterlab/handlers/ydoc.py
+++ b/jupyterlab/handlers/ydoc.py
@@ -39,6 +39,9 @@ class YNotebook(YBaseDoc):
             meta = self._ymeta.to_json(t)
             state = self._ystate.to_json(t)
         for cell in cells:
+            if "id" in cell and state["nbformat"] == 4 and state["nbformatMinor"] <= 4:
+                # strip cell ids if we have notebook format 4.0-4.4
+                del cell["id"]
             if "execution_count" in cell:
                 execution_count = cell["execution_count"]
                 if isinstance(execution_count, float):


### PR DESCRIPTION
I think there is a small bug from #11599

Before returning the content of the notebook, the NotebookModel checks the nbformat version and removes the cell id for versions previous 4.5.
https://github.com/jupyterlab/jupyterlab/blob/eeaa3f395cd755e34045611d3d9cc3947626b822/packages/notebook/src/model.ts#L260-L263

Should we do the same check when saving from the backend?

cc @davidbrochart 

## References

## Code changes

## User-facing changes

## Backwards-incompatible changes
