### PR TITLE
Optimize text mimerenderer: ansi vs autolink 

### DIFF
--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -684,7 +684,7 @@ export function renderText(options: renderText.IRenderOptions): Promise<void> {
       if (!nodes[0]) {
         combinedNodes.push(nodes[1]);
         inAnchorElement = nodes[1].nodeType !== Node.TEXT_NODE;
-        continue
+        continue;
       } else if(!nodes[1]) {
         combinedNodes.push(nodes[0]);
         inAnchorElement = false;

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -563,11 +563,12 @@ function splitShallowNode<T extends Node>(
   };
 }
 
-
 /**
  * Iterate over some nodes, while tracking cumulative start and end position.
  */
-function* nodeIter<T extends Node>(nodes: T[]): IterableIterator<{node: T, start: number, end: number, isText: boolean}> {
+function* nodeIter<T extends Node>(
+  nodes: T[]
+): IterableIterator<{ node: T; start: number; end: number; isText: boolean }> {
   let start = 0;
   let end;
   for (let node of nodes) {
@@ -576,12 +577,11 @@ function* nodeIter<T extends Node>(nodes: T[]): IterableIterator<{node: T, start
       node,
       start,
       end,
-      isText: node.nodeType === Node.TEXT_NODE,
+      isText: node.nodeType === Node.TEXT_NODE
     };
     start = end;
   }
 }
-
 
 /**
  * Align two collections of nodes.
@@ -589,7 +589,10 @@ function* nodeIter<T extends Node>(nodes: T[]): IterableIterator<{node: T, start
  * If a text node in one collections spans an element in the other, yield the spanned elements.
  * Otherwise, split the nodes such that yielded pair start and stop on the same position.
  */
-function* alignedNodes<T extends Node, U extends Node>(a: T[], b: U[]): IterableIterator<[T, null] | [null, U] | [T, U]> {
+function* alignedNodes<T extends Node, U extends Node>(
+  a: T[],
+  b: U[]
+): IterableIterator<[T, null] | [null, U] | [T, U]> {
   let iterA = nodeIter(a);
   let iterB = nodeIter(b);
   let nA = iterA.next();
@@ -622,7 +625,9 @@ function* alignedNodes<T extends Node, U extends Node>(a: T[], b: U[]): Iterable
         let { pre, post } = splitShallowNode(A.node, B.end - A.start);
         if (B.start < A.start) {
           // this node should not be yielded anywhere else, so ok to modify in-place
-          B.node.textContent = B.node.textContent?.slice(A.start - B.start) as string;
+          B.node.textContent = B.node.textContent?.slice(
+            A.start - B.start
+          ) as string;
         }
         yield [pre, B.node];
         // Modify iteration result in-place:
@@ -633,7 +638,9 @@ function* alignedNodes<T extends Node, U extends Node>(a: T[], b: U[]): Iterable
         let { pre, post } = splitShallowNode(B.node, A.end - B.start);
         if (A.start < B.start) {
           // this node should not be yielded anywhere else, so ok to modify in-place
-          A.node.textContent = A.node.textContent?.slice(B.start - A.start) as string;
+          A.node.textContent = A.node.textContent?.slice(
+            B.start - A.start
+          ) as string;
         }
         yield [A.node, pre];
         // Modify iteration result in-place:
@@ -641,12 +648,13 @@ function* alignedNodes<T extends Node, U extends Node>(a: T[], b: U[]): Iterable
         B.start = A.end;
         nA = iterA.next();
       } else {
-        throw new Error(`Unexpected intersection: ${JSON.stringify(A)} ${JSON.stringify(B)}`);
+        throw new Error(
+          `Unexpected intersection: ${JSON.stringify(A)} ${JSON.stringify(B)}`
+        );
       }
     }
   }
 }
