### PR TITLE
Unbump the major version of rendermime-interfaces

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -83,7 +83,7 @@
     "@jupyterlab/property-inspector": "~4.0.0-alpha.9",
     "@jupyterlab/rendermime": "~4.0.0-alpha.9",
     "@jupyterlab/rendermime-extension": "~4.0.0-alpha.9",
-    "@jupyterlab/rendermime-interfaces": "~4.0.0-alpha.9",
+    "@jupyterlab/rendermime-interfaces": "~3.8.0-alpha.9",
     "@jupyterlab/running": "~4.0.0-alpha.9",
     "@jupyterlab/running-extension": "~4.0.0-alpha.9",
     "@jupyterlab/services": "~7.0.0-alpha.9",

--- a/examples/federated/core_package/package.json
+++ b/examples/federated/core_package/package.json
@@ -57,7 +57,7 @@
     "@jupyterlab/pdf-extension": "~4.0.0-alpha.9",
     "@jupyterlab/rendermime": "^4.0.0-alpha.2",
     "@jupyterlab/rendermime-extension": "~4.0.0-alpha.9",
-    "@jupyterlab/rendermime-interfaces": "^4.0.0-alpha.2",
+    "@jupyterlab/rendermime-interfaces": "^3.8.0-alpha.9",
     "@jupyterlab/services": "^7.0.0-alpha.2",
     "@jupyterlab/settingeditor": "^4.0.0-alpha.2",
     "@jupyterlab/settingeditor-extension": "~4.0.0-alpha.9",

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -46,7 +46,7 @@
     "@jupyterlab/coreutils": "^6.0.0-alpha.9",
     "@jupyterlab/docregistry": "^4.0.0-alpha.9",
     "@jupyterlab/rendermime": "^4.0.0-alpha.9",
-    "@jupyterlab/rendermime-interfaces": "^4.0.0-alpha.9",
+    "@jupyterlab/rendermime-interfaces": "^3.8.0-alpha.9",
     "@jupyterlab/services": "^7.0.0-alpha.9",
     "@jupyterlab/statedb": "^4.0.0-alpha.9",
     "@jupyterlab/translation": "^4.0.0-alpha.9",

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@jupyterlab/coreutils": "^6.0.0-alpha.9",
     "@jupyterlab/observables": "^5.0.0-alpha.9",
+    "@jupyterlab/rendermime-interfaces": "^4.0.0-alpha.9",
     "@jupyterlab/services": "^7.0.0-alpha.9",
     "@jupyterlab/settingregistry": "^4.0.0-alpha.9",
     "@jupyterlab/statedb": "^4.0.0-alpha.9",

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@jupyterlab/coreutils": "^6.0.0-alpha.9",
     "@jupyterlab/observables": "^5.0.0-alpha.9",
-    "@jupyterlab/rendermime-interfaces": "^4.0.0-alpha.9",
+    "@jupyterlab/rendermime-interfaces": "^3.8.0-alpha.9",
     "@jupyterlab/services": "^7.0.0-alpha.9",
     "@jupyterlab/settingregistry": "^4.0.0-alpha.9",
     "@jupyterlab/statedb": "^4.0.0-alpha.9",

--- a/packages/apputils/src/tokens.ts
+++ b/packages/apputils/src/tokens.ts
@@ -2,6 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { IChangedArgs } from '@jupyterlab/coreutils';
+import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { Token } from '@lumino/coreutils';
 import { IDisposable } from '@lumino/disposable';
