### PR TITLE
Fixes renaming files from title while using a custom drive

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -46,6 +46,8 @@ bumped their major version (following semver convention). We want to point out p
    The type of ``IConsoleHistory.sessionContext`` has been updated to ``ISessionContext | null`` instead of ``ISessionContext``.
    This might break the compilation of plugins accessing the ``sessionContext`` from a ``ConsoleHistory``,
    in particular those with the strict null checks enabled.
+- ``@jupyterlab/docmanager`` from 3.x to 4.x
+   The ``renameDialog`` now receives the ``DocumentRegistry.Context`` instead of a path.
 - ``@jupyterlab/docprovider`` from 3.x to 4.x
    ``WebSocketProviderWithLocks`` has been renamed to ``WebSocketProvider``.
    ``acquireLock``, ``releaseLock``, ``requestInitialContent`` and ``putInitializedState`` have been removed from ``IDocumentProvider``.

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -928,7 +928,7 @@ function addLabCommands(
       // Implies contextMenuWidget() !== null
       if (isEnabled()) {
         const context = docManager.contextForWidget(contextMenuWidget()!);
-        return renameDialog(docManager, context!.path);
+        return renameDialog(docManager, context!);
       }
     }
   });

--- a/packages/docmanager/src/dialogs.ts
+++ b/packages/docmanager/src/dialogs.ts
@@ -2,6 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { Dialog, showDialog, showErrorMessage } from '@jupyterlab/apputils';
+import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { PathExt } from '@jupyterlab/coreutils';
 import { Contents } from '@jupyterlab/services';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
@@ -38,15 +39,18 @@ export interface IFileContainer extends JSONObject {
  */
 export function renameDialog(
   manager: IDocumentManager,
-  oldPath: string,
+  context: DocumentRegistry.Context,
   translator?: ITranslator
-): Promise<Contents.IModel | null> {
+): Promise<void | null> {
   translator = translator || nullTranslator;
   const trans = translator.load('jupyterlab');
 
+  const localPath = context.localPath.split('/');
+  const fileName = localPath.pop() || context.localPath;
+
   return showDialog({
     title: trans.__('Rename File'),
-    body: new RenameHandler(oldPath),
+    body: new RenameHandler(fileName),
     focusNodeSelector: 'input',
     buttons: [
       Dialog.cancelButton({ label: trans.__('Cancel') }),
@@ -68,9 +72,7 @@ export function renameDialog(
       );
       return null;
     }
-    const basePath = PathExt.dirname(oldPath);
-    const newPath = PathExt.join(basePath, result.value);
-    return renameFile(manager, oldPath, newPath);
+    return context.rename(result.value);
   });
 }
 

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -564,7 +564,7 @@ export class Context<
     if (drivName) {
       newPath = `${drivName}:${newPath}`;
     }
-    
+
     await this._manager.contents.rename(this.path, newPath);
     await this.sessionContext.session?.setPath(newPath);
     await this.sessionContext.session?.setName(newName);

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -557,10 +557,14 @@ export class Context<
    * @param newName - the new name for the document.
    */
   private async _rename(newName: string): Promise<void> {
-    const splitPath = this.path.split('/');
+    const splitPath = this.localPath.split('/');
     splitPath[splitPath.length - 1] = newName;
-    const newPath = splitPath.join('/');
-
+    let newPath = PathExt.join(...splitPath);
+    const drivName = this._manager.contents.driveName(this.path);
+    if (drivName) {
+      newPath = `${drivName}:${newPath}`;
+    }
+    
     await this._manager.contents.rename(this.path, newPath);
     await this.sessionContext.session?.setPath(newPath);
     await this.sessionContext.session?.setName(newName);

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -560,9 +560,9 @@ export class Context<
     const splitPath = this.localPath.split('/');
     splitPath[splitPath.length - 1] = newName;
     let newPath = PathExt.join(...splitPath);
-    const drivName = this._manager.contents.driveName(this.path);
-    if (drivName) {
-      newPath = `${drivName}:${newPath}`;
+    const driveName = this._manager.contents.driveName(this.path);
+    if (driveName) {
+      newPath = `${driveName}:${newPath}`;
     }
 
     await this._manager.contents.rename(this.path, newPath);

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -536,7 +536,8 @@ export class DocumentWidget<
   private async _onTitleChanged(_sender: Title<this>) {
     const validNameExp = /[\/\\:]/;
     const name = this.title.label;
-    const filename = this.context.path.split('/').pop()!;
+    // Use localPath to avoid the drive name
+    const filename = this.context.localPath.split('/').pop() || this.context.localPath;
 
     if (name === filename) {
       return;

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -537,7 +537,8 @@ export class DocumentWidget<
     const validNameExp = /[\/\\:]/;
     const name = this.title.label;
     // Use localPath to avoid the drive name
-    const filename = this.context.localPath.split('/').pop() || this.context.localPath;
+    const filename =
+      this.context.localPath.split('/').pop() || this.context.localPath;
 
     if (name === filename) {
       return;


### PR DESCRIPTION
Fixes #12755
cc @jtpio @martinRenou 

## References

## Code changes

## User-facing changes

## Backwards-incompatible changes
Yes, the rename dialog now receives the context instead of the path.
