### PR TITLE
Drop the pin on `jupyterlab_widgets` in the docs dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,8 +82,7 @@ docs = [
 docs-screenshots = [
     "altair==4.2.0",
     "ipython==8.0.0",
-    "ipywidgets==7.6.5",
-    "jupyterlab_widgets==1.1.1",
+    "ipywidgets==7.6.6",
     "jupyterlab-geojson==3.2.0",
     "jupyterlab-language-pack-zh-CN==3.2.post7",
     "matplotlib==3.5.1",


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/12967

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Now that https://github.com/jupyter-widgets/ipywidgets/pull/3551 has been merged, backported and released in `7.6.6` we can drop the pin and bump `ipywidgets`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
