### PR TITLE
Always show tooltip in hover box even if edges are out of view

### DIFF
--- a/packages/tooltip/src/widget.ts
+++ b/packages/tooltip/src/widget.ts
@@ -230,7 +230,7 @@ export class Tooltip extends Widget {
     // Calculate the geometry of the tooltip.
     HoverBox.setGeometry({
       anchor,
-      host: host,
+      host,
       maxHeight: MAX_HEIGHT,
       minHeight: MIN_HEIGHT,
       node: this.node,

--- a/packages/tooltip/src/widget.ts
+++ b/packages/tooltip/src/widget.ts
@@ -223,15 +223,23 @@ export class Tooltip extends Widget {
     const style = window.getComputedStyle(this.node);
     const paddingLeft = parseInt(style.paddingLeft!, 10) || 0;
 
+    const host =
+      (editor.host.closest('.jp-MainAreaWidget > .lm-Widget') as HTMLElement) ||
+      editor.host;
+
     // Calculate the geometry of the tooltip.
     HoverBox.setGeometry({
       anchor,
-      host: editor.host,
+      host: host,
       maxHeight: MAX_HEIGHT,
       minHeight: MIN_HEIGHT,
       node: this.node,
       offset: { horizontal: -1 * paddingLeft },
       privilege: 'below',
+      outOfViewDisplay: {
+        top: 'stick-inside',
+        bottom: 'stick-inside'
+      },
       style: style
     });
   }

--- a/packages/ui-components/src/hoverbox.ts
+++ b/packages/ui-components/src/hoverbox.ts
@@ -278,7 +278,7 @@ export namespace HoverBox {
     }
 
     if (belowTheBottom) {
-      switch (outOfViewDisplay?.bottom || 'hidden-outsdie') {
+      switch (outOfViewDisplay?.bottom || 'hidden-outside') {
         case 'hidden-inside':
           if (!bottomEdgeInside) {
             hide = true;
@@ -332,7 +332,7 @@ export namespace HoverBox {
     }
 
     if (afterTheRight) {
-      switch (outOfViewDisplay?.right || 'hidden-outsdie') {
+      switch (outOfViewDisplay?.right || 'hidden-outside') {
         case 'hidden-inside':
           if (!rightEdgeInside) {
             hide = true;


### PR DESCRIPTION
## References

Fixes #13158 by keeping the hover box visible when edges are out of view.

## Code changes

- fixed typos in defaults
- changed host for tooltip
- changed `outOfViewDisplay` to `stick-inside` for top and bottom edges

## User-facing changes

Shift-tab tooltip works in console again.

## Backwards-incompatible changes

None
