### PR TITLE
Only show duplicate LabIcon warning in debug mode

### DIFF
--- a/packages/ui-components/src/icon/labicon.tsx
+++ b/packages/ui-components/src/icon/labicon.tsx
@@ -237,10 +237,11 @@ export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
         return icon;
       } else {
         // already loaded icon svg exists; replace it and warn
-        // TODO: need to see if this warning is useful or just noisy
-        console.warn(
-          `Redefining previously loaded icon svgstr. name: ${name}, svgstrOld: ${icon.svgstr}, svgstr: ${svgstr}`
-        );
+        if (LabIcon._debug) {
+          console.warn(
+            `Redefining previously loaded icon svgstr. name: ${name}, svgstrOld: ${icon.svgstr}, svgstr: ${svgstr}`
+          );
+        }
         icon.svgstr = svgstr;
         return icon;
       }


### PR DESCRIPTION
This warning shows up if multiple prebuilt extensions use a library
package to define their icons, which is common.

`Redefining previously loaded icon svgstr.`

Also note that wrapping the warn in debug is how the warning for looking up a non existent lab icon is handled.