### PR TITLE
Set `Contents.ContentType` to string

### DIFF
--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -116,9 +116,11 @@ export namespace Contents {
   }
 
   /**
-   * A contents file type.
+   * A contents file type. It can be anything but `jupyter-server`
+   * has special treatment for `notebook` and `directory` types.
+   * Anything else is considered as `file` type.
    */
-  export type ContentType = 'notebook' | 'file' | 'directory';
+  export type ContentType = string;
 
   /**
    * A contents file format.


### PR DESCRIPTION

## References
The current `y_doc` handler of JupyterLab uses the `file_type` property of the document to create the corresponding `y_doc` document. Currently, [JupyterLab](https://github.com/jupyterlab/jupyterlab/blob/b4540166b6afaba3454492591122ca963dbb3350/packages/services/src/contents/index.ts#L121) hard-codes the file types to `file | notebook | directory` so any new file type registered with jupyter_ydoc can not be used. 
Recently, `jupyter_server` removes this constraint by allowing [any kind of file type](https://github.com/jupyter-server/jupyter_server/pull/895). This PR does the same thing for the frontend part.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Set `Contents.ContentType` of `@jupyterlab/services` to `string`

## Backwards-incompatible changes
N/A