### PR TITLE
Removes triggering an event when replacing pasted text

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -666,7 +666,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
    * @param text The text to be inserted.
    */
   replaceSelection(text: string): void {
-    this.editor.dispatch(this.state.replaceSelection(text));
+    this.state.replaceSelection(text);
   }
 
   /**


### PR DESCRIPTION

## References
Fixes #13206

## Code changes
On AttachmentsCells, we listen for `paste` events and replace the pasted text with the attachment if necessary. When this occurs, we trigger a new change event from codemirror. That's why we were pasting the text twice. This PR prevents triggering a second event.

## User-facing changes
N/A

## Backwards-incompatible changes
N/A
