### PR TITLE
Fix cell toolbar layout

### DIFF
--- a/packages/cell-toolbar/style/base.css
+++ b/packages/cell-toolbar/style/base.css
@@ -34,7 +34,7 @@
 /* Overrides for mobile view: Move cell toolbar up, don't hide it if it overlaps */
 @media only screen and (max-width: 760px) {
   .jp-toolbar-overlap .jp-cell-toolbar {
-    display: block;
+    display: flex;
   }
 
   .jp-cell-toolbar {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Addressing the issue: [Fix cell toolbar layout](https://github.com/Quansight-Labs/jupyterlab-accessible-themes/issues/35)

## Code changes
The code changes preserve the horizontal layout of the cell toolbar on 400% zoom (or more)
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
**Before:**
![Screenshot from 2022-09-06 13-21-00](https://user-images.githubusercontent.com/46336830/188578009-a3e1c0f5-3a5c-4cc5-8061-a330c21045f9.png)



**After:**
![jp](https://user-images.githubusercontent.com/46336830/188575707-b627fbf3-9ad9-4f53-9118-b1c3c175f8b8.png)

## Backwards-incompatible changes

None

