### PR TITLE
Remove `width: 100%` of `jp-WindowedPanel-inner`

### DIFF
--- a/packages/ui-components/style/windowedlist.css
+++ b/packages/ui-components/style/windowedlist.css
@@ -10,7 +10,6 @@
 
 .jp-WindowedPanel-inner {
   position: relative;
-  width: 100%;
 }
 
 .jp-WindowedPanel-window {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Similar to https://github.com/jupyterlab/jupyterlab/pull/13154.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Cleanup some CSS which does not seem required in JupyterLab, but can cause issues in downstream applications reusing the notebook component (https://github.com/jupyter/notebook/pull/6539)

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
