### PR TITLE
Conditional call to waitIsReady in reload

### DIFF
--- a/galata/src/jupyterlabpage.ts
+++ b/galata/src/jupyterlabpage.ts
@@ -492,16 +492,26 @@ export class JupyterLabPage implements IJupyterLabPage {
      * - `'domcontentloaded'` - consider operation to be finished when the `DOMContentLoaded` event is fired.
      * - `'load'` - consider operation to be finished when the `load` event is fired.
      * - `'networkidle'` - consider operation to be finished when there are no network connections for at least `500` ms.
+     * - `'commit'` - consider operation to be finished when network response is received and the document started loading.
      */
-    waitUntil?: 'load' | 'domcontentloaded' | 'networkidle';
+    waitUntil?: 'load' | 'domcontentloaded' | 'networkidle' | 'commit';
+
+    /**
+     * Whether to wait for fixture `waitIsReady` or not when reloading.
+     *
+     * Default is true.
+     */
+    waitForIsReady?: boolean;
   }): Promise<Response | null> {
     const response = await this.page.reload({
-      ...(options ?? {}),
+      timeout: options?.timeout,
       waitUntil: options?.waitUntil ?? 'domcontentloaded'
     });
     await this.waitForAppStarted();
     await this.hookHelpersUp();
-    await this.waitIsReady(this.page, this);
+    if (options?.waitForIsReady ?? true) {
+      await this.waitIsReady(this.page, this);
+    }
     return response;
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fix #12924
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Add optional attribute to `JupyterLabPage.reload` to skip waiting for `waitIsReady`

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A