### PR TITLE
Log launcher error to console

### DIFF
--- a/packages/launcher/src/widget.tsx
+++ b/packages/launcher/src/widget.tsx
@@ -237,7 +237,9 @@ export class Launcher extends VDomRenderer<ILauncher.IModel> {
  *
  * @param launcher - the Launcher instance to which this is added.
  *
- * @param launcherCallback - a callback to call after an item has been launched.
+ * @param commands - the command registry holding the command of item.
+ *
+ * @param trans - the translation bundle.
  *
  * @returns a vdom `VirtualElement` for the launcher card.
  */
@@ -276,6 +278,7 @@ function Card(
         }
       })
       .catch(err => {
+        console.error(err);
         launcher.pending = false;
         void showErrorMessage(trans._p('Error', 'Launcher Error'), err);
       });


### PR DESCRIPTION
## Reference

If a launcher fails to start, the dialog shows only the error message, not the full stack. It will be easier to debug if the error stack is logged to the console.

## Code changes

Log the error of the command of launchers to the console.

## User-facing changes

- Before 

![launcher-before](https://user-images.githubusercontent.com/4451292/182870246-ab5af622-88f4-4e89-90c1-6682e6382de6.gif)

- After

![launcher-after](https://user-images.githubusercontent.com/4451292/182870287-e4bd0809-8b97-4b88-9618-bfffddbbf0c0.gif)

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A