### PR TITLE
Support subprotocols in kernel restart

### DIFF
--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -1514,8 +1514,14 @@ export class KernelConnection implements Kernel.IKernelConnection {
           timeout / 1000
         )} seconds.`
       );
-      // Try reconnection without subprotocols.
-      this._reconnectTimeout = setTimeout(this._createSocket, timeout, false);
+      // Try reconnection with subprotocols if the server had supported them.
+      // Otherwise, try reconnection without subprotocols.
+      const useProtocols = this._selectedProtocol !== '' ? true : false;
+      this._reconnectTimeout = setTimeout(
+        this._createSocket,
+        timeout,
+        useProtocols
+      );
       this._reconnectAttempt += 1;
     } else {
       this._updateConnectionStatus('disconnected');
@@ -1551,6 +1557,8 @@ export class KernelConnection implements Kernel.IKernelConnection {
       this._updateStatus('dead');
       throw new Error(`Unknown kernel wire protocol:  ${this._ws!.protocol}`);
     }
+    // Remember the kernel wire protocol selected by the server.
+    this._selectedProtocol = this._ws!.protocol;
     this._ws!.onclose = this._onWSClose;
     this._ws!.onerror = this._onWSClose;
     this._updateConnectionStatus('connected');
@@ -1630,6 +1638,7 @@ export class KernelConnection implements Kernel.IKernelConnection {
   private _supportedProtocols: string[] = Object.values(
     KernelMessage.supportedKernelWebSocketProtocols
   );
+  private _selectedProtocol: string = '';
 
   private _futures = new Map<
     string,


### PR DESCRIPTION
## References

In #11841 we introduced subprotocols for kernels websocket, with a reconnection mechanism to fall back to "no subprotocol" when the server doesn't support them.

## Code changes

We should not reconnect with "no subprotocol" if the reconnection is the result of a kernel restart. In this case we should use subprotocols if the server previously supported them.

## User-facing changes

Better performances, as we will most likely use the new kernel wire protocol over websocket when restarting a kernel.

## Backwards-incompatible changes

None.