### PR TITLE
Don't suggest deprecated command

### DIFF
--- a/docs/source/user/jupyterhub.rst
+++ b/docs/source/user/jupyterhub.rst
@@ -19,7 +19,7 @@ Notebook (``/tree``) by default. To change the user's default user interface to
 JupyterLab, set the following configuration option in your
 :file:`jupyterhub_config.py` file::
 
-    c.Spawner.cmd=["jupyter-labhub"]
+    c.Spawner.default_url = "/lab"
 
 In this configuration, users can still access the classic Notebook at ``/tree``,
 by either typing that URL into the browser, or by using the "Launch Classic


### PR DESCRIPTION
jupyter-labhub is deprecated, based on https://github.com/jupyterhub/jupyterlab-hub. Admins can configure JupyterLab as the initial app to start by setting `default_url` instead, https://jupyterhub.readthedocs.io/en/stable/api/app.html#jupyterhub.app.JupyterHub.default_url.

## Code changes

Swaps out `.cmd` for `.default_url` in the docs.
