### PR TITLE
Explicitly set language to `en` in `conf.py`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -87,7 +87,7 @@ release = version_ns["__version__"]
 # for a list of supported languages.
 #
 # This is also used if you do content translation via gettext catalogs.
-language = 'en' # Must be set from the command line to generate various languages
+language = "en" # Must be set from the command line to generate various languages
 
 locale_dirs = ["locale/"]
 gettext_compact = False

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -87,7 +87,7 @@ release = version_ns["__version__"]
 # for a list of supported languages.
 #
 # This is also used if you do content translation via gettext catalogs.
-# language = None # Must be set from the command line to generate various languages
+language = 'en' # Must be set from the command line to generate various languages
 
 locale_dirs = ["locale/"]
 gettext_compact = False

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -87,7 +87,7 @@ release = version_ns["__version__"]
 # for a list of supported languages.
 #
 # This is also used if you do content translation via gettext catalogs.
-language = "en" # Must be set from the command line to generate various languages
+language = "en"  # Must be set from the command line to generate various languages
 
 locale_dirs = ["locale/"]
 gettext_compact = False


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

The default `language = None` started to give warnings with `sphinx` 5.

See https://github.com/jupyter/notebook/pull/6447 for a similar change.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update docs configuration.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
