### PR TITLE
Automated Changelog Entry for 3.3.4 on 3.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,44 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.3.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.3.4
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.3.3...a8a438b3bd84806b8e186e7e037d73167d371c3a))
+
+### Enhancements made
+
+- Backport PR #12364 on branch 3.3.x (type-only and lazy imports of settings widgets) [#12372](https://github.com/jupyterlab/jupyterlab/pull/12372) ([@fcollonval](https://github.com/fcollonval))
+
+### Bugs fixed
+
+- Backport PR #11925 on branch 3.3.x (position collapse heading button next to corresponding h tag (jupyter…) [#12412](https://github.com/jupyterlab/jupyterlab/pull/12412) ([@fcollonval](https://github.com/fcollonval))
+- Toolbar items may not act on the proper target [#12368](https://github.com/jupyterlab/jupyterlab/pull/12368) ([@fcollonval](https://github.com/fcollonval))
+- Add parent header to input reply kernel message [#12376](https://github.com/jupyterlab/jupyterlab/pull/12376) ([@davidbrochart](https://github.com/davidbrochart))
+- fix run cells breaking on non-header markdown cells [#12027](https://github.com/jupyterlab/jupyterlab/pull/12027) ([@andrewfulton9](https://github.com/andrewfulton9))
+- Backport PR #12393: Fix debugger extension error when notebooks is closed quickly [#12396](https://github.com/jupyterlab/jupyterlab/pull/12396) ([@fcollonval](https://github.com/fcollonval))
+- Changes Vega class name to match source code [#12378](https://github.com/jupyterlab/jupyterlab/pull/12378) ([@jweill-aws](https://github.com/jweill-aws))
+- Remove circular setting of source [#12338](https://github.com/jupyterlab/jupyterlab/pull/12338) ([@hbcarlos](https://github.com/hbcarlos))
+- Protect against undefined delegated label [#10972](https://github.com/jupyterlab/jupyterlab/pull/10972) ([@fcollonval](https://github.com/fcollonval))
+
+### Maintenance and upkeep improvements
+
+- Backport PR #12279 on branch 3.3.x (Use pre-commit) [#12404](https://github.com/jupyterlab/jupyterlab/pull/12404) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #12040 on branch 3.3.x (Update Playwright snapshots from PR comments) [#12403](https://github.com/jupyterlab/jupyterlab/pull/12403) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #12384: Bump moment from 2.29.1 to 2.29.2 [#12389](https://github.com/jupyterlab/jupyterlab/pull/12389) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+- Backport PR #12407 on branch 3.3.x (Fix GitHub link) [#12410](https://github.com/jupyterlab/jupyterlab/pull/12410) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #12040 on branch 3.3.x (Update Playwright snapshots from PR comments) [#12403](https://github.com/jupyterlab/jupyterlab/pull/12403) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-04-07&to=2022-04-15&type=c))
+
+[@aiqc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aaiqc+updated%3A2022-04-07..2022-04-15&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-04-07..2022-04-15&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-04-07..2022-04-15&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-04-07..2022-04-15&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-04-07..2022-04-15&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-04-07..2022-04-15&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-04-07..2022-04-15&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-04-07..2022-04-15&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2022-04-07..2022-04-15&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-04-07..2022-04-15&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-04-07..2022-04-15&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-04-07..2022-04-15&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-04-07..2022-04-15&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.3.3
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.3.2...d97ff7161640634f69e70b184b9e255a68620f95))
@@ -51,8 +89,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.3.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-03-14&to=2022-04-07&type=c))
 
 [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2022-03-14..2022-04-07&type=Issues) | [@aiqc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aaiqc+updated%3A2022-03-14..2022-04-07&type=Issues) | [@ajbozarth](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aajbozarth+updated%3A2022-03-14..2022-04-07&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-03-14..2022-04-07&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2022-03-14..2022-04-07&type=Issues) | [@damianavila](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adamianavila+updated%3A2022-03-14..2022-04-07&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2022-03-14..2022-04-07&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-03-14..2022-04-07&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-03-14..2022-04-07&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-03-14..2022-04-07&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2022-03-14..2022-04-07&type=Issues) | [@isabela-pf](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aisabela-pf+updated%3A2022-03-14..2022-04-07&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-03-14..2022-04-07&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-03-14..2022-04-07&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2022-03-14..2022-04-07&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-03-14..2022-04-07&type=Issues) | [@marthacryan](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Amarthacryan+updated%3A2022-03-14..2022-04-07&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AmartinRenou+updated%3A2022-03-14..2022-04-07&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-03-14..2022-04-07&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-03-14..2022-04-07&type=Issues) | [@mlucool](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Amlucool+updated%3A2022-03-14..2022-04-07&type=Issues) | [@rccern](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Arccern+updated%3A2022-03-14..2022-04-07&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-03-14..2022-04-07&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,29 +18,28 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.3.x/CHANGELOG.md'
 
 ### Enhancements made
 
-- Backport PR #12364 on branch 3.3.x (type-only and lazy imports of settings widgets) [#12372](https://github.com/jupyterlab/jupyterlab/pull/12372) ([@fcollonval](https://github.com/fcollonval))
+- Type-only and lazy imports of settings widgets [#12372](https://github.com/jupyterlab/jupyterlab/pull/12372) ([@fcollonval](https://github.com/fcollonval))
 
 ### Bugs fixed
 
-- Backport PR #11925 on branch 3.3.x (position collapse heading button next to corresponding h tag (jupyter…) [#12412](https://github.com/jupyterlab/jupyterlab/pull/12412) ([@fcollonval](https://github.com/fcollonval))
+- Position collapse heading button next to corresponding h tag (jupyter…) [#12412](https://github.com/jupyterlab/jupyterlab/pull/12412) ([@fcollonval](https://github.com/fcollonval))
 - Toolbar items may not act on the proper target [#12368](https://github.com/jupyterlab/jupyterlab/pull/12368) ([@fcollonval](https://github.com/fcollonval))
 - Add parent header to input reply kernel message [#12376](https://github.com/jupyterlab/jupyterlab/pull/12376) ([@davidbrochart](https://github.com/davidbrochart))
 - fix run cells breaking on non-header markdown cells [#12027](https://github.com/jupyterlab/jupyterlab/pull/12027) ([@andrewfulton9](https://github.com/andrewfulton9))
-- Backport PR #12393: Fix debugger extension error when notebooks is closed quickly [#12396](https://github.com/jupyterlab/jupyterlab/pull/12396) ([@fcollonval](https://github.com/fcollonval))
+- Fix debugger extension error when notebooks is closed quickly [#12396](https://github.com/jupyterlab/jupyterlab/pull/12396) ([@fcollonval](https://github.com/fcollonval))
 - Changes Vega class name to match source code [#12378](https://github.com/jupyterlab/jupyterlab/pull/12378) ([@jweill-aws](https://github.com/jweill-aws))
 - Remove circular setting of source [#12338](https://github.com/jupyterlab/jupyterlab/pull/12338) ([@hbcarlos](https://github.com/hbcarlos))
 - Protect against undefined delegated label [#10972](https://github.com/jupyterlab/jupyterlab/pull/10972) ([@fcollonval](https://github.com/fcollonval))
 
 ### Maintenance and upkeep improvements
 
-- Backport PR #12279 on branch 3.3.x (Use pre-commit) [#12404](https://github.com/jupyterlab/jupyterlab/pull/12404) ([@fcollonval](https://github.com/fcollonval))
-- Backport PR #12040 on branch 3.3.x (Update Playwright snapshots from PR comments) [#12403](https://github.com/jupyterlab/jupyterlab/pull/12403) ([@fcollonval](https://github.com/fcollonval))
-- Backport PR #12384: Bump moment from 2.29.1 to 2.29.2 [#12389](https://github.com/jupyterlab/jupyterlab/pull/12389) ([@fcollonval](https://github.com/fcollonval))
+- Use pre-commit [#12404](https://github.com/jupyterlab/jupyterlab/pull/12404) ([@fcollonval](https://github.com/fcollonval))
+- Update Playwright snapshots from PR comments [#12403](https://github.com/jupyterlab/jupyterlab/pull/12403) ([@fcollonval](https://github.com/fcollonval))
+- Bump moment from 2.29.1 to 2.29.2 [#12389](https://github.com/jupyterlab/jupyterlab/pull/12389) ([@fcollonval](https://github.com/fcollonval))
 
 ### Documentation improvements
 
-- Backport PR #12407 on branch 3.3.x (Fix GitHub link) [#12410](https://github.com/jupyterlab/jupyterlab/pull/12410) ([@fcollonval](https://github.com/fcollonval))
-- Backport PR #12040 on branch 3.3.x (Update Playwright snapshots from PR comments) [#12403](https://github.com/jupyterlab/jupyterlab/pull/12403) ([@fcollonval](https://github.com/fcollonval))
+- Fix GitHub link [#12410](https://github.com/jupyterlab/jupyterlab/pull/12410) ([@fcollonval](https://github.com/fcollonval))
 
 ### Contributors to this release
 


### PR DESCRIPTION
Automated Changelog Entry for 3.3.4 on 3.3.x
```
Python version: 3.3.4
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.3.4
@jupyterlab/buildutils: 3.3.4
@jupyterlab/template: 3.3.4
@jupyterlab/application-top: 3.3.4
@jupyterlab/example-app: 3.3.4
@jupyterlab/example-cell: 3.3.4
@jupyterlab/example-console: 3.3.4
@jupyterlab/example-federated: 2.4.4
@jupyterlab/example-federated-core: 2.4.4
@jupyterlab/example-federated-md: 2.4.4
@jupyterlab/example-federated-middle: 2.4.4
@jupyterlab/example-federated-phosphor: 2.4.4
@jupyterlab/example-filebrowser: 3.3.4
@jupyterlab/example-notebook: 3.3.4
@jupyterlab/example-terminal: 3.3.4
@jupyterlab/galata: 4.2.4
@jupyterlab/mock-extension: 3.3.4
@jupyterlab/mock-consumer: 3.3.4
@jupyterlab/mock-provider: 3.3.4
@jupyterlab/mock-token: 3.3.4
@jupyterlab/application: 3.3.4
@jupyterlab/application-extension: 3.3.4
@jupyterlab/apputils: 3.3.4
@jupyterlab/apputils-extension: 3.3.4
@jupyterlab/attachments: 3.3.4
@jupyterlab/cells: 3.3.4
@jupyterlab/celltags: 3.3.4
@jupyterlab/celltags-extension: 3.3.4
@jupyterlab/codeeditor: 3.3.4
@jupyterlab/codemirror: 3.3.4
@jupyterlab/codemirror-extension: 3.3.4
@jupyterlab/completer: 3.3.4
@jupyterlab/completer-extension: 3.3.4
@jupyterlab/console: 3.3.4
@jupyterlab/console-extension: 3.3.4
@jupyterlab/coreutils: 5.3.4
@jupyterlab/csvviewer: 3.3.4
@jupyterlab/csvviewer-extension: 3.3.4
@jupyterlab/debugger: 3.3.4
@jupyterlab/debugger-extension: 3.3.4
@jupyterlab/docmanager: 3.3.4
@jupyterlab/docmanager-extension: 3.3.4
@jupyterlab/docprovider: 3.3.4
@jupyterlab/docprovider-extension: 3.3.4
@jupyterlab/docregistry: 3.3.4
@jupyterlab/documentsearch: 3.3.4
@jupyterlab/documentsearch-extension: 3.3.4
@jupyterlab/extensionmanager: 3.3.4
@jupyterlab/extensionmanager-extension: 3.3.4
@jupyterlab/filebrowser: 3.3.4
@jupyterlab/filebrowser-extension: 3.3.4
@jupyterlab/fileeditor: 3.3.4
@jupyterlab/fileeditor-extension: 3.3.4
@jupyterlab/help-extension: 3.3.4
@jupyterlab/htmlviewer: 3.3.4
@jupyterlab/htmlviewer-extension: 3.3.4
@jupyterlab/hub-extension: 3.3.4
@jupyterlab/imageviewer: 3.3.4
@jupyterlab/imageviewer-extension: 3.3.4
@jupyterlab/inspector: 3.3.4
@jupyterlab/inspector-extension: 3.3.4
@jupyterlab/javascript-extension: 3.3.4
@jupyterlab/json-extension: 3.3.4
@jupyterlab/launcher: 3.3.4
@jupyterlab/launcher-extension: 3.3.4
@jupyterlab/logconsole: 3.3.4
@jupyterlab/logconsole-extension: 3.3.4
@jupyterlab/mainmenu: 3.3.4
@jupyterlab/mainmenu-extension: 3.3.4
@jupyterlab/markdownviewer: 3.3.4
@jupyterlab/markdownviewer-extension: 3.3.4
@jupyterlab/mathjax2: 3.3.4
@jupyterlab/mathjax2-extension: 3.3.4
@jupyterlab/metapackage: 3.3.4
@jupyterlab/nbconvert-css: 3.3.4
@jupyterlab/nbformat: 3.3.4
@jupyterlab/notebook: 3.3.4
@jupyterlab/notebook-extension: 3.3.4
@jupyterlab/observables: 4.3.4
@jupyterlab/outputarea: 3.3.4
@jupyterlab/pdf-extension: 3.3.4
@jupyterlab/property-inspector: 3.3.4
@jupyterlab/rendermime: 3.3.4
@jupyterlab/rendermime-extension: 3.3.4
@jupyterlab/rendermime-interfaces: 3.3.4
@jupyterlab/running: 3.3.4
@jupyterlab/running-extension: 3.3.4
@jupyterlab/services: 6.3.4
@jupyterlab/example-services-browser: 3.3.4
node-example: 3.3.4
@jupyterlab/example-services-outputarea: 3.3.4
@jupyterlab/settingeditor: 3.3.4
@jupyterlab/settingeditor-extension: 3.3.4
@jupyterlab/settingregistry: 3.3.4
@jupyterlab/shared-models: 3.3.4
@jupyterlab/shortcuts-extension: 3.3.4
@jupyterlab/statedb: 3.3.4
@jupyterlab/statusbar: 3.3.4
@jupyterlab/statusbar-extension: 3.3.4
@jupyterlab/terminal: 3.3.4
@jupyterlab/terminal-extension: 3.3.4
@jupyterlab/theme-dark-extension: 3.3.4
@jupyterlab/theme-light-extension: 3.3.4
@jupyterlab/toc: 5.3.4
@jupyterlab/toc-extension: 5.3.4
@jupyterlab/tooltip: 3.3.4
@jupyterlab/tooltip-extension: 3.3.4
@jupyterlab/translation: 3.3.4
@jupyterlab/translation-extension: 3.3.4
@jupyterlab/ui-components: 3.3.4
@jupyterlab/ui-components-extension: 3.3.4
@jupyterlab/vdom: 3.3.4
@jupyterlab/vdom-extension: 3.3.4
@jupyterlab/vega5-extension: 3.3.4
@jupyterlab/testutils: 3.3.4
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.3.x  |
| Version Spec | next |
| Since | v3.3.3 |