### PR TITLE
Add resize handle for scrolled cell outputs

### DIFF
--- a/packages/cells/style/widget.css
+++ b/packages/cells/style/widget.css
@@ -73,6 +73,11 @@
   overflow-y: auto;
   max-height: 24em;
   margin-left: var(--jp-private-cell-scrolling-output-offset);
+  resize: vertical;
+}
+
+.jp-CodeCell.jp-mod-outputsScrolled .jp-Cell-outputArea[style*='height'] {
+  max-height: unset;
 }
 
 .jp-CodeCell.jp-mod-outputsScrolled .jp-Cell-outputArea::after {


### PR DESCRIPTION
## References

Closes #12100.

## Code changes

This PR adds (vertical only) resizing of cell outputs when the "Scrolled Output" option is enabled in a notebook. Only a small CSS change was needed to add this.

## User-facing changes

A resize handle was added to cell outputs when the "Scrolled Output" option is enabled (see the bottom right of the cell output for the new handle).

### Before
![default](https://user-images.githubusercontent.com/14017872/176019916-677bfc58-65c4-4d72-87ca-46356debcf8c.png)

### After
![resizeable](https://user-images.githubusercontent.com/14017872/176019964-fbead31e-da35-4926-aea7-78ef38efca49.png)


## Backwards-incompatible changes

None - this is a pure CSS change.