### PR TITLE
#12717 Add a new section: automation of local dev environments

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -306,7 +306,7 @@ to do that using Vagrant as an example.
 The main advantages of using automation are: reduced time to get the environment up-and-running, reduced time to
 re-build the environment, better standardisation ("baseline", reproducible environments).
 
-A practical example can be found `here <https://github.com/markgreene74/jupyterlab-local-dev-with-vagrant>`_ and
+A practical example can be found `there <https://github.com/markgreene74/jupyterlab-local-dev-with-vagrant>`_ and
 includes a ``Vagrantfile``, the bootstrap files and additional documentation.
 
 Installing JupyterLab

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -297,6 +297,18 @@ To check which version of Node.js is installed:
 
    node -v
 
+Using automation to set up a local development environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+While there is a lot to learn by following the steps above, they can be automated to save time. This section shows how
+to do that using Vagrant as an example.
+
+The main advantages of using automation are: reduced time to get the environment up-and-running, reduced time to
+re-build the environment, better standardisation ("baseline", reproducible environments).
+
+A practical example can be found `here <https://github.com/markgreene74/jupyterlab-local-dev-with-vagrant>`_ and
+includes a ``Vagrantfile``, the bootstrap files and additional documentation.
+
 Installing JupyterLab
 ---------------------
 


### PR DESCRIPTION
## References

This PR is related to #12717.

## Code changes

With this PR a new sub-section "Using automation to set up a local development environment" is added to "Setting up a local development environment" in `contributing.rst`.

The sub-section contains a small description of some of the advantages and link to a working example of Vagrantfile and additional documentation.

## User-facing changes

Changes to the "Contribute" documentation.

## Backwards-incompatible changes

N/A, no changes to JupyterLab public APIs.
