### PR TITLE
Disable `fail-fast` for the check release workflow

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -13,6 +13,7 @@ jobs:
   check_release:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         group: [check_release, link_check]
     steps:


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This will help prevent failures happening in the `check_release` check to cause the `link_check` job to be cancelled. 

So the link check can still run without being impacted by `check_release`.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

CI workflow update.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
