### PR TITLE
Fix JSON viewer syntax highlighting

### DIFF
--- a/packages/json-extension/package.json
+++ b/packages/json-extension/package.json
@@ -33,9 +33,11 @@
   },
   "dependencies": {
     "@jupyterlab/apputils": "^4.0.0-alpha.14",
+    "@jupyterlab/codemirror": "^4.0.0-alpha.14",
     "@jupyterlab/rendermime-interfaces": "^3.8.0-alpha.14",
     "@jupyterlab/translation": "^4.0.0-alpha.14",
     "@jupyterlab/ui-components": "^4.0.0-alpha.29",
+    "@lezer/highlight": "^1.0.0",
     "@lumino/coreutils": "^2.0.0-alpha.6",
     "@lumino/messaging": "^2.0.0-alpha.6",
     "@lumino/widgets": "^2.0.0-alpha.6",

--- a/packages/json-extension/src/component.tsx
+++ b/packages/json-extension/src/component.tsx
@@ -1,8 +1,10 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import { jupyterHighlightStyle } from '@jupyterlab/codemirror';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { InputGroup } from '@jupyterlab/ui-components';
+import { Tag, tags } from '@lezer/highlight';
 import { JSONArray, JSONExt, JSONObject, JSONValue } from '@lumino/coreutils';
 import * as React from 'react';
 import Highlight from 'react-highlighter';
@@ -27,6 +29,13 @@ export interface IProps {
 export interface IState {
   filter?: string;
   value: string;
+}
+
+/**
+ * Get the CodeMirror style for a given tag.
+ */
+function getStyle(tag: Tag): string {
+  return jupyterHighlightStyle.style([tag]) ?? '';
 }
 
 /**
@@ -70,9 +79,9 @@ export class Component extends React.Component<IProps, IState> {
           collectionLimit={100}
           theme={{
             extend: theme,
-            valueLabel: 'cm-variable',
-            valueText: 'cm-string',
-            nestedNodeItemString: 'cm-comment'
+            valueLabel: getStyle(tags.variableName),
+            valueText: getStyle(tags.string),
+            nestedNodeItemString: getStyle(tags.comment)
           }}
           invertTheme={false}
           keyPath={[root]}
@@ -90,18 +99,8 @@ export class Component extends React.Component<IProps, IState> {
             )
           }
           labelRenderer={([label, type]) => {
-            // let className = 'cm-variable';
-            // if (type === 'root') {
-            //   className = 'cm-variable-2';
-            // }
-            // if (type === 'array') {
-            //   className = 'cm-variable-2';
-            // }
-            // if (type === 'Object') {
-            //   className = 'cm-variable-3';
-            // }
             return (
-              <span className="cm-keyword">
+              <span className={getStyle(tags.keyword)}>
                 <Highlight
                   search={this.state.filter}
                   matchStyle={{ backgroundColor: 'yellow' }}
@@ -112,12 +111,12 @@ export class Component extends React.Component<IProps, IState> {
             );
           }}
           valueRenderer={raw => {
-            let className = 'cm-string';
+            let className = getStyle(tags.string);
             if (typeof raw === 'number') {
-              className = 'cm-number';
+              className = getStyle(tags.number);
             }
             if (raw === 'true' || raw === 'false') {
-              className = 'cm-keyword';
+              className = getStyle(tags.keyword);
             }
             return (
               <span className={className}>

--- a/packages/json-extension/src/index.tsx
+++ b/packages/json-extension/src/index.tsx
@@ -39,7 +39,6 @@ export class RenderedJSON
     super();
     this.addClass(CSS_CLASS);
     this.addClass('CodeMirror');
-    this.addClass('cm-s-jupyter');
     this._mimeType = options.mimeType;
     this.translator = options.translator || nullTranslator;
   }

--- a/packages/json-extension/style/index.css
+++ b/packages/json-extension/style/index.css
@@ -7,5 +7,6 @@
 @import url('~@lumino/widgets/style/index.css');
 @import url('~@jupyterlab/ui-components/style/index.css');
 @import url('~@jupyterlab/apputils/style/index.css');
+@import url('~@jupyterlab/codemirror/style/index.css');
 
 @import url('./base.css');

--- a/packages/json-extension/style/index.js
+++ b/packages/json-extension/style/index.js
@@ -7,5 +7,6 @@
 import '@lumino/widgets/style/index.js';
 import '@jupyterlab/ui-components/style/index.js';
 import '@jupyterlab/apputils/style/index.js';
+import '@jupyterlab/codemirror/style/index.js';
 
 import './base.css';

--- a/packages/json-extension/tsconfig.json
+++ b/packages/json-extension/tsconfig.json
@@ -10,6 +10,9 @@
       "path": "../apputils"
     },
     {
+      "path": "../codemirror"
+    },
+    {
       "path": "../rendermime-interfaces"
     },
     {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/13170

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Use jupyter highlight style from `@jupyterlab/codemirror` to style the `JSONTree` component.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

**Before**

![image](https://user-images.githubusercontent.com/591645/194001344-e2d3ec21-652b-4991-9277-aedb0acb60ab.png)

**After**

![image](https://user-images.githubusercontent.com/591645/194001441-69e28452-ebc2-4a49-b135-5991b894d960.png)

## Backwards-incompatible changes

None


