### PR TITLE
Fix typo: `exitOnUncaughtException` in `@jupyterlab/buildutils`

### DIFF
--- a/buildutils/src/bump-js-major.ts
+++ b/buildutils/src/bump-js-major.ts
@@ -36,7 +36,7 @@ commander
   .option('--force', 'Force the upgrade')
   .option('--dry-run', 'Show what would be executed')
   .action((pkg: string, others: Array<string>, options: any) => {
-    utils.exitOnUuncaughtException();
+    utils.exitOnUncaughtException();
     others.push(pkg);
     const toBump: Set<string> = new Set();
     const ignoreBump: Set<string> = new Set();

--- a/buildutils/src/bumpversion.ts
+++ b/buildutils/src/bumpversion.ts
@@ -14,7 +14,7 @@ commander
   .option('--skip-commit', 'Whether to skip commit changes')
   .arguments('<spec>')
   .action((spec: any, opts: any) => {
-    utils.exitOnUuncaughtException();
+    utils.exitOnUncaughtException();
 
     // Get the previous version.
     const prev = utils.getPythonVersion();

--- a/buildutils/src/clean-packages.ts
+++ b/buildutils/src/clean-packages.ts
@@ -6,9 +6,9 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as glob from 'glob';
-import { exitOnUuncaughtException, readJSONFile } from './utils';
+import { exitOnUncaughtException, readJSONFile } from './utils';
 
-exitOnUuncaughtException();
+exitOnUncaughtException();
 
 // Get all of the packages.
 const basePath = path.resolve('.');

--- a/buildutils/src/local-repository.ts
+++ b/buildutils/src/local-repository.ts
@@ -282,7 +282,7 @@ program
   .option('--port <port>', 'Port to use for the registry')
   .option('--path <path>', 'Path to use for the registry')
   .action(async (options: any) => {
-    utils.exitOnUuncaughtException();
+    utils.exitOnUncaughtException();
     const out_dir = options.path || DEFAULT_OUT_DIR;
     await startLocalRegistry(out_dir, options.port || DEFAULT_PORT);
   });
@@ -291,7 +291,7 @@ program
   .command('stop')
   .option('--path <path>', 'Path to use for the registry')
   .action(async (options: any) => {
-    utils.exitOnUuncaughtException();
+    utils.exitOnUncaughtException();
     const out_dir = options.path || DEFAULT_OUT_DIR;
     await stopLocalRegistry(out_dir);
   });
@@ -300,7 +300,7 @@ program
   .command('fix-links')
   .option('--path <path>', 'Path to the directory with a yarn lock')
   .action((options: any) => {
-    utils.exitOnUuncaughtException();
+    utils.exitOnUncaughtException();
     fixLinks(options.path || process.cwd());
   });
 
@@ -308,7 +308,7 @@ program
   .command('publish-dists')
   .option('--path <path>', 'Path to the directory with npm tar balls')
   .action((options: any) => {
-    utils.exitOnUuncaughtException();
+    utils.exitOnUncaughtException();
     publishPackages(options.path || process.cwd());
   });
 

--- a/buildutils/src/patch-release.ts
+++ b/buildutils/src/patch-release.ts
@@ -13,7 +13,7 @@ commander
   .option('--all', 'Patch all JS packages instead of the changed ones')
   .option('--skip-commit', 'Whether to skip commit changes')
   .action((options: any) => {
-    utils.exitOnUuncaughtException();
+    utils.exitOnUncaughtException();
 
     // Make sure we can patch release.
     const pyVersion = utils.getPythonVersion();

--- a/buildutils/src/prepare-python-release.ts
+++ b/buildutils/src/prepare-python-release.ts
@@ -13,7 +13,7 @@ import * as utils from './utils';
 commander
   .description('Prepare the Python package for release')
   .action(async (options: any) => {
-    utils.exitOnUuncaughtException();
+    utils.exitOnUncaughtException();
 
     const distDir = './dist';
 

--- a/buildutils/src/prepublish-check.ts
+++ b/buildutils/src/prepublish-check.ts
@@ -8,7 +8,7 @@ import * as glob from 'glob';
 import * as path from 'path';
 import * as utils from './utils';
 
-utils.exitOnUuncaughtException();
+utils.exitOnUncaughtException();
 
 utils.run('npm run build:packages');
 

--- a/buildutils/src/publish.ts
+++ b/buildutils/src/publish.ts
@@ -30,7 +30,7 @@ commander
   .option('--yes', 'Publish without confirmation')
   .option('--dry-run', 'Do not actually push any assets')
   .action(async (options: any) => {
-    utils.exitOnUuncaughtException();
+    utils.exitOnUncaughtException();
 
     // No-op if we're in release helper dry run
     if (process.env.RH_DRY_RUN === 'true') {

--- a/buildutils/src/utils.ts
+++ b/buildutils/src/utils.ts
@@ -14,7 +14,7 @@ const backSlash = /\\/g;
 /**
  *  Exit with an error code on uncaught error.
  */
-export function exitOnUuncaughtException(): void {
+export function exitOnUncaughtException(): void {
   process.on('uncaughtException', function (err) {
     console.error('Uncaught exception', err);
     process.exit(1);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Caught while looking at the code.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Minor typo fix in `@jupyterlab/buildutils`.
- [ ] Document change in `@jupyterlab/buildutils` since it's a public package: https://jupyterlab.readthedocs.io/en/latest/extension/extension_migration.html#api-breaking-changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

Since this is exposed via `@jupyterlab/buildutils` we can tag as api breaking and document it in https://jupyterlab.readthedocs.io/en/latest/extension/extension_migration.html#api-breaking-changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
