### PR TITLE
Fixes behavior of `maxNumberOutputs`

### DIFF
--- a/galata/test/jupyterlab/notebook-max-outputs.test.ts
+++ b/galata/test/jupyterlab/notebook-max-outputs.test.ts
@@ -1,0 +1,77 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { expect, galata, test } from '@jupyterlab/galata';
+
+test.use({
+  mockSettings: {
+    ...galata.DEFAULT_SETTINGS,
+    '@jupyterlab/notebook-extension:tracker': {
+      ...galata.DEFAULT_SETTINGS['@jupyterlab/notebook-extension:tracker'],
+      maxNumberOutputs: 5
+    }
+  }
+});
+
+test('Limit cell outputs', async ({ page }) => {
+  await page.notebook.createNew();
+
+  await page.locator('div[role="main"] >> textarea')
+    .fill(`from IPython.display import display, Markdown
+
+for i in range(10):
+    display(Markdown('_Markdown_ **text**'))
+`);
+
+  await page.notebook.run();
+
+  await expect(page.locator('.jp-RenderedMarkdown')).toHaveCount(5);
+  await expect(page.locator('.jp-TrimmedOutputs')).toHaveText(
+    'Show more outputs'
+  );
+});
+
+test("Don't limit cell outputs if input is requested", async ({ page }) => {
+  await page.notebook.createNew();
+
+  await page.locator('div[role="main"] >> textarea')
+    .fill(`from IPython.display import display, Markdown
+
+for i in range(10):
+    display(Markdown('_Markdown_ **text**'))
+
+input('Your age:')
+`);
+
+  await page.menu.clickMenuItem('Run>Run All Cells');
+  await expect(page.locator('.jp-RenderedMarkdown')).toHaveCount(10);
+
+  await page.keyboard.press('Enter');
+});
+
+test('Display input value', async ({ page }) => {
+  await page.notebook.createNew();
+
+  await page.locator('div[role="main"] >> textarea')
+    .fill(`from IPython.display import display, Markdown
+
+for i in range(10):
+    display(Markdown('_Markdown_ **text**'))
+
+input('Your age:')
+
+for i in range(10):
+    display(Markdown('_Markdown_ **text**'))
+`);
+
+  await page.menu.clickMenuItem('Run>Run All Cells');
+  await page.waitForSelector('.jp-Stdin >> text=Your age:');
+
+  await page.keyboard.type('42');
+  await page.keyboard.press('Enter');
+
+  await expect(page.locator('.jp-RenderedMarkdown')).toHaveCount(10);
+  await expect(page.locator('.jp-RenderedText').first()).toHaveText(
+    'Your age: 42'
+  );
+});

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -433,9 +433,9 @@ export class OutputArea extends Widget {
       return;
     }
     const panel = this.layout.widgets[index] as Panel;
