### PR TITLE
Add a title to the RTC panel

### DIFF
--- a/packages/collaboration-extension/src/index.ts
+++ b/packages/collaboration-extension/src/index.ts
@@ -170,6 +170,7 @@ const rtcPanelPlugin: JupyterFrontEndPlugin<void> = {
     const userPanel = new SidePanel();
     userPanel.id = DOMUtils.createDomID();
     userPanel.title.icon = usersIcon;
+    userPanel.title.caption = trans.__('Collaboration');
     userPanel.addClass('jp-RTCPanel');
     app.shell.add(userPanel, 'left', { rank: 300 });
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Similar to https://github.com/jupyterlab/jupyterlab/pull/12987

This came up while working on https://github.com/jupyter/notebook/pull/6487:

![image](https://user-images.githubusercontent.com/591645/194311998-28db10f8-3f71-40da-a76d-d3f845c7869c.png)


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Set `title.caption` for the RTC panel.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Notebook 7 users will be able to see the proper menu entry.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
