### PR TITLE
Fix JSON Settings Editor

### DIFF
--- a/packages/settingeditor/src/splitpanel.ts
+++ b/packages/settingeditor/src/splitpanel.ts
@@ -3,24 +3,10 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-import { ISignal, Signal } from '@lumino/signaling';
-import { SplitPanel as SPanel } from '@lumino/widgets';
+import { SplitPanel } from '@lumino/widgets';
 
 /**
- * A deprecated split panel that will be removed when the phosphor split panel
- * supports a handle moved signal. See https://github.com/phosphorjs/phosphor/issues/297.
+ * @deprecated alias for `SplitPanel` from `@lumino/widgets`, will be removed in JupyterLab 4.0.
+ * Please use `import { SplitPanel } from '@lumino/widgets';` instead.
  */
-export class SplitPanel extends SPanel {
-  /**
-   * Emits when the split handle has moved.
-   */
-  readonly handleMoved: ISignal<any, void> = new Signal<any, void>(this);
-
-  handleEvent(event: Event): void {
-    super.handleEvent(event);
-
-    if (event.type === 'mouseup') {
-      (this.handleMoved as Signal<any, void>).emit(undefined);
-    }
-  }
-}
+export { SplitPanel };


### PR DESCRIPTION
## References

Fixes #12891. Backward-compatible version of #12593 which was not backported.

## Code changes

Re-export the new `SplitPanel` from `@lumino/widgets` 1.32.0+ from the same file it was previously defined in.

## User-facing changes

JSON settings editor opens.

## Backwards-incompatible changes

If downstream extension authors were overriding `handleMoved` via setter they will get an error, but they are getting this error in 3.4.4 right now anyways so I would say "none" for practical purposes.