### PR TITLE
New token providing `IWidgetOpener`

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -48,6 +48,8 @@ bumped their major version (following semver convention). We want to point out p
    in particular those with the strict null checks enabled.
 - ``@jupyterlab/docmanager`` from 3.x to 4.x
    The ``renameDialog`` now receives the ``DocumentRegistry.Context`` instead of a path.
+   The interface ``DocumentManager.IWidgetOpener`` is now ``IWidgetOpener`` and is provided
+   by a new plugin ``@jupyterlab/docmanager-extension:widget-opener``.
 - ``@jupyterlab/docprovider`` from 3.x to 4.x
    ``WebSocketProviderWithLocks`` has been renamed to ``WebSocketProvider``.
    ``acquireLock``, ``releaseLock``, ``requestInitialContent`` and ``putInitializedState`` have been removed from ``IDocumentProvider``.

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -97,7 +97,7 @@ const docManagerPluginId = '@jupyterlab/docmanager-extension:plugin';
 /**
  * A plugin providing the default document manager.
  */
-const manager: JupyterFrontEndPlugin<IWidgetOpener> = {
+const widgetOpener: JupyterFrontEndPlugin<IWidgetOpener> = {
   id: '@jupyterlab/docmanager-extension:widget-opener',
   provides: IWidgetOpener,
   optional: [
@@ -494,6 +494,7 @@ export const openBrowserTabPlugin: JupyterFrontEndPlugin<void> = {
  * Export the plugins as default.
  */
 const plugins: JupyterFrontEndPlugin<any>[] = [
+  widgetOpener,
   manager,
   docManagerPlugin,
   pathStatusPlugin,

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -632,7 +632,7 @@ export class DocumentManager implements IDocumentManager {
   protected translator: ITranslator;
   private _activateRequested = new Signal<this, string>(this);
   private _contexts: Private.IContext[] = [];
-  private _opener: DocumentManager.IWidgetOpener;
+  private _opener: IWidgetOpener;
   private _widgetManager: DocumentWidgetManager;
   private _isDisposed = false;
   private _autosave = true;
@@ -705,19 +705,6 @@ export namespace DocumentManager {
      * By default, it always returns `true`.
      */
     isConnectedCallback?: () => boolean;
-  }
-
-  /**
-   * An interface for a widget opener.
-   */
-  export interface IWidgetOpener {
-    /**
-     * Open the given widget.
-     */
-    open(
-      widget: IDocumentWidget,
-      options?: DocumentRegistry.IOpenOptions
-    ): void;
   }
 }
 

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -18,7 +18,7 @@ import { AttachedProperty } from '@lumino/properties';
 import { ISignal, Signal } from '@lumino/signaling';
 import { Widget } from '@lumino/widgets';
 import { SaveHandler } from './savehandler';
-import { IDocumentManager } from './tokens';
+import { IDocumentManager, IWidgetOpener } from './tokens';
 import { DocumentWidgetManager } from './widgetmanager';
 
 /**

--- a/packages/docmanager/src/tokens.ts
+++ b/packages/docmanager/src/tokens.ts
@@ -16,6 +16,13 @@ export const IDocumentManager = new Token<IDocumentManager>(
 );
 
 /**
+ * The document widget opener token.
+ */
+export const IWidgetOpener = new Token<IWidgetOpener>(
+  '@jupyterlab/docmanager:IWidgetOpener'
+);
+
+/**
  * The interface for a document manager.
  */
 export interface IDocumentManager extends IDisposable {
@@ -236,4 +243,14 @@ export interface IDocumentManager extends IDisposable {
    * a file.
    */
   rename(oldPath: string, newPath: string): Promise<Contents.IModel>;
+}
+
+/**
+ * An interface for a widget opener.
+ */
+export interface IWidgetOpener {
+  /**
+   * Open the given widget.
+   */
+  open(widget: IDocumentWidget, options?: DocumentRegistry.IOpenOptions): void;
 }

--- a/packages/filebrowser/test/crumbs.spec.ts
+++ b/packages/filebrowser/test/crumbs.spec.ts
@@ -53,7 +53,7 @@ describe('filebrowser/model', () => {
   let path: string;
 
   beforeAll(async () => {
-    const opener: DocumentManager.IWidgetOpener = {
+    const opener: IWidgetOpener = {
       open: widget => {
         /* no op */
       }

--- a/packages/filebrowser/test/crumbs.spec.ts
+++ b/packages/filebrowser/test/crumbs.spec.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { DocumentManager, IDocumentManager } from '@jupyterlab/docmanager';
+import {
+  DocumentManager,
+  IDocumentManager,
+  IWidgetOpener
+} from '@jupyterlab/docmanager';
 import { DocumentRegistry, TextModelFactory } from '@jupyterlab/docregistry';
 import { ServiceManager } from '@jupyterlab/services';
 import { framePromise, signalToPromise } from '@jupyterlab/testutils';

--- a/packages/filebrowser/test/model.spec.ts
+++ b/packages/filebrowser/test/model.spec.ts
@@ -50,7 +50,7 @@ describe('filebrowser/model', () => {
   let subDir: string;
   let subSubDir: string;
   let state: StateDB;
-  const opener: DocumentManager.IWidgetOpener = {
+  const opener: IWidgetOpener = {
     open: widget => {
       /* no op */
     }

--- a/packages/filebrowser/test/model.spec.ts
+++ b/packages/filebrowser/test/model.spec.ts
@@ -2,7 +2,11 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { PageConfig } from '@jupyterlab/coreutils';
-import { DocumentManager, IDocumentManager } from '@jupyterlab/docmanager';
+import {
+  DocumentManager,
+  IDocumentManager,
+  IWidgetOpener
+} from '@jupyterlab/docmanager';
 import { DocumentRegistry, TextModelFactory } from '@jupyterlab/docregistry';
 import { Contents, ServiceManager } from '@jupyterlab/services';
 import { StateDB } from '@jupyterlab/statedb';

--- a/packages/filebrowser/test/openfiledialog.spec.ts
+++ b/packages/filebrowser/test/openfiledialog.spec.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { DocumentManager, IDocumentManager } from '@jupyterlab/docmanager';
+import {
+  DocumentManager,
+  IDocumentManager,
+  IWidgetOpener
+} from '@jupyterlab/docmanager';
 import { DocumentRegistry, TextModelFactory } from '@jupyterlab/docregistry';
 import { Contents, ServiceManager } from '@jupyterlab/services';
 import {

--- a/packages/filebrowser/test/openfiledialog.spec.ts
+++ b/packages/filebrowser/test/openfiledialog.spec.ts
@@ -23,7 +23,7 @@ describe('@jupyterlab/filebrowser', () => {
   let registry: DocumentRegistry;
 
   beforeAll(async () => {
-    const opener: DocumentManager.IWidgetOpener = {
+    const opener: IWidgetOpener = {
       open: widget => {
         /* no op */
       }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #12965
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
New plugin exporting a new token `IWidgetOpener` (formerly `DocumentManager.IWidgetOpener`)

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Restore cloning a view
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None