### PR TITLE
Fix blurry icons in Launcher at 400% Zoom

### DIFF
--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -281,12 +281,8 @@ async function activateConsole(
         for (const name in specs.kernelspecs) {
           const rank = name === specs.default ? 0 : Infinity;
           const spec = specs.kernelspecs[name]!;
-          let kernelIconUrl;
-          try {
-            kernelIconUrl = spec.resources['logo-svg'];
-          } catch (error) {
-            kernelIconUrl = spec.resources['logo-64x64'];
-          }
+          const kernelIconUrl =
+            spec.resources['logo-svg'] || spec.resources['logo-64x64'];
           disposables.add(
             launcher.add({
               command: CommandIDs.create,

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -281,7 +281,12 @@ async function activateConsole(
         for (const name in specs.kernelspecs) {
           const rank = name === specs.default ? 0 : Infinity;
           const spec = specs.kernelspecs[name]!;
-          let kernelIconUrl = spec.resources['logo-64x64'];
+          let kernelIconUrl;
+          try {
+            kernelIconUrl = spec.resources['logo-svg'];
+          } catch (error) {
+            kernelIconUrl = spec.resources['logo-64x64'];
+          }
           disposables.add(
             launcher.add({
               command: CommandIDs.create,

--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -376,7 +376,8 @@ const resources: JupyterFrontEndPlugin<void> = {
           // Add the kernel banner to the Help Menu.
           const bannerCommand = `help-menu-${name}:banner`;
           const kernelName = spec.display_name;
-          let kernelIconUrl = spec.resources['logo-64x64'];
+          const kernelIconUrl =
+            spec.resources['logo-svg'] || spec.resources['logo-64x64'];
           commands.addCommand(bannerCommand, {
             label: trans.__('About the %1 Kernel', kernelName),
             isVisible: isEnabled,

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1670,7 +1670,8 @@ function activateNotebookHandler(
         for (const name in specs.kernelspecs) {
           const rank = name === specs.default ? 0 : Infinity;
           const spec = specs.kernelspecs[name]!;
-          let kernelIconUrl = spec.resources['logo-64x64'];
+          const kernelIconUrl =
+            spec.resources['logo-svg'] || spec.resources['logo-64x64'];
           disposables.add(
             launcher.add({
               command: CommandIDs.createNew,


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This PR fixes https://github.com/jupyterlab/jupyterlab/issues/12997
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
The code change gives preference to loading the svg asset, if not found the png asset will be loaded.

Note: Please note that I made PRs in the Python, Julia and R kernels to add the svg asset and it should be loaded without having to do any change in [jupyter-server](https://github.com/jupyter-server/jupyter_server/blob/7239666c231c733cb49ed2f5c18369051c255e9a/jupyter_server/services/kernelspecs/handlers.py#L34). We may need to wait until an actual release on each of the kernels for the users to see the new asset.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

Given that the new asset is `svg`, it will not get blurry regardless of zoom

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
This PR doesn't introduce any backwards-incompatible change
