### PR TITLE
Allow LauncherModel to be more extendable

### DIFF
--- a/packages/launcher/src/widget.tsx
+++ b/packages/launcher/src/widget.tsx
@@ -52,11 +52,11 @@ export class LauncherModel extends VDomModel implements ILauncher.IModel {
     // Create a copy of the options to circumvent mutations to the original.
     const item = Private.createItem(options);
 
-    this._items.push(item);
+    this.itemsList.push(item);
     this.stateChanged.emit(void 0);
 
     return new DisposableDelegate(() => {
-      ArrayExt.removeFirstOf(this._items, item);
+      ArrayExt.removeFirstOf(this.itemsList, item);
       this.stateChanged.emit(void 0);
     });
   }
@@ -65,10 +65,10 @@ export class LauncherModel extends VDomModel implements ILauncher.IModel {
    * Return an iterator of launcher items.
    */
   items(): IIterator<ILauncher.IItemOptions> {
-    return new ArrayIterator(this._items);
+    return new ArrayIterator(this.itemsList);
   }
 
-  protected _items: ILauncher.IItemOptions[] = [];
+  protected itemsList: ILauncher.IItemOptions[] = [];
 }
 
 /**

--- a/packages/launcher/src/widget.tsx
+++ b/packages/launcher/src/widget.tsx
@@ -68,7 +68,7 @@ export class LauncherModel extends VDomModel implements ILauncher.IModel {
     return new ArrayIterator(this._items);
   }
 
-  private _items: ILauncher.IItemOptions[] = [];
+  protected _items: ILauncher.IItemOptions[] = [];
 }
 
 /**


### PR DESCRIPTION
## References

No tracking issue

## Code changes

Currently when a 3rd party extension wants to override launcher
they don't have the option of overriding the LauncherModel since
the items list is private and not accessable. This updates the private
variable to be protected so the value can be accessed by extensions of
the model class.

I also had to change the var name since protected vars do not prepend
a _ but there's already a public function called items in the class.

## User-facing changes

none

## Backwards-incompatible changes

IIUC since this is surfacing a previously private var this API change is back-compatable
