### PR TITLE
Add parent header to input reply kernel message

### DIFF
--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -365,6 +365,7 @@ export class OutputArea extends Widget {
     panel.addWidget(prompt);
 
     const input = factory.createStdin({
+      parent_header: msg.header,
       prompt: stdinPrompt,
       password,
       future
@@ -855,6 +856,7 @@ export class Stdin extends Widget implements IStdin {
     this._input = this.node.getElementsByTagName('input')[0];
     this._input.focus();
     this._future = options.future;
+    this._parent_header = options.parent_header;
     this._value = options.prompt + ' ';
   }
 
@@ -880,10 +882,13 @@ export class Stdin extends Widget implements IStdin {
     if (event.type === 'keydown') {
       if ((event as KeyboardEvent).keyCode === 13) {
         // Enter
-        this._future.sendInputReply({
-          status: 'ok',
-          value: input.value
-        });
+        this._future.sendInputReply(
+          {
+            status: 'ok',
+            value: input.value
+          },
+          this._parent_header
+        );
         if (input.type === 'password') {
           this._value += Array(input.value.length + 1).join('·');
         } else {
@@ -916,6 +921,7 @@ export class Stdin extends Widget implements IStdin {
     this._input.removeEventListener('keydown', this);
   }
 
+  private _parent_header: KernelMessage.IInputReplyMsg['parent_header'];
   private _future: Kernel.IShellFuture;
   private _input: HTMLInputElement;
   private _value: string;
@@ -941,6 +947,11 @@ export namespace Stdin {
      * The kernel future associated with the request.
      */
     future: Kernel.IShellFuture;
+
+    /**
+     * The header of the input_request message.
+     */
+    parent_header: KernelMessage.IInputReplyMsg['parent_header'];
   }
 }
 

--- a/packages/outputarea/test/widget.spec.ts
+++ b/packages/outputarea/test/widget.spec.ts
@@ -379,7 +379,7 @@ describe('outputarea/widget', () => {
             parent_header: {
               date: '',
               msg_id: '',
-              msg_type: 'input_request',
+              msg_type: 'input_request' as const,
               session: '',
               username: '',
               version: ''

--- a/packages/outputarea/test/widget.spec.ts
+++ b/packages/outputarea/test/widget.spec.ts
@@ -376,6 +376,14 @@ describe('outputarea/widget', () => {
           const factory = new OutputArea.ContentFactory();
           const future = kernel.requestExecute({ code: CODE });
           const options = {
+            parent_header: {
+              date: '',
+              msg_id: '',
+              msg_type: 'input_request',
+              session: '',
+              username: '',
+              version: ''
+            },
             prompt: 'hello',
             password: false,
             future

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -816,7 +816,10 @@ export class KernelConnection implements Kernel.IKernelConnection {
    * #### Notes
    * See [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html#messages-on-the-stdin-router-dealer-sockets).
    */
-  sendInputReply(content: KernelMessage.IInputReplyMsg['content']): void {
+  sendInputReply(
+    content: KernelMessage.IInputReplyMsg['content'],
+    parent_header: KernelMessage.IInputReplyMsg['parent_header']
+  ): void {
     const msg = KernelMessage.createMessage({
       msgType: 'input_reply',
       channel: 'stdin',
@@ -824,6 +827,7 @@ export class KernelConnection implements Kernel.IKernelConnection {
       session: this._clientId,
       content
     });
+    msg.parent_header = parent_header;
 
     this._sendMessage(msg);
     this._anyMessage.emit({ msg, direction: 'send' });

--- a/packages/services/src/kernel/future.ts
+++ b/packages/services/src/kernel/future.ts
@@ -153,8 +153,11 @@ export abstract class KernelFutureHandler<
   /**
    * Send an `input_reply` message.
    */
-  sendInputReply(content: KernelMessage.IInputReplyMsg['content']): void {
-    this._kernel.sendInputReply(content);
+  sendInputReply(
+    content: KernelMessage.IInputReplyMsg['content'],
+    parent_header: KernelMessage.IInputReplyMsg['parent_header']
+  ): void {
+    this._kernel.sendInputReply(content, parent_header);
   }
 
   /**

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -367,7 +367,10 @@ export interface IKernelConnection extends IObservableDisposable {
    * #### Notes
    * See [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html#messages-on-the-stdin-router-dealer-sockets).
    */
-  sendInputReply(content: KernelMessage.IInputReplyMsg['content']): void;
+  sendInputReply(
+    content: KernelMessage.IInputReplyMsg['content'],
+    parent_header: KernelMessage.IInputReplyMsg['parent_header']
+  ): void;
 
   /**
    * Create a new comm.
@@ -775,7 +778,10 @@ export interface IFuture<
   /**
    * Send an `input_reply` message.
    */
-  sendInputReply(content: KernelMessage.IInputReplyMsg['content']): void;
+  sendInputReply(
+    content: KernelMessage.IInputReplyMsg['content'],
+    parent_header: KernelMessage.IInputReplyMsg['parent_header']
+  ): void;
 }
 
 export interface IShellFuture<

--- a/packages/services/test/kernel/ikernel.spec.ts
+++ b/packages/services/test/kernel/ikernel.spec.ts
@@ -97,7 +97,17 @@ describe('Kernel.IKernel', () => {
       defaultKernel.pendingInput.connect((sender, args) => {
         if (!called) {
           called = true;
-          defaultKernel.sendInputReply({ status: 'ok', value: 'foo' });
+          defaultKernel.sendInputReply(
+            { status: 'ok', value: 'foo' },
+            {
+              date: '',
+              msg_id: '',
+              msg_type: 'input_request',
+              session: '',
+              username: '',
+              version: ''
+            }
+          );
         }
       });
       const code = `input("Input something")`;
@@ -306,7 +316,17 @@ describe('Kernel.IKernel', () => {
           expect(direction).toBe('send');
         }
       });
-      kernel.sendInputReply({ status: 'ok', value: 'foo' });
+      kernel.sendInputReply(
+        { status: 'ok', value: 'foo' },
+        {
+          date: '',
+          msg_id: '',
+          msg_type: 'input_request',
+          session: '',
+          username: '',
+          version: ''
+        }
+      );
       await emission;
     });
   });
@@ -874,7 +894,17 @@ describe('Kernel.IKernel', () => {
         expect(msg.header.msg_type).toBe('input_reply');
         done.resolve(undefined);
       });
-      kernel.sendInputReply({ status: 'ok', value: 'test' });
+      kernel.sendInputReply(
+        { status: 'ok', value: 'test' },
+        {
+          date: '',
+          msg_id: '',
+          msg_type: 'input_request',
+          session: '',
+          username: '',
+          version: ''
+        }
+      );
       await done.promise;
       await tester.shutdown();
       tester.dispose();
@@ -891,7 +921,17 @@ describe('Kernel.IKernel', () => {
       tester.sendStatus(UUID.uuid4(), 'dead');
       await dead;
       expect(() => {
-        kernel.sendInputReply({ status: 'ok', value: 'test' });
+        kernel.sendInputReply(
+          { status: 'ok', value: 'test' },
+          {
+            date: '',
+            msg_id: '',
+            msg_type: 'input_request',
+            session: '',
+            username: '',
+            version: ''
+          }
+        );
       }).toThrowError(/Kernel is dead/);
       tester.dispose();
     });


### PR DESCRIPTION
## References

Fixes #12355.

## Code changes

The [kernel messaging protocol](https://jupyter-client.readthedocs.io/en/stable/messaging.html#parent-header) says that "`_reply` messages MUST have a `parent_header`". This PR adds the parent header to `input_reply` messages, that was missing.

## User-facing changes

None.

## Backwards-incompatible changes

None.