### PR TITLE
Add CodeViewer widget and openCodeViewer command

### DIFF
--- a/packages/codeeditor/src/index.ts
+++ b/packages/codeeditor/src/index.ts
@@ -11,4 +11,5 @@ export * from './jsoneditor';
 export * from './lineCol';
 export * from './mimetype';
 export * from './tokens';
+export * from './viewer';
 export * from './widget';

--- a/packages/codeeditor/src/viewer.ts
+++ b/packages/codeeditor/src/viewer.ts
@@ -11,11 +11,13 @@ export class CodeViewerWidget extends Widget {
    */
   constructor(options: CodeViewerWidget.IOptions) {
     super();
+    this.content = options.content;
 
     this.model = new CodeEditor.Model({
       value: options.content,
       mimeType: options.mimeType
     });
+    this.mimeType = this.model.mimeType;
 
     const editorWidget = new CodeEditorWrapper({
       factory: options.factory,
@@ -28,6 +30,8 @@ export class CodeViewerWidget extends Widget {
     layout.addWidget(editorWidget);
   }
 
+  content: string;
+  mimeType: string;
   model: CodeEditor.IModel;
   editor: CodeEditor.IEditor;
 }

--- a/packages/codeeditor/src/viewer.ts
+++ b/packages/codeeditor/src/viewer.ts
@@ -24,7 +24,7 @@ export class CodeViewerWidget extends Widget {
     layout.addWidget(editorWidget);
   }
 
-  static getCodeViewer(
+  static createCodeViewer(
     options: CodeViewerWidget.INoModelOptions
   ): CodeViewerWidget {
     const model = new CodeEditor.Model({
@@ -34,8 +34,13 @@ export class CodeViewerWidget extends Widget {
     return new CodeViewerWidget({ factory: options.factory, model });
   }
 
-  getContent = (): string => this.model.value.text;
-  getMimeType = (): string => this.model.mimeType;
+  get content(): string {
+    return this.model.value.text;
+  }
+
+  get mimeType(): string {
+    return this.model.mimeType;
+  }
 
   model: CodeEditor.IModel;
   editor: CodeEditor.IEditor;

--- a/packages/codeeditor/src/viewer.ts
+++ b/packages/codeeditor/src/viewer.ts
@@ -11,17 +11,11 @@ export class CodeViewerWidget extends Widget {
    */
   constructor(options: CodeViewerWidget.IOptions) {
     super();
-    this.content = options.content;
-
-    this.model = new CodeEditor.Model({
-      value: options.content,
-      mimeType: options.mimeType
-    });
-    this.mimeType = this.model.mimeType;
+    this.model = options.model;
 
     const editorWidget = new CodeEditorWrapper({
       factory: options.factory,
-      model: this.model
+      model: options.model
     });
     this.editor = editorWidget.editor;
     this.editor.setOption('readOnly', true);
@@ -30,8 +24,19 @@ export class CodeViewerWidget extends Widget {
     layout.addWidget(editorWidget);
   }
 
-  content: string;
-  mimeType: string;
+  static getCodeViewer(
+    options: CodeViewerWidget.INoModelOptions
+  ): CodeViewerWidget {
+    const model = new CodeEditor.Model({
+      value: options.content,
+      mimeType: options.mimeType
+    });
+    return new CodeViewerWidget({ factory: options.factory, model });
+  }
+
+  getContent = (): string => this.model.value.text;
+  getMimeType = (): string => this.model.mimeType;
+
   model: CodeEditor.IModel;
   editor: CodeEditor.IEditor;
 }
@@ -44,6 +49,21 @@ export namespace CodeViewerWidget {
    * The options used to create an code viewer widget.
    */
   export interface IOptions {
+    /**
+     * A code editor factory.
+     */
+    factory: CodeEditor.Factory;
+
+    /**
+     * The content model for the viewer.
+     */
+    model: CodeEditor.Model;
+  }
+
+  /**
+   * The options used to create an code viewer widget without a model.
+   */
+  export interface INoModelOptions {
     /**
      * A code editor factory.
      */

--- a/packages/codeeditor/src/viewer.ts
+++ b/packages/codeeditor/src/viewer.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { StackedLayout, Widget } from '@lumino/widgets';
+import { CodeEditor, CodeEditorWrapper } from './';
+
+export class CodeViewerWidget extends Widget {
+  /**
+   * Construct a new code viewer widget.
+   */
+  constructor(options: CodeViewerWidget.IOptions) {
+    super();
+
+    this.model = new CodeEditor.Model({
+      value: options.content,
+      mimeType: options.mimeType
+    });
+
+    const editorWidget = new CodeEditorWrapper({
+      factory: options.factory,
+      model: this.model
+    });
+    this.editor = editorWidget.editor;
+    this.editor.setOption('readOnly', true);
+
+    const layout = (this.layout = new StackedLayout());
+    layout.addWidget(editorWidget);
+  }
+
+  public model: CodeEditor.IModel;
+  public editor: CodeEditor.IEditor;
+}
+
+/**
+ * The namespace for code viewer widget.
+ */
+export namespace CodeViewerWidget {
+  /**
+   * The options used to create an code viewer widget.
+   */
+  export interface IOptions {
+    /**
+     * A code editor factory.
+     */
+    factory: CodeEditor.Factory;
+
+    /**
+     * The content to display in the viewer.
+     */
+    content: string;
+
+    /**
+     * The mime type for the content.
+     */
+    mimeType?: string;
+  }
+}

--- a/packages/codeeditor/src/viewer.ts
+++ b/packages/codeeditor/src/viewer.ts
@@ -2,7 +2,8 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { StackedLayout, Widget } from '@lumino/widgets';
-import { CodeEditor, CodeEditorWrapper } from './';
+import { CodeEditor } from './editor';
+import { CodeEditorWrapper } from './widget';
 
 export class CodeViewerWidget extends Widget {
   /**
@@ -27,8 +28,8 @@ export class CodeViewerWidget extends Widget {
     layout.addWidget(editorWidget);
   }
 
-  public model: CodeEditor.IModel;
-  public editor: CodeEditor.IEditor;
+  model: CodeEditor.IModel;
+  editor: CodeEditor.IEditor;
 }
 
 /**

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -1228,7 +1228,7 @@ export namespace Commands {
         );
       }
 
-      const widget = new CodeViewerWidget({
+      const widget = CodeViewerWidget.getCodeViewer({
         factory,
         content: args.content,
         mimeType: mimetype

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -1228,7 +1228,7 @@ export namespace Commands {
         );
       }
 
-      const widget = CodeViewerWidget.getCodeViewer({
+      const widget = CodeViewerWidget.createCodeViewer({
         factory,
         content: args.content,
         mimeType: mimetype
@@ -1252,6 +1252,7 @@ export namespace Commands {
     };
 
     app.commands.addCommand(CommandIDs.openCodeViewer, {
+      label: trans.__('Open Code Viewer'),
       execute: (args: any) => {
         return openCodeViewer(args);
       }

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import { ILayoutRestorer, JupyterFrontEnd } from '@jupyterlab/application';
 import {
   Clipboard,
   ICommandPalette,
@@ -36,13 +37,13 @@ import {
   textEditorIcon,
   undoIcon
 } from '@jupyterlab/ui-components';
+import { toArray } from '@lumino/algorithm';
 import { CommandRegistry } from '@lumino/commands';
 import {
   JSONObject,
   ReadonlyJSONObject,
   ReadonlyPartialJSONObject
 } from '@lumino/coreutils';
-import { JupyterFrontEnd } from '@jupyterlab/application';
 
 const autoClosingBracketsNotebook = 'notebook:toggle-autoclosing-brackets';
 const autoClosingBracketsConsole = 'console:toggle-autoclosing-brackets';

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -1204,7 +1204,8 @@ export namespace Commands {
 
   export function addOpenCodeViewerCommand(
     app: JupyterFrontEnd,
-    editorServices: IEditorServices
+    editorServices: IEditorServices,
+    trans: TranslationBundle
   ) {
     const openCodeViewer = (args: {
       content: string;
@@ -1230,7 +1231,7 @@ export namespace Commands {
         content: args.content,
         mimeType: mimetype
       });
-      widget.title.label = args.label || 'Code Viewer';
+      widget.title.label = args.label || trans.__('Code Viewer');
       widget.title.caption = widget.title.label;
 
       // Get the fileType based on the mimetype to determine the icon

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -1205,14 +1205,16 @@ export namespace Commands {
   export function addOpenCodeViewerCommand(
     app: JupyterFrontEnd,
     editorServices: IEditorServices,
+    tracker: WidgetTracker<MainAreaWidget<CodeViewerWidget>>,
     trans: TranslationBundle
   ) {
-    const openCodeViewer = (args: {
+    const openCodeViewer = async (args: {
       content: string;
       label?: string;
       mimeType?: string;
       extension?: string;
-    }): void => {
+      widgetId?: string;
+    }): Promise<CodeViewerWidget> => {
       const func = editorServices.factoryService.newDocumentEditor;
       const factory: CodeEditor.Factory = options => {
         return func(options);
@@ -1240,13 +1242,18 @@ export namespace Commands {
       });
       widget.title.icon = fileType?.icon ?? textEditorIcon;
 
+      if (args.widgetId) {
+        widget.id = args.widgetId;
+      }
       const main = new MainAreaWidget({ content: widget });
+      await tracker.add(main);
       app.shell.add(main, 'main');
+      return widget;
     };
 
     app.commands.addCommand(CommandIDs.openCodeViewer, {
       execute: (args: any) => {
-        openCodeViewer(args);
+        return openCodeViewer(args);
       }
     });
   }

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { ILayoutRestorer, JupyterFrontEnd } from '@jupyterlab/application';
+import { JupyterFrontEnd } from '@jupyterlab/application';
 import {
   Clipboard,
   ICommandPalette,

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -347,6 +347,8 @@ function activate(
     sessionDialogs
   );
 
+  Commands.addOpenCodeViewerCommand(app, editorServices);
+
   // Add a launcher item if the launcher is available.
   if (launcher) {
     Commands.addLauncherItems(launcher, trans);

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -360,9 +360,9 @@ function activate(
     void restorer.restore(codeViewerTracker, {
       command: CommandIDs.openCodeViewer,
       args: widget => ({
-        content: widget.content.getContent(),
+        content: widget.content.content,
         label: widget.content.title.label,
-        mimeType: widget.content.getMimeType(),
+        mimeType: widget.content.mimeType,
         widgetId: widget.content.id
       }),
       name: widget => widget.content.id

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -347,7 +347,7 @@ function activate(
     sessionDialogs
   );
 
-  Commands.addOpenCodeViewerCommand(app, editorServices);
+  Commands.addOpenCodeViewerCommand(app, editorServices, trans);
 
   // Add a launcher item if the launcher is available.
   if (launcher) {

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -360,9 +360,9 @@ function activate(
     void restorer.restore(codeViewerTracker, {
       command: CommandIDs.openCodeViewer,
       args: widget => ({
-        content: widget.content.content,
+        content: widget.content.getContent(),
         label: widget.content.title.label,
-        mimeType: widget.content.mimeType,
+        mimeType: widget.content.getMimeType(),
         widgetId: widget.content.id
       }),
       name: widget => widget.content.id


### PR DESCRIPTION
Code Viewer is a transient readonly editor that displays the given code without persisting it to the file system.

## References

Fixes #12361

## Code changes

Adds the CodeViewer widget and the command to open a code viewer.

The widget is added to the codeeditor package as all its imports are in that package. The command is added in the file editor-extension package as that extension was the closest in functionality of the extensions dealing with the codeeditor package.

## Screenshots

Here is a screen record showing a use case of the Code Viewer in Elyra. In it we open a "file" returned by an api call without persisting it to the file system.

https://user-images.githubusercontent.com/13952758/164115722-b663b49f-7b33-4edd-a4f9-3140cd515209.mov

---
Edited: Add keyword in from of issue to link it