### PR TITLE
Split commands in two blocks in the contributing guide

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -321,7 +321,7 @@ Additionally, you might want to execute the following optional commands:
    jlpm run build:core
 
    # Build the app dir assets (optional)
-   jupyter lab build  
+   jupyter lab build
 
 Notes:
 

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -312,8 +312,16 @@ Then use the following steps:
    pip install -e ".[test]"
    jlpm install
    jlpm run build  # Build the dev mode assets (optional)
-   jlpm run build:core  # Build the core mode assets (optional)
-   jupyter lab build  # Build the app dir assets (optional)
+
+Additionally, you might want to execute the following optional commands:
+
+.. code:: bash
+
+   # Build the core mode assets (optional)
+   jlpm run build:core
+
+   # Build the app dir assets (optional)
+   jupyter lab build  
 
 Notes:
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Minor tweak to the contributing guide to move some optional commands to a separate block.

For folks copy pasting with the button:

![image](https://user-images.githubusercontent.com/591645/182394021-b3071319-42c1-46ed-b2e0-d841ba0d4fff.png)


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Documentation changes.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

![image](https://user-images.githubusercontent.com/591645/182393949-a791d677-558a-4526-9552-70d830df2df2.png)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
