### PR TITLE
Ignore the commit introducing import sort during blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # Run pre-commit with black: https://github.com/jupyterlab/jupyterlab/pull/12279
 6df5e0b6e8ec740ffa2f84f198820d1968e4d74d
+# Add linter rule for sorting import: https://github.com/jupyterlab/jupyterlab/pull/10344
+dbdefed9db9332381fe4104bdf53ec314451951f


### PR DESCRIPTION
## References

Closes #10607

## Code changes

Just added dbdefed9db9332381fe4104bdf53ec314451951f commit hash for #10344 as the file itself was already created in #12290

## User-facing changes

None

## Backwards-incompatible changes

None