### PR TITLE
Automated Changelog Entry for 3.4.1 on 3.4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,34 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.4.1
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.4.0...d8d94b351da08181d4d5e0493539c0eb082a1516))
+
+### Enhancements made
+
+- Setting to use the advanced setting editor for the settings [#12466](https://github.com/jupyterlab/jupyterlab/pull/12466) ([@echarles](https://github.com/echarles))
+
+### Bugs fixed
+
+- Allow users to yarn link @jupyterlab/builder [#12533](https://github.com/jupyterlab/jupyterlab/pull/12533) ([@ajbozarth](https://github.com/ajbozarth))
+- Get Auto Close Brackets working consistently in Consoles [#12508](https://github.com/jupyterlab/jupyterlab/pull/12508) ([@Jessie-Newman](https://github.com/Jessie-Newman))
+- Handled new dialog creation with no buttons [#12496](https://github.com/jupyterlab/jupyterlab/pull/12496) ([@Jnnamchi](https://github.com/Jnnamchi))
+- Handle missing `preferredPath` from the page config [#12521](https://github.com/jupyterlab/jupyterlab/pull/12521) ([@jtpio](https://github.com/jtpio))
+
+### Maintenance and upkeep improvements
+
+- Backport PR #12551: Add cell-toolbar to CI and labeler [#12555](https://github.com/jupyterlab/jupyterlab/pull/12555) ([@fcollonval](https://github.com/fcollonval))
+- Allow bot PRs to be automatically labeled [#12509](https://github.com/jupyterlab/jupyterlab/pull/12509) ([@blink1073](https://github.com/blink1073))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-05-03&to=2022-05-12&type=c))
+
+[@ajbozarth](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aajbozarth+updated%3A2022-05-03..2022-05-12&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-05-03..2022-05-12&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-05-03..2022-05-12&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-05-03..2022-05-12&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-05-03..2022-05-12&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-05-03..2022-05-12&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-05-03..2022-05-12&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-05-03..2022-05-12&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.4.0
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.3.4...06e043de7cc211e360711fd042b6b474e9b0037b))
@@ -67,8 +95,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-04-15&to=2022-05-03&type=c))
 
 [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2022-04-15..2022-05-03&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2022-04-15..2022-05-03&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2022-04-15..2022-05-03&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-04-15..2022-05-03&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-04-15..2022-05-03&type=Issues) | [@gabalafou](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agabalafou+updated%3A2022-04-15..2022-05-03&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-04-15..2022-05-03&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-04-15..2022-05-03&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-04-15..2022-05-03&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2022-04-15..2022-05-03&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-04-15..2022-05-03&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-04-15..2022-05-03&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-04-15..2022-05-03&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-04-15..2022-05-03&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## v3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 
 ### Maintenance and upkeep improvements
 
-- Backport PR #12551: Add cell-toolbar to CI and labeler [#12555](https://github.com/jupyterlab/jupyterlab/pull/12555) ([@fcollonval](https://github.com/fcollonval))
+- Add cell-toolbar to CI and labeler [#12555](https://github.com/jupyterlab/jupyterlab/pull/12555) ([@fcollonval](https://github.com/fcollonval))
 - Allow bot PRs to be automatically labeled [#12509](https://github.com/jupyterlab/jupyterlab/pull/12509) ([@blink1073](https://github.com/blink1073))
 
 ### Contributors to this release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 - Get Auto Close Brackets working consistently in Consoles [#12508](https://github.com/jupyterlab/jupyterlab/pull/12508) ([@Jessie-Newman](https://github.com/Jessie-Newman))
 - Handled new dialog creation with no buttons [#12496](https://github.com/jupyterlab/jupyterlab/pull/12496) ([@Jnnamchi](https://github.com/Jnnamchi))
 - Handle missing `preferredPath` from the page config [#12521](https://github.com/jupyterlab/jupyterlab/pull/12521) ([@jtpio](https://github.com/jtpio))
+- Setting form editor has a formState to avoid focus lost [#12490](https://github.com/jupyterlab/jupyterlab/pull/12490) ([@echarles](https://github.com/echarles))
 
 ### Maintenance and upkeep improvements
 


### PR DESCRIPTION
Automated Changelog Entry for 3.4.1 on 3.4.x
```
Python version: 3.4.1
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.4.1
@jupyterlab/buildutils: 3.4.1
@jupyterlab/template: 3.4.1
@jupyterlab/application-top: 3.4.1
@jupyterlab/example-app: 3.4.1
@jupyterlab/example-cell: 3.4.1
@jupyterlab/example-console: 3.4.1
@jupyterlab/example-federated: 2.5.1
@jupyterlab/example-federated-core: 2.5.1
@jupyterlab/example-federated-md: 2.5.1
@jupyterlab/example-federated-middle: 2.5.1
@jupyterlab/example-federated-phosphor: 2.5.1
@jupyterlab/example-filebrowser: 3.4.1
@jupyterlab/example-notebook: 3.4.1
@jupyterlab/example-terminal: 3.4.1
@jupyterlab/galata: 4.3.1
@jupyterlab/mock-extension: 3.4.1
@jupyterlab/mock-consumer: 3.4.1
@jupyterlab/mock-provider: 3.4.1
@jupyterlab/mock-token: 3.4.1
@jupyterlab/application: 3.4.1
@jupyterlab/application-extension: 3.4.1
@jupyterlab/apputils: 3.4.1
@jupyterlab/apputils-extension: 3.4.1
@jupyterlab/attachments: 3.4.1
@jupyterlab/cell-toolbar: 3.4.1
@jupyterlab/cell-toolbar-extension: 3.4.1
@jupyterlab/cells: 3.4.1
@jupyterlab/celltags: 3.4.1
@jupyterlab/celltags-extension: 3.4.1
@jupyterlab/codeeditor: 3.4.1
@jupyterlab/codemirror: 3.4.1
@jupyterlab/codemirror-extension: 3.4.1
@jupyterlab/completer: 3.4.1
@jupyterlab/completer-extension: 3.4.1
@jupyterlab/console: 3.4.1
@jupyterlab/console-extension: 3.4.1
@jupyterlab/coreutils: 5.4.1
@jupyterlab/csvviewer: 3.4.1
@jupyterlab/csvviewer-extension: 3.4.1
@jupyterlab/debugger: 3.4.1
@jupyterlab/debugger-extension: 3.4.1
@jupyterlab/docmanager: 3.4.1
@jupyterlab/docmanager-extension: 3.4.1
@jupyterlab/docprovider: 3.4.1
@jupyterlab/docprovider-extension: 3.4.1
@jupyterlab/docregistry: 3.4.1
@jupyterlab/documentsearch: 3.4.1
@jupyterlab/documentsearch-extension: 3.4.1
@jupyterlab/extensionmanager: 3.4.1
@jupyterlab/extensionmanager-extension: 3.4.1
@jupyterlab/filebrowser: 3.4.1
@jupyterlab/filebrowser-extension: 3.4.1
@jupyterlab/fileeditor: 3.4.1
@jupyterlab/fileeditor-extension: 3.4.1
@jupyterlab/help-extension: 3.4.1
@jupyterlab/htmlviewer: 3.4.1
@jupyterlab/htmlviewer-extension: 3.4.1
@jupyterlab/hub-extension: 3.4.1
@jupyterlab/imageviewer: 3.4.1
@jupyterlab/imageviewer-extension: 3.4.1
@jupyterlab/inspector: 3.4.1
@jupyterlab/inspector-extension: 3.4.1
@jupyterlab/javascript-extension: 3.4.1
@jupyterlab/json-extension: 3.4.1
@jupyterlab/launcher: 3.4.1
@jupyterlab/launcher-extension: 3.4.1
@jupyterlab/logconsole: 3.4.1
@jupyterlab/logconsole-extension: 3.4.1
@jupyterlab/mainmenu: 3.4.1
@jupyterlab/mainmenu-extension: 3.4.1
@jupyterlab/markdownviewer: 3.4.1
@jupyterlab/markdownviewer-extension: 3.4.1
@jupyterlab/mathjax2: 3.4.1
@jupyterlab/mathjax2-extension: 3.4.1
@jupyterlab/metapackage: 3.4.1
@jupyterlab/nbconvert-css: 3.4.1
@jupyterlab/nbformat: 3.4.1
@jupyterlab/notebook: 3.4.1
@jupyterlab/notebook-extension: 3.4.1
@jupyterlab/observables: 4.4.1
@jupyterlab/outputarea: 3.4.1
@jupyterlab/pdf-extension: 3.4.1
@jupyterlab/property-inspector: 3.4.1
@jupyterlab/rendermime: 3.4.1
@jupyterlab/rendermime-extension: 3.4.1
@jupyterlab/rendermime-interfaces: 3.4.1
@jupyterlab/running: 3.4.1
@jupyterlab/running-extension: 3.4.1
@jupyterlab/services: 6.4.1
@jupyterlab/example-services-browser: 3.4.1
node-example: 3.4.1
@jupyterlab/example-services-outputarea: 3.4.1
@jupyterlab/settingeditor: 3.4.1
@jupyterlab/settingeditor-extension: 3.4.1
@jupyterlab/settingregistry: 3.4.1
@jupyterlab/shared-models: 3.4.1
@jupyterlab/shortcuts-extension: 3.4.1
@jupyterlab/statedb: 3.4.1
@jupyterlab/statusbar: 3.4.1
@jupyterlab/statusbar-extension: 3.4.1
@jupyterlab/terminal: 3.4.1
@jupyterlab/terminal-extension: 3.4.1
@jupyterlab/theme-dark-extension: 3.4.1
@jupyterlab/theme-light-extension: 3.4.1
@jupyterlab/toc: 5.4.1
@jupyterlab/toc-extension: 5.4.1
@jupyterlab/tooltip: 3.4.1
@jupyterlab/tooltip-extension: 3.4.1
@jupyterlab/translation: 3.4.1
@jupyterlab/translation-extension: 3.4.1
@jupyterlab/ui-components: 3.4.1
@jupyterlab/ui-components-extension: 3.4.1
@jupyterlab/vdom: 3.4.1
@jupyterlab/vdom-extension: 3.4.1
@jupyterlab/vega5-extension: 3.4.1
@jupyterlab/testutils: 3.4.1
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.4.x  |
| Version Spec | patch |
| Since | v3.4.0 |