### PR TITLE
Prompt for renaming at first manual save

### DIFF
--- a/docs/source/extension/ui_helpers.rst
+++ b/docs/source/extension/ui_helpers.rst
@@ -10,6 +10,44 @@ Those speed up development and ensure a common look and feel.
 Dialogs
 -------
 
+Generic Dialog
+^^^^^^^^^^^^^^
+
+The generic way to display a dialog is through ``showDialog`` function from ``@jupyterlab/apputils``.
+
+The options available are:
+
+.. code:: typescript
+
+   showDialog({
+     title: 'Dialog title', // Can be a text or a react element
+     body: 'Dialog body', // Can be a text, a widget or a react element
+     host: document.body, // Host element
+     buttons: [ // List of buttons
+      {
+        label: 'my button', // Button label
+        caption: 'my button title', // Button title
+        className: 'my-button', // Additional button CSS class
+        accept: true, // Whether this is the discarding or accepting the dialog
+        displayType: 'default' // 'default' or 'warn' to tune style
+      }
+     ],
+     checkbox: { // Optional checkbox in dialog footer
+       label: 'check me', // Checkbox label
+       caption: 'check me I\'magic', // Checkbox title
+       className: 'my-checkbox', // Additional checkbox CSS class
+       checked: true, // Default checkbox state
+     },
+     defaultButton: 0, // Index of the default button
+     focusNodeSelector: '.my-input', // Selector to use for focusing an element on display
+     hasClose: false, // Whether to display a close button or not
+     renderer: undefined // To define to customize dialog structure.
+   })
+
+.. note::
+
+   If you do not specify any options, the dialog will only contain two buttons *OK* and *Cancel*.
+
 Message Dialogs
 ^^^^^^^^^^^^^^^
 

--- a/docs/source/extension/ui_helpers.rst
+++ b/docs/source/extension/ui_helpers.rst
@@ -13,7 +13,7 @@ Dialogs
 Generic Dialog
 ^^^^^^^^^^^^^^
 
-The generic way to display a dialog is through ``showDialog`` function from ``@jupyterlab/apputils``.
+To display a generic dialog, use ``showDialog`` function from ``@jupyterlab/apputils``.
 
 The options available are:
 

--- a/docs/source/extension/ui_helpers.rst
+++ b/docs/source/extension/ui_helpers.rst
@@ -20,33 +20,33 @@ The options available are:
 .. code:: typescript
 
    showDialog({
-     title: 'Dialog title', // Can be a text or a react element
-     body: 'Dialog body', // Can be a text, a widget or a react element
-     host: document.body, // Host element
+     title: 'Dialog title', // Can be text or a react element
+     body: 'Dialog body', // Can be text, a widget or a react element
+     host: document.body, // Parent element for rendering the dialog
      buttons: [ // List of buttons
       {
         label: 'my button', // Button label
         caption: 'my button title', // Button title
         className: 'my-button', // Additional button CSS class
-        accept: true, // Whether this is the discarding or accepting the dialog
-        displayType: 'default' // 'default' or 'warn' to tune style
+        accept: true, // Whether this button will discard or accept the dialog
+        displayType: 'default' // applies 'default' or 'warn' styles
       }
      ],
-     checkbox: { // Optional checkbox in dialog footer
+     checkbox: { // Optional checkbox in the dialog footer
        label: 'check me', // Checkbox label
        caption: 'check me I\'magic', // Checkbox title
        className: 'my-checkbox', // Additional checkbox CSS class
        checked: true, // Default checkbox state
      },
      defaultButton: 0, // Index of the default button
-     focusNodeSelector: '.my-input', // Selector to use for focusing an element on display
+     focusNodeSelector: '.my-input', // Selector for focussing an input element when dialog opens
      hasClose: false, // Whether to display a close button or not
-     renderer: undefined // To define to customize dialog structure.
+     renderer: undefined // To define customized dialog structure
    })
 
 .. note::
 
-   If you do not specify any options, the dialog will only contain two buttons *OK* and *Cancel*.
+   If no options are specified, the dialog will only contain *OK* and *Cancel* buttons.
 
 Message Dialogs
 ^^^^^^^^^^^^^^^

--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -97,15 +97,23 @@ export class Dialog<T> extends Widget {
         return renderer.createButtonNode(button);
       })
     );
-    this._checkboxNode = normalized.checkbox
-      ? renderer.createCheckboxNode({
-          label: normalized.checkbox.label ?? '',
-          caption:
-            normalized.checkbox.caption ?? normalized.checkbox.label ?? '',
-          checked: normalized.checkbox.checked ?? false,
-          className: normalized.checkbox.className ?? ''
-        })
-      : null;
+
+    this._checkboxNode = null;
+    if (normalized.checkbox) {
+      const {
+        label = '',
+        caption = '',
+        checked = false,
+        className = ''
+      } = normalized.checkbox;
+      this._checkboxNode = renderer.createCheckboxNode({
+        label,
+        caption: caption ?? label,
+        checked,
+        className
+      });
+    }
+
     this._lastMouseDownInDialog = false;
 
     const layout = (this.layout = new PanelLayout());

