### PR TITLE
Inverse dependencies link between translation and rendermime interfaces

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -61,6 +61,9 @@ bumped their major version (following semver convention):
   The markdown parser has been extracted to its own plugin ``@jupyterlab/markedparser-extension:plugin``
   that provides a new token ``IMarkdownParser`` (defined in ``@jupyterlab/rendermime``).
   Consequently the ``IRendererFactory.createRenderer`` has a new option ``markdownParser``.
+- ``@jupyterlab/rendermime-interfaces`` from 3.x to 4.x
+  Remove ``IRenderMime.IRenderer.translator?`` attribute; the translator object is still passed to
+  the constructor if needed by the renderer factory.
 - ``@jupyterlab/shared-models`` from 3.x to 4.x
    The ``createCellFromType`` function has been renamed to ``createCellModelFromSharedType``
 - ``@jupyterlab/buildutils`` from 3.x to 4.x

--- a/packages/rendermime-interfaces/package.json
+++ b/packages/rendermime-interfaces/package.json
@@ -30,7 +30,6 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/translation": "^4.0.0-alpha.9",
     "@lumino/coreutils": "^1.12.0",
     "@lumino/widgets": "^1.31.1"
   },

--- a/packages/rendermime-interfaces/src/index.ts
+++ b/packages/rendermime-interfaces/src/index.ts
@@ -7,7 +7,6 @@
  * @module rendermime-interfaces
  */
 
-import { ITranslator } from '@jupyterlab/translation';
 import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
 import { Widget } from '@lumino/widgets';
 
@@ -278,11 +277,6 @@ export namespace IRenderMime {
    */
   export interface IRenderer extends Widget {
     /**
-     * The application language translator.
-     */
-    translator?: ITranslator;
-
-    /**
      * Render a mime model.
      *
      * @param model - The mime model to render.
@@ -449,5 +443,158 @@ export namespace IRenderMime {
      * @returns - A promise of the string.
      */
     render(source: string): Promise<string>;
+  }
+
+  // ********************** //
+  // Translation interfaces //
+  // ********************** //
+
+  /**
+   * Bundle of gettext-based translation functions for a specific domain.
+   */
+  export type TranslationBundle = {
+    /**
+     * Alias for `gettext` (translate strings without number inflection)
+     * @param msgid message (text to translate)
+     * @param args
+     *
+     * @returns A translated string if found, or the original string.
+     */
+    __(msgid: string, ...args: any[]): string;
+    /**
+     * Alias for `ngettext` (translate accounting for plural forms)
+     * @param msgid message for singular
+     * @param msgid_plural message for plural
+     * @param n determines which plural form to use
+     * @param args
+     *
+     * @returns A translated string if found, or the original string.
+     */
+    _n(msgid: string, msgid_plural: string, n: number, ...args: any[]): string;
+    /**
+     * Alias for `pgettext` (translate in given context)
+     * @param msgctxt context
+     * @param msgid message (text to translate)
+     * @param args
+     *
+     * @returns A translated string if found, or the original string.
+     */
+    _p(msgctxt: string, msgid: string, ...args: any[]): string;
+    /**
+     * Alias for `npgettext` (translate accounting for plural forms in given context)
+     * @param msgctxt context
+     * @param msgid message for singular
+     * @param msgid_plural message for plural
+     * @param n number used to determine which plural form to use
+     * @param args
+     *
+     * @returns A translated string if found, or the original string.
+     */
+    _np(
+      msgctxt: string,
+      msgid: string,
+      msgid_plural: string,
+      n: number,
+      ...args: any[]
+    ): string;
+    /**
+     * Look up the message id in the catalog and return the corresponding message string.
+     * Otherwise, the message id is returned.
+     *
+     * @param msgid message (text to translate)
+     * @param args
+     *
+     * @returns A translated string if found, or the original string.
+     */
+    gettext(msgid: string, ...args: any[]): string;
+    /**
+     * Do a plural-forms lookup of a message id. msgid is used as the message id for
+     * purposes of lookup in the catalog, while n is used to determine which plural form
+     * to use. Otherwise, when n is 1 msgid is returned, and msgid_plural is returned in
+     * all other cases.
+     *
+     * @param msgid message for singular
+     * @param msgid_plural message for plural
+     * @param n determines which plural form to use
+     * @param args
+     *
+     * @returns A translated string if found, or the original string.
+     */
+    ngettext(
+      msgid: string,
+      msgid_plural: string,
+      n: number,
+      ...args: any[]
+    ): string;
+    /**
+     * Look up the context and message id in the catalog and return the corresponding
+     * message string. Otherwise, the message id is returned.
+     *
+     * @param msgctxt context
+     * @param msgid message (text to translate)
+     * @param args
+     *
+     * @returns A translated string if found, or the original string.
+     */
+    pgettext(msgctxt: string, msgid: string, ...args: any[]): string;
+    /**
+     * Do a plural-forms lookup of a message id. msgid is used as the message id for
+     * purposes of lookup in the catalog, while n is used to determine which plural
+     * form to use. Otherwise, when n is 1 msgid is returned, and msgid_plural is
+     * returned in all other cases.
+     *
+     * @param msgctxt context
+     * @param msgid message for singular
+     * @param msgid_plural message for plural
+     * @param n number used to determine which plural form to use
+     * @param args
+     *
+     * @returns A translated string if found, or the original string.
+     */
+    npgettext(
+      msgctxt: string,
+      msgid: string,
+      msgid_plural: string,
+      n: number,
+      ...args: any[]
+    ): string;
+
+    /**
+     * Do a plural-forms lookup of a message id. msgid is used as the message id for
+     * purposes of lookup in the catalog, while n is used to determine which plural
+     * form to use. Otherwise, when n is 1 msgid is returned, and msgid_plural is
+     * returned in all other cases.
+     *
+     * @param domain - The translations domain.
+     * @param msgctxt - The message context.
+     * @param msgid - The singular string to translate.
+     * @param msgid_plural - The plural string to translate.
+     * @param n - The number for pluralization.
+     * @param args - Any additional values to use with interpolation
+     *
+     * @returns A translated string if found, or the original string.
+     */
+    dcnpgettext(
+      domain: string,
+      msgctxt: string,
+      msgid: string,
+      msgid_plural: string,
+      n: number,
+      ...args: any[]
+    ): string;
+  };
+
+  /**
+   * Translation provider interface
+   */
+  export interface ITranslator {
+    /**
+     * Load translation bundles for a given domain.
+     *
+     * @param domain The translation domain to use for translations.
+     *
+     * @returns The translation bundle if found, or the English bundle.
+     */
+    load(domain: string): TranslationBundle;
   }
 }

