### PR TITLE
Fix UI documentation CI

### DIFF
--- a/galata/src/galata.ts
+++ b/galata/src/galata.ts
@@ -257,6 +257,11 @@ export namespace galata {
     export const contents = /.*\/api\/contents(?<path>\/.+)?\?/;
 
     /**
+     * Extensions API
+     */
+    export const extensions = /.*\/lab\/api\/extensions/;
+
+    /**
      * Sessions API
      *
      * The session id can be found in the named group `id`.

--- a/galata/test/documentation/data/extensions.json
+++ b/galata/test/documentation/data/extensions.json
@@ -1,0 +1,34 @@
+[
+  {
+    "name": "@jupyterlab/geojson-extension",
+    "description": "GeoJSON renderer for JupyterLab",
+    "url": "https://github.com/jupyterlab/jupyter-renderers",
+    "enabled": true,
+    "core": false,
+    "latest_version": "3.2.0",
+    "installed_version": "3.2.0",
+    "status": "error",
+    "pkg_type": "prebuilt",
+    "install": {
+      "packageManager": "python",
+      "packageName": "jupyterlab-geojson",
+      "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package jupyterlab-geojson"
+    }
+  },
+  {
+    "name": "@jupyter-widgets/jupyterlab-manager",
+    "description": "The JupyterLab extension providing Jupyter widgets.",
+    "url": "https://github.com/jupyter-widgets/ipywidgets",
+    "enabled": true,
+    "core": false,
+    "latest_version": "3.1.0",
+    "installed_version": "3.1.0",
+    "status": "error",
+    "pkg_type": "prebuilt",
+    "install": {
+      "packageManager": "python",
+      "packageName": "jupyterlab_widgets",
+      "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package jupyterlab_widgets"
+    }
+  }
+]

--- a/galata/test/documentation/extension_manager.test.ts
+++ b/galata/test/documentation/extension_manager.test.ts
@@ -8,6 +8,7 @@ import {
   test
 } from '@jupyterlab/galata';
 import { generateCaptureArea, setLeftSidebarWidth } from './utils';
+import { default as extensionsList } from './data/extensions.json';
 
 test.use({
   autoGoto: false,
@@ -16,6 +17,22 @@ test.use({
 });
 
 test.describe('Extension Manager', () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock get extensions list
+    await page.route(galata.Routes.extensions, async (route, request) => {
+      switch (request.method()) {
+        case 'GET':
+          return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(extensionsList)
+          });
+        default:
+          return route.continue();
+      }
+    });
+  });
+
   test('Sidebar', async ({ page }) => {
     await page.goto();
 

--- a/galata/test/documentation/utils.ts
+++ b/galata/test/documentation/utils.ts
@@ -59,6 +59,12 @@ export function positionMouse(position: { x: number; y: number }): string {
 </svg>`;
 }
 
+/**
+ * Set the left sidebar width
+ *
+ * @param page Page object
+ * @param width Sidebar width in pixels
+ */
 export async function setLeftSidebarWidth(
   page: Page,
   width = 251


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Documentation CI is failing since the release of jupyterlab-pygments (dependency of nbconvert) that now includes a JupyterLab extension.

This freeze the list of installed extension in the integration tests to be more robust to such uncontrolled changes.
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Mock /lab/api/extensions#GET in extension manager integration tests

Add a new `galata.Routes.extensions` helper

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None