### PR TITLE
Automated Changelog Entry for 3.5.0a0 on 3.5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,33 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.5.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.5.0a0
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.4.8...a2e4a9a7e867e34ed664d97a672cdae8a9ea2b02))
+
+### Enhancements made
+
+- Collapse debugger panel when disabling debugger [#13088](https://github.com/jupyterlab/jupyterlab/pull/13088) ([@yanmulin](https://github.com/yanmulin))
+- File Browser: add support for filtering directories on search [#12342](https://github.com/jupyterlab/jupyterlab/pull/12342) ([@jtpio](https://github.com/jtpio))
+- Prompt for renaming at first manual save [#12953](https://github.com/jupyterlab/jupyterlab/pull/12953) ([@fcollonval](https://github.com/fcollonval))
+- Raise ceiling on jupyter_server dependency to < 3 [#13068](https://github.com/jupyterlab/jupyterlab/pull/13068) ([@Zsailer](https://github.com/Zsailer))
+
+### Maintenance and upkeep improvements
+
+- Bump to latest Lumino 1.x [#13190](https://github.com/jupyterlab/jupyterlab/pull/13190) ([@fcollonval](https://github.com/fcollonval))
+- Update branch configuration [#13184](https://github.com/jupyterlab/jupyterlab/pull/13184) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+- Prompt for renaming at first manual save [#12953](https://github.com/jupyterlab/jupyterlab/pull/12953) ([@fcollonval](https://github.com/fcollonval))
+- Update branch configuration [#13184](https://github.com/jupyterlab/jupyterlab/pull/13184) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-10-04&to=2022-10-06&type=c))
+
+[@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-10-04..2022-10-06&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-10-04..2022-10-06&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-10-04..2022-10-06&type=Issues)
+
 <!-- <END NEW CHANGELOG ENTRY> -->
 
 ## v3.4
@@ -44,8 +71,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.5.x/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-09-12&to=2022-10-04&type=c))
 
 [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2022-09-12..2022-10-04&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2022-09-12..2022-10-04&type=Issues) | [@dmonad](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Admonad+updated%3A2022-09-12..2022-10-04&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-09-12..2022-10-04&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2022-09-12..2022-10-04&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-09-12..2022-10-04&type=Issues) | [@firai](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afirai+updated%3A2022-09-12..2022-10-04&type=Issues) | [@gabalafou](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agabalafou+updated%3A2022-09-12..2022-10-04&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-09-12..2022-10-04&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-09-12..2022-10-04&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-09-12..2022-10-04&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-09-12..2022-10-04&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-09-12..2022-10-04&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-09-12..2022-10-04&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASylvainCorlay+updated%3A2022-09-12..2022-10-04&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-09-12..2022-10-04&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.4.7
 


### PR DESCRIPTION
Automated Changelog Entry for 3.5.0a0 on 3.5.x
```
Python version: 3.5.0a0
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.5.0-alpha.0
@jupyterlab/buildutils: 3.5.0-alpha.0
@jupyterlab/template: 3.5.0-alpha.0
@jupyterlab/application-top: 3.5.0-alpha.0
@jupyterlab/example-app: 3.5.0-alpha.0
@jupyterlab/example-cell: 3.5.0-alpha.0
@jupyterlab/example-console: 3.5.0-alpha.0
@jupyterlab/example-federated: 2.6.0-alpha.0
@jupyterlab/example-federated-core: 2.6.0-alpha.0
@jupyterlab/example-federated-md: 2.6.0-alpha.0
@jupyterlab/example-federated-middle: 2.6.0-alpha.0
@jupyterlab/example-federated-phosphor: 2.6.0-alpha.0
@jupyterlab/example-filebrowser: 3.5.0-alpha.0
@jupyterlab/example-notebook: 3.5.0-alpha.0
@jupyterlab/example-terminal: 3.5.0-alpha.0
@jupyterlab/galata: 4.4.0-alpha.0
@jupyterlab/mock-extension: 3.5.0-alpha.0
@jupyterlab/mock-consumer: 3.5.0-alpha.0
@jupyterlab/mock-provider: 3.5.0-alpha.0
@jupyterlab/mock-token: 3.5.0-alpha.0
@jupyterlab/application: 3.5.0-alpha.0
@jupyterlab/application-extension: 3.5.0-alpha.0
@jupyterlab/apputils: 3.5.0-alpha.0
@jupyterlab/apputils-extension: 3.5.0-alpha.0
@jupyterlab/attachments: 3.5.0-alpha.0
@jupyterlab/cell-toolbar: 3.5.0-alpha.0
@jupyterlab/cell-toolbar-extension: 3.5.0-alpha.0
@jupyterlab/cells: 3.5.0-alpha.0
@jupyterlab/celltags: 3.5.0-alpha.0
@jupyterlab/celltags-extension: 3.5.0-alpha.0
@jupyterlab/codeeditor: 3.5.0-alpha.0
@jupyterlab/codemirror: 3.5.0-alpha.0
@jupyterlab/codemirror-extension: 3.5.0-alpha.0
@jupyterlab/completer: 3.5.0-alpha.0
@jupyterlab/completer-extension: 3.5.0-alpha.0
@jupyterlab/console: 3.5.0-alpha.0
@jupyterlab/console-extension: 3.5.0-alpha.0
@jupyterlab/coreutils: 5.5.0-alpha.0
@jupyterlab/csvviewer: 3.5.0-alpha.0
@jupyterlab/csvviewer-extension: 3.5.0-alpha.0
@jupyterlab/debugger: 3.5.0-alpha.0
@jupyterlab/debugger-extension: 3.5.0-alpha.0
@jupyterlab/docmanager: 3.5.0-alpha.0
@jupyterlab/docmanager-extension: 3.5.0-alpha.0
@jupyterlab/docprovider: 3.5.0-alpha.0
@jupyterlab/docprovider-extension: 3.5.0-alpha.0
@jupyterlab/docregistry: 3.5.0-alpha.0
@jupyterlab/documentsearch: 3.5.0-alpha.0
@jupyterlab/documentsearch-extension: 3.5.0-alpha.0
@jupyterlab/extensionmanager: 3.5.0-alpha.0
@jupyterlab/extensionmanager-extension: 3.5.0-alpha.0
@jupyterlab/filebrowser: 3.5.0-alpha.0
@jupyterlab/filebrowser-extension: 3.5.0-alpha.0
@jupyterlab/fileeditor: 3.5.0-alpha.0
@jupyterlab/fileeditor-extension: 3.5.0-alpha.0
@jupyterlab/help-extension: 3.5.0-alpha.0
@jupyterlab/htmlviewer: 3.5.0-alpha.0
@jupyterlab/htmlviewer-extension: 3.5.0-alpha.0
@jupyterlab/hub-extension: 3.5.0-alpha.0
@jupyterlab/imageviewer: 3.5.0-alpha.0
@jupyterlab/imageviewer-extension: 3.5.0-alpha.0
@jupyterlab/inspector: 3.5.0-alpha.0
@jupyterlab/inspector-extension: 3.5.0-alpha.0
@jupyterlab/javascript-extension: 3.5.0-alpha.0
@jupyterlab/json-extension: 3.5.0-alpha.0
@jupyterlab/launcher: 3.5.0-alpha.0
@jupyterlab/launcher-extension: 3.5.0-alpha.0
@jupyterlab/logconsole: 3.5.0-alpha.0
@jupyterlab/logconsole-extension: 3.5.0-alpha.0
@jupyterlab/mainmenu: 3.5.0-alpha.0
@jupyterlab/mainmenu-extension: 3.5.0-alpha.0
@jupyterlab/markdownviewer: 3.5.0-alpha.0
@jupyterlab/markdownviewer-extension: 3.5.0-alpha.0
@jupyterlab/mathjax2: 3.5.0-alpha.0
@jupyterlab/mathjax2-extension: 3.5.0-alpha.0
@jupyterlab/metapackage: 3.5.0-alpha.0
@jupyterlab/nbconvert-css: 3.5.0-alpha.0
@jupyterlab/nbformat: 3.5.0-alpha.0
@jupyterlab/notebook: 3.5.0-alpha.0
@jupyterlab/notebook-extension: 3.5.0-alpha.0
@jupyterlab/observables: 4.5.0-alpha.0
@jupyterlab/outputarea: 3.5.0-alpha.0
@jupyterlab/pdf-extension: 3.5.0-alpha.0
@jupyterlab/property-inspector: 3.5.0-alpha.0
@jupyterlab/rendermime: 3.5.0-alpha.0
@jupyterlab/rendermime-extension: 3.5.0-alpha.0
@jupyterlab/rendermime-interfaces: 3.5.0-alpha.0
@jupyterlab/running: 3.5.0-alpha.0
@jupyterlab/running-extension: 3.5.0-alpha.0
@jupyterlab/services: 6.5.0-alpha.0
@jupyterlab/example-services-browser: 3.5.0-alpha.0
node-example: 3.5.0-alpha.0
@jupyterlab/example-services-outputarea: 3.5.0-alpha.0
@jupyterlab/settingeditor: 3.5.0-alpha.0
@jupyterlab/settingeditor-extension: 3.5.0-alpha.0
@jupyterlab/settingregistry: 3.5.0-alpha.0
@jupyterlab/shared-models: 3.5.0-alpha.0
@jupyterlab/shortcuts-extension: 3.5.0-alpha.0
@jupyterlab/statedb: 3.5.0-alpha.0
@jupyterlab/statusbar: 3.5.0-alpha.0
@jupyterlab/statusbar-extension: 3.5.0-alpha.0
@jupyterlab/terminal: 3.5.0-alpha.0
@jupyterlab/terminal-extension: 3.5.0-alpha.0
@jupyterlab/theme-dark-extension: 3.5.0-alpha.0
@jupyterlab/theme-light-extension: 3.5.0-alpha.0
@jupyterlab/toc: 5.5.0-alpha.0
@jupyterlab/toc-extension: 5.5.0-alpha.0
@jupyterlab/tooltip: 3.5.0-alpha.0
@jupyterlab/tooltip-extension: 3.5.0-alpha.0
@jupyterlab/translation: 3.5.0-alpha.0
@jupyterlab/translation-extension: 3.5.0-alpha.0
@jupyterlab/ui-components: 3.5.0-alpha.0
@jupyterlab/ui-components-extension: 3.5.0-alpha.0
@jupyterlab/vdom: 3.5.0-alpha.0
@jupyterlab/vdom-extension: 3.5.0-alpha.0
@jupyterlab/vega5-extension: 3.5.0-alpha.0
@jupyterlab/testutils: 3.5.0-alpha.0
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyterlab/jupyterlab/releases/tag/untagged-bb0d6be60cce86f80642  |
| Since | v3.4.8 |