### PR TITLE
Wait until file browser commands are ready before activating file browser widget

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -32,6 +32,7 @@ import {
   FileBrowser,
   FileUploadStatus,
   FilterFileBrowserModel,
+  IFileBrowserCommands,
   IFileBrowserFactory,
   Uploader
 } from '@jupyterlab/filebrowser';
@@ -151,6 +152,7 @@ const browser: JupyterFrontEndPlugin<void> = {
     ITreePathUpdater,
     ICommandPalette
   ],
+  provides: IFileBrowserCommands,
   autoStart: true,
   activate: async (
     app: JupyterFrontEnd,
@@ -200,7 +202,7 @@ const browser: JupyterFrontEndPlugin<void> = {
       updateBrowserTitle();
     });
 
-    void Promise.all([app.restored, browser.model.restored]).then(() => {
+    return void Promise.all([app.restored, browser.model.restored]).then(() => {
       if (treePathUpdater) {
         browser.model.pathChanged.connect((sender, args) => {
           treePathUpdater(args.newValue);
@@ -389,7 +391,8 @@ const browserWidget: JupyterFrontEndPlugin<void> = {
     ISettingRegistry,
     IToolbarWidgetRegistry,
     ITranslator,
-    ILabShell
+    ILabShell,
+    IFileBrowserCommands
   ],
   autoStart: true,
   activate: (

--- a/packages/filebrowser/src/tokens.ts
+++ b/packages/filebrowser/src/tokens.ts
@@ -106,3 +106,10 @@ export namespace IFileBrowserFactory {
     state?: IStateDB | null;
   }
 }
+
+/**
+ * The token that indicates the default file browser commands are loaded.
+ */
+export const IFileBrowserCommands = new Token<void>(
+  '@jupyterlab/filebrowser:IFileBrowserCommands'
+);


### PR DESCRIPTION

## References
An issue raised by @fcollonval in the JupyterLab weekly call https://github.com/jupyterlab/team-compass/issues/135#issuecomment-1091630484 where there is a potential race condition because the file browser widget needs the file browser commands to be loaded but could not explicitly waiting for them.

## Code changes
Adds a `Token<void>` called `IFileBrowserCommands` that allows an extension to wait until the core file browser extension has finished loading before activating.

## User-facing changes
N/A

## Backwards-incompatible changes
N/A
