### PR TITLE
Rename `registerFactory` to `addFactory` in `IToolbarWidgetRegistry`

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -15,7 +15,8 @@ API breaking changes
 ^^^^^^^^^^^^^^^^^^^^
 
 Here is a list of JupyterLab npm packages that encountered API changes and therefore have
-bumped their major version (following semver convention):
+bumped their major version (following semver convention). We want to point out particularly
+``@jupyterlab/documentsearch`` and ``@jupyterlab/toc`` API that have been fully reworked.
 
 - ``@jupyterlab/application`` from 3.x to 4.x
    Major version bump to allow alternate ``ServiceManager`` implementations in ``JupyterFrontEnd``.
@@ -24,6 +25,8 @@ bumped their major version (following semver convention):
    given and allow a shell that meets the ``ILabShell`` interface.
    As a consequence, all other ``@jupyterlab/`` packages have their major version bumped too.
    See https://github.com/jupyterlab/jupyterlab/pull/11537 for more details.
+- ``@jupyterlab/apputils`` from 3.x to 4.x
+   Rename ``IToolbarWidgetRegistry.registerFactory`` to ``IToolbarWidgetRegistry.addFactory``
 - ``@jupyterlab/buildutils`` from 3.x to 4.x
    * The ``create-theme`` script has been removed. If you want to create a new theme extension, you
      should use the `Theme Cookiecutter <https://github.com/jupyterlab/theme-cookiecutter>`_ instead.
@@ -36,6 +39,10 @@ bumped their major version (following semver convention):
    of ``ICompletableAttributes`` interface by ``ICompletionProvider``. To create a completer provider
    for JupyterLab, users need to implement the interface ``ICompletionProvider`` and then register
    this provider with ``ICompletionProviderManager`` token.
+- ``@jupyterlab/console`` from 3.x to 4.x
+   The type of ``IConsoleHistory.sessionContext`` has been updated to ``ISessionContext | null`` instead of ``ISessionContext``.
+   This might break the compilation of plugins accessing the ``sessionContext`` from a ``ConsoleHistory``,
+   in particular those with the strict null checks enabled.
 - ``@jupyterlab/docprovider`` from 3.x to 4.x
    ``WebSocketProviderWithLocks`` has been renamed to ``WebSocketProvider``.
    ``acquireLock`` and ``releaseLock`` have been removed from ``IDocumentProvider``.
@@ -43,10 +50,11 @@ bumped their major version (following semver convention):
 - ``@jupyterlab/documentsearch`` from 3.x to 4.x
    ``@jupyterlab/documentsearch:plugin`` renamed ``@jupyterlab/documentsearch-extension:plugin``
    This may impact application configuration (for instance if the plugin was disabled).
-- ``@jupyterlab/console`` from 3.x to 4.x
-   The type of ``IConsoleHistory.sessionContext`` has been updated to ``ISessionContext | null`` instead of ``ISessionContext``.
-   This might break the compilation of plugins accessing the ``sessionContext`` from a ``ConsoleHistory``,
-   in particular those with the strict null checks enabled.
+   The search provider API has been fully reworked. But the logic is similar, for new type of documents
+   you will need to register a ``ISearchProviderFactory`` to the ``ISearchProviderRegistry``. The
+   factory will build a ``ISearchProvider`` for the document widget.
+- ``@jupyterlab/fileeditor`` from 3.x to 4.x
+   Removed the class ``FileEditorCodeWrapper``, instead, you can use ``CodeEditorWrapper`` from ``@jupyterlab/codeeditor``.
 - ``@jupyterlab/notebook`` from 3.x to 4.x
    * The ``NotebookPanel._onSave`` method is now ``private``.
    * ``NotebookActions.collapseAll`` method renamed to ``NotebookActions.collapseAllHeadings``.
@@ -88,8 +96,6 @@ bumped their major version (following semver convention):
    As a result of the update to TypeScript 4.5+, a couple of interfaces have had their definitions changed.
    The ``anchor`` parameter of ``HoverBox.IOptions`` is now a ``DOMRect`` instead of ``ClientRect``.
    The ``CodeEditor.ICoordinate`` interface now extends ``DOMRectReadOnly`` instead of ``JSONObject, ClientRect``.
