### PR TITLE
Allow for an optional label for the uploader widget

### DIFF
--- a/packages/filebrowser/src/upload.ts
+++ b/packages/filebrowser/src/upload.ts
@@ -20,6 +20,7 @@ export class Uploader extends ToolbarButton {
   constructor(options: Uploader.IOptions) {
     super({
       icon: fileUploadIcon,
+      label: options.label,
       onClick: () => {
         this._input.click();
       },
@@ -85,6 +86,11 @@ export namespace Uploader {
      * The language translator.
      */
     translator?: ITranslator;
+
+    /**
+     * An optional label.
+     */
+    label?: string;
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Allow passing an optional `label` to the `Uploader` component, which can then be used in downstream distribution like Notebook v7 or third-party extensions.

## Code changes

Add an optional `label` to the `Uploader.IOptions` interface.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

If provided, the button could then show a label next to the icon: 

![image](https://user-images.githubusercontent.com/591645/161420675-91e8c796-661e-4461-95c6-98c72d94e4bb.png)

This is however *not* enabled by default in JupyterLab, which still shows the icon only:

![image](https://user-images.githubusercontent.com/591645/161420750-a792a9f3-7507-42bd-ab0f-31a8cecff02d.png)

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
