### PR TITLE
Add readonly indicator

### DIFF
--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -13,8 +13,6 @@ import {
   JupyterLab
 } from '@jupyterlab/application';
 import {
-  addCommandToolbarButtonClass,
-  CommandToolbarButtonComponent,
   Dialog,
   ICommandPalette,
   InputDialog,
@@ -33,7 +31,7 @@ import {
   SavingStatus
 } from '@jupyterlab/docmanager';
 import { IDocumentProviderFactory } from '@jupyterlab/docprovider';
-import { DocumentRegistry } from '@jupyterlab/docregistry';
+import { DocumentRegistry, DocumentWidget } from '@jupyterlab/docregistry';
 import { Contents, Kernel } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IStatusBar } from '@jupyterlab/statusbar';
@@ -42,7 +40,12 @@ import {
   nullTranslator,
   TranslationBundle
 } from '@jupyterlab/translation';
-import { saveIcon } from '@jupyterlab/ui-components';
+import {
+  addCommandToolbarButtonClass,
+  CommandToolbarButtonComponent,
+  readonlyIcon,
+  saveIcon
+} from '@jupyterlab/ui-components';
 import { each, map, some, toArray } from '@lumino/algorithm';
 import { CommandRegistry } from '@lumino/commands';
 import { JSONExt } from '@lumino/coreutils';
