### PR TITLE
Allow downstream extension to set toolbar layout

### DIFF
--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -7,7 +7,7 @@ import { CommandRegistry } from '@lumino/commands';
 import { ReadonlyJSONObject } from '@lumino/coreutils';
 import { Message, MessageLoop } from '@lumino/messaging';
 import { AttachedProperty } from '@lumino/properties';
-import { PanelLayout, Widget } from '@lumino/widgets';
+import { Layout, PanelLayout, Widget } from '@lumino/widgets';
 import { Throttler } from '@lumino/polling';
 import * as React from 'react';
 import { Button } from './button';
@@ -164,10 +164,10 @@ export class Toolbar<T extends Widget = Widget> extends Widget {
   /**
    * Construct a new toolbar widget.
    */
-  constructor() {
+  constructor(options: Toolbar.IOptions = {}) {
     super();
     this.addClass(TOOLBAR_CLASS);
-    this.layout = new ToolbarLayout();
+    this.layout = options.layout ?? new ToolbarLayout();
   }
 
   /**
@@ -546,6 +546,16 @@ export class ReactiveToolbar extends Toolbar<Widget> {
  * The namespace for Toolbar class statics.
  */
 export namespace Toolbar {
+  /**
+   * The options used to create a toolbar.
+   */
+  export interface IOptions {
+    /**
+     * Toolbar widget layout.
+     */
+    layout?: Layout;
+  }
+
   /**
    * Widget with associated toolbar
    */


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
In [cell toolbar extension](https://github.com/jupyterlab-contrib/jlab-enhanced-cell-toolbar), the specific toolbar layout is not playing nicely. This allows extension to reuse the toolbar class while providing a custom layout.
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Toolbar constructor now accepts a layout to override the default one.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A