### PR TITLE
Use more explicit name for the releaser dist files uploaded as artifacts

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -38,6 +38,6 @@ jobs:
         if: ${{ matrix.group == 'check_release' }}
         uses: actions/upload-artifact@v2
         with:
-          name: dist-files
+          name: jupyterlab-releaser-dist-${{ github.run_number }}
           path: |
             .jupyter_releaser_checkout/dist/*.*


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

For now all dist files artifacts uploaded as part of the check release CI run are named `dist-files`:

![image](https://user-images.githubusercontent.com/591645/164283467-71044abb-c249-4309-8a20-8df7a03b8425.png)

This updates the name so it also includes `jupyterlab` and the GitHub run number. This is useful when downloading these files for this repo or other repos using the releaser, so it's easier to differentiate them.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

CI workflow update.


<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
