### PR TITLE
Handle missing `preferredPath` from the page config

### DIFF
--- a/packages/filebrowser/src/crumbs.ts
+++ b/packages/filebrowser/src/crumbs.ts
@@ -73,8 +73,8 @@ export class BreadCrumbs extends Widget {
     this.addClass(BREADCRUMB_CLASS);
     this._crumbs = Private.createCrumbs();
     this._crumbSeps = Private.createCrumbSeparators();
-    this._hasPreferred =
-      PageConfig.getOption('preferredPath') !== '/' ? true : false;
+    const hasPreferred = PageConfig.getOption('preferredPath');
+    this._hasPreferred = hasPreferred && hasPreferred !== '/' ? true : false;
     if (this._hasPreferred) {
       this.node.appendChild(this._crumbs[Private.Crumb.Preferred]);
     }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/pull/12297#pullrequestreview-951865576

This allows alternative lab-based applications like JupyterLite to not have to provide a `preferredPath` in the page config, since this might not be relevant in all cases.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Handle the case where `preferredPath` is missing from the page config.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Should be none for most users.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
