### PR TITLE
Added scroll to Running Panel

### DIFF
--- a/packages/ui-components/style/sidepanel.css
+++ b/packages/ui-components/style/sidepanel.css
@@ -7,6 +7,7 @@
   display: flex;
   flex-direction: column;
   min-width: var(--jp-sidebar-min-width);
+  overflow-y: scroll;
   color: var(--jp-ui-font-color1);
   background: var(--jp-layout-color1);
   font-size: var(--jp-ui-font-size1);


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fix https://github.com/jupyter/notebook/issues/6559

## Code changes

<!-- Describe the code changes and how they address the issue. -->
The code changes allow access to all sections of the Running Panel (by scrolling).

## User-facing changes

**Before**

[before.webm](https://user-images.githubusercontent.com/46336830/195672378-05bbe6ba-4084-49d3-93c8-2d936a3ae119.webm)



**After**

[after.webm](https://user-images.githubusercontent.com/46336830/195671350-5d05356a-3d8b-4adc-8c6b-b0cc280b52bb.webm)



## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
