### PR TITLE
Toolbar items may not act on the proper target

### DIFF
--- a/galata/test/jupyterlab/notebook-toolbar.test.ts
+++ b/galata/test/jupyterlab/notebook-toolbar.test.ts
@@ -13,7 +13,6 @@ async function populateNotebook(page: IJupyterLabPageFixture) {
     '## This is **bold** and *italic* [link to jupyter.org!](http://jupyter.org)'
   );
   await page.notebook.addCell('code', '2 ** 3');
-  // await page.notebook.runCell(2, true);
 }
 
 test.describe('Notebook Toolbar', () => {
@@ -99,4 +98,45 @@ test.describe('Notebook Toolbar', () => {
 
     expect(await nbPanel.screenshot()).toMatchSnapshot(imageName);
   });
+});
+
+test('Toolbar items act on owner widget', async ({ page }) => {
+  // Given two side-by-side notebooks and the second being active
+  const file1 = 'notebook1.ipynb';
+  await page.notebook.createNew(file1);
+  const panel1 = await page.activity.getPanel(file1);
+  const tab1 = await page.activity.getTab(file1);
+
+  // FIXME Calling a second time `page.notebook.createNew` is not robust
+  await page.menu.clickMenuItem('File>New>Notebook');
+  try {
+    await page.waitForSelector('.jp-Dialog', { timeout: 5000 });
+    await page.click('.jp-Dialog .jp-mod-accept');
+  } catch (reason) {
+    // no-op
+  }
+
+  const tab2 = await page.activity.getTab();
+
+  const tab2BBox = await tab2.boundingBox();
+  await page.mouse.move(
+    tab2BBox.x + 0.5 * tab2BBox.width,
+    tab2BBox.y + 0.5 * tab2BBox.height
+  );
+  await page.mouse.down();
+  await page.mouse.move(900, tab2BBox.y + tab2BBox.height + 200);
+  await page.mouse.up();
+
+  const classlist = await tab1.getAttribute('class');
+  expect(classlist.split(' ')).not.toContain('jp-mod-current');
+
+  // When clicking on toolbar item of the first file
+  await (
+    await panel1.$('button[data-command="notebook:insert-cell-below"]')
+  ).click();
+
+  // Then the first file is activated and the action is performed
+  const classlistEnd = await tab1.getAttribute('class');
+  expect(classlistEnd.split(' ')).toContain('jp-mod-current');
+  expect(await page.notebook.getCellCount()).toEqual(2);
 });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #12177
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Due to the definition of toolbar items from a data description, the primarly actions are calling a command. To figure out the targeted widget for a command, a tracker is commonly used. Therefore when displaying side-by-side multiple documents, clicking on a toolbar button in the non-active document needs first to turn the widget own as the active widget. As CommandToolbarButton action is triggered on `mousedown` event to avoid focusing the button itself (and losing the focus on the working cell for example), the fix in this PR is using `mousedown` event listener at capture phase (that occurs before the classical bubbling phase) to focus the widget if it contains the event target and if it does not contain the active element (best guess for the current focused element).

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Toolbar button should act on the expected widget
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A