### PR TITLE
Update to webpack 5.72

### DIFF
--- a/builder/package.json
+++ b/builder/package.json
@@ -61,7 +61,7 @@
     "supports-color": "^7.2.0",
     "terser-webpack-plugin": "^4.1.0",
     "to-string-loader": "^1.1.6",
-    "webpack": "^5.71.0",
+    "webpack": "^5.72.0",
     "webpack-cli": "^4.9.2",
     "webpack-merge": "^5.8.0",
     "worker-loader": "^3.0.2"

--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -196,7 +196,7 @@
     "source-map-loader": "~1.0.2",
     "style-loader": "~3.3.1",
     "terser-webpack-plugin": "^4.1.0",
-    "webpack": "^5.71.0",
+    "webpack": "^5.72.0",
     "webpack-bundle-analyzer": "^3.6.0",
     "webpack-cli": "^4.9.2",
     "webpack-merge": "^5.8.0",

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -86,6 +86,9 @@ Extension Development Changes
   ``private`` package has now been removed in ``4.0``. If you were using this field to develop source extensions against
   a development build of JupyterLab, you should instead switch to the federated extensions system (via the ``--extensions-in-dev-mode`` flag)
   or to using the ``--splice-source`` option. See :ref:`prebuilt_dev_workflow` and :ref:`source_dev_workflow` for more information.
+- The ``webpack`` dependency has been updated to ``5.72`` (or greater). Base rules have been updated to use the
+  `Asset Modules <https://webpack.js.org/guides/asset-modules>`_ instead of the previous ``file-loader``, ``raw-loader`` and ``url-loader```.
+  This might affect third-party extensions if they were relying on specific behaviors from these loaders.
 
 JupyterLab 3.0 to 3.1
 ---------------------

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -86,7 +86,7 @@ Extension Development Changes
   ``private`` package has now been removed in ``4.0``. If you were using this field to develop source extensions against
   a development build of JupyterLab, you should instead switch to the federated extensions system (via the ``--extensions-in-dev-mode`` flag)
   or to using the ``--splice-source`` option. See :ref:`prebuilt_dev_workflow` and :ref:`source_dev_workflow` for more information.
-- The ``webpack`` dependency has been updated to ``5.72`` (or greater). Base rules have been updated to use the
+- The ``webpack`` dependency in ``@jupyterlab/builder`` has been updated to ``5.72`` (or greater). Base rules have been updated to use the
   `Asset Modules <https://webpack.js.org/guides/asset-modules>`_ instead of the previous ``file-loader``, ``raw-loader`` and ``url-loader```.
   This might affect third-party extensions if they were relying on specific behaviors from these loaders.
 

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -86,8 +86,8 @@ Extension Development Changes
   ``private`` package has now been removed in ``4.0``. If you were using this field to develop source extensions against
   a development build of JupyterLab, you should instead switch to the federated extensions system (via the ``--extensions-in-dev-mode`` flag)
   or to using the ``--splice-source`` option. See :ref:`prebuilt_dev_workflow` and :ref:`source_dev_workflow` for more information.
-- The ``webpack`` dependency in ``@jupyterlab/builder`` has been updated to ``5.72`` (or greater). Base rules have been updated to use the
-  `Asset Modules <https://webpack.js.org/guides/asset-modules>`_ instead of the previous ``file-loader``, ``raw-loader`` and ``url-loader```.
+- The ``webpack`` dependency in ``@jupyterlab/builder`` has been updated to ``5.72`` (or newer). Base rules have been updated to use the
+  `Asset Modules <https://webpack.js.org/guides/asset-modules>`_ instead of the previous ``file-loader``, ``raw-loader`` and ``url-loader``.
   This might affect third-party extensions if they were relying on specific behaviors from these loaders.
 
 JupyterLab 3.0 to 3.1

--- a/examples/app/package.json
+++ b/examples/app/package.json
@@ -54,7 +54,7 @@
     "rimraf": "~3.0.0",
     "style-loader": "~3.3.1",
     "to-string-loader": "^1.1.6",
-    "webpack": "^5.71.0",
+    "webpack": "^5.72.0",
     "webpack-cli": "^4.9.2",
     "whatwg-fetch": "^3.0.0"
   },

--- a/examples/cell/package.json
+++ b/examples/cell/package.json
@@ -28,7 +28,7 @@
     "rimraf": "~3.0.0",
     "style-loader": "~3.3.1",
     "typescript": "~4.6.3",
-    "webpack": "^5.71.0",
+    "webpack": "^5.72.0",
     "webpack-cli": "^4.9.2",
     "whatwg-fetch": "^3.0.0"
   }

--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -26,7 +26,7 @@
     "rimraf": "~3.0.0",
     "style-loader": "~3.3.1",
     "typescript": "~4.6.3",
-    "webpack": "^5.71.0",
+    "webpack": "^5.72.0",
     "webpack-cli": "^4.9.2",
     "whatwg-fetch": "^3.0.0"
   }

