### PR TITLE
Store original path as returned from contents API in the `Contents.IModel`

### DIFF
--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -50,6 +50,14 @@ export namespace Contents {
     readonly path: string;
 
     /**
+     * The path as returned by the server contents API.
+     *
+     * #### Notes
+     * Differently to `path` it does not include IDrive API prefix.
+     */
+    readonly serverPath?: string;
+
+    /**
      * The type of file.
      */
     readonly type: ContentType;
@@ -716,12 +724,14 @@ export class ContentsManager implements Contents.IManager {
         return {
           ...contentsModel,
           path: this._toGlobalPath(drive, localPath),
-          content: listing
+          content: listing,
+          serverPath: contentsModel.path
         } as Contents.IModel;
       } else {
         return {
           ...contentsModel,
-          path: this._toGlobalPath(drive, localPath)
+          path: this._toGlobalPath(drive, localPath),
+          serverPath: contentsModel.path
         } as Contents.IModel;
       }
     });
@@ -759,7 +769,8 @@ export class ContentsManager implements Contents.IManager {
         .then(contentsModel => {
           return {
             ...contentsModel,
-            path: PathExt.join(globalPath, contentsModel.name)
+            path: PathExt.join(globalPath, contentsModel.name),
+            serverPath: contentsModel.path
           } as Contents.IModel;
         });
     } else {
@@ -798,7 +809,8 @@ export class ContentsManager implements Contents.IManager {
     return drive1.rename(path1, path2).then(contentsModel => {
       return {
         ...contentsModel,
-        path: this._toGlobalPath(drive1, path2)
+        path: this._toGlobalPath(drive1, path2),
+        serverPath: contentsModel.path
       } as Contents.IModel;
     });
   }
@@ -825,7 +837,11 @@ export class ContentsManager implements Contents.IManager {
     return drive
       .save(localPath, { ...options, path: localPath })
       .then(contentsModel => {
-        return { ...contentsModel, path: globalPath } as Contents.IModel;
+        return {
+          ...contentsModel,
+          path: globalPath,
+          serverPath: contentsModel.path
+        } as Contents.IModel;
       });
   }
 
@@ -849,7 +865,8 @@ export class ContentsManager implements Contents.IManager {
       return drive1.copy(path1, path2).then(contentsModel => {
         return {
           ...contentsModel,
-          path: this._toGlobalPath(drive1, contentsModel.path)
+          path: this._toGlobalPath(drive1, contentsModel.path),
+          serverPath: contentsModel.path
         } as Contents.IModel;
       });
     } else {

--- a/packages/services/test/contents/index.spec.ts
+++ b/packages/services/test/contents/index.spec.ts
@@ -262,6 +262,24 @@ describe('contents', () => {
       const get = contents.get('/foo');
       await expect(get).rejects.toThrow(/Invalid response: 201 Created/);
     });
+
+    it('should store original server path for directory', async () => {
+      const drive = new Drive({ name: 'other', serverSettings });
+      contents.addDrive(drive);
+      handleRequest(drive, 200, DEFAULT_DIR);
+      const options: Contents.IFetchOptions = { type: 'directory' };
+      const model = await contents.get('other:/foo', options);
+      expect(model.serverPath).toBe('foo/bar');
+    });
+
+    it('should store original server path for a file', async () => {
+      const drive = new Drive({ name: 'other', serverSettings });
+      contents.addDrive(drive);
+      handleRequest(drive, 200, DEFAULT_FILE);
+      const options: Contents.IFetchOptions = { type: 'file' };
+      const model = await contents.get('other:/foo', options);
+      expect(model.serverPath).toBe('foo/test');
+    });
   });
 
   describe('#getDownloadUrl()', () => {


### PR DESCRIPTION
## References

Fixes #13155 using solution (b) as proposed solutions in https://github.com/jupyterlab/jupyterlab/issues/13155#issuecomment-1264770051. I have moderate doubts on whether this is the best solution; (c) seems cleaner but I am not convinced if getting the cleaner solution is worth introducing a breaking change, see discussion in #13155 (whereas this PR could still be backported to 3.5).

## Code changes

Adds optional `serverPath` attribute to `Contents.IModel` and populates it in `ContentsManager` methods by path returned by the server.

Note: an example of the issue was actually in our tests all along: `DEFAULT_FILE` has path `foo/test` which is correctly returned when creating a file:

https://github.com/jupyterlab/jupyterlab/blob/376e52c2fbeae00849a836533d6621ce1b724197/packages/services/test/contents/index.spec.ts#L329-L335

but when a file is queried with `get`:

https://github.com/jupyterlab/jupyterlab/blob/376e52c2fbeae00849a836533d6621ce1b724197/packages/services/test/contents/index.spec.ts#L242-L249

then `other:foo` instead of `other:foo/test` gets returned. This PR adds `foo/test` on extra property, `serverPath` (which for now is optional in the interface).

## User-facing changes

None.

## Backwards-incompatible changes

None