### PR TITLE
Remove `width: 100%` of `jp-WindowedPanel-window`

### DIFF
--- a/packages/ui-components/style/windowedlist.css
+++ b/packages/ui-components/style/windowedlist.css
@@ -16,5 +16,4 @@
 .jp-WindowedPanel-window {
   position: absolute;
   overflow: visible;
-  width: 100%;
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Noticed while iterating on the JupyterLab update for Notebook 7 in https://github.com/jupyter/notebook/pull/6539.

This extra `width: 100%` causes some layout issues in Notebook 7 and does not seem necessary in JupyterLab. 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update CSS for `jp-WindowedPanel-window`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
