### PR TITLE
Display default value in setting editor for changed values

### DIFF
--- a/packages/settingeditor/src/SettingsFormEditor.tsx
+++ b/packages/settingeditor/src/SettingsFormEditor.tsx
@@ -318,6 +318,11 @@ const CustomTemplate = (props: FieldTemplateProps) => {
         {schema.description && needsDescription && (
           <div className="jp-FormGroup-description">{schema.description}</div>
         )}
+        {isModified && schema.default !== undefined && (
+          <div className="jp-FormGroup-default">
+            Default: {schema.default?.toLocaleString()}
+          </div>
+        )}
         <div className="validationErrors">{errors}</div>
       </div>
     </div>

--- a/packages/settingeditor/style/base.css
+++ b/packages/settingeditor/style/base.css
@@ -306,6 +306,11 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
   padding: 4px 7px;
 }
 
+.jp-SettingsPanel .jp-FormGroup-default {
+  flex-basis: 100%;
+  padding: 4px 7px;
+}
+
 .jp-SettingsPanel #root__description {
   display: none;
 }


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/12284

## Code changes

Show the default value in the settings editor for changed settings.

## User-facing changes

![Untitled4](https://user-images.githubusercontent.com/226720/165118397-b3cb36a1-38b0-4aad-8aae-fbdcbd49f467.gif)

## Backwards-incompatible changes

None.
