### PR TITLE
Move cell toolbar below search document widget

### DIFF
--- a/packages/cell-toolbar/style/base.css
+++ b/packages/cell-toolbar/style/base.css
@@ -15,7 +15,7 @@
   flex-direction: row;
   padding: 2px 0;
   min-height: 25px;
-  z-index: 10;
+  z-index: 6;
   position: absolute;
   top: 5px;
   right: 8px;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #12465
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Set z-index to 6 (search widget z-index - 1)

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

Cell toolbar is behind the search widget

| before | after |
| --- | --- |
| ![Screenshot from 2022-04-25 16-32-05](https://user-images.githubusercontent.com/8435071/165112781-ae28c2f0-9bd1-4192-bbc0-6eed88f92863.png) | ![Screenshot from 2022-04-25 16-38-23](https://user-images.githubusercontent.com/8435071/165112792-d7719f50-7f4b-47c9-9964-18de6ce68ae3.png) |


<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A