### PR TITLE
Enable RTC by default when starting JL in the Gitpod setup

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -32,7 +32,7 @@ tasks:
       source /workspace/bin/activate-env.sh
       # Set no token and allow any origin, so that you can open it in a new tab
       # Disable iframe security so can load in the editor as well
-      jupyter lab --dev-mode --watch --LabApp.token='' --LabApp.allow_origin=* --LabApp.tornado_settings='{"headers": {"Content-Security-Policy": "frame-ancestors *"}}'
+      jupyter lab --collaborative --dev-mode --watch --LabApp.token='' --LabApp.allow_origin=* --LabApp.tornado_settings='{"headers": {"Content-Security-Policy": "frame-ancestors *"}}'
 
   - name: auto-activate
     command: |


### PR DESCRIPTION
## References

https://github.com/jupyterlab/jupyterlab/issues/13049#issuecomment-1277740779

## Code changes

Enable RTC by default when JupyterLab is started as part of Gitpod setup. The users sidebar shows up in JL in the test environment, and other RTC features can be tested once the 8888 port is made public in Gitpod.

## User-facing changes

None

## Backwards-incompatible changes

None
