### PR TITLE
Update docs to `jupyter_server_config.py`

### DIFF
--- a/binder/start
+++ b/binder/start
@@ -3,6 +3,8 @@ import sys
 import shutil
 import os
 
+# using jupyter_notebook_config.py for now since Binder is still starting the
+# classic notebook server
 argv = sys.argv[1:] + ["--config", "binder/jupyter_notebook_config.py"]
 print(argv)
 

--- a/docs/source/getting_started/faq.rst
+++ b/docs/source/getting_started/faq.rst
@@ -42,4 +42,4 @@ Tips and Tricks
 
 - How do I start JupyterLab with a clean workspace every time?
 
-Add ``'c.NotebookApp.default_url = '/lab?reset'`` to your ``jupyter_notebook_config.py``. See `How to create a jupyter_notebook_config.py <https://jupyter-notebook.readthedocs.io/en/stable/config.html>`__ for more information.
+Add ``'c.ServerApp.default_url = '/lab?reset'`` to your ``jupyter_server_config.py``. See `How to create a jupyter_server_config.py <https://jupyter-server.readthedocs.io/en/latest/users/configuration.html>`__ for more information.

--- a/docs/source/user/directories.rst
+++ b/docs/source/user/directories.rst
@@ -59,7 +59,7 @@ Disabling Rebuild Checks
 JupyterLab automatically checks to see if it needs to rebuild on startup. In
 some cases, such as automated testing, you may wish to disable the startup
 rebuild checks altogether. This can be achieved through setting ``buildCheck``
-and ``buildAvailable`` in ``jupyter_notebook_config.json`` (or ``.py``
+and ``buildAvailable`` in ``jupyter_server_config.json`` (or ``.py``
 equivalent) in any of the ``config`` locations returned by ``jupyter
 --paths``.
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/12897

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Updates the `latest` docs to mention `jupyter_server_config,py` instead of the deprecated `jupyter_notebook_config.py`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Documentation update.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
