### PR TITLE
Fix URL when falling back to node-fetch

### DIFF
--- a/galata/src/contents.ts
+++ b/galata/src/contents.ts
@@ -417,7 +417,7 @@ export class ContentsHelper {
         data: request.body
       });
     } else {
-      response = await fetch(url, request);
+      response = await fetch(URLExt.join(this.baseURL, url), request);
     }
     return response;
   }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Error seen in https://github.com/jupyterlab/benchmarks/runs/8249387499?check_suite_focus=true
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
node-fetch does not know about the server baseURL as playwright API Request does.

> `node-fetch` dependency was removed in master. Hence the target 3.4.x for this PR

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A