### PR TITLE
Pin exactly jupyter_ydoc

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,8 +41,7 @@ install_requires =
     jupyter_server>=1.16.0,<2
     notebook_shim>=0.1
     jinja2>=3.0.3
-    ypy-websocket>=0.1.6
-    jupyter_ydoc>=0.1.8
+    jupyter_ydoc==0.1.10
 
 [options.extras_require]
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     jupyter_server>=1.16.0,<2
     notebook_shim>=0.1
     jinja2>=3.0.3
+    ypy-websocket
     jupyter_ydoc==0.1.10
 
 [options.extras_require]


### PR DESCRIPTION
## References

See https://github.com/jupyter-server/jupyter_ydoc/pull/27#pullrequestreview-979745409.

## Code changes

We need to exactly pin `jupyter_ydoc` because when we change a document schema, as in https://github.com/jupyter-server/jupyter_ydoc/pull/27, the equivalent change has to be done in `@jupyterlab/shared-models`, which has to be released, but tests won't pass if `jupyter_ydoc` is not released first...

## User-facing changes

None.

## Backwards-incompatible changes

None.