### PR TITLE
Bump jupyter_server_ydoc>=0.1.9

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     jupyter_core
     jupyterlab_server>=2.11.1,<3
     jupyter_server>=1.16.0,<2
-    jupyter_server_ydoc>=0.1.8,<0.2.0
+    jupyter_server_ydoc>=0.1.9,<0.2.0
     notebook_shim>=0.1
     jinja2>=3.0.3
 


### PR DESCRIPTION
## References

Closes #12874.

## Code changes

Bump `jupyter_server_ydoc` minimum version to `0.1.9`.

## User-facing changes

Fixes Binder.

## Backwards-incompatible changes

None.