--- a/packages/rendermime-interfaces/tsconfig.json
+++ b/packages/rendermime-interfaces/tsconfig.json
@@ -5,9 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src/*"],
-  "references": [
-    {
-      "path": "../translation"
-    }
-  ]
+  "references": []
 }

--- a/packages/translation/package.json
+++ b/packages/translation/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@jupyterlab/coreutils": "^6.0.0-alpha.9",
+    "@jupyterlab/rendermime-interfaces": "^4.0.0-alpha.9",
     "@jupyterlab/services": "^7.0.0-alpha.9",
     "@jupyterlab/statedb": "^4.0.0-alpha.9",
     "@lumino/coreutils": "^1.12.0"

--- a/packages/translation/src/tokens.ts
+++ b/packages/translation/src/tokens.ts
@@ -3,6 +3,7 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
+import type { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 import { ServerConnection } from '@jupyterlab/services';
 import { DataConnector, IDataConnector } from '@jupyterlab/statedb';
 import { Token } from '@lumino/coreutils';
@@ -46,83 +47,14 @@ export class TranslatorConnector
 }
 
 /**
- * Bundle of gettext-based translation functions.
- *
- * The calls to the functions in this bundle will be automatically
- * extracted by `jupyterlab-translate` package to generate translation
- * template files if the bundle is assigned to:
- * - variable named `trans`,
- * - public attribute named `trans` (`this.trans`),
- * - private attribute named `trans` (`this._trans`),
- * - `trans` attribute `props` variable (`props.trans`),
- * - `trans` attribute `props` attribute (`this.props.trans`)
+ * Bundle of gettext-based translation functions for a specific domain.
  */
-export type TranslationBundle = {
-  /**
-   * Alias for `gettext` (translate strings without number inflection)
-   * @param msgid message (text to translate)
-   * @param args
-   */
-  __(msgid: string, ...args: any[]): string;
-  /**
-   * Alias for `ngettext` (translate accounting for plural forms)
-   * @param msgid message for singular
-   * @param msgid_plural message for plural
-   * @param n determines which plural form to use
-   * @param args
-   */
-  _n(msgid: string, msgid_plural: string, n: number, ...args: any[]): string;
-  /**
-   * Alias for `pgettext` (translate in given context)
-   * @param msgctxt context
-   * @param msgid message (text to translate)
-   * @param args
-   */
-  _p(msgctxt: string, msgid: string, ...args: any[]): string;
-  /**
-   * Alias for `npgettext` (translate accounting for plural forms in given context)
-   * @param msgctxt context
-   * @param msgid message for singular
-   * @param msgid_plural message for plural
-   * @param n number used to determine which plural form to use
-   * @param args
-   */
-  _np(
-    msgctxt: string,
-    msgid: string,
-    msgid_plural: string,
-    n: number,
-    ...args: any[]
-  ): string;
-  gettext(msgid: string, ...args: any[]): string;
-  ngettext(
-    msgid: string,
-    msgid_plural: string,
-    n: number,
-    ...args: any[]
-  ): string;
-  pgettext(msgctxt: string, msgid: string, ...args: any[]): string;
-  npgettext(
-    msgctxt: string,
-    msgid: string,
-    msgid_plural: string,
-    n: number,
-    ...args: any[]
-  ): string;
-  dcnpgettext(
-    domain: string,
-    msgctxt: string,
-    msgid: string,
-    msgid_plural: string,
-    n: number,
-    ...args: any[]
-  ): string;
-};
+export type TranslationBundle = IRenderMime.TranslationBundle;
 
-export interface ITranslator {
-  load(domain: string): TranslationBundle;
-  // locale(): string;
-}
+/**
+ * Translation provider interface
+ */
+export interface ITranslator extends IRenderMime.ITranslator {}
 
 export const ITranslator = new Token<ITranslator>(
   '@jupyterlab/translation:ITranslator'

--- a/packages/translation/tsconfig.json
+++ b/packages/translation/tsconfig.json
@@ -10,6 +10,9 @@
       "path": "../coreutils"
     },
     {
+      "path": "../rendermime-interfaces"
+    },
+    {
       "path": "../services"
     },
     {

--- a/packages/translation/tsconfig.test.json
+++ b/packages/translation/tsconfig.test.json
@@ -6,6 +6,9 @@
       "path": "../coreutils"
     },
     {
+      "path": "../rendermime-interfaces"
+    },
+    {
       "path": "../services"
     },
     {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #11748
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
The rendermime interfaces package should be independent of the other packages.

Remove `IRenderer.translator?` as a renderer has only two contracts: 
- Be a `Widget`
- Have a `renderModel` method

> It receives the translator object at construction if it needs it.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
Remove `IRenderer.translator?`