### PR TITLE
Added mimeType for .webp image files

### DIFF
--- a/packages/rendermime/src/factories.ts
+++ b/packages/rendermime/src/factories.ts
@@ -21,12 +21,12 @@ export const htmlRendererFactory: IRenderMime.IRendererFactory = {
 export const imageRendererFactory: IRenderMime.IRendererFactory = {
   safe: true,
   mimeTypes: [
-  'image/bmp',
-  'image/png',
-  'image/jpeg',
-  'image/gif',
-  'image/webp'
-],
+    'image/bmp',
+    'image/png',
+    'image/jpeg',
+    'image/gif',
+    'image/webp'
+  ],
   defaultRank: 90,
   createRenderer: options => new widgets.RenderedImage(options)
 };

--- a/packages/rendermime/src/factories.ts
+++ b/packages/rendermime/src/factories.ts
@@ -20,7 +20,13 @@ export const htmlRendererFactory: IRenderMime.IRendererFactory = {
  */
 export const imageRendererFactory: IRenderMime.IRendererFactory = {
   safe: true,
-  mimeTypes: ['image/bmp', 'image/png', 'image/jpeg', 'image/gif', 'image/webp'],
+  mimeTypes: [
+  'image/bmp',
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp'
+],
   defaultRank: 90,
   createRenderer: options => new widgets.RenderedImage(options)
 };

--- a/packages/rendermime/src/factories.ts
+++ b/packages/rendermime/src/factories.ts
@@ -20,7 +20,7 @@ export const htmlRendererFactory: IRenderMime.IRendererFactory = {
  */
 export const imageRendererFactory: IRenderMime.IRendererFactory = {
   safe: true,
-  mimeTypes: ['image/bmp', 'image/png', 'image/jpeg', 'image/gif'],
+  mimeTypes: ['image/bmp', 'image/png', 'image/jpeg', 'image/gif', 'image/webp'],
   defaultRank: 90,
   createRenderer: options => new widgets.RenderedImage(options)
 };

--- a/packages/rendermime/test/factories.spec.ts
+++ b/packages/rendermime/test/factories.spec.ts
@@ -429,7 +429,8 @@ describe('rendermime/factories', () => {
           'image/bmp',
           'image/png',
           'image/jpeg',
-          'image/gif'
+          'image/gif',
+          'image/webp'
         ]);
       });
     });


### PR DESCRIPTION
This commit resolves #12961, by adding support for .webp image files.

## Code changes

<!-- Describe the code changes and how they address the issue. -->
The ```image/webp``` mimeType was added to line 23 of ```jupyterlab/packages/rendermime/src/factories.ts``` to enable MIME support for WebP images in JupyterLab.


## User-facing changes
In issue #12961, users encountered the following error when attempting to add certain .webp files:
![webp-error](https://user-images.githubusercontent.com/52685467/189016785-db46cbc8-20a7-4960-a565-091cea77a80f.png)

This patch resolves the issue by adding support for WebP files. Hence, users can import these image files, and will no longer be greeted with the error above.