### PR TITLE
Handled new dialog creation with no buttons

### DIFF
--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -249,9 +249,7 @@ export class Dialog<T> extends Widget {
         this._primary = el as HTMLElement;
       }
     }
-    if (this._primary) {
-      this._primary.focus();
-    }
+    this._primary?.focus();
   }
 
   /**
@@ -394,9 +392,7 @@ export class Dialog<T> extends Widget {
     const target = event.target as HTMLElement;
     if (!this.node.contains(target as HTMLElement)) {
       event.stopPropagation();
-      if (this._buttonNodes && this._buttonNodes[this._defaultButton]) {
-        this._buttonNodes[this._defaultButton].focus();
-      }
+      this._buttonNodes[this._defaultButton]?.focus();
     }
   }
 

--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -249,7 +249,9 @@ export class Dialog<T> extends Widget {
         this._primary = el as HTMLElement;
       }
     }
-    this._primary.focus();
+    if (this._primary) {
+      this._primary.focus();
+    }
   }
 
   /**
@@ -392,7 +394,9 @@ export class Dialog<T> extends Widget {
     const target = event.target as HTMLElement;
     if (!this.node.contains(target as HTMLElement)) {
       event.stopPropagation();
-      this._buttonNodes[this._defaultButton].focus();
+      if (this._buttonNodes && this._buttonNodes[this._defaultButton]) {
+        this._buttonNodes[this._defaultButton].focus();
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

NOTE: The git pre-commit and pre-push scripts fail at the flake8 installation with the following error:
```
stderr:
      error: subprocess-exited-with-error

      × python setup.py egg_info did not run successfully.
      │ exit code: 1
      ╰─> [40 lines of output]
          /Users/jnnamchi/.cache/pre-commit/repotdj18xwv/py_env-default/lib/python3.10/site-packages/setuptools/installer.py:27: SetuptoolsDeprecationWarning: setuptools.installer is deprecated. Requirements should be satisfied by a PEP 517 installer.
```

## References

Pull request related to the following issue: https://github.com/jupyterlab/jupyterlab/issues/11897

## Code changes

Added handling to dialog class when initialized with no buttons. Code checks the presence of a primary button before invoking the focus() method on it, if defined.

## User-facing changes

No visual changes.

## Backwards-incompatible changes

No backwards incompatible changes