### PR TITLE
Add `(developer)` label to the developer facing commands

### DIFF
--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -164,7 +164,7 @@ class BaseExtensionApp(JupyterApp, DebugLogFileMixin):
 
 
 class InstallLabExtensionApp(BaseExtensionApp):
-    description = """Install labextension(s)
+    description = """Install one or several JupyterLab extensions
 
      Usage
 
@@ -204,7 +204,7 @@ class InstallLabExtensionApp(BaseExtensionApp):
 
 
 class DevelopLabExtensionApp(BaseExtensionApp):
-    description = "Develop labextension"
+    description = "(developer) Develop labextension"
     flags = develop_flags
 
     user = Bool(False, config=True, help="Whether to do a user install")
@@ -232,7 +232,7 @@ class DevelopLabExtensionApp(BaseExtensionApp):
 
 
 class BuildLabExtensionApp(BaseExtensionApp):
-    description = "Build labextension"
+    description = "(developer) Build labextension"
 
     static_url = Unicode("", config=True, help="Sets the url for static assets when building")
 
@@ -266,7 +266,7 @@ class BuildLabExtensionApp(BaseExtensionApp):
 
 
 class WatchLabExtensionApp(BaseExtensionApp):
-    description = "Watch labextension"
+    description = "(developer) Watch labextension"
 
     development = Bool(True, config=True, help="Build in development mode")
 
@@ -459,13 +459,13 @@ class CheckLabExtensionsApp(BaseExtensionApp):
             self.exit(1)
 
 
-_examples = """
+_EXAMPLES = """
 jupyter labextension list                        # list all configured labextensions
-jupyter labextension develop                     # develop a prebuilt labextension
-jupyter labextension build                       # build a prebuilt labextension
-jupyter labextension watch                       # watch a prebuilt labextension
 jupyter labextension install <extension name>    # install a labextension
 jupyter labextension uninstall <extension name>  # uninstall a labextension
+jupyter labextension develop                     # (developer) develop a prebuilt labextension
+jupyter labextension build                       # (developer) build a prebuilt labextension
+jupyter labextension watch                       # (developer) watch a prebuilt labextension
 """
 
 
@@ -475,13 +475,10 @@ class LabExtensionApp(JupyterApp):
     name = "jupyter labextension"
     version = VERSION
     description = "Work with JupyterLab extensions"
-    examples = _examples
+    examples = _EXAMPLES
 
     subcommands = dict(
         install=(InstallLabExtensionApp, "Install labextension(s)"),
-        develop=(DevelopLabExtensionApp, "Develop labextension(s)"),
-        build=(BuildLabExtensionApp, "Build labextension"),
-        watch=(WatchLabExtensionApp, "Watch labextension"),
         update=(UpdateLabExtensionApp, "Update labextension(s)"),
         uninstall=(UninstallLabExtensionApp, "Uninstall labextension(s)"),
         list=(ListLabExtensionsApp, "List labextensions"),
@@ -490,6 +487,9 @@ class LabExtensionApp(JupyterApp):
         enable=(EnableLabExtensionsApp, "Enable labextension(s)"),
         disable=(DisableLabExtensionsApp, "Disable labextension(s)"),
         check=(CheckLabExtensionsApp, "Check labextension(s)"),
+        develop=(DevelopLabExtensionApp, "(developer) Develop labextension(s)"),
+        build=(BuildLabExtensionApp, "(developer) Build labextension"),
+        watch=(WatchLabExtensionApp, "(developer) Watch labextension"),
     )
 
     def start(self):

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -164,7 +164,7 @@ class BaseExtensionApp(JupyterApp, DebugLogFileMixin):
 
 
 class InstallLabExtensionApp(BaseExtensionApp):
-    description = """Install one or several JupyterLab extensions
+    description = """Install labextension(s)
 
      Usage
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/9700

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Takes the simpler approach of adding a `(developer)` label to the developer facing command descriptions. 

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Updates to the output of `jupyter labextension -h`:

```
Work with JupyterLab extensions

Subcommands
===========
Subcommands are launched as `jupyter labextension cmd [args]`. For information
on using subcommand 'cmd', do: `jupyter labextension cmd -h`.

install
    Install labextension(s)
update
    Update labextension(s)
uninstall
    Uninstall labextension(s)
list
    List labextensions
link
    Link labextension(s)
unlink
    Unlink labextension(s)
enable
    Enable labextension(s)
disable
    Disable labextension(s)
check
    Check labextension(s)
develop
    (developer) Develop labextension(s)
build
    (developer) Build labextension
watch
    (developer) Watch labextension

Options
=======
The options below are convenience aliases to configurable class-options,
as listed in the "Equivalent to" description-line of the aliases.
To see all configurable class-options for some <cmd>, use:
    <cmd> --help-all

--debug
    set log level to logging.DEBUG (maximize logging output)
    Equivalent to: [--Application.log_level=10]
--show-config
    Show the application's configuration (human-readable format)
    Equivalent to: [--Application.show_config=True]
--show-config-json
    Show the application's configuration (json format)
    Equivalent to: [--Application.show_config_json=True]
--generate-config
    generate default config file
    Equivalent to: [--JupyterApp.generate_config=True]
-y
    Answer yes to any questions instead of prompting.
    Equivalent to: [--JupyterApp.answer_yes=True]
--log-level=<Enum>
    Set the log level by value or name.
    Choices: any of [0, 10, 20, 30, 40, 50, 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL']
    Default: 30
    Equivalent to: [--Application.log_level]
--config=<Unicode>
    Full path of a config file.
    Default: ''
    Equivalent to: [--JupyterApp.config_file]

Examples
--------

    jupyter labextension list                        # list all configured labextensions
    jupyter labextension install <extension name>    # install a labextension
    jupyter labextension uninstall <extension name>  # uninstall a labextension
    jupyter labextension develop                     # (developer) develop a prebuilt labextension
    jupyter labextension build                       # (developer) build a prebuilt labextension
    jupyter labextension watch                       # (developer) watch a prebuilt labextension

To see all available configurables, use `--help-all`.
```

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
