### PR TITLE
Automated Changelog Entry for 3.4.7 on 3.4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,29 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.4.7
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.4.6...f713e06179bb5e57fc03da5fcf49b9c8e543f684))
+
+### Enhancements made
+
+- Get package name from pyproject if available [#13076](https://github.com/jupyterlab/jupyterlab/pull/13076) ([@blink1073](https://github.com/blink1073))
+- Backport PR #13057: Fix blurry icons in Launcher at 400% Zoom [#13065](https://github.com/jupyterlab/jupyterlab/pull/13065) ([@fcollonval](https://github.com/fcollonval))
+
+### Bugs fixed
+
+- Added mimeType for .webp image files [#13066](https://github.com/jupyterlab/jupyterlab/pull/13066) ([@alec-kr](https://github.com/alec-kr))
+- Fix URL when falling back to node-fetch [#13067](https://github.com/jupyterlab/jupyterlab/pull/13067) ([@fcollonval](https://github.com/fcollonval))
+- Keep completer visible when anchor is horizontally scrolled out of view  [#13046](https://github.com/jupyterlab/jupyterlab/pull/13046) ([@krassowski](https://github.com/krassowski))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-09-05&to=2022-09-12&type=c))
+
+[@agoose77](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aagoose77+updated%3A2022-09-05..2022-09-12&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-09-05..2022-09-12&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2022-09-05..2022-09-12&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-09-05..2022-09-12&type=Issues) | [@gabalafou](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agabalafou+updated%3A2022-09-05..2022-09-12&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-09-05..2022-09-12&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-09-05..2022-09-12&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-09-05..2022-09-12&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-09-05..2022-09-12&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-09-05..2022-09-12&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-09-05..2022-09-12&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.4.6
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.4.5...76459a67511b1c54df853e52d83a7fbd3badae7b))
@@ -39,8 +62,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-08-10&to=2022-09-05&type=c))
 
 [@ajbozarth](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aajbozarth+updated%3A2022-08-10..2022-09-05&type=Issues) | [@athornton](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aathornton+updated%3A2022-08-10..2022-09-05&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-08-10..2022-09-05&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2022-08-10..2022-09-05&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-08-10..2022-09-05&type=Issues) | [@goanpeca](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agoanpeca+updated%3A2022-08-10..2022-09-05&type=Issues) | [@ian-r-rose](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aian-r-rose+updated%3A2022-08-10..2022-09-05&type=Issues) | [@isabela-pf](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aisabela-pf+updated%3A2022-08-10..2022-09-05&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-08-10..2022-09-05&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-08-10..2022-09-05&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2022-08-10..2022-09-05&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-08-10..2022-09-05&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2022-08-10..2022-09-05&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-08-10..2022-09-05&type=Issues) | [@KrishnaKumarHariprasannan](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AKrishnaKumarHariprasannan+updated%3A2022-08-10..2022-09-05&type=Issues) | [@malemburg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Amalemburg+updated%3A2022-08-10..2022-09-05&type=Issues) | [@manfromjupyter](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Amanfromjupyter+updated%3A2022-08-10..2022-09-05&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-08-10..2022-09-05&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-08-10..2022-09-05&type=Issues) | [@mlucool](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Amlucool+updated%3A2022-08-10..2022-09-05&type=Issues) | [@saulshanabrook](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Asaulshanabrook+updated%3A2022-08-10..2022-09-05&type=Issues) | [@telamonian](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atelamonian+updated%3A2022-08-10..2022-09-05&type=Issues) | [@tgeorgeux](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atgeorgeux+updated%3A2022-08-10..2022-09-05&type=Issues) | [@trallard](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrallard+updated%3A2022-08-10..2022-09-05&type=Issues) | [@VersBersh](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AVersBersh+updated%3A2022-08-10..2022-09-05&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Avidartf+updated%3A2022-08-10..2022-09-05&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-08-10..2022-09-05&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 
 - Added mimeType for .webp image files [#13066](https://github.com/jupyterlab/jupyterlab/pull/13066) ([@alec-kr](https://github.com/alec-kr))
 - Fix URL when falling back to node-fetch [#13067](https://github.com/jupyterlab/jupyterlab/pull/13067) ([@fcollonval](https://github.com/fcollonval))
-- Keep completer visible when anchor is horizontally scrolled out of view  [#13046](https://github.com/jupyterlab/jupyterlab/pull/13046) ([@krassowski](https://github.com/krassowski))
+- Keep completer visible when anchor is horizontally scrolled out of view [#13046](https://github.com/jupyterlab/jupyterlab/pull/13046) ([@krassowski](https://github.com/krassowski))
 
 ### Contributors to this release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 ### Enhancements made
 
 - Get package name from pyproject if available [#13076](https://github.com/jupyterlab/jupyterlab/pull/13076) ([@blink1073](https://github.com/blink1073))
-- Backport PR #13057: Fix blurry icons in Launcher at 400% Zoom [#13065](https://github.com/jupyterlab/jupyterlab/pull/13065) ([@fcollonval](https://github.com/fcollonval))
+- Fix blurry icons in Launcher at 400% Zoom [#13065](https://github.com/jupyterlab/jupyterlab/pull/13065) ([@fcollonval](https://github.com/fcollonval))
 
 ### Bugs fixed
 


### PR DESCRIPTION
Automated Changelog Entry for 3.4.7 on 3.4.x
```
Python version: 3.4.7
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.4.7
@jupyterlab/buildutils: 3.4.7
@jupyterlab/template: 3.4.7
@jupyterlab/application-top: 3.4.7
@jupyterlab/example-app: 3.4.7
@jupyterlab/example-cell: 3.4.7
@jupyterlab/example-console: 3.4.7
@jupyterlab/example-federated: 2.5.7
@jupyterlab/example-federated-core: 2.5.7
@jupyterlab/example-federated-md: 2.5.7
@jupyterlab/example-federated-middle: 2.5.7
@jupyterlab/example-federated-phosphor: 2.5.7
@jupyterlab/example-filebrowser: 3.4.7
@jupyterlab/example-notebook: 3.4.7
@jupyterlab/example-terminal: 3.4.7
@jupyterlab/galata: 4.3.7
@jupyterlab/mock-extension: 3.4.7
@jupyterlab/mock-consumer: 3.4.7
@jupyterlab/mock-provider: 3.4.7
@jupyterlab/mock-token: 3.4.7
@jupyterlab/application: 3.4.7
@jupyterlab/application-extension: 3.4.7
@jupyterlab/apputils: 3.4.7
@jupyterlab/apputils-extension: 3.4.7
@jupyterlab/attachments: 3.4.7
@jupyterlab/cell-toolbar: 3.4.7
@jupyterlab/cell-toolbar-extension: 3.4.7
@jupyterlab/cells: 3.4.7
@jupyterlab/celltags: 3.4.7
@jupyterlab/celltags-extension: 3.4.7
@jupyterlab/codeeditor: 3.4.7
@jupyterlab/codemirror: 3.4.7
@jupyterlab/codemirror-extension: 3.4.7
@jupyterlab/completer: 3.4.7
@jupyterlab/completer-extension: 3.4.7
@jupyterlab/console: 3.4.7
@jupyterlab/console-extension: 3.4.7
@jupyterlab/coreutils: 5.4.7
@jupyterlab/csvviewer: 3.4.7
@jupyterlab/csvviewer-extension: 3.4.7
@jupyterlab/debugger: 3.4.7
@jupyterlab/debugger-extension: 3.4.7
@jupyterlab/docmanager: 3.4.7
@jupyterlab/docmanager-extension: 3.4.7
@jupyterlab/docprovider: 3.4.7
@jupyterlab/docprovider-extension: 3.4.7
@jupyterlab/docregistry: 3.4.7
@jupyterlab/documentsearch: 3.4.7
@jupyterlab/documentsearch-extension: 3.4.7
@jupyterlab/extensionmanager: 3.4.7
@jupyterlab/extensionmanager-extension: 3.4.7
@jupyterlab/filebrowser: 3.4.7
@jupyterlab/filebrowser-extension: 3.4.7
@jupyterlab/fileeditor: 3.4.7
@jupyterlab/fileeditor-extension: 3.4.7
@jupyterlab/help-extension: 3.4.7
@jupyterlab/htmlviewer: 3.4.7
@jupyterlab/htmlviewer-extension: 3.4.7
@jupyterlab/hub-extension: 3.4.7
@jupyterlab/imageviewer: 3.4.7
@jupyterlab/imageviewer-extension: 3.4.7
@jupyterlab/inspector: 3.4.7
@jupyterlab/inspector-extension: 3.4.7
@jupyterlab/javascript-extension: 3.4.7
@jupyterlab/json-extension: 3.4.7
@jupyterlab/launcher: 3.4.7
@jupyterlab/launcher-extension: 3.4.7
@jupyterlab/logconsole: 3.4.7
@jupyterlab/logconsole-extension: 3.4.7
@jupyterlab/mainmenu: 3.4.7
@jupyterlab/mainmenu-extension: 3.4.7
@jupyterlab/markdownviewer: 3.4.7
@jupyterlab/markdownviewer-extension: 3.4.7
@jupyterlab/mathjax2: 3.4.7
@jupyterlab/mathjax2-extension: 3.4.7
@jupyterlab/metapackage: 3.4.7
@jupyterlab/nbconvert-css: 3.4.7
@jupyterlab/nbformat: 3.4.7
@jupyterlab/notebook: 3.4.7
@jupyterlab/notebook-extension: 3.4.7
@jupyterlab/observables: 4.4.7
@jupyterlab/outputarea: 3.4.7
@jupyterlab/pdf-extension: 3.4.7
@jupyterlab/property-inspector: 3.4.7
@jupyterlab/rendermime: 3.4.7
@jupyterlab/rendermime-extension: 3.4.7
@jupyterlab/rendermime-interfaces: 3.4.7
@jupyterlab/running: 3.4.7
@jupyterlab/running-extension: 3.4.7
@jupyterlab/services: 6.4.7
@jupyterlab/example-services-browser: 3.4.7
node-example: 3.4.7
@jupyterlab/example-services-outputarea: 3.4.7
@jupyterlab/settingeditor: 3.4.7
@jupyterlab/settingeditor-extension: 3.4.7
@jupyterlab/settingregistry: 3.4.7
@jupyterlab/shared-models: 3.4.7
@jupyterlab/shortcuts-extension: 3.4.7
@jupyterlab/statedb: 3.4.7
@jupyterlab/statusbar: 3.4.7
@jupyterlab/statusbar-extension: 3.4.7
@jupyterlab/terminal: 3.4.7
@jupyterlab/terminal-extension: 3.4.7
@jupyterlab/theme-dark-extension: 3.4.7
@jupyterlab/theme-light-extension: 3.4.7
@jupyterlab/toc: 5.4.7
@jupyterlab/toc-extension: 5.4.7
@jupyterlab/tooltip: 3.4.7
@jupyterlab/tooltip-extension: 3.4.7
@jupyterlab/translation: 3.4.7
@jupyterlab/translation-extension: 3.4.7
@jupyterlab/ui-components: 3.4.7
@jupyterlab/ui-components-extension: 3.4.7
@jupyterlab/vdom: 3.4.7
@jupyterlab/vdom-extension: 3.4.7
@jupyterlab/vega5-extension: 3.4.7
@jupyterlab/testutils: 3.4.7
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyterlab/jupyterlab/releases/tag/untagged-bff6d31065e95ee8a95f  |
| Since | v3.4.6 |