### PR TITLE
Reorder of webpackConfig merge

### DIFF
--- a/builder/src/extensionConfig.ts
+++ b/builder/src/extensionConfig.ts
@@ -262,12 +262,13 @@ function generateConfig({
           path: staticPath,
           publicPath: staticUrl || 'auto'
         },
-        module: {
-          rules: [{ test: /\.html$/, type: 'asset/resource' }]
-        },
         plugins
       },
-      webpackConfig
+      webpackConfig, {
+      module: {
+        rules: [{ test: /\.html$/, type: 'asset/resource' }]
+      }
+    }
     )
   ].concat(extras);
 

--- a/builder/src/extensionConfig.ts
+++ b/builder/src/extensionConfig.ts
@@ -264,11 +264,12 @@ function generateConfig({
         },
         plugins
       },
-      webpackConfig, {
-      module: {
-        rules: [{ test: /\.html$/, type: 'asset/resource' }]
+      webpackConfig, 
+      {
+        module: {
+          rules: [{ test: /\.html$/, type: 'asset/resource' }]
+        }
       }
-    }
     )
   ].concat(extras);
 

--- a/builder/src/extensionConfig.ts
+++ b/builder/src/extensionConfig.ts
@@ -264,7 +264,7 @@ function generateConfig({
         },
         plugins
       },
-      webpackConfig, 
+      webpackConfig,
       {
         module: {
           rules: [{ test: /\.html$/, type: 'asset/resource' }]


### PR DESCRIPTION
The merge order of the different webpack config items currently pre-empts any
`.html`-catching rules.

## References

 - #13032

## Code changes

This changes the webpackConfig merge order to allow it to pre-empt the rule for
.html files.  Putting the `.html` rule after the inclusion of `webpackConfig`
allows extension developers to override that rule, which is helpful for
situations such as VueJS extensions that use `vue-loader`.  Previously,
`vue-loader` was testing if `.vue.html` would be caught by it.  The order of
config merging prevented the `.vue.html` from being executed.  This change
shouldn't affect any situations where `.html` was *not* being specified in the
`webpackConfig` override.

Closes #13032.

## User-facing changes

This should not have any user-facing changes, and any developer-facing changes
should only arise in the case that a `webpackConfig` rule was specified and
*not* caught by the overridden configuration, which would arguably not be
intended behavior anyway.

## Backwards-incompatible changes

There should be no changes.
