### PR TITLE
Pin tornado >=6.2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     importlib-resources>=1.4;python_version<"3.9"
     ipykernel
     packaging
-    tornado>=6.1.0
+    tornado>=6.2.0
     jupyter_core
     jupyterlab_server>=2.11.1,<3
     jupyter_server>=1.16.0,<2


### PR DESCRIPTION
## References

We are seeing errors on Binder with master branch that could be related to Tornado:
```
[D 07:27:52.414 NotebookApp] 101 GET /binder/jupyter/user/jupyterlab-jupyterlab-gij02he9/lab-dev/api/yjs/text:file:setup.py (91.160.50.123) 0.650000ms
[I 07:27:52.414 NotebookApp] Trying to establish websocket connection to ws://localhost:48159/binder/jupyter/user/jupyterlab-jupyterlab-gij02he9/lab-dev/api/yjs/text:file:setup.py
[E 07:27:52.417 NotebookApp] Uncaught exception GET /binder/jupyter/user/jupyterlab-jupyterlab-gij02he9/lab-dev/api/yjs/text:file:setup.py (91.160.50.123)
    HTTPServerRequest(protocol='http', host='notebooks.gesis.org', method='GET', uri='/binder/jupyter/user/jupyterlab-jupyterlab-gij02he9/lab-dev/api/yjs/text:file:setup.py', version='HTTP/1.1', remote_ip='91.160.50.123')
    Traceback (most recent call last):
      File "/srv/conda/envs/notebook/lib/python3.8/site-packages/tornado/websocket.py", line 956, in _accept_connection
        await open_result
      File "/srv/conda/envs/notebook/lib/python3.8/site-packages/jupyter_server_proxy/handlers.py", line 672, in open
        return await super().open(self.port, path)
      File "/srv/conda/envs/notebook/lib/python3.8/site-packages/jupyter_server_proxy/handlers.py", line 494, in open
        return await self.proxy_open('localhost', port, proxied_path)
      File "/srv/conda/envs/notebook/lib/python3.8/site-packages/jupyter_server_proxy/handlers.py", line 444, in proxy_open
        await start_websocket_connection()
      File "/srv/conda/envs/notebook/lib/python3.8/site-packages/jupyter_server_proxy/handlers.py", line 435, in start_websocket_connection
        self.ws = await pingable_ws_connect(request=request,
      File "/srv/conda/envs/notebook/lib/python3.8/asyncio/tasks.py", line 349, in __wakeup
        future.result()
    tornado.httpclient.HTTPClientError: HTTP 404: Not Found
```

## Code changes

Require `tornado >=6.2.0`.

## User-facing changes

None.

## Backwards-incompatible changes

None.