### PR TITLE
Remove manuall added entry in changelog for 3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 - Get Auto Close Brackets working consistently in Consoles [#12508](https://github.com/jupyterlab/jupyterlab/pull/12508) ([@Jessie-Newman](https://github.com/Jessie-Newman))
 - Handled new dialog creation with no buttons [#12496](https://github.com/jupyterlab/jupyterlab/pull/12496) ([@Jnnamchi](https://github.com/Jnnamchi))
 - Handle missing `preferredPath` from the page config [#12521](https://github.com/jupyterlab/jupyterlab/pull/12521) ([@jtpio](https://github.com/jtpio))
-- Setting form editor has a formState to avoid focus lost [#12490](https://github.com/jupyterlab/jupyterlab/pull/12490) ([@echarles](https://github.com/echarles))
 
 ### Maintenance and upkeep improvements
 


### PR DESCRIPTION
## References

https://github.com/jupyterlab/jupyterlab/pull/12560

## Code changes

For some reason (milestone not correctly set on the PR https://github.com/jupyterlab/jupyterlab/pull/12560), a bug entry was not in the changelog. I have added it manually but now the full release fails with 

```
Found 26 items, which will take 1 pages
Found 25 items, which will take 1 pages
```

Correctly setting the milestone does not help.

## User-facing changes

None

## Backwards-incompatible changes

None.
