### PR TITLE
[memory-leaks] Fixes following cell addition analysis

### DIFF
--- a/packages/cell-toolbar/src/celltoolbartracker.ts
+++ b/packages/cell-toolbar/src/celltoolbartracker.ts
@@ -139,8 +139,8 @@ export class CellToolbarTracker implements IDisposable {
       this._findToolbarWidgets(cell).forEach(widget => widget.dispose());
       // Attempt to remove the resize and changed event handlers.
       cell.displayChanged.disconnect(this._resizeEventCallback, this);
-      cell.model.contentChanged.disconnect(this._changedEventCallback, this);
     }
+    model.contentChanged.disconnect(this._changedEventCallback, this);
   }
 
   /**

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -503,6 +503,7 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
     if (this.isDisposed) {
       return;
     }
+    this._resizeDebouncer.dispose();
     this._input = null!;
     this._model = null!;
     this._inputWrapper = null!;
@@ -1652,6 +1653,14 @@ export class MarkdownCell extends AttachmentsCell<IMarkdownCellModel> {
    */
   get renderer(): IRenderMime.IRenderer {
     return this._renderer;
+  }
+
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this._monitor.dispose();
+    super.dispose();
   }
 
   protected maybeCreateCollapseButton(): void {

--- a/packages/debugger/src/model.ts
+++ b/packages/debugger/src/model.ts
@@ -128,6 +128,7 @@ export class DebuggerModel implements IDebugger.Model.IService {
       return;
     }
     this._isDisposed = true;
+    this.kernelSources.dispose();
     this._disposed.emit();
   }
 

--- a/packages/debugger/src/panels/kernelSources/model.ts
+++ b/packages/debugger/src/panels/kernelSources/model.ts
@@ -52,6 +52,13 @@ export class KernelSourcesModel implements IDebugger.Model.IKernelSources {
   }
 
   /**
+   * Whether the kernel sources model is disposed or not.
+   */
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
+  /**
    * Get the kernel sources.
    */
   get kernelSources(): IDebugger.KernelSource[] | null {
@@ -88,6 +95,18 @@ export class KernelSourcesModel implements IDebugger.Model.IKernelSources {
   }
 
   /**
+   * Dispose the kernel sources model
+   */
+  dispose(): void {
+    if (this._isDisposed) {
+      return;
+    }
+    this._isDisposed = true;
+    this._refreshDebouncer.dispose();
+    Signal.clearData(this);
+  }
+
+  /**
    * Open a source in the main area.
    */
   open(kernelSource: IDebugger.Source): void {
@@ -112,9 +131,10 @@ export class KernelSourcesModel implements IDebugger.Model.IKernelSources {
     this._changed.emit(this._filteredKernelSources);
   }
 
-  private _kernelSources: IDebugger.KernelSource[] | null = null;
   private _filteredKernelSources: IDebugger.KernelSource[] | null = null;
   private _filter = '';
+  private _isDisposed = false;
+  private _kernelSources: IDebugger.KernelSource[] | null = null;
   private _refreshDebouncer: Debouncer;
   private _changed = new Signal<this, IDebugger.KernelSource[] | null>(this);
   private _filterChanged = new Signal<this, string>(this);

--- a/packages/debugger/src/tokens.ts
+++ b/packages/debugger/src/tokens.ts
@@ -7,7 +7,7 @@ import { KernelMessage, Session } from '@jupyterlab/services';
 
 import { ReadonlyJSONObject, Token } from '@lumino/coreutils';
 
-import { IObservableDisposable } from '@lumino/disposable';
+import { IDisposable, IObservableDisposable } from '@lumino/disposable';
 
 import { ISignal, Signal } from '@lumino/signaling';
 
@@ -914,7 +914,7 @@ export namespace IDebugger {
     /**
      * The kernel sources UI model.
      */
-    export interface IKernelSources {
+    export interface IKernelSources extends IDisposable {
       /**
        * The kernel source.
        */

--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -358,6 +358,17 @@ export class ListModel extends VDomModel {
   }
 
   /**
+   * Dispose the extensions list model.
+   */
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this._debouncedUpdate.dispose();
+    super.dispose();
+  }
+
+  /**
    * Initialize the model.
    */
   initialize(): Promise<void> {

--- a/packages/inspector/src/handler.ts
+++ b/packages/inspector/src/handler.ts
@@ -102,6 +102,7 @@ export class InspectionHandler implements IDisposable, IInspector.IInspectable {
       return;
     }
     this._isDisposed = true;
+    this._debouncer.dispose();
     this._disposed.emit(void 0);
     Signal.clearData(this);
   }

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -213,7 +213,6 @@ export class StaticNotebook extends Widget {
     // Section for the virtual-notebook behavior.
     this._idleCallBack = null;
     this._toRenderMap = new Map<string, { index: number; cell: Cell }>();
-    this._cellsArray = new Array<Cell>();
     if ('IntersectionObserver' in window) {
       this._observer = new IntersectionObserver(
         (entries, observer) => {
@@ -586,7 +585,6 @@ export class StaticNotebook extends Widget {
     widget.addClass(NB_CELL_CLASS);
 
     const layout = this.layout as PanelLayout;
-    this._cellsArray.push(widget);
     if (
       this._observer &&
       insertType === 'push' &&
@@ -654,7 +652,7 @@ export class StaticNotebook extends Widget {
     }
 
     if (
-      this._renderedCellsCount < this._cellsArray.length &&
+      this._renderedCellsCount < (this.model?.cells.length ?? 0) &&
       this._renderedCellsCount >=
         this.notebookConfig.numberCellsToRenderDirectly
     ) {
@@ -870,10 +868,8 @@ export class StaticNotebook extends Widget {
     // Control editor visibility for read-only Markdown cells
     const showEditorForReadOnlyMarkdown =
       this._notebookConfig.showEditorForReadOnlyMarkdown;
-    // 'this._cellsArray' check is here as '_updateNotebookConfig()'
-    // can be called before 'this._cellsArray' is defined
-    if (showEditorForReadOnlyMarkdown !== undefined && this._cellsArray) {
-      for (const cell of this._cellsArray) {
+    if (showEditorForReadOnlyMarkdown !== undefined) {
+      for (const cell of this.widgets) {
         if (cell.model.type === 'markdown') {
           (cell as MarkdownCell).showEditorForReadOnly =
             showEditorForReadOnlyMarkdown;
@@ -907,7 +903,6 @@ export class StaticNotebook extends Widget {
   private _renderedCellsCount = 0;
   private _toRenderMap: Map<string, { index: number; cell: Cell }>;
   private _idleCallBack: any;
-  private _cellsArray: Array<Cell>;
   private _renderingLayout: RenderingLayout | undefined;
   private _renderingLayoutChanged = new Signal<this, RenderingLayout>(this);
 }

--- a/packages/settingeditor/src/SettingsFormEditor.tsx
+++ b/packages/settingeditor/src/SettingsFormEditor.tsx
@@ -412,6 +412,10 @@ export class SettingsFormEditor extends React.Component<
     }
   }
 
+  componentWillUnmount(): void {
+    this._debouncer.dispose();
+  }
+
   /**
    * Handler for edits made in the form editor.
    * @param data - Form data sent from the form editor


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Linked to https://github.com/jupyterlab/benchmarks/pull/100
Follow-up of https://github.com/jupyterlab/jupyterlab/pull/12750
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
- Disconnect signal in cell toolbar tracker
- Ensure debouncers are disposed
- Remove `StaticNotebook._cellsArray`

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
`IKernelSources` extends `IDisposable`