### PR TITLE
Automated Changelog Entry for 3.4.0a0 on 3.4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,51 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.4.0a0
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.3.4...0d166ef26bc505950abd65ee4e220d11eb197c1a))
+
+### Enhancements made
+
+- Creates cell-toolbar, cell-toolbar-extension packages and populates toolbar [#12028](https://github.com/jupyterlab/jupyterlab/pull/12028) ([@jweill-aws](https://github.com/jweill-aws))
+- Backport PR #12281: Customize the file browser toolbar via the settings [#12441](https://github.com/jupyterlab/jupyterlab/pull/12441) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #12369: Wait until file browser commands are ready before activating file browser widget [#12435](https://github.com/jupyterlab/jupyterlab/pull/12435) ([@fcollonval](https://github.com/fcollonval))
+- Add a "New Tab" button that opens the launcher [#12195](https://github.com/jupyterlab/jupyterlab/pull/12195) ([@ajbozarth](https://github.com/ajbozarth))
+- Simplify galata import by proxying `expect` [#12311](https://github.com/jupyterlab/jupyterlab/pull/12311) ([@fcollonval](https://github.com/fcollonval))
+- Open terminal in cwd from launcher [#12250](https://github.com/jupyterlab/jupyterlab/pull/12250) ([@rccern](https://github.com/rccern))
+- Add support for filtering by field names in setting editor [#12082](https://github.com/jupyterlab/jupyterlab/pull/12082) ([@marthacryan](https://github.com/marthacryan))
+- Use transform to quickly switch between tabs. [#11074](https://github.com/jupyterlab/jupyterlab/pull/11074) ([@fcollonval](https://github.com/fcollonval))
+- Pop up select kernel dialog when run a cell without kernel [#12379](https://github.com/jupyterlab/jupyterlab/pull/12379) ([@a3626a](https://github.com/a3626a))
+- Allow LauncherModel to be more extendable [#12344](https://github.com/jupyterlab/jupyterlab/pull/12344) ([@ajbozarth](https://github.com/ajbozarth))
+- Add argument `searchText` and `replaceText` to search and replace commands [#12310](https://github.com/jupyterlab/jupyterlab/pull/12310) ([@fcollonval](https://github.com/fcollonval))
+- Add argument line and column to codemirror go to line command [#12204](https://github.com/jupyterlab/jupyterlab/pull/12204) ([@fcollonval](https://github.com/fcollonval))
+- Default is no virtual rendering + Relax virtual notebook rendering and ensure no structural change until rendering is completed [#12258](https://github.com/jupyterlab/jupyterlab/pull/12258) ([@echarles](https://github.com/echarles))
+
+### Bugs fixed
+
+- Use css variable for font size. [#12255](https://github.com/jupyterlab/jupyterlab/pull/12255) ([@Carreau](https://github.com/Carreau))
+
+### Maintenance and upkeep improvements
+
+- Backport #12413 on branch 3.4.x (Update benchmark snapshots) [#12451](https://github.com/jupyterlab/jupyterlab/pull/12451) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+- Creates cell-toolbar, cell-toolbar-extension packages and populates toolbar [#12028](https://github.com/jupyterlab/jupyterlab/pull/12028) ([@jweill-aws](https://github.com/jweill-aws))
+- Backport PR #12281: Customize the file browser toolbar via the settings [#12441](https://github.com/jupyterlab/jupyterlab/pull/12441) ([@fcollonval](https://github.com/fcollonval))
+
+### Deprecated features
+
+- Deprecate FileEditorCodeWrapper [#12381](https://github.com/jupyterlab/jupyterlab/pull/12381) ([@hbcarlos](https://github.com/hbcarlos))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-04-15&to=2022-04-21&type=c))
+
+[@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2022-04-15..2022-04-21&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2022-04-15..2022-04-21&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-04-15..2022-04-21&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-04-15..2022-04-21&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-04-15..2022-04-21&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-04-15..2022-04-21&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-04-15..2022-04-21&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2022-04-15..2022-04-21&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-04-15..2022-04-21&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.3.4
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.3.3...a8a438b3bd84806b8e186e7e037d73167d371c3a))
@@ -46,8 +91,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-04-07&to=2022-04-15&type=c))
 
 [@aiqc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aaiqc+updated%3A2022-04-07..2022-04-15&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-04-07..2022-04-15&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-04-07..2022-04-15&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-04-07..2022-04-15&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-04-07..2022-04-15&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-04-07..2022-04-15&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-04-07..2022-04-15&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-04-07..2022-04-15&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2022-04-07..2022-04-15&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-04-07..2022-04-15&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-04-07..2022-04-15&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-04-07..2022-04-15&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-04-07..2022-04-15&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 
 # JupyterLab Changelog
 
-## v3.3
+## v3.4
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
@@ -19,8 +19,8 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 ### Enhancements made
 
 - Creates cell-toolbar, cell-toolbar-extension packages and populates toolbar [#12028](https://github.com/jupyterlab/jupyterlab/pull/12028) ([@jweill-aws](https://github.com/jweill-aws))
-- Backport PR #12281: Customize the file browser toolbar via the settings [#12441](https://github.com/jupyterlab/jupyterlab/pull/12441) ([@fcollonval](https://github.com/fcollonval))
-- Backport PR #12369: Wait until file browser commands are ready before activating file browser widget [#12435](https://github.com/jupyterlab/jupyterlab/pull/12435) ([@fcollonval](https://github.com/fcollonval))
+- Customize the file browser toolbar via the settings [#12441](https://github.com/jupyterlab/jupyterlab/pull/12441) ([@fcollonval](https://github.com/fcollonval))
+- Wait until file browser commands are ready before activating file browser widget [#12435](https://github.com/jupyterlab/jupyterlab/pull/12435) ([@fcollonval](https://github.com/fcollonval))
 - Add a "New Tab" button that opens the launcher [#12195](https://github.com/jupyterlab/jupyterlab/pull/12195) ([@ajbozarth](https://github.com/ajbozarth))
 - Simplify galata import by proxying `expect` [#12311](https://github.com/jupyterlab/jupyterlab/pull/12311) ([@fcollonval](https://github.com/fcollonval))
 - Open terminal in cwd from launcher [#12250](https://github.com/jupyterlab/jupyterlab/pull/12250) ([@rccern](https://github.com/rccern))
@@ -38,12 +38,7 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 
 ### Maintenance and upkeep improvements
 
-- Backport #12413 on branch 3.4.x (Update benchmark snapshots) [#12451](https://github.com/jupyterlab/jupyterlab/pull/12451) ([@fcollonval](https://github.com/fcollonval))
-
-### Documentation improvements
-
-- Creates cell-toolbar, cell-toolbar-extension packages and populates toolbar [#12028](https://github.com/jupyterlab/jupyterlab/pull/12028) ([@jweill-aws](https://github.com/jweill-aws))
-- Backport PR #12281: Customize the file browser toolbar via the settings [#12441](https://github.com/jupyterlab/jupyterlab/pull/12441) ([@fcollonval](https://github.com/fcollonval))
+- Update benchmark snapshots [#12451](https://github.com/jupyterlab/jupyterlab/pull/12451) ([@fcollonval](https://github.com/fcollonval))
 
 ### Deprecated features
 
@@ -56,6 +51,8 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2022-04-15..2022-04-21&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2022-04-15..2022-04-21&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-04-15..2022-04-21&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-04-15..2022-04-21&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-04-15..2022-04-21&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-04-15..2022-04-21&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-04-15..2022-04-21&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2022-04-15..2022-04-21&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-04-15..2022-04-21&type=Issues)
 
 <!-- <END NEW CHANGELOG ENTRY> -->
+
+## v3.3
 
 ## 3.3.4
 


### PR DESCRIPTION
Automated Changelog Entry for 3.4.0a0 on 3.4.x
```
Python version: 3.4.0a0
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.4.0-alpha.0
@jupyterlab/buildutils: 3.4.0-alpha.0
@jupyterlab/template: 3.4.0-alpha.0
@jupyterlab/application-top: 3.4.0-alpha.0
@jupyterlab/example-app: 3.4.0-alpha.0
@jupyterlab/example-cell: 3.4.0-alpha.0
@jupyterlab/example-console: 3.4.0-alpha.0
@jupyterlab/example-federated: 2.5.0-alpha.0
@jupyterlab/example-federated-core: 2.5.0-alpha.0
@jupyterlab/example-federated-md: 2.5.0-alpha.0
@jupyterlab/example-federated-middle: 2.5.0-alpha.0
@jupyterlab/example-federated-phosphor: 2.5.0-alpha.0
@jupyterlab/example-filebrowser: 3.4.0-alpha.0
@jupyterlab/example-notebook: 3.4.0-alpha.0
@jupyterlab/example-terminal: 3.4.0-alpha.0
@jupyterlab/galata: 4.3.0-alpha.0
@jupyterlab/mock-extension: 3.4.0-alpha.0
@jupyterlab/mock-consumer: 3.4.0-alpha.0
@jupyterlab/mock-provider: 3.4.0-alpha.0
@jupyterlab/mock-token: 3.4.0-alpha.0
@jupyterlab/application: 3.4.0-alpha.0
@jupyterlab/application-extension: 3.4.0-alpha.0
@jupyterlab/apputils: 3.4.0-alpha.0
@jupyterlab/apputils-extension: 3.4.0-alpha.0
@jupyterlab/attachments: 3.4.0-alpha.0
@jupyterlab/cell-toolbar: 3.4.0-alpha.0
@jupyterlab/cell-toolbar-extension: 3.4.0-alpha.0
@jupyterlab/cells: 3.4.0-alpha.0
@jupyterlab/celltags: 3.4.0-alpha.0
@jupyterlab/celltags-extension: 3.4.0-alpha.0
@jupyterlab/codeeditor: 3.4.0-alpha.0
@jupyterlab/codemirror: 3.4.0-alpha.0
@jupyterlab/codemirror-extension: 3.4.0-alpha.0
@jupyterlab/completer: 3.4.0-alpha.0
@jupyterlab/completer-extension: 3.4.0-alpha.0
@jupyterlab/console: 3.4.0-alpha.0
@jupyterlab/console-extension: 3.4.0-alpha.0
@jupyterlab/coreutils: 5.4.0-alpha.0
@jupyterlab/csvviewer: 3.4.0-alpha.0
@jupyterlab/csvviewer-extension: 3.4.0-alpha.0
@jupyterlab/debugger: 3.4.0-alpha.0
@jupyterlab/debugger-extension: 3.4.0-alpha.0
@jupyterlab/docmanager: 3.4.0-alpha.0
@jupyterlab/docmanager-extension: 3.4.0-alpha.0
@jupyterlab/docprovider: 3.4.0-alpha.0
@jupyterlab/docprovider-extension: 3.4.0-alpha.0
@jupyterlab/docregistry: 3.4.0-alpha.0
@jupyterlab/documentsearch: 3.4.0-alpha.0
@jupyterlab/documentsearch-extension: 3.4.0-alpha.0
@jupyterlab/extensionmanager: 3.4.0-alpha.0
@jupyterlab/extensionmanager-extension: 3.4.0-alpha.0
@jupyterlab/filebrowser: 3.4.0-alpha.0
@jupyterlab/filebrowser-extension: 3.4.0-alpha.0
@jupyterlab/fileeditor: 3.4.0-alpha.0
@jupyterlab/fileeditor-extension: 3.4.0-alpha.0
@jupyterlab/help-extension: 3.4.0-alpha.0
@jupyterlab/htmlviewer: 3.4.0-alpha.0
@jupyterlab/htmlviewer-extension: 3.4.0-alpha.0
@jupyterlab/hub-extension: 3.4.0-alpha.0
@jupyterlab/imageviewer: 3.4.0-alpha.0
@jupyterlab/imageviewer-extension: 3.4.0-alpha.0
@jupyterlab/inspector: 3.4.0-alpha.0
@jupyterlab/inspector-extension: 3.4.0-alpha.0
@jupyterlab/javascript-extension: 3.4.0-alpha.0
@jupyterlab/json-extension: 3.4.0-alpha.0
@jupyterlab/launcher: 3.4.0-alpha.0
@jupyterlab/launcher-extension: 3.4.0-alpha.0
@jupyterlab/logconsole: 3.4.0-alpha.0
@jupyterlab/logconsole-extension: 3.4.0-alpha.0
@jupyterlab/mainmenu: 3.4.0-alpha.0
@jupyterlab/mainmenu-extension: 3.4.0-alpha.0
@jupyterlab/markdownviewer: 3.4.0-alpha.0
@jupyterlab/markdownviewer-extension: 3.4.0-alpha.0
@jupyterlab/mathjax2: 3.4.0-alpha.0
@jupyterlab/mathjax2-extension: 3.4.0-alpha.0
@jupyterlab/metapackage: 3.4.0-alpha.0
@jupyterlab/nbconvert-css: 3.4.0-alpha.0
@jupyterlab/nbformat: 3.4.0-alpha.0
@jupyterlab/notebook: 3.4.0-alpha.0
@jupyterlab/notebook-extension: 3.4.0-alpha.0
@jupyterlab/observables: 4.4.0-alpha.0
@jupyterlab/outputarea: 3.4.0-alpha.0
@jupyterlab/pdf-extension: 3.4.0-alpha.0
@jupyterlab/property-inspector: 3.4.0-alpha.0
@jupyterlab/rendermime: 3.4.0-alpha.0
@jupyterlab/rendermime-extension: 3.4.0-alpha.0
@jupyterlab/rendermime-interfaces: 3.4.0-alpha.0
@jupyterlab/running: 3.4.0-alpha.0
@jupyterlab/running-extension: 3.4.0-alpha.0
@jupyterlab/services: 6.4.0-alpha.0
@jupyterlab/example-services-browser: 3.4.0-alpha.0
node-example: 3.4.0-alpha.0
@jupyterlab/example-services-outputarea: 3.4.0-alpha.0
@jupyterlab/settingeditor: 3.4.0-alpha.0
@jupyterlab/settingeditor-extension: 3.4.0-alpha.0
@jupyterlab/settingregistry: 3.4.0-alpha.0
@jupyterlab/shared-models: 3.4.0-alpha.0
@jupyterlab/shortcuts-extension: 3.4.0-alpha.0
@jupyterlab/statedb: 3.4.0-alpha.0
@jupyterlab/statusbar: 3.4.0-alpha.0
@jupyterlab/statusbar-extension: 3.4.0-alpha.0
@jupyterlab/terminal: 3.4.0-alpha.0
@jupyterlab/terminal-extension: 3.4.0-alpha.0
@jupyterlab/theme-dark-extension: 3.4.0-alpha.0
@jupyterlab/theme-light-extension: 3.4.0-alpha.0
@jupyterlab/toc: 5.4.0-alpha.0
@jupyterlab/toc-extension: 5.4.0-alpha.0
@jupyterlab/tooltip: 3.4.0-alpha.0
@jupyterlab/tooltip-extension: 3.4.0-alpha.0
@jupyterlab/translation: 3.4.0-alpha.0
@jupyterlab/translation-extension: 3.4.0-alpha.0
@jupyterlab/ui-components: 3.4.0-alpha.0
@jupyterlab/ui-components-extension: 3.4.0-alpha.0
@jupyterlab/vdom: 3.4.0-alpha.0
@jupyterlab/vdom-extension: 3.4.0-alpha.0
@jupyterlab/vega5-extension: 3.4.0-alpha.0
@jupyterlab/testutils: 3.4.0-alpha.0
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.4.x  |
| Version Spec | minor |
| Since | v3.3.4 |