### PR TITLE
Fix kernel in the statusbar does not match the actual

### DIFF
--- a/packages/apputils/src/kernelstatuses.tsx
+++ b/packages/apputils/src/kernelstatuses.tsx
@@ -191,9 +191,17 @@ export namespace KernelStatus {
     }
     set sessionContext(sessionContext: ISessionContext | null) {
       this._sessionContext?.statusChanged.disconnect(
-        this._onKernelStatusChanged
+        this._onKernelStatusChanged,
+        this
       );
-      this._sessionContext?.kernelChanged.disconnect(this._onKernelChanged);
+      this._sessionContext?.connectionStatusChanged.disconnect(
+        this._onKernelStatusChanged,
+        this
+      );
+      this._sessionContext?.kernelChanged.disconnect(
+        this._onKernelChanged,
+        this
+      );
 
       const oldState = this._getAllState();
       this._sessionContext = sessionContext;
@@ -212,25 +220,25 @@ export namespace KernelStatus {
     /**
      * React to changes to the kernel status.
      */
-    private _onKernelStatusChanged = () => {
+    private _onKernelStatusChanged() {
       this._kernelStatus = this._sessionContext?.kernelDisplayStatus;
       this.stateChanged.emit(void 0);
-    };
+    }
 
     /**
      * React to changes in the kernel.
      */
-    private _onKernelChanged = (
+    private _onKernelChanged(
       _sessionContext: ISessionContext,
       change: Session.ISessionConnection.IKernelChangedArgs
-    ) => {
+    ) {
       const oldState = this._getAllState();
 
       // sync setting of status and display name
       this._kernelStatus = this._sessionContext?.kernelDisplayStatus;
       this._kernelName = _sessionContext.kernelDisplayName;
       this._triggerChange(oldState, this._getAllState());
-    };
+    }
 
     private _getAllState(): Private.State {
       return [this._kernelName, this._kernelStatus, this._activityName];


### PR DESCRIPTION
fix #12592

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
#12592
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

The `disconnect` be check the `thisArg`, will result in the previous callback function not being disconnected.
~~In this case, both functions are arrow functions, we don't need the `thisArg`.~~
As described in https://github.com/jupyterlab/jupyterlab/pull/12865#issuecomment-1197766873, now use the class style to call these methods

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
N/A
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
N/A
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