--- a/examples/federated/core_package/package.json
+++ b/examples/federated/core_package/package.json
@@ -149,7 +149,7 @@
     "rimraf": "~3.0.0",
     "style-loader": "~3.3.1",
     "to-string-loader": "^1.1.6",
-    "webpack": "^5.71.0",
+    "webpack": "^5.72.0",
     "webpack-cli": "^4.9.2",
     "webpack-merge": "^5.8.0",
     "whatwg-fetch": "^3.0.0"

--- a/examples/filebrowser/package.json
+++ b/examples/filebrowser/package.json
@@ -32,7 +32,7 @@
     "rimraf": "~3.0.0",
     "style-loader": "~3.3.1",
     "typescript": "~4.6.3",
-    "webpack": "^5.71.0",
+    "webpack": "^5.72.0",
     "webpack-cli": "^4.9.2",
     "whatwg-fetch": "^3.0.0"
   }

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -32,7 +32,7 @@
     "rimraf": "~3.0.0",
     "style-loader": "~3.3.1",
     "typescript": "~4.6.3",
-    "webpack": "^5.71.0",
+    "webpack": "^5.72.0",
     "webpack-cli": "^4.9.2",
     "whatwg-fetch": "^3.0.0"
   }

--- a/examples/terminal/package.json
+++ b/examples/terminal/package.json
@@ -22,7 +22,7 @@
     "rimraf": "~3.0.0",
     "style-loader": "~3.3.1",
     "typescript": "~4.6.3",
-    "webpack": "^5.71.0",
+    "webpack": "^5.72.0",
     "webpack-cli": "^4.9.2",
     "whatwg-fetch": "^3.0.0"
   }

--- a/galata/package.json
+++ b/galata/package.json
@@ -79,7 +79,7 @@
     "svgo-loader": "^2.2.1",
     "ts-loader": "^6.2.1",
     "typescript": "~4.6.3",
-    "webpack": "^5.71.0",
+    "webpack": "^5.72.0",
     "webpack-cli": "^4.9.2"
   },
   "publishConfig": {

--- a/packages/nbconvert-css/package.json
+++ b/packages/nbconvert-css/package.json
@@ -44,7 +44,7 @@
     "mini-css-extract-plugin": "~1.3.2",
     "null-loader": "^4.0.0",
     "rimraf": "~3.0.0",
-    "webpack": "^5.71.0",
+    "webpack": "^5.72.0",
     "webpack-cli": "^4.9.2"
   },
   "publishConfig": {

--- a/packages/services/examples/browser/package.json
+++ b/packages/services/examples/browser/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typescript": "~4.6.3",
-    "webpack": "^5.71.0",
+    "webpack": "^5.72.0",
     "webpack-cli": "^4.9.2"
   }
 }

--- a/packages/services/examples/typescript-browser-with-output/package.json
+++ b/packages/services/examples/typescript-browser-with-output/package.json
@@ -26,7 +26,7 @@
     "rimraf": "~3.0.0",
     "style-loader": "~3.3.1",
     "typescript": "~4.6.3",
-    "webpack": "^5.71.0",
+    "webpack": "^5.72.0",
     "webpack-cli": "^4.9.2"
   },
   "styleModule": "style/index.js"

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -71,7 +71,7 @@
     "ts-jest": "^26.3.0",
     "typedoc": "~0.22.10",
     "typescript": "~4.6.3",
-    "webpack": "^5.71.0",
+    "webpack": "^5.72.0",
     "webpack-cli": "^4.9.2"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13499,10 +13499,10 @@ webpack-sources@^3.2.3:
   resolved "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@^5.71.0:
-  version "5.71.0"
-  resolved "https://registry.npmjs.org/webpack/-/webpack-5.71.0.tgz"
-  integrity sha512-g4dFT7CFG8LY0iU5G8nBL6VlkT21Z7dcYDpJAEJV5Q1WLb9UwnFbrem1k7K52ILqEmomN7pnzWFxxE6SlDY56A==
+webpack@^5.72.0:
+  version "5.72.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.72.0.tgz#f8bc40d9c6bb489a4b7a8a685101d6022b8b6e28"
+  integrity sha512-qmSmbspI0Qo5ld49htys8GY9XhS9CGqFoHTsOVAnjBdg0Zn79y135R+k4IR4rKK6+eKaabMhJwiVB7xw0SJu5w==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^0.0.51"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/12350

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Update to webpack 5.72 which includes some changes to the way assets are being concatenated, as mentioned in https://github.com/jupyterlab/jupyterlab/pull/12350#issuecomment-1092252327.
- [x] Update migration guide to mention the base rules have switched to using the assets module

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Should be none.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

Should be none for end users.

We can however document this change for extension developers since the webpack version and base config are part of `@jupyterlab/builder`. 

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
