### PR TITLE
Get package name from pyproject if available

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     nbclassic
     notebook<7
     jinja2>=2.1
+    tomli
 
 [options.extras_require]
 test =


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Partial backport of https://github.com/jupyterlab/jupyterlab/pull/12606 to accommodate https://github.com/jupyterlab/extension-cookiecutter-ts/pull/230.
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Allows project name of plugin to be found in `pyproject.toml` instead of by invoking `setup.py`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Extension authors can use https://github.com/agoose77/hatch-nodejs-version to simplify versioning and metadata sharing between the Python and NPM Packages.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
