### PR TITLE
Switch to `pull_request_target` to have write permission on forks

### DIFF
--- a/.github/workflows/enforce-label.yml
+++ b/.github/workflows/enforce-label.yml
@@ -1,7 +1,7 @@
 name: Enforce PR label
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled, unlabeled, opened, edited, synchronize]
 jobs:
   enforce-label:

--- a/.github/workflows/license-header.yml
+++ b/.github/workflows/license-header.yml
@@ -1,7 +1,7 @@
 name: Fix License Headers
 
 on:
-  pull_request:
+  pull_request_target:
 
 permissions:
   contents: write


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Write permission cannot be granted to `pull_request` event from forks => this is the reason the license header job is failing to commit changes.

This uses `pull_request_target` to fix the CI jobs.

See [documentation](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)

## Code changes

<!-- Describe the code changes and how they address the issue. -->
N/A

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A