### PR TITLE
Add a title to the debugger sidebar widget

### DIFF
--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -740,7 +740,7 @@ const main: JupyterFrontEndPlugin<void> = {
     sidebar.node.setAttribute('role', 'region');
     sidebar.node.setAttribute('aria-label', trans.__('Debugger section'));
 
-    sidebar.title.caption = trans.__('Debugger Sidebar');
+    sidebar.title.caption = trans.__('Debugger');
 
     shell.add(sidebar, 'right', { type: 'Debugger' });
 

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -740,7 +740,7 @@ const main: JupyterFrontEndPlugin<void> = {
     sidebar.node.setAttribute('role', 'region');
     sidebar.node.setAttribute('aria-label', trans.__('Debugger section'));
 
-    sidebar.title.caption = trans.__('Debugger');
+    sidebar.title.caption = trans.__('Debugger Sidebar');
 
     shell.add(sidebar, 'right', { type: 'Debugger' });
 

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -45,6 +45,7 @@ import {
 import { Session } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { ITranslator } from '@jupyterlab/translation';
+import { bugIcon } from '@jupyterlab/ui-components';
 
 /**
  * A plugin that provides visual debugging support for consoles.
@@ -739,6 +740,9 @@ const main: JupyterFrontEndPlugin<void> = {
 
     sidebar.node.setAttribute('role', 'region');
     sidebar.node.setAttribute('aria-label', trans.__('Debugger section'));
+
+    sidebar.title.icon = bugIcon;
+    sidebar.title.caption = trans.__('Debugger');
 
     shell.add(sidebar, 'right', { type: 'Debugger' });
 

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -45,7 +45,6 @@ import {
 import { Session } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { ITranslator } from '@jupyterlab/translation';
-import { bugIcon } from '@jupyterlab/ui-components';
 
 /**
  * A plugin that provides visual debugging support for consoles.
@@ -741,7 +740,6 @@ const main: JupyterFrontEndPlugin<void> = {
     sidebar.node.setAttribute('role', 'region');
     sidebar.node.setAttribute('aria-label', trans.__('Debugger section'));
 
-    sidebar.title.icon = bugIcon;
     sidebar.title.caption = trans.__('Debugger');
 
     shell.add(sidebar, 'right', { type: 'Debugger' });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This was noticed when trying to reuse the debugger sidebar in Notebook v7: https://github.com/jupyter/notebook/pull/6487

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Add a `title` to the debugger sidebar widget.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None for stock JupyterLab users. 

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
