### PR TITLE
Removes FileEditorCodeWrapper

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -78,6 +78,8 @@ bumped their major version (following semver convention):
    As a result of the update to TypeScript 4.5, a couple of interfaces have had their definitions changed.
    The ``anchor`` parameter of ``HoverBox.IOptions`` is now a ``DOMRect`` instead of ``ClientRect``.
    The ``CodeEditor.ICoordinate`` interface now extends ``DOMRectReadOnly`` instead of ``JSONObject, ClientRect``.
+- ``@jupyterlab/fileeditor`` from 3.x to 4.x
+   Removed the class ``FileEditorCodeWrapper``, instead, you can use ``CodeEditorWrapper`` from ``@jupyterlab/codeeditor``.
 
 Extension Development Changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -42,13 +42,13 @@ export class FileEditor extends Widget {
     const context = (this._context = options.context);
     this._mimeTypeService = options.mimeTypeService;
 
-    const editorWidget = (this.editorWidget = new CodeEditorWrapper({
+    const editorWidget = (this._editorWidget = new CodeEditorWrapper({
       factory: options.factory,
       model: context.model
     }));
-    this.editorWidget.addClass('jp-FileEditorCodeWrapper');
-    this.editorWidget.node.dataset[CODE_RUNNER] = 'true';
-    this.editorWidget.node.dataset[UNDOER] = 'true';
+    this._editorWidget.addClass('jp-FileEditorCodeWrapper');
+    this._editorWidget.node.dataset[CODE_RUNNER] = 'true';
+    this._editorWidget.node.dataset[UNDOER] = 'true';
 
     this.editor = editorWidget.editor;
     this.model = editorWidget.model;
@@ -161,10 +161,10 @@ export class FileEditor extends Widget {
     );
   }
 
-  private editorWidget: CodeEditorWrapper;
-  public model: CodeEditor.IModel;
-  public editor: CodeEditor.IEditor;
-  protected _context: DocumentRegistry.Context;
+  model: CodeEditor.IModel;
+  editor: CodeEditor.IEditor;
+  private _context: DocumentRegistry.Context;
+  private _editorWidget: CodeEditorWrapper;
   private _mimeTypeService: IEditorMimeTypeService;
   private _ready = new PromiseDelegate<void>();
 }

--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -29,110 +29,6 @@ const CODE_RUNNER = 'jpCodeRunner';
 const UNDOER = 'jpUndoer';
 
 /**
- * A code editor wrapper for the file editor.
- *
- * @deprecated since v3.4
- * Note: This class will be removed in v4.0.
- * From now on, you can directly use the class
- * `CodeEditorWrapper` instead on `FileEditorCodeWrapper`.
- */
-export class FileEditorCodeWrapper extends CodeEditorWrapper {
-  /**
-   * Construct a new editor widget.
-   */
-  constructor(options: FileEditor.IOptions) {
-    super({
-      factory: options.factory,
-      model: options.context.model
-    });
-
-    const context = (this._context = options.context);
-
-    // TODO: move this to the FileEditor when removing the
-    // `FileEditorCodeWrapper`
-    this.addClass('jp-FileEditorCodeWrapper');
-    this.node.dataset[CODE_RUNNER] = 'true';
-    this.node.dataset[UNDOER] = 'true';
-
-    void context.ready.then(() => {
-      this._onContextReady();
-    });
-
-    if (context.model.modelDB.isCollaborative) {
-      const modelDB = context.model.modelDB;
-      void modelDB.connected.then(() => {
-        const collaborators = modelDB.collaborators;
-        if (!collaborators) {
-          return;
-        }
-
-        // Setup the selection style for collaborators
-        const localCollaborator = collaborators.localCollaborator;
-        this.editor.uuid = localCollaborator.sessionId;
-
-        this.editor.selectionStyle = {
-          ...CodeEditor.defaultSelectionStyle,
-          color: localCollaborator.color
-        };
-
-        collaborators.changed.connect(this._onCollaboratorsChanged, this);
-        // Trigger an initial onCollaboratorsChanged event.
-        this._onCollaboratorsChanged();
-      });
-    }
-  }
-
-  /**
-   * Get the context for the editor widget.
-   */
-  get context(): DocumentRegistry.Context {
-    return this._context;
-  }
-
-  /**
-   * A promise that resolves when the file editor is ready.
-   */
-  get ready(): Promise<void> {
-    return this._ready.promise;
-  }
-
-  /**
-   * Handle actions that should be taken when the context is ready.
-   */
-  private _onContextReady(): void {
-    if (this.isDisposed) {
-      return;
-    }
-
-    // Prevent the initial loading from disk from being in the editor history.
-    this.editor.clearHistory();
-    // Resolve the ready promise.
-    this._ready.resolve(undefined);
-  }
-
-  /**
-   * Handle a change to the collaborators on the model
-   * by updating UI elements associated with them.
-   */
-  private _onCollaboratorsChanged(): void {
-    // If there are selections corresponding to non-collaborators,
-    // they are stale and should be removed.
-    const collaborators = this._context.model.modelDB.collaborators;
-    if (!collaborators) {
-      return;
-    }
-    for (const key of this.editor.model.selections.keys()) {
-      if (!collaborators.has(key)) {
-        this.editor.model.selections.delete(key);
-      }
-    }
-  }
-
-  protected _context: DocumentRegistry.Context;
-  private _ready = new PromiseDelegate<void>();
-}
-
-/**
  * A widget for editors.
  */
 export class FileEditor extends Widget {
@@ -146,11 +42,20 @@ export class FileEditor extends Widget {
     const context = (this._context = options.context);
     this._mimeTypeService = options.mimeTypeService;
 
-    const editorWidget = (this.editorWidget = new FileEditorCodeWrapper(
-      options
-    ));
+    const editorWidget = (this.editorWidget = new CodeEditorWrapper({
+      factory: options.factory,
+      model: context.model
+    }));
+    this.editorWidget.addClass('jp-FileEditorCodeWrapper');
+    this.editorWidget.node.dataset[CODE_RUNNER] = 'true';
+    this.editorWidget.node.dataset[UNDOER] = 'true';
+
     this.editor = editorWidget.editor;
     this.model = editorWidget.model;
+
+    void context.ready.then(() => {
+      this._onContextReady();
+    });
 
     // Listen for changes to the path.
     context.pathChanged.connect(this._onPathChanged, this);
@@ -164,14 +69,14 @@ export class FileEditor extends Widget {
    * Get the context for the editor widget.
    */
   get context(): DocumentRegistry.Context {
-    return this.editorWidget.context;
+    return this._context;
   }
 
   /**
    * A promise that resolves when the file editor is ready.
    */
   get ready(): Promise<void> {
-    return this.editorWidget.ready;
+    return this.ready;
   }
 
   /**
@@ -231,6 +136,20 @@ export class FileEditor extends Widget {
   }
 
   /**
+   * Handle actions that should be taken when the context is ready.
+   */
+  private _onContextReady(): void {
+    if (this.isDisposed) {
+      return;
+    }
+
+    // Prevent the initial loading from disk from being in the editor history.
+    this.editor.clearHistory();
+    // Resolve the ready promise.
+    this._ready.resolve(undefined);
+  }
+
+  /**
    * Handle a change to the path.
    */
   private _onPathChanged(): void {
@@ -242,11 +161,12 @@ export class FileEditor extends Widget {
     );
   }
 
-  private editorWidget: FileEditorCodeWrapper;
+  private editorWidget: CodeEditorWrapper;
   public model: CodeEditor.IModel;
   public editor: CodeEditor.IEditor;
   protected _context: DocumentRegistry.Context;
   private _mimeTypeService: IEditorMimeTypeService;
+  private _ready = new PromiseDelegate<void>();
 }
 
 /**

--- a/packages/fileeditor/test/widget.spec.ts
+++ b/packages/fileeditor/test/widget.spec.ts
@@ -11,11 +11,7 @@ import {
   DocumentWidget,
   TextModelFactory
 } from '@jupyterlab/docregistry';
-import {
-  FileEditor,
-  FileEditorCodeWrapper,
-  FileEditorFactory
-} from '@jupyterlab/fileeditor';
+import { FileEditor, FileEditorFactory } from '@jupyterlab/fileeditor';
 import { ServiceManager } from '@jupyterlab/services';
 import { framePromise } from '@jupyterlab/testutils';
 import * as Mock from '@jupyterlab/testutils/lib/mock';
@@ -60,43 +56,6 @@ describe('fileeditorcodewrapper', () => {
   beforeAll(() => {
     manager = new Mock.ServiceManagerMock();
     return manager.ready;
-  });
-
-  describe('FileEditorCodeWrapper', () => {
-    let widget: FileEditorCodeWrapper;
-
-    beforeEach(() => {
-      const path = UUID.uuid4() + '.py';
-      context = new Context({ manager, factory: modelFactory, path });
-      widget = new FileEditorCodeWrapper({
-        factory: options => factoryService.newDocumentEditor(options),
-        mimeTypeService,
-        context
-      });
-    });
-
-    afterEach(() => {
-      widget.dispose();
-    });
-
-    describe('#constructor()', () => {
-      it('should create an editor wrapper widget', () => {
-        expect(widget).toBeInstanceOf(FileEditorCodeWrapper);
-      });
-
-      it('should update the editor text when the model changes', async () => {
-        await context.initialize(true);
-        await context.ready;
-        widget.context.model.fromString('foo');
-        expect(widget.editor.model.value.text).toBe('foo');
-      });
-    });
-
-    describe('#context', () => {
-      it('should be the context used by the widget', () => {
-        expect(widget.context).toBe(context);
-      });
-    });
   });
 
   describe('FileEditor', () => {


### PR DESCRIPTION
## References
Follow up:
- #12338
- #12381

## Code changes
Removes the FileEditorCodeWrapper class.

## User-facing changes

## Backwards-incompatible changes
Removes the class FileEditorCodeWrapper, instead, you can use the CodeEditorWrapper from `@jupyterlab/codeeditor`.