### PR TITLE
Update `yjs-codemirror.next`

### DIFF
--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -80,7 +80,7 @@
     "@lumino/widgets": "^1.33.0",
     "react": "^17.0.1",
     "style-mod": "~4.0.0",
-    "y-codemirror.next": "~0.3.0",
+    "y-codemirror.next": "~0.3.2",
     "y-protocols": "^1.0.5",
     "yjs": "^13.5.34"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13482,10 +13482,10 @@ xterm@~4.18.0:
   resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.18.0.tgz#a1f6ab2c330c3918fb094ae5f4c2562987398ea1"
   integrity sha512-JQoc1S0dti6SQfI0bK1AZvGnAxH4MVw45ZPFSO6FHTInAiau3Ix77fSxNx3mX4eh9OL4AYa8+4C8f5UvnSfppQ==
 
-y-codemirror.next@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/y-codemirror.next/-/y-codemirror.next-0.3.0.tgz#79ac9c198c095619f77be467367eef5aaee4ca94"
-  integrity sha512-UqM2w32+62GF4j0jZ49OhWeXdzp25rw4y92vK9nttux0audUGTlsya0LfBqtKfQ/8GBeedpAu9kjZbEHj1yvfA==
+y-codemirror.next@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/y-codemirror.next/-/y-codemirror.next-0.3.2.tgz#15f7afec14a56fba4f25811d5f90b986e1cc644c"
+  integrity sha512-3ksMXoietzNkrgluG9ut+5q4PNHCS6sQ+mHd44hNX1s7TBe4iDgOOIswfY3oLsdamZLAUPr+TnRdYgYuNDs7Qg==
   dependencies:
     lib0 "^0.2.42"
 


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Replaces https://github.com/jupyterlab/jupyterlab/pull/12877
Closes https://github.com/jupyterlab/jupyterlab/pull/12877

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update `yjs-codemirror.next` which has fixes for CM6.

From #12877:

> This PR fixes an issue in collaborative mode; prior to this change, when opening a notebook with many cells, the cursor of collaborators was jumping from one cell to another one quite fast. This was due to a backward incompatible change in CM6 (between the alpha and the official release) that y-codemirror.next hadn't taken into account yet. The last release fixes it.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes



<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
