### PR TITLE
Drop node-fetch for galata helpers

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -65,6 +65,12 @@ bumped their major version (following semver convention). We want to point out p
 - ``@jupyterlab/filebrowser-extension`` from 3.x to 4.x
    Remove command ``filebrowser:create-main-launcher``. You can replace by ``launcher:create`` (same behavior)
    All launcher creation actions are moved to ``@jupyterlab/launcher-extension``.
+- ``@jupyterlab/galata`` from 4.x to 5.x
+   * ``ContentsHelper`` and ``galata.newContentsHelper`` have new constructor arguments to use Playwright API request object:
+     ``new ContentsHelper(baseURL, page?, request?)`` -> ``new ContentsHelper(request?, page?)``
+     ``galata.newContentsHelper(baseURL, page?, request?)`` -> ``galata.newContentsHelper(request?, page?)``
+     you need to provide ``request`` or ``page``; they both are fixtures provided by Playwright.
+   * ``galata.Mock.clearRunners(baseURL, runners, type)`` -> ``galata.Mock.clearRunners(request, runners, type)``
 - ``@jupyterlab/notebook`` from 3.x to 4.x
    * The ``NotebookPanel._onSave`` method is now ``private``.
    * ``NotebookActions.collapseAll`` method renamed to ``NotebookActions.collapseAllHeadings``.

--- a/galata/package.json
+++ b/galata/package.json
@@ -62,7 +62,6 @@
     "fs-extra": "^9.0.1",
     "http-server": "^13.0.0",
     "json5": "^2.1.1",
-    "node-fetch": "^2.6.0",
     "path": "~0.12.7",
     "systeminformation": "^5.8.6",
     "vega": "^5.20.0",
