### PR TITLE
Adjust CSS styles degrading performance in Chromium browsers

### DIFF
--- a/galata/test/jupyterlab/styles.test.ts
+++ b/galata/test/jupyterlab/styles.test.ts
@@ -1,0 +1,203 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { expect, test } from '@jupyterlab/galata';
+
+// posssibly incomplete (as new tags get added) list of HTML tags as defined in HTML standards (including deprecated elements)
+const standardHTMLTags = new Set([
+  'a',
+  'abbr',
+  'address',
+  'area',
+  'article',
+  'aside',
+  'audio',
+  'b',
+  'base',
+  'bdi',
+  'bdo',
+  'blockquote',
+  'body',
+  'br',
+  'button',
+  'canvas',
+  'caption',
+  'cite',
+  'code',
+  'col',
+  'colgroup',
+  'data',
+  'datalist',
+  'dd',
+  'del',
+  'details',
+  'dfn',
+  'dialog',
+  'div',
+  'dl',
+  'dt',
+  'em',
+  'embed',
+  'fieldset',
+  'figcaption',
+  'figure',
+  'footer',
+  'form',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'head',
+  'header',
+  'hgroup',
+  'hr',
+  'html',
+  'i',
+  'iframe',
+  'img',
+  'input',
+  'ins',
+  'kbd',
+  'label',
+  'legend',
+  'li',
+  'link',
+  'main',
+  'map',
+  'mark',
+  'menu',
+  'meta',
+  'meter',
+  'nav',
+  'noscript',
+  'object',
+  'ol',
+  'optgroup',
+  'option',
+  'output',
+  'p',
+  'param',
+  'picture',
+  'pre',
+  'progress',
+  'q',
+  'rp',
+  'rt',
+  'ruby',
+  's',
+  'samp',
+  'script',
+  'section',
+  'select',
+  'slot',
+  'small',
+  'source',
+  'span',
+  'strong',
+  'style',
+  'sub',
+  'summary',
+  'sup',
+  'table',
+  'tbody',
+  'td',
+  'template',
+  'textarea',
+  'tfoot',
+  'th',
+  'thead',
+  'time',
+  'title',
+  'tr',
+  'track',
+  'u',
+  'ul',
+  'var',
+  'video',
+  'wbr'
+]);
+
+const fileName = 'notebook.ipynb';
+
+test.describe('CSS Selectors', () => {
+  const themes = ['light', 'dark'];
+  for (const theme of themes) {
+    /** Upon hover event (as of 2022) Chromuim's blink invalidates all elements
+     * that match tags in selectors in the format `some-selector:hover some-tag`
+     * and `some-selector:hover > some-tag` as analysed in:
+     * https://github.com/jupyterlab/jupyterlab/issues/9757#issuecomment-1264399740
+     * and reported in:
+     * https://bugs.chromium.org/p/chromium/issues/detail?id=1248496
+     * Since those cause significant UI lag when many elements of `some-tag` are
+     * present we avoid having even a single selector like that, especialy since
+     * changing the selector to increase specificity (e.g. replacing `some-tag`
+     * with a class) is sufficient to workaround the problem.
+     */
+    test(`No non-specific selectors after pseudo-class (${theme} theme)`, async ({
+      page
+    }) => {
+      switch (theme) {
+        case 'dark':
+          await page.theme.setDarkTheme();
+          break;
+        case 'light':
+          await page.theme.setLightTheme();
+          break;
+        default:
+          expect(false);
+      }
+
+      // Create a new notebook and add a MathJax 2 element to ensure that
+      // we cover MathJax styles which get injected dynamically.
+      await page.notebook.createNew(fileName);
+      await page.notebook.addCell('markdown', '$test$');
+      await page.notebook.runCell(1, true);
+      await page.locator('.MathJax').isVisible();
+
+      const detectedTags = new Set(
+        await page.evaluate(() =>
+          [...document.body.getElementsByTagName('*')].map(element =>
+            element.tagName.toLowerCase()
+          )
+        )
+      );
+      // We do not rely on present element tags only as outputs in user notebooks may
+      // include additional element tags not used by JupyterLab itself; we do not rely on
+      // known tags only either, as JupyterLab or extensions may use tags we did not
+      // include in the list of known tags.
+
+      const allTags = new Set([...standardHTMLTags, ...detectedTags]);
+
+      const selectors: string[] = await page.evaluate(() =>
+        [...document.querySelectorAll('style')]
+          .map(style => [...style.sheet.cssRules])
+          .flat()
+          .filter((rule: CSSRule) => rule instanceof CSSStyleRule)
+          .map((rule: CSSStyleRule) => rule.selectorText)
+      );
+      const matcher = new RegExp(
+        ':hover.*\\s+(' + [...allTags].join('|') + ')($|\\s)'
+      );
+
+      const matchedSelectors: string[] = [];
+
+      for (const selectorGroup of selectors) {
+        for (const selector of selectorGroup.split(',')) {
+          if (selector.match(matcher)) {
+            matchedSelectors.push(selector);
+          }
+        }
+      }
+
+      if (matchedSelectors.length) {
+        console.warn(
+          'Detected CSS selectors that might cause performance issues in Chromium',
+          matchedSelectors
+        );
+      }
+      expect(matchedSelectors).toHaveLength(0);
+    });
+  }
+});

