### PR TITLE
Fix customize expected reference

### DIFF
--- a/galata/README.md
+++ b/galata/README.md
@@ -423,7 +423,8 @@ The benchmark can be customized using the following environment variables:
 
 - `BENCHMARK_NUMBER_SAMPLES`: Number of samples to compute the execution time distribution; default 20.
 - `BENCHMARK_OUTPUTFILE`: Benchmark result output file; default `benchmark.json`. It is overridden in the [`playwright-benchmark.config.js`](playwright-benchmark.config.js).
-- `BENCHMARK_REFERENCE`: Reference name of the data; default is `actual` for current data and `expected` for the reference.
+- `BENCHMARK_REFERENCE`: Reference name of the data; default is `actual`.
+- `BENCHMARK_EXPECTED_REFERENCE`: Reference name of the reference data; default is `expected`.
 
 ## Development
 

--- a/galata/src/benchmarkReporter.ts
+++ b/galata/src/benchmarkReporter.ts
@@ -344,6 +344,9 @@ class BenchmarkReporter implements Reporter {
 
     this._comparison = options.comparison ?? 'snapshot';
 
+    this._expectedReference =
+      process.env['BENCHMARK_EXPECTED_REFERENCE'] ??
+      benchmark.DEFAULT_EXPECTED_REFERENCE;
     this._reference =
       process.env['BENCHMARK_REFERENCE'] ?? benchmark.DEFAULT_REFERENCE;
 
@@ -434,7 +437,10 @@ class BenchmarkReporter implements Reporter {
         if (!hasExpectations || this.config.updateSnapshots === 'all') {
           expectations = {
             values: report.values.map(d => {
-              return { ...d, reference: benchmark.DEFAULT_EXPECTED_REFERENCE };
+              return {
+                ...d,
+                reference: this._expectedReference
+              };
             }),
             metadata: report.metadata
           };
@@ -582,7 +588,7 @@ class BenchmarkReporter implements Reporter {
     reportContent.push(new Array(nFiles + 2).fill('|').join(' --- '));
     const filler = new Array(nFiles).fill('|').join(' ');
 
-    let changeReference = benchmark.DEFAULT_EXPECTED_REFERENCE;
+    let changeReference = this._expectedReference;
 
     for (const [test, testGroup] of groups) {
       reportContent.push(`| **${test}** | ` + filler);
@@ -596,10 +602,7 @@ class BenchmarkReporter implements Reporter {
             const [q1, median, q3] = vs.quartiles(dataGroup);
 
             if (compare) {
-              if (
-                reference === benchmark.DEFAULT_REFERENCE ||
-                !actual.has(filename)
-              ) {
+              if (reference === this._reference || !actual.has(filename)) {
                 actual.set(filename, dataGroup);
               } else {
                 changeReference = reference;
@@ -737,6 +740,7 @@ class BenchmarkReporter implements Reporter {
   protected config: FullConfig;
   protected suite: Suite;
   private _comparison: 'snapshot' | 'project';
+  private _expectedReference: string;
   private _outputFile: string;
   private _reference: string;
   private _report: IReportRecord[];


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
_expected_ is not customized as seen in https://github.com/jupyterlab/benchmarks/actions/runs/2919374023
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
_expected_ label can be customized through environment variable `BENCHMARK_EXPECTED_REFERENCE`

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A