### PR TITLE
Remove reference to unmaintained nb_conda_kernels

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -288,14 +288,6 @@ To check which version of Node.js is installed:
 Installing JupyterLab
 ---------------------
 
-If you use ``conda``, you may also want to install ``nb_conda_kernels`` to have a kernel
-option for different `conda
-environments <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`__
-
-.. code:: bash
-
-   conda install -c conda-forge nb_conda_kernels
-
 Fork the JupyterLab
 `repository <https://github.com/jupyterlab/jupyterlab>`__.
 


### PR DESCRIPTION
The `nb_conda_kernels` is not necessary to install JupyterLab in development mode. It is also unmaintained since 2020.