### PR TITLE
Optimize debugger editor `eachLine` loops

### DIFF
--- a/packages/debugger/src/handlers/editor.ts
+++ b/packages/debugger/src/handlers/editor.ts
@@ -298,8 +298,10 @@ export namespace EditorHandler {
       return;
     }
     const cmEditor = editor as CodeMirrorEditor;
-    cmEditor.doc.eachLine(line => {
-      cmEditor.editor.removeLineClass(line, 'wrap', LINE_HIGHLIGHT_CLASS);
+    cmEditor.editor.operation(() => {
+      cmEditor.doc.eachLine(line => {
+        cmEditor.editor.removeLineClass(line, 'wrap', LINE_HIGHLIGHT_CLASS);
+      });
     });
   }
 
@@ -313,11 +315,7 @@ export namespace EditorHandler {
       return;
     }
     const cmEditor = editor as CodeMirrorEditor;
-    cmEditor.doc.eachLine(line => {
-      if ((line as Private.ILineInfo).gutterMarkers) {
-        cmEditor.editor.setGutterMarker(line, 'breakpoints', null);
-      }
-    });
+    cmEditor.editor.clearGutter('breakpoints');
   }
 }
 


### PR DESCRIPTION
When modifying each line of a large document it is very important that we do not update the DOM after each update. In CodeMirror this is done by wrapping loops in operations.

## References

None.

## Code changes

For `clearHighlight`, we wrap the loop in an operation.

For `clearGutter` we just call the already defined method in CM, which uses an operation by default. It might also be slightly more optimized in other ways.

## User-facing changes

No visual changes expected. Improvement to speed when navigating away from large files in the debugger editor.

## Backwards-incompatible changes

None.
