### PR TITLE
Adding default parameter to reload method in Galata 

### DIFF
--- a/galata/src/jupyterlabpage.ts
+++ b/galata/src/jupyterlabpage.ts
@@ -474,34 +474,44 @@ export class JupyterLabPage implements IJupyterLabPage {
    * - the splash screen to have disappeared
    * - the launcher to be visible
    *
+   * @param waitForLauncher
    * @param options
    */
-  async reload(options?: {
+  async reload(
     /**
-     * Maximum operation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be
-     * changed by using the
-     * [browserContext.setDefaultNavigationTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-navigation-timeout),
-     * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout),
-     * [page.setDefaultNavigationTimeout(timeout)](https://playwright.dev/docs/api/class-page#page-set-default-navigation-timeout)
-     * or [page.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-page#page-set-default-timeout) methods.
+     * Whether to wait for the JupyterLab launcher to be visible after reloading.
      */
-    timeout?: number;
+    waitForLauncher: boolean = true,
 
-    /**
-     * When to consider operation succeeded, defaults to `load`. Events can be either:
-     * - `'domcontentloaded'` - consider operation to be finished when the `DOMContentLoaded` event is fired.
-     * - `'load'` - consider operation to be finished when the `load` event is fired.
-     * - `'networkidle'` - consider operation to be finished when there are no network connections for at least `500` ms.
-     */
-    waitUntil?: 'load' | 'domcontentloaded' | 'networkidle';
-  }): Promise<Response | null> {
+    options?: {
+      /**
+       * Maximum operation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be
+       * changed by using the
+       * [browserContext.setDefaultNavigationTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-navigation-timeout),
+       * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout),
+       * [page.setDefaultNavigationTimeout(timeout)](https://playwright.dev/docs/api/class-page#page-set-default-navigation-timeout)
+       * or [page.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-page#page-set-default-timeout) methods.
+       */
+      timeout?: number;
+
+      /**
+       * When to consider operation succeeded, defaults to `load`. Events can be either:
+       * - `'domcontentloaded'` - consider operation to be finished when the `DOMContentLoaded` event is fired.
+       * - `'load'` - consider operation to be finished when the `load` event is fired.
+       * - `'networkidle'` - consider operation to be finished when there are no network connections for at least `500` ms.
+       */
+      waitUntil?: 'load' | 'domcontentloaded' | 'networkidle';
+    }
+  ): Promise<Response | null> {
     const response = await this.page.reload({
       ...(options ?? {}),
       waitUntil: options?.waitUntil ?? 'domcontentloaded'
     });
     await this.waitForAppStarted();
     await this.hookHelpersUp();
-    await this.waitIsReady(this.page, this);
+    if (waitForLauncher) {
+      await this.waitIsReady(this.page, this);
+    }
     return response;
   }
 


### PR DESCRIPTION
Galata has overridden the page.reload method of Playwright and as a result, has introduced assertions that are only true if the JupyterLab Launcher is visible after reload.


## References

This was by the suggestion of @fcollonval on the issue: https://github.com/jupyterlab/jupyterlab/issues/12924

## Code changes

A boolean-valued default parameter named `waitForLauncher` has been introduced, which is set to true by default. If you wish to bypass the assertions that the Launcher is visible, you can set it equal to false.

## User-facing changes

None

## Backwards-incompatible changes

Should be backwards compatible, so none. 
