### PR TITLE
Remove drive prefix from the file path when creating the new path

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -361,7 +361,8 @@ export class DirListing extends Widget {
 
     each(this._clipboard, path => {
       if (this._isCut) {
-        const parts = path.split('/');
+        const localPath = this._manager.services.contents.localPath(path);
+        const parts = localPath.split('/');
         const name = parts[parts.length - 1];
         const newPath = PathExt.join(basePath, name);
         promises.push(this._model.manager.rename(path, newPath));


### PR DESCRIPTION
There is a small issue with the DirListing. When using a custom drive, if we try to cut a file/dir, move to a folder, and paste the file/dir. The operation will fail because the new path of the file will be something like this: `DriveName:/path/to/the/new/folder/DriveName:original/path`.

The document manager allows registering new Drives that we can use to handle files on a remote file system. These drives are indexed by their names, see:
https://github.com/jupyterlab/jupyterlab/blob/32fd153ddc780e8b8b2719cda3bdd8dd0f2822c1/packages/services/src/contents/index.ts#L1004

When creating a new FileBrowser, we can indicate what drive we want to use. Then the file browser will use the name of the drive as a prefix for the path of each file, see:
https://github.com/jupyterlab/jupyterlab/blob/32fd153ddc780e8b8b2719cda3bdd8dd0f2822c1/packages/filebrowser/src/model.ts#L70-L81
https://github.com/jupyterlab/jupyterlab/blob/32fd153ddc780e8b8b2719cda3bdd8dd0f2822c1/packages/filebrowser/src/model.ts#L154-L156
This way, when the file browser requests an operation to the document manager, the document manager knows what drive to use.

The issue comes from here:
https://github.com/jupyterlab/jupyterlab/blob/32fd153ddc780e8b8b2719cda3bdd8dd0f2822c1/packages/filebrowser/src/listing.ts#L363-L367
When cutting a file, we add its path to `this._clipboard`, see:
https://github.com/jupyterlab/jupyterlab/blob/32fd153ddc780e8b8b2719cda3bdd8dd0f2822c1/packages/filebrowser/src/listing.ts#L335-L339
and 
https://github.com/jupyterlab/jupyterlab/blob/32fd153ddc780e8b8b2719cda3bdd8dd0f2822c1/packages/filebrowser/src/listing.ts#L1564-L1569
but, the path contains the name of the drive as a prefix, and when we try to paste it into a new folder, we create the new path by appending the path of the folder without previously removing the drive name from the old path.

This issue does not affect the default file browser because the drive name is an empty string.

## References


## Code changes
Remove the drive prefix from the file path when creating the new path.

## User-facing changes
N/A

## Backwards-incompatible changes
N/A