@@ -484,8 +487,38 @@ export default plugins;
  */
 export namespace ToolbarItems {
   /**
+   * create readonly label toolbar item
+   */
+  export function createReadonlyLabel(
+    panel: DocumentWidget,
+    translator?: ITranslator
+  ): Widget {
+    const trans = (translator || nullTranslator).load('jupyterlab');
+    return addCommandToolbarButtonClass(
+      ReactWidget.create(
+        <UseSignal signal={panel.context.fileChanged}>
+          {() =>
+            !panel.context.contentsModel?.writable ? (
+              <readonlyIcon.react
+                className="jp-ToolbarLabelComponent-icon"
+                label="readonly document"
+                stylesheet="toolbarButton"
+                tag="span"
+                title={trans.__(
+                  `document is permissioned readonly; "save" is disabled, use "save as..." instead`
+                )}
+              />
+            ) : (
+              <></>
+            )
+          }
+        </UseSignal>
+      )
+    );
+  }
+
+  /**
    * Create save button toolbar item.
-   *
    */
   export function createSaveButton(
     commands: CommandRegistry,

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -505,6 +505,15 @@ export class DocumentWidget<
   constructor(options: DocumentWidget.IOptions<T, U>) {
     // Include the context ready promise in the widget reveal promise
     options.reveal = Promise.all([options.reveal, options.context.ready]);
+    // Expose the readonly status of the doc in the widget header elem
+
+    // options.contentHeader = new BoxPanel({
+    //   direction: 'top-to-bottom',
+    //   spacing: 0,
+
+    // });
+    // options.contentHeader.dataset.readonly =
+
     super(options);
 
     this.context = options.context;
@@ -561,6 +570,9 @@ export class DocumentWidget<
     path: string
   ): void {
     this.title.label = PathExt.basename(sender.localPath);
+    this.contentHeader.dataset.readonly = this.context.contentsModel?.writable
+      ? 'false'
+      : 'true';
   }
 
   /**

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -505,15 +505,6 @@ export class DocumentWidget<
   constructor(options: DocumentWidget.IOptions<T, U>) {
     // Include the context ready promise in the widget reveal promise
     options.reveal = Promise.all([options.reveal, options.context.ready]);
-    // Expose the readonly status of the doc in the widget header elem
-
-    // options.contentHeader = new BoxPanel({
-    //   direction: 'top-to-bottom',
-    //   spacing: 0,
-
-    // });
-    // options.contentHeader.dataset.readonly =
-
     super(options);
 
     this.context = options.context;
@@ -570,7 +561,7 @@ export class DocumentWidget<
     path: string
   ): void {
     this.title.label = PathExt.basename(sender.localPath);
-    this.contentHeader.dataset.readonly = this.context.contentsModel?.writable
+    this.node.dataset.readonly = this.context.contentsModel?.writable
       ? 'false'
       : 'true';
   }

--- a/packages/docregistry/style/base.css
+++ b/packages/docregistry/style/base.css
@@ -6,3 +6,14 @@
 .jp-MimeDocument {
   outline: none;
 }
+
+.jp-Document {
+  min-width: 120px;
+  min-height: 120px;
+  outline: none;
+}
+
+.jp-MainAreaWidget.jp-Document {
+  display: flex;
+  flex-direction: column;
+}

--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -317,9 +317,3 @@
   overflow: auto;
   background-color: var(--jp-layout-color1);
 }
-
-.jp-Document {
-  min-width: 120px;
-  min-height: 120px;
-  outline: none;
-}

--- a/packages/notebook-extension/schema/panel.json
+++ b/packages/notebook-extension/schema/panel.json
@@ -3,6 +3,7 @@
   "description": "Notebook Panel settings.",
   "jupyter.lab.toolbars": {
     "Notebook": [
+      { "name": "readonlyLabel", "rank": 9 },
       { "name": "save", "rank": 10 },
       {
         "name": "insert",

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -986,6 +986,9 @@ function activateWidgetFactory(
   toolbarRegistry.addFactory<NotebookPanel>(FACTORY, 'cellType', panel =>
     ToolbarItems.createCellTypeItem(panel, translator)
   );
+  toolbarRegistry.addFactory<NotebookPanel>(FACTORY, 'readonlyLabel', panel =>
+    DocToolbarItems.createReadonlyLabel(panel, translator)
+  );
   toolbarRegistry.addFactory<NotebookPanel>(FACTORY, 'kernelName', panel =>
     Toolbar.createKernelNameItem(
       panel.sessionContext,

--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -52,15 +52,15 @@ class ToolbarLayout extends PanelLayout {
    */
   protected onFitRequest(msg: Message): void {
     super.onFitRequest(msg);
-    if (this.parent!.isAttached) {
+    if (this.parent && this.parent.isAttached) {
       // If there are any widgets not explicitly hidden, expand the toolbar to
       // accommodate them.
       if (some(this.widgets, w => !w.isHidden)) {
-        this.parent!.node.style.minHeight = 'var(--jp-private-toolbar-height)';
-        this.parent!.removeClass('jp-Toolbar-micro');
+        this.parent.node.style.minHeight = 'var(--jp-private-toolbar-height)';
+        this.parent.removeClass('jp-Toolbar-micro');
       } else {
-        this.parent!.node.style.minHeight = '';
-        this.parent!.addClass('jp-Toolbar-micro');
+        this.parent.node.style.minHeight = '';
+        this.parent.addClass('jp-Toolbar-micro');
       }
     }
 

--- a/packages/ui-components/src/icon/iconimports.ts
+++ b/packages/ui-components/src/icon/iconimports.ts
@@ -77,6 +77,7 @@ import pdfSvgstr from '../../style/icons/filetype/pdf.svg';
 import pythonSvgstr from '../../style/icons/filetype/python.svg';
 import rKernelSvgstr from '../../style/icons/filetype/r-kernel.svg';
 import reactSvgstr from '../../style/icons/filetype/react.svg';
+import readonlySvgstr from '../../style/icons/toolbar/readonly.svg';
 import redoSvgstr from '../../style/icons/toolbar/redo.svg';
 import refreshSvgstr from '../../style/icons/toolbar/refresh.svg';
 import regexSvgstr from '../../style/icons/search/regex.svg';
@@ -171,6 +172,7 @@ export const pdfIcon = new LabIcon({ name: 'ui-components:pdf', svgstr: pdfSvgst
 export const pythonIcon = new LabIcon({ name: 'ui-components:python', svgstr: pythonSvgstr });
 export const rKernelIcon = new LabIcon({ name: 'ui-components:r-kernel', svgstr: rKernelSvgstr });
 export const reactIcon = new LabIcon({ name: 'ui-components:react', svgstr: reactSvgstr });
+export const readonlyIcon = new LabIcon({ name: 'ui-components:readonly', svgstr: readonlySvgstr });
 export const redoIcon = new LabIcon({ name: 'ui-components:redo', svgstr: redoSvgstr });
 export const refreshIcon = new LabIcon({ name: 'ui-components:refresh', svgstr: refreshSvgstr });
 export const regexIcon = new LabIcon({ name: 'ui-components:regex', svgstr: regexSvgstr });

--- a/packages/ui-components/src/style/icon.ts
+++ b/packages/ui-components/src/style/icon.ts
@@ -444,7 +444,7 @@ export namespace LabIconStyle {
         display: 'flex'
       },
       element: {
-        display: 'block',
+        display: 'inline-block',
         ...extra
       }
     };

--- a/packages/ui-components/style/deprecated.css
+++ b/packages/ui-components/style/deprecated.css
@@ -81,6 +81,7 @@
   --jp-icon-python: url('icons/filetype/python.svg');
   --jp-icon-r-kernel: url('icons/filetype/r-kernel.svg');
   --jp-icon-react: url('icons/filetype/react.svg');
+  --jp-icon-readonly: url('icons/toolbar/readonly.svg');
   --jp-icon-redo: url('icons/toolbar/redo.svg');
   --jp-icon-refresh: url('icons/toolbar/refresh.svg');
   --jp-icon-regex: url('icons/search/regex.svg');
@@ -382,6 +383,10 @@
 
 .jp-ReactIcon {
   background-image: var(--jp-icon-react);
+}
+
+.jp-ReadonlyIcon {
+  background-image: var(--jp-icon-readonly);
 }
 
 .jp-RedoIcon {

--- a/packages/ui-components/style/icons/toolbar/readonly.svg
+++ b/packages/ui-components/style/icons/toolbar/readonly.svg
@@ -1,0 +1,23 @@
+<svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+  <mask id="donutHole">
+    <rect width="24" height="24" fill="white"/>
+    <circle cx="12" cy="12" r="10" fill="black"/>
+  </mask>
+
+  <g class="jp-icon3" fill="#616161">
+    <rect height="2" width="4" x="10" y="17" transform="rotate(225,12,12)"/>
+    <rect height="3" width="4" x="10" y="13" transform="rotate(225,12,12)"/>
+    <rect height="3" width="4" x="10" y="7" transform="rotate(225,12,12)"/>
+    <polygon points="10,4 6,4 8,7.46" transform="translate(5.6, 8.2) rotate(45), scale(.9)"/>
+  </g>
+
+  <g class="jp-icon3" fill="#616161" stroke="#616161" stroke-linejoin="round">
+    <rect height="1" width="3" x="10.5" y="18" transform="rotate(225,12,12)"/>
+    <polygon points="10,4 6,4 8,7.46" transform="translate(6.2, 8.75) rotate(45) scale(.80)"/>
+  </g>
+
+  <g class="jp-icon3" fill="#616161">
+    <rect height="24" width="2" x="11" y="0" transform="rotate(315,12,12)"/>
+    <circle cx="12" cy="12" r="12" mask="url(#donutHole)"/>
+  </g>
+</svg>

--- a/packages/ui-components/style/toolbar.css
+++ b/packages/ui-components/style/toolbar.css
@@ -100,6 +100,26 @@ button.jp-ToolbarButtonComponent .jp-ToolbarButtonComponent-label {
   color: var(--jp-ui-font-color1);
 }
 
+.jp-ToolbarLabelComponent-icon {
+  background-color: var(--jp-brand-color1);
+  color: white;
+}
+
+.jp-ToolbarLabelComponent-icon .jp-icon3[fill] {
+  fill: white;
+}
+
+.jp-ToolbarLabelComponent-icon .jp-icon3[stroke] {
+  stroke: white;
+}
+
+span.jp-ToolbarLabelComponent-icon {
+  font-size: var(--jp-ui-font-size1);
+  line-height: 100%;
+  padding: 0 0 0 2px;
+  flex: 0 0 auto;
+}
+
 #jp-main-dock-panel[data-mode='single-document']
   .jp-MainAreaWidget
   > .jp-Toolbar.jp-Toolbar-micro {


### PR DESCRIPTION
## References

Fixes #7980

## Code changes

Adds a slightly somewhat (visually) loud indicator for the readonly status of the current document. My goal with this PR is to implement some version of UI proposals `1)` and `2)` made by @isabela-pf in #7980