### PR TITLE
Revert "Pin hatch-jupyter-builder for now"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ exclude = [
 ]
 
 [tool.hatch.build.hooks.jupyter-builder]
-dependencies = ["hatch-jupyter-builder>=0.3.2,<0.6.0"]
+dependencies = ["hatch-jupyter-builder>=0.3.2"]
 build-function = "buildapi.builder"
 ensured-targets = [
     "jupyterlab/static/package.json",


### PR DESCRIPTION
hatch-jupyter-builder 0.6.2 has been released with a fix

Reverts jupyterlab/jupyterlab#13083

Fixes #13082