### PR TITLE
Update dependency version

### DIFF
--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -64,7 +64,7 @@
     "@lumino/signaling": "^1.10.0",
     "@lumino/virtualdom": "^1.14.0",
     "@lumino/widgets": "^1.30.0",
-    "marked": "^2.0.0",
+    "marked": "^4.0.10",
     "react": "^17.0.1"
   },
   "devDependencies": {

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -70,6 +70,7 @@
   "devDependencies": {
     "@jupyterlab/testutils": "^3.4.0",
     "@types/jest": "^26.0.10",
+    "@types/marked": "^4.0.1",
     "@types/react": "^17.0.0",
     "jest": "^26.4.2",
     "rimraf": "~3.0.0",

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -3,7 +3,7 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-import marked from 'marked';
+import { marked } from 'marked';
 
 import { AttachmentsResolver } from '@jupyterlab/attachments';
 

--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -55,7 +55,7 @@
     "@lumino/signaling": "^1.10.0",
     "@lumino/widgets": "^1.30.0",
     "lodash.escape": "^4.0.1",
-    "marked": "^2.0.0"
+    "marked": "^4.0.10"
   },
   "devDependencies": {
     "@jupyterlab/mathjax2": "^3.4.0",

--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -62,7 +62,7 @@
     "@jupyterlab/testutils": "^3.4.0",
     "@types/jest": "^26.0.10",
     "@types/lodash.escape": "^4.0.6",
-    "@types/marked": "^1.1.0",
+    "@types/marked": "^4.0.1",
     "jest": "^26.4.2",
     "json2html": "^0.0.8",
     "rimraf": "~3.0.0",

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -10,7 +10,7 @@ import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { toArray } from '@lumino/algorithm';
 import escape from 'lodash.escape';
-import marked from 'marked';
+import { marked } from 'marked';
 import { removeMath, replaceMath } from './latex';
 
 /**

--- a/tsconfigdoc.json
+++ b/tsconfigdoc.json
@@ -176,9 +176,6 @@
       "path": "./packages/markdownviewer-extension"
     },
     {
-      "path": "./packages/markedparser-extension"
-    },
-    {
       "path": "./packages/mathjax2"
     },
     {
@@ -248,9 +245,6 @@
       "path": "./packages/statusbar-extension"
     },
     {
-      "path": "./packages/tabmanager-extension"
-    },
-    {
       "path": "./packages/terminal"
     },
     {
@@ -285,12 +279,6 @@
     },
     {
       "path": "./packages/ui-components-extension"
-    },
-    {
-      "path": "./packages/user"
-    },
-    {
-      "path": "./packages/user-extension"
     },
     {
       "path": "./packages/vdom"

--- a/tsconfigdoc.json
+++ b/tsconfigdoc.json
@@ -176,6 +176,9 @@
       "path": "./packages/markdownviewer-extension"
     },
     {
+      "path": "./packages/markedparser-extension"
+    },
+    {
       "path": "./packages/mathjax2"
     },
     {
@@ -245,6 +248,9 @@
       "path": "./packages/statusbar-extension"
     },
     {
+      "path": "./packages/tabmanager-extension"
+    },
+    {
       "path": "./packages/terminal"
     },
     {
@@ -279,6 +285,12 @@
     },
     {
       "path": "./packages/ui-components-extension"
+    },
+    {
+      "path": "./packages/user"
+    },
+    {
+      "path": "./packages/user-extension"
     },
     {
       "path": "./packages/vdom"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3562,10 +3562,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/marked@^1.1.0":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-1.2.2.tgz#1f858a0e690247ecf3b2eef576f98f86e8d960d4"
-  integrity sha512-wLfw1hnuuDYrFz97IzJja0pdVsC0oedtS4QsKH1/inyW9qkLQbXgMUqEQT0MVtUBx3twjWeInUfjQbhBVLECXw==
+"@types/marked@^4.0.1":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-4.0.3.tgz#2098f4a77adaba9ce881c9e0b6baf29116e5acc4"
+  integrity sha512-HnMWQkLJEf/PnxZIfbm0yGJRRZYYMhb++O9M36UCTA9z53uPvVoSlAwJr3XOpDEryb7Hwl1qAx/MV6YIW1RXxg==
 
 "@types/micromatch@^4.0.1":
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11763,10 +11763,15 @@ marked@^0.3.9:
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
   integrity sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==
 
-marked@^2.0.0, marked@^2.0.1, marked@^2.1.1:
+marked@^2.0.1, marked@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/marked/-/marked-2.1.3.tgz#bd017cef6431724fd4b27e0657f5ceb14bff3753"
   integrity sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==
+
+marked@^4.0.10:
+  version "4.0.15"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.15.tgz#0216b7c9d5fcf6ac5042343c41d81a8b1b5e1b4a"
+  integrity sha512-esX5lPdTfG4p8LDkv+obbRCyOKzB+820ZZyMOXJZygZBHrH9b3xXR64X4kT3sPe9Nx8qQXbmcz6kFSMt4Nfk6Q==
 
 marky@^1.2.0:
   version "1.2.2"


### PR DESCRIPTION
Updates `marked` dependency version used in rendermime and cells package, in order to address vulnerability issues found in JupyterLab 3.x.

## References
Addresses vulnerability concerns found in current version used in 3.x, as described in issue #12492

## Code changes
Bumps `marked` dependency version to >= 4.0.10 

## User-facing changes

## Backwards-incompatible changes
Need backport update in all 3.x branches.
