### PR TITLE
Add more explanation for internationalization (translation python package)

### DIFF
--- a/docs/source/extension/internationalization.rst
+++ b/docs/source/extension/internationalization.rst
@@ -49,6 +49,34 @@ You could also look at the following pull requests on the
 There are two options: you can either add your extension to the JupyterLab `language packs <https://github.com/jupyterlab/language-packs/#adding-a-new-extension>`_
 or you can create a python package to distribute your extension translation (see `test example <https://github.com/jupyterlab/jupyterlab_server/tree/main/tests/translations/jupyterlab-some-package>`_).
 
+Create translation python package
+---------------------------------
+
+Jupyter Lab follows Gettext's approach for translation. Gettext extracts strings from source code, and compiles them with provided translation. This `document <https://www.labri.fr/perso/fleury/posts/programming/a-quick-gettext-tutorial.html>`_ briefly explains how Gettext works.
+
+By using `jupyterlab-translate <https://github.com/jupyterlab/jupyterlab-translate>`_, you can easily extract, update, and compile your translation.
+
+After that, you must include your compiled translation(.json, .mo) to your python package. This can be done by editing these two files.
+
+setup.py:
+
+.. code:: python
+
+    from setuptools import setup
+
+    setup(
+        # ...
+        entry_points={"jupyterlab.locale": ["jupyterlab_some_package = jupyterlab_some_package"]},
+    )
+
+
+MANIFEST.in:
+
+.. code:: text
+
+    recursive-include jupyterlab_some_package *.json
+    recursive-include jupyterlab_some_package *.mo
+
 
 Settings translation
 --------------------

--- a/docs/source/extension/internationalization.rst
+++ b/docs/source/extension/internationalization.rst
@@ -79,7 +79,6 @@ MANIFEST.in:
 
 .. note::
    An example is available in the `server test <https://github.com/jupyterlab/jupyterlab_server/tree/main/tests/translations/jupyterlab-some-package>`_
-   
 Settings translation
 --------------------
 

--- a/docs/source/extension/internationalization.rst
+++ b/docs/source/extension/internationalization.rst
@@ -79,6 +79,7 @@ MANIFEST.in:
 
 .. note::
    An example is available in the `server test <https://github.com/jupyterlab/jupyterlab_server/tree/main/tests/translations/jupyterlab-some-package>`_
+
 Settings translation
 --------------------
 

--- a/docs/source/extension/internationalization.rst
+++ b/docs/source/extension/internationalization.rst
@@ -47,16 +47,16 @@ You could also look at the following pull requests on the
 4. Create and publish the translation for your extension.
 
 There are two options: you can either add your extension to the JupyterLab `language packs <https://github.com/jupyterlab/language-packs/#adding-a-new-extension>`_
-or you can create a python package to distribute your extension translation (see `test example <https://github.com/jupyterlab/jupyterlab_server/tree/main/tests/translations/jupyterlab-some-package>`_).
+or you can create a python package to distribute your extension translation (see below).
 
 Create translation python package
 ---------------------------------
 
 Jupyter Lab follows Gettext's approach for translation. Gettext extracts strings from source code, and compiles them with provided translation. This `article <https://www.labri.fr/perso/fleury/posts/programming/a-quick-gettext-tutorial.html>`_ briefly explains how Gettext works.
 
-By using `jupyterlab-translate <https://github.com/jupyterlab/jupyterlab-translate>`_, you can easily extract, update, and compile your translation.
+By using `jupyterlab-translate <https://github.com/jupyterlab/jupyterlab-translate>`_, you can extract, update, and compile your translation.
 
-After that, you must include your compiled translation(.json, .mo) to your python package. This can be done by editing these two files.
+After that, you must include your compiled translation (.json, .mo) to your python package. This can be done by editing these two files.
 
 setup.py:
 
@@ -77,7 +77,9 @@ MANIFEST.in:
     recursive-include jupyterlab_some_package *.json
     recursive-include jupyterlab_some_package *.mo
 
-
+.. note::
+   An example is available in the `server test <https://github.com/jupyterlab/jupyterlab_server/tree/main/tests/translations/jupyterlab-some-package>`_
+   
 Settings translation
 --------------------
 

--- a/docs/source/extension/internationalization.rst
+++ b/docs/source/extension/internationalization.rst
@@ -52,7 +52,7 @@ or you can create a python package to distribute your extension translation (see
 Create translation python package
 ---------------------------------
 
-Jupyter Lab follows Gettext's approach for translation. Gettext extracts strings from source code, and compiles them with provided translation. This `document <https://www.labri.fr/perso/fleury/posts/programming/a-quick-gettext-tutorial.html>`_ briefly explains how Gettext works.
+Jupyter Lab follows Gettext's approach for translation. Gettext extracts strings from source code, and compiles them with provided translation. This `article <https://www.labri.fr/perso/fleury/posts/programming/a-quick-gettext-tutorial.html>`_ briefly explains how Gettext works.
 
 By using `jupyterlab-translate <https://github.com/jupyterlab/jupyterlab-translate>`_, you can easily extract, update, and compile your translation.
 


### PR DESCRIPTION
## References
Original Internationalization Document 
- https://github.com/team-monolith-product/jupyterlab/blob/doc/i18n/docs/source/extension/internationalization.rst
- https://jupyterlab.readthedocs.io/en/stable/extension/internationalization.html

## Code changes
Nope. This is documentation PR.

## User-facing changes
Nope. This is documentation PR.

## Backwards-incompatible changes
Nope. This is documentation PR.


Recently, I tried to follow this [documentation](https://jupyterlab.readthedocs.io/en/stable/extension/internationalization.html)(or tutorial). I found that there are almost no information about translating a custom jupyter lab extension. I finally get this work. I'm here to share my experience for others.

I think 'jupyterlab-translate' must be mentioned here. (previously it was not).

Documentation about 'jupyterlab.locale' entry-point is not available anywhere, but I don't think here is a right place to include a documentation for 'jupyterlabl.locale'. So I just include a simple example adopted from [this repo](https://github.com/jupyterlab/jupyterlab_server/tree/main/tests/translations/jupyterlab-some-package).

Paragraph about Gettext is optional.