-    const renderer = (panel.widgets
-      ? panel.widgets[1]
-      : panel) as IRenderMime.IRenderer;
+    const renderer = (
+      panel.widgets ? panel.widgets[1] : panel
+    ) as IRenderMime.IRenderer;
     // Check whether it is safe to reuse renderer:
     // - Preferred mime type has not changed
     // - Isolation has not changed

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -88,14 +88,15 @@ export class OutputArea extends Widget {
    */
   constructor(options: OutputArea.IOptions) {
     super();
-    const model = (this.model = options.model);
     this.addClass(OUTPUT_AREA_CLASS);
-    this.rendermime = options.rendermime;
+
     this.contentFactory =
       options.contentFactory || OutputArea.defaultContentFactory;
     this.layout = new PanelLayout();
+    this.rendermime = options.rendermime;
     this._maxNumberOutputs = options.maxNumberOutputs ?? Infinity;
 
+    const model = (this.model = options.model);
     for (
       let i = 0;
       i < Math.min(model.length, this._maxNumberOutputs + 1);
@@ -109,14 +110,19 @@ export class OutputArea extends Widget {
   }
 
   /**
-   * The model used by the widget.
-   */
-  readonly model: IOutputAreaModel;
-
-  /**
    * The content factory used by the widget.
    */
   readonly contentFactory: OutputArea.IContentFactory;
+
+  /**
+   * Narrow the type of OutputArea's layout prop
+   */
+  readonly layout: PanelLayout;
+
+  /**
+   * The model used by the widget.
+   */
+  readonly model: IOutputAreaModel;
 
   /**
    * The rendermime instance used by the widget.
@@ -127,7 +133,7 @@ export class OutputArea extends Widget {
    * A read-only sequence of the children widgets in the output area.
    */
   get widgets(): ReadonlyArray<Widget> {
-    return (this.layout as PanelLayout).widgets;
+    return this.layout.widgets;
   }
 
   /**
@@ -394,14 +400,21 @@ export class OutputArea extends Widget {
     input.addClass(OUTPUT_AREA_OUTPUT_CLASS);
     panel.addWidget(input);
 
-    const layout = this.layout as PanelLayout;
-    layout.addWidget(panel);
+    // Increase number of outputs to display the result up to the input request.
+    if (this.model.length >= this.maxNumberOutputs) {
+      this.maxNumberOutputs = this.model.length;
+    }
+    this.layout.addWidget(panel);
 
     /**
      * Wait for the stdin to complete, add it to the model (so it persists)
      * and remove the stdin widget.
      */
     void input.value.then(value => {
+      // Increase number of outputs to display the result of stdin if needed.
+      if (this.model.length >= this.maxNumberOutputs) {
+        this.maxNumberOutputs = this.model.length;
+      }
       // Use stdin as the stream so it does not get combined with stdout.
       this.model.add({
         output_type: 'stream',
@@ -419,12 +432,10 @@ export class OutputArea extends Widget {
     if (index >= this._maxNumberOutputs) {
       return;
     }
-
-    const layout = this.layout as PanelLayout;
-    const panel = layout.widgets[index] as Panel;
-    const renderer = (
-      panel.widgets ? panel.widgets[1] : panel
-    ) as IRenderMime.IRenderer;
+    const panel = this.layout.widgets[index] as Panel;
+    const renderer = (panel.widgets
+      ? panel.widgets[1]
+      : panel) as IRenderMime.IRenderer;
     // Check whether it is safe to reuse renderer:
     // - Preferred mime type has not changed
     // - Isolation has not changed
@@ -439,7 +450,7 @@ export class OutputArea extends Widget {
     ) {
       void renderer.renderModel(model);
     } else {
-      layout.widgets[index].dispose();
+      this.layout.widgets[index].dispose();
       this._insertOutput(index, model);
     }
   }
@@ -907,7 +918,7 @@ export class Stdin extends Widget implements IStdin {
     // make users aware of the line history feature
     this._input.placeholder = '↑↓ for history';
     this._future = options.future;
-    this._parent_header = options.parent_header;
+    this._parentHeader = options.parent_header;
     this._value = options.prompt + ' ';
   }
 
@@ -959,7 +970,7 @@ export class Stdin extends Widget implements IStdin {
             status: 'ok',
             value: input.value
           },
-          this._parent_header
+          this._parentHeader
         );
         if (input.type === 'password') {
           this._value += Array(input.value.length + 1).join('·');
@@ -995,7 +1006,7 @@ export class Stdin extends Widget implements IStdin {
   }
 
   private _historyIndex: number;
-  private _parent_header: KernelMessage.IInputReplyMsg['parent_header'];
+  private _parentHeader: KernelMessage.IInputReplyMsg['parent_header'];
   private _future: Kernel.IShellFuture;
   private _input: HTMLInputElement;
   private _value: string;
@@ -1186,13 +1197,13 @@ namespace Private {
       onClick: (event: MouseEvent) => void
     ) {
       const node = document.createElement('div');
+      const title = `The first ${maxNumberOutputs} are displayed`;
+      const msg = 'Show more outputs';
       node.insertAdjacentHTML(
         'afterbegin',
-        `<a>
-        <pre>Output of this cell has been trimmed on the initial display.</pre>
-        <pre>Displaying the first ${maxNumberOutputs} top outputs.</pre>
-        <pre>Click on this message to get the complete output.</pre>
-      </a>`
+        `<a title=${title}>
+          <pre>${msg}</pre>
+        </a>`
       );
       super({
         node

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -413,7 +413,7 @@ export class OutputArea extends Widget {
     void input.value.then(value => {
       // Increase number of outputs to display the result of stdin if needed.
       if (this.model.length >= this.maxNumberOutputs) {
-        this.maxNumberOutputs = this.model.length;
+        this.maxNumberOutputs = this.model.length + 1;
       }
       // Use stdin as the stream so it does not get combined with stdout.
       this.model.add({

--- a/packages/outputarea/style/base.css
+++ b/packages/outputarea/style/base.css
@@ -134,6 +134,13 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated::before {
   margin: 0;
 }
 
+.jp-TrimmedOutputs pre {
+  background: var(--jp-layout-color3);
+  font-size: calc(var(--jp-code-font-size) * 1.4);
+  text-align: center;
+  text-transform: uppercase;
+}
+
 /* Hide the gutter in case of
  *  - nested output areas (e.g. in the case of output widgets)
  *  - mirrored output areas

--- a/packages/outputarea/test/widget.spec.ts
+++ b/packages/outputarea/test/widget.spec.ts
@@ -121,16 +121,12 @@ describe('outputarea/widget', () => {
             // eslint-disable-next-line jest/no-conditional-expect
             expect(
               widget.widgets[widget.widgets.length - 1].node.textContent
-            ).toContain(
-              `Show more outputs`
-            );
+            ).toContain('Show more outputs');
           } else {
             // eslint-disable-next-line jest/no-conditional-expect
             expect(
               widget.widgets[widget.widgets.length - 1].node.textContent
-            ).not.toContain(
-              `Show more outputs`
-            );
+            ).not.toContain('Show more outputs');
           }
         }
       );

--- a/packages/outputarea/test/widget.spec.ts
+++ b/packages/outputarea/test/widget.spec.ts
@@ -122,14 +122,14 @@ describe('outputarea/widget', () => {
             expect(
               widget.widgets[widget.widgets.length - 1].node.textContent
             ).toContain(
-              `Displaying the first ${maxNumberOutputs} top outputs.`
+              `Show more outputs`
             );
           } else {
             // eslint-disable-next-line jest/no-conditional-expect
             expect(
               widget.widgets[widget.widgets.length - 1].node.textContent
             ).not.toContain(
-              `Displaying the first ${maxNumberOutputs} top outputs.`
+              `Show more outputs`
             );
           }
         }


### PR DESCRIPTION
## References

fixes #12321, fixes #12497

## Code changes

Fixes code/logic implementing the behavior of `maxNumberOutputs`. Of the two choices for correct behavior that I mentioned in #12497:

> a) behave in a paginated way. Once `maxNumberOutputs` of outputs are shown, display the warning. If the warning is clicked, show up to `maxNumberOutputs * 2` outputs before displaying a new warning. If that warning is clicked, keep going until `maxNumberOutputs * 3`, and so forth
> 
> b) behave as a one-time flood control. Once `maxNumberOutputs` of outputs are shown, display the warning. If the warning is clicked, show all further outputs

I went for now with option b). The code in this PR is designed to make switching to option a) straightforward, if we decide that's better. Also includes some streamlining of typing and conditional logic in `OutputArea`.

## User-facing changes

Fixes behavior of `maxNumberOutputs`; no more lost outputs.

## Backwards-incompatible changes

none