--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -921,9 +921,9 @@ export namespace Dialog {
       e.title = checkbox.caption;
       e.insertAdjacentHTML(
         'afterbegin',
-        `${checkbox.label}<input type="checkbox" ${
-          checkbox.checked ? 'checked' : ''
-        }>`
+        `<input type="checkbox" ${checkbox.checked ? 'checked' : ''}>${
+          checkbox.label
+        }`
       );
       return e;
     }

--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -97,6 +97,15 @@ export class Dialog<T> extends Widget {
         return renderer.createButtonNode(button);
       })
     );
+    this._checkboxNode = normalized.checkbox
+      ? renderer.createCheckboxNode({
+          label: normalized.checkbox.label ?? '',
+          caption:
+            normalized.checkbox.caption ?? normalized.checkbox.label ?? '',
+          checked: normalized.checkbox.checked ?? false,
+          className: normalized.checkbox.className ?? ''
+        })
+      : null;
     this._lastMouseDownInDialog = false;
 
     const layout = (this.layout = new PanelLayout());
@@ -115,7 +124,7 @@ export class Dialog<T> extends Widget {
       options
     );
     const body = renderer.createBody(normalized.body);
-    const footer = renderer.createFooter(this._buttonNodes);
+    const footer = renderer.createFooter(this._buttonNodes, this._checkboxNode);
     content.addWidget(header);
     content.addWidget(body);
     content.addWidget(footer);
