### PR TITLE
Avoid menus overflowing in small screens

### DIFF
--- a/packages/mainmenu/src/mainmenu.ts
+++ b/packages/mainmenu/src/mainmenu.ts
@@ -24,7 +24,8 @@ export class MainMenu extends MenuBar implements IMainMenu {
    * Construct the main menu bar.
    */
   constructor(commands: CommandRegistry) {
-    super();
+    let options = { forceItemsPosition: { forceX: false, forceY: true } };
+    super(options);
     this._commands = commands;
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

Fixes https://github.com/jupyterlab/lumino/issues/418

## Code changes

<!-- Describe the code changes and how they address the issue. -->
This code changes avoid forcing the `x` value in menus, which avoid the overflowing in small screens or high zoom.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

The change is perceptible just in small screens or when high zoom is present like the following screenshots,

### New behavior

<img width="1791" alt="image" src="https://user-images.githubusercontent.com/20992645/191376375-ef137f4c-dafb-42dd-8f91-a7af87ca1e8d.png">

### Old behavior

![image](https://user-images.githubusercontent.com/20992645/191376334-87a43ea0-c392-4a07-aa20-b7ac466e0b64.png)

In 100% zoom it continues working without any change. It would be interesting to know if there's some idea why the `x` was enforced given that this is not the default Lumino value.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

There's no backwards incompatible change.
