### PR TITLE
Automated Changelog Entry for 3.4.2 on 3.4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.4.2
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.4.1...1c8f008679c49e74d8a4ee3c6aa0782dfa6a1d35))
+
+### Bugs fixed
+
+- Building extensions fail if not using latest patch [#12571](https://github.com/jupyterlab/jupyterlab/pull/12571) ([@ajbozarth](https://github.com/ajbozarth))
+- fixed shouldOverwrite is never called when rename target exists [#12543](https://github.com/jupyterlab/jupyterlab/pull/12543) ([@ephes](https://github.com/ephes))
+
+### Maintenance and upkeep improvements
+
+- Update dependency version [#12535](https://github.com/jupyterlab/jupyterlab/pull/12535) ([@karlaspuldaro](https://github.com/karlaspuldaro))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-05-12&to=2022-05-12&type=c))
+
+[@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-05-12..2022-05-12&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-05-12..2022-05-12&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-05-12..2022-05-12&type=Issues) | [@karlaspuldaro](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akarlaspuldaro+updated%3A2022-05-12..2022-05-12&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-05-12..2022-05-12&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-05-12..2022-05-12&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.4.1
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.4.0...d8d94b351da08181d4d5e0493539c0eb082a1516))
@@ -37,8 +58,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-05-03&to=2022-05-12&type=c))
 
 [@ajbozarth](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aajbozarth+updated%3A2022-05-03..2022-05-12&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-05-03..2022-05-12&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-05-03..2022-05-12&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-05-03..2022-05-12&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-05-03..2022-05-12&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-05-03..2022-05-12&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-05-03..2022-05-12&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-05-03..2022-05-12&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.4.0
 


### PR DESCRIPTION
Automated Changelog Entry for 3.4.2 on 3.4.x
```
Python version: 3.4.2
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.4.2
@jupyterlab/buildutils: 3.4.2
@jupyterlab/template: 3.4.2
@jupyterlab/application-top: 3.4.2
@jupyterlab/example-app: 3.4.2
@jupyterlab/example-cell: 3.4.2
@jupyterlab/example-console: 3.4.2
@jupyterlab/example-federated: 2.5.2
@jupyterlab/example-federated-core: 2.5.2
@jupyterlab/example-federated-md: 2.5.2
@jupyterlab/example-federated-middle: 2.5.2
@jupyterlab/example-federated-phosphor: 2.5.2
@jupyterlab/example-filebrowser: 3.4.2
@jupyterlab/example-notebook: 3.4.2
@jupyterlab/example-terminal: 3.4.2
@jupyterlab/galata: 4.3.2
@jupyterlab/mock-extension: 3.4.2
@jupyterlab/mock-consumer: 3.4.2
@jupyterlab/mock-provider: 3.4.2
@jupyterlab/mock-token: 3.4.2
@jupyterlab/application: 3.4.2
@jupyterlab/application-extension: 3.4.2
@jupyterlab/apputils: 3.4.2
@jupyterlab/apputils-extension: 3.4.2
@jupyterlab/attachments: 3.4.2
@jupyterlab/cell-toolbar: 3.4.2
@jupyterlab/cell-toolbar-extension: 3.4.2
@jupyterlab/cells: 3.4.2
@jupyterlab/celltags: 3.4.2
@jupyterlab/celltags-extension: 3.4.2
@jupyterlab/codeeditor: 3.4.2
@jupyterlab/codemirror: 3.4.2
@jupyterlab/codemirror-extension: 3.4.2
@jupyterlab/completer: 3.4.2
@jupyterlab/completer-extension: 3.4.2
@jupyterlab/console: 3.4.2
@jupyterlab/console-extension: 3.4.2
@jupyterlab/coreutils: 5.4.2
@jupyterlab/csvviewer: 3.4.2
@jupyterlab/csvviewer-extension: 3.4.2
@jupyterlab/debugger: 3.4.2
@jupyterlab/debugger-extension: 3.4.2
@jupyterlab/docmanager: 3.4.2
@jupyterlab/docmanager-extension: 3.4.2
@jupyterlab/docprovider: 3.4.2
@jupyterlab/docprovider-extension: 3.4.2
@jupyterlab/docregistry: 3.4.2
@jupyterlab/documentsearch: 3.4.2
@jupyterlab/documentsearch-extension: 3.4.2
@jupyterlab/extensionmanager: 3.4.2
@jupyterlab/extensionmanager-extension: 3.4.2
@jupyterlab/filebrowser: 3.4.2
@jupyterlab/filebrowser-extension: 3.4.2
@jupyterlab/fileeditor: 3.4.2
@jupyterlab/fileeditor-extension: 3.4.2
@jupyterlab/help-extension: 3.4.2
@jupyterlab/htmlviewer: 3.4.2
@jupyterlab/htmlviewer-extension: 3.4.2
@jupyterlab/hub-extension: 3.4.2
@jupyterlab/imageviewer: 3.4.2
@jupyterlab/imageviewer-extension: 3.4.2
@jupyterlab/inspector: 3.4.2
@jupyterlab/inspector-extension: 3.4.2
@jupyterlab/javascript-extension: 3.4.2
@jupyterlab/json-extension: 3.4.2
@jupyterlab/launcher: 3.4.2
@jupyterlab/launcher-extension: 3.4.2
@jupyterlab/logconsole: 3.4.2
@jupyterlab/logconsole-extension: 3.4.2
@jupyterlab/mainmenu: 3.4.2
@jupyterlab/mainmenu-extension: 3.4.2
@jupyterlab/markdownviewer: 3.4.2
@jupyterlab/markdownviewer-extension: 3.4.2
@jupyterlab/mathjax2: 3.4.2
@jupyterlab/mathjax2-extension: 3.4.2
@jupyterlab/metapackage: 3.4.2
@jupyterlab/nbconvert-css: 3.4.2
@jupyterlab/nbformat: 3.4.2
@jupyterlab/notebook: 3.4.2
@jupyterlab/notebook-extension: 3.4.2
@jupyterlab/observables: 4.4.2
@jupyterlab/outputarea: 3.4.2
@jupyterlab/pdf-extension: 3.4.2
@jupyterlab/property-inspector: 3.4.2
@jupyterlab/rendermime: 3.4.2
@jupyterlab/rendermime-extension: 3.4.2
@jupyterlab/rendermime-interfaces: 3.4.2
@jupyterlab/running: 3.4.2
@jupyterlab/running-extension: 3.4.2
@jupyterlab/services: 6.4.2
@jupyterlab/example-services-browser: 3.4.2
node-example: 3.4.2
@jupyterlab/example-services-outputarea: 3.4.2
@jupyterlab/settingeditor: 3.4.2
@jupyterlab/settingeditor-extension: 3.4.2
@jupyterlab/settingregistry: 3.4.2
@jupyterlab/shared-models: 3.4.2
@jupyterlab/shortcuts-extension: 3.4.2
@jupyterlab/statedb: 3.4.2
@jupyterlab/statusbar: 3.4.2
@jupyterlab/statusbar-extension: 3.4.2
@jupyterlab/terminal: 3.4.2
@jupyterlab/terminal-extension: 3.4.2
@jupyterlab/theme-dark-extension: 3.4.2
@jupyterlab/theme-light-extension: 3.4.2
@jupyterlab/toc: 5.4.2
@jupyterlab/toc-extension: 5.4.2
@jupyterlab/tooltip: 3.4.2
@jupyterlab/tooltip-extension: 3.4.2
@jupyterlab/translation: 3.4.2
@jupyterlab/translation-extension: 3.4.2
@jupyterlab/ui-components: 3.4.2
@jupyterlab/ui-components-extension: 3.4.2
@jupyterlab/vdom: 3.4.2
@jupyterlab/vdom-extension: 3.4.2
@jupyterlab/vega5-extension: 3.4.2
@jupyterlab/testutils: 3.4.2
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.4.x  |
| Version Spec | next |
| Since Last Stable | true |