### PR TITLE
Old command jupyter lab did not work on Windows 11

### DIFF
--- a/docs/source/getting_started/starting.rst
+++ b/docs/source/getting_started/starting.rst
@@ -10,7 +10,7 @@ Start JupyterLab using:
 
 .. code:: bash
 
-    jupyter lab
+    python -m jupyterlab
 
 JupyterLab will open automatically in your browser.
 


### PR DESCRIPTION
Must use command python -m jupyterlab . This is very dangerous content for new commers.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
