### PR TITLE
Fix the side-by-side cell resize handle

### DIFF
--- a/packages/cells/src/resizeHandle.ts
+++ b/packages/cells/src/resizeHandle.ts
@@ -11,7 +11,6 @@ const CELL_RESIZED_CLASS = 'jp-mod-resizedCell';
 export class ResizeHandle extends Widget {
   private _isActive: boolean = false;
   private _isDragging: boolean = false;
-  private _mouseOffset: number;
   private _protectedWidth = 10;
 
   constructor(protected targetNode: HTMLElement) {
@@ -43,17 +42,13 @@ export class ResizeHandle extends Widget {
         this.targetNode.parentNode?.childNodes.forEach(node => {
           (node as HTMLElement).classList.remove(CELL_RESIZED_CLASS);
         });
-
         document.documentElement.style.setProperty(
-          '--jp-side-by-side-resized-cell',
-          ''
+          '--jp-side-by-side-output-size',
+          `1fr`
         );
-
         this._isActive = false;
         break;
       case 'mousedown':
-        this._mouseOffset =
-          (event as MouseEvent).clientX - this.node.getBoundingClientRect().x;
         this._isDragging = true;
         if (!this._isActive) {
           this.targetNode.parentNode?.childNodes.forEach(node => {
@@ -70,24 +65,17 @@ export class ResizeHandle extends Widget {
           return;
         }
         const targetRect = this.targetNode.getBoundingClientRect();
-        const inputWidth =
-          (event as MouseEvent).clientX - targetRect.x - this._mouseOffset;
 
-        const resizedRatio =
-          1 -
-          Math.min(
-            Math.max(inputWidth, this._protectedWidth),
-            targetRect.width - this._protectedWidth
-          ) /
-            (targetRect.width - this._protectedWidth);
+        const width = targetRect.width - this._protectedWidth * 2;
+        const position =
+          (event as MouseEvent).clientX - targetRect.x - this._protectedWidth;
 
-        // Added friction to the dragging interaction
-        if (Math.round(resizedRatio * 100) % 10 == 0) {
-          document.documentElement.style.setProperty(
-            '--jp-side-by-side-resized-cell',
-            resizedRatio + 'fr'
-          );
-        }
+        const outputRatio = width / position - 1;
+
+        document.documentElement.style.setProperty(
+          '--jp-side-by-side-output-size',
+          `${outputRatio}fr`
+        );
 
         break;
       }


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/12158

## Code changes

Change the way the ratio is computed in the `ResizeHandle` class.

## User-facing changes

![Untitled5](https://user-images.githubusercontent.com/226720/169816321-df6048a7-f79b-4923-834b-0c92cde7963d.gif)

## Backwards-incompatible changes

None.