### PR TITLE
Changes Vega class name to match source code

### DIFF
--- a/packages/vega5-extension/style/base.css
+++ b/packages/vega5-extension/style/base.css
@@ -3,12 +3,12 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-.jp-RenderedVegaCommon4 {
+.jp-RenderedVegaCommon5 {
   margin-left: 8px;
   margin-top: 8px;
 }
 
-.jp-MimeDocument .jp-RenderedVegaCommon4 {
+.jp-MimeDocument .jp-RenderedVegaCommon5 {
   padding: 16px;
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #12377

## Code changes

Changes CSS class name in source code.

## User-facing changes

Screen shot before changing the style sheet
![image](https://user-images.githubusercontent.com/93281816/162330538-3970d5f7-850d-42d4-9736-d40a41801ea3.png)

Screen shot after changing the style sheet
![image](https://user-images.githubusercontent.com/93281816/162330936-9cd2b40c-2121-4bc1-9b2b-1856129ddf27.png)

Note that Firefox disregards the `margin-left` and `margin-right` rules because it doesn't apply them to elements with style `display: table-cell`, like this one.

## Backwards-incompatible changes

None.
