### PR TITLE
Automated Changelog Entry for 4.0.0a26 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,66 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 4.0.0a26
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v4.0.0a25...09d12a0bbfdcecbfeb410a434c7111af88547c69))
+
+### New features added
+
+- Persistent side-by-side ratio setting [#12633](https://github.com/jupyterlab/jupyterlab/pull/12633) ([@echarles](https://github.com/echarles))
+
+### Enhancements made
+
+- Make password inputs not give away how many characters were typed [#12659](https://github.com/jupyterlab/jupyterlab/pull/12659) ([@jasongrout](https://github.com/jasongrout))
+- Persistent side-by-side ratio setting [#12633](https://github.com/jupyterlab/jupyterlab/pull/12633) ([@echarles](https://github.com/echarles))
+- add "close all tabs" context action [#12620](https://github.com/jupyterlab/jupyterlab/pull/12620) ([@rursprung](https://github.com/rursprung))
+- Fix the side-by-side cell resize handle [#12609](https://github.com/jupyterlab/jupyterlab/pull/12609) ([@echarles](https://github.com/echarles))
+- Invert relationship between launcher and filebrowser [#12585](https://github.com/jupyterlab/jupyterlab/pull/12585) ([@fcollonval](https://github.com/fcollonval))
+
+### Bugs fixed
+
+- Remove ipywidgets message count in the execution indicator model [#12665](https://github.com/jupyterlab/jupyterlab/pull/12665) ([@trungleduc](https://github.com/trungleduc))
+- Fix arrow position on unrendered markdown cell [#12650](https://github.com/jupyterlab/jupyterlab/pull/12650) ([@fcollonval](https://github.com/fcollonval))
+- Fix kernel protocol serialization [#12619](https://github.com/jupyterlab/jupyterlab/pull/12619) ([@davidbrochart](https://github.com/davidbrochart))
+- Break loop activeCell -> activeHeading [#12612](https://github.com/jupyterlab/jupyterlab/pull/12612) ([@fcollonval](https://github.com/fcollonval))
+- Pin exactly jupyter_ydoc [#12602](https://github.com/jupyterlab/jupyterlab/pull/12602) ([@davidbrochart](https://github.com/davidbrochart))
+- Always check local packages against abspath [#10662](https://github.com/jupyterlab/jupyterlab/pull/10662) ([@mlucool](https://github.com/mlucool))
+
+### Maintenance and upkeep improvements
+
+- [pre-commit.ci] pre-commit autoupdate [#12658](https://github.com/jupyterlab/jupyterlab/pull/12658) ([@pre-commit-ci](https://github.com/pre-commit-ci))
+- Remove scripts linked to test [#12654](https://github.com/jupyterlab/jupyterlab/pull/12654) ([@fcollonval](https://github.com/fcollonval))
+- Update codeql action from v1 to v2 [#12645](https://github.com/jupyterlab/jupyterlab/pull/12645) ([@fcollonval](https://github.com/fcollonval))
+- Update snapshot for the extension manager [#12643](https://github.com/jupyterlab/jupyterlab/pull/12643) ([@jtpio](https://github.com/jtpio))
+- Bump actions/setup-python from 2 to 3 [#12642](https://github.com/jupyterlab/jupyterlab/pull/12642) ([@dependabot](https://github.com/dependabot))
+- Bump actions/checkout from 2 to 3 [#12641](https://github.com/jupyterlab/jupyterlab/pull/12641) ([@dependabot](https://github.com/dependabot))
+- Bump toshimaru/auto-author-assign from 1.3.4 to 1.5.0 [#12640](https://github.com/jupyterlab/jupyterlab/pull/12640) ([@dependabot](https://github.com/dependabot))
+- Bump dessant/lock-threads from 2 to 3 [#12639](https://github.com/jupyterlab/jupyterlab/pull/12639) ([@dependabot](https://github.com/dependabot))
+- Bump actions/setup-node from 2 to 3 [#12638](https://github.com/jupyterlab/jupyterlab/pull/12638) ([@dependabot](https://github.com/dependabot))
+- Bump pre-commit/action from 2.0.0 to 2.0.3 [#12637](https://github.com/jupyterlab/jupyterlab/pull/12637) ([@dependabot](https://github.com/dependabot))
+- Add bot to update github actions and remove codeql temporary fix [#12634](https://github.com/jupyterlab/jupyterlab/pull/12634) ([@fcollonval](https://github.com/fcollonval))
+- [pre-commit.ci] pre-commit autoupdate [#12626](https://github.com/jupyterlab/jupyterlab/pull/12626) ([@pre-commit-ci](https://github.com/pre-commit-ci))
+- Remove unneeded build:all and test config [#12618](https://github.com/jupyterlab/jupyterlab/pull/12618) ([@fcollonval](https://github.com/fcollonval))
+- Fix `documentsearch-extension` plugin id [#12604](https://github.com/jupyterlab/jupyterlab/pull/12604) ([@jtpio](https://github.com/jtpio))
+- Fix GitHub user rename for check-link [#12601](https://github.com/jupyterlab/jupyterlab/pull/12601) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+- Add more explanation for internationalization (translation python package) [#12635](https://github.com/jupyterlab/jupyterlab/pull/12635) ([@a3626a](https://github.com/a3626a))
+- Fix failing check links [#12627](https://github.com/jupyterlab/jupyterlab/pull/12627) ([@jtpio](https://github.com/jtpio))
+- Update README wording [#12610](https://github.com/jupyterlab/jupyterlab/pull/12610) ([@fcollonval](https://github.com/fcollonval))
+- Fix `documentsearch-extension` plugin id [#12604](https://github.com/jupyterlab/jupyterlab/pull/12604) ([@jtpio](https://github.com/jtpio))
+- Fix GitHub user rename for check-link [#12601](https://github.com/jupyterlab/jupyterlab/pull/12601) ([@fcollonval](https://github.com/fcollonval))
+- Invert relationship between launcher and filebrowser [#12585](https://github.com/jupyterlab/jupyterlab/pull/12585) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-05-19&to=2022-06-09&type=c))
+
+[@a3626a](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aa3626a+updated%3A2022-05-19..2022-06-09&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-05-19..2022-06-09&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2022-05-19..2022-06-09&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adependabot+updated%3A2022-05-19..2022-06-09&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-05-19..2022-06-09&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2022-05-19..2022-06-09&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-05-19..2022-06-09&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-05-19..2022-06-09&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-05-19..2022-06-09&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-05-19..2022-06-09&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2022-05-19..2022-06-09&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-05-19..2022-06-09&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-05-19..2022-06-09&type=Issues) | [@mlucool](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Amlucool+updated%3A2022-05-19..2022-06-09&type=Issues) | [@pre-commit-ci](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Apre-commit-ci+updated%3A2022-05-19..2022-06-09&type=Issues) | [@rursprung](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Arursprung+updated%3A2022-05-19..2022-06-09&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrungleduc+updated%3A2022-05-19..2022-06-09&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-05-19..2022-06-09&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 4.0.0a25
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v4.0.0a24...9cfad42aac66025f5ce2f9a33f91bfc83cff5b49))
@@ -106,8 +166,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-04-25&to=2022-05-19&type=c))
 
 [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2022-04-25..2022-05-19&type=Issues) | [@ajbozarth](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aajbozarth+updated%3A2022-04-25..2022-05-19&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-04-25..2022-05-19&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2022-04-25..2022-05-19&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2022-04-25..2022-05-19&type=Issues) | [@divyansshhh](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adivyansshhh+updated%3A2022-04-25..2022-05-19&type=Issues) | [@dmonad](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Admonad+updated%3A2022-04-25..2022-05-19&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-04-25..2022-05-19&type=Issues) | [@ephes](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aephes+updated%3A2022-04-25..2022-05-19&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-04-25..2022-05-19&type=Issues) | [@gabalafou](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agabalafou+updated%3A2022-04-25..2022-05-19&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-04-25..2022-05-19&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2022-04-25..2022-05-19&type=Issues) | [@Jessie-Newman](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AJessie-Newman+updated%3A2022-04-25..2022-05-19&type=Issues) | [@Jnnamchi](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AJnnamchi+updated%3A2022-04-25..2022-05-19&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-04-25..2022-05-19&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-04-25..2022-05-19&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2022-04-25..2022-05-19&type=Issues) | [@marthacryan](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Amarthacryan+updated%3A2022-04-25..2022-05-19&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-04-25..2022-05-19&type=Issues) | [@pre-commit-ci](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Apre-commit-ci+updated%3A2022-04-25..2022-05-19&type=Issues) | [@telamonian](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atelamonian+updated%3A2022-04-25..2022-05-19&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-04-25..2022-05-19&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 4.0.0a24
 


### PR DESCRIPTION
Automated Changelog Entry for 4.0.0a26 on master
```
Python version: 4.0.0a26
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 4.0.0-alpha.11
@jupyterlab/buildutils: 4.0.0-alpha.11
@jupyterlab/template: 4.0.0-alpha.11
@jupyterlab/application-top: 4.0.0-alpha.11
@jupyterlab/example-app: 4.0.0-alpha.11
@jupyterlab/example-cell: 4.0.0-alpha.11
@jupyterlab/example-console: 4.0.0-alpha.11
@jupyterlab/example-federated: 3.0.0-alpha.11
@jupyterlab/example-federated-core: 3.0.0-alpha.11
@jupyterlab/example-federated-md: 3.0.0-alpha.11
@jupyterlab/example-federated-middle: 3.0.0-alpha.11
@jupyterlab/example-federated-phosphor: 3.0.0-alpha.11
@jupyterlab/example-filebrowser: 4.0.0-alpha.11
@jupyterlab/example-notebook: 4.0.0-alpha.11
@jupyterlab/example-terminal: 4.0.0-alpha.11
@jupyterlab/galata: 5.0.0-alpha.11
@jupyterlab/mock-extension: 4.0.0-alpha.11
@jupyterlab/mock-consumer: 4.0.0-alpha.11
@jupyterlab/mock-provider: 4.0.0-alpha.11
@jupyterlab/mock-token: 4.0.0-alpha.11
@jupyterlab/application: 4.0.0-alpha.11
@jupyterlab/application-extension: 4.0.0-alpha.11
@jupyterlab/apputils: 4.0.0-alpha.11
@jupyterlab/apputils-extension: 4.0.0-alpha.11
@jupyterlab/attachments: 4.0.0-alpha.11
@jupyterlab/cell-toolbar: 4.0.0-alpha.11
@jupyterlab/cell-toolbar-extension: 4.0.0-alpha.11
@jupyterlab/cells: 4.0.0-alpha.11
@jupyterlab/celltags: 4.0.0-alpha.11
@jupyterlab/celltags-extension: 4.0.0-alpha.11
@jupyterlab/codeeditor: 4.0.0-alpha.11
@jupyterlab/codemirror: 4.0.0-alpha.11
@jupyterlab/codemirror-extension: 4.0.0-alpha.11
@jupyterlab/completer: 4.0.0-alpha.11
@jupyterlab/completer-extension: 4.0.0-alpha.11
@jupyterlab/console: 4.0.0-alpha.11
@jupyterlab/console-extension: 4.0.0-alpha.11
@jupyterlab/coreutils: 6.0.0-alpha.11
@jupyterlab/csvviewer: 4.0.0-alpha.11
@jupyterlab/csvviewer-extension: 4.0.0-alpha.11
@jupyterlab/debugger: 4.0.0-alpha.11
@jupyterlab/debugger-extension: 4.0.0-alpha.11
@jupyterlab/docmanager: 4.0.0-alpha.11
@jupyterlab/docmanager-extension: 4.0.0-alpha.11
@jupyterlab/docprovider: 4.0.0-alpha.11
@jupyterlab/docprovider-extension: 4.0.0-alpha.11
@jupyterlab/docregistry: 4.0.0-alpha.11
@jupyterlab/documentsearch: 4.0.0-alpha.11
@jupyterlab/documentsearch-extension: 4.0.0-alpha.11
@jupyterlab/extensionmanager: 4.0.0-alpha.11
@jupyterlab/extensionmanager-extension: 4.0.0-alpha.11
@jupyterlab/filebrowser: 4.0.0-alpha.11
@jupyterlab/filebrowser-extension: 4.0.0-alpha.11
@jupyterlab/fileeditor: 4.0.0-alpha.11
@jupyterlab/fileeditor-extension: 4.0.0-alpha.11
@jupyterlab/help-extension: 4.0.0-alpha.11
@jupyterlab/htmlviewer: 4.0.0-alpha.11
@jupyterlab/htmlviewer-extension: 4.0.0-alpha.11
@jupyterlab/hub-extension: 4.0.0-alpha.11
@jupyterlab/imageviewer: 4.0.0-alpha.11
@jupyterlab/imageviewer-extension: 4.0.0-alpha.11
@jupyterlab/inspector: 4.0.0-alpha.11
@jupyterlab/inspector-extension: 4.0.0-alpha.11
@jupyterlab/javascript-extension: 4.0.0-alpha.11
@jupyterlab/json-extension: 4.0.0-alpha.11
@jupyterlab/launcher: 4.0.0-alpha.11
@jupyterlab/launcher-extension: 4.0.0-alpha.11
@jupyterlab/logconsole: 4.0.0-alpha.11
@jupyterlab/logconsole-extension: 4.0.0-alpha.11
@jupyterlab/mainmenu: 4.0.0-alpha.11
@jupyterlab/mainmenu-extension: 4.0.0-alpha.11
@jupyterlab/markdownviewer: 4.0.0-alpha.11
@jupyterlab/markdownviewer-extension: 4.0.0-alpha.11
@jupyterlab/markedparser-extension: 4.0.0-alpha.11
@jupyterlab/mathjax2: 4.0.0-alpha.11
@jupyterlab/mathjax2-extension: 4.0.0-alpha.11
@jupyterlab/metapackage: 4.0.0-alpha.11
@jupyterlab/nbconvert-css: 4.0.0-alpha.11
@jupyterlab/nbformat: 4.0.0-alpha.11
@jupyterlab/notebook: 4.0.0-alpha.11
@jupyterlab/notebook-extension: 4.0.0-alpha.11
@jupyterlab/observables: 5.0.0-alpha.11
@jupyterlab/outputarea: 4.0.0-alpha.11
@jupyterlab/pdf-extension: 4.0.0-alpha.11
@jupyterlab/property-inspector: 4.0.0-alpha.11
@jupyterlab/rendermime: 4.0.0-alpha.11
@jupyterlab/rendermime-extension: 4.0.0-alpha.11
@jupyterlab/rendermime-interfaces: 3.8.0-alpha.11
@jupyterlab/running: 4.0.0-alpha.11
@jupyterlab/running-extension: 4.0.0-alpha.11
@jupyterlab/services: 7.0.0-alpha.11
@jupyterlab/example-services-browser: 4.0.0-alpha.11
node-example: 4.0.0-alpha.11
@jupyterlab/example-services-outputarea: 4.0.0-alpha.11
@jupyterlab/settingeditor: 4.0.0-alpha.11
@jupyterlab/settingeditor-extension: 4.0.0-alpha.11
@jupyterlab/settingregistry: 4.0.0-alpha.11
@jupyterlab/shared-models: 4.0.0-alpha.11
@jupyterlab/shortcuts-extension: 4.0.0-alpha.11
@jupyterlab/statedb: 4.0.0-alpha.11
@jupyterlab/statusbar: 4.0.0-alpha.11
@jupyterlab/statusbar-extension: 4.0.0-alpha.11
@jupyterlab/terminal: 4.0.0-alpha.11
@jupyterlab/terminal-extension: 4.0.0-alpha.11
@jupyterlab/theme-dark-extension: 4.0.0-alpha.11
@jupyterlab/theme-light-extension: 4.0.0-alpha.11
@jupyterlab/toc: 6.0.0-alpha.11
@jupyterlab/toc-extension: 6.0.0-alpha.11
@jupyterlab/tooltip: 4.0.0-alpha.11
@jupyterlab/tooltip-extension: 4.0.0-alpha.11
@jupyterlab/translation: 4.0.0-alpha.11
@jupyterlab/translation-extension: 4.0.0-alpha.11
@jupyterlab/ui-components: 4.0.0-alpha.26
@jupyterlab/ui-components-extension: 4.0.0-alpha.11
@jupyterlab/user: 4.0.0-alpha.11
@jupyterlab/user-extension: 4.0.0-alpha.11
@jupyterlab/vdom: 4.0.0-alpha.11
@jupyterlab/vdom-extension: 4.0.0-alpha.11
@jupyterlab/vega5-extension: 4.0.0-alpha.11
@jupyterlab/testutils: 4.0.0-alpha.11
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | master  |
| Version Spec | next |
| Since | v4.0.0a25 |