### PR TITLE
File Browser: add support for filtering directories on search

### DIFF
--- a/packages/filebrowser-extension/schema/browser.json
+++ b/packages/filebrowser-extension/schema/browser.json
@@ -210,6 +210,12 @@
       "description": "Whether to apply fuzzy algorithm while filtering on file names",
       "default": true
     },
+    "filterDirectories": {
+      "type": "boolean",
+      "title": "Filter directories",
+      "description": "Whether to apply the search on directories",
+      "default": true
+    },
     "showLastModifiedColumn": {
       "type": "boolean",
       "title": "Show last modified column",

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -208,7 +208,6 @@ const browser: JupyterFrontEndPlugin<void> = {
       }
 
       if (settingRegistry) {
-
         void settingRegistry
           .load('@jupyterlab/filebrowser-extension:browser')
           .then(settings => {
@@ -219,16 +218,27 @@ const browser: JupyterFrontEndPlugin<void> = {
               navigateToCurrentDirectory: false,
               showLastModifiedColumn: true,
               useFuzzyFilter: true,
-              showHiddenFiles: false,
-              filterDirectories: true,
-            }
+              showHiddenFiles: false
+            };
+            const fileBrowserModelConfig = {
+              filterDirectories: true
+            };
 
-            function onSettingsChanged(settings: ISettingRegistry.ISettings): void {
-              for (const key of fileBrowserConfig) {
+            function onSettingsChanged(
+              settings: ISettingRegistry.ISettings
+            ): void {
+              for (const key in fileBrowserConfig) {
                 const value = settings.get(key).composite as boolean;
-                fileBrowserConfig[key] = value;
-                browser.model[key] = value;
-              };
+                fileBrowserConfig[
+                  key as keyof typeof fileBrowserConfig
+                ] = value;
+                browser[key as keyof typeof fileBrowserConfig] = value;
+              }
+
+              const value = settings.get('filterDirectories')
+                .composite as boolean;
+              fileBrowserModelConfig.filterDirectories = value;
+              browser.model.filterDirectories = value;
             }
             settings.changed.connect(onSettingsChanged);
             onSettingsChanged(settings);

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -223,7 +223,7 @@ const browser: JupyterFrontEndPlugin<void> = {
               filterDirectories: true,
             }
 
-            function onSettingsChanged(settings: ISettingRegistry.IPlugin): void {
+            function onSettingsChanged(settings: ISettingRegistry.ISettings): void {
               for (const key of fileBrowserConfig) {
                 const value = settings.get(key).composite as boolean;
                 fileBrowserConfig[key] = value;

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -207,63 +207,31 @@ const browser: JupyterFrontEndPlugin<void> = {
         });
       }
 
-      let navigateToCurrentDirectory: boolean = false;
-      let showLastModifiedColumn: boolean = true;
-      let useFuzzyFilter: boolean = true;
-      let showHiddenFiles: boolean = false;
-      let filterDirectories: boolean = true;
-
       if (settingRegistry) {
+
         void settingRegistry
           .load('@jupyterlab/filebrowser-extension:browser')
           .then(settings => {
-            settings.changed.connect(settings => {
-              navigateToCurrentDirectory = settings.get(
-                'navigateToCurrentDirectory'
-              ).composite as boolean;
-              browser.navigateToCurrentDirectory = navigateToCurrentDirectory;
-            });
-            navigateToCurrentDirectory = settings.get(
-              'navigateToCurrentDirectory'
-            ).composite as boolean;
-            browser.navigateToCurrentDirectory = navigateToCurrentDirectory;
+            /**
+             * File browser configuration.
+             */
+            const fileBrowserConfig = {
+              navigateToCurrentDirectory: false,
+              showLastModifiedColumn: true,
+              useFuzzyFilter: true,
+              showHiddenFiles: false,
+              filterDirectories: true,
+            }
 
-            settings.changed.connect(settings => {
-              showLastModifiedColumn = settings.get('showLastModifiedColumn')
-                .composite as boolean;
-              browser.showLastModifiedColumn = showLastModifiedColumn;
-            });
-            showLastModifiedColumn = settings.get('showLastModifiedColumn')
-              .composite as boolean;
-
-            browser.showLastModifiedColumn = showLastModifiedColumn;
-
-            settings.changed.connect(settings => {
-              useFuzzyFilter = settings.get('useFuzzyFilter')
-                .composite as boolean;
-              browser.useFuzzyFilter = useFuzzyFilter;
-            });
-            useFuzzyFilter = settings.get('useFuzzyFilter')
-              .composite as boolean;
-            browser.useFuzzyFilter = useFuzzyFilter;
-
-            settings.changed.connect(settings => {
-              showHiddenFiles = settings.get('showHiddenFiles')
-                .composite as boolean;
-              browser.showHiddenFiles = showHiddenFiles;
-            });
-            showHiddenFiles = settings.get('showHiddenFiles')
-              .composite as boolean;
-
-            settings.changed.connect(settings => {
-              filterDirectories = settings.get('filterDirectories')
-                .composite as boolean;
-              browser.model.filterDirectories = filterDirectories;
-            });
-            filterDirectories = settings.get('filterDirectories')
-              .composite as boolean;
-
-            browser.model.filterDirectories = filterDirectories;
+            function onSettingsChanged(settings: ISettingRegistry.IPlugin): void {
+              for (const key of fileBrowserConfig) {
+                const value = settings.get(key).composite as boolean;
+                fileBrowserConfig[key] = value;
+                browser.model[key] = value;
+              };
+            }
+            settings.changed.connect(onSettingsChanged);
+            onSettingsChanged(settings);
           });
       }
     });

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -30,7 +30,6 @@ import { IDocumentManager } from '@jupyterlab/docmanager';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import {
   FileBrowser,
-  FileDialog,
   FileUploadStatus,
   FilterFileBrowserModel,
   IFileBrowserFactory,
@@ -299,10 +298,6 @@ const factory: JupyterFrontEndPlugin<IFileBrowserFactory> = {
       id: string,
       options: IFileBrowserFactory.IOptions = {}
     ) => {
-      setTimeout(() => {
-        FileDialog.getExistingDirectory({ manager: docManager });
-      }, 2000);
-
       const model = new FilterFileBrowserModel({
         translator: translator,
         auto: options.auto ?? true,

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -30,6 +30,7 @@ import { IDocumentManager } from '@jupyterlab/docmanager';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import {
   FileBrowser,
+  FileDialog,
   FileUploadStatus,
   FilterFileBrowserModel,
   IFileBrowserFactory,
@@ -298,6 +299,10 @@ const factory: JupyterFrontEndPlugin<IFileBrowserFactory> = {
       id: string,
       options: IFileBrowserFactory.IOptions = {}
     ) => {
+      setTimeout(() => {
+        FileDialog.getExistingDirectory({ manager: docManager });
+      }, 2000);
+
       const model = new FilterFileBrowserModel({
         translator: translator,
         auto: options.auto ?? true,

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -211,6 +211,7 @@ const browser: JupyterFrontEndPlugin<void> = {
       let showLastModifiedColumn: boolean = true;
       let useFuzzyFilter: boolean = true;
       let showHiddenFiles: boolean = false;
+      let filterDirectories: boolean = true;
 
       if (settingRegistry) {
         void settingRegistry
@@ -254,7 +255,15 @@ const browser: JupyterFrontEndPlugin<void> = {
             showHiddenFiles = settings.get('showHiddenFiles')
               .composite as boolean;
 
-            browser.showHiddenFiles = showHiddenFiles;
+            settings.changed.connect(settings => {
+              filterDirectories = settings.get('filterDirectories')
+                .composite as boolean;
+              browser.model.filterDirectories = filterDirectories;
+            });
+            filterDirectories = settings.get('filterDirectories')
+              .composite as boolean;
+
+            browser.model.filterDirectories = filterDirectories;
           });
       }
     });

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -155,7 +155,10 @@ export class FileBrowser extends SidePanel {
    */
   set useFuzzyFilter(value: boolean) {
     this._useFuzzyFilter = value;
+    this._createFilenameSearcher();
+  }
 
+  private _createFilenameSearcher() {
     // Detach and dispose the current widget
     this._filenameSearcher.parent = null;
     this._filenameSearcher.dispose();

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -155,10 +155,7 @@ export class FileBrowser extends SidePanel {
    */
   set useFuzzyFilter(value: boolean) {
     this._useFuzzyFilter = value;
-    this._createFilenameSearcher();
-  }
 
-  private _createFilenameSearcher() {
     // Detach and dispose the current widget
     this._filenameSearcher.parent = null;
     this._filenameSearcher.dispose();

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -774,6 +774,14 @@ export class FilterFileBrowserModel extends TogglableHiddenFileBrowserModel {
   constructor(options: FilterFileBrowserModel.IOptions) {
     super(options);
     this._filter = options.filter ? options.filter : model => true;
+    this._filterDirectories = options.filterDirectories ?? false;
+  }
+
+  /**
+   * Whether to filter directories.
+   */
+  set filterDirectories(value: boolean) {
+    this._filterDirectories = value;
   }
 
   /**
@@ -783,7 +791,7 @@ export class FilterFileBrowserModel extends TogglableHiddenFileBrowserModel {
    */
   items(): IIterator<Contents.IModel> {
     return filter(super.items(), (value, index) => {
-      if (value.type === 'directory') {
+      if (!this._filterDirectories && value.type === 'directory') {
         return true;
       } else {
         return this._filter(value);
@@ -797,6 +805,7 @@ export class FilterFileBrowserModel extends TogglableHiddenFileBrowserModel {
   }
 
   private _filter: (value: Contents.IModel) => boolean;
+  private _filterDirectories: boolean;
 }
 
 /**
@@ -811,5 +820,10 @@ export namespace FilterFileBrowserModel {
      * Filter function on file browser item model
      */
     filter?: (value: Contents.IModel) => boolean;
+
+    /**
+     * Filter directories
+     */
+    filterDirectories?: boolean;
   }
 }

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -774,7 +774,7 @@ export class FilterFileBrowserModel extends TogglableHiddenFileBrowserModel {
   constructor(options: FilterFileBrowserModel.IOptions) {
     super(options);
     this._filter = options.filter ? options.filter : model => true;
-    this._filterDirectories = options.filterDirectories ?? false;
+    this._filterDirectories = options.filterDirectories ?? true;
   }
 
   /**

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -780,6 +780,9 @@ export class FilterFileBrowserModel extends TogglableHiddenFileBrowserModel {
   /**
    * Whether to filter directories.
    */
+  get filterDirectories(): boolean {
+     return this._filterDirectories;
+  }
   set filterDirectories(value: boolean) {
     this._filterDirectories = value;
   }

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -781,7 +781,7 @@ export class FilterFileBrowserModel extends TogglableHiddenFileBrowserModel {
    * Whether to filter directories.
    */
   get filterDirectories(): boolean {
-     return this._filterDirectories;
+    return this._filterDirectories;
   }
   set filterDirectories(value: boolean) {
     this._filterDirectories = value;

--- a/packages/filebrowser/src/opendialog.ts
+++ b/packages/filebrowser/src/opendialog.ts
@@ -122,7 +122,8 @@ class OpenDialog
   constructor(
     manager: IDocumentManager,
     filter?: (value: Contents.IModel) => boolean,
-    translator?: ITranslator
+    translator?: ITranslator,
+    filterDirectories?: boolean
   ) {
     super();
     translator = translator ?? nullTranslator;
@@ -134,7 +135,8 @@ class OpenDialog
       manager,
       filter,
       {},
-      translator
+      translator,
+      filterDirectories
     );
 
     // Add toolbar items
@@ -230,7 +232,8 @@ namespace Private {
     manager: IDocumentManager,
     filter?: (value: Contents.IModel) => boolean,
     options: IFileBrowserFactory.IOptions = {},
-    translator?: ITranslator
+    translator?: ITranslator,
+    filterDirectories?: boolean
   ): FileBrowser => {
     translator = translator || nullTranslator;
     const model = new FilterFileBrowserModel({
@@ -238,7 +241,8 @@ namespace Private {
       filter,
       translator,
       driveName: options.driveName,
-      refreshInterval: options.refreshInterval
+      refreshInterval: options.refreshInterval,
+      filterDirectories
     });
     const widget = new FileBrowser({
       id,

--- a/packages/filebrowser/src/opendialog.ts
+++ b/packages/filebrowser/src/opendialog.ts
@@ -108,7 +108,7 @@ export namespace FileDialog {
   ): Promise<Dialog.IResult<Contents.IModel[]>> {
     return getOpenFiles({
       ...options,
-      filter: model => false
+      filter: model => model.type === 'directory'
     });
   }
 }

--- a/packages/filebrowser/test/openfiledialog.spec.ts
+++ b/packages/filebrowser/test/openfiledialog.spec.ts
@@ -75,10 +75,11 @@ describe('@jupyterlab/filebrowser', () => {
         expect(filteredItems.length).toBe(items.length);
       });
 
-      it('should list all directories whatever the filter', async () => {
+      it('should list all directories if filterDirectories is false', async () => {
         const filteredModel = new FilterFileBrowserModel({
           manager,
-          filter: (model: Contents.IModel) => false
+          filter: (model: Contents.IModel) => false,
+          filterDirectories: false
         });
         await filteredModel.cd();
         const model = new FileBrowserModel({ manager });
@@ -88,6 +89,20 @@ describe('@jupyterlab/filebrowser', () => {
         const items = toArray(model.items());
         const folders = items.filter(item => item.type === 'directory');
         expect(filteredItems.length).toBe(folders.length);
+      });
+
+      it('should filter files and directories if filterDirectories is true', async () => {
+        const filteredModel = new FilterFileBrowserModel({
+          manager,
+          filter: (model: Contents.IModel) => false,
+          filterDirectories: true
+        });
+        await filteredModel.cd();
+        const model = new FileBrowserModel({ manager });
+        await model.cd();
+
+        const filteredItems = toArray(filteredModel.items());
+        expect(filteredItems.length).toBe(0);
       });
 
       it('should respect the filter', async () => {
@@ -103,9 +118,7 @@ describe('@jupyterlab/filebrowser', () => {
           filteredModel.items()
         ) as Contents.IModel[];
         const items = toArray(model.items());
-        const shownItems = items.filter(
-          item => item.type === 'directory' || item.type === 'notebook'
-        );
+        const shownItems = items.filter(item => item.type === 'notebook');
         expect(filteredItems.length).toBe(shownItems.length);
         const notebooks = filteredItems.filter(
           item => item.type === 'notebook'


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/12055

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Add a setting to also filter directories when searching for files in the file browser.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

In this PR the new setting is **true** by default.

https://user-images.githubusercontent.com/591645/161615666-24a26073-9c0c-4e91-b7a2-089cda5efc00.mp4

## Backwards-incompatible changes

None (new parameters are optional).

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
