### PR TITLE
Fix failing check links

### DIFF
--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -365,7 +365,7 @@ For example, to set blocked extensions, launch the server with
 ``http://example.com/blocklist.json`` is a JSON file as described below.
 
 The details for the listings_request_options are listed
-on `this page <https://2.python-requests.org/en/v2.7.0/api/#requests.request>`__
+on `this page <https://requests.readthedocs.io/en/stable/api/#requests.request>`__
 (for example, you could pass ``{'timeout': 10}`` to change the HTTP request timeout value).
 
 The listings are json files hosted on the URIs you have given.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This should fix the failing check links check on CI.

For example: https://github.com/jupyterlab/jupyterlab/runs/6658803923?check_suite_focus=true

```
Error: /home/runner/work/jupyterlab/jupyterlab/.jupyter_releaser_checkout/docs/source/user/extensions.rst: https://2.python-requests.org/en/v2.7.0/api/#requests.request
```

This seems to be tracked in https://github.com/psf/requests/issues/6140

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Point to ReadTheDocs instead.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Fix dead link in the user documentation.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
