### PR TITLE
Bump version of `marked` and `@types/marked`

### DIFF
--- a/packages/markedparser-extension/package.json
+++ b/packages/markedparser-extension/package.json
@@ -37,10 +37,10 @@
     "@jupyterlab/application": "^4.0.0-alpha.11",
     "@jupyterlab/codemirror": "^4.0.0-alpha.11",
     "@jupyterlab/rendermime": "^4.0.0-alpha.11",
-    "marked": "^4.0.10"
+    "marked": "^4.0.17"
   },
   "devDependencies": {
-    "@types/marked": "^4.0.1",
+    "@types/marked": "^4.0.3",
     "rimraf": "~3.0.0",
     "typescript": "~4.7.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2789,10 +2789,10 @@
   resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz"
   integrity sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==
 
-"@types/marked@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/@types/marked/-/marked-4.0.1.tgz"
-  integrity sha512-ZigEmCWdNUU7IjZEuQ/iaimYdDHWHfTe3kg8ORfKjyGYd9RWumPoOJRQXB0bO+XLkNwzCthW3wUIQtANaEZ1ag==
+"@types/marked@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-4.0.3.tgz#2098f4a77adaba9ce881c9e0b6baf29116e5acc4"
+  integrity sha512-HnMWQkLJEf/PnxZIfbm0yGJRRZYYMhb++O9M36UCTA9z53uPvVoSlAwJr3XOpDEryb7Hwl1qAx/MV6YIW1RXxg==
 
 "@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.5"
@@ -9182,10 +9182,10 @@ marked@^3.0.8:
   resolved "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz"
   integrity sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==
 
-marked@^4.0.10:
-  version "4.0.10"
-  resolved "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz"
-  integrity sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==
+marked@^4.0.17:
+  version "4.0.17"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.17.tgz#1186193d85bb7882159cdcfc57d1dfccaffb3fe9"
+  integrity sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA==
 
 marky@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
## References

Should fix #12745

https://github.com/markedjs/marked/compare/v4.0.10...v4.0.17

I can rebase once https://github.com/jupyterlab/jupyterlab/pull/12742 is in. This PR will require manual backport (marked lives in `packages/rendermime` in 3.x)

## Code changes

None

## User-facing changes

Pulling a number of fixes from marked.js

## Backwards-incompatible changes

None