@@ -277,16 +278,7 @@ export namespace ToolbarRegistry {
   /**
    * Interface of item to be inserted in a toolbar
    */
-  export interface IToolbarItem {
-    /**
-     * Unique item name
-     */
-    name: string;
-    /**
-     * Toolbar widget
-     */
-    widget: Widget;
-  }
+  export interface IToolbarItem extends IRenderMime.IToolbarItem {}
 
   /**
    * Interface describing a toolbar item widget

--- a/packages/apputils/tsconfig.json
+++ b/packages/apputils/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../observables"
     },
     {
+      "path": "../rendermime-interfaces"
+    },
+    {
       "path": "../services"
     },
     {

--- a/packages/apputils/tsconfig.test.json
+++ b/packages/apputils/tsconfig.test.json
@@ -9,6 +9,9 @@
       "path": "../observables"
     },
     {
+      "path": "../rendermime-interfaces"
+    },
+    {
       "path": "../services"
     },
     {

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -39,7 +39,7 @@
     "@jupyterlab/nbformat": "^4.0.0-alpha.9",
     "@jupyterlab/observables": "^5.0.0-alpha.9",
     "@jupyterlab/rendermime": "^4.0.0-alpha.9",
-    "@jupyterlab/rendermime-interfaces": "^4.0.0-alpha.9",
+    "@jupyterlab/rendermime-interfaces": "^3.8.0-alpha.9",
     "@lumino/disposable": "^1.10.1",
     "@lumino/signaling": "^1.10.1"
   },

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -48,7 +48,7 @@
     "@jupyterlab/docprovider": "^4.0.0-alpha.9",
     "@jupyterlab/observables": "^5.0.0-alpha.9",
     "@jupyterlab/rendermime": "^4.0.0-alpha.9",
-    "@jupyterlab/rendermime-interfaces": "^4.0.0-alpha.9",
+    "@jupyterlab/rendermime-interfaces": "^3.8.0-alpha.9",
     "@jupyterlab/services": "^7.0.0-alpha.9",
     "@jupyterlab/shared-models": "^4.0.0-alpha.9",
     "@jupyterlab/translation": "^4.0.0-alpha.9",

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1052,44 +1052,15 @@ export namespace DocumentRegistry {
   /**
    * The options used to initialize a widget factory.
    */
-  export interface IWidgetFactoryOptions<T extends Widget = Widget> {
-    /**
-     * A unique name identifying of the widget.
-     */
-    readonly name: string;
-
-    /**
-     * The label of the widget to display in dialogs.
-     * If not given, name is used instead.
-     */
-    readonly label?: string;
-
-    /**
-     * The file types the widget can view.
-     */
-    readonly fileTypes: ReadonlyArray<string>;
-
-    /**
-     * The file types for which the factory should be the default.
-     */
-    readonly defaultFor?: ReadonlyArray<string>;
-
-    /**
-     * The file types for which the factory should be the default for rendering,
-     * if that is different than the default factory (which may be for editing).
-     * If undefined, then it will fall back on the default file type.
-     */
-    readonly defaultRendered?: ReadonlyArray<string>;
-
+  export interface IWidgetFactoryOptions<T extends Widget = Widget>
+    extends Omit<
+      IRenderMime.IDocumentWidgetFactoryOptions,
+      'primaryFileType' | 'toolbarFactory'
+    > {
     /**
      * Whether the widget factory is read only.
      */
     readonly readOnly?: boolean;
-
-    /**
-     * The registered name of the model type used to create the widgets.
-     */
-    readonly modelName?: string;
 
     /**
      * Whether the widgets prefer having a kernel started.
@@ -1105,11 +1076,6 @@ export namespace DocumentRegistry {
      * Whether the kernel should be shutdown when the widget is closed.
      */
     readonly shutdownOnClose?: boolean;
-
-    /**
-     * The application language translator.
-     */
-    readonly translator?: ITranslator;
 
     /**
      * A function producing toolbar widgets, overriding the default toolbar widgets.
@@ -1249,47 +1215,11 @@ export namespace DocumentRegistry {
   /**
    * An interface for a file type.
    */
-  export interface IFileType {
-    /**
-     * The name of the file type.
-     */
-    readonly name: string;
-
-    /**
-     * The mime types associated the file type.
-     */
-    readonly mimeTypes: ReadonlyArray<string>;
-
-    /**
-     * The extensions of the file type (e.g. `".txt"`).  Can be a compound
-     * extension (e.g. `".table.json`).
-     */
-    readonly extensions: ReadonlyArray<string>;
-
-    /**
-     * An optional display name for the file type.
-     */
-    readonly displayName?: string;
-
-    /**
-     * An optional pattern for a file name (e.g. `^Dockerfile$`).
-     */
-    readonly pattern?: string;
-
+  export interface IFileType extends IRenderMime.IFileType {
     /**
      * The icon for the file type.
      */
     readonly icon?: LabIcon;
-
-    /**
-     * The icon class name for the file type.
-     */
-    readonly iconClass?: string;
-
-    /**
-     * The icon label for the file type.
-     */
-    readonly iconLabel?: string;
 
     /**
      * The content type of the new file.

--- a/packages/javascript-extension/package.json
+++ b/packages/javascript-extension/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@jupyterlab/rendermime": "^4.0.0-alpha.9",
-    "@jupyterlab/rendermime-interfaces": "^4.0.0-alpha.9"
+    "@jupyterlab/rendermime-interfaces": "^3.8.0-alpha.9"
   },
   "devDependencies": {
     "rimraf": "~3.0.0",

--- a/packages/json-extension/package.json
+++ b/packages/json-extension/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@jupyterlab/apputils": "^4.0.0-alpha.9",
-    "@jupyterlab/rendermime-interfaces": "^4.0.0-alpha.9",
+    "@jupyterlab/rendermime-interfaces": "^3.8.0-alpha.9",
     "@jupyterlab/translation": "^4.0.0-alpha.9",
     "@jupyterlab/ui-components": "^4.0.0-alpha.24",
     "@lumino/coreutils": "^1.12.0",

--- a/packages/mathjax2/package.json
+++ b/packages/mathjax2/package.json
@@ -33,7 +33,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/rendermime-interfaces": "^4.0.0-alpha.9",
+    "@jupyterlab/rendermime-interfaces": "^3.8.0-alpha.9",
     "@lumino/coreutils": "^1.12.0"
   },
   "devDependencies": {

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -97,7 +97,7 @@
     "@jupyterlab/property-inspector": "^4.0.0-alpha.9",
     "@jupyterlab/rendermime": "^4.0.0-alpha.9",
     "@jupyterlab/rendermime-extension": "^4.0.0-alpha.9",
-    "@jupyterlab/rendermime-interfaces": "^4.0.0-alpha.9",
+    "@jupyterlab/rendermime-interfaces": "^3.8.0-alpha.9",
     "@jupyterlab/running": "^4.0.0-alpha.9",
     "@jupyterlab/running-extension": "^4.0.0-alpha.9",
     "@jupyterlab/services": "^7.0.0-alpha.9",

--- a/packages/outputarea/package.json
+++ b/packages/outputarea/package.json
@@ -45,7 +45,7 @@
     "@jupyterlab/nbformat": "^4.0.0-alpha.9",
     "@jupyterlab/observables": "^5.0.0-alpha.9",
     "@jupyterlab/rendermime": "^4.0.0-alpha.9",
-    "@jupyterlab/rendermime-interfaces": "^4.0.0-alpha.9",
+    "@jupyterlab/rendermime-interfaces": "^3.8.0-alpha.9",
     "@jupyterlab/services": "^7.0.0-alpha.9",
     "@lumino/algorithm": "^1.9.1",
     "@lumino/coreutils": "^1.12.0",

--- a/packages/pdf-extension/package.json
+++ b/packages/pdf-extension/package.json
@@ -36,7 +36,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/rendermime-interfaces": "^4.0.0-alpha.9",
+    "@jupyterlab/rendermime-interfaces": "^3.8.0-alpha.9",
     "@lumino/coreutils": "^1.12.0",
     "@lumino/disposable": "^1.10.1",
     "@lumino/widgets": "^1.31.1"

--- a/packages/rendermime-interfaces/package.json
+++ b/packages/rendermime-interfaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/rendermime-interfaces",
-  "version": "4.0.0-alpha.9",
+  "version": "3.8.0-alpha.9",
   "description": "JupyterLab - Interfaces for Mime Renderers",
   "homepage": "https://github.com/jupyterlab/jupyterlab",
   "bugs": {

--- a/packages/rendermime-interfaces/src/index.ts
+++ b/packages/rendermime-interfaces/src/index.ts
@@ -7,8 +7,8 @@
  * @module rendermime-interfaces
  */
 
-import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
-import { Widget } from '@lumino/widgets';
+import type { ReadonlyPartialJSONObject } from '@lumino/coreutils';
+import type { Widget } from '@lumino/widgets';
 
 /**
  * A namespace for rendermime associated interfaces.
@@ -72,7 +72,7 @@ export namespace IRenderMime {
    */
   export interface IToolbarItem {
     /**
-     * Item name
+     * Unique item name
      */
     name: string;
     /**
@@ -92,6 +92,12 @@ export namespace IRenderMime {
      * The name of the widget to display in dialogs.
      */
     readonly name: string;
+
+    /**
+     * The label of the widget to display in dialogs.
+     * If not given, name is used instead.
+     */
+    readonly label?: string;
 
     /**
      * The name of the document model type.
@@ -121,9 +127,14 @@ export namespace IRenderMime {
     readonly defaultRendered?: ReadonlyArray<string>;
 
     /**
+     * The application language translator.
+     */
+    readonly translator?: ITranslator;
+
+    /**
      * A function returning a list of toolbar items to add to the toolbar.
      */
-    readonly toolbarFactory?: (widget?: IRenderer) => IToolbarItem[];
+    readonly toolbarFactory?: (widget?: Widget) => IToolbarItem[];
   }
 
   export namespace LabIcon {
@@ -150,8 +161,7 @@ export namespace IRenderMime {
      */
     export interface IRenderer {
       readonly render: (container: HTMLElement, options?: any) => void;
-      // TODO: make unrenderer optional once @lumino/virtualdom > 1.4.1 is used
-      readonly unrender: (container: HTMLElement) => void;
+      readonly unrender?: (container: HTMLElement, options?: any) => void;
     }
 
     /**
@@ -210,7 +220,7 @@ export namespace IRenderMime {
     /**
      * The file format for the file type ('text', 'base64', or 'json').
      */
-    readonly fileFormat?: string;
+    readonly fileFormat?: string | null;
   }
 
   /**

--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -45,7 +45,7 @@
     "@jupyterlab/coreutils": "^6.0.0-alpha.9",
     "@jupyterlab/nbformat": "^4.0.0-alpha.9",
     "@jupyterlab/observables": "^5.0.0-alpha.9",
-    "@jupyterlab/rendermime-interfaces": "^4.0.0-alpha.9",
+    "@jupyterlab/rendermime-interfaces": "^3.8.0-alpha.9",
     "@jupyterlab/services": "^7.0.0-alpha.9",
     "@jupyterlab/translation": "^4.0.0-alpha.9",
     "@lumino/algorithm": "^1.9.1",

--- a/packages/translation/package.json
+++ b/packages/translation/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@jupyterlab/coreutils": "^6.0.0-alpha.9",
-    "@jupyterlab/rendermime-interfaces": "^4.0.0-alpha.9",
+    "@jupyterlab/rendermime-interfaces": "^3.8.0-alpha.9",
     "@jupyterlab/services": "^7.0.0-alpha.9",
     "@jupyterlab/statedb": "^4.0.0-alpha.9",
     "@lumino/coreutils": "^1.12.0"

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@jupyterlab/coreutils": "^6.0.0-alpha.9",
-    "@jupyterlab/rendermime-interfaces": "^6.0.0-alpha.9",
+    "@jupyterlab/rendermime-interfaces": "^3.8.0-alpha.9",
     "@jupyterlab/translation": "^4.0.0-alpha.9",
     "@lumino/algorithm": "^1.9.1",
     "@lumino/commands": "^1.20.0",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@jupyterlab/coreutils": "^6.0.0-alpha.9",
+    "@jupyterlab/rendermime-interfaces": "^6.0.0-alpha.9",
     "@jupyterlab/translation": "^4.0.0-alpha.9",
     "@lumino/algorithm": "^1.9.1",
     "@lumino/commands": "^1.20.0",

--- a/packages/ui-components/src/icon/labicon.tsx
+++ b/packages/ui-components/src/icon/labicon.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 import { UUID } from '@lumino/coreutils';
 import { Signal } from '@lumino/signaling';
 import { ElementAttrs, VirtualElement, VirtualNode } from '@lumino/virtualdom';
@@ -622,20 +623,7 @@ export namespace LabIcon {
   /**
    * The simplest possible interface for defining a generic icon.
    */
-  export interface IIcon {
-    /**
-     * The name of the icon. By convention, the icon name will be namespaced
-     * as so:
-     *
-     *     "pkg-name:icon-name"
-     */
-    readonly name: string;
-
-    /**
-     * A string containing the raw contents of an svg file.
-     */
-    svgstr: string;
-  }
+  export interface IIcon extends IRenderMime.LabIcon.IIcon {}
 
   export interface IRendererOptions {
     attrs?: ElementAttrs;
@@ -702,9 +690,7 @@ export namespace LabIcon {
   /**
    * A type that can be resolved to a LabIcon instance.
    */
-  export type IResolvable =
-    | string
-    | (IIcon & Partial<VirtualElement.IRenderer>);
+  export type IResolvable = IRenderMime.LabIcon.IResolvable;
 
   /**
    * A type that maybe can be resolved to a LabIcon instance.

--- a/packages/ui-components/tsconfig.json
+++ b/packages/ui-components/tsconfig.json
@@ -11,6 +11,9 @@
       "path": "../coreutils"
     },
     {
+      "path": "../rendermime-interfaces"
+    },
+    {
       "path": "../translation"
     }
   ]

--- a/packages/ui-components/tsconfig.test.json
+++ b/packages/ui-components/tsconfig.test.json
@@ -6,6 +6,9 @@
       "path": "../coreutils"
     },
     {
+      "path": "../rendermime-interfaces"
+    },
+    {
       "path": "../translation"
     },
     {

--- a/packages/vdom/package.json
+++ b/packages/vdom/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@jupyterlab/apputils": "^4.0.0-alpha.9",
     "@jupyterlab/docregistry": "^4.0.0-alpha.9",
-    "@jupyterlab/rendermime-interfaces": "^4.0.0-alpha.9",
+    "@jupyterlab/rendermime-interfaces": "^3.8.0-alpha.9",
     "@jupyterlab/services": "^7.0.0-alpha.9",
     "@lumino/coreutils": "^1.12.0",
     "@lumino/messaging": "^1.10.1",

--- a/packages/vega5-extension/package.json
+++ b/packages/vega5-extension/package.json
@@ -32,7 +32,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/rendermime-interfaces": "^4.0.0-alpha.9",
+    "@jupyterlab/rendermime-interfaces": "^3.8.0-alpha.9",
     "@lumino/coreutils": "^1.12.0",
     "@lumino/widgets": "^1.31.1",
     "vega": "^5.20.0",


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
As discussed at JupyterLab meeting
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Unbump @jupyterlab/rendermime-interfaces to 3.8.0 to keep some space for minor releases.

Make LabIcon and DocumentRegistry extends those interfaces to reduce possible future breakage.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A