@@ -156,7 +165,11 @@ export class Dialog<T> extends Widget {
     return promises.then(() => {
       // Do not show Dialog if it was disposed of before it was at the front of the launch queue
       if (!this._promise) {
-        return Promise.resolve({ button: Dialog.cancelButton(), value: null });
+        return Promise.resolve({
+          button: Dialog.cancelButton(),
+          isChecked: null,
+          value: null
+        });
       }
       Widget.attach(this, this._host);
       return promise.promise;
@@ -431,11 +444,18 @@ export class Dialog<T> extends Widget {
       value = body.getValue();
     }
     this.dispose();
-    promise.resolve({ button, value });
+    promise.resolve({
+      button,
+      isChecked:
+        this._checkboxNode?.querySelector<HTMLInputElement>('input')?.checked ??
+        null,
+      value
+    });
   }
 
   private _buttonNodes: ReadonlyArray<HTMLElement>;
   private _buttons: ReadonlyArray<Dialog.IButton>;
+  private _checkboxNode: HTMLElement | null;
   private _original: HTMLElement;
   private _first: HTMLElement;
   private _primary: HTMLElement;
@@ -518,6 +538,31 @@ export namespace Dialog {
   }
 
   /**
+   * The options used to make a checkbox item.
+   */
+  export interface ICheckbox {
+    /**
+     * The label for the checkbox.
+     */
+    label: string;
+
+    /**
+     * The caption for the checkbox.
+     */
+    caption: string;
+
+    /**
+     * The initial checkbox state.
+     */
+    checked: boolean;
+
+    /**
+     * The extra class name for the checkbox.
+     */
+    className: string;
+  }
+
+  /**
    * Error object interface
    */
   export interface IError {
@@ -559,6 +604,11 @@ export namespace Dialog {
      * The buttons to display. Defaults to cancel and accept buttons.
      */
     buttons: ReadonlyArray<IButton>;
+
+    /**
+     * The checkbox to display in the footer. Defaults no checkbox.
+     */
+    checkbox: Partial<ICheckbox> | null;
 
     /**
      * The index of the default button.  Defaults to the last button.
@@ -615,10 +665,14 @@ export namespace Dialog {
      * Create the footer of the dialog.
      *
      * @param buttons - The button nodes to add to the footer.
+     * @param checkbox - The checkbox node to add to the footer.
      *
      * @returns A widget for the footer.
      */
-    createFooter(buttons: ReadonlyArray<HTMLElement>): Widget;
+    createFooter(
+      buttons: ReadonlyArray<HTMLElement>,
+      checkbox: HTMLElement | null
+    ): Widget;
 
     /**
      * Create a button node for the dialog.
@@ -628,6 +682,15 @@ export namespace Dialog {
      * @returns A node for the button.
      */
     createButtonNode(button: IButton): HTMLElement;
+
+    /**
+     * Create a checkbox node for the dialog.
+     *
+     * @param checkbox - The checkbox data.
+     *
+     * @returns A node for the checkbox.
+     */
+    createCheckboxNode(checkbox: ICheckbox): HTMLElement;
   }
 
   /**
@@ -638,6 +701,14 @@ export namespace Dialog {
      * The button that was pressed.
      */
     button: IButton;
+
+    /**
+     * State of the dialog checkbox.
+     *
+     * #### Notes
+     * It will be null if no checkbox is defined for the dialog.
+     */
+    isChecked: boolean | null;
 
     /**
      * The value retrieved from `.getValue()` if given on the widget.
@@ -798,12 +869,23 @@ export namespace Dialog {
      * Create the footer of the dialog.
      *
      * @param buttons - The buttons nodes to add to the footer.
+     * @param checkbox - The checkbox node to add to the footer.
      *
      * @returns A widget for the footer.
      */
-    createFooter(buttons: ReadonlyArray<HTMLElement>): Widget {
+    createFooter(
+      buttons: ReadonlyArray<HTMLElement>,
+      checkbox: HTMLElement | null
+    ): Widget {
       const footer = new Widget();
       footer.addClass('jp-Dialog-footer');
+      if (checkbox) {
+        footer.node.appendChild(checkbox);
+        footer.node.insertAdjacentHTML(
+          'beforeend',
+          '<div class="jp-Dialog-spacer"></div>'
+        );
+      }
       each(buttons, button => {
         footer.node.appendChild(button);
       });
@@ -823,6 +905,26 @@ export namespace Dialog {
       e.className = this.createItemClass(button);
       e.appendChild(this.renderIcon(button));
       e.appendChild(this.renderLabel(button));
+      return e;
+    }
+
+    /**
+     * Create a checkbox node for the dialog.
+     *
+     * @param checkbox - The checkbox data.
+     *
+     * @returns A node for the checkbox.
+     */
+    createCheckboxNode(checkbox: ICheckbox): HTMLElement {
+      const e = document.createElement('label');
+      e.className = `jp-Dialog-checkbox ${checkbox.className}`.trim();
+      e.title = checkbox.caption;
+      e.insertAdjacentHTML(
+        'afterbegin',
+        `${checkbox.label}<input type="checkbox" ${
+          checkbox.checked ? 'checked' : ''
+        }>`
+      );
       return e;
     }
 
@@ -942,6 +1044,7 @@ namespace Private {
       title: options.title ?? '',
       body: options.body ?? '',
       host: options.host ?? document.body,
+      checkbox: options.checkbox ?? null,
       buttons,
       defaultButton: options.defaultButton ?? buttons.length - 1,
       renderer: options.renderer ?? Dialog.defaultRenderer,

--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { nullTranslator } from '@jupyterlab/translation';
 import {
   Button,
   closeIcon,
@@ -453,8 +452,6 @@ export class Dialog<T> extends Widget {
  * The namespace for Dialog class statics.
  */
 export namespace Dialog {
-  export let trans = nullTranslator.load('jupyterlab');
-
   /**
    * The body input types.
    */
@@ -800,7 +797,7 @@ export namespace Dialog {
     /**
      * Create the footer of the dialog.
      *
-     * @param buttonNodes - The buttons nodes to add to the footer.
+     * @param buttons - The buttons nodes to add to the footer.
      *
      * @returns A widget for the footer.
      */

--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import { nullTranslator } from '@jupyterlab/translation';
 import {
   Button,
   closeIcon,
@@ -452,6 +453,8 @@ export class Dialog<T> extends Widget {
  * The namespace for Dialog class statics.
  */
 export namespace Dialog {
+  export let trans = nullTranslator.load('jupyterlab');
+
   /**
    * The body input types.
    */
@@ -605,7 +608,7 @@ export namespace Dialog {
     /**
      * Create the body of the dialog.
      *
-     * @param value - The input value for the body.
+     * @param body - The input value for the body.
      *
      * @returns A widget for the body.
      */

--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -917,14 +917,16 @@ export namespace Dialog {
      */
     createCheckboxNode(checkbox: ICheckbox): HTMLElement {
       const e = document.createElement('label');
-      e.className = `jp-Dialog-checkbox ${checkbox.className}`.trim();
+      e.className = 'jp-Dialog-checkbox';
+      if (checkbox.className) {
+        e.classList.add(checkbox.className);
+      }
       e.title = checkbox.caption;
-      e.insertAdjacentHTML(
-        'afterbegin',
-        `<input type="checkbox" ${checkbox.checked ? 'checked' : ''}>${
-          checkbox.label
-        }`
-      );
+      e.textContent = checkbox.label;
+      const input = document.createElement('input') as HTMLInputElement;
+      input.type = 'checkbox';
+      input.checked = !!checkbox.checked;
+      e.insertAdjacentElement('afterbegin', input);
       return e;
     }
 

--- a/packages/apputils/src/inputdialog.ts
+++ b/packages/apputils/src/inputdialog.ts
@@ -2,6 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { Styling } from '@jupyterlab/ui-components';
+import { Message } from '@lumino/messaging';
 import { Widget } from '@lumino/widgets';
 import { Dialog, showDialog } from './dialog';
 
@@ -174,6 +175,13 @@ export namespace InputDialog {
      * Placeholder text
      */
     placeholder?: string;
+    /**
+     * Selection range
+     *
+     * Number of characters to pre-select when displaying the dialog.
+     * Default is to select all default input if defined.
+     */
+    selectionRange?: number;
   }
 
   /**
@@ -205,7 +213,7 @@ export namespace InputDialog {
    * @returns A promise that resolves with whether the dialog was accepted
    */
   export function getPassword(
-    options: ITextOptions
+    options: Omit<ITextOptions, 'selectionRange'>
   ): Promise<Dialog.IResult<string>> {
     return showDialog({
       ...options,
@@ -322,6 +330,20 @@ class InputTextDialog extends InputDialogBase<string> {
     if (options.placeholder) {
       this._input.placeholder = options.placeholder;
     }
+    this._initialSelectionRange = Math.min(
+      this._input.value.length,
+      Math.max(0, options.selectionRange ?? 0)
+    );
+  }
+
+  /**
+   *  A message handler invoked on an `'after-attach'` message.
+   */
+  protected onAfterAttach(msg: Message): void {
+    super.onAfterAttach(msg);
+    if (this._initialSelectionRange > 0 && this._input.value) {
+      this._input.setSelectionRange(0, this._initialSelectionRange);
+    }
   }
 
   /**
@@ -330,6 +352,8 @@ class InputTextDialog extends InputDialogBase<string> {
   getValue(): string {
     return this._input.value;
   }
+
+  private _initialSelectionRange: number;
 }
 
 /**
@@ -348,6 +372,16 @@ class InputPasswordDialog extends InputDialogBase<string> {
     this._input.value = options.text ? options.text : '';
     if (options.placeholder) {
       this._input.placeholder = options.placeholder;
+    }
+  }
+
+  /**
+   *  A message handler invoked on an `'after-attach'` message.
+   */
+  protected onAfterAttach(msg: Message): void {
+    super.onAfterAttach(msg);
+    if (this._input.value) {
+      this._input.select();
     }
   }
 

--- a/packages/apputils/src/inputdialog.ts
+++ b/packages/apputils/src/inputdialog.ts
@@ -18,7 +18,7 @@ export namespace InputDialog {
    */
   export interface IOptions {
     /**
-     * The top level text for the dialog.  Defaults to an empty string.
+     * The top level text for the dialog. Defaults to an empty string.
      */
     title: Dialog.Header;
 
@@ -33,7 +33,7 @@ export namespace InputDialog {
     label?: string;
 
     /**
-     * An optional renderer for dialog items.  Defaults to a shared
+     * An optional renderer for dialog items. Defaults to a shared
      * default renderer.
      */
     renderer?: Dialog.IRenderer;
@@ -47,6 +47,11 @@ export namespace InputDialog {
      * Label for cancel button.
      */
     cancelLabel?: string;
+
+    /**
+     * The checkbox to display in the footer. Defaults no checkbox.
+     */
+    checkbox?: Partial<Dialog.ICheckbox> | null;
   }
 
   /**

--- a/packages/apputils/src/inputdialog.ts
+++ b/packages/apputils/src/inputdialog.ts
@@ -178,8 +178,8 @@ export namespace InputDialog {
     /**
      * Selection range
      *
-     * Number of characters to pre-select when displaying the dialog.
-     * Default is to select all default input if defined.
+     * Number of characters to pre-select when dialog opens.
+     * Default is to select the whole input text if present.
      */
     selectionRange?: number;
   }

--- a/packages/apputils/src/inputdialog.ts
+++ b/packages/apputils/src/inputdialog.ts
@@ -332,7 +332,7 @@ class InputTextDialog extends InputDialogBase<string> {
     }
     this._initialSelectionRange = Math.min(
       this._input.value.length,
-      Math.max(0, options.selectionRange ?? 0)
+      Math.max(0, options.selectionRange ?? this._input.value.length)
     );
   }
 

--- a/packages/apputils/style/dialog.css
+++ b/packages/apputils/style/dialog.css
@@ -110,10 +110,24 @@ button.jp-Dialog-close-button {
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
+  align-items: center;
   flex: 0 0 auto;
   margin-left: -12px;
   margin-right: -12px;
   padding: 12px;
+}
+
+.jp-Dialog-checkbox {
+  padding-right: 5px;
+}
+
+.jp-Dialog-checkbox > input:focus-visible {
+  outline: 1px solid var(--jp-brand-color1);
+  outline-offset: 1px;
+}
+
+.jp-Dialog-spacer {
+  flex: 1 1 auto;
 }
 
 .jp-Dialog-title {

--- a/packages/apputils/style/dialog.css
+++ b/packages/apputils/style/dialog.css
@@ -122,7 +122,7 @@ button.jp-Dialog-close-button {
 }
 
 .jp-Dialog-checkbox > input:focus-visible {
-  outline: 1px solid var(--jp-brand-color1);
+  outline: 1px solid var(--jp-input-active-border-color);
   outline-offset: 1px;
 }
 

--- a/packages/apputils/test/dialog.spec.tsx
+++ b/packages/apputils/test/dialog.spec.tsx
@@ -348,6 +348,13 @@ describe('@jupyterlab/apputils', () => {
     describe('.Renderer', () => {
       const renderer = Dialog.defaultRenderer;
 
+      const checkbox: Dialog.ICheckbox = {
+        label: 'foo',
+        caption: 'hello',
+        className: 'baz',
+        checked: false
+      };
+
       const data: Dialog.IButton = {
         label: 'foo',
         iconClass: 'bar',
@@ -411,7 +418,7 @@ describe('@jupyterlab/apputils', () => {
           const nodes = buttons.map((button: Dialog.IButton) => {
             return renderer.createButtonNode(button);
           });
-          const footer = renderer.createFooter(nodes);
+          const footer = renderer.createFooter(nodes, null);
           const buttonNodes = footer.node.querySelectorAll('button');
 
           expect(footer.hasClass('jp-Dialog-footer')).toBe(true);
@@ -422,6 +429,16 @@ describe('@jupyterlab/apputils', () => {
             expect(node.className).toContain('jp-mod-styled');
           });
         });
+
+        it('should create the footer of the dialog with checkbox', () => {
+          const buttons = [Dialog.okButton, { label: 'foo' }];
+          const nodes = buttons.map((button: Dialog.IButton) => {
+            return renderer.createButtonNode(button);
+          });
+          const cboxNode = renderer.createCheckboxNode(checkbox);
+          const footer = renderer.createFooter(nodes, cboxNode);
+          expect(footer.node.contains(cboxNode)).toBe(true);
+        });
       });
 
       describe('#createButtonNode()', () => {
@@ -430,6 +447,15 @@ describe('@jupyterlab/apputils', () => {
           expect(node.className).toContain('jp-Dialog-button');
           expect(node.querySelector('.jp-Dialog-buttonIcon')).toBeTruthy();
           expect(node.querySelector('.jp-Dialog-buttonLabel')).toBeTruthy();
+        });
+      });
+
+      describe('#createCheckboxNode()', () => {
+        it('should create a checkbox node for the dialog', () => {
+          const node = renderer.createCheckboxNode(checkbox);
+          expect(node.className).toContain('jp-Dialog-checkbox');
+          expect(node.tagName).toEqual('LABEL');
+          expect(node.querySelector('input')?.type).toEqual('checkbox');
         });
       });
 
@@ -495,6 +521,7 @@ describe('@jupyterlab/apputils', () => {
       const result = await prompt;
 
       expect(result.button.accept).toBe(false);
+      expect(result.isChecked).toBe(null);
       expect(result.value).toBe(null);
       document.body.removeChild(node);
     });
@@ -618,6 +645,95 @@ describe('@jupyterlab/apputils', () => {
 
       expect(result.button.accept).toBe(false);
       expect(result.button.actions).toEqual(['reload']);
+      expect(result.value).toBe(null);
+      document.body.removeChild(node);
+    });
+
+    it('should accept checkbox options', async () => {
+      const node = document.createElement('div');
+
+      document.body.appendChild(node);
+
+      const prompt = showDialog({
+        title: 'foo',
+        body: 'Hello',
+        host: node,
+        defaultButton: 0,
+        buttons: [Dialog.cancelButton(), Dialog.okButton()],
+        checkbox: {
+          label: 'foo',
+          caption: 'bar',
+          className: 'baz'
+        }
+      });
+
+      await acceptDialog();
+
+      const result = await prompt;
+
+      expect(result.button.accept).toBe(false);
+      expect(result.isChecked).toBe(false);
+      expect(result.value).toBe(null);
+      document.body.removeChild(node);
+    });
+
+    it('should accept checkbox checked state', async () => {
+      const node = document.createElement('div');
+
+      document.body.appendChild(node);
+
+      const prompt = showDialog({
+        title: 'foo',
+        body: 'Hello',
+        host: node,
+        defaultButton: 0,
+        buttons: [Dialog.cancelButton(), Dialog.okButton()],
+        checkbox: {
+          label: 'foo',
+          caption: 'bar',
+          className: 'baz',
+          checked: true
+        }
+      });
+
+      await acceptDialog();
+
+      const result = await prompt;
+
+      expect(result.button.accept).toBe(false);
+      expect(result.isChecked).toBe(true);
+      expect(result.value).toBe(null);
+      document.body.removeChild(node);
+    });
+
+    it('should return the checkbox state', async () => {
+      const node = document.createElement('div');
+
+      document.body.appendChild(node);
+
+      const prompt = showDialog({
+        title: 'foo',
+        body: 'Hello',
+        host: node,
+        defaultButton: 0,
+        buttons: [Dialog.cancelButton(), Dialog.okButton()],
+        checkbox: {
+          label: 'foo',
+          caption: 'bar',
+          className: 'baz'
+        }
+      });
+
+      await waitForDialog();
+
+      node.querySelector<HTMLInputElement>('input[type="checkbox"]')!.click();
+
+      await acceptDialog();
+
+      const result = await prompt;
+
+      expect(result.button.accept).toBe(false);
+      expect(result.isChecked).toBe(true);
       expect(result.value).toBe(null);
       document.body.removeChild(node);
     });

--- a/packages/docmanager-extension/schema/plugin.json
+++ b/packages/docmanager-extension/schema/plugin.json
@@ -128,6 +128,12 @@
       "additionalProperties": {
         "type": "string"
       }
+    },
+    "renameUntitledFileOnSave": {
+      "type": "boolean",
+      "title": "Rename Untitled File On First Save",
+      "description": "Whether to prompt to rename untitled file on first manual save.",
+      "default": true
     }
   },
   "additionalProperties": false,

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -801,7 +801,7 @@ function addCommands(
               checkbox: {
                 label: trans.__("Don't ask me again."),
                 caption: trans.__(
-                  'If checked, you will no be asked to rename future untitled files when saving them.'
+                  'If checked, you will not be asked to rename future untitled files when saving them.'
                 )
               }
             });

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -213,6 +213,10 @@ const docManagerPlugin: JupyterFrontEndPlugin<void> = {
         .composite as number | null;
       docManager.lastModifiedCheckMargin = lastModifiedCheckMargin || 500;
 
+      const renameUntitledFile = settings.get('renameUntitledFileOnSave')
+        .composite as boolean;
+      docManager.renameUntitledFileOnSave = renameUntitledFile ?? true;
+
       // Handle default widget factory overrides.
       const defaultViewers = settings.get('defaultViewers').composite as {
         [ft: string]: string;
@@ -781,15 +785,24 @@ function addCommands(
 
           saveInProgress.add(context);
 
-          let newName = '';
           const oldName = PathExt.basename(context.contentsModel?.path ?? '');
+          let newName = oldName;
 
-          if ((widget as IDocumentWidget).isUntitled === true) {
+          if (
+            docManager.renameUntitledFileOnSave &&
+            (widget as IDocumentWidget).isUntitled === true
+          ) {
             const result = await InputDialog.getText({
               title: trans.__('Rename file'),
               okLabel: trans.__('Rename'),
               placeholder: trans.__('File name'),
-              text: PathExt.basename(context.contentsModel?.path ?? '')
+              text: PathExt.basename(context.contentsModel?.path ?? ''),
+              checkbox: {
+                label: trans.__("Don't ask me again."),
+                caption: trans.__(
+                  'If checked, you will no be asked to rename future untitled files when saving them.'
+                )
+              }
             });
 
             if (result.button.accept) {

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -796,7 +796,8 @@ function addCommands(
               title: trans.__('Rename file'),
               okLabel: trans.__('Rename'),
               placeholder: trans.__('File name'),
-              text: PathExt.basename(context.contentsModel?.path ?? ''),
+              text: oldName,
+              selectionRange: oldName.length - PathExt.extname(oldName).length,
               checkbox: {
                 label: trans.__("Don't ask me again."),
                 caption: trans.__(
@@ -808,6 +809,27 @@ function addCommands(
             if (result.button.accept) {
               newName = result.value ?? oldName;
               (widget as IDocumentWidget).isUntitled = false;
+              if (typeof result.isChecked === 'boolean') {
+                const currentSetting = (
+                  await settingRegistry.get(
+                    docManagerPluginId,
+                    'renameUntitledFileOnSave'
+                  )
+                ).composite as boolean;
+                if (result.isChecked === currentSetting) {
+                  settingRegistry
+                    .set(
+                      docManagerPluginId,
+                      'renameUntitledFileOnSave',
+                      !result.isChecked
+                    )
+                    .catch(reason => {
+                      console.error(
+                        `Fail to set 'renameUntitledFileOnSave:\n${reason}`
+                      );
+                    });
+                }
+              }
             }
           }
 

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -790,7 +790,7 @@ function addCommands(
 
           if (
             docManager.renameUntitledFileOnSave &&
-            (widget as IDocumentWidget).isUntitled === true
+            (widget as IDocumentWidget).hasAutoName === true
           ) {
             const result = await InputDialog.getText({
               title: trans.__('Rename file'),
@@ -808,7 +808,7 @@ function addCommands(
 
             if (result.button.accept) {
               newName = result.value ?? oldName;
-              (widget as IDocumentWidget).isUntitled = false;
+              (widget as IDocumentWidget).hasAutoName = false;
               if (typeof result.isChecked === 'boolean') {
                 const currentSetting = (
                   await settingRegistry.get(

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -790,7 +790,7 @@ function addCommands(
 
           if (
             docManager.renameUntitledFileOnSave &&
-            (widget as IDocumentWidget).hasAutoName === true
+            (widget as IDocumentWidget).isUntitled === true
           ) {
             const result = await InputDialog.getText({
               title: trans.__('Rename file'),
@@ -808,7 +808,7 @@ function addCommands(
 
             if (result.button.accept) {
               newName = result.value ?? oldName;
-              (widget as IDocumentWidget).hasAutoName = false;
+              (widget as IDocumentWidget).isUntitled = false;
               if (typeof result.isChecked === 'boolean') {
                 const currentSetting = (
                   await settingRegistry.get(

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -134,6 +134,17 @@ export class DocumentManager implements IDocumentManager {
   }
 
   /**
+   * Whether to ask the user to rename untitled file on first manual save.
+   */
+  get renameUntitledFileOnSave(): boolean {
+    return this._renameUntitledFileOnSave;
+  }
+
+  set renameUntitledFileOnSave(value: boolean) {
+    this._renameUntitledFileOnSave = value;
+  }
+
+  /**
    * Get whether the document manager has been disposed.
    */
   get isDisposed(): boolean {
@@ -626,6 +637,7 @@ export class DocumentManager implements IDocumentManager {
   private _autosave = true;
   private _autosaveInterval = 120;
   private _lastModifiedCheckMargin = 500;
+  private _renameUntitledFileOnSave = true;
   private _when: Promise<void>;
   private _setBusy: (() => IDisposable) | undefined;
   private _dialogs: ISessionContext.IDialogs;

--- a/packages/docmanager/src/tokens.ts
+++ b/packages/docmanager/src/tokens.ts
@@ -50,6 +50,11 @@ export interface IDocumentManager extends IDisposable {
   lastModifiedCheckMargin: number;
 
   /**
+   * Whether to ask the user to rename untitled file on first manual save.
+   */
+  renameUntitledFileOnSave: boolean;
+
+  /**
    * Clone a widget.
    *
    * @param widget - The source widget.

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1508,14 +1508,23 @@ export interface IDocumentWidget<
   readonly content: T;
 
   /**
-   * A promise resolving after the content widget is revealed.
-   */
-  readonly revealed: Promise<void>;
-
-  /**
    * The context associated with the document.
    */
   readonly context: DocumentRegistry.IContext<U>;
+
+  /**
+   * Whether the content is untitled or not.
+   *
+   * #### Notes
+   * A document is untitled if its name is untitled and up
+   * to the instant the user saves it manually for the first time.
+   */
+  isUntitled?: boolean;
+
+  /**
+   * A promise resolving after the content widget is revealed.
+   */
+  readonly revealed: Promise<void>;
 
   /**
    * The toolbar for the widget.

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1513,13 +1513,13 @@ export interface IDocumentWidget<
   readonly context: DocumentRegistry.IContext<U>;
 
   /**
-   * Whether the content is untitled or not.
+   * Whether the document has an auto-generated name or not.
    *
    * #### Notes
-   * A document is untitled if its name is untitled and up
+   * A document has auto-generated name if its name is untitled and up
    * to the instant the user saves it manually for the first time.
    */
-  isUntitled?: boolean;
+  hasAutoName?: boolean;
 
   /**
    * A promise resolving after the content widget is revealed.

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1519,7 +1519,7 @@ export interface IDocumentWidget<
    * A document has auto-generated name if its name is untitled and up
    * to the instant the user saves it manually for the first time.
    */
-  hasAutoName?: boolean;
+  isUntitled?: boolean;
 
   /**
    * A promise resolving after the content widget is revealed.

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -956,7 +956,7 @@ export namespace Commands {
         path: model.path,
         factory: FACTORY
       })) as unknown as IDocumentWidget;
-      widget.hasAutoName = true;
+      widget.isUntitled = true;
       return widget;
     }
   }

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -956,7 +956,7 @@ export namespace Commands {
         path: model.path,
         factory: FACTORY
       })) as unknown as IDocumentWidget;
-      widget.isUntitled = true;
+      widget.hasAutoName = true;
       return widget;
     }
   }

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -941,25 +941,24 @@ export namespace Commands {
   /**
    * Function to create a new untitled text file, given the current working directory.
    */
-  function createNew(
+  async function createNew(
     commands: CommandRegistry,
     cwd: string,
     ext: string = 'txt'
   ) {
-    return commands
-      .execute('docmanager:new-untitled', {
-        path: cwd,
-        type: 'file',
-        ext
-      })
-      .then(model => {
-        if (model != undefined) {
-          return commands.execute('docmanager:open', {
-            path: model.path,
-            factory: FACTORY
-          });
-        }
-      });
+    const model = await commands.execute('docmanager:new-untitled', {
+      path: cwd,
+      type: 'file',
+      ext
+    });
+    if (model != undefined) {
+      const widget = (await commands.execute('docmanager:open', {
+        path: model.path,
+        factory: FACTORY
+      })) as unknown as IDocumentWidget;
+      widget.isUntitled = true;
+      return widget;
+    }
   }
 
   /**

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -37,7 +37,7 @@ import { PageConfig } from '@jupyterlab/coreutils';
 
 import { IDocumentManager } from '@jupyterlab/docmanager';
 import { ToolbarItems as DocToolbarItems } from '@jupyterlab/docmanager-extension';
-import { DocumentRegistry } from '@jupyterlab/docregistry';
+import { DocumentRegistry, IDocumentWidget } from '@jupyterlab/docregistry';
 import { ISearchProviderRegistry } from '@jupyterlab/documentsearch';
 import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
 import { ILauncher } from '@jupyterlab/launcher';
@@ -1612,18 +1612,20 @@ function activateNotebookHandler(
   }
 
   // Utility function to create a new notebook.
-  const createNew = (cwd: string, kernelName?: string) => {
-    return commands
-      .execute('docmanager:new-untitled', { path: cwd, type: 'notebook' })
-      .then(model => {
-        if (model != undefined) {
-          return commands.execute('docmanager:open', {
-            path: model.path,
-            factory: FACTORY,
-            kernel: { name: kernelName }
-          });
-        }
-      });
+  const createNew = async (cwd: string, kernelName?: string) => {
+    const model = await commands.execute('docmanager:new-untitled', {
+      path: cwd,
+      type: 'notebook'
+    });
+    if (model != undefined) {
+      const widget = (await commands.execute('docmanager:open', {
+        path: model.path,
+        factory: FACTORY,
+        kernel: { name: kernelName }
+      })) as unknown as IDocumentWidget;
+      widget.isUntitled = true;
+      return widget;
+    }
   };
 
   // Add a command for creating a new notebook.

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1623,7 +1623,7 @@ function activateNotebookHandler(
         factory: FACTORY,
         kernel: { name: kernelName }
       })) as unknown as IDocumentWidget;
-      widget.isUntitled = true;
+      widget.hasAutoName = true;
       return widget;
     }
   };

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1623,7 +1623,7 @@ function activateNotebookHandler(
         factory: FACTORY,
         kernel: { name: kernelName }
       })) as unknown as IDocumentWidget;
-      widget.hasAutoName = true;
+      widget.isUntitled = true;
       return widget;
     }
   };


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fix #5207
Fix https://github.com/jupyterlab/jupyterlab/issues/5617

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

- Add optional flag `hasAutoName` to `IDocumentWidget`
- Trigger rename dialog for document widgets on save for widget with that flag
- [x] Add _Don't show me again_ checkbox to dialog.
  - This adds to all dialog an new optional `checkbox` option to be displayed on the left in the footer (see screencast below)
  - The inputs are: `label` (checkbox label), `caption` (checkbox title), `checked` (initial value), `className` (additional class)
  - The output `isChecked` is added in `Dialog.IResult`. It is `null` if the dialog does not have a checkbox or is not displayed (for example if a dialog is already opened).
  - New setting `renameUntitledFileOnSave` for `@jupyterlab/docmanager-extension:plugin`
- `InputDialog.getText` has a new option `selectionRange` to set the default range of characters to select on dialog attachment; the default is to select the full text.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Got prompt to rename untitled files at first manual save

![demo-rename-untitled-on-save](https://user-images.githubusercontent.com/8435071/185343665-1079122a-c839-485b-847d-f2c9307e9ad5.gif)

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None