### PR TITLE
Use error names instead of messages for validation

### DIFF
--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -782,8 +782,7 @@ function addCommands(
             })
             .catch(err => {
               // If the save was canceled by user-action, do nothing.
-              // FIXME-TRANS: Is this using the text on the button or?
-              if (err.message === 'Cancel') {
+              if (err.name === 'ModalCancelError') {
                 return;
               }
               throw err;

--- a/packages/docmanager/src/savehandler.ts
+++ b/packages/docmanager/src/savehandler.ts
@@ -134,11 +134,8 @@ export class SaveHandler implements IDisposable {
       })
       .catch(err => {
         // If the user canceled the save, do nothing.
-        // FIXME-TRANS: Is this affected by localization?
-        if (
-          err.message === 'Cancel' ||
-          err.message === 'Modal is already displayed'
-        ) {
+        const { name } = err;
+        if (name === 'ModalCancelError' || name === 'ModalDuplicateError') {
           return;
         }
         // Otherwise, log the error.

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -616,22 +616,19 @@ export class Context<
       // Emit completion.
       this._saveState.emit('completed');
     } catch (err) {
-      // If the save has been canceled by the user,
-      // throw the error so that whoever called save()
-      // can decide what to do.
-      if (
-        err.message === 'Cancel' ||
-        err.message === 'Modal is already displayed'
-      ) {
+      // If the save has been canceled by the user, throw the error
+      // so that whoever called save() can decide what to do.
+      const { name } = err;
+      if (name === 'ModalCancelError' || name === 'ModalDuplicateError') {
         throw err;
       }
 
       // Otherwise show an error message and throw the error.
       const localPath = this._manager.contents.localPath(this._path);
-      const name = PathExt.basename(localPath);
+      const file = PathExt.basename(localPath);
       void this._handleError(
         err,
-        this._trans.__('File Save Error for %1', name)
+        this._trans.__('File Save Error for %1', file)
       );
 
       // Emit failure.
@@ -838,7 +835,9 @@ export class Context<
         `${tDisk}`
     );
     if (this._timeConflictModalIsOpen) {
-      return Promise.reject(new Error('Modal is already displayed'));
+      const error = new Error('Modal is already displayed');
+      error.name = 'ModalDuplicateError';
+      return Promise.reject(error);
     }
     const body = this._trans.__(
       `"%1" has changed on disk since the last time it was opened or saved.
@@ -869,7 +868,9 @@ or load the version on disk (revert)?`,
           return model;
         });
       }
-      return Promise.reject(new Error('Cancel')); // Otherwise cancel the save.
+      const error = new Error('Cancel');
+      error.name = 'ModalCancelError';
+      return Promise.reject(error); // Otherwise cancel the save.
     });
   }
 


### PR DESCRIPTION
This PR has client code check for `Error.prototype.name` values instead of `Error.prototype.message` in order to be less brittle if an error message is changed or translated in the future.

## References
N/A

## Code changes
Updates business logic to check against specified error names.

## User-facing changes
N/A

## Backwards-incompatible changes
N/A