### PR TITLE
Get Auto Close Brackets working consistently in Consoles

### DIFF
--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -469,6 +469,9 @@ async function activateConsole(
 
     const setWidgetOptions = (widget: ConsolePanel) => {
       widget.console.node.dataset.jpInteractionMode = interactionMode;
+      // Update future promptCells
+      widget.console.editorConfig = promptCellConfig;
+      // Update promptCell already on screen
       setOption(widget.console.promptCell?.editor, promptCellConfig);
     };
 

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -164,6 +164,11 @@ export class CodeConsole extends Widget {
   readonly sessionContext: ISessionContext;
 
   /**
+   * The configuration options for the text editor widget.
+   */
+  editorConfig?: Partial<CodeEditor.IConfig>;
+
+  /**
    * The list of content cells in the console.
    *
    * #### Notes
@@ -719,7 +724,14 @@ export class CodeConsole extends Widget {
     const modelFactory = this.modelFactory;
     const model = modelFactory.createCodeCell({});
     const rendermime = this.rendermime;
-    return { model, rendermime, contentFactory, placeholder: false };
+    const editorConfig = this.editorConfig;
+    return {
+      model,
+      rendermime,
+      contentFactory,
+      editorConfig,
+      placeholder: false
+    };
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #10874

## Code changes

Adds the promptCellConfig/editorConfig into the CodeConsole when we update settings. PromptCells pull from there by default to get settings.

## User-facing changes

Previously when turning on Auto Close Brackets for Console, it only worked the very first time. Now it works every time.

## Backwards-incompatible changes

N/A


---

Edited to link the issue with the PR.