### PR TITLE
Fix resizing and selection of debugger variable explorer grid

### DIFF
--- a/packages/debugger/src/panels/variables/grid.ts
+++ b/packages/debugger/src/panels/variables/grid.ts
@@ -508,23 +508,6 @@ namespace Private {
     }
 
     /**
-     * Handle the mouse down event for the data grid.
-     *
-     * @param grid - The data grid of interest.
-     *
-     * @param event - The mouse down event of interest.
-     */
-    onMouseDown(grid: DataGrid, event: MouseEvent): void {
-      // Unpack the event.
-      let { clientX, clientY } = event;
-
-      // Hit test the grid.
-      let hit = grid.hitTest(clientX, clientY);
-
-      this._selected.emit(hit);
-    }
-
-    /**
      * Handle the context menu event for the data grid.
      *
      * @param grid - The data grid of interest.

--- a/packages/debugger/src/panels/variables/grid.ts
+++ b/packages/debugger/src/panels/variables/grid.ts
@@ -508,6 +508,26 @@ namespace Private {
     }
 
     /**
+     * Handle the mouse down event for the data grid.
+     *
+     * @param grid - The data grid of interest.
+     *
+     * @param event - The mouse down event of interest.
+     */
+    onMouseDown(grid: DataGrid, event: MouseEvent): void {
+      // Unpack the event.
+      let { clientX, clientY } = event;
+
+      // Hit test the grid.
+      let hit = grid.hitTest(clientX, clientY);
+
+      this._selected.emit(hit);
+
+      // Propagate event to Lumino DataGrid BasicMouseHandler.
+      super.onMouseDown(grid, event);
+    }
+
+    /**
      * Handle the context menu event for the data grid.
      *
      * @param grid - The data grid of interest.


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/12942.

## Code changes

Propagate debugger variable explorer grid `onMouseDown` event from the custom handler, which does not handle grid resize and selection, to the `@lumino/datagrid` `BasicMouseHandler` default `onMouseDown` (https://github.com/jupyterlab/lumino/blob/f7b9915cb74e6836adaa86696446a9c1cac27208/packages/datagrid/src/basicmousehandler.ts#L129-L410), so that the latter can handle resize and selection requests.

## User-facing changes

Debugger variable explorer table view columns and rows become resizable, and cells/rows/columns become selectable.

## Backwards-incompatible changes

None
