### PR TITLE
Add scrolling to `debugger` variable renderer

### DIFF
--- a/packages/debugger/src/panels/variables/mimerenderer.ts
+++ b/packages/debugger/src/panels/variables/mimerenderer.ts
@@ -32,7 +32,6 @@ export class VariableMimeRenderer extends MainAreaWidget<Panel> {
       content,
       reveal: Promise.all([dataLoader, loaded.promise])
     });
-    this.addClass(MIME_RENDERER_CLASS);
     this.trans = (translator ?? nullTranslator).load('jupyterlab');
     this.dataLoader = dataLoader;
     this.renderMime = rendermime;
@@ -77,6 +76,7 @@ export class VariableMimeRenderer extends MainAreaWidget<Panel> {
 
         if (mimeType) {
           const widget = this.renderMime.createRenderer(mimeType);
+          widget.addClass(MIME_RENDERER_CLASS);
           const model = new MimeModel({ ...data, trusted: true });
           this._dataHash = hash;
           await widget.renderModel(model);

--- a/packages/debugger/src/panels/variables/mimerenderer.ts
+++ b/packages/debugger/src/panels/variables/mimerenderer.ts
@@ -15,7 +15,7 @@ import { Panel } from '@lumino/widgets';
 import { murmur2 } from '../../hash';
 import { IDebugger } from '../../tokens';
 
-const MIME_RENDERER_CLASS = 'jp-MimeRenderer';
+const MIME_RENDERER_CLASS = 'jp-VariableRenderer';
 
 /**
  * Debugger variable mime type renderer

--- a/packages/debugger/src/panels/variables/mimerenderer.ts
+++ b/packages/debugger/src/panels/variables/mimerenderer.ts
@@ -15,6 +15,8 @@ import { Panel } from '@lumino/widgets';
 import { murmur2 } from '../../hash';
 import { IDebugger } from '../../tokens';
 
+const MIME_RENDERER_CLASS = 'jp-MimeRenderer';
+
 /**
  * Debugger variable mime type renderer
  */
@@ -30,6 +32,7 @@ export class VariableMimeRenderer extends MainAreaWidget<Panel> {
       content,
       reveal: Promise.all([dataLoader, loaded.promise])
     });
+    this.addClass(MIME_RENDERER_CLASS);
     this.trans = (translator ?? nullTranslator).load('jupyterlab');
     this.dataLoader = dataLoader;
     this.renderMime = rendermime;

--- a/packages/debugger/src/panels/variables/mimerenderer.ts
+++ b/packages/debugger/src/panels/variables/mimerenderer.ts
@@ -15,7 +15,8 @@ import { Panel } from '@lumino/widgets';
 import { murmur2 } from '../../hash';
 import { IDebugger } from '../../tokens';
 
-const MIME_RENDERER_CLASS = 'jp-VariableRenderer';
+const RENDERER_PANEL_CLASS = 'jp-VariableRendererPanel';
+const RENDERER_PANEL_RENDERER_CLASS = 'jp-VariableRendererPanel-renderer';
 
 /**
  * Debugger variable mime type renderer
@@ -32,7 +33,7 @@ export class VariableMimeRenderer extends MainAreaWidget<Panel> {
       content,
       reveal: Promise.all([dataLoader, loaded.promise])
     });
-    this.content.addClass(MIME_RENDERER_CLASS);
+    this.content.addClass(RENDERER_PANEL_CLASS);
     this.trans = (translator ?? nullTranslator).load('jupyterlab');
     this.dataLoader = dataLoader;
     this.renderMime = rendermime;
@@ -77,7 +78,7 @@ export class VariableMimeRenderer extends MainAreaWidget<Panel> {
 
         if (mimeType) {
           const widget = this.renderMime.createRenderer(mimeType);
-          widget.addClass(MIME_RENDERER_CLASS);
+          widget.addClass(RENDERER_PANEL_RENDERER_CLASS);
           const model = new MimeModel({ ...data, trusted: true });
           this._dataHash = hash;
           await widget.renderModel(model);

--- a/packages/debugger/src/panels/variables/mimerenderer.ts
+++ b/packages/debugger/src/panels/variables/mimerenderer.ts
@@ -32,6 +32,7 @@ export class VariableMimeRenderer extends MainAreaWidget<Panel> {
       content,
       reveal: Promise.all([dataLoader, loaded.promise])
     });
+    this.content.addClass(MIME_RENDERER_CLASS);
     this.trans = (translator ?? nullTranslator).load('jupyterlab');
     this.dataLoader = dataLoader;
     this.renderMime = rendermime;

--- a/packages/debugger/style/base.css
+++ b/packages/debugger/style/base.css
@@ -24,3 +24,7 @@
 .jp-DebuggerBugButton[aria-pressed='true'] path {
   fill: var(--jp-warn-color0);
 }
+
+.jp-MimeRenderer {
+  overflow: auto;
+}

--- a/packages/debugger/style/base.css
+++ b/packages/debugger/style/base.css
@@ -24,7 +24,3 @@
 .jp-DebuggerBugButton[aria-pressed='true'] path {
   fill: var(--jp-warn-color0);
 }
-
-.jp-MimeRenderer {
-  overflow: auto;
-}

--- a/packages/debugger/style/variables.css
+++ b/packages/debugger/style/variables.css
@@ -114,8 +114,13 @@
   color: var(--jp-content-font-color0);
 }
 
-.jp-VariableRenderer {
+.jp-VariableRendererPanel {
   overflow: auto;
+}
+
+.jp-VariableRendererPanel-renderer {
+  overflow: auto;
+  height: 100%
 }
 
 .jp-VariableRenderer-TrustButton[aria-pressed='true'] {

--- a/packages/debugger/style/variables.css
+++ b/packages/debugger/style/variables.css
@@ -114,6 +114,10 @@
   color: var(--jp-content-font-color0);
 }
 
+.jp-VariableRenderer {
+  overflow: auto;
+}
+
 .jp-VariableRenderer-TrustButton[aria-pressed='true'] {
   box-shadow: inset 0 var(--jp-border-width) 4px
     rgba(

--- a/packages/debugger/style/variables.css
+++ b/packages/debugger/style/variables.css
@@ -120,7 +120,7 @@
 
 .jp-VariableRendererPanel-renderer {
   overflow: auto;
-  height: 100%
+  height: 100%;
 }
 
 .jp-VariableRenderer-TrustButton[aria-pressed='true'] {


### PR DESCRIPTION
## References

Fixes #12964.

## Code changes

- Create and add `.jp-VariableRendererPanel` class to `VariableMimeRenderer.content` with `overflow: auto` to allow vertical scrolling
- Create and add `.jp-VariableRendererPanel-renderer` class to `VariableMimeRenderer.renderMime` `widget` with `overflow: auto` to allow horizontal scrolling
    - Set `height: 100%` to set horizontal scrollbar at the bottom of parent, rather than bottom of content

## User-facing changes

`debugger` variable renderer becomes scrollable.

![Animation](https://user-images.githubusercontent.com/23555/185636419-ccbdde5d-cc97-456f-82a1-2f7d2a3c7633.gif)

## Backwards-incompatible changes

None
