### PR TITLE
Fix loading toolbar factory twice

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -1200,7 +1200,7 @@ namespace Private {
   ): Promise<void> {
     const trans = translator.load('jupyterlab');
     const pluginId = contextMenuPlugin.id;
-    let canonical: ISettingRegistry.ISchema | null;
+    let canonical: ISettingRegistry.ISchema | null = null;
     let loaded: { [name: string]: ISettingRegistry.IContextMenuItem[] } = {};
 
     /**
@@ -1286,8 +1286,6 @@ namespace Private {
 
     // Repopulate the canonical variable after the setting registry has
     // preloaded all initial plugins.
-    canonical = null;
-
     const settings = await registry.load(pluginId);
 
     const contextItems: ISettingRegistry.IContextMenuItem[] =

--- a/packages/apputils/src/toolbar/factory.ts
+++ b/packages/apputils/src/toolbar/factory.ts
@@ -62,7 +62,6 @@ async function setToolbarItems(
   const trans = translator.load('jupyterlab');
   let canonical: ISettingRegistry.ISchema | null = null;
   let loaded: { [name: string]: ISettingRegistry.IToolbarItem[] } = {};
-  let gatheredItems = new Array<ISettingRegistry.IToolbarItem>();
 
   /**
    * Populate the plugin's schema defaults.
@@ -198,13 +197,11 @@ async function setToolbarItems(
   });
 
   const transferSettings = (newItems: ISettingRegistry.IToolbarItem[]) => {
-    // Need to keep the non-filtered items to reconciliate correctly for late plugin registration.
-    gatheredItems = newItems;
     // This is not optimal but safer because a toolbar item with the same
     // name cannot be inserted (it will be a no-op). But that could happen
     // if the settings are changing the items order.
     toolbarItems.clear();
-    toolbarItems.pushAll(gatheredItems.filter(item => !item.disabled));
+    toolbarItems.pushAll(newItems.filter(item => !item.disabled));
   };
 
   // Initialize the toolbar

--- a/packages/apputils/src/toolbar/factory.ts
+++ b/packages/apputils/src/toolbar/factory.ts
@@ -190,7 +190,7 @@ async function setToolbarItems(
       // As the plugin storing the toolbar definition is transformed using
       // the above definition, if it changes, this means that a request to
       // reload was triggered. Hence the toolbar definitions from the other
-      // plugins has been automatically reset during the transform step.
+      // plugins have been automatically reset during the transform step.
       if (plugin !== pluginId) {
         // If a plugin changed its toolbar items
         const oldItems = loaded[plugin] ?? [];

--- a/packages/apputils/src/toolbar/factory.ts
+++ b/packages/apputils/src/toolbar/factory.ts
@@ -62,6 +62,7 @@ async function setToolbarItems(
   const trans = translator.load('jupyterlab');
   let canonical: ISettingRegistry.ISchema | null;
   let loaded: { [name: string]: ISettingRegistry.IToolbarItem[] } = {};
+  let gatheredItems = new Array<ISettingRegistry.IToolbarItem>();
 
   /**
    * Populate the plugin's schema defaults.
@@ -194,7 +195,7 @@ async function setToolbarItems(
           loaded[plugin] = JSONExt.deepCopy(newItems);
           const newList = (
             SettingRegistry.reconcileToolbarItems(
-              toArray(toolbarItems),
+              gatheredItems,
               newItems,
               false
             ) ?? []
@@ -210,11 +211,13 @@ async function setToolbarItems(
   });
 
   const transferSettings = (newItems: ISettingRegistry.IToolbarItem[]) => {
+    // Need to keep the non-filtered items to reconciliate correctly for late plugin registration.
+    gatheredItems = newItems;
     // This is not optimal but safer because a toolbar item with the same
     // name cannot be inserted (it will be a no-op). But that could happen
     // if the settings are changing the items order.
     toolbarItems.clear();
-    toolbarItems.pushAll(newItems.filter(item => !item.disabled));
+    toolbarItems.pushAll(gatheredItems.filter(item => !item.disabled));
   };
 
   // Initialize the toolbar

--- a/packages/apputils/src/toolbar/factory.ts
+++ b/packages/apputils/src/toolbar/factory.ts
@@ -189,7 +189,7 @@ async function setToolbarItems(
     registry.pluginChanged.connect(async (sender, plugin) => {
       // As the plugin storing the toolbar definition is transformed using
       // the above definition, if it changes, this means that a request to
-      // reloaded was triggered. Hence the toolbar definitions from the other
+      // reload was triggered. Hence the toolbar definitions from the other
       // plugins has been automatically reset during the transform step.
       if (plugin !== pluginId) {
         // If a plugin changed its toolbar items

--- a/packages/apputils/src/toolbar/factory.ts
+++ b/packages/apputils/src/toolbar/factory.ts
@@ -98,17 +98,16 @@ async function setToolbarItems(
       // Apply default value as last step to take into account overrides.json
       // The standard toolbars default is [] as the plugin must use
       // `jupyter.lab.toolbars.<factory>` to define its default value.
-      schema.properties![
-        propertyId
-      ].default = SettingRegistry.reconcileToolbarItems(
-        pluginDefaults,
-        schema.properties![propertyId].default as any[],
-        true
-      )!.sort(
-        (a, b) =>
-          (a.rank ?? DEFAULT_TOOLBAR_ITEM_RANK) -
-          (b.rank ?? DEFAULT_TOOLBAR_ITEM_RANK)
-      );
+      schema.properties![propertyId].default =
+        SettingRegistry.reconcileToolbarItems(
+          pluginDefaults,
+          schema.properties![propertyId].default as any[],
+          true
+        )!.sort(
+          (a, b) =>
+            (a.rank ?? DEFAULT_TOOLBAR_ITEM_RANK) -
+            (b.rank ?? DEFAULT_TOOLBAR_ITEM_RANK)
+        );
     }
 
     // Transform the plugin object to return different schema than the default.
@@ -162,7 +161,7 @@ async function setToolbarItems(
       }
     });
   } catch (error) {
-    if (error.message === `${pluginId} already has a transformer.`) {
+    if (error.name === 'TransformError') {
       // Assume the existing transformer is the toolbar builder transformer
       // from another factory set up.
       listenPlugin = false;

--- a/packages/apputils/test/toolbar.spec.ts
+++ b/packages/apputils/test/toolbar.spec.ts
@@ -12,22 +12,22 @@ import { ISettingRegistry, SettingRegistry } from '@jupyterlab/settingregistry';
 import { IDataConnector } from '@jupyterlab/statedb';
 import {
   createSessionContext,
-  framePromise
-  // JupyterServer
+  framePromise,
+  JupyterServer
 } from '@jupyterlab/testutils';
 import { ITranslator } from '@jupyterlab/translation';
 import { JSONExt, PromiseDelegate } from '@lumino/coreutils';
 import { Widget } from '@lumino/widgets';
 
-// const server = new JupyterServer();
+const server = new JupyterServer();
 
-// beforeAll(async () => {
-//   await server.start();
-// });
+beforeAll(async () => {
+  await server.start();
+});
 
-// afterAll(async () => {
-//   await server.shutdown();
-// });
+afterAll(async () => {
+  await server.shutdown();
+});
 
 describe('@jupyterlab/apputils', () => {
   describe('Toolbar', () => {

--- a/packages/apputils/test/toolbar.spec.ts
+++ b/packages/apputils/test/toolbar.spec.ts
@@ -12,22 +12,22 @@ import { ISettingRegistry, SettingRegistry } from '@jupyterlab/settingregistry';
 import { IDataConnector } from '@jupyterlab/statedb';
 import {
   createSessionContext,
-  framePromise,
-  JupyterServer
+  framePromise
+  // JupyterServer
 } from '@jupyterlab/testutils';
 import { ITranslator } from '@jupyterlab/translation';
 import { JSONExt, PromiseDelegate } from '@lumino/coreutils';
 import { Widget } from '@lumino/widgets';
 
-const server = new JupyterServer();
+// const server = new JupyterServer();
 
-beforeAll(async () => {
-  await server.start();
-});
+// beforeAll(async () => {
+//   await server.start();
+// });
 
-afterAll(async () => {
-  await server.shutdown();
-});
+// afterAll(async () => {
+//   await server.shutdown();
+// });
 
 describe('@jupyterlab/apputils', () => {
   describe('Toolbar', () => {
@@ -424,8 +424,6 @@ describe('@jupyterlab/apputils', () => {
         if (
           !JSONExt.deepEqual(baseToolbar, barPlugin.composite['toolbar'] as any)
         ) {
-          console.log(baseToolbar);
-          console.log(barPlugin.composite['toolbar']);
           waitForChange.resolve();
         }
       });

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -785,7 +785,7 @@ namespace Private {
     translator: ITranslator
   ): Promise<void> {
     const trans = translator.load('jupyterlab');
-    let canonical: ISettingRegistry.ISchema | null;
+    let canonical: ISettingRegistry.ISchema | null = null;
     let loaded: { [name: string]: ISettingRegistry.IMenu[] } = {};
 
     /**
@@ -863,8 +863,6 @@ namespace Private {
 
     // Repopulate the canonical variable after the setting registry has
     // preloaded all initial plugins.
-    canonical = null;
-
     const settings = await registry.load(PLUGIN_ID);
 
     const currentMenus: ISettingRegistry.IMenu[] =

--- a/packages/settingregistry/src/settingregistry.ts
+++ b/packages/settingregistry/src/settingregistry.ts
@@ -1191,7 +1191,7 @@ export namespace SettingRegistry {
 
     // Merge array element depending on the type
     addition.forEach(item => {
-      // Name must be unique so it sufficient to only compare it
+      // Name must be unique so it's sufficient to only compare it
       const refIndex = items.findIndex(ref => ref.name === item.name);
       if (refIndex < 0) {
         items.push({ ...item });

--- a/packages/settingregistry/src/settingregistry.ts
+++ b/packages/settingregistry/src/settingregistry.ts
@@ -1191,39 +1191,19 @@ export namespace SettingRegistry {
 
     // Merge array element depending on the type
     addition.forEach(item => {
-      switch (item.type) {
-        case 'command':
-          if (item.command) {
-            const refIndex = items.findIndex(
-              ref =>
-                ref.name === item.name &&
-                ref.command === item.command &&
-                JSONExt.deepEqual(ref.args ?? {}, item.args ?? {})
-            );
-            if (refIndex < 0) {
-              items.push({ ...item });
-            } else {
-              if (warn) {
-                console.warn(
-                  `Toolbar item for command '${item.command}' is duplicated.`
-                );
-              }
-              items[refIndex] = { ...items[refIndex], ...item };
-            }
-          }
-          break;
-        case 'spacer':
-        default: {
-          const refIndex = items.findIndex(ref => ref.name === item.name);
-          if (refIndex < 0) {
-            items.push({ ...item });
-          } else {
-            if (warn) {
-              console.warn(`Toolbar item '${item.name}' is duplicated.`);
-            }
-            items[refIndex] = { ...items[refIndex], ...item };
-          }
+      // Name must be unique so it sufficient to only compare it
+      const refIndex = items.findIndex(ref => ref.name === item.name);
+      if (refIndex < 0) {
+        if (item.type === 'command' && !item.command) {
+          // Don't add invalid item
+          return;
         }
+        items.push({ ...item });
+      } else {
+        if (warn) {
+          console.warn(`Toolbar item '${item.name}' is duplicated.`);
+        }
+        items[refIndex] = { ...items[refIndex], ...item };
       }
     });
 

--- a/packages/settingregistry/src/settingregistry.ts
+++ b/packages/settingregistry/src/settingregistry.ts
@@ -1194,13 +1194,12 @@ export namespace SettingRegistry {
       // Name must be unique so it sufficient to only compare it
       const refIndex = items.findIndex(ref => ref.name === item.name);
       if (refIndex < 0) {
-        if (item.type === 'command' && !item.command) {
-          // Don't add invalid item
-          return;
-        }
         items.push({ ...item });
       } else {
-        if (warn) {
+        if (
+          warn &&
+          JSONExt.deepEqual(Object.keys(item), Object.keys(items[refIndex]))
+        ) {
           console.warn(`Toolbar item '${item.name}' is duplicated.`);
         }
         items[refIndex] = { ...items[refIndex], ...item };

--- a/packages/settingregistry/src/settingregistry.ts
+++ b/packages/settingregistry/src/settingregistry.ts
@@ -461,7 +461,9 @@ export class SettingRegistry implements ISettingRegistry {
     const transformers = this._transformers;
 
     if (plugin in transformers) {
-      throw new Error(`${plugin} already has a transformer.`);
+      const error = new Error(`${plugin} already has a transformer.`);
+      error.name = 'TransformError';
+      throw error;
     }
 
     transformers[plugin] = {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Seen in https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/pull/32
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
- Tolerate to create a toolbar factory multiple times from the same plugin (like multiple filebrowser with the same buttons).
- For late plugin registration, we reload all plugin toolbar definitions as for the shortcuts.
- Compare only the toolbar item name to determine if definitions must be merged

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A