### PR TITLE
showDocsPanel should receive a boolean

### DIFF
--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -132,8 +132,8 @@ export class Completer extends Widget {
   /**
    * Enable/disable the document panel.
    */
-  set showDocsPanel(showDoc: boolean | null) {
-    this._showDoc = showDoc ?? true;
+  set showDocsPanel(showDoc: boolean) {
+    this._showDoc = showDoc;
   }
 
   get showDocsPanel(): boolean {


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/12345

## Code changes

showDocsPanel should now receives a `boolean` instead of `boolean | null`.

cc/ @krassowski

## User-facing changes

None

## Backwards-incompatible changes

None.