### PR TITLE
Stop creating search provider for status

### DIFF
--- a/packages/documentsearch-extension/src/index.ts
+++ b/packages/documentsearch-extension/src/index.ts
@@ -57,8 +57,7 @@ const labShellWidgetListener: JupyterFrontEndPlugin<void> = {
       if (!widget) {
         return;
       }
-      const providerForWidget = registry.getProvider(widget);
-      if (providerForWidget) {
+      if (registry.hasProvider(widget)) {
         widget.addClass(SEARCHABLE_CLASS);
       } else {
         widget.removeClass(SEARCHABLE_CLASS);
@@ -135,7 +134,7 @@ const extension: JupyterFrontEndPlugin<ISearchProviderRegistry> = {
       if (!widget) {
         return false;
       }
-      return registry.getProvider(widget) !== undefined;
+      return registry.hasProvider(widget);
     };
 
     const getSearchWidget = (widget: Widget | null) => {

--- a/packages/documentsearch/src/searchproviderregistry.ts
+++ b/packages/documentsearch/src/searchproviderregistry.ts
@@ -46,10 +46,30 @@ export class SearchProviderRegistry implements ISearchProviderRegistry {
    * @param widget - The widget to search over.
    * @returns the search provider, or undefined if none exists.
    */
-  getProvider<T extends Widget = Widget>(
-    widget: T
-  ): ISearchProvider | undefined {
-    return this._findMatchingProvider(this._providerMap, widget);
+  getProvider(widget: Widget): ISearchProvider | undefined {
+    // iterate through all providers and ask each one if it can search on the
+    // widget.
+    for (const P of this._providerMap.values()) {
+      if (P.isApplicable(widget)) {
+        return P.createNew(widget, this.translator);
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Whether the registry as a matching provider for the widget.
+   *
+   * @param widget - The widget to search over.
+   * @returns Provider existence
+   */
+  hasProvider(widget: Widget): boolean {
+    for (const P of this._providerMap.values()) {
+      if (P.isApplicable(widget)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -60,27 +80,6 @@ export class SearchProviderRegistry implements ISearchProviderRegistry {
     return this._changed;
   }
 
-  private _findMatchingProvider<T extends Widget = Widget>(
-    providerMap: Private.ProviderMap,
-    widget: T
-  ): ISearchProvider | undefined {
-    // iterate through all providers and ask each one if it can search on the
-    // widget.
-    for (const P of providerMap.values()) {
-      if (P.isApplicable(widget)) {
-        return P.createNew(widget, this.translator);
-      }
-    }
-    return undefined;
-  }
-
   private _changed = new Signal<this, void>(this);
-  private _providerMap: Private.ProviderMap = new Map<
-    string,
-    ISearchProviderFactory<Widget>
-  >();
-}
-
-namespace Private {
-  export type ProviderMap = Map<string, ISearchProviderFactory<Widget>>;
+  private _providerMap = new Map<string, ISearchProviderFactory<Widget>>();
 }

--- a/packages/documentsearch/src/tokens.ts
+++ b/packages/documentsearch/src/tokens.ts
@@ -197,6 +197,14 @@ export interface ISearchProviderRegistry {
   getProvider(widget: Widget): ISearchProvider | undefined;
 
   /**
+   * Whether the registry as a matching provider for the widget.
+   *
+   * @param widget - The widget to search over.
+   * @returns Provider existence
+   */
+  hasProvider(widget: Widget): boolean;
+
+  /**
    * Signal that emits when a new search provider has been registered
    * or removed.
    */


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Seen when working on https://github.com/jupyterlab/jupyterlab/pull/12554
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Add new method `hasProvider` to avoid generating search provider when only availability status is needed

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A