### PR TITLE
update tab name after file rename

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -342,7 +342,7 @@ async function updateTabTitle(workspace: string, db: IStateDB, name: string) {
     }`;
   } else {
     // File name from current path
-    let currentFile: string = PathExt.basename(current.split(':')[1]);
+    let currentFile: string = PathExt.basename(window.location.href);
     // Truncate to first 12 characters of current document name + ... if length > 15
     currentFile =
       currentFile.length > 15


### PR DESCRIPTION
Fixes #12705

<!-- Note any other pull requests that address this issue and how this pull request is different. -->
No other pull requests have been made to address this issue thus far.
## Code changes

<!-- Describe the code changes and how they address the issue. -->
https://github.com/jupyterlab/jupyterlab/blob/dc55eca669b2730ec33025e8e9bbde91c9b0629c/packages/apputils-extension/src/index.ts#L336-L345 
Since currentFile is only declared when the tabname should be the name of a file, thus I would propose changing: `let currentFile: string = PathExt.basename(current.split(':')[1]); ` to `let currentFile: string = PathExt.basename(window.location.href);`
So if the user renamed a file, the tab title would update based on the last part of the path to the new file, instead of the old file name.

## User-facing changes

Previously the browser tab did not update when the name of a file was changed as the image below shows
<img width="702" alt="newtab" src="https://user-images.githubusercontent.com/34143233/178169991-1b5c67ca-e28a-4a65-99f5-d668a74d5929.png">
Afterwards, it would look like this, with both the file name and tab name matching.
<img width="702" alt="previoustab" src="https://user-images.githubusercontent.com/34143233/178170158-ec5fa494-16bd-4bbc-a602-578b36cf9c14.png">


---

Edited to link the issue
