### PR TITLE
Fix cell toolbar overlap in side-by-side render mode

### DIFF
--- a/packages/cell-toolbar/src/celltoolbartracker.ts
+++ b/packages/cell-toolbar/src/celltoolbartracker.ts
@@ -3,7 +3,7 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 import { createDefaultFactory, ToolbarRegistry } from '@jupyterlab/apputils';
-import { Cell, ICellModel, MarkdownCell } from '@jupyterlab/cells';
+import { Cell, CodeCell, ICellModel, MarkdownCell } from '@jupyterlab/cells';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { Notebook, NotebookPanel } from '@jupyterlab/notebook';
 import { IObservableList, ObservableList } from '@jupyterlab/observables';
@@ -13,6 +13,15 @@ import { CommandRegistry } from '@lumino/commands';
 import { IDisposable } from '@lumino/disposable';
 import { Signal } from '@lumino/signaling';
 import { PanelLayout, Widget } from '@lumino/widgets';
+
+/*
+ * Text mime types
+ */
+const TEXT_MIME_TYPES = [
+  'text/plain',
+  'application/vnd.jupyter.stdout',
+  'application/vnd.jupyter.stderr'
+];
 
 /**
  * Widget cell toolbar classes
@@ -42,6 +51,12 @@ export class CellToolbarTracker implements IDisposable {
 
     // Only add the toolbar to the notebook's active cell (if any) once it has fully rendered and been revealed.
     panel.revealed.then(() => this._onActiveCellChanged(panel.content));
+
+    // Check whether the toolbar should be rendered upon a layout change
+    panel.content.renderingLayoutChanged.connect(
+      this._onActiveCellChanged,
+      this
+    );
 
     // Handle subsequent changes of active cell.
     panel.content.activeCellChanged.connect(this._onActiveCellChanged, this);
@@ -194,7 +209,11 @@ export class CellToolbarTracker implements IDisposable {
     }
 
     // Check for overlap in code content
-    return this._codeOverlapsToolbar(activeCell);
+    if (this._panel?.content.renderingLayout === 'default') {
+      return this._codeOverlapsToolbar(activeCell);
+    } else {
+      return this._outputOverlapsToolbar(activeCell);
+    }
   }
 
   /**
@@ -230,6 +249,41 @@ export class CellToolbarTracker implements IDisposable {
     return toolbarLeft === null ? false : lineRight > toolbarLeft;
   }
 
+  private _outputOverlapsToolbar(activeCell: Cell<ICellModel>): boolean {
+    const outputArea = (activeCell as CodeCell).outputArea.node;
+    if (outputArea) {
+      const outputs = outputArea.querySelectorAll('[data-mime-type]');
+      const toolbarRect = this._cellToolbarRect(activeCell);
+      if (toolbarRect) {
+        const { left: toolbarLeft, bottom: toolbarBottom } = toolbarRect;
+        return Array.from(outputs).some(output => {
+          const node = output.firstElementChild;
+          if (node) {
+            const range = new Range();
+            if (
+              TEXT_MIME_TYPES.includes(
+                output.getAttribute('data-mime-type') || ''
+              )
+            ) {
+              // If the node is plain text, it's in a <pre>. To get the true bounding box of the
+              // text, the node contents need to be selected.
+              range.selectNodeContents(node);
+            } else {
+              range.selectNode(node);
+            }
+            const { right: nodeRight, top: nodeTop } =
+              range.getBoundingClientRect();
+
+            // Note: y-coordinate increases toward the bottom of page
+            return nodeRight > toolbarLeft && nodeTop < toolbarBottom;
+          }
+          return false;
+        });
+      }
+    }
+    return false;
+  }
+
   private _codeOverlapsToolbar(activeCell: Cell<ICellModel>): boolean {
     const editorWidget = activeCell.editorWidget;
     const editor = activeCell.editor;
@@ -258,14 +312,18 @@ export class CellToolbarTracker implements IDisposable {
     return activeCell.editorWidget.node.getBoundingClientRect().right;
   }
 
-  private _cellToolbarLeft(activeCell: Cell<ICellModel>): number | null {
+  private _cellToolbarRect(activeCell: Cell<ICellModel>): DOMRect | null {
     const toolbarWidgets = this._findToolbarWidgets(activeCell);
     if (toolbarWidgets.length < 1) {
       return null;
     }
     const activeCellToolbar = toolbarWidgets[0].node;
 
-    return activeCellToolbar.getBoundingClientRect().left;
+    return activeCellToolbar.getBoundingClientRect();
+  }
+
+  private _cellToolbarLeft(activeCell: Cell<ICellModel>): number | null {
+    return this._cellToolbarRect(activeCell)?.left || null;
   }
 
   private _isDisposed = false;

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -273,6 +273,13 @@ export class StaticNotebook extends Widget {
   }
 
   /**
+   * A signal emitted when the rendering layout of the notebook changes.
+   */
+  get renderingLayoutChanged(): ISignal<this, RenderingLayout> {
+    return this._renderingLayoutChanged;
+  }
+
+  /**
    * The cell factory used by the widget.
    */
   readonly contentFactory: StaticNotebook.IContentFactory;
@@ -370,6 +377,7 @@ export class StaticNotebook extends Widget {
     } else {
       this.node.classList.remove(SIDE_BY_SIDE_CLASS);
     }
+    this._renderingLayoutChanged.emit(this._renderingLayout ?? 'default');
   }
 
   /**
@@ -901,6 +909,7 @@ export class StaticNotebook extends Widget {
   private _idleCallBack: any;
   private _cellsArray: Array<Cell>;
   private _renderingLayout: RenderingLayout | undefined;
+  private _renderingLayoutChanged = new Signal<this, RenderingLayout>(this);
 }
 
 /**


### PR DESCRIPTION
## References
https://github.com/jupyterlab/jupyterlab/issues/12647

## Code changes
* When the notebook's `renderingLayout === 'side-by-side'`, a new check has been introduced which ensures that the output(s) of each cell do not overlap with the cell toolbar. If they do, the toolbar is hidden (as is currently done for `renderingLayout === 'default'`. If not, the toolbar will be shown.
* Added a new `renderingLayoutChanged` signal to the `StaticNotebook`, and made the cell toolbar re-render upon receiving this signal. This handles an edge case where if the user is in `default` render layout mode the toolbar can be visible; but if they switch to `side-by-side` render layout, it may overlap with cell output. This check ensures this doesn't happen.

## User-facing changes

* This PR changes how the cell toolbar is shown or is hidden according to the current rendering layout.

### Before
![before](https://user-images.githubusercontent.com/14017872/174231311-de8a734d-b13d-4d02-803f-9d6340af5d37.png)

### After
![after](https://user-images.githubusercontent.com/14017872/174231323-7c16ea84-c585-4229-a9ab-e753e05e5073.png)

## Backwards-incompatible changes
None