### PR TITLE
Check-all checkbox should be unchecked when current directory is empty

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -806,7 +806,7 @@ export class DirListing extends Widget {
     const checkAllCheckbox = renderer.getCheckboxNode(this.headerNode);
     if (checkAllCheckbox) {
       const totalSelected = Object.keys(this.selection).length;
-      const allSelected = totalSelected === items.length;
+      const allSelected = items.length > 0 && totalSelected === items.length;
       const someSelected = !allSelected && totalSelected > 0;
       checkAllCheckbox.checked = allSelected;
       checkAllCheckbox.indeterminate = someSelected;

--- a/packages/filebrowser/test/listing.spec.ts
+++ b/packages/filebrowser/test/listing.spec.ts
@@ -52,10 +52,10 @@ describe('filebrowser/listing', () => {
     beforeEach(async () => {
       const options = createOptionsForConstructor();
 
-      // Start with some files instead of empty before creating the
-      // DirListing. This makes it easier to test checking/unchecking because
-      // after the DirListing is created, if a file is added, the DirListing
-      // will select that file (=checkbox checked).
+      // Start with some files instead of empty before creating the DirListing.
+      // This makes it easier to test checking/unchecking because after the
+      // DirListing is created, whenever a file is added, the DirListing selects
+      // that file, which causes the file's checkbox to be checked.
       await options.model.manager.newUntitled({ type: 'file' });
       await options.model.manager.newUntitled({ type: 'file' });
 
@@ -215,6 +215,19 @@ describe('filebrowser/listing', () => {
     });
 
     describe('check-all checkbox', () => {
+      it('should be unchecked when the current directory is empty', async () => {
+        const { path } = await dirListing.model.manager.newUntitled({
+          type: 'directory'
+        });
+        await dirListing.model.cd(path);
+        await signalToPromise(dirListing.updated);
+        const headerCheckbox = dirListing.renderer.getCheckboxNode!(
+          dirListing.headerNode
+        ) as HTMLInputElement;
+        expect(headerCheckbox.checked).toBe(false);
+        expect(headerCheckbox!.indeterminate).toBe(false);
+      });
+
       describe('when previously unchecked', () => {
         it('check initial conditions', () => {
           const headerCheckbox = dirListing.renderer.getCheckboxNode!(


### PR DESCRIPTION
## References

Fixes issue #12478.

## Code changes

Fixes some logic (edge case error), adds regression test.

## User-facing changes

See issue  #12478.

## Backwards-incompatible changes

Same as PR #12299.
