### PR TITLE
Add `yDocumentType` to `IModelFactory`

### DIFF
--- a/jupyterlab/handlers/ydoc_handler.py
+++ b/jupyterlab/handlers/ydoc_handler.py
@@ -29,9 +29,9 @@ class JupyterRoom(YRoom):
 
 class JupyterWebsocketServer(WebsocketServer):
     def get_room(self, path: str) -> JupyterRoom:
-        file_format, file_type, file_path = path.split(":", 2)
+        file_format, file_type, file_path, ydoc_type = path.split(":", 3)
         if path not in self.rooms.keys():
-            self.rooms[path] = JupyterRoom(file_type)
+            self.rooms[path] = JupyterRoom(ydoc_type)
         return self.rooms[path]
 
 
@@ -58,7 +58,7 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
 
     def get_file_info(self) -> Tuple[str]:
         room_name = self.websocket_server.get_room_name(self.room)
-        file_format, file_type, file_path = room_name.split(":", 2)
+        file_format, file_type, file_path, ydoc_type = room_name.split(":", 3)
         return file_format, file_type, file_path
 
     def set_file_info(self, value: str) -> None:

--- a/packages/docprovider/src/tokens.ts
+++ b/packages/docprovider/src/tokens.ts
@@ -47,8 +47,22 @@ export namespace IDocumentProviderFactory {
      * The name (id) of the room
      */
     path: string;
+
+    /**
+     * The content type of the file.
+     */
     contentType: string;
+
+    /**
+     * The format of the file.
+     */
     format: string;
+
+    /**
+     * The type of the y-document associated with this model. Fall back
+     * to `contentType` if it is not defined.
+     */
+    yDocumentType?: string;
 
     /**
      * The YNotebook.

--- a/packages/docprovider/src/yprovider.ts
+++ b/packages/docprovider/src/yprovider.ts
@@ -32,7 +32,9 @@ export class WebSocketProvider
   constructor(options: WebSocketProvider.IOptions) {
     super(
       options.url,
-      options.format + ':' + options.contentType + ':' + options.path,
+      `${options.format}:${options.contentType}:${options.path}:${
+        options.yDocumentType || options.contentType
+      }`,
       options.ymodel.ydoc,
       {
         awareness: options.ymodel.awareness
@@ -40,6 +42,7 @@ export class WebSocketProvider
     );
     this._path = options.path;
     this._contentType = options.contentType;
+    this._yDocType = options.yDocumentType || options.contentType;
     this._format = options.format;
     this._serverUrl = options.url;
 
@@ -82,7 +85,7 @@ export class WebSocketProvider
       // writing a utf8 string to the encoder
       const escapedPath = unescape(
         encodeURIComponent(
-          this._format + ':' + this._contentType + ':' + newPath
+          `${this._format}:${this._contentType}:${newPath}:${this._yDocType}`
         )
       );
       for (let i = 0; i < escapedPath.length; i++) {
@@ -129,6 +132,7 @@ export class WebSocketProvider
 
   private _path: string;
   private _contentType: string;
+  private _yDocType: string;
   private _format: string;
   private _serverUrl: string;
   private _renameAck: PromiseDelegate<boolean>;

--- a/packages/docprovider/test/yprovider.spec.ts
+++ b/packages/docprovider/test/yprovider.spec.ts
@@ -2,11 +2,67 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { WebSocketProvider } from '../src';
+import * as yws from 'y-websocket';
+
+jest.mock('y-websocket');
 
 describe('@jupyterlab/docprovider', () => {
+  let Provider: jest.Mock;
+  beforeAll(() => {
+    Provider = yws.WebsocketProvider as jest.Mock;
+    Provider.mockImplementation(() => {
+      return {
+        messageHandlers: {}
+      };
+    });
+  });
+  afterAll(() => {
+    Provider.mockRestore();
+  });
   describe('docprovider', () => {
     it('should have a type', () => {
       expect(WebSocketProvider).not.toBeUndefined();
+    });
+    it('should deduce the Y document type from content type if it is missing', () => {
+      new WebSocketProvider({
+        ymodel: {} as any,
+        format: 'text',
+        contentType: 'file',
+        url: 'foo',
+        user: {
+          isReady: false,
+          changed: { connect: jest.fn(), disconnect: jest.fn() },
+          ready: { connect: jest.fn(), disconnect: jest.fn() }
+        } as any,
+        path: 'bar.txt'
+      });
+      expect(yws.WebsocketProvider).toBeCalledWith(
+        'foo',
+        'text:file:bar.txt:file',
+        undefined,
+        { awareness: undefined }
+      );
+    });
+    it('should send the Y document type if it is defined', () => {
+      new WebSocketProvider({
+        ymodel: {} as any,
+        format: 'text',
+        contentType: 'file',
+        url: 'foo',
+        user: {
+          isReady: false,
+          changed: { connect: jest.fn(), disconnect: jest.fn() },
+          ready: { connect: jest.fn(), disconnect: jest.fn() }
+        } as any,
+        path: 'bar.txt',
+        yDocumentType: 'customType'
+      });
+      expect(yws.WebsocketProvider).toBeCalledWith(
+        'foo',
+        'text:file:bar.txt:customType',
+        undefined,
+        { awareness: undefined }
+      );
     });
   });
 });

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -80,6 +80,7 @@ export class Context<
           path: this._path,
           contentType: this._factory.contentType,
           format: this._factory.fileFormat!,
+          yDocumentType: this._factory.yDocumentType,
           ymodel
         })
       : new ProviderMock();

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1189,6 +1189,12 @@ export namespace DocumentRegistry {
     readonly fileFormat: Contents.FileFormat;
 
     /**
+     * The type of the y-document associated with this model. Fall back
+     * to `contentType` if it is not defined.
+     */
+    readonly yDocumentType?: string;
+
+    /**
      * Create a new model for a given path.
      *
      * @param languagePreference - An optional kernel language preference.


### PR DESCRIPTION
## References

Closes https://github.com/jupyterlab/jupyterlab/issues/12711

## Code changes

Add `yDocumentType` property to `DocumentRegistry.IModelFactory` to define the type of the Y document. This is an optional property and `WebSocketProvider` will fall back to the content type if `yDocumentType` is not defined.

## User-facing changes

N/A

## Backwards-incompatible changes

N/A
