### PR TITLE
Focus not set when clicking on cell margin

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1918,7 +1918,12 @@ export class Notebook extends StaticNotebook {
         activeCell.editor.focus();
       }
     }
-    if (force && !this.node.contains(document.activeElement)) {
+    if (
+      (force && !this.node.contains(document.activeElement)) ||
+      // Focus the notebook if the active cell changes but as not the focus
+      // Xref: https://github.com/jupyterlab/jupyterlab/issues/12437
+      (activeCell && !activeCell.node.contains(document.activeElement))
+    ) {
       this.node.focus();
     }
   }

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1920,7 +1920,7 @@ export class Notebook extends StaticNotebook {
     }
     if (
       (force && !this.node.contains(document.activeElement)) ||
-      // Focus the notebook if the active cell changes but as not the focus
+      // Focus notebook if active cell changes but does not have focus.
       // Xref: https://github.com/jupyterlab/jupyterlab/issues/12437
       (activeCell && !activeCell.node.contains(document.activeElement))
     ) {

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1921,7 +1921,6 @@ export class Notebook extends StaticNotebook {
     if (
       (force && !this.node.contains(document.activeElement)) ||
       // Focus notebook if active cell changes but does not have focus.
-      // Xref: https://github.com/jupyterlab/jupyterlab/issues/12437
       (activeCell && !activeCell.node.contains(document.activeElement))
     ) {
       this.node.focus();


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #12437
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Focus the notebook node if the active cell changes but does not contain the focused element.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Fixes the issue
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A