### PR TITLE
Fix kernel protocol serialization

### DIFF
--- a/packages/services/src/kernel/serialize.ts
+++ b/packages/services/src/kernel/serialize.ts
@@ -109,11 +109,41 @@ namespace Private {
     let offsets: number[] = [];
     offsets.push(8 * (1 + offsetNumber));
     offsets.push(msg.channel.length + offsets[offsets.length - 1]);
+    const encoder = new TextEncoder();
+    const channelEncoded = encoder.encode(msg.channel);
+    const headerEncoded = encoder.encode(header);
+    const parentHeaderEncoded = encoder.encode(parentHeader);
+    const metadataEncoded = encoder.encode(metadata);
+    const contentEncoded = encoder.encode(content);
+    const binMsgNoBuff = new Uint8Array(
+      channelEncoded.length +
+        headerEncoded.length +
+        parentHeaderEncoded.length +
+        metadataEncoded.length +
+        contentEncoded.length
+    );
+    binMsgNoBuff.set(channelEncoded);
+    binMsgNoBuff.set(headerEncoded, channelEncoded.length);
+    binMsgNoBuff.set(
+      parentHeaderEncoded,
+      channelEncoded.length + headerEncoded.length
+    );
+    binMsgNoBuff.set(
+      metadataEncoded,
+      channelEncoded.length + headerEncoded.length + parentHeaderEncoded.length
+    );
+    binMsgNoBuff.set(
+      contentEncoded,
+      channelEncoded.length +
+        headerEncoded.length +
+        parentHeaderEncoded.length +
+        metadataEncoded.length
+    );
     for (let length of [
-      header.length,
-      parentHeader.length,
-      metadata.length,
-      content.length
+      headerEncoded.length,
+      parentHeaderEncoded.length,
+      metadataEncoded.length,
+      contentEncoded.length
     ]) {
       offsets.push(length + offsets[offsets.length - 1]);
     }
@@ -123,10 +153,6 @@ namespace Private {
       offsets.push(length + offsets[offsets.length - 1]);
       buffersByteLength += length;
     }
-    const encoder = new TextEncoder();
-    const binMsgNoBuff = encoder.encode(
-      msg.channel + header + parentHeader + metadata + content
-    );
     const binMsg = new Uint8Array(
       8 * (1 + offsetNumber) + binMsgNoBuff.byteLength + buffersByteLength
     );


### PR DESCRIPTION
## References

Fixes https://github.com/jupyter-server/jupyter_server/issues/857.

## Code changes

In the serialization of kernel messages over WebSocket `v1.kernel.websocket.jupyter.org`, we were computing offsets directly on the `JSON.stringified` objects, but then we use a `TextEncoder` to write the objects in binary. The problem is that with the former, emojis are kept as-is (not encoded), and with the latter they are encoded, resulting in a bigger size:
```js
'✅'.length
// 1
```
```js
encoder = new TextEncoder();
encoder.encode('✅').length
// 3
```
In this PR we compute the offsets on the encoded objects.

## User-facing changes

None.

## Backwards-incompatible changes

None.

cc @echarles @jasongrout 