--- a/galata/test/jupyterlab/styles.test.ts
+++ b/galata/test/jupyterlab/styles.test.ts
@@ -3,7 +3,7 @@
 
 import { expect, test } from '@jupyterlab/galata';
 
-// posssibly incomplete (as new tags get added) list of HTML tags as defined in HTML standards (including deprecated elements)
+// possibly incomplete (as new tags get added) list of HTML tags as defined in HTML standards (including deprecated elements)
 const standardHTMLTags = new Set([
   'a',
   'abbr',

--- a/packages/codemirror/style/base.css
+++ b/packages/codemirror/style/base.css
@@ -95,22 +95,21 @@
 }
 
 /* Styles for shared cursors (remote cursor locations and selected ranges) */
-.jp-CodeMirrorEditor .remote-caret {
+.jp-CodeMirrorEditor .cm-ySelectionCaret {
   position: relative;
-  border-left: 2px solid black;
+  border-left: 1px solid black;
   margin-left: -1px;
   margin-right: -1px;
   box-sizing: border-box;
 }
 
-.jp-CodeMirrorEditor .remote-caret > div {
+.jp-CodeMirrorEditor .cm-ySelectionCaret > .cm-ySelectionInfo {
   white-space: nowrap;
   position: absolute;
   top: -1.15em;
   padding-bottom: 0.05em;
-  left: -2px;
+  left: -1px;
   font-size: 0.95em;
-  background-color: rgb(250, 129, 0);
   font-family: var(--jp-ui-font-family);
   font-weight: bold;
   line-height: normal;
@@ -118,16 +117,16 @@
   color: white;
   padding-left: 2px;
   padding-right: 2px;
-  z-index: 3;
+  z-index: 101;
   transition: opacity 0.3s ease-in-out;
 }
 
-.jp-CodeMirrorEditor .remote-caret.hide-name > div {
+.jp-CodeMirrorEditor .cm-ySelectionInfo {
   transition-delay: 0.7s;
   opacity: 0;
 }
 
-.jp-CodeMirrorEditor .remote-caret:hover > div {
+.jp-CodeMirrorEditor .cm-ySelectionCaret:hover > .cm-ySelectionInfo {
   opacity: 1;
   transition-delay: 0s;
 }

--- a/packages/mathjax2/src/index.ts
+++ b/packages/mathjax2/src/index.ts
@@ -102,6 +102,19 @@ export class MathJaxTypesetter implements IRenderMime.ILatexTypesetter {
       skipStartupTypeset: true,
       messageStyle: 'none'
     });
+
+    MathJax.Hub.Register.StartupHook('End Config', () => {
+      // Disable `:hover span` styles which cause performance issues in Chromium browsers
+      // c-f https://github.com/jupyterlab/jupyterlab/issues/9757
+      // Note that we cannot overwrite them in config earlier due to how `CombineConfig`
+      // is implemented in MathJax 2 (it does not allow removing styles, just expanding).
+      delete MathJax.Hub?.config?.MathEvents?.styles[
+        '.MathJax_Hover_Arrow:hover span'
+      ];
+      delete MathJax.Hub?.config?.MathMenu?.styles[
+        '.MathJax_MenuClose:hover span'
+      ];
+    });
     MathJax.Hub.Configured();
     this._initPromise.resolve(void 0);
   }

--- a/packages/running/style/base.css
+++ b/packages/running/style/base.css
@@ -98,7 +98,8 @@
   background: var(--jp-layout-color3);
 }
 
-.jp-RunningSessions-shutdownAll.jp-mod-styled > span {
+.jp-RunningSessions-shutdownAll.jp-mod-styled
+  > .jp-ToolbarButtonComponent-label {
   color: var(--jp-warn-color1);
   background-color: transparent;
   border-radius: 2px;
@@ -107,20 +108,24 @@
   text-overflow: ellipsis;
 }
 
-.jp-RunningSessions-shutdownAll.jp-mod-styled:hover > span {
+.jp-RunningSessions-shutdownAll.jp-mod-styled:hover
+  > .jp-ToolbarButtonComponent-label {
   background-color: var(--jp-layout-color2);
 }
 
-.jp-RunningSessions-shutdownAll.jp-mod-styled:focus > span {
+.jp-RunningSessions-shutdownAll.jp-mod-styled:focus
+  > .jp-ToolbarButtonComponent-label {
   border: none;
   box-shadow: none;
   background-color: var(--jp-layout-color2);
 }
 
-.jp-RunningSessions-shutdownAll.jp-mod-styled.jp-mod-disabled > span {
+.jp-RunningSessions-shutdownAll.jp-mod-styled.jp-mod-disabled
+  > .jp-ToolbarButtonComponent-label {
   color: var(--jp-ui-font-color2);
 }
 
-.jp-RunningSessions-shutdownAll.jp-mod-styled.jp-mod-disabled:hover > span {
+.jp-RunningSessions-shutdownAll.jp-mod-styled.jp-mod-disabled:hover
+  > .jp-ToolbarButtonComponent-label {
   background: none;
 }

--- a/packages/shortcuts-extension/src/componentStyle/ShortcutTitleItemStyle.tsx
+++ b/packages/shortcuts-extension/src/componentStyle/ShortcutTitleItemStyle.tsx
@@ -9,14 +9,14 @@ export const HeaderStyle = style({
   display: 'flex',
 
   $nest: {
-    '&:hover div': {
+    '&:hover .jp-ShortcutTitleItem-sortButton': {
       fontWeight: 600,
       color: 'var(--jp-ui-font-color0)'
     },
-    '&:focus div': {
+    '&:focus .jp-ShortcutTitleItem-sortButton': {
       outline: 'none'
     },
-    '&:active div': {
+    '&:active .jp-ShortcutTitleItem-sortButton': {
       fontWeight: 600,
       color: 'var(--jp-ui-font-color0)'
     }

--- a/packages/shortcuts-extension/src/components/ShortcutTitleItem.tsx
+++ b/packages/shortcuts-extension/src/components/ShortcutTitleItem.tsx
@@ -31,7 +31,9 @@ export class ShortcutTitleItem extends React.Component<IShortcutTitleItemProps> 
         onClick={() => this.props.updateSort(this.props.title.toLowerCase())}
       >
         {this.props.title}
-        <div className={SortButtonStyle}>⌃</div>
+        <div className={`${SortButtonStyle} jp-ShortcutTitleItem-sortButton`}>
+          ⌃
+        </div>
       </div>
     );
   }

--- a/packages/ui-components/src/icon/widgets/commandpalettesvg.ts
+++ b/packages/ui-components/src/icon/widgets/commandpalettesvg.ts
@@ -8,7 +8,8 @@ import { classes } from '../../utils';
 import { checkIcon, filterListIcon } from '../iconimports';
 
 const searchHeaderIcon = filterListIcon.bindprops({
-  stylesheet: 'commandPaletteHeader'
+  stylesheet: 'commandPaletteHeader',
+  className: 'jp-icon-hoverShow-content'
 });
 
 export namespace CommandPaletteSvg {

--- a/packages/ui-components/style/iconshover.css
+++ b/packages/ui-components/style/iconshover.css
@@ -3,7 +3,7 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-.jp-icon-hoverShow:not(:hover) svg {
+.jp-icon-hoverShow:not(:hover) .jp-icon-hoverShow-content {
   display: none !important;
 }
 


### PR DESCRIPTION
## References

Fixes #9757 and fixes #13160.

## Code changes

- [x] adds a test case which initially is expected to fail on main branch with:
  ```
  Detected CSS selectors that might cause performance issues in Chromium [
    '.jp-icon-hoverShow:not(:hover) svg',
    '.jp-CodeMirrorEditor .remote-caret:hover > div',
    '.jp-RunningSessions-shutdownAll.jp-mod-styled:hover > span',
    '.jp-RunningSessions-shutdownAll.jp-mod-styled.jp-mod-disabled:hover > span',
    '.f437k8z:hover div',
    '.MathJax_Hover_Arrow:hover span',
    '.MathJax_MenuClose:hover span'
  ]
  ```
- [x] removes or increases specificity of the above selectors

Follow-up tasks:
- check other pseudo-classes
- check if we can reduce time for other performance-critical tasks by the approach of dissecting style recalculation

## How to test

1. Download [`gh-9757-reproducer.ipynb`](https://gist.github.com/krassowski/eb2b312576e8597f935817c4c4d81fa5)
2. Run all cells
3. Open menu and compare how responsive it is to hover events before and after the patch
4. (Optionally) record performance profile and compare the `Recalculate Style` event duration

| Before | After |
|--|--|
| ![Screenshot from 2022-10-02 21-52-39](https://user-images.githubusercontent.com/5832902/193475757-6472e729-0b5d-4c89-9617-38d2abf5b29e.png) | ![Screenshot from 2022-10-02 21-49-56](https://user-images.githubusercontent.com/5832902/193475720-e6ab897b-a5a6-4461-81f6-e37eeeff9aa8.png) |

## User-facing changes

- Menu interactions and other `:hover` actions should no longer be sluggish when many `<div>`, `<span>` or `<svg>` nodes are present.
- Styles for caret are applied again, adapted to [CodeMirror 6 y.js styling](https://github.com/yjs/y-codemirror.next/blob/d49a2bde50adc08d88c50f4332ade752e2558496/src/y-remote-selections.js#L12-L67). The cursor is now 1px rather than 2px in 3.x since now there is a dot over the cursor to help with visibility.
  | Before (on 4.0.0-alpha29) | After (as it was on 3.x, adapted) |
  |----|-----|
  | ![Screenshot from 2022-10-02 20-13-32](https://user-images.githubusercontent.com/5832902/193472039-986d6e4c-4987-4bd7-b9d9-194fac26c97f.png) | ![Screenshot from 2022-10-02 20-13-16](https://user-images.githubusercontent.com/5832902/193472036-0f385f20-0846-48e8-986e-33e8121f2364.png) |
- `jp-icon-hoverShow` now requires the icon inside of the container to be marked with `jp-icon-hoverShow-content` class. Note that in JupyterLab codebase this is only used by the command palette headers to show the filter icon on hover, and these headers (`.lm-CommandPalette-header`) are hidden in the modal palette.

## Backwards-incompatible changes

`jp-icon-hoverShow-content` requirement