@@ -70,7 +69,6 @@
     "vega-statistics": "^1.7.9"
   },
   "devDependencies": {
-    "@types/node-fetch": "^2.5.4",
     "css-loader": "^6.7.1",
     "mini-svg-data-uri": "^1.4.4",
     "rimraf": "~3.0.0",

--- a/galata/src/fixtures.ts
+++ b/galata/src/fixtures.ts
@@ -202,17 +202,13 @@ export const test: TestType<
    *
    * By default the sessions created during a test will be tracked and disposed at the end.
    */
-  sessions: async ({ baseURL }, use) => {
+  sessions: async ({ request }, use) => {
     const sessions = new Map<string, Session.IModel>();
 
     await use(sessions);
 
     if (sessions.size > 0) {
-      await galata.Mock.clearRunners(
-        baseURL!,
-        [...sessions.keys()],
-        'sessions'
-      );
+      await galata.Mock.clearRunners(request, [...sessions.keys()], 'sessions');
     }
   },
   /**
@@ -224,14 +220,14 @@ export const test: TestType<
    *
    * By default the Terminals created during a test will be tracked and disposed at the end.
    */
-  terminals: async ({ baseURL }, use) => {
+  terminals: async ({ request }, use) => {
     const terminals = new Map<string, TerminalAPI.IModel>();
 
     await use(terminals);
 
     if (terminals.size > 0) {
       await galata.Mock.clearRunners(
-        baseURL!,
+        request,
         [...terminals.keys()],
         'terminals'
       );
@@ -243,13 +239,13 @@ export const test: TestType<
    * Note: if you override this string, you will need to take care of creating the
    * folder and cleaning it.
    */
-  tmpPath: async ({ baseURL, serverFiles, request }, use, testInfo) => {
+  tmpPath: async ({ request, serverFiles }, use, testInfo) => {
     // Remove appended retry part for reproducibility
     const testFolder = path
       .basename(testInfo.outputDir)
       .replace(/-retry\d+$/i, '');
 
-    const contents = new ContentsHelper(baseURL!, undefined, request);
+    const contents = new ContentsHelper(request);
 
     if (await contents.directoryExists(testFolder)) {
       await contents.deleteDirectory(testFolder);

--- a/galata/src/galata.ts
+++ b/galata/src/galata.ts
@@ -7,7 +7,6 @@ import { Session, TerminalAPI, Workspace } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { APIRequestContext, Browser, Page } from '@playwright/test';
 import * as json5 from 'json5';
-import fetch from 'node-fetch';
 import { ContentsHelper } from './contents';
 import { PerformanceHelper } from './helpers';
 import {
@@ -183,17 +182,15 @@ export namespace galata {
   /**
    * Create a contents REST API helpers object
    *
-   * @param baseURL Application base URL
-   * @param page Playwright page model
    * @param request Playwright API request context
+   * @param page Playwright page model
    * @returns Contents REST API helpers
    */
   export function newContentsHelper(
-    baseURL: string,
-    page?: Page,
-    request?: APIRequestContext
+    request?: APIRequestContext,
+    page?: Page
   ): ContentsHelper {
-    return new ContentsHelper(baseURL, page, request);
+    return new ContentsHelper(request, page);
   }
 
   /**
@@ -493,23 +490,18 @@ export namespace galata {
      * @returns Whether the runners were closed or not
      */
     export async function clearRunners(
-      baseURL: string,
+      request: APIRequestContext,
       runners: string[],
-      type: 'sessions' | 'terminals',
-      request?: APIRequestContext
+      type: 'sessions' | 'terminals'
     ): Promise<boolean> {
       const responses = await Promise.all(
         [...new Set(runners)].map(id =>
-          request
-            ? request.fetch(`/api/${type}/${id}`, {
-                method: 'DELETE'
-              })
-            : fetch(`${baseURL}/api/${type}/${id}`, { method: 'DELETE' })
+          request.fetch(`/api/${type}/${id}`, {
+            method: 'DELETE'
+          })
         )
       );
-      return responses.every(response =>
-        typeof response.ok === 'function' ? response.ok() : response.ok
-      );
+      return responses.every(response => response.ok());
     }
 
     /**

--- a/galata/src/jupyterlabpage.ts
+++ b/galata/src/jupyterlabpage.ts
@@ -262,7 +262,7 @@ export class JupyterLabPage implements IJupyterLabPage {
   ) {
     this.waitIsReady = waitForApplication;
     this.activity = new ActivityHelper(page);
-    this.contents = new ContentsHelper(baseURL, page, page.context().request);
+    this.contents = new ContentsHelper(page.context().request, page);
     this.filebrowser = new FileBrowserHelper(page, this.contents);
     this.kernel = new KernelHelper(page);
     this.logconsole = new LogConsoleHelper(page);

--- a/galata/test/benchmark/notebook.spec.ts
+++ b/galata/test/benchmark/notebook.spec.ts
@@ -21,8 +21,8 @@ const parameters = [].concat(
 
 test.describe('Benchmark', () => {
   // Generate the files for the benchmark
-  test.beforeAll(async ({ baseURL, request }) => {
-    const content = galata.newContentsHelper(baseURL, undefined, request);
+  test.beforeAll(async ({ request }) => {
+    const content = galata.newContentsHelper(request);
     const codeContent = galata.Notebook.generateNotebook(300, 'code', [
       'for x in range(OUTPUT_LENGTH):\n',
       '    print(f"{PREFIX} {x}")'
@@ -75,8 +75,8 @@ test.describe('Benchmark', () => {
   });
 
   // Remove benchmark files
-  test.afterAll(async ({ baseURL, request }) => {
-    const content = galata.newContentsHelper(baseURL, undefined, request);
+  test.afterAll(async ({ request }) => {
+    const content = galata.newContentsHelper(request);
     await content.deleteDirectory(tmpPath);
   });
 

--- a/galata/test/jupyterlab/contextmenu.test.ts
+++ b/galata/test/jupyterlab/contextmenu.test.ts
@@ -15,8 +15,8 @@ test.use({
 });
 
 test.describe('Application Context Menu', () => {
-  test.beforeAll(async ({ baseURL, request, tmpPath }) => {
-    const contents = galata.newContentsHelper(baseURL, undefined, request);
+  test.beforeAll(async ({ request, tmpPath }) => {
+    const contents = galata.newContentsHelper(request);
 
     // Create some dummy content
     await contents.uploadFile(
@@ -42,8 +42,8 @@ test.describe('Application Context Menu', () => {
     await page.filebrowser.openHomeDirectory();
   });
 
-  test.afterAll(async ({ baseURL, request, tmpPath }) => {
-    const contents = galata.newContentsHelper(baseURL, undefined, request);
+  test.afterAll(async ({ request, tmpPath }) => {
+    const contents = galata.newContentsHelper(request);
     await contents.deleteDirectory(tmpPath);
   });
 

--- a/galata/test/jupyterlab/notebook-run-vega.test.ts
+++ b/galata/test/jupyterlab/notebook-run-vega.test.ts
@@ -9,8 +9,8 @@ const fileName = 'vega_notebook.ipynb';
 test.use({ tmpPath: 'notebook-run-vega-test' });
 
 test.describe.serial('Notebook Run Vega', () => {
-  test.beforeAll(async ({ baseURL, request, tmpPath }) => {
-    const contents = galata.newContentsHelper(baseURL, undefined, request);
+  test.beforeAll(async ({ request, tmpPath }) => {
+    const contents = galata.newContentsHelper(request);
     await contents.uploadFile(
       path.resolve(__dirname, `./notebooks/${fileName}`),
       `${tmpPath}/${fileName}`
@@ -21,8 +21,8 @@ test.describe.serial('Notebook Run Vega', () => {
     await page.filebrowser.openDirectory(tmpPath);
   });
 
-  test.afterAll(async ({ baseURL, request, tmpPath }) => {
-    const contents = galata.newContentsHelper(baseURL, undefined, request);
+  test.afterAll(async ({ request, tmpPath }) => {
+    const contents = galata.newContentsHelper(request);
     await contents.deleteDirectory(tmpPath);
   });
 

--- a/galata/test/jupyterlab/notebook-run.test.ts
+++ b/galata/test/jupyterlab/notebook-run.test.ts
@@ -9,8 +9,8 @@ const fileName = 'simple_notebook.ipynb';
 test.use({ tmpPath: 'notebook-run-test' });
 
 test.describe.serial('Notebook Run', () => {
-  test.beforeAll(async ({ baseURL, request, tmpPath }) => {
-    const contents = galata.newContentsHelper(baseURL, undefined, request);
+  test.beforeAll(async ({ request, tmpPath }) => {
+    const contents = galata.newContentsHelper(request);
     await contents.uploadFile(
       path.resolve(__dirname, `./notebooks/${fileName}`),
       `${tmpPath}/${fileName}`
@@ -25,8 +25,8 @@ test.describe.serial('Notebook Run', () => {
     await page.filebrowser.openDirectory(tmpPath);
   });
 
-  test.afterAll(async ({ baseURL, request, tmpPath }) => {
-    const contents = galata.newContentsHelper(baseURL, undefined, request);
+  test.afterAll(async ({ request, tmpPath }) => {
+    const contents = galata.newContentsHelper(request);
     await contents.deleteDirectory(tmpPath);
   });
 

--- a/galata/test/jupyterlab/toc.test.ts
+++ b/galata/test/jupyterlab/toc.test.ts
@@ -9,8 +9,8 @@ const fileName = 'toc_notebook.ipynb';
 test.use({ tmpPath: 'test-toc' });
 
 test.describe('Table of Contents', () => {
-  test.beforeAll(async ({ baseURL, request, tmpPath }) => {
-    const contents = galata.newContentsHelper(baseURL, undefined, request);
+  test.beforeAll(async ({ request, tmpPath }) => {
+    const contents = galata.newContentsHelper(request);
     await contents.uploadFile(
       path.resolve(__dirname, `./notebooks/${fileName}`),
       `${tmpPath}/${fileName}`
@@ -30,8 +30,8 @@ test.describe('Table of Contents', () => {
     await page.notebook.close(true);
   });
 
-  test.afterAll(async ({ baseURL, request, tmpPath }) => {
-    const contents = galata.newContentsHelper(baseURL, undefined, request);
+  test.afterAll(async ({ request, tmpPath }) => {
+    const contents = galata.newContentsHelper(request);
     await contents.deleteDirectory(tmpPath);
   });
 

--- a/galata/test/jupyterlab/workspace.test.ts
+++ b/galata/test/jupyterlab/workspace.test.ts
@@ -22,8 +22,8 @@ test.use({
 });
 
 test.describe('Workspace', () => {
-  test.beforeAll(async ({ baseURL, request, tmpPath }) => {
-    const contents = galata.newContentsHelper(baseURL, undefined, request);
+  test.beforeAll(async ({ request, tmpPath }) => {
+    const contents = galata.newContentsHelper(request);
     await contents.uploadFile(
       path.resolve(__dirname, `./notebooks/${nbFile}`),
       `${tmpPath}/${nbFile}`
@@ -34,8 +34,8 @@ test.describe('Workspace', () => {
     );
   });
 
-  test.afterAll(async ({ baseURL, request, tmpPath }) => {
-    const contents = galata.newContentsHelper(baseURL, undefined, request);
+  test.afterAll(async ({ request, tmpPath }) => {
+    const contents = galata.newContentsHelper(request);
     await contents.deleteDirectory(tmpPath);
   });
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Follow-up of #13015
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Use Playwright API request instead of node-fetch in galata helpers

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
The main change is on the constructor of `ContentsHelper` for which you must provide the APIrequest or the Page from Playwright.