### PR TITLE
Add "Open in Simple Mode" contextMenu option

### DIFF
--- a/docs/source/user/index.md
+++ b/docs/source/user/index.md
@@ -23,4 +23,5 @@ export
 language
 rtc
 directories
+ui_customization
 ```

--- a/docs/source/user/ui_customization.rst
+++ b/docs/source/user/ui_customization.rst
@@ -1,0 +1,23 @@
+.. _interface-customization:
+
+Interface Customization
+=======================
+
+.. _context-menu-customization:
+
+Context Menu
+------------
+
+File Browser
+^^^^^^^^^^^^
+
+Users can add a "Open in Simple Mode" context menu option by adding the following to *Settings* -> *Application Context Menu* -> ``contextMenu``
+
+.. code:: json
+
+    {
+        "command": "filebrowser:open-browser-tab",
+        "args": { "mode": "single-document" },
+        "selector": ".jp-DirListing-item[data-isdir=\"false\"]",
+        "rank": 1.6
+    }

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -101,9 +101,6 @@ namespace CommandIDs {
 
   export const openBrowserTab = 'filebrowser:open-browser-tab';
 
-  export const openBrowserTabInSimpleMode =
-    'filebrowser:open-browser-tab-in-simple-mode';
-
   export const paste = 'filebrowser:paste';
 
   export const createNewDirectory = 'filebrowser:create-new-directory';


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fix #12325 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Adds a new `openBrowserTabInSimpleMode` command and plugin.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

This adds a "Open in Simple Mode" contextMenu option to
filebrowser-extension

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

---
Edited to link the issue