-- ``@jupyterlab/fileeditor`` from 3.x to 4.x
-   Removed the class ``FileEditorCodeWrapper``, instead, you can use ``CodeEditorWrapper`` from ``@jupyterlab/codeeditor``.
 
 Extension Development Changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -145,7 +151,7 @@ For more information, have a look at :ref:`testing_with_jest`.
 
 .. _extension_migration_2_3:
 
-JupyterLab 2.x to 3.x
+JupyterLab 2.x to 3.x
 ---------------------
 
 Here are some helpful tips for migrating an extension from JupyterLab 2.x to JupyterLab 3.x.

--- a/packages/apputils/src/tokens.ts
+++ b/packages/apputils/src/tokens.ts
@@ -319,6 +319,20 @@ export namespace ToolbarRegistry {
  */
 export interface IToolbarWidgetRegistry {
   /**
+   * Add a new toolbar item factory
+   *
+   * @param widgetFactory The widget factory name that creates the toolbar
+   * @param toolbarItemName The unique toolbar item
+   * @param factory The factory function that receives the widget containing the toolbar and returns the toolbar widget.
+   * @returns The previously defined factory
+   */
+  addFactory<T extends Widget = Widget>(
+    widgetFactory: string,
+    toolbarItemName: string,
+    factory: (main: T) => Widget
+  ): ((main: T) => Widget) | undefined;
+
+  /**
    * Default toolbar item factory
    */
   defaultFactory: (
@@ -348,6 +362,8 @@ export interface IToolbarWidgetRegistry {
    * @param toolbarItemName The unique toolbar item
    * @param factory The factory function that receives the widget containing the toolbar and returns the toolbar widget.
    * @returns The previously defined factory
+   *
+   * @deprecated since v4 use `addFactory` instead
    */
   registerFactory<T extends Widget = Widget>(
     widgetFactory: string,

--- a/packages/apputils/src/toolbar/registry.ts
+++ b/packages/apputils/src/toolbar/registry.ts
@@ -55,14 +55,14 @@ export class ToolbarWidgetRegistry implements IToolbarWidgetRegistry {
   }
 
   /**
-   * Register a new toolbar item factory
+   * Add a new toolbar item factory
    *
    * @param widgetFactory The widget factory name that creates the toolbar
    * @param toolbarItemName The unique toolbar item
    * @param factory The factory function that receives the widget containing the toolbar and returns the toolbar widget.
    * @returns The previously defined factory
    */
-  registerFactory<T extends Widget = Widget>(
+  addFactory<T extends Widget = Widget>(
     widgetFactory: string,
     toolbarItemName: string,
     factory: (main: T) => Widget
@@ -75,6 +75,24 @@ export class ToolbarWidgetRegistry implements IToolbarWidgetRegistry {
     }
     namespace.set(toolbarItemName, factory);
     return oldFactory;
+  }
+
+  /**
+   * Register a new toolbar item factory
+   *
+   * @param widgetFactory The widget factory name that creates the toolbar
+   * @param toolbarItemName The unique toolbar item
+   * @param factory The factory function that receives the widget containing the toolbar and returns the toolbar widget.
+   * @returns The previously defined factory
+   *
+   * @deprecated since v4 use `addFactory` instead
+   */
+  registerFactory<T extends Widget = Widget>(
+    widgetFactory: string,
+    toolbarItemName: string,
+    factory: (main: T) => Widget
+  ): ((main: T) => Widget) | undefined {
+    return this.addFactory(widgetFactory, toolbarItemName, factory);
   }
 
   protected _defaultFactory: (

--- a/packages/apputils/test/toolbar.spec.ts
+++ b/packages/apputils/test/toolbar.spec.ts
@@ -195,7 +195,7 @@ describe('@jupyterlab/apputils', () => {
           name: 'test'
         };
 
-        registry.registerFactory('factory', item.name, dummy);
+        registry.addFactory('factory', item.name, dummy);
 
         const widget = registry.createWidget('factory', documentWidget, item);
 
@@ -205,7 +205,7 @@ describe('@jupyterlab/apputils', () => {
       });
     });
 
-    describe('#registerFactory', () => {
+    describe('#addFactory', () => {
       it('should return the previous registered factory', () => {
         const defaultFactory = jest.fn();
         const dummy = jest.fn();
@@ -219,11 +219,9 @@ describe('@jupyterlab/apputils', () => {
         };
 
         expect(
-          registry.registerFactory('factory', item.name, dummy)
+          registry.addFactory('factory', item.name, dummy)
         ).toBeUndefined();
-        expect(registry.registerFactory('factory', item.name, dummy2)).toBe(
-          dummy
-        );
+        expect(registry.addFactory('factory', item.name, dummy2)).toBe(dummy);
       });
     });
   });

--- a/packages/csvviewer-extension/src/index.ts
+++ b/packages/csvviewer-extension/src/index.ts
@@ -105,7 +105,7 @@ function activateCsv(
     | undefined;
 
   if (toolbarRegistry) {
-    toolbarRegistry.registerFactory<IDocumentWidget<CSVViewer>>(
+    toolbarRegistry.addFactory<IDocumentWidget<CSVViewer>>(
       FACTORY_CSV,
       'delimiter',
       widget =>
@@ -249,7 +249,7 @@ function activateTsv(
     | undefined;
 
   if (toolbarRegistry) {
-    toolbarRegistry.registerFactory<IDocumentWidget<CSVViewer>>(
+    toolbarRegistry.addFactory<IDocumentWidget<CSVViewer>>(
       FACTORY_TSV,
       'delimiter',
       widget =>

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -402,7 +402,7 @@ const browserWidget: JupyterFrontEndPlugin<void> = {
     browser.title.icon = folderIcon;
 
     // Toolbar
-    toolbarRegistry.registerFactory(
+    toolbarRegistry.addFactory(
       FILE_BROWSER_FACTORY,
       'uploader',
       (browser: FileBrowser) =>

--- a/packages/htmlviewer-extension/src/index.tsx
+++ b/packages/htmlviewer-extension/src/index.tsx
@@ -76,10 +76,10 @@ function activateHTMLViewer(
   const trans = translator.load('jupyterlab');
 
   if (toolbarRegistry) {
-    toolbarRegistry.registerFactory<HTMLViewer>(FACTORY, 'refresh', widget =>
+    toolbarRegistry.addFactory<HTMLViewer>(FACTORY, 'refresh', widget =>
       ToolbarItems.createRefreshButton(widget, translator)
     );
-    toolbarRegistry.registerFactory<HTMLViewer>(FACTORY, 'trust', widget =>
+    toolbarRegistry.addFactory<HTMLViewer>(FACTORY, 'trust', widget =>
       ToolbarItems.createTrustButton(widget, translator)
     );
 

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -979,13 +979,13 @@ function activateWidgetFactory(
     | undefined;
 
   // Register notebook toolbar widgets
-  toolbarRegistry.registerFactory<NotebookPanel>(FACTORY, 'save', panel =>
+  toolbarRegistry.addFactory<NotebookPanel>(FACTORY, 'save', panel =>
     DocToolbarItems.createSaveButton(commands, panel.context.fileChanged)
   );
-  toolbarRegistry.registerFactory<NotebookPanel>(FACTORY, 'cellType', panel =>
+  toolbarRegistry.addFactory<NotebookPanel>(FACTORY, 'cellType', panel =>
     ToolbarItems.createCellTypeItem(panel, translator)
   );
-  toolbarRegistry.registerFactory<NotebookPanel>(FACTORY, 'kernelName', panel =>
+  toolbarRegistry.addFactory<NotebookPanel>(FACTORY, 'kernelName', panel =>
     Toolbar.createKernelNameItem(
       panel.sessionContext,
       sessionContextDialogs,
@@ -993,7 +993,7 @@ function activateWidgetFactory(
     )
   );
 
-  toolbarRegistry.registerFactory<NotebookPanel>(
+  toolbarRegistry.addFactory<NotebookPanel>(
     FACTORY,
     'executionProgress',
     panel => {


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Rename `registerFactory` to `addFactory` in `IToolbarWidgetRegistry`
add is more homogeneous with the application API

The old name has been marked as deprecated

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A