### PR TITLE
Remove circular setting of source

### DIFF
--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -229,7 +229,6 @@ export namespace CodeEditor {
      */
     constructor(options?: Model.IOptions) {
       options = options || {};
-
       if (options.modelDB) {
         this.modelDB = options.modelDB;
       } else {

--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -42,13 +42,13 @@ export class FileEditorCodeWrapper extends CodeEditorWrapper {
     });
 
     const context = (this._context = options.context);
-    const editor = this.editor;
 
+    // TODO: move this to the FileEditor when removing the
+    // `FileEditorCodeWrapper`
     this.addClass('jp-FileEditorCodeWrapper');
     this.node.dataset[CODE_RUNNER] = 'true';
     this.node.dataset[UNDOER] = 'true';
 
-    editor.model.value.text = context.model.toString();
     void context.ready.then(() => {
       this._onContextReady();
     });
@@ -98,34 +98,11 @@ export class FileEditorCodeWrapper extends CodeEditorWrapper {
     if (this.isDisposed) {
       return;
     }
-    const contextModel = this._context.model;
-    const editor = this.editor;
-    const editorModel = editor.model;
-
-    // Set the editor model value.
-    editorModel.value.text = contextModel.toString();
 
     // Prevent the initial loading from disk from being in the editor history.
-    editor.clearHistory();
-
-    // Wire signal connections.
-    contextModel.contentChanged.connect(this._onContentChanged, this);
-
+    this.editor.clearHistory();
     // Resolve the ready promise.
     this._ready.resolve(undefined);
-  }
-
-  /**
-   * Handle a change in context model content.
-   */
-  private _onContentChanged(): void {
-    const editorModel = this.editor.model;
-    const oldValue = editorModel.value.text;
-    const newValue = this._context.model.toString();
-
-    if (oldValue !== newValue) {
-      editorModel.value.text = newValue;
-    }
   }
 
   /**


### PR DESCRIPTION
There is something weird in the FileEditor that I'm not sure what is its purpose and it is dangerous for the data leak.

The file editor contains a [`FileEditorCodeWrapper`](https://github.com/jupyterlab/jupyterlab/blob/43a987414af05b8413429594207f9c5a4784599b/packages/fileeditor/src/widget.ts#L34) for the text editor. For what I could see, the only purpose of the class `FileEditorCodeWrapper` is to sync the content from the `IContext.model` into the `CodeEditor.IEditor.model`. The problem is that the `IContext.model` and `CodeEditor.IEditor.model` is the same instance, we are creating the editor using the model from the context. see:
https://github.com/jupyterlab/jupyterlab/blob/43a987414af05b8413429594207f9c5a4784599b/packages/fileeditor/src/widget.ts#L41

And the `FileEditorCodeWrapper` class the only purpose seems to be syncing the content from the context into the editor:
https://github.com/jupyterlab/jupyterlab/blob/43a987414af05b8413429594207f9c5a4784599b/packages/fileeditor/src/widget.ts#L121-L129

Apart from that, in the constructor of the class, we are taking the content from the model before the model is initialized (there is not content yet) and adding it again into the model. That in the shared model creates an operation that deletes the content when a new client joins and this operation is synced with other clients later when the context is initialized.

https://github.com/jupyterlab/jupyterlab/blob/43a987414af05b8413429594207f9c5a4784599b/packages/fileeditor/src/widget.ts#L51-L54

Could be that the data leak we are having comes from here but I'm not sure.

## References

## Code changes

## User-facing changes

## Backwards-incompatible changes

