### PR TITLE
Add a setter to TagWidget's parent

### DIFF
--- a/packages/celltags/src/widget.ts
+++ b/packages/celltags/src/widget.ts
@@ -23,10 +23,13 @@ export class TagWidget extends Widget {
   }
 
   /**
-   * Get the parent tag tool widget.
+   * Get/set the parent tag tool widget.
    */
   get parent(): TagTool | null {
     return super.parent as TagTool | null;
+  }
+  set parent(tagTool: TagTool | null) {
+    super.parent = tagTool;
   }
 
   /**


### PR DESCRIPTION
A getter has been added to the `TagWidget`'s *parent* attribute in `v4.0.0a28`, without setter (which should rely to its parent class).

It look like Typescript does not allow overriding the getter without the setter and vice versa.

At the end, it is not possible to add a new tag to a cell : 

![image](https://user-images.githubusercontent.com/32258950/191737020-d85dae06-a702-4397-9e9c-18f8445f8976.png)

## Code changes

Add a setter to `TagWidget`'s *parent* attribute.

## Backwards-incompatible changes

None 