### PR TITLE
Use keystroke format consistent with menus

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -1148,7 +1148,7 @@ const modeSwitchPlugin: JupyterFrontEndPlugin<void> = {
         b => b.command === 'application:toggle-mode'
       );
       if (binding) {
-        const ks = CommandRegistry.formatKeystroke(binding.keys.join(' '));
+        const ks = binding.keys.map(CommandRegistry.formatKeystroke).join(', ');
         modeSwitch.caption = trans.__('Simple Interface (%1)', ks);
       } else {
         modeSwitch.caption = trans.__('Simple Interface');

--- a/packages/apputils-extension/src/palette.ts
+++ b/packages/apputils-extension/src/palette.ts
@@ -137,7 +137,7 @@ export namespace Palette {
         b => b.command === CommandIDs.activate
       );
       if (binding) {
-        const ks = CommandRegistry.formatKeystroke(binding.keys.join(' '));
+        const ks = binding.keys.map(CommandRegistry.formatKeystroke).join(', ');
         palette.title.caption = trans.__('Commands (%1)', ks);
       } else {
         palette.title.caption = trans.__('Commands');

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -190,7 +190,7 @@ const browser: JupyterFrontEndPlugin<void> = {
         b => b.command === CommandIDs.toggleBrowser
       );
       if (binding) {
-        const ks = CommandRegistry.formatKeystroke(binding.keys.join(' '));
+        const ks = binding.keys.map(CommandRegistry.formatKeystroke).join(', ');
         browser.title.caption = trans.__('File Browser (%1)', ks);
       } else {
         browser.title.caption = trans.__('File Browser');

--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -1073,7 +1073,7 @@ namespace Private {
     // Shows hot keys in tooltips
     const binding = commands.keyBindings.find(b => b.command === id);
     if (binding) {
-      const ks = CommandRegistry.formatKeystroke(binding.keys.join(' '));
+      const ks = binding.keys.map(CommandRegistry.formatKeystroke).join(', ');
       tooltip = `${tooltip} (${ks})`;
     }
     const onClick = () => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #13180
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Format a list of keystrokes as for Lumino menus

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Multiple keystroke shortcut will be correctly displayed (like `D, D` on command toolbar button)

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None