### PR TITLE
Rename Notebook from title: fix drive issue

### DIFF
--- a/packages/docmanager/src/dialogs.ts
+++ b/packages/docmanager/src/dialogs.ts
@@ -43,10 +43,11 @@ export function renameDialog(
 ): Promise<Contents.IModel | null> {
   translator = translator || nullTranslator;
   const trans = translator.load('jupyterlab');
+  const localPath = manager.services.contents.localPath(oldPath);
 
   return showDialog({
     title: trans.__('Rename File'),
-    body: new RenameHandler(oldPath),
+    body: new RenameHandler(localPath),
     focusNodeSelector: 'input',
     buttons: [
       Dialog.cancelButton({ label: trans.__('Cancel') }),
@@ -68,8 +69,10 @@ export function renameDialog(
       );
       return null;
     }
+    const driveName = manager.services.contents.driveName(oldPath);
+    const drivePrefix = driveName ? driveName + ':' : '';
     const basePath = PathExt.dirname(oldPath);
-    const newPath = PathExt.join(basePath, result.value);
+    const newPath = drivePrefix + PathExt.join(basePath, result.value);
     return renameFile(manager, oldPath, newPath);
   });
 }


### PR DESCRIPTION
## References

cc. @jtpio 

Fix issue mentioned in https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/pull/34#issuecomment-1156452964

Renaming from the title bar was not taking the current `drive` into account, failing with:
```
ContentsManager: renaming files must occur within a Drive
```

## Code changes



## User-facing changes

Users can now rename files in custom drives from the title bar

## Backwards-incompatible changes

None
