### PR TITLE
Update copyright date to 2022 in the about dialog

### DIFF
--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -135,7 +135,7 @@ const about: JupyterFrontEndPlugin<void> = {
         );
         const copyright = (
           <span className="jp-About-copyright">
-            {trans.__('© 2015-2021 Project Jupyter Contributors')}
+            {trans.__('© 2015-2022 Project Jupyter Contributors')}
           </span>
         );
         const body = (


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Similar to https://github.com/jupyterlab/jupyterlab/pull/10052 last year.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

This is a manual bump based on the discussions in https://github.com/jupyterlab/jupyterlab/pull/10052

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Users will see 2022 in the about dialog:

![image](https://user-images.githubusercontent.com/591645/165255713-205d434e-f265-4139-921a-d1000529a579.png)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
