### PR TITLE
Automated Changelog Entry for 3.4.8 on 3.4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,37 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.4.8
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.4.7...f382949b11c54384eee8e58a0d7defe879c21718))
+
+### Enhancements made
+
+- Adjust CSS styles degrading performance in Chromium browsers [#13159](https://github.com/jupyterlab/jupyterlab/pull/13159) ([@krassowski](https://github.com/krassowski))
+
+### Bugs fixed
+
+- Always show tooltip in hover box even if edges are out of view [#13161](https://github.com/jupyterlab/jupyterlab/pull/13161) ([@krassowski](https://github.com/krassowski))
+- Fix workspace URL while cloning a workspace [#12794](https://github.com/jupyterlab/jupyterlab/pull/12794) ([@aditya211935](https://github.com/aditya211935))
+- Switch back to `display` to hide tabs [#13103](https://github.com/jupyterlab/jupyterlab/pull/13103) ([@fcollonval](https://github.com/fcollonval))
+- Backport PR #13090 (Preserve kernel icon aspect ratio) [#13122](https://github.com/jupyterlab/jupyterlab/pull/13122) ([@fcollonval](https://github.com/fcollonval))
+- Fix cell toolbar layout [#13059](https://github.com/jupyterlab/jupyterlab/pull/13059) ([@kulsoomzahra](https://github.com/kulsoomzahra))
+- Avoid menus overflowing in small screens [#13109](https://github.com/jupyterlab/jupyterlab/pull/13109) ([@steff456](https://github.com/steff456))
+
+### Maintenance and upkeep improvements
+
+- Fix storybook error [#13135](https://github.com/jupyterlab/jupyterlab/pull/13135) ([@fcollonval](https://github.com/fcollonval))
+- Remove xeus-python installation for debugger test [#13113](https://github.com/jupyterlab/jupyterlab/pull/13113) ([@fcollonval](https://github.com/fcollonval))
+- Resolve core_path before calling nodejs [#13126](https://github.com/jupyterlab/jupyterlab/pull/13126) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-09-12&to=2022-10-04&type=c))
+
+[@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2022-09-12..2022-10-04&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2022-09-12..2022-10-04&type=Issues) | [@dmonad](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Admonad+updated%3A2022-09-12..2022-10-04&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-09-12..2022-10-04&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2022-09-12..2022-10-04&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-09-12..2022-10-04&type=Issues) | [@firai](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afirai+updated%3A2022-09-12..2022-10-04&type=Issues) | [@gabalafou](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agabalafou+updated%3A2022-09-12..2022-10-04&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-09-12..2022-10-04&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-09-12..2022-10-04&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-09-12..2022-10-04&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-09-12..2022-10-04&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-09-12..2022-10-04&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-09-12..2022-10-04&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASylvainCorlay+updated%3A2022-09-12..2022-10-04&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-09-12..2022-10-04&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.4.7
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.4.6...f713e06179bb5e57fc03da5fcf49b9c8e543f684))
@@ -32,8 +63,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.4.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-09-05&to=2022-09-12&type=c))
 
 [@agoose77](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aagoose77+updated%3A2022-09-05..2022-09-12&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-09-05..2022-09-12&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2022-09-05..2022-09-12&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-09-05..2022-09-12&type=Issues) | [@gabalafou](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agabalafou+updated%3A2022-09-05..2022-09-12&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-09-05..2022-09-12&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-09-05..2022-09-12&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-09-05..2022-09-12&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-09-05..2022-09-12&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-09-05..2022-09-12&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-09-05..2022-09-12&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.4.6
 


### PR DESCRIPTION
Automated Changelog Entry for 3.4.8 on 3.4.x
```
Python version: 3.4.8
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.4.8
@jupyterlab/buildutils: 3.4.8
@jupyterlab/template: 3.4.8
@jupyterlab/application-top: 3.4.8
@jupyterlab/example-app: 3.4.8
@jupyterlab/example-cell: 3.4.8
@jupyterlab/example-console: 3.4.8
@jupyterlab/example-federated: 2.5.8
@jupyterlab/example-federated-core: 2.5.8
@jupyterlab/example-federated-md: 2.5.8
@jupyterlab/example-federated-middle: 2.5.8
@jupyterlab/example-federated-phosphor: 2.5.8
@jupyterlab/example-filebrowser: 3.4.8
@jupyterlab/example-notebook: 3.4.8
@jupyterlab/example-terminal: 3.4.8
@jupyterlab/galata: 4.3.8
@jupyterlab/mock-extension: 3.4.8
@jupyterlab/mock-consumer: 3.4.8
@jupyterlab/mock-provider: 3.4.8
@jupyterlab/mock-token: 3.4.8
@jupyterlab/application: 3.4.8
@jupyterlab/application-extension: 3.4.8
@jupyterlab/apputils: 3.4.8
@jupyterlab/apputils-extension: 3.4.8
@jupyterlab/attachments: 3.4.8
@jupyterlab/cell-toolbar: 3.4.8
@jupyterlab/cell-toolbar-extension: 3.4.8
@jupyterlab/cells: 3.4.8
@jupyterlab/celltags: 3.4.8
@jupyterlab/celltags-extension: 3.4.8
@jupyterlab/codeeditor: 3.4.8
@jupyterlab/codemirror: 3.4.8
@jupyterlab/codemirror-extension: 3.4.8
@jupyterlab/completer: 3.4.8
@jupyterlab/completer-extension: 3.4.8
@jupyterlab/console: 3.4.8
@jupyterlab/console-extension: 3.4.8
@jupyterlab/coreutils: 5.4.8
@jupyterlab/csvviewer: 3.4.8
@jupyterlab/csvviewer-extension: 3.4.8
@jupyterlab/debugger: 3.4.8
@jupyterlab/debugger-extension: 3.4.8
@jupyterlab/docmanager: 3.4.8
@jupyterlab/docmanager-extension: 3.4.8
@jupyterlab/docprovider: 3.4.8
@jupyterlab/docprovider-extension: 3.4.8
@jupyterlab/docregistry: 3.4.8
@jupyterlab/documentsearch: 3.4.8
@jupyterlab/documentsearch-extension: 3.4.8
@jupyterlab/extensionmanager: 3.4.8
@jupyterlab/extensionmanager-extension: 3.4.8
@jupyterlab/filebrowser: 3.4.8
@jupyterlab/filebrowser-extension: 3.4.8
@jupyterlab/fileeditor: 3.4.8
@jupyterlab/fileeditor-extension: 3.4.8
@jupyterlab/help-extension: 3.4.8
@jupyterlab/htmlviewer: 3.4.8
@jupyterlab/htmlviewer-extension: 3.4.8
@jupyterlab/hub-extension: 3.4.8
@jupyterlab/imageviewer: 3.4.8
@jupyterlab/imageviewer-extension: 3.4.8
@jupyterlab/inspector: 3.4.8
@jupyterlab/inspector-extension: 3.4.8
@jupyterlab/javascript-extension: 3.4.8
@jupyterlab/json-extension: 3.4.8
@jupyterlab/launcher: 3.4.8
@jupyterlab/launcher-extension: 3.4.8
@jupyterlab/logconsole: 3.4.8
@jupyterlab/logconsole-extension: 3.4.8
@jupyterlab/mainmenu: 3.4.8
@jupyterlab/mainmenu-extension: 3.4.8
@jupyterlab/markdownviewer: 3.4.8
@jupyterlab/markdownviewer-extension: 3.4.8
@jupyterlab/mathjax2: 3.4.8
@jupyterlab/mathjax2-extension: 3.4.8
@jupyterlab/metapackage: 3.4.8
@jupyterlab/nbconvert-css: 3.4.8
@jupyterlab/nbformat: 3.4.8
@jupyterlab/notebook: 3.4.8
@jupyterlab/notebook-extension: 3.4.8
@jupyterlab/observables: 4.4.8
@jupyterlab/outputarea: 3.4.8
@jupyterlab/pdf-extension: 3.4.8
@jupyterlab/property-inspector: 3.4.8
@jupyterlab/rendermime: 3.4.8
@jupyterlab/rendermime-extension: 3.4.8
@jupyterlab/rendermime-interfaces: 3.4.8
@jupyterlab/running: 3.4.8
@jupyterlab/running-extension: 3.4.8
@jupyterlab/services: 6.4.8
@jupyterlab/example-services-browser: 3.4.8
node-example: 3.4.8
@jupyterlab/example-services-outputarea: 3.4.8
@jupyterlab/settingeditor: 3.4.8
@jupyterlab/settingeditor-extension: 3.4.8
@jupyterlab/settingregistry: 3.4.8
@jupyterlab/shared-models: 3.4.8
@jupyterlab/shortcuts-extension: 3.4.8
@jupyterlab/statedb: 3.4.8
@jupyterlab/statusbar: 3.4.8
@jupyterlab/statusbar-extension: 3.4.8
@jupyterlab/terminal: 3.4.8
@jupyterlab/terminal-extension: 3.4.8
@jupyterlab/theme-dark-extension: 3.4.8
@jupyterlab/theme-light-extension: 3.4.8
@jupyterlab/toc: 5.4.8
@jupyterlab/toc-extension: 5.4.8
@jupyterlab/tooltip: 3.4.8
@jupyterlab/tooltip-extension: 3.4.8
@jupyterlab/translation: 3.4.8
@jupyterlab/translation-extension: 3.4.8
@jupyterlab/ui-components: 3.4.8
@jupyterlab/ui-components-extension: 3.4.8
@jupyterlab/vdom: 3.4.8
@jupyterlab/vdom-extension: 3.4.8
@jupyterlab/vega5-extension: 3.4.8
@jupyterlab/testutils: 3.4.8
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyterlab/jupyterlab/releases/tag/untagged-f58609b874fafc665dac  |
| Since | v3.4.7 |