### PR TITLE
Add line history (via arrow up/down) to all `Stdin` widgets in cell outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,7 @@ junit.xml
 # ms IDE stuff
 *.code-workspace
 .history
-.vscode/settings.json
+.vscode/*
+!.vscode/extension.json
 
 .jupyter_releaser_checkout

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -519,12 +519,12 @@
     {
       "command": "notebook:move-cursor-heading-above-or-collapse",
       "keys": ["ArrowLeft"],
-      "selector": ".jp-Notebook.jp-mod-commandMode"
+      "selector": ".jp-Notebook:focus.jp-mod-commandMode"
     },
     {
       "command": "notebook:move-cursor-heading-below-or-expand",
       "keys": ["ArrowRight"],
-      "selector": ".jp-Notebook.jp-mod-commandMode"
+      "selector": ".jp-Notebook:focus.jp-mod-commandMode"
     },
     {
       "command": "notebook:insert-heading-above",

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -878,7 +878,7 @@ export class Stdin extends Widget implements IStdin {
     this._input = this.node.getElementsByTagName('input')[0];
     this._input.focus();
     // make users aware of the line history feature
-    this._input.placeholder = 'press ⇵ for history';
+    this._input.placeholder = '↑↓ for history';
     this._future = options.future;
     this._parent_header = options.parent_header;
     this._value = options.prompt + ' ';

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -845,6 +845,27 @@ export interface IStdin extends Widget {
  * The default stdin widget.
  */
 export class Stdin extends Widget implements IStdin {
+  private static _history: string[] = [];
+
+  private static _historyAt(ix: number): string | undefined {
+    const len = Stdin._history.length;
+    // interpret negative ix exactly like Array.at
+    ix = ix < 0 ? len + ix : ix;
+
+    if (ix < len) {
+      return Stdin._history[ix];
+    }
+    // return undefined if ix is out of bounds
+  }
+
+  private static _historyPush(line: string): void {
+    Stdin._history.push(line);
+    if (Stdin._history.length > 1000) {
+      // truncate line history if it's too long
+      Stdin._history.shift();
+    }
+  }
+
   /**
    * Construct a new input widget.
    */
@@ -853,6 +874,7 @@ export class Stdin extends Widget implements IStdin {
       node: Private.createInputWidgetNode(options.prompt, options.password)
     });
     this.addClass(STDIN_CLASS);
+    this._history_ix = 0;
     this._input = this.node.getElementsByTagName('input')[0];
     this._input.focus();
     this._future = options.future;
@@ -877,11 +899,32 @@ export class Stdin extends Widget implements IStdin {
    * called in response to events on the dock panel's node. It should
    * not be called directly by user code.
    */
-  handleEvent(event: Event): void {
+  handleEvent(event: KeyboardEvent): void {
     const input = this._input;
     if (event.type === 'keydown') {
-      if ((event as KeyboardEvent).keyCode === 13) {
-        // Enter
+      if (event.key === 'ArrowUp') {
+        const historyLine = Stdin._historyAt(this._history_ix - 1);
+        if (historyLine) {
+          if (this._history_ix === 0) {
+            this._value_cache = input.value;
+          }
+          input.value = historyLine;
+          --this._history_ix;
+        }
+      } else if (event.key === 'ArrowDown') {
+        if (this._history_ix === 0) {
+          // do nothing
+        } else if (this._history_ix === -1) {
+          input.value = this._value_cache;
+          ++this._history_ix;
+        } else {
+          const historyLine = Stdin._historyAt(this._history_ix + 1);
+          if (historyLine) {
+            input.value = historyLine;
+            ++this._history_ix;
+          }
+        }
+      } else if (event.key === 'Enter') {
         this._future.sendInputReply(
           {
             status: 'ok',
@@ -893,6 +936,7 @@ export class Stdin extends Widget implements IStdin {
           this._value += Array(input.value.length + 1).join('·');
         } else {
           this._value += input.value;
+          Stdin._historyPush(input.value);
         }
         this._promise.resolve(void 0);
       }
@@ -921,10 +965,12 @@ export class Stdin extends Widget implements IStdin {
     this._input.removeEventListener('keydown', this);
   }
 
+  private _history_ix: number;
   private _parent_header: KernelMessage.IInputReplyMsg['parent_header'];
   private _future: Kernel.IShellFuture;
   private _input: HTMLInputElement;
   private _value: string;
+  private _value_cache: string;
   private _promise = new PromiseDelegate<void>();
 }
 

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -877,6 +877,8 @@ export class Stdin extends Widget implements IStdin {
     this._history_ix = 0;
     this._input = this.node.getElementsByTagName('input')[0];
     this._input.focus();
+    // make users aware of the line history feature
+    this._input.placeholder = 'press ⇵ for history';
     this._future = options.future;
     this._parent_header = options.parent_header;
     this._value = options.prompt + ' ';

--- a/packages/outputarea/style/base.css
+++ b/packages/outputarea/style/base.css
@@ -194,8 +194,16 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated::before {
   flex: 0 0 70%;
 }
 
+.jp-Stdin-input::placeholder {
+  opacity: 0;
+}
+
 .jp-Stdin-input:focus {
   box-shadow: none;
+}
+
+.jp-Stdin-input:focus::placeholder {
+  opacity: 1;
 }
 
 /*-----------------------------------------------------------------------------


### PR DESCRIPTION
## References

fixes #7006, fixes #12319, fixes #12500

Adds very basic line history to all `Stdin` widgets in cell outputs. Among other things, this means that interactive ipdb sessions (eg what you get when you use `set_trace()` or `breakpoint()` in your code) now have line history.

In comparison to say, bash line history or the functionality provided by `gnu readline`, this implementation of line history is currently lacking all bells and whistles. But it does the basics:

- pressing up moves you backwards in line history, pressing down moves you forwards in line history
- while browsing the line history the current input value is stored and can be recovered (ie by pressing down repeatedly)

The line history is shared among all `Stdin` widgets across all cell outputs and all notebooks. However, the line history is currently stored only in memory, and so will not persist between reload/restarts of jlab. In the future we may want to consider persisting the line history by adding it to a user's workspace.

## Code changes

In the `Stdin` widget class, added some line history-related static props/function, and added handling of up/down keys.

Also, there's a bug in master that prevents `Stdin` from handling presses of the left/right arrow keys (see #12500). Turns out that was caused by an overly broad default selector for the `notebook:move-cursor-heading-above-or-collapse` and `notebook:move-cursor-heading-bellow-or-expand` cmds. This PR also has a fix for that issue. The selector was changed from

```
.jp-Notebook.jp-mod-commandMode
```

to

```
.jp-Notebook:focus.jp-mod-commandMode
```

## User-facing changes

See above

## Backwards-incompatible changes

n/a