### PR TITLE
Don't show alert when leaving window in collaborative mode

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -723,11 +723,13 @@ const dirty: JupyterFrontEndPlugin<void> = {
     // attribute needs to set in addition to a return value being returned.
     // For more information, see:
     // https://developer.mozilla.org/en/docs/Web/Events/beforeunload
-    window.addEventListener('beforeunload', event => {
-      if (app.status.isDirty) {
-        return ((event as any).returnValue = message);
-      }
-    });
+    if (PageConfig.getOption('collaborative') !== 'true') {
+      window.addEventListener('beforeunload', event => {
+        if (app.status.isDirty) {
+          return ((event as any).returnValue = message);
+        }
+      });
+    }
   }
 };
 


### PR DESCRIPTION
## Code changes

When in collaborative mode, it doesn't make sense to ask the user to confirm that they want to leave the page if the document is dirty in collaborative mode, because the document is auto-saved anyway from the back-end (if the server is not stopped in the next second after the last change).
However, I can see that after the page is reloaded, the document is left in a wrong state, e.g. the kernel doesn't appear to be running even though it was running previously, the cell output doesn't show the stream, etc. But this looks like an independent problem that should be fixed in another PR.

## User-facing changes

No alert box when leaving page in collaborative mode.

## Backwards-incompatible changes

None.