### PR TITLE
Automated Changelog Entry for 3.4.4 on 3.4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,57 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.4.4
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.4.3...998cf0e146fdb7c61c42d9487ebb89c16581faf8))
+
+### Enhancements made
+
+- Adds version maintenance policy [#12829](https://github.com/jupyterlab/jupyterlab/pull/12829) ([@jweill-aws](https://github.com/jweill-aws))
+- Increase title width in simple mode [#11546](https://github.com/jupyterlab/jupyterlab/pull/11546) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Bump xtermjs to latest [#12715](https://github.com/jupyterlab/jupyterlab/pull/12715) ([@yuvipanda](https://github.com/yuvipanda))
+- Debugger: Make kernel source list react based [#12751](https://github.com/jupyterlab/jupyterlab/pull/12751) ([@vidartf](https://github.com/vidartf))
+- Optimize debugger editor `eachLine` loops [#12746](https://github.com/jupyterlab/jupyterlab/pull/12746) ([@vidartf](https://github.com/vidartf))
+- Make password inputs not give away how many characters were typed [#12659](https://github.com/jupyterlab/jupyterlab/pull/12659) ([@jasongrout](https://github.com/jasongrout))
+
+### Bugs fixed
+
+- Remove drive prefix from the file path when creating the new path [#12824](https://github.com/jupyterlab/jupyterlab/pull/12824) ([@hbcarlos](https://github.com/hbcarlos))
+- Use path to extract `tmpPath` [#12823](https://github.com/jupyterlab/jupyterlab/pull/12823) ([@fcollonval](https://github.com/fcollonval))
+- update tab name after file rename [#12791](https://github.com/jupyterlab/jupyterlab/pull/12791) ([@RobbyPratl](https://github.com/RobbyPratl))
+- Update base.css [#12783](https://github.com/jupyterlab/jupyterlab/pull/12783) ([@siddartha-10](https://github.com/siddartha-10))
+- Pin nbclassic below 0.4.0 [#12767](https://github.com/jupyterlab/jupyterlab/pull/12767) ([@fcollonval](https://github.com/fcollonval))
+- Set focus when active cell changes only from mouse click [#12735](https://github.com/jupyterlab/jupyterlab/pull/12735) ([@fcollonval](https://github.com/fcollonval))
+- Fix staging/yarn.lock registry [#12742](https://github.com/jupyterlab/jupyterlab/pull/12742) ([@vidartf](https://github.com/vidartf))
+- Debugger: Fix CSS for variables inspecting [#12749](https://github.com/jupyterlab/jupyterlab/pull/12749) ([@martinRenou](https://github.com/martinRenou))
+- Translate "Default: " and "Remove" in custom fields [#12732](https://github.com/jupyterlab/jupyterlab/pull/12732) ([@krassowski](https://github.com/krassowski))
+- Fix cell toolbar overlap in side-by-side render mode [#12710](https://github.com/jupyterlab/jupyterlab/pull/12710) ([@peytondmurray](https://github.com/peytondmurray))
+- Remove ipywidgets message count in the execution indicator model [#12665](https://github.com/jupyterlab/jupyterlab/pull/12665) ([@trungleduc](https://github.com/trungleduc))
+
+### Maintenance and upkeep improvements
+
+- Backport #12799 on branch 3.4.x (Update verdaccio, start registry on … [#12825](https://github.com/jupyterlab/jupyterlab/pull/12825) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #12785: Use Vega SVG renderer to drop canvas dependency [#12811](https://github.com/jupyterlab/jupyterlab/pull/12811) ([@fcollonval](https://github.com/fcollonval))
+- Bump moment from 2.29.2 to 2.29.4 [#12781](https://github.com/jupyterlab/jupyterlab/pull/12781) ([@dependabot[bot]](https://github.com/apps/dependabot))
+- [memory-leaks] Fixes following cell addition analysis [#12774](https://github.com/jupyterlab/jupyterlab/pull/12774) ([@fcollonval](https://github.com/fcollonval))
+- Bump @lumino/widgets to 1.33.0 [#12777](https://github.com/jupyterlab/jupyterlab/pull/12777) ([@fcollonval](https://github.com/fcollonval))
+- Fix memory leaks [#12750](https://github.com/jupyterlab/jupyterlab/pull/12750) ([@fcollonval](https://github.com/fcollonval))
+- Bump version of `marked` and `@types/marked` [#12747](https://github.com/jupyterlab/jupyterlab/pull/12747) ([@krassowski](https://github.com/krassowski))
+- Drop pre-commit from build dependencies (#12680) [#12706](https://github.com/jupyterlab/jupyterlab/pull/12706) ([@jtpio](https://github.com/jtpio))
+
+### Documentation improvements
+
+- Adds version maintenance policy [#12829](https://github.com/jupyterlab/jupyterlab/pull/12829) ([@jweill-aws](https://github.com/jweill-aws))
+- Backport PR #12707: Explicitly set language to `en` in `conf.py` [#12712](https://github.com/jupyterlab/jupyterlab/pull/12712) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-06-07&to=2022-07-21&type=c))
+
+[@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2022-06-07..2022-07-21&type=Issues) | [@aiqc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aaiqc+updated%3A2022-06-07..2022-07-21&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2022-06-07..2022-07-21&type=Issues) | [@dlqqq](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adlqqq+updated%3A2022-06-07..2022-07-21&type=Issues) | [@dmonad](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Admonad+updated%3A2022-06-07..2022-07-21&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-06-07..2022-07-21&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2022-06-07..2022-07-21&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-06-07..2022-07-21&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-06-07..2022-07-21&type=Issues) | [@goanpeca](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agoanpeca+updated%3A2022-06-07..2022-07-21&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2022-06-07..2022-07-21&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-06-07..2022-07-21&type=Issues) | [@JohanMabille](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AJohanMabille+updated%3A2022-06-07..2022-07-21&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-06-07..2022-07-21&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2022-06-07..2022-07-21&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-06-07..2022-07-21&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2022-06-07..2022-07-21&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-06-07..2022-07-21&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AmartinRenou+updated%3A2022-06-07..2022-07-21&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-06-07..2022-07-21&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-06-07..2022-07-21&type=Issues) | [@siddartha-10](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Asiddartha-10+updated%3A2022-06-07..2022-07-21&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASylvainCorlay+updated%3A2022-06-07..2022-07-21&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-06-07..2022-07-21&type=Issues) | [@williamstein](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awilliamstein+updated%3A2022-06-07..2022-07-21&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.4.3
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.4.2...b05da6fae42dcf5a5ad0dd9b46a8b75d64804799))
@@ -51,8 +102,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-05-13&to=2022-06-07&type=c))
 
 [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2022-05-13..2022-06-07&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-05-13..2022-06-07&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2022-05-13..2022-06-07&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2022-05-13..2022-06-07&type=Issues) | [@dmonad](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Admonad+updated%3A2022-05-13..2022-06-07&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-05-13..2022-06-07&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2022-05-13..2022-06-07&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-05-13..2022-06-07&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-05-13..2022-06-07&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2022-05-13..2022-06-07&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-05-13..2022-06-07&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2022-05-13..2022-06-07&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-05-13..2022-06-07&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-05-13..2022-06-07&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-05-13..2022-06-07&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-05-13..2022-06-07&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.4.2
 


### PR DESCRIPTION
Automated Changelog Entry for 3.4.4 on 3.4.x
```
Python version: 3.4.4
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.4.4
@jupyterlab/buildutils: 3.4.4
@jupyterlab/template: 3.4.4
@jupyterlab/application-top: 3.4.4
@jupyterlab/example-app: 3.4.4
@jupyterlab/example-cell: 3.4.4
@jupyterlab/example-console: 3.4.4
@jupyterlab/example-federated: 2.5.4
@jupyterlab/example-federated-core: 2.5.4
@jupyterlab/example-federated-md: 2.5.4
@jupyterlab/example-federated-middle: 2.5.4
@jupyterlab/example-federated-phosphor: 2.5.4
@jupyterlab/example-filebrowser: 3.4.4
@jupyterlab/example-notebook: 3.4.4
@jupyterlab/example-terminal: 3.4.4
@jupyterlab/galata: 4.3.4
@jupyterlab/mock-extension: 3.4.4
@jupyterlab/mock-consumer: 3.4.4
@jupyterlab/mock-provider: 3.4.4
@jupyterlab/mock-token: 3.4.4
@jupyterlab/application: 3.4.4
@jupyterlab/application-extension: 3.4.4
@jupyterlab/apputils: 3.4.4
@jupyterlab/apputils-extension: 3.4.4
@jupyterlab/attachments: 3.4.4
@jupyterlab/cell-toolbar: 3.4.4
@jupyterlab/cell-toolbar-extension: 3.4.4
@jupyterlab/cells: 3.4.4
@jupyterlab/celltags: 3.4.4
@jupyterlab/celltags-extension: 3.4.4
@jupyterlab/codeeditor: 3.4.4
@jupyterlab/codemirror: 3.4.4
@jupyterlab/codemirror-extension: 3.4.4
@jupyterlab/completer: 3.4.4
@jupyterlab/completer-extension: 3.4.4
@jupyterlab/console: 3.4.4
@jupyterlab/console-extension: 3.4.4
@jupyterlab/coreutils: 5.4.4
@jupyterlab/csvviewer: 3.4.4
@jupyterlab/csvviewer-extension: 3.4.4
@jupyterlab/debugger: 3.4.4
@jupyterlab/debugger-extension: 3.4.4
@jupyterlab/docmanager: 3.4.4
@jupyterlab/docmanager-extension: 3.4.4
@jupyterlab/docprovider: 3.4.4
@jupyterlab/docprovider-extension: 3.4.4
@jupyterlab/docregistry: 3.4.4
@jupyterlab/documentsearch: 3.4.4
@jupyterlab/documentsearch-extension: 3.4.4
@jupyterlab/extensionmanager: 3.4.4
@jupyterlab/extensionmanager-extension: 3.4.4
@jupyterlab/filebrowser: 3.4.4
@jupyterlab/filebrowser-extension: 3.4.4
@jupyterlab/fileeditor: 3.4.4
@jupyterlab/fileeditor-extension: 3.4.4
@jupyterlab/help-extension: 3.4.4
@jupyterlab/htmlviewer: 3.4.4
@jupyterlab/htmlviewer-extension: 3.4.4
@jupyterlab/hub-extension: 3.4.4
@jupyterlab/imageviewer: 3.4.4
@jupyterlab/imageviewer-extension: 3.4.4
@jupyterlab/inspector: 3.4.4
@jupyterlab/inspector-extension: 3.4.4
@jupyterlab/javascript-extension: 3.4.4
@jupyterlab/json-extension: 3.4.4
@jupyterlab/launcher: 3.4.4
@jupyterlab/launcher-extension: 3.4.4
@jupyterlab/logconsole: 3.4.4
@jupyterlab/logconsole-extension: 3.4.4
@jupyterlab/mainmenu: 3.4.4
@jupyterlab/mainmenu-extension: 3.4.4
@jupyterlab/markdownviewer: 3.4.4
@jupyterlab/markdownviewer-extension: 3.4.4
@jupyterlab/mathjax2: 3.4.4
@jupyterlab/mathjax2-extension: 3.4.4
@jupyterlab/metapackage: 3.4.4
@jupyterlab/nbconvert-css: 3.4.4
@jupyterlab/nbformat: 3.4.4
@jupyterlab/notebook: 3.4.4
@jupyterlab/notebook-extension: 3.4.4
@jupyterlab/observables: 4.4.4
@jupyterlab/outputarea: 3.4.4
@jupyterlab/pdf-extension: 3.4.4
@jupyterlab/property-inspector: 3.4.4
@jupyterlab/rendermime: 3.4.4
@jupyterlab/rendermime-extension: 3.4.4
@jupyterlab/rendermime-interfaces: 3.4.4
@jupyterlab/running: 3.4.4
@jupyterlab/running-extension: 3.4.4
@jupyterlab/services: 6.4.4
@jupyterlab/example-services-browser: 3.4.4
node-example: 3.4.4
@jupyterlab/example-services-outputarea: 3.4.4
@jupyterlab/settingeditor: 3.4.4
@jupyterlab/settingeditor-extension: 3.4.4
@jupyterlab/settingregistry: 3.4.4
@jupyterlab/shared-models: 3.4.4
@jupyterlab/shortcuts-extension: 3.4.4
@jupyterlab/statedb: 3.4.4
@jupyterlab/statusbar: 3.4.4
@jupyterlab/statusbar-extension: 3.4.4
@jupyterlab/terminal: 3.4.4
@jupyterlab/terminal-extension: 3.4.4
@jupyterlab/theme-dark-extension: 3.4.4
@jupyterlab/theme-light-extension: 3.4.4
@jupyterlab/toc: 5.4.4
@jupyterlab/toc-extension: 5.4.4
@jupyterlab/tooltip: 3.4.4
@jupyterlab/tooltip-extension: 3.4.4
@jupyterlab/translation: 3.4.4
@jupyterlab/translation-extension: 3.4.4
@jupyterlab/ui-components: 3.4.4
@jupyterlab/ui-components-extension: 3.4.4
@jupyterlab/vdom: 3.4.4
@jupyterlab/vdom-extension: 3.4.4
@jupyterlab/vega5-extension: 3.4.4
@jupyterlab/testutils: 3.4.4
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.4.x  |
| Version Spec | next |
| Since | v3.4.3 |