### PR TITLE
Automated Changelog Entry for 3.4.6 on 3.4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 
 ### Bugs fixed
 
-- Backport PR #13035: Update Python icon to be PSF Trademark compliant [#13044](https://github.com/jupyterlab/jupyterlab/pull/13044) ([@fcollonval](https://github.com/fcollonval))
-- Backport PR #13040: Reorder of webpackConfig merge [#13042](https://github.com/jupyterlab/jupyterlab/pull/13042) ([@fcollonval](https://github.com/fcollonval))
-- Backport PR #12974: update xterm.js dependency [#13036](https://github.com/jupyterlab/jupyterlab/pull/13036) ([@fcollonval](https://github.com/fcollonval))
+- Update Python icon to be PSF Trademark compliant [#13044](https://github.com/jupyterlab/jupyterlab/pull/13044) ([@fcollonval](https://github.com/fcollonval))
+- Reorder of webpackConfig merge [#13042](https://github.com/jupyterlab/jupyterlab/pull/13042) ([@fcollonval](https://github.com/fcollonval))
+- Update xterm.js dependency [#13036](https://github.com/jupyterlab/jupyterlab/pull/13036) ([@fcollonval](https://github.com/fcollonval))
 - Support stateStorage for API calls [#13015](https://github.com/jupyterlab/jupyterlab/pull/13015) ([@fcollonval](https://github.com/fcollonval))
 - Conditional call to waitIsReady in reload [#13011](https://github.com/jupyterlab/jupyterlab/pull/13011) ([@fcollonval](https://github.com/fcollonval))
 - Add scrolling to `debugger` variable renderer [#12968](https://github.com/jupyterlab/jupyterlab/pull/12968) ([@firai](https://github.com/firai))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,36 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.4.6
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.4.5...76459a67511b1c54df853e52d83a7fbd3badae7b))
+
+### Bugs fixed
+
+- Backport PR #13035: Update Python icon to be PSF Trademark compliant [#13044](https://github.com/jupyterlab/jupyterlab/pull/13044) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #13040: Reorder of webpackConfig merge [#13042](https://github.com/jupyterlab/jupyterlab/pull/13042) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #12974: update xterm.js dependency [#13036](https://github.com/jupyterlab/jupyterlab/pull/13036) ([@fcollonval](https://github.com/fcollonval))
+- Support stateStorage for API calls [#13015](https://github.com/jupyterlab/jupyterlab/pull/13015) ([@fcollonval](https://github.com/fcollonval))
+- Conditional call to waitIsReady in reload [#13011](https://github.com/jupyterlab/jupyterlab/pull/13011) ([@fcollonval](https://github.com/fcollonval))
+- Add scrolling to `debugger` variable renderer [#12968](https://github.com/jupyterlab/jupyterlab/pull/12968) ([@firai](https://github.com/firai))
+- Fix resizing and selection of debugger variable explorer grid [#12943](https://github.com/jupyterlab/jupyterlab/pull/12943) ([@firai](https://github.com/firai))
+
+### Maintenance and upkeep improvements
+
+- Fix lumino API documentation links [#13021](https://github.com/jupyterlab/jupyterlab/pull/13021) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+- Fix lumino API documentation links [#13021](https://github.com/jupyterlab/jupyterlab/pull/13021) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-08-10&to=2022-09-05&type=c))
+
+[@ajbozarth](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aajbozarth+updated%3A2022-08-10..2022-09-05&type=Issues) | [@athornton](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aathornton+updated%3A2022-08-10..2022-09-05&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-08-10..2022-09-05&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2022-08-10..2022-09-05&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-08-10..2022-09-05&type=Issues) | [@goanpeca](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agoanpeca+updated%3A2022-08-10..2022-09-05&type=Issues) | [@ian-r-rose](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aian-r-rose+updated%3A2022-08-10..2022-09-05&type=Issues) | [@isabela-pf](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aisabela-pf+updated%3A2022-08-10..2022-09-05&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-08-10..2022-09-05&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-08-10..2022-09-05&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2022-08-10..2022-09-05&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-08-10..2022-09-05&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2022-08-10..2022-09-05&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-08-10..2022-09-05&type=Issues) | [@KrishnaKumarHariprasannan](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AKrishnaKumarHariprasannan+updated%3A2022-08-10..2022-09-05&type=Issues) | [@malemburg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Amalemburg+updated%3A2022-08-10..2022-09-05&type=Issues) | [@manfromjupyter](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Amanfromjupyter+updated%3A2022-08-10..2022-09-05&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-08-10..2022-09-05&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-08-10..2022-09-05&type=Issues) | [@mlucool](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Amlucool+updated%3A2022-08-10..2022-09-05&type=Issues) | [@saulshanabrook](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Asaulshanabrook+updated%3A2022-08-10..2022-09-05&type=Issues) | [@telamonian](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atelamonian+updated%3A2022-08-10..2022-09-05&type=Issues) | [@tgeorgeux](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atgeorgeux+updated%3A2022-08-10..2022-09-05&type=Issues) | [@trallard](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrallard+updated%3A2022-08-10..2022-09-05&type=Issues) | [@VersBersh](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AVersBersh+updated%3A2022-08-10..2022-09-05&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Avidartf+updated%3A2022-08-10..2022-09-05&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-08-10..2022-09-05&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.4.5
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.4.4...385ea4be3d3e65e1f62d82e8bfedbe554736b2bb))
@@ -46,8 +76,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-07-21&to=2022-08-10&type=c))
 
 [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2022-07-21..2022-08-10&type=Issues) | [@agoose77](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aagoose77+updated%3A2022-07-21..2022-08-10&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-07-21..2022-08-10&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2022-07-21..2022-08-10&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-07-21..2022-08-10&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-07-21..2022-08-10&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-07-21..2022-08-10&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2022-07-21..2022-08-10&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-07-21..2022-08-10&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-07-21..2022-08-10&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AmartinRenou+updated%3A2022-07-21..2022-08-10&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-07-21..2022-08-10&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-07-21..2022-08-10&type=Issues) | [@ryanlovett](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aryanlovett+updated%3A2022-07-21..2022-08-10&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASylvainCorlay+updated%3A2022-07-21..2022-08-10&type=Issues) | [@telamonian](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atelamonian+updated%3A2022-07-21..2022-08-10&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrungleduc+updated%3A2022-07-21..2022-08-10&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-07-21..2022-08-10&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.4.4
 


### PR DESCRIPTION
Automated Changelog Entry for 3.4.6 on 3.4.x
```
Python version: 3.4.6
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.4.6
@jupyterlab/buildutils: 3.4.6
@jupyterlab/template: 3.4.6
@jupyterlab/application-top: 3.4.6
@jupyterlab/example-app: 3.4.6
@jupyterlab/example-cell: 3.4.6
@jupyterlab/example-console: 3.4.6
@jupyterlab/example-federated: 2.5.6
@jupyterlab/example-federated-core: 2.5.6
@jupyterlab/example-federated-md: 2.5.6
@jupyterlab/example-federated-middle: 2.5.6
@jupyterlab/example-federated-phosphor: 2.5.6
@jupyterlab/example-filebrowser: 3.4.6
@jupyterlab/example-notebook: 3.4.6
@jupyterlab/example-terminal: 3.4.6
@jupyterlab/galata: 4.3.6
@jupyterlab/mock-extension: 3.4.6
@jupyterlab/mock-consumer: 3.4.6
@jupyterlab/mock-provider: 3.4.6
@jupyterlab/mock-token: 3.4.6
@jupyterlab/application: 3.4.6
@jupyterlab/application-extension: 3.4.6
@jupyterlab/apputils: 3.4.6
@jupyterlab/apputils-extension: 3.4.6
@jupyterlab/attachments: 3.4.6
@jupyterlab/cell-toolbar: 3.4.6
@jupyterlab/cell-toolbar-extension: 3.4.6
@jupyterlab/cells: 3.4.6
@jupyterlab/celltags: 3.4.6
@jupyterlab/celltags-extension: 3.4.6
@jupyterlab/codeeditor: 3.4.6
@jupyterlab/codemirror: 3.4.6
@jupyterlab/codemirror-extension: 3.4.6
@jupyterlab/completer: 3.4.6
@jupyterlab/completer-extension: 3.4.6
@jupyterlab/console: 3.4.6
@jupyterlab/console-extension: 3.4.6
@jupyterlab/coreutils: 5.4.6
@jupyterlab/csvviewer: 3.4.6
@jupyterlab/csvviewer-extension: 3.4.6
@jupyterlab/debugger: 3.4.6
@jupyterlab/debugger-extension: 3.4.6
@jupyterlab/docmanager: 3.4.6
@jupyterlab/docmanager-extension: 3.4.6
@jupyterlab/docprovider: 3.4.6
@jupyterlab/docprovider-extension: 3.4.6
@jupyterlab/docregistry: 3.4.6
@jupyterlab/documentsearch: 3.4.6
@jupyterlab/documentsearch-extension: 3.4.6
@jupyterlab/extensionmanager: 3.4.6
@jupyterlab/extensionmanager-extension: 3.4.6
@jupyterlab/filebrowser: 3.4.6
@jupyterlab/filebrowser-extension: 3.4.6
@jupyterlab/fileeditor: 3.4.6
@jupyterlab/fileeditor-extension: 3.4.6
@jupyterlab/help-extension: 3.4.6
@jupyterlab/htmlviewer: 3.4.6
@jupyterlab/htmlviewer-extension: 3.4.6
@jupyterlab/hub-extension: 3.4.6
@jupyterlab/imageviewer: 3.4.6
@jupyterlab/imageviewer-extension: 3.4.6
@jupyterlab/inspector: 3.4.6
@jupyterlab/inspector-extension: 3.4.6
@jupyterlab/javascript-extension: 3.4.6
@jupyterlab/json-extension: 3.4.6
@jupyterlab/launcher: 3.4.6
@jupyterlab/launcher-extension: 3.4.6
@jupyterlab/logconsole: 3.4.6
@jupyterlab/logconsole-extension: 3.4.6
@jupyterlab/mainmenu: 3.4.6
@jupyterlab/mainmenu-extension: 3.4.6
@jupyterlab/markdownviewer: 3.4.6
@jupyterlab/markdownviewer-extension: 3.4.6
@jupyterlab/mathjax2: 3.4.6
@jupyterlab/mathjax2-extension: 3.4.6
@jupyterlab/metapackage: 3.4.6
@jupyterlab/nbconvert-css: 3.4.6
@jupyterlab/nbformat: 3.4.6
@jupyterlab/notebook: 3.4.6
@jupyterlab/notebook-extension: 3.4.6
@jupyterlab/observables: 4.4.6
@jupyterlab/outputarea: 3.4.6
@jupyterlab/pdf-extension: 3.4.6
@jupyterlab/property-inspector: 3.4.6
@jupyterlab/rendermime: 3.4.6
@jupyterlab/rendermime-extension: 3.4.6
@jupyterlab/rendermime-interfaces: 3.4.6
@jupyterlab/running: 3.4.6
@jupyterlab/running-extension: 3.4.6
@jupyterlab/services: 6.4.6
@jupyterlab/example-services-browser: 3.4.6
node-example: 3.4.6
@jupyterlab/example-services-outputarea: 3.4.6
@jupyterlab/settingeditor: 3.4.6
@jupyterlab/settingeditor-extension: 3.4.6
@jupyterlab/settingregistry: 3.4.6
@jupyterlab/shared-models: 3.4.6
@jupyterlab/shortcuts-extension: 3.4.6
@jupyterlab/statedb: 3.4.6
@jupyterlab/statusbar: 3.4.6
@jupyterlab/statusbar-extension: 3.4.6
@jupyterlab/terminal: 3.4.6
@jupyterlab/terminal-extension: 3.4.6
@jupyterlab/theme-dark-extension: 3.4.6
@jupyterlab/theme-light-extension: 3.4.6
@jupyterlab/toc: 5.4.6
@jupyterlab/toc-extension: 5.4.6
@jupyterlab/tooltip: 3.4.6
@jupyterlab/tooltip-extension: 3.4.6
@jupyterlab/translation: 3.4.6
@jupyterlab/translation-extension: 3.4.6
@jupyterlab/ui-components: 3.4.6
@jupyterlab/ui-components-extension: 3.4.6
@jupyterlab/vdom: 3.4.6
@jupyterlab/vdom-extension: 3.4.6
@jupyterlab/vega5-extension: 3.4.6
@jupyterlab/testutils: 3.4.6
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab  |
| Branch  | 3.4.x  |
| Version Spec | next |
| Since | v3.4.5 |