### PR TITLE
Fix Yjs message

### DIFF
--- a/jupyterlab/handlers/yjs_echo_ws.py
+++ b/jupyterlab/handlers/yjs_echo_ws.py
@@ -127,7 +127,7 @@ message_yjs_update = 2
 
 def read_sync_step1(handler, doc, encoded_state_vector):
     message = Y.encode_state_as_update(doc, encoded_state_vector)
-    message = bytes([message_yjs_sync_step2] + write_var_uint(len(message)) + message)
+    message = bytes([0, message_yjs_sync_step2] + write_var_uint(len(message)) + message)
     handler.write_message(message, binary=True)
 
 


### PR DESCRIPTION
## References

See https://github.com/jupyterlab/jupyterlab/pull/11599#discussion_r841795706.

## Code changes

Add `0` to Yjs sync message.

## User-facing changes

None.

## Backwards-incompatible changes

None.