### PR TITLE
Remove xeus-python installation for debugger test

### DIFF
--- a/scripts/ci_install.sh
+++ b/scripts/ci_install.sh
@@ -37,8 +37,3 @@ if [[ $GROUP == nonode ]]; then
     sudo rm -rf $(which node)
     ! node
 fi
-
-# The debugger tests require a kernel that supports debugging
-if [[ $GROUP == js-debugger ]]; then
-    pip install xeus-python">=0.9.0,<0.10.0"
-fi


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
CI is failing because the `xeus-python` package pin in `ci_install.sh` script is too old for the new default Python version.

As that pin predate the ability of ipykernel to support debugger protocol, I'm simply dropping that specific installation.

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Drop installing xeus-python for _js-debugger_

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A