### PR TITLE
Adjust css to not leave trace of deleted widgets

### DIFF
--- a/packages/outputarea/style/base.css
+++ b/packages/outputarea/style/base.css
@@ -149,6 +149,12 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated::before {
   display: none;
 }
 
+/* Hide empty lines in the output area, for instance due to cleared widgets */
+jp-OutputArea-prompt:empty {
+  padding: 0;
+  border: 0;
+}
+
 /*-----------------------------------------------------------------------------
 | executeResult is added to any Output-result for the display of the object
 | returned by a cell

--- a/packages/outputarea/style/base.css
+++ b/packages/outputarea/style/base.css
@@ -150,7 +150,7 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated::before {
 }
 
 /* Hide empty lines in the output area, for instance due to cleared widgets */
-jp-OutputArea-prompt:empty {
+.jp-OutputArea-prompt:empty {
   padding: 0;
   border: 0;
 }


### PR DESCRIPTION
## References
Fixes #7354
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

The change removes the padding and border around entries in the output that are completely empty. This is the case for ipywidgets that have cleared themselves. Previously they would leave a whitespace that could build up, for instance when running `tqdm` in a nested loop.

## User-facing changes
See images below. I cannot think of any situations where the new behaviour is undesirable or breaking. 

I had to test them using inline css called via the notebook, since I was unable to install the ipywidgets labextension in my development environment. This may be due to it being an ARM cpu (M1 Mac), but I've now spent over an hour trying to no avail. (tested both the v8 and v7 ipywidgets branches).

# Before
<img width="1071" alt="image" src="https://user-images.githubusercontent.com/2721423/180304348-554dc138-a470-40c8-8019-d05da54aed32.png">

# After
<img width="1077" alt="image" src="https://user-images.githubusercontent.com/2721423/180304406-8f371aae-d81b-42b8-88ca-ec66ce4f47b0.png">

# After
## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
