### PR TITLE
Allow users to yarn link @jupyterlab/builder

### DIFF
--- a/jupyterlab/federated_labextensions.py
+++ b/jupyterlab/federated_labextensions.py
@@ -275,12 +275,6 @@ def _ensure_builder(ext_path, core_path):
     if "/" in depVersion2:
         with open(osp.join(ext_path, depVersion2, "package.json")) as fid:
             depVersion2 = json.load(fid).get("version")
-    overlap = _test_overlap(depVersion1, depVersion2, drop_prerelease1=True, drop_prerelease2=True)
-    if not overlap:
-        raise ValueError(
-            "Extensions require a devDependency on @jupyterlab/builder@%s, you have a dependency on %s"
-            % (depVersion1, depVersion2)
-        )
     if not osp.exists(osp.join(ext_path, "node_modules")):
         subprocess.check_call(["jlpm"], cwd=ext_path)
 
@@ -291,6 +285,15 @@ def _ensure_builder(ext_path, core_path):
         if osp.dirname(target) == target:
             raise ValueError("Could not find @jupyterlab/builder")
         target = osp.dirname(target)
+
+    with open(osp.join(target, "node_modules", "@jupyterlab", "builder", "package.json")) as fid:
+        depVersion2 = json.load(fid).get("version")
+    overlap = _test_overlap(depVersion1, depVersion2, drop_prerelease1=True, drop_prerelease2=True)
+    if not overlap:
+        raise ValueError(
+            "Extensions require a devDependency on @jupyterlab/builder@%s, you have a dependency on %s"
+            % (depVersion1, depVersion2)
+        )
 
     return osp.join(
         target, "node_modules", "@jupyterlab", "builder", "lib", "build-labextension.js"


### PR DESCRIPTION
Currently the compatable version check for the builder will fail
even if a user has used `yarn link` to use the local instance of
@jupyterlab/builder without also changing the version in thier
package.json

This moves that check farther into the function and allows the case
where the version of @jupyterlab/builder found in `node_modules` is
valid, despite the version in the package.json

## References

https://github.com/jupyterlab/team-compass/issues/135

A follow up to my discussion point at the May 4th 2022 meeting

## Code changes

Moves an error raise farther along in the ensure_builder function and adds a new valid case where the version of @jupyterlab/builder found in node_modules has a valid version despite the wrong version in the package.json

## User-facing changes

none
