### PR TITLE
Building extensions fail if not using latest patch

### DIFF
--- a/jupyterlab/federated_labextensions.py
+++ b/jupyterlab/federated_labextensions.py
@@ -288,9 +288,13 @@ def _ensure_builder(ext_path, core_path):
 
     overlap = _test_overlap(depVersion1, depVersion2, drop_prerelease1=True, drop_prerelease2=True)
     if not overlap:
-        with open(osp.join(target, "node_modules", "@jupyterlab", "builder", "package.json")) as fid:
+        with open(
+            osp.join(target, "node_modules", "@jupyterlab", "builder", "package.json")
+        ) as fid:
             depVersion2 = json.load(fid).get("version")
-        overlap = _test_overlap(depVersion1, depVersion2, drop_prerelease1=True, drop_prerelease2=True)
+        overlap = _test_overlap(
+            depVersion1, depVersion2, drop_prerelease1=True, drop_prerelease2=True
+        )
 
     if not overlap:
         raise ValueError(

--- a/jupyterlab/federated_labextensions.py
+++ b/jupyterlab/federated_labextensions.py
@@ -286,9 +286,12 @@ def _ensure_builder(ext_path, core_path):
             raise ValueError("Could not find @jupyterlab/builder")
         target = osp.dirname(target)
 
-    with open(osp.join(target, "node_modules", "@jupyterlab", "builder", "package.json")) as fid:
-        depVersion2 = json.load(fid).get("version")
     overlap = _test_overlap(depVersion1, depVersion2, drop_prerelease1=True, drop_prerelease2=True)
+    if not overlap:
+        with open(osp.join(target, "node_modules", "@jupyterlab", "builder", "package.json")) as fid:
+            depVersion2 = json.load(fid).get("version")
+        overlap = _test_overlap(depVersion1, depVersion2, drop_prerelease1=True, drop_prerelease2=True)
+
     if not overlap:
         raise ValueError(
             "Extensions require a devDependency on @jupyterlab/builder@%s, you have a dependency on %s"


### PR DESCRIPTION
Due to my changes in https://github.com/jupyterlab/jupyterlab/pull/12533
which were included in v3.4.1 extension builds may fail without an explicit
upgrade to the new patch (should not be necessary for patches).

This is because my change will compare against the exact version installed
rather than the range defined in the package.json, this update makes the
new check conditional to the original failure it was addressing.

## References

Original source of the bug https://github.com/jupyterlab/jupyterlab/pull/12533

