### PR TITLE
type-only and lazy imports of settings widgets

### DIFF
--- a/galata/test/jupyterlab/texteditor.test.ts
+++ b/galata/test/jupyterlab/texteditor.test.ts
@@ -25,6 +25,7 @@ test.describe('Text Editor Tests', () => {
 
     await page.menu.clickMenuItem('Settings>Settings Editor');
 
+    await page.waitForSelector('text=Text Editor');
     await page.click('text=Text Editor');
 
     // Add two rulers

--- a/packages/completer-extension/src/index.ts
+++ b/packages/completer-extension/src/index.ts
@@ -17,7 +17,7 @@ import {
 } from '@jupyterlab/completer';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IFormComponentRegistry } from '@jupyterlab/ui-components';
-import { FieldProps } from '@rjsf/core';
+import type { FieldProps } from '@rjsf/core';
 
 import { renderAvailableProviders } from './renderer';
 

--- a/packages/completer-extension/src/renderer.tsx
+++ b/packages/completer-extension/src/renderer.tsx
@@ -1,6 +1,6 @@
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
-import { FieldProps } from '@rjsf/core';
+import type { FieldProps } from '@rjsf/core';
 import React, { useState } from 'react';
 
 const AVAILABLE_PROVIDERS = 'availableProviders';

--- a/packages/settingeditor-extension/src/index.ts
+++ b/packages/settingeditor-extension/src/index.ts
@@ -28,7 +28,9 @@ import {
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import {
   IJSONSettingEditorTracker,
-  ISettingEditorTracker,
+  ISettingEditorTracker
+} from '@jupyterlab/settingeditor/lib/tokens';
+import type {
   JsonSettingEditor,
   SettingsEditor
 } from '@jupyterlab/settingeditor';
@@ -107,13 +109,15 @@ function activate(
   }
 
   commands.addCommand(CommandIDs.open, {
-    execute: () => {
+    execute: async () => {
       if (tracker.currentWidget) {
         shell.activateById(tracker.currentWidget.id);
         return;
       }
 
       const key = plugin.id;
+
+      const { SettingsEditor } = await import('@jupyterlab/settingeditor');
 
       const editor = new MainAreaWidget<SettingsEditor>({
         content: new SettingsEditor({
@@ -210,7 +214,7 @@ function activateJSON(
   }
 
   commands.addCommand(CommandIDs.openJSON, {
-    execute: () => {
+    execute: async () => {
       if (tracker.currentWidget) {
         shell.activateById(tracker.currentWidget.id);
         return;
@@ -218,6 +222,8 @@ function activateJSON(
 
       const key = plugin.id;
       const when = app.restored;
+
+      const { JsonSettingEditor } = await import('@jupyterlab/settingeditor');
 
       const editor = new JsonSettingEditor({
         commands: {

--- a/packages/ui-components/src/FormComponentRegistry.tsx
+++ b/packages/ui-components/src/FormComponentRegistry.tsx
@@ -4,7 +4,7 @@
 |----------------------------------------------------------------------------*/
 
 import { Token } from '@lumino/coreutils';
-import { Field } from '@rjsf/core';
+import type { Field } from '@rjsf/core';
 
 /**
  * A registry for rendering fields used in the FormEditor component.


### PR DESCRIPTION
## References

- fixes #12363

## Code changes

- [x] use type imports for heavy widgets from `settingseditor`
- [x] lazy import when first used `SettingsEditor` and `JsonSettingEditor`

## User-facing changes

- should not load the rjsf bundle up front

## Backwards-incompatible changes

- n/a