-
 
 /**
  * Render text into a host node.
@@ -680,12 +688,11 @@ export function renderText(options: renderText.IRenderOptions): Promise<void> {
     const preNodes = Array.from(pre.childNodes) as (Text | HTMLSpanElement)[];
 
     for (let nodes of alignedNodes(preNodes, linkedNodes)) {
-
       if (!nodes[0]) {
         combinedNodes.push(nodes[1]);
         inAnchorElement = nodes[1].nodeType !== Node.TEXT_NODE;
         continue;
-      } else if(!nodes[1]) {
+      } else if (!nodes[1]) {
         combinedNodes.push(nodes[0]);
         inAnchorElement = false;
         continue;

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -622,7 +622,7 @@ function* alignedNodes<T extends Node, U extends Node>(a: T[], b: U[]): Iterable
         let { pre, post } = splitShallowNode(A.node, B.end - A.start);
         if (B.start < A.start) {
           // this node should not be yielded anywhere else, so ok to modify in-place
-          B.node.textContent = B.node.textContent?.slice(B.start - A.start) as string;
+          B.node.textContent = B.node.textContent?.slice(A.start - B.start) as string;
         }
         yield [pre, B.node];
         // Modify iteration result in-place:
@@ -633,7 +633,7 @@ function* alignedNodes<T extends Node, U extends Node>(a: T[], b: U[]): Iterable
         let { pre, post } = splitShallowNode(B.node, A.end - B.start);
         if (A.start < B.start) {
           // this node should not be yielded anywhere else, so ok to modify in-place
-          A.node.textContent = A.node.textContent?.slice(A.start - B.start) as string;
+          A.node.textContent = A.node.textContent?.slice(B.start - A.start) as string;
         }
         yield [A.node, pre];
         // Modify iteration result in-place:

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -665,6 +665,7 @@ export function renderText(options: renderText.IRenderOptions): Promise<void> {
   });
 
   // Set the sanitized content for the host node.
+  const ret = document.createElement('pre');
   const pre = document.createElement('pre');
   pre.innerHTML = content;
 
@@ -720,10 +721,13 @@ export function renderText(options: renderText.IRenderOptions): Promise<void> {
         }
       }
     }
-    pre.replaceChildren(...combinedNodes);
+    // Do not reuse `pre` element. Clearing out previous children is too slow...
+    for (const child of combinedNodes) {
+      ret.appendChild(child);
+    }
   }
 
-  host.appendChild(pre);
+  host.appendChild(ret);
 
   // Return the rendered promise.
   return Promise.resolve(undefined);

--- a/packages/rendermime/test/factories.spec.ts
+++ b/packages/rendermime/test/factories.spec.ts
@@ -89,12 +89,12 @@ describe('rendermime/factories', () => {
         ],
         [
           'Prefix \x1b[48;2;185;0;129m spacer www.example.\x1b[0m\x1b[48;2;113;0;119mcom\x1b[0m',
-          '<pre>Prefix <span style="background-color:rgb(185,0,129)"> spacer </span><a href="https://www.example.com" rel="noopener" target="_blank"><span style=\"background-color:rgb(185,0,129)\">www.example.</span><span style="background-color:rgb(113,0,119)">com</span></a></pre>'
+          '<pre>Prefix <span style="background-color:rgb(185,0,129)"> spacer </span><a href="https://www.example.com" rel="noopener" target="_blank"><span style="background-color:rgb(185,0,129)">www.example.</span><span style="background-color:rgb(113,0,119)">com</span></a></pre>'
         ],
         [
           'Prefix www.example.\x1b[0m\x1b[48;2;113;0;119mcom postfix\x1b[0m',
           '<pre>Prefix <a href="https://www.example.com" rel="noopener" target="_blank">www.example.<span style="background-color:rgb(113,0,119)">com</span></a><span style="background-color:rgb(113,0,119)"> postfix</span></pre>'
-        ],
+        ]
       ])(
         'should output the correct HTML with ansi colors',
         async (source, expected) => {

--- a/packages/rendermime/test/factories.spec.ts
+++ b/packages/rendermime/test/factories.spec.ts
@@ -86,7 +86,15 @@ describe('rendermime/factories', () => {
         [
           '\x1b[48;2;185;0;129mwww.example.\x1b[0m\x1b[48;2;113;0;119mcom\x1b[0m',
           '<pre><a href="https://www.example.com" rel="noopener" target="_blank"><span style="background-color:rgb(185,0,129)">www.example.</span><span style="background-color:rgb(113,0,119)">com</span></a></pre>'
-        ]
+        ],
+        [
+          'Prefix \x1b[48;2;185;0;129m spacer www.example.\x1b[0m\x1b[48;2;113;0;119mcom\x1b[0m',
+          '<pre>Prefix <span style="background-color:rgb(185,0,129)"> spacer </span><a href="https://www.example.com" rel="noopener" target="_blank"><span style=\"background-color:rgb(185,0,129)\">www.example.</span><span style="background-color:rgb(113,0,119)">com</span></a></pre>'
+        ],
+        [
+          'Prefix www.example.\x1b[0m\x1b[48;2;113;0;119mcom postfix\x1b[0m',
+          '<pre>Prefix <a href="https://www.example.com" rel="noopener" target="_blank">www.example.<span style="background-color:rgb(113,0,119)">com</span></a><span style="background-color:rgb(113,0,119)"> postfix</span></pre>'
+        ],
       ])(
         'should output the correct HTML with ansi colors',
         async (source, expected) => {
@@ -165,18 +173,18 @@ describe('rendermime/factories', () => {
           })
         );
       });
-    });
 
-    it('should autolink multiple URLs', async () => {
-      const source = 'www.example.com\nwww.python.org';
-      const expected =
-        '<pre><a href="https://www.example.com" rel="noopener" target="_blank">www.example.com</a>\n<a href="https://www.python.org" rel="noopener" target="_blank">www.python.org</a></pre>';
-      const f = textRendererFactory;
-      const mimeType = 'text/plain';
-      const model = createModel(mimeType, source);
-      const w = f.createRenderer({ mimeType, ...defaultOptions });
-      await w.renderModel(model);
-      expect(w.node.innerHTML).toBe(expected);
+      it('should autolink multiple URLs', async () => {
+        const source = 'www.example.com\nwww.python.org';
+        const expected =
+          '<pre><a href="https://www.example.com" rel="noopener" target="_blank">www.example.com</a>\n<a href="https://www.python.org" rel="noopener" target="_blank">www.python.org</a></pre>';
+        const f = textRendererFactory;
+        const mimeType = 'text/plain';
+        const model = createModel(mimeType, source);
+        const w = f.createRenderer({ mimeType, ...defaultOptions });
+        await w.renderModel(model);
+        expect(w.node.innerHTML).toBe(expected);
+      });
     });
   });
 

--- a/testutils/src/jest-config.ts
+++ b/testutils/src/jest-config.ts
@@ -8,9 +8,9 @@ import path from 'path';
 const esModules = [
   '@codemirror',
   'lib0',
-  'vscode\\-ws\\-jsonrpc',
-  'y\\-protocols',
-  'y\\-websocket',
+  'vscode-ws-jsonrpc',
+  'y-protocols',
+  'y-websocket',
   'yjs'
 ].join('|');
 


### PR DESCRIPTION
## References

Fixes JS tests on Windows by removing some backslashes that were added in #10301.

Optimizes ansi color coding vs auto-linking in plain text rendermime. #11272

## Code changes

This optimizes the rendering for cases where there are many more elements of one type than the other. E.g. for a large syntax highlighted source file. In this case there can be many (tens of) thousands of span elements, but likely only a few links. In this case, multiple span elements will all correspond to a single text node in the autolink output. In these cases, we can simply use the nodes from the span element list, without splitting / cloning any nodes. This greatly reduces the time spent.

## User-facing changes

UI hangs less. For an extremely symptomatic file in the inspector, time spent is reduced from ~40s to ~4s.

Old, 41s:
![renderText-old-41s](https://user-images.githubusercontent.com/510760/194617139-8edbc4c0-4412-4deb-bfb5-38e3c77106cd.png)

New, 4s:
![renderText-new-3s](https://user-images.githubusercontent.com/510760/194617148-bd4f7874-acf4-486a-a968-8283e140d457.png)

## Backwards-incompatible changes

Should only change internal details. Ideally this would be backported to 3.x , but then we would likely need to rewrite using lumino iterators.
