### PR TITLE
Deprecate FileEditorCodeWrapper

### DIFF
--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -30,6 +30,11 @@ const UNDOER = 'jpUndoer';
 
 /**
  * A code editor wrapper for the file editor.
+ *
+ * @deprecated since v3.4
+ * Note: This class will be removed in v4.0.
+ * From now on, you can directly use the class
+ * `CodeEditorWrapper` instead on `FileEditorCodeWrapper`.
  */
 export class FileEditorCodeWrapper extends CodeEditorWrapper {
   /**


### PR DESCRIPTION
Deprecate FileEditorCodeWrapper.

I believe this should go into v3.4. I'll open another PR to remove the class for v4.0

## References
Follow up #12338

## Code changes

## User-facing changes

## Backwards-incompatible changes

