### PR TITLE
Remove ipywidgets message count in the execution indicator model

### DIFF
--- a/packages/notebook/src/executionindicator.tsx
+++ b/packages/notebook/src/executionindicator.tsx
@@ -117,7 +117,7 @@ export function ExecutionIndicatorComponent(
     return reactElement('busy', progressBar(percentage), [
       <span key={0}>
         {trans.__(
-          `Executed ${executedCellNumber}/${scheduledCellNumber} requests`
+          `Executed ${executedCellNumber}/${scheduledCellNumber} cells`
         )}
       </span>,
       <span key={1}>
@@ -125,26 +125,29 @@ export function ExecutionIndicatorComponent(
       </span>
     ]);
   } else {
-    if (time === 0) {
-      return reactElement('idle', progressBar(100), []);
-    } else {
-      return reactElement('idle', progressBar(100), [
-        <span key={0}>
-          {trans._n(
-            'Executed %1 request',
-            'Executed %1 requests',
-            scheduledCellNumber
-          )}
-        </span>,
-        <span key={1}>
-          {trans._n(
-            'Elapsed time: %1 second',
-            'Elapsed time: %1 seconds',
-            time
-          )}
-        </span>
-      ]);
-    }
+    // No cell is scheduled, fall back to the status of kernel
+    const progress = state.kernelStatus === 'busy' ? 0 : 100;
+    const popup =
+      state.kernelStatus === 'busy' || time === 0
+        ? []
+        : [
+            <span key={0}>
+              {trans._n(
+                'Executed %1 cell',
+                'Executed %1 cells',
+                scheduledCellNumber
+              )}
+            </span>,
+            <span key={1}>
+              {trans._n(
+                'Elapsed time: %1 second',
+                'Elapsed time: %1 seconds',
+                time
+              )}
+            </span>
+          ];
+
+    return reactElement(state.kernelStatus, progressBar(progress), popup);
   }
 }
 
@@ -292,17 +295,7 @@ export namespace ExecutionIndicator {
             const message = msg.msg;
             const msgId = message.header.msg_id;
 
-            if (
-              KernelMessage.isCommMsgMsg(message) &&
-              message.content.data['method']
-            ) {
-              // Execution request from Comm message
-              const method = message.content.data['method'];
-              if (method !== 'request_state' && method !== 'update') {
-                this._cellScheduledCallback(nb, msgId);
-                this._startTimer(nb);
-              }
-            } else if (message.header.msg_type === 'execute_request') {
+            if (message.header.msg_type === 'execute_request') {
               // A cell code is scheduled for executing
               this._cellScheduledCallback(nb, msgId);
             } else if (

--- a/packages/notebook/test/executionindicator.spec.tsx
+++ b/packages/notebook/test/executionindicator.spec.tsx
@@ -211,7 +211,7 @@ describe('@jupyterlab/notebook', () => {
       );
       const htmlElement = ReactDOMServer.renderToString(element);
       expect(htmlElement).toContain(FILLED_CIRCLE);
-      expect(htmlElement).toContain(`Executed 0/2 requests`);
+      expect(htmlElement).toContain(`Executed 0/2 cells`);
     });
 
     it('Should render a half filled circle with 1/2 cell executed message', () => {
@@ -228,10 +228,10 @@ describe('@jupyterlab/notebook', () => {
       );
       const htmlElement = ReactDOMServer.renderToString(element);
       expect(htmlElement).toContain(HALF_FILLED_CIRCLE);
-      expect(htmlElement).toContain(`Executed 1/2 requests`);
+      expect(htmlElement).toContain(`Executed 1/2 cells`);
     });
 
-    it('Should render an empty circle with 2 requests executed message', () => {
+    it('Should render an empty circle with 2 cells executed message', () => {
       defaultState.scheduledCellNumber = 2;
       defaultState.executionStatus = 'idle';
       defaultState.totalTime = 1;
@@ -244,7 +244,7 @@ describe('@jupyterlab/notebook', () => {
       );
       const htmlElement = ReactDOMServer.renderToString(element);
       expect(htmlElement).toContain(EMPTY_CIRCLE);
-      expect(htmlElement).toContain(`Executed 2 requests`);
+      expect(htmlElement).toContain(`Executed 2 cells`);
     });
   });
 });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Closes https://github.com/jupyterlab/jupyterlab/issues/12616
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- Remove `ipywidgets` execution message count in the indicator model
- Fall back to  the kernel status if the scheduled cell list is empty

## User-facing changes

- Executions invoked by widgets are no longer counted in the execution indicator, but the kernel status is still shown.

![indicator](https://user-images.githubusercontent.com/4451292/172441502-f0cd4cfd-6c29-4d84-b7e9-8858eda5b4db.gif)

## Backwards-incompatible changes
N/A
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
