### PR TITLE
Provide `IDocumentManager` in a separate plugin

### DIFF
--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -170,15 +170,7 @@ const docManagerPlugin: JupyterFrontEndPlugin<void> = {
   id: docManagerPluginId,
   autoStart: true,
   requires: [IDocumentManager, ISettingRegistry],
-  optional: [
-    ITranslator,
-    ILabStatus,
-    ICommandPalette,
-    ILabShell,
-    ISessionContextDialogs,
-    IDocumentProviderFactory,
-    JupyterLab.IInfo
-  ],
+  optional: [ITranslator, ICommandPalette, ILabShell],
   activate: (
     app: JupyterFrontEnd,
     docManager: IDocumentManager,

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -168,6 +168,7 @@ const manager: JupyterFrontEndPlugin<IDocumentManager> = {
  */
 const docManagerPlugin: JupyterFrontEndPlugin<void> = {
   id: docManagerPluginId,
+  autoStart: true,
   requires: [IDocumentManager, ISettingRegistry],
   optional: [
     ITranslator,

--- a/packages/docmanager/src/tokens.ts
+++ b/packages/docmanager/src/tokens.ts
@@ -45,6 +45,11 @@ export interface IDocumentManager extends IDisposable {
   autosaveInterval: number;
 
   /**
+   * Defines max acceptable difference, in milliseconds, between last modified timestamps on disk and client.
+   */
+  lastModifiedCheckMargin: number;
+
+  /**
    * Clone a widget.
    *
    * @param widget - The source widget.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This should help with https://github.com/jupyter/notebook/issues/6344.

## Code changes

Move the instantiation of the `DocumentManager` and the way the `IDocumentManager` token is provided to a separate plugin.

This should make it easier for downstream applications to provide a different `IDocumentManager`, while still reusing the default commands and settings.

## User-facing changes

None

## Backwards-incompatible changes

- Add `lastModifiedCheckMargin` to the `IDocumentManager` interface for consistency
- Some plugin restructuring.