### PR TITLE
Automated Changelog Entry for 3.4.5 on 3.4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,43 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.4.5
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.4.4...385ea4be3d3e65e1f62d82e8bfedbe554736b2bb))
+
+### Enhancements made
+
+- Add an option to enable "fast checks" of the jupyter lab build. [#12844](https://github.com/jupyterlab/jupyterlab/pull/12844) ([@thetorpedodog](https://github.com/thetorpedodog))
+- feat: Add .webp filetype in docRegistry. [#12839](https://github.com/jupyterlab/jupyterlab/pull/12839) ([@yangql176](https://github.com/yangql176))
+
+### Bugs fixed
+
+- Only show "Shut Down Kernel" if kernel is running [#12919](https://github.com/jupyterlab/jupyterlab/pull/12919) ([@krassowski](https://github.com/krassowski))
+- Fix JSON Settings Editor [#12892](https://github.com/jupyterlab/jupyterlab/pull/12892) ([@krassowski](https://github.com/krassowski))
+- Fix progress bar not working after uploading multiple files finished [#12871](https://github.com/jupyterlab/jupyterlab/pull/12871) ([@hsuanxyz](https://github.com/hsuanxyz))
+- Fix kernel in the statusbar does not match the actual [#12865](https://github.com/jupyterlab/jupyterlab/pull/12865) ([@hsuanxyz](https://github.com/hsuanxyz))
+- Adjust css to not leave trace of deleted widgets [#12838](https://github.com/jupyterlab/jupyterlab/pull/12838) ([@thomasaarholt](https://github.com/thomasaarholt))
+
+### Maintenance and upkeep improvements
+
+- Log launcher error to console [#12909](https://github.com/jupyterlab/jupyterlab/pull/12909) ([@trungleduc](https://github.com/trungleduc))
+
+### Documentation improvements
+
+- Add alt text to documentation [#12879](https://github.com/jupyterlab/jupyterlab/pull/12879) ([@isabela-pf](https://github.com/isabela-pf))
+- Split commands in two blocks in the contributing guide [#12898](https://github.com/jupyterlab/jupyterlab/pull/12898) ([@jtpio](https://github.com/jtpio))
+- Remove reference to unmaintained nb_conda_kernels [#12878](https://github.com/jupyterlab/jupyterlab/pull/12878) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Document building JupyterLab on osx-arm64 platforms [#12882](https://github.com/jupyterlab/jupyterlab/pull/12882) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Don't suggest deprecated command [#12855](https://github.com/jupyterlab/jupyterlab/pull/12855) ([@ryanlovett](https://github.com/ryanlovett))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-07-21&to=2022-08-10&type=c))
+
+[@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2022-07-21..2022-08-10&type=Issues) | [@agoose77](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aagoose77+updated%3A2022-07-21..2022-08-10&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-07-21..2022-08-10&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2022-07-21..2022-08-10&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-07-21..2022-08-10&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-07-21..2022-08-10&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-07-21..2022-08-10&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2022-07-21..2022-08-10&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-07-21..2022-08-10&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-07-21..2022-08-10&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AmartinRenou+updated%3A2022-07-21..2022-08-10&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-07-21..2022-08-10&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-07-21..2022-08-10&type=Issues) | [@ryanlovett](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aryanlovett+updated%3A2022-07-21..2022-08-10&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASylvainCorlay+updated%3A2022-07-21..2022-08-10&type=Issues) | [@telamonian](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atelamonian+updated%3A2022-07-21..2022-08-10&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrungleduc+updated%3A2022-07-21..2022-08-10&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-07-21..2022-08-10&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.4.4
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.4.3...998cf0e146fdb7c61c42d9487ebb89c16581faf8))
@@ -60,8 +97,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-06-07&to=2022-07-21&type=c))
 
 [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2022-06-07..2022-07-21&type=Issues) | [@aiqc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aaiqc+updated%3A2022-06-07..2022-07-21&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2022-06-07..2022-07-21&type=Issues) | [@dlqqq](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adlqqq+updated%3A2022-06-07..2022-07-21&type=Issues) | [@dmonad](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Admonad+updated%3A2022-06-07..2022-07-21&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-06-07..2022-07-21&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2022-06-07..2022-07-21&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-06-07..2022-07-21&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-06-07..2022-07-21&type=Issues) | [@goanpeca](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agoanpeca+updated%3A2022-06-07..2022-07-21&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2022-06-07..2022-07-21&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-06-07..2022-07-21&type=Issues) | [@JohanMabille](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AJohanMabille+updated%3A2022-06-07..2022-07-21&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-06-07..2022-07-21&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2022-06-07..2022-07-21&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-06-07..2022-07-21&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2022-06-07..2022-07-21&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-06-07..2022-07-21&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AmartinRenou+updated%3A2022-06-07..2022-07-21&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-06-07..2022-07-21&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-06-07..2022-07-21&type=Issues) | [@siddartha-10](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Asiddartha-10+updated%3A2022-06-07..2022-07-21&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASylvainCorlay+updated%3A2022-06-07..2022-07-21&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-06-07..2022-07-21&type=Issues) | [@williamstein](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awilliamstein+updated%3A2022-06-07..2022-07-21&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.4.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 ### Enhancements made
 
 - Add an option to enable "fast checks" of the jupyter lab build. [#12844](https://github.com/jupyterlab/jupyterlab/pull/12844) ([@thetorpedodog](https://github.com/thetorpedodog))
-- feat: Add .webp filetype in docRegistry. [#12839](https://github.com/jupyterlab/jupyterlab/pull/12839) ([@yangql176](https://github.com/yangql176))
+- Add .webp filetype in docRegistry. [#12839](https://github.com/jupyterlab/jupyterlab/pull/12839) ([@yangql176](https://github.com/yangql176))
 
 ### Bugs fixed
 


### PR DESCRIPTION
Automated Changelog Entry for 3.4.5 on 3.4.x
```
Python version: 3.4.5
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.4.5
@jupyterlab/buildutils: 3.4.5
@jupyterlab/template: 3.4.5
@jupyterlab/application-top: 3.4.5
@jupyterlab/example-app: 3.4.5
@jupyterlab/example-cell: 3.4.5
@jupyterlab/example-console: 3.4.5
@jupyterlab/example-federated: 2.5.5
@jupyterlab/example-federated-core: 2.5.5
@jupyterlab/example-federated-md: 2.5.5
@jupyterlab/example-federated-middle: 2.5.5
@jupyterlab/example-federated-phosphor: 2.5.5
@jupyterlab/example-filebrowser: 3.4.5
@jupyterlab/example-notebook: 3.4.5
@jupyterlab/example-terminal: 3.4.5
@jupyterlab/galata: 4.3.5
@jupyterlab/mock-extension: 3.4.5
@jupyterlab/mock-consumer: 3.4.5
@jupyterlab/mock-provider: 3.4.5
@jupyterlab/mock-token: 3.4.5
@jupyterlab/application: 3.4.5
@jupyterlab/application-extension: 3.4.5
@jupyterlab/apputils: 3.4.5
@jupyterlab/apputils-extension: 3.4.5
@jupyterlab/attachments: 3.4.5
@jupyterlab/cell-toolbar: 3.4.5
@jupyterlab/cell-toolbar-extension: 3.4.5
@jupyterlab/cells: 3.4.5
@jupyterlab/celltags: 3.4.5
@jupyterlab/celltags-extension: 3.4.5
@jupyterlab/codeeditor: 3.4.5
@jupyterlab/codemirror: 3.4.5
@jupyterlab/codemirror-extension: 3.4.5
@jupyterlab/completer: 3.4.5
@jupyterlab/completer-extension: 3.4.5
@jupyterlab/console: 3.4.5
@jupyterlab/console-extension: 3.4.5
@jupyterlab/coreutils: 5.4.5
@jupyterlab/csvviewer: 3.4.5
@jupyterlab/csvviewer-extension: 3.4.5
@jupyterlab/debugger: 3.4.5
@jupyterlab/debugger-extension: 3.4.5
@jupyterlab/docmanager: 3.4.5
@jupyterlab/docmanager-extension: 3.4.5
@jupyterlab/docprovider: 3.4.5
@jupyterlab/docprovider-extension: 3.4.5
@jupyterlab/docregistry: 3.4.5
@jupyterlab/documentsearch: 3.4.5
@jupyterlab/documentsearch-extension: 3.4.5
@jupyterlab/extensionmanager: 3.4.5
@jupyterlab/extensionmanager-extension: 3.4.5
@jupyterlab/filebrowser: 3.4.5
@jupyterlab/filebrowser-extension: 3.4.5
@jupyterlab/fileeditor: 3.4.5
@jupyterlab/fileeditor-extension: 3.4.5
@jupyterlab/help-extension: 3.4.5
@jupyterlab/htmlviewer: 3.4.5
@jupyterlab/htmlviewer-extension: 3.4.5
@jupyterlab/hub-extension: 3.4.5
@jupyterlab/imageviewer: 3.4.5
@jupyterlab/imageviewer-extension: 3.4.5
@jupyterlab/inspector: 3.4.5
@jupyterlab/inspector-extension: 3.4.5
@jupyterlab/javascript-extension: 3.4.5
@jupyterlab/json-extension: 3.4.5
@jupyterlab/launcher: 3.4.5
@jupyterlab/launcher-extension: 3.4.5
@jupyterlab/logconsole: 3.4.5
@jupyterlab/logconsole-extension: 3.4.5
@jupyterlab/mainmenu: 3.4.5
@jupyterlab/mainmenu-extension: 3.4.5
@jupyterlab/markdownviewer: 3.4.5
@jupyterlab/markdownviewer-extension: 3.4.5
@jupyterlab/mathjax2: 3.4.5
@jupyterlab/mathjax2-extension: 3.4.5
@jupyterlab/metapackage: 3.4.5
@jupyterlab/nbconvert-css: 3.4.5
@jupyterlab/nbformat: 3.4.5
@jupyterlab/notebook: 3.4.5
@jupyterlab/notebook-extension: 3.4.5
@jupyterlab/observables: 4.4.5
@jupyterlab/outputarea: 3.4.5
@jupyterlab/pdf-extension: 3.4.5
@jupyterlab/property-inspector: 3.4.5
@jupyterlab/rendermime: 3.4.5
@jupyterlab/rendermime-extension: 3.4.5
@jupyterlab/rendermime-interfaces: 3.4.5
@jupyterlab/running: 3.4.5
@jupyterlab/running-extension: 3.4.5
@jupyterlab/services: 6.4.5
@jupyterlab/example-services-browser: 3.4.5
node-example: 3.4.5
@jupyterlab/example-services-outputarea: 3.4.5
@jupyterlab/settingeditor: 3.4.5
@jupyterlab/settingeditor-extension: 3.4.5
@jupyterlab/settingregistry: 3.4.5
@jupyterlab/shared-models: 3.4.5
@jupyterlab/shortcuts-extension: 3.4.5
@jupyterlab/statedb: 3.4.5
@jupyterlab/statusbar: 3.4.5
@jupyterlab/statusbar-extension: 3.4.5
@jupyterlab/terminal: 3.4.5
@jupyterlab/terminal-extension: 3.4.5
@jupyterlab/theme-dark-extension: 3.4.5
@jupyterlab/theme-light-extension: 3.4.5
@jupyterlab/toc: 5.4.5
@jupyterlab/toc-extension: 5.4.5
@jupyterlab/tooltip: 3.4.5
@jupyterlab/tooltip-extension: 3.4.5
@jupyterlab/translation: 3.4.5
@jupyterlab/translation-extension: 3.4.5
@jupyterlab/ui-components: 3.4.5
@jupyterlab/ui-components-extension: 3.4.5
@jupyterlab/vdom: 3.4.5
@jupyterlab/vdom-extension: 3.4.5
@jupyterlab/vega5-extension: 3.4.5
@jupyterlab/testutils: 3.4.5
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.4.x  |
| Version Spec | next |
| Since | v3.4.4 |