### PR TITLE
fixed shouldOverwrite is never called when rename target exists

### DIFF
--- a/packages/docmanager/src/dialogs.ts
+++ b/packages/docmanager/src/dialogs.ts
@@ -77,15 +77,10 @@ export function renameDialog(
 /**
  * Rename a file, asking for confirmation if it is overwriting another.
  */
-type shouldOverwriteType = (
-  path: string,
-  translator?: ITranslator
-) => Promise<boolean>;
 export function renameFile(
   manager: IDocumentManager,
   oldPath: string,
-  newPath: string,
-  shouldOverwriteCallback: shouldOverwriteType = shouldOverwrite
+  newPath: string
 ): Promise<Contents.IModel | null> {
   return manager.rename(oldPath, newPath).catch(error => {
     if (error.response.status !== 409) {
@@ -94,7 +89,7 @@ export function renameFile(
     }
 
     // otherwise, ask for confirmation
-    return shouldOverwriteCallback(newPath).then((value: boolean) => {
+    return shouldOverwrite(newPath).then((value: boolean) => {
       if (value) {
         return manager.overwrite(oldPath, newPath);
       }

--- a/packages/docmanager/test/dialog.spec.ts
+++ b/packages/docmanager/test/dialog.spec.ts
@@ -1,0 +1,84 @@
+import { DocumentRegistry } from '@jupyterlab/docregistry';
+import { Contents, ServiceManager } from '@jupyterlab/services';
+import { Widget } from '@lumino/widgets';
+import * as Mock from '@jupyterlab/testutils/lib/mock';
+import { DocumentManager, renameFile } from '../src';
+
+function shouldOverwriteFalse(path: string): Promise<boolean> {
+  return Promise.resolve(false);
+}
+
+describe('docregistry/dialog', () => {
+  let manager: DocumentManager;
+  let services: ServiceManager.IManager;
+  let alreadyExistsError: any = {};
+
+  beforeAll(() => {
+    const registry = new DocumentRegistry({});
+    services = new Mock.ServiceManagerMock();
+    manager = new DocumentManager({
+      registry,
+      manager: services,
+      opener: {
+        open: (widget: Widget) => {
+          // no-op
+        }
+      }
+    });
+  });
+
+  beforeEach(() => {
+    alreadyExistsError = {
+      name: 'file already exists',
+      message: 'File already exists: bar.ipynb',
+      response: {
+        status: 409
+      }
+    };
+    manager.rename = (oldPath, newPath) => {
+      const renamePromise = new Promise(function (resolve, reject) {
+        throw alreadyExistsError;
+      }) as Promise<Contents.IModel>;
+      return renamePromise;
+    };
+  });
+
+  describe('@jupyterlab/docmanager', () => {
+    describe('#renameFile()', () => {
+      it('should show overwrite dialog when file is already existing', async () => {
+        alreadyExistsError.response.status = 409;
+        await renameFile(
+          manager,
+          'foo.ipynb',
+          'bar.ipynb',
+          shouldOverwriteFalse
+        ).catch(error => {
+          // error should be 'File not renamed'
+          expect(error).not.toBe(alreadyExistsError);
+        });
+      });
+      it('should throw error on no status', async () => {
+        alreadyExistsError.response = {};
+        await renameFile(
+          manager,
+          'foo.ipynb',
+          'bar.ipynb',
+          shouldOverwriteFalse
+        ).catch(error => {
+          expect(error).toBe(alreadyExistsError);
+        });
+      });
+      it('should throw error on not 409 status', async () => {
+        alreadyExistsError.response.status = 408;
+        await renameFile(
+          manager,
+          'foo.ipynb',
+          'bar.ipynb',
+          shouldOverwriteFalse
+        ).catch(error => {
+          expect(error).toBe(alreadyExistsError);
+        });
+      });
+    });
+  });
+});

--- a/packages/docmanager/test/dialog.spec.ts
+++ b/packages/docmanager/test/dialog.spec.ts
@@ -1,12 +1,9 @@
+import { DocumentManager, renameFile } from '@jupyterlab/docmanager';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { ServiceManager } from '@jupyterlab/services';
-import { Widget } from '@lumino/widgets';
+import { dismissDialog } from '@jupyterlab/testutils';
 import * as Mock from '@jupyterlab/testutils/lib/mock';
-import { DocumentManager, renameFile } from '../src';
-
-function shouldOverwriteFalse(path: string): Promise<boolean> {
-  return Promise.resolve(false);
-}
+import { Widget } from '@lumino/widgets';
 
 describe('docregistry/dialog', () => {
   let manager: DocumentManager;
@@ -43,37 +40,30 @@ describe('docregistry/dialog', () => {
     describe('#renameFile()', () => {
       it('should show overwrite dialog when file is already existing', async () => {
         alreadyExistsError.response.status = 409;
-        await renameFile(
-          manager,
-          'foo.ipynb',
-          'bar.ipynb',
-          shouldOverwriteFalse
-        ).catch(error => {
-          // error should be 'File not renamed'
-          expect(error).not.toBe(alreadyExistsError);
-        });
+        await expect(
+          Promise.all([
+            dismissDialog(),
+            renameFile(manager, 'foo.ipynb', 'bar.ipynb')
+          ])
+        ).rejects.toBe('File not renamed');
       });
       it('should throw error on no status', async () => {
         alreadyExistsError.response = {};
-        await renameFile(
-          manager,
-          'foo.ipynb',
-          'bar.ipynb',
-          shouldOverwriteFalse
-        ).catch(error => {
-          expect(error).toBe(alreadyExistsError);
-        });
+        await expect(
+          Promise.all([
+            dismissDialog(),
+            renameFile(manager, 'foo.ipynb', 'bar.ipynb')
+          ])
+        ).rejects.toBe(alreadyExistsError);
       });
       it('should throw error on not 409 status', async () => {
         alreadyExistsError.response.status = 408;
-        await renameFile(
-          manager,
-          'foo.ipynb',
-          'bar.ipynb',
-          shouldOverwriteFalse
-        ).catch(error => {
-          expect(error).toBe(alreadyExistsError);
-        });
+        await expect(
+          Promise.all([
+            dismissDialog(),
+            renameFile(manager, 'foo.ipynb', 'bar.ipynb')
+          ])
+        ).rejects.toBe(alreadyExistsError);
       });
     });
   });

--- a/packages/docmanager/test/dialog.spec.ts
+++ b/packages/docmanager/test/dialog.spec.ts
@@ -1,5 +1,5 @@
 import { DocumentRegistry } from '@jupyterlab/docregistry';
-import { Contents, ServiceManager } from '@jupyterlab/services';
+import { ServiceManager } from '@jupyterlab/services';
 import { Widget } from '@lumino/widgets';
 import * as Mock from '@jupyterlab/testutils/lib/mock';
 import { DocumentManager, renameFile } from '../src';
@@ -35,12 +35,8 @@ describe('docregistry/dialog', () => {
         status: 409
       }
     };
-    manager.rename = (oldPath, newPath) => {
-      const renamePromise = new Promise(function (resolve, reject) {
-        throw alreadyExistsError;
-      }) as Promise<Contents.IModel>;
-      return renamePromise;
-    };
+    const spyRename = jest.spyOn(manager, 'rename');
+    spyRename.mockRejectedValue(alreadyExistsError);
   });
 
   describe('@jupyterlab/docmanager', () => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fix #12541

## Code changes

<!-- Describe the code changes and how they address the issue. -->

The main fix is to not look at `error.message` to determine if the error was cause by an already existing notebook with this name but `error.response.status`.

I also added 3 tests to make sure `shouldOverwrite` is called when `error.response.status` is `409`. And that other errors are re-thrown and don't cause `shouldOverwrite` to be called.

I'm a javascript newbie and had trouble to mock `shouldOverwrite`. Therefore I added a callback parameter to `renameFile` to be able to pass a mock callback in the tests. But probably somebody with more javascript experience should have a look at the tests, there's probably an easier way.

## User-facing changes

Nothing really changed besides the missing dialog is now shown.

## Backwards-incompatible changes

---
Edited to link the issue