### PR TITLE
Make password inputs not give away how many characters were typed

### DIFF
--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -920,6 +920,7 @@ export class Stdin extends Widget implements IStdin {
     this._future = options.future;
     this._parentHeader = options.parent_header;
     this._value = options.prompt + ' ';
+    this._password = options.password;
   }
 
   /**
@@ -972,8 +973,8 @@ export class Stdin extends Widget implements IStdin {
           },
           this._parentHeader
         );
-        if (input.type === 'password') {
-          this._value += Array(input.value.length + 1).join('·');
+        if (this._password) {
+          this._value += '········';
         } else {
           this._value += input.value;
           Stdin._historyPush(input.value);
@@ -1012,6 +1013,7 @@ export class Stdin extends Widget implements IStdin {
   private _value: string;
   private _valueCache: string;
   private _promise = new PromiseDelegate<void>();
+  private _password: boolean;
 }
 
 export namespace Stdin {


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Adjusts the original password input implementation from #517 to not give away how many characters were typed.

## Code changes

Make password inputs not give away how many characters were typed

This aligns with classic Jupyter Notebook behavior (always show 8 dots), and is generally a good security idea.

Also, this decouples the implementation of the HTML input widget and the notion of the input being a password input by storing the password field as a private attribute of the stdin control, rather than relying on how the input was created.

## User-facing changes

Always show 8 dots as the value of the password input

<img width="330" alt="Screen Shot 2022-06-06 at 18 31 35" src="https://user-images.githubusercontent.com/192614/172271147-36d18046-68c7-4e1d-af71-926ab981bf4e.png">


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
