### PR TITLE
Pop up select kernel dialog when run a cell without kernel

### DIFF
--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -5,6 +5,7 @@ import {
   Clipboard,
   Dialog,
   ISessionContext,
+  sessionContextDialogs,
   showDialog
 } from '@jupyterlab/apputils';
 import {
@@ -2137,6 +2138,10 @@ namespace Private {
               buttons: [Dialog.okButton({ label: trans.__('Ok') })]
             });
             return Promise.resolve(false);
+          }
+          if (sessionContext.hasNoKernel) {
+            void sessionContextDialogs.selectKernel(sessionContext);
+            break;
           }
           const deletedCells = notebook.model?.deletedCells ?? [];
           executionScheduled.emit({ notebook, cell });

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2141,7 +2141,7 @@ namespace Private {
           }
           if (sessionContext.hasNoKernel) {
             void sessionContextDialogs.selectKernel(sessionContext);
-            break;
+            return Promise.resolve(false);
           }
           const deletedCells = notebook.model?.deletedCells ?? [];
           executionScheduled.emit({ notebook, cell });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## Introduction

Experienced users can manage their kernels and resources, but beginners like students are not familiar with managing resources. I am implementing useful features for them, including [limiting number of running kernels](https://github.com/jupyter/notebook/issues/615) and this PR.

In some cases, kernels can be killed while the file tabs are still open.
1) When users kill their kernel manually,
![image](https://user-images.githubusercontent.com/4434752/162380601-6e18168e-65d8-4493-ab9b-a384196d69f8.png)
2) By [custom kernel managers](https://github.com/jupyter/notebook/issues/615#issuecomment-1092382232)

In such cases, Jupyter Lab does nothing when users try to execute cells.
_no kernel, before execution_
![image](https://user-images.githubusercontent.com/4434752/162381668-1611c73c-9825-4836-93b5-f888329e4238.png)

_no kernel, after execution_
![image](https://user-images.githubusercontent.com/4434752/162381699-00468062-e7ed-49cb-821f-91cc4bc6b55d.png)

I think poping up select kernel dialog is much better user experience especially for beginners.
_with this PR, after execution_
![image](https://user-images.githubusercontent.com/4434752/162382065-ada6cf94-e5d1-423a-b61c-6e7072eb6820.png)


## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

I've found some cases that pop up dialogs before cell execution, like
![image](https://user-images.githubusercontent.com/4434752/162382307-342ab64d-4fb1-4829-8b10-1cc56780b781.png)

This feature is implemented in `packages/notebook/src/actions.tsx`

I just added a new condition and a dialog there. I am not sure about what to return `Promise.resolve(true)` or `Promise.resolve(false)`

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

_before, no response from the Lab_
![image](https://user-images.githubusercontent.com/4434752/162381699-00468062-e7ed-49cb-821f-91cc4bc6b55d.png)

_after, select kernel dialog pops up_
![image](https://user-images.githubusercontent.com/4434752/162382065-ada6cf94-e5d1-423a-b61c-6e7072eb6820.png)

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

No.