### PR TITLE
Drop modelDB from code editor

### DIFF
--- a/galata/test/jupyterlab/cells-motion.spec.ts
+++ b/galata/test/jupyterlab/cells-motion.spec.ts
@@ -1,0 +1,170 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { expect, test } from '@jupyterlab/galata';
+
+const fileName = 'motion.ipynb';
+const cellSelector = '[role="main"] >> .jp-NotebookPanel >> .jp-Cell';
+
+test.beforeEach(async ({ page }) => {
+  await page.notebook.createNew(fileName);
+
+  // Populate the notebook
+  await page.notebook.setCell(0, 'markdown', '# Heading 1');
+  await page.notebook.addCell('code', '1+1');
+  await page.notebook.addCell('markdown', '## Heading 1.1');
+  await page.notebook.addCell('code', '2+2');
+  await page.notebook.addCell('markdown', '# Heading 2');
+  await page.notebook.addCell('code', '3+3');
+
+  await page.notebook.run();
+});
+
+test('Move down a cell', async ({ page }) => {
+  const content = await page
+    .locator(`${cellSelector} >> nth=2`)
+    .allTextContents();
+  await page
+    .locator(`${cellSelector} >> nth=2 >> .jp-InputArea-prompt`)
+    .click();
+
+  await page.keyboard.press('Control+Shift+ArrowDown');
+
+  await expect(page.locator(`${cellSelector} >> nth=3`)).toHaveClass(
+    /jp-mod-active/
+  );
+  expect(
+    await page.locator(`${cellSelector} >> nth=3`).allTextContents()
+  ).toEqual(content);
+});
+
+test('Move up a cell', async ({ page }) => {
+  const content = await page
+    .locator(`${cellSelector} >> nth=2`)
+    .allTextContents();
+  await page
+    .locator(`${cellSelector} >> nth=2 >> .jp-InputArea-prompt`)
+    .click();
+  await page.keyboard.press('Control+Shift+ArrowUp');
+
+  await expect(page.locator(`${cellSelector} >> nth=1`)).toHaveClass(
+    /jp-mod-active/
+  );
+  expect(
+    await page.locator(`${cellSelector} >> nth=1`).allTextContents()
+  ).toEqual(content);
+});
+
+test('Move down two cells with first active', async ({ page }) => {
+  const content1 = await page
+    .locator(`${cellSelector} >> nth=2`)
+    .allTextContents();
+  const content2 = await page
+    .locator(`${cellSelector} >> nth=3`)
+    .allTextContents();
+
+  await page
+    .locator(`${cellSelector} >> nth=3 >> .jp-InputArea-prompt`)
+    .click();
+
+  await page.keyboard.press('Shift+ArrowUp');
+  await page.keyboard.press('Control+Shift+ArrowDown');
+
+  await expect(page.locator(`${cellSelector} >> nth=3`)).toHaveClass(
+    /jp-mod-active/
+  );
+  await expect(page.locator(`${cellSelector} >> nth=4`)).toHaveClass(
+    /jp-mod-selected/
+  );
+  expect(
+    await page.locator(`${cellSelector} >> nth=3`).allTextContents()
+  ).toEqual(content1);
+  expect(
+    await page.locator(`${cellSelector} >> nth=4`).allTextContents()
+  ).toEqual(content2);
+});
+
+test('Move up two cells with first active', async ({ page }) => {
+  const content1 = await page
+    .locator(`${cellSelector} >> nth=2`)
+    .allTextContents();
+  const content2 = await page
+    .locator(`${cellSelector} >> nth=3`)
+    .allTextContents();
+
+  await page
+    .locator(`${cellSelector} >> nth=3 >> .jp-InputArea-prompt`)
+    .click();
+
+  await page.keyboard.press('Shift+ArrowUp');
+  await page.keyboard.press('Control+Shift+ArrowUp');
+
+  await expect(page.locator(`${cellSelector} >> nth=1`)).toHaveClass(
+    /jp-mod-active/
+  );
+  await expect(page.locator(`${cellSelector} >> nth=2`)).toHaveClass(
+    /jp-mod-selected/
+  );
+  expect(
+    await page.locator(`${cellSelector} >> nth=1`).allTextContents()
+  ).toEqual(content1);
+  expect(
+    await page.locator(`${cellSelector} >> nth=2`).allTextContents()
+  ).toEqual(content2);
+});
+
+test('Move down two cells with last active', async ({ page }) => {
+  const content1 = await page
+    .locator(`${cellSelector} >> nth=2`)
+    .allTextContents();
+  const content2 = await page
+    .locator(`${cellSelector} >> nth=3`)
+    .allTextContents();
+
+  await page
+    .locator(`${cellSelector} >> nth=2 >> .jp-InputArea-prompt`)
+    .click();
+  await page.keyboard.press('Shift+ArrowDown');
+  await page.keyboard.press('Control+Shift+ArrowDown');
+
+  await expect(page.locator(`${cellSelector} >> nth=3`)).toHaveClass(
+    /jp-mod-selected/
+  );
+  await expect(page.locator(`${cellSelector} >> nth=4`)).toHaveClass(
+    /jp-mod-active/
+  );
+  expect(
+    await page.locator(`${cellSelector} >> nth=3`).allTextContents()
+  ).toEqual(content1);
+  expect(
+    await page.locator(`${cellSelector} >> nth=4`).allTextContents()
+  ).toEqual(content2);
+});
+
+test('Move up two cells with last active', async ({ page }) => {
+  const content1 = await page
+    .locator(`${cellSelector} >> nth=2`)
+    .allTextContents();
+  const content2 = await page
+    .locator(`${cellSelector} >> nth=3`)
+    .allTextContents();
+  await page
+    .locator(`${cellSelector} >> nth=2 >> .jp-InputArea-prompt`)
+    .click();
+
+  await page.keyboard.press('Shift+ArrowDown');
+  await page.keyboard.press('Control+Shift+ArrowDown');
+
+  await expect(page.locator(`${cellSelector} >> nth=3`)).toHaveClass(
+    /jp-mod-selected/
+  );
+  await expect(page.locator(`${cellSelector} >> nth=4`)).toHaveClass(
+    /jp-mod-active/
+  );
+  expect(
+    await page.locator(`${cellSelector} >> nth=3`).allTextContents()
+  ).toEqual(content1);
+  expect(
+    await page.locator(`${cellSelector} >> nth=4`).allTextContents()
+  ).toEqual(content2);
+});

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -217,9 +217,15 @@ export function isRawCellModel(model: ICellModel): model is IRawCellModel {
  */
 export abstract class CellModel extends CodeEditor.Model implements ICellModel {
   constructor(options: CellModel.IOptions<ISharedCell> = {}) {
+    const { cell_type, sharedModel, ...others } = options;
     super({
-      sharedModel: createStandaloneCell({ cell_type: 'raw', id: options.id }),
-      ...options
+      sharedModel:
+        sharedModel ??
+        createStandaloneCell({
+          cell_type: cell_type ?? 'raw',
+          id: options.id
+        }),
+      ...others
     });
     this.standaloneModel = typeof options.sharedModel === 'undefined';
     this.trusted = !!this.getMetadata('trusted') || !!options.trusted;
@@ -369,6 +375,12 @@ export namespace CellModel {
      * The cell shared model.
      */
     sharedModel?: T;
+
+    /**
+     * The cell type
+     */
+    cell_type?: string;
+
     /**
      * Whether the cell is trusted or not.
      */
@@ -464,15 +476,15 @@ export class RawCellModel extends AttachmentsCellModel {
   /**
    * Construct a raw cell model from optional shared model.
    */
-  constructor(options: AttachmentsCellModel.IOptions<ISharedRawCell> = {}) {
+  constructor(
+    options: Omit<
+      AttachmentsCellModel.IOptions<ISharedRawCell>,
+      'cell_type'
+    > = {}
+  ) {
     super({
-      ...options,
-      sharedModel:
-        options?.sharedModel ||
-        (createStandaloneCell({
-          cell_type: 'raw',
-          id: options.id
-        }) as ISharedRawCell)
+      cell_type: 'raw',
+      ...options
     });
   }
 
@@ -499,16 +511,14 @@ export class MarkdownCellModel extends AttachmentsCellModel {
    * Construct a markdown cell model from optional shared model.
    */
   constructor(
-    options: AttachmentsCellModel.IOptions<ISharedMarkdownCell> = {}
+    options: Omit<
+      AttachmentsCellModel.IOptions<ISharedMarkdownCell>,
+      'cell_type'
+    > = {}
   ) {
     super({
-      ...options,
-      sharedModel:
-        options?.sharedModel ||
-        (createStandaloneCell({
-          cell_type: 'markdown',
-          id: options.id
-        }) as ISharedMarkdownCell)
+      cell_type: 'markdown',
+      ...options
     });
     // Use the Github-flavored markdown mode.
     this.mimeType = 'text/x-ipythongfm';
@@ -538,10 +548,8 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
    */
   constructor(options: CodeCellModel.IOptions = {}) {
     super({
-      ...options,
-      sharedModel:
-        options?.sharedModel ??
-        createStandaloneCell({ cell_type: 'code', id: options.id })
+      cell_type: 'code',
+      ...options
     });
 
     const factory =
@@ -740,7 +748,8 @@ export namespace CodeCellModel {
   /**
    * The options used to initialize a `CodeCellModel`.
    */
-  export interface IOptions extends CellModel.IOptions<ISharedCodeCell> {
+  export interface IOptions
+    extends Omit<CellModel.IOptions<ISharedCodeCell>, 'cell_type'> {
     /**
      * The factory for output area model creation.
      */

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -13,27 +13,23 @@ import { IChangedArgs } from '@jupyterlab/coreutils';
 
 import * as nbformat from '@jupyterlab/nbformat';
 
-import * as models from '@jupyterlab/shared-models';
-
-import { JSONExt } from '@lumino/coreutils';
-
-import {
-  IObservableJSON,
-  IObservableValue,
-  ObservableValue
-} from '@jupyterlab/observables';
+import { ObservableValue } from '@jupyterlab/observables';
 
 import { IOutputAreaModel, OutputAreaModel } from '@jupyterlab/outputarea';
 
 import {
+  CellChange,
+  createMutex,
   createStandaloneCell,
+  IMapChange,
   ISharedCell,
   ISharedCodeCell,
   ISharedMarkdownCell,
-  ISharedRawCell
+  ISharedRawCell,
+  YCodeCell
 } from '@jupyterlab/shared-models';
 
-const globalModelDBMutex = models.createMutex();
+const globalModelDBMutex = createMutex();
 
 /**
  * The definition of a model object for a cell.
@@ -69,13 +65,49 @@ export interface ICellModel extends CodeEditor.IModel {
 
   /**
    * The metadata associated with the cell.
+   *
+   * ### Notes
+   * This is a copy of the metadata. Changing a part of it
+   * won't affect the model.
+   * As this returns a copy of all metadata, it is advised to
+   * use `getMetadata` to speed up the process of getting a single key.
    */
-  readonly metadata: IObservableJSON;
+  readonly metadata: Omit<nbformat.IBaseCellMetadata, 'trusted'>;
+
+  /**
+   * Signal emitted when cell metadata changes.
+   */
+  readonly metadataChanged: ISignal<ICellModel, IMapChange>;
 
   /**
    * The cell shared model.
    */
-  readonly sharedModel: models.ISharedCell;
+  readonly sharedModel: ISharedCell;
+
+  /**
+   * Delete a metadata.
+   *
+   * @param key Metadata key
+   */
+  deleteMetadata(key: string): void;
+
+  /**
+   * Get a metadata
+   *
+   * ### Notes
+   * This returns a copy of the key value.
+   *
+   * @param key Metadata key
+   */
+  getMetadata(key: string): any;
+
+  /**
+   * Set a metadata
+   *
+   * @param key Metadata key
+   * @param value Metadata value
+   */
+  setMetadata(key: string, value: any): void;
 
   /**
    * Serialize the model to JSON.
@@ -133,7 +165,7 @@ export interface ICodeCellModel extends ICellModel {
   /**
    * The code cell shared model
    */
-  readonly sharedModel: models.ISharedCodeCell;
+  readonly sharedModel: ISharedCodeCell;
 }
 
 /**
@@ -183,45 +215,37 @@ export function isRawCellModel(model: ICellModel): model is IRawCellModel {
 /**
  * An implementation of the cell model.
  */
-export class CellModel extends CodeEditor.Model implements ICellModel {
+export abstract class CellModel extends CodeEditor.Model implements ICellModel {
   constructor(options: CellModel.IOptions<ISharedCell> = {}) {
     super({
       sharedModel: createStandaloneCell({ cell_type: 'raw', id: options.id }),
       ...options
     });
-    this._standaloneModel = typeof options.sharedModel === 'undefined';
+    this.standaloneModel = typeof options.sharedModel === 'undefined';
+    this.trusted = !!this.getMetadata('trusted') || !!options.trusted;
 
     this.sharedModel.changed.connect(this.onGenericChange, this);
-    this.sharedModel.changed.connect(this.onSharedModelChanged, this);
-
-    const observableMetadata = this.modelDB.createMap('metadata');
-    const metadata = JSONExt.deepCopy(this.sharedModel.getMetadata());
-    const trusted = this.modelDB.createValue('trusted');
-    const cellType = this.modelDB.createValue('type');
-    cellType.set(this.type);
-    for (const key in metadata) {
-      observableMetadata.set(key, metadata[key]);
-    }
-    observableMetadata.changed.connect(this.onModelDBMetadataChange, this);
-    trusted.changed.connect(this.onTrustedChanged, this);
-    trusted.set(!!metadata.trusted || !!options.trusted);
+    this.sharedModel.metadataChanged.connect(this._onMetadataChanged, this);
   }
 
-  readonly sharedModel: models.ISharedCell;
+  readonly sharedModel: ISharedCell;
 
   /**
    * The type of cell.
    */
-  get type(): nbformat.CellType {
-    // This getter really should be abstract, but our current constructor
-    // depends on .type working
-    return 'raw';
-  }
+  abstract get type(): nbformat.CellType;
 
   /**
    * A signal emitted when the state of the model changes.
    */
   readonly contentChanged = new Signal<this, void>(this);
+
+  /**
+   * Signal emitted when cell metadata changes.
+   */
+  get metadataChanged(): ISignal<ICellModel, IMapChange> {
+    return this._metadataChanged;
+  }
 
   /**
    * A signal emitted when a model state changes.
@@ -241,36 +265,22 @@ export class CellModel extends CodeEditor.Model implements ICellModel {
   /**
    * The metadata associated with the cell.
    */
-  get metadata(): IObservableJSON {
-    return this.modelDB.get('metadata') as IObservableJSON;
+  get metadata(): Omit<nbformat.IBaseCellMetadata, 'trusted'> {
+    return this.sharedModel.metadata;
   }
 
   /**
-   * Get the trusted state of the model.
+   * The trusted state of the model.
    */
   get trusted(): boolean {
-    return this.modelDB.getValue('trusted') as boolean;
+    return this._trusted;
   }
-
-  /**
-   * Set the trusted state of the model.
-   */
   set trusted(newValue: boolean) {
     const oldValue = this.trusted;
-    if (oldValue === newValue) {
-      return;
+    if (oldValue !== newValue) {
+      this._trusted = newValue;
+      this.onTrustedChanged(this, { newValue, oldValue });
     }
-    this.modelDB.setValue('trusted', newValue);
-  }
-
-  dispose(): void {
-    if (this.isDisposed) {
-      return;
-    }
-    if (this._standaloneModel) {
-      this.sharedModel.dispose();
-    }
-    super.dispose();
   }
 
   /**
@@ -279,10 +289,45 @@ export class CellModel extends CodeEditor.Model implements ICellModel {
    * The default implementation is a no-op.
    */
   onTrustedChanged(
-    trusted: IObservableValue,
+    trusted: CellModel,
     args: ObservableValue.IChangedArgs
   ): void {
     /* no-op */
+  }
+
+  /**
+   * Delete a metadata
+   *
+   * @param key Metadata key
+   */
+  deleteMetadata(key: string): any {
+    return this.sharedModel.deleteMetadata(key);
+  }
+
+  /**
+   * Get a metadata
+   *
+   * ### Notes
+   * This returns a copy of the key value.
+   *
+   * @param key Metadata key
+   */
+  getMetadata(key: string): any {
+    return this.sharedModel.getMetadata(key);
+  }
+
+  /**
+   * Set a metadata
+   *
+   * @param key Metadata key
+   * @param value Metadata value
+   */
+  setMetadata(key: string, value: any): void {
+    if (typeof value === 'undefined') {
+      this.sharedModel.deleteMetadata(key);
+    } else {
+      this.sharedModel.setMetadata(key, value);
+    }
   }
 
   /**
@@ -299,105 +344,12 @@ export class CellModel extends CodeEditor.Model implements ICellModel {
     this.contentChanged.emit(void 0);
   }
 
-  /**
-   * Handle a change to the cell metadata modelDB and reflect it in the shared model.
-   */
-  protected onModelDBMetadataChange(
-    sender: IObservableJSON,
-    event: IObservableJSON.IChangedArgs
-  ): void {
-    const metadata = this.sharedModel.getMetadata();
-    switch (event.type) {
-      case 'add':
-        this._changeCellMetadata(metadata, event);
-        break;
-      case 'change':
-        this._changeCellMetadata(metadata, event);
-        break;
-      case 'remove':
-        delete metadata[event.key];
-        if (event.key === 'collapsed' && metadata.jupyter) {
-          delete metadata.jupyter.outputs_hidden;
-          if (Object.keys(metadata.jupyter).length === 0) {
-            delete metadata.jupyter;
-          }
-        }
-        if (event.key === 'jupyter') {
-          delete metadata.collapsed;
-        }
-        break;
-      default:
-        throw new Error(`Invalid event type: ${event.type}`);
-    }
-    this.sharedModel.setMetadata(metadata);
+  private _onMetadataChanged(sender: ISharedCell, change: IMapChange) {
+    this._metadataChanged.emit(change);
   }
 
-  protected onSharedModelChanged(
-    sender: models.ISharedCell,
-    change: models.CellChange<nbformat.IBaseCellMetadata>
-  ) {
-    if (change.metadataChange) {
-      const newValue = change.metadataChange.newValue ?? {};
-      const oldValue = change.metadataChange.oldValue ?? {};
-      for (const key in newValue) {
-        if (
-          oldValue[key] === undefined ||
-          !JSONExt.deepEqual(newValue[key]!, oldValue[key]!)
-        ) {
-          this.metadata.set(key, newValue[key]);
-        }
-      }
-      this.metadata.keys().forEach(key => {
-        if (newValue[key] === undefined) {
-          this.metadata.delete(key);
-        }
-      });
-    }
-  }
-
-  /**
-   * Change the cell metadata for a given event.
-   *
-   * @param metadata The cell metadata.
-   * @param event The event to handle.
-   */
-  private _changeCellMetadata(
-    metadata: Partial<nbformat.IBaseCellMetadata>,
-    event: IObservableJSON.IChangedArgs
-  ): void {
-    switch (event.key) {
-      case 'jupyter':
-        metadata.jupyter = event.newValue as any;
-        if (metadata.jupyter?.outputs_hidden != null) {
-          metadata.collapsed = metadata.jupyter.outputs_hidden;
-        } else {
-          delete metadata.collapsed;
-        }
-        break;
-      case 'collapsed':
-        metadata.collapsed = event.newValue as any;
-        break;
-      case 'name':
-        metadata.name = event.newValue as any;
-        break;
-      case 'scrolled':
-        metadata.scrolled = event.newValue as any;
-        break;
-      case 'tags':
-        metadata.tags = event.newValue as any;
-        break;
-      case 'trusted':
-        metadata.trusted = event.newValue as any;
-        break;
-      default:
-        // The default is applied for custom metadata that are not
-        // defined in the official nbformat but which are defined
-        // by the user.
-        metadata[event.key] = event.newValue as any;
-    }
-  }
-
-  private readonly _standaloneModel: boolean;
+  private _metadataChanged = new Signal<this, IMapChange>(this);
+  private _trusted = false;
 }
 
 /**
@@ -427,7 +379,7 @@ export namespace CellModel {
 /**
  * A base implementation for cell models with attachments.
  */
-export class AttachmentsCellModel extends CellModel {
+export abstract class AttachmentsCellModel extends CellModel {
   /**
    * Construct a new cell with optional attachments.
    */
@@ -588,18 +540,19 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
     super({
       ...options,
       sharedModel:
-        options?.sharedModel ||
+        options?.sharedModel ??
         createStandaloneCell({ cell_type: 'code', id: options.id })
     });
-    const factory =
-      options?.contentFactory || CodeCellModel.defaultContentFactory;
-    const trusted = this.trusted;
-    let outputs: nbformat.IOutput[] = this.sharedModel.getOutputs();
-    this.sharedModel.changed.connect(this._onValueChanged, this);
 
+    const factory =
+      options?.contentFactory ?? CodeCellModel.defaultContentFactory;
+    const trusted = this.trusted;
+    const outputs = this.sharedModel.getOutputs();
     this._outputs = factory.createOutputArea({ trusted, values: outputs });
+
+    this.sharedModel.changed.connect(this._onSharedModelChanged, this);
     this._outputs.changed.connect(this.onGenericChange, this);
-    this._outputs.changed.connect(this.onModelDBOutputsChange, this);
+    this._outputs.changed.connect(this.onOutputsChange, this);
   }
 
   /**
@@ -638,7 +591,7 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
     return this._outputs;
   }
 
-  readonly sharedModel: models.ISharedCodeCell;
+  readonly sharedModel: ISharedCodeCell;
 
   clearExecution(): void {
     this.outputs.clear();
@@ -663,7 +616,7 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
    * Handle a change to the trusted state.
    */
   onTrustedChanged(
-    trusted: IObservableValue,
+    trusted: CellModel,
     args: ObservableValue.IChangedArgs
   ): void {
     const newTrusted = args.newValue as boolean;
@@ -693,11 +646,11 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
   /**
    * Handle a change to the cell outputs modelDB and reflect it in the shared model.
    */
-  protected onModelDBOutputsChange(
+  protected onOutputsChange(
     sender: IOutputAreaModel,
     event: IOutputAreaModel.ChangedArgs
   ): void {
-    const codeCell = this.sharedModel as models.YCodeCell;
+    const codeCell = this.sharedModel as YCodeCell;
     globalModelDBMutex(() => {
       switch (event.type) {
         case 'add': {
@@ -724,34 +677,19 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
   }
 
   /**
-   * Handle a change to the output shared model and reflect it in modelDB.
-   * We update the modeldb metadata when the nbcell changes.
-   *
-   * This method overrides the CellModel protected _onSharedModelChanged
-   * so we first call super._onSharedModelChanged
-   *
-   * @override CellModel._onSharedModelChanged
-   */
-  protected onSharedModelChanged(
-    sender: models.ISharedCodeCell,
-    change: models.CellChange<nbformat.ICodeCellMetadata>
-  ): void {
-    super.onSharedModelChanged(sender, change);
-    globalModelDBMutex(() => {
-      if (change.outputsChange) {
-        this.outputs.clear();
-        sender.getOutputs().forEach(output => this._outputs.add(output));
-      }
-    });
-  }
-
-  /**
    * Handle a change to the code cell value.
    */
-  private _onValueChanged(
-    slot: models.ISharedCodeCell,
-    change: models.CellChange<nbformat.ICodeCellMetadata>
+  private _onSharedModelChanged(
+    slot: ISharedCodeCell,
+    change: CellChange<nbformat.ICodeCellMetadata>
   ): void {
+    if (change.outputsChange) {
+      globalModelDBMutex(() => {
+        this.outputs.clear();
+        slot.getOutputs().forEach(output => this._outputs.add(output));
+      });
+    }
+
     if (change.executionCountChange) {
       if (
         change.executionCountChange.newValue &&
@@ -790,7 +728,7 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
     }
   }
 
-  private _executedCode: string = '';
+  private _executedCode = '';
   private _isDirty = false;
   private _outputs: IOutputAreaModel;
 }

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -624,7 +624,7 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
       this._outputs.trusted = newTrusted;
     }
     if (newTrusted) {
-      const codeCell = this.sharedModel as models.YCodeCell;
+      const codeCell = this.sharedModel as YCodeCell;
       const metadata = codeCell.getMetadata();
       metadata.trusted = true;
       codeCell.setMetadata(metadata);

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1154,9 +1154,7 @@ export class CodeCell extends Cell<ICodeCellModel> {
     // to changes in metadata until we have fully committed our changes.
     // Otherwise setting one key can trigger a write to the other key to
     // maintain the synced consistency.
-    this._savingMetadata = true;
-
-    try {
+    this.model.sharedModel.transact(() => {
       super.saveCollapseState();
 
       const collapsed = this.model.getMetadata('collapsed');
@@ -1175,9 +1173,7 @@ export class CodeCell extends Cell<ICodeCellModel> {
       } else {
         this.model.deleteMetadata('collapsed');
       }
-    } finally {
-      this._savingMetadata = false;
-    }
+    });
   }
 
   /**
@@ -1345,10 +1341,6 @@ export class CodeCell extends Cell<ICodeCellModel> {
    * Handle changes in the metadata.
    */
   protected onMetadataChanged(model: CellModel, args: IMapChange): void {
-    if (this._savingMetadata) {
-      // We are in middle of a metadata transaction, so don't react to it.
-      return;
-    }
     switch (args.key) {
       case 'scrolled':
         if (this.syncScrolled) {
@@ -1387,7 +1379,6 @@ export class CodeCell extends Cell<ICodeCellModel> {
   private _outputPlaceholder: OutputPlaceholder | null = null;
   private _output: OutputArea;
   private _syncScrolled = false;
-  private _savingMetadata = false;
 }
 
 /**

--- a/packages/cells/test/model.spec.ts
+++ b/packages/cells/test/model.spec.ts
@@ -34,7 +34,7 @@ describe('cells/model', () => {
   describe('CellModel', () => {
     describe('#constructor()', () => {
       it('should create a cell model', () => {
-        const model = new CodeCellModel({
+        const model = new TestModel({
           sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         expect(model).toBeInstanceOf(CellModel);
@@ -46,7 +46,7 @@ describe('cells/model', () => {
           source: 'foo',
           metadata: { trusted: false }
         }) as YRawCell;
-        const model = new RawCellModel({ sharedModel });
+        const model = new TestModel({ sharedModel });
         expect(model).toBeInstanceOf(CellModel);
         expect(model.sharedModel.getSource()).toBe('foo');
       });
@@ -58,7 +58,7 @@ describe('cells/model', () => {
           metadata: { trusted: false },
           id: 'cell_id'
         }) as YRawCell;
-        const model = new RawCellModel({ sharedModel });
+        const model = new TestModel({ sharedModel });
         expect(model).toBeInstanceOf(CellModel);
         expect(model.sharedModel.getSource()).toBe('foo\n\nbar\n\nbaz');
       });
@@ -70,13 +70,13 @@ describe('cells/model', () => {
           metadata: { trusted: false },
           id: 'cell_id'
         }) as YRawCell;
-        const model = new RawCellModel({ sharedModel, id: 'my_id' });
+        const model = new TestModel({ sharedModel, id: 'my_id' });
         expect(model).toBeInstanceOf(CellModel);
         expect(model.id).toBe('cell_id');
       });
 
       it('should use the id if an cell is not supplied', () => {
-        const model = new RawCellModel({ id: 'cell_id' });
+        const model = new TestModel({ id: 'cell_id' });
         expect(model).toBeInstanceOf(CellModel);
         expect(model.id).toBe('cell_id');
       });
@@ -87,7 +87,7 @@ describe('cells/model', () => {
           source: ['foo\n', 'bar\n', 'baz'],
           metadata: { trusted: false }
         }) as YRawCell;
-        const model = new RawCellModel({ sharedModel });
+        const model = new TestModel({ sharedModel });
         expect(model).toBeInstanceOf(CellModel);
         expect(model.id.length).toBeGreaterThan(0);
       });
@@ -95,7 +95,7 @@ describe('cells/model', () => {
 
     describe('#contentChanged', () => {
       it('should signal when model content has changed', () => {
-        const model = new CodeCellModel({
+        const model = new TestModel({
           sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         let called = false;
@@ -154,7 +154,6 @@ describe('cells/model', () => {
 
       it('should update the trusted state of the output models', () => {
         const model = new CodeCellModel();
-        console.log(model.trusted);
         model.outputs.add(NBTestUtils.DEFAULT_OUTPUTS[0]);
         expect(model.outputs.get(0).trusted).toBe(false);
         model.trusted = true;
@@ -207,14 +206,14 @@ describe('cells/model', () => {
 
     describe('#isDisposed', () => {
       it('should be false by default', () => {
-        const model = new CodeCellModel({
+        const model = new TestModel({
           sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         expect(model.isDisposed).toBe(false);
       });
 
       it('should be true after model is disposed', () => {
-        const model = new CodeCellModel({
+        const model = new TestModel({
           sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         model.dispose();
@@ -232,7 +231,7 @@ describe('cells/model', () => {
       });
 
       it('should be safe to call multiple times', () => {
-        const model = new CodeCellModel({
+        const model = new TestModel({
           sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         model.dispose();
@@ -274,7 +273,7 @@ describe('cells/model', () => {
 
     describe('#metadata', () => {
       it('should handle a metadata for the cell', () => {
-        const model = new CodeCellModel({
+        const model = new TestModel({
           sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         expect(model.getMetadata('foo')).toBeUndefined();
@@ -283,7 +282,7 @@ describe('cells/model', () => {
       });
 
       it('should get a list of user metadata keys', () => {
-        const model = new CodeCellModel({
+        const model = new TestModel({
           sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         expect(Array.from(Object.keys(model.metadata))).toHaveLength(0);
@@ -292,7 +291,7 @@ describe('cells/model', () => {
       });
 
       it('should trigger changed signal', () => {
-        const model = new CodeCellModel({
+        const model = new TestModel({
           sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         let called = false;

--- a/packages/cells/test/model.spec.ts
+++ b/packages/cells/test/model.spec.ts
@@ -34,8 +34,8 @@ describe('cells/model', () => {
   describe('CellModel', () => {
     describe('#constructor()', () => {
       it('should create a cell model', () => {
-        const model = new CellModel({
-          sharedModel: createStandaloneCell({ cell_type: 'code' })
+        const model = new CodeCellModel({
+          sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         expect(model).toBeInstanceOf(CellModel);
       });
@@ -45,8 +45,8 @@ describe('cells/model', () => {
           cell_type: 'raw',
           source: 'foo',
           metadata: { trusted: false }
-        });
-        const model = new CellModel({ sharedModel });
+        }) as YRawCell;
+        const model = new RawCellModel({ sharedModel });
         expect(model).toBeInstanceOf(CellModel);
         expect(model.sharedModel.getSource()).toBe('foo');
       });
@@ -57,8 +57,8 @@ describe('cells/model', () => {
           source: ['foo\n', 'bar\n', 'baz'],
           metadata: { trusted: false },
           id: 'cell_id'
-        });
-        const model = new CellModel({ sharedModel });
+        }) as YRawCell;
+        const model = new RawCellModel({ sharedModel });
         expect(model).toBeInstanceOf(CellModel);
         expect(model.sharedModel.getSource()).toBe('foo\n\nbar\n\nbaz');
       });
@@ -69,14 +69,14 @@ describe('cells/model', () => {
           source: ['foo\n', 'bar\n', 'baz'],
           metadata: { trusted: false },
           id: 'cell_id'
-        });
-        const model = new CellModel({ sharedModel, id: 'my_id' });
+        }) as YRawCell;
+        const model = new RawCellModel({ sharedModel, id: 'my_id' });
         expect(model).toBeInstanceOf(CellModel);
         expect(model.id).toBe('cell_id');
       });
 
       it('should use the id if an cell is not supplied', () => {
-        const model = new CellModel({ id: 'cell_id' });
+        const model = new RawCellModel({ id: 'cell_id' });
         expect(model).toBeInstanceOf(CellModel);
         expect(model.id).toBe('cell_id');
       });
@@ -86,8 +86,8 @@ describe('cells/model', () => {
           cell_type: 'raw',
           source: ['foo\n', 'bar\n', 'baz'],
           metadata: { trusted: false }
-        });
-        const model = new CellModel({ sharedModel });
+        }) as YRawCell;
+        const model = new RawCellModel({ sharedModel });
         expect(model).toBeInstanceOf(CellModel);
         expect(model.id.length).toBeGreaterThan(0);
       });
@@ -95,8 +95,8 @@ describe('cells/model', () => {
 
     describe('#contentChanged', () => {
       it('should signal when model content has changed', () => {
-        const model = new CellModel({
-          sharedModel: createStandaloneCell({ cell_type: 'code' })
+        const model = new CodeCellModel({
+          sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         let called = false;
         model.contentChanged.connect(() => {
@@ -154,6 +154,7 @@ describe('cells/model', () => {
 
       it('should update the trusted state of the output models', () => {
         const model = new CodeCellModel();
+        console.log(model.trusted);
         model.outputs.add(NBTestUtils.DEFAULT_OUTPUTS[0]);
         expect(model.outputs.get(0).trusted).toBe(false);
         model.trusted = true;
@@ -168,9 +169,9 @@ describe('cells/model', () => {
           value = args.newValue;
         };
         let value = '';
-        model.metadata.changed.connect(listener);
+        model.metadataChanged.connect(listener);
         expect(Object.keys(value)).toHaveLength(0);
-        model.metadata.set('foo', 'bar');
+        model.setMetadata('foo', 'bar');
         expect(value).toBe('bar');
       });
 
@@ -179,13 +180,13 @@ describe('cells/model', () => {
           sharedModel: createStandaloneCell({ cell_type: 'code' })
         });
         let called = 0;
-        model.metadata.changed.connect(() => {
+        model.metadataChanged.connect(() => {
           called++;
         });
         expect(called).toBe(0);
-        model.metadata.set('foo', 'bar');
+        model.setMetadata('foo', 'bar');
         expect(called).toBe(1);
-        model.metadata.set('foo', 'bar');
+        model.setMetadata('foo', 'bar');
         expect(called).toBe(1);
       });
     });
@@ -206,15 +207,15 @@ describe('cells/model', () => {
 
     describe('#isDisposed', () => {
       it('should be false by default', () => {
-        const model = new CellModel({
-          sharedModel: createStandaloneCell({ cell_type: 'code' })
+        const model = new CodeCellModel({
+          sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         expect(model.isDisposed).toBe(false);
       });
 
       it('should be true after model is disposed', () => {
-        const model = new CellModel({
-          sharedModel: createStandaloneCell({ cell_type: 'code' })
+        const model = new CodeCellModel({
+          sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         model.dispose();
         expect(model.isDisposed).toBe(true);
@@ -231,8 +232,8 @@ describe('cells/model', () => {
       });
 
       it('should be safe to call multiple times', () => {
-        const model = new CellModel({
-          sharedModel: createStandaloneCell({ cell_type: 'code' })
+        const model = new CodeCellModel({
+          sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         model.dispose();
         model.dispose();
@@ -273,32 +274,32 @@ describe('cells/model', () => {
 
     describe('#metadata', () => {
       it('should handle a metadata for the cell', () => {
-        const model = new CellModel({
-          sharedModel: createStandaloneCell({ cell_type: 'code' })
+        const model = new CodeCellModel({
+          sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
-        expect(model.metadata.get('foo')).toBeUndefined();
-        model.metadata.set('foo', 1);
-        expect(model.metadata.get('foo')).toBe(1);
+        expect(model.getMetadata('foo')).toBeUndefined();
+        model.setMetadata('foo', 1);
+        expect(model.getMetadata('foo')).toBe(1);
       });
 
       it('should get a list of user metadata keys', () => {
-        const model = new CellModel({
-          sharedModel: createStandaloneCell({ cell_type: 'code' })
+        const model = new CodeCellModel({
+          sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
-        expect(Array.from(model.metadata.keys())).toHaveLength(0);
-        model.metadata.set('foo', 1);
-        expect(model.metadata.keys()).toEqual(['foo']);
+        expect(Array.from(Object.keys(model.metadata))).toHaveLength(0);
+        model.setMetadata('foo', 1);
+        expect(Object.keys(model.metadata)).toEqual(['foo']);
       });
 
       it('should trigger changed signal', () => {
-        const model = new CellModel({
-          sharedModel: createStandaloneCell({ cell_type: 'code' })
+        const model = new CodeCellModel({
+          sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         let called = false;
-        model.metadata.changed.connect(() => {
+        model.metadataChanged.connect(() => {
           called = true;
         });
-        model.metadata.set('foo', 1);
+        model.setMetadata('foo', 1);
         expect(called).toBe(true);
       });
     });
@@ -408,8 +409,8 @@ describe('cells/model', () => {
             metadata: { collapsed: true }
           }) as YCodeCell
         });
-        expect(model.metadata.get('collapsed')).toBe(true);
-        jupyter = model.metadata.get('jupyter') as JSONObject;
+        expect(model.getMetadata('collapsed')).toBe(true);
+        jupyter = model.getMetadata('jupyter') as JSONObject;
         expect(jupyter.outputs_hidden).toBe(true);
 
         // Setting `jupyter.outputs_hidden` works
@@ -420,8 +421,8 @@ describe('cells/model', () => {
             metadata: { jupyter: { outputs_hidden: true } }
           }) as YCodeCell
         });
-        expect(model.metadata.get('collapsed')).toBe(true);
-        jupyter = model.metadata.get('jupyter') as JSONObject;
+        expect(model.getMetadata('collapsed')).toBe(true);
+        jupyter = model.getMetadata('jupyter') as JSONObject;
         expect(jupyter.outputs_hidden).toBe(true);
 
         // `collapsed` takes precedence
@@ -432,8 +433,8 @@ describe('cells/model', () => {
             metadata: { collapsed: false, jupyter: { outputs_hidden: true } }
           }) as YCodeCell
         });
-        expect(model.metadata.get('collapsed')).toBe(false);
-        jupyter = model.metadata.get('jupyter') as JSONObject;
+        expect(model.getMetadata('collapsed')).toBe(false);
+        jupyter = model.getMetadata('jupyter') as JSONObject;
         expect(jupyter.outputs_hidden).toBe(false);
       });
     });
@@ -571,7 +572,7 @@ describe('cells/model', () => {
       });
     });
 
-    describe('#onModelDBOutputsChange()', () => {
+    describe('#onOutputsChange()', () => {
       const output0 = {
         output_type: 'display_data',
         data: {
@@ -616,7 +617,7 @@ describe('cells/model', () => {
           oldIndex: -1,
           newIndex: 0
         } as any;
-        model['onModelDBOutputsChange'](null as any, newEvent0);
+        model['onOutputsChange'](null as any, newEvent0);
         expect(sharedModel.ymodel.get('outputs').length).toBe(1);
         expect(sharedModel.ymodel.get('outputs').get(0)).toEqual(output0);
 
@@ -627,7 +628,7 @@ describe('cells/model', () => {
           oldIndex: -1,
           newIndex: 1
         } as any;
-        model['onModelDBOutputsChange'](null as any, newEvent1);
+        model['onOutputsChange'](null as any, newEvent1);
         expect(sharedModel.ymodel.get('outputs').length).toBe(2);
         expect(sharedModel.ymodel.get('outputs').get(1)).toEqual(output1);
       });
@@ -646,7 +647,7 @@ describe('cells/model', () => {
           oldIndex: 0,
           newIndex: 0
         } as any;
-        model['onModelDBOutputsChange'](null as any, newEvent0);
+        model['onOutputsChange'](null as any, newEvent0);
         expect(sharedModel.ymodel.get('outputs').length).toBe(2);
         expect(sharedModel.ymodel.get('outputs').get(0)).toEqual(output2);
         const newEvent1 = {
@@ -656,7 +657,7 @@ describe('cells/model', () => {
           oldIndex: 1,
           newIndex: 1
         } as any;
-        model['onModelDBOutputsChange'](null as any, newEvent1);
+        model['onOutputsChange'](null as any, newEvent1);
         expect(sharedModel.ymodel.get('outputs').length).toBe(2);
         expect(sharedModel.ymodel.get('outputs').get(1)).toEqual(output2);
       });
@@ -674,75 +675,75 @@ describe('cells/model', () => {
           oldIndex: 0,
           newIndex: 0
         } as any;
-        model['onModelDBOutputsChange'](null as any, newEvent0);
+        model['onOutputsChange'](null as any, newEvent0);
         expect(sharedModel.ymodel.get('outputs').length).toBe(0);
       });
     });
 
     describe('.metadata', () => {
       it('should sync collapsed and jupyter.outputs_hidden metadata when changed', () => {
-        const metadata = new CodeCellModel().metadata;
+        const cell = new CodeCellModel();
 
-        expect(metadata.get('collapsed')).toBeUndefined();
-        expect(metadata.get('jupyter')).toBeUndefined();
+        expect(cell.getMetadata('collapsed')).toBeUndefined();
+        expect(cell.getMetadata('jupyter')).toBeUndefined();
 
         // Setting collapsed sets jupyter.outputs_hidden
-        metadata.set('collapsed', true);
-        expect(metadata.get('collapsed')).toBe(true);
-        expect(metadata.get('jupyter')).toEqual({
+        cell.setMetadata('collapsed', true);
+        expect(cell.getMetadata('collapsed')).toBe(true);
+        expect(cell.getMetadata('jupyter')).toEqual({
           outputs_hidden: true
         });
 
-        metadata.set('collapsed', false);
-        expect(metadata.get('collapsed')).toBe(false);
-        expect(metadata.get('jupyter')).toEqual({
+        cell.setMetadata('collapsed', false);
+        expect(cell.getMetadata('collapsed')).toBe(false);
+        expect(cell.getMetadata('jupyter')).toEqual({
           outputs_hidden: false
         });
 
-        metadata.delete('collapsed');
-        expect(metadata.get('collapsed')).toBeUndefined();
-        expect(metadata.get('jupyter')).toBeUndefined();
+        cell.deleteMetadata('collapsed');
+        expect(cell.getMetadata('collapsed')).toBeUndefined();
+        expect(cell.getMetadata('jupyter')).toBeUndefined();
 
         // Setting jupyter.outputs_hidden sets collapsed
-        metadata.set('jupyter', { outputs_hidden: true });
-        expect(metadata.get('collapsed')).toBe(true);
-        expect(metadata.get('jupyter')).toEqual({
+        cell.setMetadata('jupyter', { outputs_hidden: true });
+        expect(cell.getMetadata('collapsed')).toBe(true);
+        expect(cell.getMetadata('jupyter')).toEqual({
           outputs_hidden: true
         });
 
-        metadata.set('jupyter', { outputs_hidden: false });
-        expect(metadata.get('collapsed')).toBe(false);
-        expect(metadata.get('jupyter')).toEqual({
+        cell.setMetadata('jupyter', { outputs_hidden: false });
+        expect(cell.getMetadata('collapsed')).toBe(false);
+        expect(cell.getMetadata('jupyter')).toEqual({
           outputs_hidden: false
         });
 
-        metadata.delete('jupyter');
-        expect(metadata.get('collapsed')).toBeUndefined();
-        expect(metadata.get('jupyter')).toBeUndefined();
+        cell.deleteMetadata('jupyter');
+        expect(cell.getMetadata('collapsed')).toBeUndefined();
+        expect(cell.getMetadata('jupyter')).toBeUndefined();
 
         // Deleting jupyter.outputs_hidden preserves other jupyter fields
-        metadata.set('jupyter', { outputs_hidden: true, other: true });
-        expect(metadata.get('collapsed')).toBe(true);
-        expect(metadata.get('jupyter')).toEqual({
+        cell.setMetadata('jupyter', { outputs_hidden: true, other: true });
+        expect(cell.getMetadata('collapsed')).toBe(true);
+        expect(cell.getMetadata('jupyter')).toEqual({
           outputs_hidden: true,
           other: true
         });
-        metadata.set('jupyter', { other: true });
-        expect(metadata.get('collapsed')).toBeUndefined();
-        expect(metadata.get('jupyter')).toEqual({
+        cell.setMetadata('jupyter', { other: true });
+        expect(cell.getMetadata('collapsed')).toBeUndefined();
+        expect(cell.getMetadata('jupyter')).toEqual({
           other: true
         });
 
         // Deleting collapsed preserves other jupyter fields
-        metadata.set('jupyter', { outputs_hidden: true, other: true });
-        expect(metadata.get('collapsed')).toBe(true);
-        expect(metadata.get('jupyter')).toEqual({
+        cell.setMetadata('jupyter', { outputs_hidden: true, other: true });
+        expect(cell.getMetadata('collapsed')).toBe(true);
+        expect(cell.getMetadata('jupyter')).toEqual({
           outputs_hidden: true,
           other: true
         });
-        metadata.delete('collapsed');
-        expect(metadata.get('collapsed')).toBeUndefined();
-        expect(metadata.get('jupyter')).toEqual({
+        cell.deleteMetadata('collapsed');
+        expect(cell.getMetadata('collapsed')).toBeUndefined();
+        expect(cell.getMetadata('jupyter')).toEqual({
           other: true
         });
       });

--- a/packages/cells/test/widget.spec.ts
+++ b/packages/cells/test/widget.spec.ts
@@ -6,6 +6,7 @@ import {
   Cell,
   CellFooter,
   CellHeader,
+  CellModel,
   CodeCell,
   CodeCellModel,
   InputArea,
@@ -32,12 +33,18 @@ import { Widget } from '@lumino/widgets';
 const RENDERED_CLASS = 'jp-mod-rendered';
 const rendermime = NBTestUtils.defaultRenderMime();
 
+class TestModel extends CellModel {
+  get type(): 'raw' {
+    return 'raw';
+  }
+}
+
 class LogBaseCell extends Cell {
   methods: string[] = [];
 
   constructor() {
     super({
-      model: new CodeCellModel({
+      model: new TestModel({
         sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
       }),
       placeholder: false
@@ -105,7 +112,7 @@ describe('cells/widget', () => {
   const editorFactory = NBTestUtils.editorFactory;
 
   describe('Cell', () => {
-    const model = new CodeCellModel({
+    const model = new TestModel({
       sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
     });
 
@@ -141,7 +148,7 @@ describe('cells/widget', () => {
 
     describe('#model', () => {
       it('should be the model used by the widget', () => {
-        const model = new CodeCellModel({
+        const model = new TestModel({
           sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         const widget = new Cell({
@@ -237,7 +244,7 @@ describe('cells/widget', () => {
 
     describe('#loadEditableState()', () => {
       it('should load the editable state from the model', () => {
-        const model = new CodeCellModel({
+        const model = new TestModel({
           sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         const widget = new Cell({ model }).initializeState();
@@ -255,7 +262,7 @@ describe('cells/widget', () => {
 
     describe('#saveEditableState()', () => {
       it('should save the editable state to the model', () => {
-        const model = new CodeCellModel({
+        const model = new TestModel({
           sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         const widget = new Cell({
@@ -277,7 +284,7 @@ describe('cells/widget', () => {
 
     describe('#syncEditable', () => {
       it('should control automatic syncing of editable state with model', () => {
-        const model = new CodeCellModel({
+        const model = new TestModel({
           sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         const widget = new Cell({
@@ -314,7 +321,7 @@ describe('cells/widget', () => {
 
     describe('#loadCollapseState()', () => {
       it('should load the input collapse state from the model', () => {
-        const model = new CodeCellModel({
+        const model = new TestModel({
           sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         const widget = new Cell({
@@ -335,7 +342,7 @@ describe('cells/widget', () => {
 
     describe('#saveCollapseState()', () => {
       it('should save the collapse state to the model', () => {
-        const model = new CodeCellModel({
+        const model = new TestModel({
           sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         const widget = new Cell({
@@ -359,7 +366,7 @@ describe('cells/widget', () => {
 
     describe('#syncCollapse', () => {
       it('should control automatic syncing of collapse state with model', () => {
-        const model = new CodeCellModel({
+        const model = new TestModel({
           sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         const widget = new Cell({

--- a/packages/cells/test/widget.spec.ts
+++ b/packages/cells/test/widget.spec.ts
@@ -6,7 +6,6 @@ import {
   Cell,
   CellFooter,
   CellHeader,
-  CellModel,
   CodeCell,
   CodeCellModel,
   InputArea,
@@ -19,7 +18,7 @@ import {
 import { CodeEditor, CodeEditorWrapper } from '@jupyterlab/codeeditor';
 import { OutputArea, OutputPrompt } from '@jupyterlab/outputarea';
 import { IExecuteReplyMsg } from '@jupyterlab/services/lib/kernel/messages';
-import { createStandaloneCell } from '@jupyterlab/shared-models';
+import { createStandaloneCell, YCodeCell } from '@jupyterlab/shared-models';
 import {
   createSessionContext,
   framePromise,
@@ -38,8 +37,8 @@ class LogBaseCell extends Cell {
 
   constructor() {
     super({
-      model: new CellModel({
-        sharedModel: createStandaloneCell({ cell_type: 'code' })
+      model: new CodeCellModel({
+        sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
       }),
       placeholder: false
     });
@@ -106,8 +105,8 @@ describe('cells/widget', () => {
   const editorFactory = NBTestUtils.editorFactory;
 
   describe('Cell', () => {
-    const model = new CellModel({
-      sharedModel: createStandaloneCell({ cell_type: 'code' })
+    const model = new CodeCellModel({
+      sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
     });
 
     describe('#constructor()', () => {
@@ -142,8 +141,8 @@ describe('cells/widget', () => {
 
     describe('#model', () => {
       it('should be the model used by the widget', () => {
-        const model = new CellModel({
-          sharedModel: createStandaloneCell({ cell_type: 'code' })
+        const model = new CodeCellModel({
+          sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         const widget = new Cell({
           model,
@@ -217,7 +216,7 @@ describe('cells/widget', () => {
       });
 
       it('should reflect model metadata', () => {
-        model.metadata.set('editable', false);
+        model.setMetadata('editable', false);
 
         const widget = new Cell({
           model,
@@ -238,17 +237,17 @@ describe('cells/widget', () => {
 
     describe('#loadEditableState()', () => {
       it('should load the editable state from the model', () => {
-        const model = new CellModel({
-          sharedModel: createStandaloneCell({ cell_type: 'code' })
+        const model = new CodeCellModel({
+          sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         const widget = new Cell({ model }).initializeState();
         expect(widget.readOnly).toEqual(false);
 
-        model.metadata.set('editable', false);
+        model.setMetadata('editable', false);
         widget.loadEditableState();
         expect(widget.readOnly).toEqual(true);
 
-        model.metadata.set('editable', true);
+        model.setMetadata('editable', true);
         widget.loadEditableState();
         expect(widget.readOnly).toEqual(false);
       });
@@ -256,8 +255,8 @@ describe('cells/widget', () => {
 
     describe('#saveEditableState()', () => {
       it('should save the editable state to the model', () => {
-        const model = new CellModel({
-          sharedModel: createStandaloneCell({ cell_type: 'code' })
+        const model = new CodeCellModel({
+          sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         const widget = new Cell({
           model,
@@ -267,19 +266,19 @@ describe('cells/widget', () => {
 
         widget.readOnly = true;
         widget.saveEditableState();
-        expect(model.metadata.get('editable')).toEqual(false);
+        expect(model.getMetadata('editable')).toEqual(false);
 
         widget.readOnly = false;
         widget.saveEditableState();
         // Default values are not saved explicitly
-        expect(model.metadata.get('editable')).toEqual(undefined);
+        expect(model.getMetadata('editable')).toEqual(undefined);
       });
     });
 
     describe('#syncEditable', () => {
       it('should control automatic syncing of editable state with model', () => {
-        const model = new CellModel({
-          sharedModel: createStandaloneCell({ cell_type: 'code' })
+        const model = new CodeCellModel({
+          sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         const widget = new Cell({
           model,
@@ -290,33 +289,33 @@ describe('cells/widget', () => {
 
         // Not synced if setting widget attribute
         widget.readOnly = true;
-        expect(model.metadata.get('editable')).toEqual(undefined);
+        expect(model.getMetadata('editable')).toEqual(undefined);
 
         // Not synced if setting metadata attribute
-        model.metadata.set('editable', true);
+        model.setMetadata('editable', true);
         expect(widget.readOnly).toEqual(true);
 
         widget.syncEditable = true;
 
         // Setting sync does an initial sync from model to view. This also sets
         // the metadata to undefined if it is the default value.
-        expect(model.metadata.get('editable')).toEqual(undefined);
+        expect(model.getMetadata('editable')).toEqual(undefined);
         expect(widget.readOnly).toEqual(false);
 
         // Synced if setting widget attribute
         widget.readOnly = true;
-        expect(model.metadata.get('editable')).toEqual(false);
+        expect(model.getMetadata('editable')).toEqual(false);
 
         // Synced if setting metadata attribute
-        model.metadata.set('editable', true);
+        model.setMetadata('editable', true);
         expect(widget.readOnly).toEqual(false);
       });
     });
 
     describe('#loadCollapseState()', () => {
       it('should load the input collapse state from the model', () => {
-        const model = new CellModel({
-          sharedModel: createStandaloneCell({ cell_type: 'code' })
+        const model = new CodeCellModel({
+          sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         const widget = new Cell({
           model,
@@ -324,11 +323,11 @@ describe('cells/widget', () => {
         }).initializeState();
         expect(widget.inputHidden).toEqual(false);
 
-        model.metadata.set('jupyter', { source_hidden: true });
+        model.setMetadata('jupyter', { source_hidden: true });
         widget.loadCollapseState();
         expect(widget.inputHidden).toEqual(true);
 
-        model.metadata.set('jupyter', { source_hidden: false });
+        model.setMetadata('jupyter', { source_hidden: false });
         widget.loadCollapseState();
         expect(widget.inputHidden).toEqual(false);
       });
@@ -336,8 +335,8 @@ describe('cells/widget', () => {
 
     describe('#saveCollapseState()', () => {
       it('should save the collapse state to the model', () => {
-        const model = new CellModel({
-          sharedModel: createStandaloneCell({ cell_type: 'code' })
+        const model = new CodeCellModel({
+          sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         const widget = new Cell({
           model,
@@ -347,21 +346,21 @@ describe('cells/widget', () => {
 
         widget.inputHidden = true;
         widget.saveCollapseState();
-        expect(model.metadata.get('jupyter')).toEqual({
+        expect(model.getMetadata('jupyter')).toEqual({
           source_hidden: true
         });
 
         widget.inputHidden = false;
         widget.saveCollapseState();
         // Default values are not saved explicitly
-        expect(model.metadata.get('jupyter')).toEqual(undefined);
+        expect(model.getMetadata('jupyter')).toEqual(undefined);
       });
     });
 
     describe('#syncCollapse', () => {
       it('should control automatic syncing of collapse state with model', () => {
-        const model = new CellModel({
-          sharedModel: createStandaloneCell({ cell_type: 'code' })
+        const model = new CodeCellModel({
+          sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
         });
         const widget = new Cell({
           model,
@@ -372,27 +371,27 @@ describe('cells/widget', () => {
 
         // Not synced if setting widget attribute
         widget.inputHidden = true;
-        expect(model.metadata.get('jupyter')).toEqual(undefined);
+        expect(model.getMetadata('jupyter')).toEqual(undefined);
 
         // Not synced if setting metadata attribute
-        model.metadata.set('jupyter', { source_hidden: false });
+        model.setMetadata('jupyter', { source_hidden: false });
         expect(widget.inputHidden).toEqual(true);
 
         widget.syncCollapse = true;
 
         // Setting sync does an initial sync from model to view. This also sets
         // the metadata to undefined if it is the default value.
-        expect(model.metadata.get('jupyter')).toEqual(undefined);
+        expect(model.getMetadata('jupyter')).toEqual(undefined);
         expect(widget.inputHidden).toEqual(false);
 
         // Synced if setting widget attribute
         widget.inputHidden = true;
-        expect(model.metadata.get('jupyter')).toEqual({
+        expect(model.getMetadata('jupyter')).toEqual({
           source_hidden: true
         });
 
         // Synced if setting metadata attribute
-        model.metadata.set('jupyter', {});
+        model.setMetadata('jupyter', {});
         expect(widget.inputHidden).toEqual(false);
       });
     });
@@ -544,13 +543,13 @@ describe('cells/widget', () => {
         widget.initializeState();
         expect(widget.outputHidden).toEqual(false);
 
-        collapsedModel.metadata.set('collapsed', true);
+        collapsedModel.setMetadata('collapsed', true);
         widget = new CodeCell({ model: collapsedModel, rendermime });
         widget.initializeState();
         expect(widget.outputHidden).toEqual(true);
 
-        collapsedModel.metadata.delete('collapsed');
-        collapsedModel.metadata.set('jupyter', { outputs_hidden: true });
+        collapsedModel.deleteMetadata('collapsed');
+        collapsedModel.setMetadata('jupyter', { outputs_hidden: true });
         widget = new CodeCell({ model: collapsedModel, rendermime });
         widget.initializeState();
         expect(widget.outputHidden).toEqual(true);
@@ -572,17 +571,17 @@ describe('cells/widget', () => {
         widget.initializeState();
         expect(widget.outputsScrolled).toEqual(false);
 
-        model.metadata.set('scrolled', false);
+        model.setMetadata('scrolled', false);
         widget = new CodeCell({ model, rendermime });
         widget.initializeState();
         expect(widget.outputsScrolled).toEqual(false);
 
-        model.metadata.set('scrolled', 'auto');
+        model.setMetadata('scrolled', 'auto');
         widget = new CodeCell({ model, rendermime });
         widget.initializeState();
         expect(widget.outputsScrolled).toEqual(false);
 
-        model.metadata.set('scrolled', true);
+        model.setMetadata('scrolled', true);
         widget = new CodeCell({ model, rendermime });
         widget.initializeState();
         expect(widget.outputsScrolled).toEqual(true);
@@ -596,11 +595,11 @@ describe('cells/widget', () => {
         widget.initializeState();
         expect(widget.outputsScrolled).toEqual(false);
 
-        model.metadata.set('scrolled', true);
+        model.setMetadata('scrolled', true);
         widget.loadScrolledState();
         expect(widget.outputsScrolled).toEqual(true);
 
-        model.metadata.set('scrolled', false);
+        model.setMetadata('scrolled', false);
         widget.loadScrolledState();
         expect(widget.outputsScrolled).toEqual(false);
       });
@@ -615,12 +614,12 @@ describe('cells/widget', () => {
 
         widget.outputsScrolled = true;
         widget.saveScrolledState();
-        expect(model.metadata.get('scrolled')).toEqual(true);
+        expect(model.getMetadata('scrolled')).toEqual(true);
 
         widget.outputsScrolled = false;
         widget.saveScrolledState();
         // Default values are not saved explicitly
-        expect(model.metadata.get('scrolled')).toEqual(undefined);
+        expect(model.getMetadata('scrolled')).toEqual(undefined);
       });
     });
 
@@ -634,25 +633,25 @@ describe('cells/widget', () => {
 
         // Not synced if setting widget attribute
         widget.outputsScrolled = true;
-        expect(model.metadata.get('scrolled')).toEqual(undefined);
+        expect(model.getMetadata('scrolled')).toEqual(undefined);
 
         // Not synced if setting metadata attribute
-        model.metadata.set('scrolled', false);
+        model.setMetadata('scrolled', false);
         expect(widget.outputsScrolled).toEqual(true);
 
         widget.syncScrolled = true;
 
         // Setting sync does an initial sync from model to view. This also sets
         // the metadata to undefined if it is the default value.
-        expect(model.metadata.get('scrolled')).toEqual(undefined);
+        expect(model.getMetadata('scrolled')).toEqual(undefined);
         expect(widget.outputsScrolled).toEqual(false);
 
         // Synced if setting widget attribute
         widget.outputsScrolled = true;
-        expect(model.metadata.get('scrolled')).toEqual(true);
+        expect(model.getMetadata('scrolled')).toEqual(true);
 
         // Synced if setting metadata attribute
-        model.metadata.set('scrolled', false);
+        model.setMetadata('scrolled', false);
         expect(widget.outputsScrolled).toEqual(false);
       });
     });
@@ -665,11 +664,11 @@ describe('cells/widget', () => {
         widget.loadCollapseState();
         expect(widget.outputHidden).toEqual(false);
 
-        model.metadata.set('collapsed', true);
+        model.setMetadata('collapsed', true);
         widget.loadCollapseState();
         expect(widget.outputHidden).toEqual(true);
 
-        model.metadata.set('collapsed', false);
+        model.setMetadata('collapsed', false);
         widget.loadCollapseState();
         expect(widget.outputHidden).toEqual(false);
       });
@@ -684,18 +683,18 @@ describe('cells/widget', () => {
 
         widget.outputHidden = true;
         widget.saveCollapseState();
-        expect(model.metadata.get('collapsed')).toEqual(true);
+        expect(model.getMetadata('collapsed')).toEqual(true);
 
         // Default values are not saved explicitly
         widget.outputHidden = false;
         widget.saveCollapseState();
-        expect(model.metadata.get('collapsed')).toEqual(undefined);
+        expect(model.getMetadata('collapsed')).toEqual(undefined);
 
         // Default values are explicitly deleted
-        model.metadata.set('collapsed', false);
+        model.setMetadata('collapsed', false);
         widget.outputHidden = false;
         widget.saveCollapseState();
-        expect(model.metadata.get('collapsed')).toEqual(undefined);
+        expect(model.getMetadata('collapsed')).toEqual(undefined);
       });
     });
 
@@ -709,30 +708,30 @@ describe('cells/widget', () => {
 
         // Not synced if setting widget attribute
         widget.outputHidden = true;
-        expect(model.metadata.get('collapsed')).toEqual(undefined);
+        expect(model.getMetadata('collapsed')).toEqual(undefined);
 
         // Not synced if setting metadata attribute
-        model.metadata.set('collapsed', false);
+        model.setMetadata('collapsed', false);
         expect(widget.outputHidden).toEqual(true);
 
         widget.syncCollapse = true;
 
         // Setting sync does an initial sync from model to view.
-        expect(model.metadata.get('collapsed')).toEqual(undefined);
+        expect(model.getMetadata('collapsed')).toEqual(undefined);
         expect(widget.outputHidden).toEqual(false);
 
         // Synced if setting widget attribute
         widget.outputHidden = true;
-        expect(model.metadata.get('collapsed')).toEqual(true);
+        expect(model.getMetadata('collapsed')).toEqual(true);
 
         // Synced if setting metadata attribute
-        model.metadata.set('collapsed', false);
+        model.setMetadata('collapsed', false);
         expect(widget.outputHidden).toEqual(false);
 
         // Synced if deleting collapsed metadata attribute
         widget.outputHidden = true;
-        expect(model.metadata.get('collapsed')).toEqual(true);
-        model.metadata.delete('collapsed');
+        expect(model.getMetadata('collapsed')).toEqual(true);
+        model.deleteMetadata('collapsed');
         expect(widget.outputHidden).toEqual(false);
       });
     });
@@ -768,7 +767,7 @@ describe('cells/widget', () => {
         const method = 'onMetadataChanged';
         const widget = new LogCodeCell().initializeState();
         expect(widget.methods).not.toContain(method);
-        widget.model.metadata.set('foo', 1);
+        widget.model.setMetadata('foo', 1);
         expect(widget.methods).toContain(method);
       });
     });
@@ -831,7 +830,7 @@ describe('cells/widget', () => {
           placeholder: false
         });
         await CodeCell.execute(widget, sessionContext);
-        expect(widget.model.metadata.get('execution')).toBeUndefined();
+        expect(widget.model.getMetadata('execution')).toBeUndefined();
       });
       it('should save timing info if requested', async () => {
         const widget = new CodeCell({
@@ -841,8 +840,8 @@ describe('cells/widget', () => {
           placeholder: false
         });
         await CodeCell.execute(widget, sessionContext, { recordTiming: true });
-        expect(widget.model.metadata.get('execution')).toBeDefined();
-        const timingInfo = widget.model.metadata.get('execution') as any;
+        expect(widget.model.getMetadata('execution')).toBeDefined();
+        const timingInfo = widget.model.getMetadata('execution') as any;
         for (const key of TIMING_KEYS) {
           expect(timingInfo[key]).toBeDefined();
         }

--- a/packages/celltags/package.json
+++ b/packages/celltags/package.json
@@ -45,6 +45,7 @@
     "@jupyterlab/translation": "^4.0.0-alpha.15",
     "@jupyterlab/ui-components": "^4.0.0-alpha.30",
     "@lumino/algorithm": "^2.0.0-alpha.6",
+    "@lumino/coreutils": "^2.0.0-alpha.6",
     "@lumino/messaging": "^2.0.0-alpha.6",
     "@lumino/signaling": "^2.0.0-alpha.6",
     "@lumino/widgets": "^2.0.0-alpha.6"

--- a/packages/celltags/src/tool.ts
+++ b/packages/celltags/src/tool.ts
@@ -62,7 +62,7 @@ export class TagTool extends NotebookTools.Tool {
   checkApplied(name: string): boolean {
     const activeCell = this.tracker?.activeCell;
     if (activeCell) {
-      const tags = activeCell.model.metadata.get('tags') as string[];
+      const tags = activeCell.model.getMetadata('tags') as string[];
       if (tags) {
         return tags.includes(name);
       }
@@ -78,12 +78,10 @@ export class TagTool extends NotebookTools.Tool {
   addTag(name: string): void {
     const cell = this.tracker?.activeCell;
     if (cell) {
-      const oldTags = [
-        ...((cell.model.metadata.get('tags') as string[]) ?? [])
-      ];
+      const oldTags = [...((cell.model.getMetadata('tags') as string[]) ?? [])];
       let tagsToAdd = name.split(/[,\s]+/);
       tagsToAdd = tagsToAdd.filter(tag => tag !== '' && !oldTags.includes(tag));
-      cell.model.metadata.set('tags', oldTags.concat(tagsToAdd));
+      cell.model.setMetadata('tags', oldTags.concat(tagsToAdd));
       this.refreshTags();
       this.loadActiveTags();
     }
@@ -97,13 +95,11 @@ export class TagTool extends NotebookTools.Tool {
   removeTag(name: string): void {
     const cell = this.tracker?.activeCell;
     if (cell) {
-      const oldTags = [
-        ...((cell.model.metadata.get('tags') as string[]) ?? [])
-      ];
+      const oldTags = [...((cell.model.getMetadata('tags') as string[]) ?? [])];
       let tags = oldTags.filter(tag => tag !== name);
-      cell.model.metadata.set('tags', tags);
+      cell.model.setMetadata('tags', tags);
       if (tags.length === 0) {
-        cell.model.metadata.delete('tags');
+        cell.model.deleteMetadata('tags');
       }
       this.refreshTags();
       this.loadActiveTags();
@@ -131,7 +127,7 @@ export class TagTool extends NotebookTools.Tool {
     const allTags = reduce(
       cells,
       (allTags: string[], cell) => {
-        const tags = (cell.metadata.get('tags') as string[]) ?? [];
+        const tags = (cell.getMetadata('tags') as string[]) ?? [];
         return [...allTags, ...tags];
       },
       []
@@ -175,7 +171,7 @@ export class TagTool extends NotebookTools.Tool {
       []
     );
     const validTags = [...new Set(tags)].filter(tag => tag !== '');
-    cell.model.metadata.set('tags', validTags);
+    cell.model.setMetadata('tags', validTags);
     this.refreshTags();
     this.loadActiveTags();
   }
@@ -223,9 +219,7 @@ export class TagTool extends NotebookTools.Tool {
    * Handle a change to active cell metadata.
    */
   protected onActiveCellMetadataChanged(): void {
-    const tags = this.tracker.activeCell!.model.metadata.get(
-      'tags'
-    ) as string[];
+    const tags = this.tracker.activeCell!.model.getMetadata('tags') as string[];
     let taglist: string[] = [];
     if (tags) {
       if (typeof tags === 'string') {

--- a/packages/celltags/src/tool.ts
+++ b/packages/celltags/src/tool.ts
@@ -12,6 +12,7 @@ import {
   TranslationBundle
 } from '@jupyterlab/translation';
 import { reduce } from '@lumino/algorithm';
+import { JSONExt } from '@lumino/coreutils';
 import { Message } from '@lumino/messaging';
 import { Signal } from '@lumino/signaling';
 import { PanelLayout } from '@lumino/widgets';
@@ -171,7 +172,9 @@ export class TagTool extends NotebookTools.Tool {
       []
     );
     const validTags = [...new Set(tags)].filter(tag => tag !== '');
-    cell.model.setMetadata('tags', validTags);
+    if (!JSONExt.deepEqual(cell.model.getMetadata('tags') ?? [], validTags)) {
+      cell.model.setMetadata('tags', validTags);
+    }
     this.refreshTags();
     this.loadActiveTags();
   }

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -196,7 +196,7 @@ export namespace CodeEditor {
     constructor(options: Model.IOptions = {}) {
       // Track if we need to dispose the model or not.
       this.standaloneModel = typeof options.sharedModel === 'undefined';
-      this.sharedModel = options.sharedModel ?? YFile.create();
+      this.sharedModel = options.sharedModel ?? new YFile();
       this._mimeType = options.mimeType ?? 'text/plain';
     }
 

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -2,14 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { IChangedArgs } from '@jupyterlab/coreutils';
-import * as nbformat from '@jupyterlab/nbformat';
-import {
-  IModelDB,
-  IObservableMap,
-  IObservableValue,
-  ModelDB,
-  ObservableValue
-} from '@jupyterlab/observables';
+import { IObservableMap, ObservableMap } from '@jupyterlab/observables';
 import * as models from '@jupyterlab/shared-models';
 import { ISharedText, YFile } from '@jupyterlab/shared-models';
 import { ITranslator } from '@jupyterlab/translation';
@@ -175,11 +168,6 @@ export namespace CodeEditor {
     mimeTypeChanged: ISignal<IModel, IChangedArgs<string>>;
 
     /**
-     * A signal emitted when the shared model was switched.
-     */
-    sharedModelSwitched: ISignal<IModel, boolean>;
-
-    /**
      * A mime type of the model.
      *
      * #### Notes
@@ -206,29 +194,16 @@ export namespace CodeEditor {
      * Construct a new Model.
      */
     constructor(options: Model.IOptions = {}) {
-      this.modelDB = new ModelDB();
-      this.sharedModel = options?.sharedModel || YFile.create();
-      const mimeType = this.modelDB.createValue('mimeType');
-      mimeType.changed.connect(this._onModelDBMimeTypeChanged, this);
-      mimeType.set(options?.mimeType || 'text/plain');
-
-      this.modelDB.createMap('selections');
-    }
-
-    get type(): nbformat.CellType {
-      return 'code';
+      // Track if we need to dispose the model or not.
+      this.standaloneModel = typeof options.sharedModel === 'undefined';
+      this.sharedModel = options.sharedModel ?? YFile.create();
+      this._mimeType = options.mimeType ?? 'text/plain';
     }
 
     /**
      * The shared model for the cell editor.
      */
     readonly sharedModel: models.ISharedText;
-
-    /**
-     * The underlying `IModelDB` instance in which state is
-     * stored in an observable manner.
-     */
-    protected readonly modelDB: IModelDB;
 
     /**
      * A signal emitted when a mimetype changes.
@@ -238,31 +213,29 @@ export namespace CodeEditor {
     }
 
     /**
-     * A signal emitted when the shared model was switched.
-     */
-    get sharedModelSwitched(): ISignal<this, boolean> {
-      return this._sharedModelSwitched;
-    }
-
-    /**
      * Get the selections for the model.
      */
     get selections(): IObservableMap<ITextSelection[]> {
-      return this.modelDB.get('selections') as IObservableMap<ITextSelection[]>;
+      return this._selections;
     }
 
     /**
      * A mime type of the model.
      */
     get mimeType(): string {
-      return this.modelDB.getValue('mimeType') as string;
+      return this._mimeType;
     }
     set mimeType(newValue: string) {
       const oldValue = this.mimeType;
       if (oldValue === newValue) {
         return;
       }
-      this.modelDB.setValue('mimeType', newValue);
+      this._mimeType = newValue;
+      this._mimeTypeChanged.emit({
+        name: 'mimeType',
+        oldValue: oldValue,
+        newValue: newValue
+      });
     }
 
     /**
@@ -280,24 +253,21 @@ export namespace CodeEditor {
         return;
       }
       this._isDisposed = true;
-      this.modelDB.dispose();
+      if (this.standaloneModel) {
+        this.sharedModel.dispose();
+      }
       Signal.clearData(this);
     }
 
-    private _onModelDBMimeTypeChanged(
-      mimeType: IObservableValue,
-      args: ObservableValue.IChangedArgs
-    ): void {
-      this._mimeTypeChanged.emit({
-        name: 'mimeType',
-        oldValue: args.oldValue as string,
-        newValue: args.newValue as string
-      });
-    }
+    /**
+     * Whether the model should disposed the shared model on disposal or not.
+     */
+    protected standaloneModel = false;
 
     private _isDisposed = false;
+    private _selections = new ObservableMap<ITextSelection[]>();
+    private _mimeType = 'text/plain';
     private _mimeTypeChanged = new Signal<this, IChangedArgs<string>>(this);
-    private _sharedModelSwitched = new Signal<this, boolean>(this);
   }
 
   /**

--- a/packages/codeeditor/src/jsoneditor.ts
+++ b/packages/codeeditor/src/jsoneditor.ts
@@ -150,8 +150,6 @@ export class JSONEditor extends Widget {
       return;
     }
 
-    // The model does not dispose the shared model by default
-    this.model.sharedModel.dispose();
     this.model.dispose();
     this.editor.dispose();
 

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -247,9 +247,6 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
       ]
     );
 
-    // every time the model is switched, we need to re-initialize the editor binding
-    this.model.sharedModelSwitched.connect(this._initializeEditorBinding, this);
-
     this._onMimeTypeChanged();
     this._onCursorActivity();
 

--- a/packages/completer/test/manager.spec.ts
+++ b/packages/completer/test/manager.spec.ts
@@ -43,6 +43,12 @@ function contextFactory(): Context<INotebookModel> {
   return context;
 }
 
+class TestCellModel extends CellModel {
+  get type(): string {
+    return 'code';
+  }
+}
+
 class CustomCompleterModel extends CompleterModel {}
 
 class FooCompletionProvider implements ICompletionProvider {
@@ -182,7 +188,7 @@ describe('completer/manager', () => {
 
         await manager.updateCompleter(completerContext);
         const cell = new Cell({
-          model: new CellModel({
+          model: new TestCellModel({
             sharedModel: createStandaloneCell({ cell_type: 'code' })
           }),
           placeholder: false

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -343,7 +343,7 @@ export class CodeConsole extends Widget {
     const cell = this.createCodeCell();
     cell.model.sharedModel.setSource(code);
     for (const key of Object.keys(metadata)) {
-      cell.model.metadata.set(key, metadata[key]);
+      cell.model.setMetadata(key, metadata[key]);
     }
     this.addCell(cell);
     return this._execute(cell);

--- a/packages/debugger/src/factory.ts
+++ b/packages/debugger/src/factory.ts
@@ -6,7 +6,7 @@ import {
   CodeEditorWrapper,
   IEditorServices
 } from '@jupyterlab/codeeditor';
-import { IDebugger } from '.';
+import { IDebugger } from './tokens';
 
 /**
  * A widget factory for read only editors.

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -158,10 +158,7 @@ export class DocumentModel
     this.dirty = true;
   }
 
-  private _onStateChanged(
-    sender: ISharedFile,
-    changes: DocumentChange
-  ): void {
+  private _onStateChanged(sender: ISharedFile, changes: DocumentChange): void {
     if ((changes as FileChange).sourceChange) {
       this.triggerContentChange();
     }

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -7,7 +7,11 @@ import { Mode } from '@jupyterlab/codemirror';
 import { IChangedArgs, PathExt } from '@jupyterlab/coreutils';
 import { IObservableList } from '@jupyterlab/observables';
 import { Contents } from '@jupyterlab/services';
-import * as models from '@jupyterlab/shared-models';
+import {
+  DocumentChange,
+  FileChange,
+  ISharedFile
+} from '@jupyterlab/shared-models';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { PartialJSONValue } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
@@ -25,7 +29,7 @@ export class DocumentModel
    * Construct a new document model.
    */
   constructor(languagePreference?: string) {
-    super({ sharedModel: new models.YFile() as models.ISharedText });
+    super();
     this._defaultLang = languagePreference || '';
     this.sharedModel.changed.connect(this._onStateChanged, this);
   }
@@ -155,10 +159,10 @@ export class DocumentModel
   }
 
   private _onStateChanged(
-    sender: models.ISharedFile,
-    changes: models.DocumentChange
+    sender: ISharedFile,
+    changes: DocumentChange
   ): void {
-    if ((changes as models.FileChange).sourceChange) {
+    if ((changes as FileChange).sourceChange) {
       this.triggerContentChange();
     }
     if (changes.stateChange) {
@@ -182,7 +186,7 @@ export class DocumentModel
   /**
    * The shared notebook model.
    */
-  readonly sharedModel: models.ISharedFile;
+  readonly sharedModel: ISharedFile;
   private _defaultLang = '';
   private _dirty = false;
   private _readOnly = false;

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1215,7 +1215,7 @@ function activateCodeConsole(
       const { context, content } = current;
 
       const cell = content.activeCell;
-      const metadata = cell?.model.metadata.toJSON();
+      const metadata = cell?.model.metadata;
       const path = context.path;
       // ignore action in non-code cell
       if (!cell || cell.model.type !== 'code') {

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2649,11 +2649,14 @@ namespace Private {
       headingLevel: number,
       notebook: Notebook
     ): Promise<void> {
+      headingLevel = Math.min(Math.max(headingLevel, 1), 6);
       const state = Private.getState(notebook);
       const model = notebook.model!;
       const sharedModel = model!.sharedModel;
-      sharedModel.insertCell(cellIndex, { cell_type: 'markdown' });
-      Private.setMarkdownHeader(model.cells.get(cellIndex), headingLevel);
+      sharedModel.insertCell(cellIndex, {
+        cell_type: 'markdown',
+        source: '#'.repeat(headingLevel) + ' '
+      });
       notebook.activeCellIndex = cellIndex;
       if (notebook.activeCell?.inViewport === false) {
         await signalToPromise(notebook.activeCell.inViewportChanged, 200).catch(

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2031,12 +2031,12 @@ namespace Private {
     wasFocused: boolean;
 
     /**
-     * The active cell model before the action.
+     * The active cell id before the action.
      *
-     * We cannot rely on the Cell widget as it may be
+     * We cannot rely on the Cell widget or model as it may be
      * discarded by action such as move.
      */
-    activeCellModel: ICellModel | null;
+    activeCellId: string | null;
   }
 
   /**
@@ -2045,7 +2045,7 @@ namespace Private {
   export function getState(notebook: Notebook): IState {
     return {
       wasFocused: notebook.node.contains(document.activeElement),
-      activeCellModel: notebook.activeCell?.model ?? null
+      activeCellId: notebook.activeCell?.model.id ?? null
     };
   }
 
@@ -2081,9 +2081,9 @@ namespace Private {
     if (state.wasFocused || notebook.mode === 'edit') {
       notebook.activate();
     }
-    if (scroll && state.activeCellModel) {
+    if (scroll && state.activeCellId) {
       const index = notebook.widgets.findIndex(
-        w => w.model === state.activeCellModel
+        w => w.model.id === state.activeCellId
       );
       if (notebook.widgets[index]?.inputArea) {
         notebook.scrollToItem(index).catch(reason => {

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1203,7 +1203,9 @@ export namespace NotebookActions {
 
           notebook.widgets.forEach((child, index) => {
             const deletable =
-              child.model.sharedModel.getMetadata().deletable !== false;
+              (child.model.sharedModel.getMetadata(
+                'deletable'
+              ) as unknown as boolean) !== false;
 
             if (notebook.isSelectedOrActive(child) && deletable) {
               toDelete.push(index);
@@ -1606,7 +1608,7 @@ export namespace NotebookActions {
     let latestCellIdx: number | null = null;
     notebook.widgets.forEach((cell, cellIndx) => {
       if (cell.model.type === 'code') {
-        const execution = (cell as CodeCell).model.metadata.get('execution');
+        const execution = cell.model.getMetadata('execution');
         if (
           execution &&
           JSONExt.isObject(execution) &&
@@ -2421,7 +2423,7 @@ namespace Private {
 
     // Find the cells to delete.
     notebook.widgets.forEach((child, index) => {
-      const deletable = child.model.metadata.get('deletable') !== false;
+      const deletable = child.model.getMetadata('deletable') !== false;
 
       if (notebook.isSelectedOrActive(child) && deletable) {
         toDelete.push(index);

--- a/packages/notebook/src/celllist.ts
+++ b/packages/notebook/src/celllist.ts
@@ -2,19 +2,21 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
+  CellModel,
   CodeCellModel,
   ICellModel,
   MarkdownCellModel,
   RawCellModel
 } from '@jupyterlab/cells';
+import { IObservableList } from '@jupyterlab/observables';
 import {
-  IObservableList,
-  IObservableMap,
-  ObservableList,
-  ObservableMap
-} from '@jupyterlab/observables';
-import * as models from '@jupyterlab/shared-models';
-import { ISharedRawCell } from '@jupyterlab/shared-models';
+  ISharedCell,
+  ISharedCodeCell,
+  ISharedMarkdownCell,
+  ISharedNotebook,
+  ISharedRawCell,
+  NotebookChange
+} from '@jupyterlab/shared-models';
 import { ISignal, Signal } from '@lumino/signaling';
 
 /**
@@ -24,60 +26,10 @@ export class CellList {
   /**
    * Construct the cell list.
    */
-  constructor(model: models.ISharedNotebook) {
-    this._cellOrder = new ObservableList();
-    this._cellMap = new ObservableMap<ICellModel>();
-    this.nbmodel = model;
-    this._cellOrder.changed.connect(this._onOrderChanged, this);
-    this.nbmodel.changed.connect(this.onSharedModelChanged, this);
-    this._insertCells(0, this.nbmodel.cells);
-  }
+  constructor(protected model: ISharedNotebook) {
+    this._insertCells(0, this.model.cells);
 
-  type: 'List';
-  nbmodel: models.ISharedNotebook;
-
-  private _insertCells(index: number, cells: Array<models.ISharedCell>) {
-    const cellModels = cells.map(nbcell => {
-      switch (nbcell.cell_type) {
-        case 'code': {
-          return new CodeCellModel({
-            sharedModel: nbcell as models.ISharedCodeCell
-          });
-        }
-        case 'markdown': {
-          return new MarkdownCellModel({
-            sharedModel: nbcell as models.ISharedMarkdownCell
-          });
-        }
-        default: {
-          return new RawCellModel({
-            sharedModel: nbcell as ISharedRawCell
-          });
-        }
-      }
-    });
-    for (const cell of cellModels) {
-      this._cellMap.set(cell.id, cell);
-      this._cellOrder.insert(index++, cell.id);
-    }
-    return this.length;
-  }
-
-  private onSharedModelChanged(
-    self: models.ISharedNotebook,
-    change: models.NotebookChange
-  ) {
-    let currpos = 0;
-    change.cellsChange?.forEach(delta => {
-      if (delta.insert != null) {
-        this._insertCells(currpos, delta.insert);
-        currpos += delta.insert.length;
-      } else if (delta.delete != null) {
-        this._cellOrder.removeRange(currpos, currpos + delta.delete);
-      } else if (delta.retain != null) {
-        currpos += delta.retain;
-      }
-    });
+    this.model.changed.connect(this._onSharedModelChanged, this);
   }
 
   /**
@@ -95,39 +47,12 @@ export class CellList {
   }
 
   /**
-   * Test whether the list is empty.
-   *
-   * @returns `true` if the cell list is empty, `false` otherwise.
-   *
-   * #### Notes
-   * This is a read-only property.
-   *
-   * #### Complexity
-   * Constant.
-   *
-   * #### Iterator Validity
-   * No changes.
-   */
-  get isEmpty(): boolean {
-    return this._cellOrder.length === 0;
-  }
-
-  /**
    * Get the length of the cell list.
    *
    * @returns The number of cells in the cell list.
-   *
-   * #### Notes
-   * This is a read-only property.
-   *
-   * #### Complexity
-   * Constant.
-   *
-   * #### Iterator Validity
-   * No changes.
    */
   get length(): number {
-    return this._cellOrder.length;
+    return this.model.cells.length;
   }
 
   /**
@@ -136,8 +61,8 @@ export class CellList {
    * @returns A new iterator starting at the front of the cell list.
    */
   *[Symbol.iterator](): IterableIterator<ICellModel> {
-    for (const id of this._cellOrder) {
-      yield this._cellMap.get(id)!;
+    for (const cell of this.model.cells) {
+      yield this._cellMap.get(cell)!;
     }
   }
 
@@ -149,13 +74,12 @@ export class CellList {
       return;
     }
     this._isDisposed = true;
-    Signal.clearData(this);
+
     // Clean up the cell map and cell order objects.
-    for (const cell of this._cellMap.values()) {
-      cell.dispose();
+    for (const cell of this.model.cells) {
+      this._cellMap.get(cell)?.dispose();
     }
-    this._cellMap.dispose();
-    this._cellOrder.dispose();
+    Signal.clearData(this);
   }
 
   /**
@@ -164,45 +88,80 @@ export class CellList {
    * @param index - The positive integer index of interest.
    *
    * @returns The cell at the specified index.
-   *
-   * #### Complexity
-   * Constant.
-   *
-   * #### Iterator Validity
-   * No changes.
-   *
-   * #### Undefined Behavior
-   * An `index` which is non-integral or out of range.
    */
   get(index: number): ICellModel {
-    return this._cellMap.get(this._cellOrder.get(index))!;
+    return this._cellMap.get(this.model.cells[index])!;
   }
 
-  private _onOrderChanged(
-    order: IObservableList<string>,
-    change: IObservableList.IChangedArgs<string>
-  ): void {
-    const newValues: ICellModel[] = [];
-    const oldValues: ICellModel[] = [];
-    for (const id of change.newValues) {
-      newValues.push(this._cellMap.get(id)!);
-    }
-    for (const id of change.oldValues) {
-      oldValues.push(this._cellMap.get(id)!);
-    }
-    this._changed.emit({
-      type: change.type,
-      oldIndex: change.oldIndex,
-      newIndex: change.newIndex,
-      oldValues,
-      newValues
+  private _insertCells(index: number, cells: Array<ISharedCell>) {
+    cells.forEach(sharedModel => {
+      let cellModel: CellModel;
+      switch (sharedModel.cell_type) {
+        case 'code': {
+          cellModel = new CodeCellModel({
+            sharedModel: sharedModel as ISharedCodeCell
+          });
+          break;
+        }
+        case 'markdown': {
+          cellModel = new MarkdownCellModel({
+            sharedModel: sharedModel as ISharedMarkdownCell
+          });
+          break;
+        }
+        default: {
+          cellModel = new RawCellModel({
+            sharedModel: sharedModel as ISharedRawCell
+          });
+        }
+      }
+
+      this._cellMap.set(sharedModel, cellModel);
+      sharedModel.disposed.connect(() => {
+        cellModel.dispose();
+        this._cellMap.delete(sharedModel);
+      });
     });
+
+    return this.length;
   }
 
-  private _isDisposed: boolean = false;
-  private _cellOrder: IObservableList<string>;
-  private _cellMap: IObservableMap<ICellModel>;
+  private _onSharedModelChanged(self: ISharedNotebook, change: NotebookChange) {
+    let currpos = 0;
+    // We differ emitting the list changes to ensure cell model for all current shared cell have been created.
+    const events = new Array<IObservableList.IChangedArgs<ICellModel>>();
+    change.cellsChange?.forEach(delta => {
+      if (delta.insert != null) {
+        this._insertCells(currpos, delta.insert);
+        events.push({
+          type: 'add',
+          newIndex: currpos,
+          newValues: delta.insert.map(c => this._cellMap.get(c)!),
+          oldIndex: -2,
+          oldValues: []
+        });
+
+        currpos += delta.insert.length;
+      } else if (delta.delete != null) {
+        events.push({
+          type: 'remove',
+          newIndex: -1,
+          newValues: [],
+          oldIndex: currpos,
+          // Cells have been disposed, so we don't know which one are gone.
+          oldValues: new Array(delta.delete).fill(undefined)
+        });
+      } else if (delta.retain != null) {
+        currpos += delta.retain;
+      }
+    });
+
+    events.forEach(msg => this._changed.emit(msg));
+  }
+
+  private _cellMap = new WeakMap<ISharedCell, ICellModel>();
   private _changed = new Signal<this, IObservableList.IChangedArgs<ICellModel>>(
     this
   );
+  private _isDisposed = false;
 }

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -107,7 +107,11 @@ export class NotebookModel implements INotebookModel {
     this._trans = (options.translator || nullTranslator).load('jupyterlab');
     this._deletedCells = [];
 
-    // Handle initial metadata.
+    // Initialize the notebook
+    // In collaboration mode, this will be overridden by the initialization coming
+    // from the document provider.
+    (this.sharedModel as YNotebook).nbformat_minor = nbformat.MINOR_VERSION;
+    (this.sharedModel as YNotebook).nbformat = nbformat.MAJOR_VERSION;
     this._ensureMetadata(options.languagePreference ?? '');
 
     this.sharedModel.metadataChanged.connect(this._onMetadataChanged, this);

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -6,19 +6,18 @@ import { ICellModel } from '@jupyterlab/cells';
 import { IChangedArgs } from '@jupyterlab/coreutils';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import * as nbformat from '@jupyterlab/nbformat';
+import { IObservableList } from '@jupyterlab/observables';
 import {
-  IObservableJSON,
-  IObservableList,
-  IObservableMap,
-  ObservableJSON
-} from '@jupyterlab/observables';
-import * as sharedModels from '@jupyterlab/shared-models';
+  IMapChange,
+  ISharedNotebook,
+  NotebookChange,
+  YNotebook
+} from '@jupyterlab/shared-models';
 import {
   ITranslator,
   nullTranslator,
   TranslationBundle
 } from '@jupyterlab/translation';
-import { JSONObject, ReadonlyPartialJSONValue } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 import { CellList } from './celllist';
 
@@ -43,17 +42,54 @@ export interface INotebookModel extends DocumentRegistry.IModel {
 
   /**
    * The metadata associated with the notebook.
+   *
+   * ### Notes
+   * This is a copy of the metadata. Changing a part of it
+   * won't affect the model.
+   * As this returns a copy of all metadata, it is advised to
+   * use `getMetadata` to speed up the process of getting a single key.
    */
-  readonly metadata: IObservableJSON;
+  readonly metadata: nbformat.INotebookMetadata;
+
+  /**
+   * Signal emitted when notebook metadata changes.
+   */
+  readonly metadataChanged: ISignal<INotebookModel, IMapChange>;
 
   /**
    * The array of deleted cells since the notebook was last run.
    */
   readonly deletedCells: string[];
+
   /**
    * Shared model
    */
-  readonly sharedModel: sharedModels.ISharedNotebook;
+  readonly sharedModel: ISharedNotebook;
+
+  /**
+   * Delete a metadata
+   *
+   * @param key Metadata key
+   */
+  deleteMetadata(key: string): void;
+
+  /**
+   * Get a metadata
+   *
+   * ### Notes
+   * This returns a copy of the key value.
+   *
+   * @param key Metadata key
+   */
+  getMetadata(key: string): any;
+
+  /**
+   * Set a metadata
+   *
+   * @param key Metadata key
+   * @param value Metadata value
+   */
+  setMetadata(key: string, value: any): void;
 }
 
 /**
@@ -64,23 +100,18 @@ export class NotebookModel implements INotebookModel {
    * Construct a new notebook model.
    */
   constructor(options: NotebookModel.IOptions = {}) {
-    this.sharedModel = sharedModels.YNotebook.create({
+    this.sharedModel = YNotebook.create({
       disableDocumentWideUndoRedo: options.disableDocumentWideUndoRedo ?? false
-    }) as sharedModels.ISharedNotebook;
+    });
     this._cells = new CellList(this.sharedModel);
     this._trans = (options.translator || nullTranslator).load('jupyterlab');
-    this._cells.changed.connect(this._onCellsChanged, this);
-
-    // Handle initial metadata.
-    this._metadata = new ObservableJSON();
-    if (!this._metadata.has('language_info')) {
-      const name = options.languagePreference || '';
-      this._metadata.set('language_info', { name });
-    }
-    this._ensureMetadata();
-    this._metadata.changed.connect(this._onMetadataChanged, this);
     this._deletedCells = [];
 
+    // Handle initial metadata.
+    this._ensureMetadata(options.languagePreference ?? '');
+
+    this.sharedModel.metadataChanged.connect(this._onMetadataChanged, this);
+    this._cells.changed.connect(this._onCellsChanged, this);
     this.sharedModel.changed.connect(this._onStateChanged, this);
   }
   /**
@@ -91,10 +122,24 @@ export class NotebookModel implements INotebookModel {
   }
 
   /**
+   * Signal emitted when notebook metadata changes.
+   */
+  get metadataChanged(): ISignal<INotebookModel, IMapChange<any>> {
+    return this._metadataChanged;
+  }
+
+  /**
    * A signal emitted when the document state changes.
    */
   get stateChanged(): ISignal<this, IChangedArgs<any>> {
     return this._stateChanged;
+  }
+
+  /**
+   * Get the observable list of notebook cells.
+   */
+  get cells(): CellList {
+    return this._cells;
   }
 
   /**
@@ -133,40 +178,37 @@ export class NotebookModel implements INotebookModel {
 
   /**
    * The metadata associated with the notebook.
+   *
+   * ### Notes
+   * This is a copy of the metadata. Changing a part of it
+   * won't affect the model.
+   * As this returns a copy of all metadata, it is advised to
+   * use `getMetadata` to speed up the process of getting a single key.
    */
-  get metadata(): IObservableJSON {
-    return this._metadata;
-  }
-
-  /**
-   * Get the observable list of notebook cells.
-   */
-  get cells(): CellList {
-    return this._cells;
+  get metadata(): nbformat.INotebookMetadata {
+    return this.sharedModel.metadata;
   }
 
   /**
    * The major version number of the nbformat.
    */
   get nbformat(): number {
-    return this._nbformat;
+    return this.sharedModel.nbformat;
   }
 
   /**
    * The minor version number of the nbformat.
    */
   get nbformatMinor(): number {
-    return this._nbformatMinor;
+    return this.sharedModel.nbformat_minor;
   }
 
   /**
    * The default kernel name of the document.
    */
   get defaultKernelName(): string {
-    const spec = this.metadata.get(
-      'kernelspec'
-    ) as nbformat.IKernelspecMetadata;
-    return spec ? spec.name : '';
+    const spec = this.getMetadata('kernelspec');
+    return spec?.name ?? '';
   }
 
   /**
@@ -180,10 +222,8 @@ export class NotebookModel implements INotebookModel {
    * The default kernel language of the document.
    */
   get defaultKernelLanguage(): string {
-    const info = this.metadata.get(
-      'language_info'
-    ) as nbformat.ILanguageInfoMetadata;
-    return info ? info.name : '';
+    const info = this.getMetadata('language_info');
+    return info?.name ?? '';
   }
 
   /**
@@ -194,12 +234,48 @@ export class NotebookModel implements INotebookModel {
     if (this.isDisposed) {
       return;
     }
+    this._isDisposed = true;
+
     const cells = this.cells;
     this._cells = null!;
     cells.dispose();
     this.sharedModel.dispose();
-    this._isDisposed = true;
     Signal.clearData(this);
+  }
+
+  /**
+   * Delete a metadata
+   *
+   * @param key Metadata key
+   */
+  deleteMetadata(key: string): void {
+    return this.sharedModel.deleteMetadata(key);
+  }
+
+  /**
+   * Get a metadata
+   *
+   * ### Notes
+   * This returns a copy of the key value.
+   *
+   * @param key Metadata key
+   */
+  getMetadata(key: string): any {
+    return this.sharedModel.getMetadata(key);
+  }
+
+  /**
+   * Set a metadata
+   *
+   * @param key Metadata key
+   * @param value Metadata value
+   */
+  setMetadata(key: string, value: any): void {
+    if (typeof value === 'undefined') {
+      this.sharedModel.deleteMetadata(key);
+    } else {
+      this.sharedModel.setMetadata(key, value);
+    }
   }
 
   /**
@@ -223,26 +299,8 @@ export class NotebookModel implements INotebookModel {
    * Serialize the model to JSON.
    */
   toJSON(): nbformat.INotebookContent {
-    const cells: nbformat.ICell[] = [];
-    for (let i = 0; i < (this.cells?.length ?? 0); i++) {
-      const cell = this.cells.get(i).toJSON();
-      if (this._nbformat === 4 && this._nbformatMinor <= 4) {
-        // strip cell ids if we have notebook format 4.0-4.4
-        delete cell.id;
-      }
-      cells.push(cell);
-    }
     this._ensureMetadata();
-    const metadata = this.sharedModel.getMetadata();
-    for (const key of this.metadata.keys()) {
-      metadata[key] = JSON.parse(JSON.stringify(this.metadata.get(key)));
-    }
-    return {
-      metadata,
-      nbformat_minor: this._nbformatMinor,
-      nbformat: this._nbformat,
-      cells
-    };
+    return this.sharedModel.toJSON();
   }
 
   /**
@@ -269,23 +327,23 @@ export class NotebookModel implements INotebookModel {
       this.sharedModel.deleteCellRange(0, this.sharedModel.cells.length);
     });
 
-    (this.sharedModel as sharedModels.YNotebook).nbformat_minor =
-      nbformat.MINOR_VERSION;
-    (this.sharedModel as sharedModels.YNotebook).nbformat =
-      nbformat.MAJOR_VERSION;
+    (this.sharedModel as YNotebook).nbformat_minor = nbformat.MINOR_VERSION;
+    (this.sharedModel as YNotebook).nbformat = nbformat.MAJOR_VERSION;
     const origNbformat = value.metadata.orig_nbformat;
 
-    if (value.nbformat !== this._nbformat) {
-      (this.sharedModel as sharedModels.YNotebook).nbformat = value.nbformat;
+    if (value.nbformat !== this.sharedModel.nbformat) {
+      (this.sharedModel as YNotebook).nbformat = value.nbformat;
     }
-    if (value.nbformat_minor > this._nbformatMinor) {
-      (this.sharedModel as sharedModels.YNotebook).nbformat_minor =
-        value.nbformat_minor;
+    if (
+      value.nbformat_minor >
+      ((this.sharedModel as YNotebook).nbformat_minor ?? -1)
+    ) {
+      (this.sharedModel as YNotebook).nbformat_minor = value.nbformat_minor;
     }
 
     // Alert the user if the format changes.
-    if (origNbformat !== undefined && this._nbformat !== origNbformat) {
-      const newer = this._nbformat > origNbformat;
+    if (origNbformat !== undefined && this.nbformat !== origNbformat) {
+      const newer = this.nbformat > origNbformat;
       let msg: string;
 
       if (newer) {
@@ -296,7 +354,7 @@ The next time you save this notebook, the current notebook format (v%2) will be 
 'Older versions of Jupyter may not be able to read the new format.' To preserve the original format version,
 close the notebook without saving it.`,
           origNbformat,
-          this._nbformat
+          this.nbformat
         );
       } else {
         msg = this._trans.__(
@@ -306,7 +364,7 @@ The next time you save this notebook, the current notebook format (v%2) will be 
 Some features of the original notebook may not be available.' To preserve the original format version,
 close the notebook without saving it.`,
           origNbformat,
-          this._nbformat
+          this.nbformat
         );
       }
       void showDialog({
@@ -317,15 +375,14 @@ close the notebook without saving it.`,
     }
 
     // Update the metadata.
-    this.metadata.clear();
     const metadata = value.metadata;
     for (const key in metadata) {
       // orig_nbformat is not intended to be stored per spec.
       if (key === 'orig_nbformat') {
         continue;
       }
-      this.metadata.set(key, metadata[key]);
     }
+    this.sharedModel.metadata = metadata;
     this._ensureMetadata();
     this.dirty = true;
   }
@@ -356,9 +413,17 @@ close the notebook without saving it.`,
     this.triggerContentChange();
   }
 
+  private _onMetadataChanged(
+    sender: ISharedNotebook,
+    changes: IMapChange
+  ): void {
+    this._metadataChanged.emit(changes);
+    this.triggerContentChange();
+  }
+
   private _onStateChanged(
-    sender: sharedModels.ISharedNotebook,
-    changes: sharedModels.NotebookChange
+    sender: ISharedNotebook,
+    changes: NotebookChange
   ): void {
     if (changes.stateChange) {
       changes.stateChange.forEach(value => {
@@ -376,48 +441,20 @@ close the notebook without saving it.`,
         }
       });
     }
-
-    if (changes.nbformatChanged) {
-      const change = changes.nbformatChanged;
-      if (change.key === 'nbformat' && change.newValue !== undefined) {
-        this._nbformat = change.newValue;
-      }
-      if (change.key === 'nbformat_minor' && change.newValue !== undefined) {
-        this._nbformatMinor = change.newValue;
-      }
-    }
-
-    if (changes.metadataChange) {
-      const metadata = changes.metadataChange.newValue as JSONObject;
-      this._modelDBMutex(() => {
-        this.metadata.clear();
-        Object.entries(metadata).forEach(([key, value]) => {
-          this.metadata.set(key, value);
-        });
-      });
-    }
-  }
-
-  private _onMetadataChanged(
-    metadata: IObservableJSON,
-    change: IObservableMap.IChangedArgs<ReadonlyPartialJSONValue | undefined>
-  ): void {
-    this._modelDBMutex(() => {
-      this.sharedModel.setMetadata(metadata.toJSON());
-    });
-    this.triggerContentChange();
   }
 
   /**
    * Make sure we have the required metadata fields.
    */
-  private _ensureMetadata(): void {
-    const metadata = this.metadata;
-    if (!metadata.has('language_info')) {
-      metadata.set('language_info', { name: '' });
+  private _ensureMetadata(languageName: string = ''): void {
+    if (!this.getMetadata('language_info')) {
+      this.sharedModel.setMetadata('language_info', { name: languageName });
     }
-    if (!metadata.has('kernelspec')) {
-      metadata.set('kernelspec', { name: '', display_name: '' });
+    if (!this.getMetadata('kernelspec')) {
+      this.sharedModel.setMetadata('kernelspec', {
+        name: '',
+        display_name: ''
+      });
     }
   }
 
@@ -446,12 +483,7 @@ close the notebook without saving it.`,
   /**
    * The shared notebook model.
    */
-  readonly sharedModel: sharedModels.ISharedNotebook;
-
-  /**
-   * A mutex to update the shared model.
-   */
-  protected readonly _modelDBMutex = sharedModels.createMutex();
+  readonly sharedModel: ISharedNotebook;
 
   private _dirty = false;
   private _readOnly = false;
@@ -460,11 +492,9 @@ close the notebook without saving it.`,
 
   private _trans: TranslationBundle;
   private _cells: CellList;
-  private _metadata: IObservableJSON;
-  private _nbformat = nbformat.MAJOR_VERSION;
-  private _nbformatMinor = nbformat.MINOR_VERSION;
   private _deletedCells: string[];
   private _isDisposed = false;
+  private _metadataChanged = new Signal<NotebookModel, IMapChange>(this);
 }
 
 /**

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -100,7 +100,7 @@ export class NotebookModel implements INotebookModel {
    * Construct a new notebook model.
    */
   constructor(options: NotebookModel.IOptions = {}) {
-    this.sharedModel = YNotebook.create({
+    this.sharedModel = new YNotebook({
       disableDocumentWideUndoRedo: options.disableDocumentWideUndoRedo ?? false
     });
     this._cells = new CellList(this.sharedModel);

--- a/packages/notebook/src/notebooktools.ts
+++ b/packages/notebook/src/notebooktools.ts
@@ -10,7 +10,8 @@ import {
 import { CodeEditor, JSONEditor } from '@jupyterlab/codeeditor';
 import { Mode } from '@jupyterlab/codemirror';
 import * as nbformat from '@jupyterlab/nbformat';
-import { IObservableMap, ObservableJSON } from '@jupyterlab/observables';
+import { ObservableJSON } from '@jupyterlab/observables';
+import { IMapChange, ISharedText } from '@jupyterlab/shared-models';
 import {
   ITranslator,
   nullTranslator,
@@ -19,17 +20,17 @@ import {
 import { Collapser, Styling } from '@jupyterlab/ui-components';
 import { ArrayExt } from '@lumino/algorithm';
 import {
+  JSONObject,
   ReadonlyPartialJSONObject,
   ReadonlyPartialJSONValue
 } from '@lumino/coreutils';
 import { ConflatableMessage, Message, MessageLoop } from '@lumino/messaging';
-import { h, VirtualDOM, VirtualNode } from '@lumino/virtualdom';
 import { Debouncer } from '@lumino/polling';
+import { h, VirtualDOM, VirtualNode } from '@lumino/virtualdom';
 import { PanelLayout, Widget } from '@lumino/widgets';
 import { INotebookModel } from './model';
 import { NotebookPanel } from './panel';
 import { INotebookTools, INotebookTracker } from './tokens';
-import { ISharedText } from '@jupyterlab/shared-models';
 
 class RankedPanel<T extends Widget = Widget> extends Widget {
   constructor() {
@@ -156,7 +157,7 @@ export class NotebookTools extends Widget implements INotebookTools {
       this._prevActiveNotebookModel &&
       !this._prevActiveNotebookModel.isDisposed
     ) {
-      this._prevActiveNotebookModel.metadata.changed.disconnect(
+      this._prevActiveNotebookModel.metadataChanged.disconnect(
         this._onActiveNotebookPanelMetadataChanged,
         this
       );
@@ -167,7 +168,7 @@ export class NotebookTools extends Widget implements INotebookTools {
         : null;
     this._prevActiveNotebookModel = activeNBModel;
     if (activeNBModel) {
-      activeNBModel.metadata.changed.connect(
+      activeNBModel.metadataChanged.connect(
         this._onActiveNotebookPanelMetadataChanged,
         this
       );
@@ -182,7 +183,7 @@ export class NotebookTools extends Widget implements INotebookTools {
    */
   private _onActiveCellChanged(): void {
     if (this._prevActiveCell && !this._prevActiveCell.isDisposed) {
-      this._prevActiveCell.metadata.changed.disconnect(
+      this._prevActiveCell.metadataChanged.disconnect(
         this._onActiveCellMetadataChanged,
         this
       );
@@ -190,7 +191,7 @@ export class NotebookTools extends Widget implements INotebookTools {
     const activeCell = this.activeCell ? this.activeCell.model : null;
     this._prevActiveCell = activeCell;
     if (activeCell) {
-      activeCell.metadata.changed.connect(
+      activeCell.metadataChanged.connect(
         this._onActiveCellMetadataChanged,
         this
       );
@@ -213,12 +214,12 @@ export class NotebookTools extends Widget implements INotebookTools {
    * Handle a change in the active cell metadata.
    */
   private _onActiveNotebookPanelMetadataChanged(
-    sender: IObservableMap<ReadonlyPartialJSONValue | undefined>,
-    args: IObservableMap.IChangedArgs<ReadonlyPartialJSONValue>
+    sender: INotebookModel,
+    args: IMapChange
   ): void {
     const message = new ObservableJSON.ChangeMessage(
       'activenotebookpanel-metadata-changed',
-      args
+      { oldValue: undefined, newValue: undefined, ...args }
     );
     for (const widget of this._toolChildren()) {
       MessageLoop.sendMessage(widget, message);
@@ -229,12 +230,12 @@ export class NotebookTools extends Widget implements INotebookTools {
    * Handle a change in the notebook model metadata.
    */
   private _onActiveCellMetadataChanged(
-    sender: IObservableMap<ReadonlyPartialJSONValue | undefined>,
-    args: IObservableMap.IChangedArgs<ReadonlyPartialJSONValue>
+    sender: ICellModel,
+    args: IMapChange
   ): void {
     const message = new ObservableJSON.ChangeMessage(
       'activecell-metadata-changed',
-      args
+      { newValue: undefined, oldValue: undefined, ...args }
     );
     for (const widget of this._toolChildren()) {
       MessageLoop.sendMessage(widget, message);
@@ -631,11 +632,26 @@ export namespace NotebookTools {
       this._update();
     }
 
+    private _onSourceChanged() {
+      if (this.editor.source) {
+        this.notebookTools.activeNotebookPanel?.content.model?.sharedModel.setMetadata(
+          this.editor.source.toJSON()
+        );
+      }
+    }
+
     private _update() {
-      const nb =
-        this.notebookTools.activeNotebookPanel &&
-        this.notebookTools.activeNotebookPanel.content;
-      this.editor.source = nb?.model?.metadata ?? null;
+      if (this.editor.source) {
+        this.editor.source.changed.disconnect(this._onSourceChanged, this);
+      }
+      const nb = this.notebookTools.activeNotebookPanel?.content;
+      this.editor.source = nb?.model?.metadata
+        ? new ObservableJSON({ values: nb.model.metadata as JSONObject })
+        : null;
+
+      if (this.editor.source) {
+        this.editor.source.changed.connect(this._onSourceChanged, this);
+      }
     }
   }
 
@@ -668,9 +684,25 @@ export namespace NotebookTools {
       this._update();
     }
 
+    private _onSourceChanged() {
+      if (this.editor.source) {
+        this.notebookTools.activeCell?.model?.sharedModel.setMetadata(
+          this.editor.source.toJSON()
+        );
+      }
+    }
+
     private _update() {
+      if (this.editor.source) {
+        this.editor.source.changed.disconnect(this._onSourceChanged, this);
+      }
       const cell = this.notebookTools.activeCell;
-      this.editor.source = cell ? cell.model.metadata : null;
+      this.editor.source = cell
+        ? new ObservableJSON({ values: cell.model.metadata as JSONObject })
+        : null;
+      if (this.editor.source) {
+        this.editor.source.changed.connect(this._onSourceChanged, this);
+      }
     }
   }
 
@@ -805,7 +837,7 @@ export namespace NotebookTools {
      * Get the value for the data.
      */
     private _getValue = (cell: Cell) => {
-      let value = cell.model.metadata.get(this.key);
+      let value = cell.model.getMetadata(this.key);
       if (value === undefined) {
         value = this._default;
       }
@@ -820,9 +852,9 @@ export namespace NotebookTools {
       value: ReadonlyPartialJSONValue | undefined
     ) => {
       if (value === this._default) {
-        cell.model.metadata.delete(this.key);
+        cell.model.deleteMetadata(this.key);
       } else {
-        cell.model.metadata.set(this.key, value);
+        cell.model.setMetadata(this.key, value);
       }
     };
 
@@ -921,7 +953,7 @@ export namespace NotebookTools {
       const metadata = nb?.model?.metadata ?? null;
       if (metadata) {
         const keyPath = this._key.split('/');
-        const value = { ...((metadata.get(keyPath[0]) ?? {}) as any) };
+        const value = { ...((metadata[keyPath[0]] ?? {}) as any) };
         let lastObj = value;
         for (let p = 1; p < keyPath.length - 1; p++) {
           if (lastObj[keyPath[p]] === undefined) {
@@ -932,7 +964,7 @@ export namespace NotebookTools {
         lastObj[keyPath[keyPath.length - 1]] =
           this.inputNode.valueAsNumber ?? 1;
 
-        metadata.set(keyPath[0], value);
+        nb!.model!.setMetadata(keyPath[0], value);
       }
     }
 
@@ -943,7 +975,7 @@ export namespace NotebookTools {
       const metadata = nb?.model?.metadata ?? null;
       if (metadata) {
         const keyPath = this._key.split('/');
-        let value = metadata.get(keyPath[0]) as any;
+        let value = metadata[keyPath[0]] as any;
         for (let p = 1; p < keyPath.length; p++) {
           value = (value ?? {})[keyPath[p]];
         }
@@ -1052,13 +1084,13 @@ export namespace NotebookTools {
         [trans.__('Notes'), 'notes']
       ],
       getter: cell => {
-        const value = cell.model.metadata.get('slideshow') as
+        const value = cell.model.getMetadata('slideshow') as
           | ReadonlyPartialJSONObject
           | undefined;
         return value && value['slide_type'];
       },
       setter: (cell, value) => {
-        let data = cell.model.metadata.get('slideshow') || Object.create(null);
+        let data = cell.model.getMetadata('slideshow') || Object.create(null);
         if (value === null) {
           // Make a shallow copy so we aren't modifying the original metadata.
           data = { ...data };
@@ -1067,9 +1099,9 @@ export namespace NotebookTools {
           data = { ...data, slide_type: value };
         }
         if (Object.keys(data).length > 0) {
-          cell.model.metadata.set('slideshow', data);
+          cell.model.setMetadata('slideshow', data);
         } else {
-          cell.model.metadata.delete('slideshow');
+          cell.model.deleteMetadata('slideshow');
         }
       }
     };

--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -226,7 +226,7 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
    * Update the kernel language.
    */
   private _updateLanguage(language: KernelMessage.ILanguageInfo): void {
-    this.model!.metadata.set('language_info', language);
+    this.model!.setMetadata('language_info', language);
   }
 
   /**
@@ -237,7 +237,7 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
     if (this.isDisposed) {
       return;
     }
-    this.model!.metadata.set('kernelspec', {
+    this.model!.setMetadata('kernelspec', {
       name: kernel.name,
       display_name: spec?.display_name,
       language: spec?.language

--- a/packages/notebook/src/toc.ts
+++ b/packages/notebook/src/toc.ts
@@ -88,7 +88,7 @@ export class NotebookToCModel extends TableOfContentsModel<
       this.setConfiguration({});
     });
 
-    this.widget.context.model.metadata.changed.connect(
+    this.widget.context.model.metadataChanged.connect(
       this.onMetadataChanged,
       this
     );
@@ -168,7 +168,7 @@ export class NotebookToCModel extends TableOfContentsModel<
     }
 
     this.headingsChanged.disconnect(this.onHeadingsChanged, this);
-    this.widget.context?.model?.metadata?.changed.disconnect(
+    this.widget.context?.model?.metadataChanged.disconnect(
       this.onMetadataChanged,
       this
     );
@@ -308,7 +308,7 @@ export class NotebookToCModel extends TableOfContentsModel<
           }
 
           const keyPath = key.split('/');
-          let value = nbModel.metadata.get(keyPath[0]) as any;
+          let value = nbModel.getMetadata(keyPath[0]);
           for (let p = 1; p < keyPath.length; p++) {
             value = (value ?? {})[keyPath[p]];
           }

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1365,7 +1365,7 @@ export class Notebook extends StaticNotebook {
   }
 
   /**
-   * Move a cell preserving widget view state.
+   * Move cells preserving widget view state.
    *
    * #### Notes
    * This is required because at the model level a move is a deletion

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -362,7 +362,7 @@ export class StaticNotebook extends WindowedList {
   }
 
   /**
-   * Move a cell preserving widget view state.
+   * Move cells preserving widget view state.
    *
    * #### Notes
    * This is required because at the model level a move is a deletion
@@ -395,13 +395,14 @@ export class StaticNotebook extends WindowedList {
       }
     }
 
-    this.model!.sharedModel.moveCell(from, boundedTo, n);
+    this.model!.sharedModel.moveCells(from, boundedTo, n);
 
     for (let i = 0; i < n; i++) {
       const newCell = this.widgets[to + i];
-      for (const state in viewModel) {
+      const view = viewModel[i];
+      for (const state in view) {
         // @ts-expect-error Cell has no index signature
-        newCell[state] = viewModel[i][state];
+        newCell[state] = view[state];
       }
     }
   }

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -1237,6 +1237,13 @@ describe('@jupyterlab/notebook', () => {
         expect(widget.activeCellIndex).toBe(0);
       });
 
+      it('should move the last cell up', () => {
+        const lastIndex = widget.model!.cells.length - 1;
+        widget.activeCellIndex = lastIndex;
+        NotebookActions.moveUp(widget);
+        expect(widget.activeCellIndex).toBe(lastIndex - 1);
+      });
+
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         NotebookActions.moveUp(widget);

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -349,12 +349,10 @@ describe('@jupyterlab/notebook', () => {
             const markdownCell = widget.widgets[i] as MarkdownCell;
             const attachment: IMimeBundle = { 'text/plain': 'test' };
             markdownCell.model.attachments.set(UUID.uuid4(), attachment);
-            console.log(markdownCell.model.attachments);
             widget.select(markdownCell);
           }
           NotebookActions.mergeCells(widget);
           const model = (widget.activeCell as MarkdownCell).model;
-          console.log(model.attachments);
           expect(model.attachments.length).toBe(2);
         }
       );

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -349,10 +349,12 @@ describe('@jupyterlab/notebook', () => {
             const markdownCell = widget.widgets[i] as MarkdownCell;
             const attachment: IMimeBundle = { 'text/plain': 'test' };
             markdownCell.model.attachments.set(UUID.uuid4(), attachment);
+            console.log(markdownCell.model.attachments);
             widget.select(markdownCell);
           }
           NotebookActions.mergeCells(widget);
           const model = (widget.activeCell as MarkdownCell).model;
+          console.log(model.attachments);
           expect(model.attachments.length).toBe(2);
         }
       );
@@ -1315,7 +1317,7 @@ describe('@jupyterlab/notebook', () => {
       it('should delete metadata.deletable', () => {
         const next = widget.widgets[1];
         widget.select(next);
-        next.model.metadata.set('deletable', false);
+        next.model.setMetadata('deletable', false);
         NotebookActions.copy(widget);
         const data = utils.clipboard.getData(JUPYTER_CELL_MIME) as JSONArray;
         data.map(cell => {

--- a/packages/notebook/test/model.spec.ts
+++ b/packages/notebook/test/model.spec.ts
@@ -16,7 +16,7 @@ describe('@jupyterlab/notebook', () => {
 
       it('should accept an optional language preference', () => {
         const model = new NotebookModel({ languagePreference: 'python' });
-        const lang = model.metadata.get(
+        const lang = model.getMetadata(
           'language_info'
         ) as nbformat.ILanguageInfoMetadata;
         expect(lang.name).toBe('python');
@@ -27,25 +27,25 @@ describe('@jupyterlab/notebook', () => {
       it('should be emitted when a metadata field changes', () => {
         const model = new NotebookModel();
         let called = false;
-        model.metadata.changed.connect((sender, args) => {
-          expect(sender).toBe(model.metadata);
+        model.metadataChanged.connect((sender, args) => {
+          expect(sender).toBe(model);
           expect(args.key).toBe('foo');
           expect(args.oldValue).toBeUndefined();
           expect(args.newValue).toBe(1);
           called = true;
         });
-        model.metadata.set('foo', 1);
+        model.setMetadata('foo', 1);
         expect(called).toBe(true);
       });
 
       it('should not be emitted when the value does not change', () => {
         const model = new NotebookModel();
         let called = false;
-        model.metadata.set('foo', 1);
-        model.metadata.changed.connect(() => {
+        model.setMetadata('foo', 1);
+        model.metadataChanged.connect(() => {
           called = true;
         });
-        model.metadata.set('foo', 1);
+        model.setMetadata('foo', 1);
         expect(called).toBe(false);
       });
     });
@@ -135,7 +135,7 @@ describe('@jupyterlab/notebook', () => {
           model.contentChanged.connect(() => {
             called = true;
           });
-          model.metadata.set('foo', 'bar');
+          model.setMetadata('foo', 'bar');
           expect(called).toBe(true);
         });
 
@@ -182,7 +182,7 @@ describe('@jupyterlab/notebook', () => {
     describe('#defaultKernelName()', () => {
       it('should get the default kernel name of the document', () => {
         const model = new NotebookModel();
-        model.metadata.set('kernelspec', { name: 'python3' });
+        model.setMetadata('kernelspec', { name: 'python3' });
         expect(model.defaultKernelName).toBe('python3');
       });
 
@@ -195,7 +195,7 @@ describe('@jupyterlab/notebook', () => {
     describe('#defaultKernelLanguage', () => {
       it('should get the default kernel language of the document', () => {
         const model = new NotebookModel();
-        model.metadata.set('language_info', { name: 'python' });
+        model.setMetadata('language_info', { name: 'python' });
         expect(model.defaultKernelLanguage).toBe('python');
       });
 
@@ -308,15 +308,15 @@ describe('@jupyterlab/notebook', () => {
       it('should have default values', () => {
         const model = new NotebookModel();
         const metadata = model.metadata;
-        expect(metadata.has('kernelspec')).toBeTruthy();
-        expect(metadata.has('language_info')).toBeTruthy();
-        expect(metadata.size).toBe(2);
+        expect(metadata['kernelspec']).toBeTruthy();
+        expect(metadata['language_info']).toBeTruthy();
+        expect(Object.keys(metadata)).toHaveLength(2);
       });
 
       it('should set the dirty flag when changed', () => {
         const model = new NotebookModel();
         expect(model.dirty).toBe(false);
-        model.metadata.set('foo', 'bar');
+        model.setMetadata('foo', 'bar');
         expect(model.dirty).toBe(true);
       });
 
@@ -326,21 +326,21 @@ describe('@jupyterlab/notebook', () => {
         model.contentChanged.connect(() => {
           called = true;
         });
-        model.metadata.set('foo', 'bar');
+        model.setMetadata('foo', 'bar');
         expect(called).toBe(true);
       });
 
       it('should emit the `metadataChanged` signal', () => {
         const model = new NotebookModel();
         let called = false;
-        model.metadata.changed.connect((sender, args) => {
-          expect(sender).toBe(model.metadata);
+        model.metadataChanged.connect((sender, args) => {
+          expect(sender).toBe(model);
           expect(args.key).toBe('foo');
           expect(args.oldValue).toBeUndefined();
           expect(args.newValue).toBe('bar');
           called = true;
         });
-        model.metadata.set('foo', 'bar');
+        model.setMetadata('foo', 'bar');
         expect(called).toBe(true);
       });
     });

--- a/packages/notebook/test/notebooktools.spec.ts
+++ b/packages/notebook/test/notebooktools.spec.ts
@@ -251,9 +251,9 @@ describe('@jupyterlab/notebook', () => {
           const tool = new LogTool({});
           notebookTools.addItem({ tool });
           tool.methods = [];
-          const metadata = notebookTools.activeCell!.model.metadata;
-          metadata.set('foo', 1);
-          metadata.set('foo', 2);
+          const model = notebookTools.activeCell!.model;
+          model.setMetadata('foo', 1);
+          model.setMetadata('foo', 2);
           expect(tool.methods).toContain('onActiveCellMetadataChanged');
         });
       });
@@ -263,9 +263,9 @@ describe('@jupyterlab/notebook', () => {
           const tool = new LogTool({});
           notebookTools.addItem({ tool });
           tool.methods = [];
-          const metadata = notebookTools.activeNotebookPanel!.model!.metadata;
-          metadata.set('foo', 1);
-          metadata.set('foo', 2);
+          const model = notebookTools.activeNotebookPanel!.model!;
+          model.setMetadata('foo', 1);
+          model.setMetadata('foo', 2);
           expect(tool.methods).toContain(
             'onActiveNotebookPanelMetadataChanged'
           );
@@ -285,7 +285,7 @@ describe('@jupyterlab/notebook', () => {
         notebookTools.addItem({ tool });
         const widget = tracker.currentWidget!;
         widget.content.activeCellIndex++;
-        widget.content.activeCell!.model.metadata.set('bar', 1);
+        widget.content.activeCell!.model.setMetadata('bar', 1);
         expect(tool.node.querySelector('pre')).toBeTruthy();
       });
     });
@@ -310,7 +310,7 @@ describe('@jupyterlab/notebook', () => {
         expect(JSON.stringify(model.sharedModel.getSource())).toBeTruthy();
         const widget = tracker.currentWidget!;
         widget.content.activeCellIndex++;
-        widget.content.activeCell!.model.metadata.set('bar', 1);
+        widget.content.activeCell!.model.setMetadata('bar', 1);
         expect(
           JSON.stringify(tool.editor.model.sharedModel.getSource())
         ).toContain('bar');
@@ -323,9 +323,9 @@ describe('@jupyterlab/notebook', () => {
         notebookTools.addItem({ tool });
         const model = tool.editor.model;
         const previous = model.sharedModel.getSource();
-        const metadata = notebookTools.activeCell!.model.metadata;
-        metadata.set('foo', 1);
-        expect(model.sharedModel.getSource()).not.toBe(previous);
+        const cellModel = notebookTools.activeCell!.model;
+        cellModel.setMetadata('foo', 1);
+        expect(tool.editor.model.sharedModel.getSource()).not.toBe(previous);
       });
     });
 
@@ -341,8 +341,8 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should handle a change to the active notebook', () => {
-        panel0.model!.metadata.set('panel0', 1);
-        panel1.model!.metadata.set('panel1', 1);
+        panel0.model!.setMetadata('panel0', 1);
+        panel1.model!.setMetadata('panel1', 1);
         const tool = new NotebookTools.NotebookMetadataEditorTool({
           editorFactory
         });
@@ -378,7 +378,7 @@ describe('@jupyterlab/notebook', () => {
         expect(JSON.stringify(model.sharedModel.getSource())).not.toContain(
           'newvalue'
         );
-        widget.content.model!.metadata.set('newvalue', 1);
+        widget.content.model!.setMetadata('newvalue', 1);
         expect(JSON.stringify(model.sharedModel.getSource())).toContain(
           'newvalue'
         );
@@ -432,8 +432,8 @@ describe('@jupyterlab/notebook', () => {
             select.selectedIndex = 1;
             simulate(select, 'change');
             expect(tool.events).toContain('change');
-            const metadata = notebookTools.activeCell!.model.metadata;
-            expect(metadata.get('foo')).toEqual([1, 2, 'a']);
+            const model = notebookTools.activeCell!.model;
+            expect(model.getMetadata('foo')).toEqual([1, 2, 'a']);
           });
         });
 
@@ -488,15 +488,15 @@ describe('@jupyterlab/notebook', () => {
           select.selectedIndex = 1;
           simulate(select, 'change');
           expect(tool.methods).toContain('onValueChanged');
-          const metadata = notebookTools.activeCell!.model.metadata;
-          expect(metadata.get('foo')).toEqual([1, 2, 'a']);
+          const model = notebookTools.activeCell!.model;
+          expect(model.getMetadata('foo')).toEqual([1, 2, 'a']);
         });
       });
 
       describe('#onActiveCellChanged()', () => {
         it('should update the select value', () => {
           const cell = panel0.content.model!.cells.get(1);
-          cell.metadata.set('foo', 1);
+          cell.setMetadata('foo', 1);
           panel0.content.activeCellIndex = 1;
           expect(tool.methods).toContain('onActiveCellChanged');
           expect(tool.selectNode.value).toBe('1');
@@ -505,8 +505,8 @@ describe('@jupyterlab/notebook', () => {
 
       describe('#onActiveCellMetadataChanged()', () => {
         it('should update the select value', () => {
-          const metadata = notebookTools.activeCell!.model.metadata;
-          metadata.set('foo', 1);
+          const model = notebookTools.activeCell!.model;
+          model.setMetadata('foo', 1);
           expect(tool.methods).toContain('onActiveCellMetadataChanged');
           expect(tool.selectNode.value).toBe('1');
         });
@@ -524,12 +524,12 @@ describe('@jupyterlab/notebook', () => {
         expect(tool.key).toBe('slideshow');
         const select = tool.selectNode;
         expect(select.value).toBe('');
-        const metadata = notebookTools.activeCell!.model.metadata;
-        expect(metadata.get('slideshow')).toBeUndefined();
+        const model = notebookTools.activeCell!.model;
+        expect(model.getMetadata('slideshow')).toBeUndefined();
         simulate(select, 'focus');
         tool.selectNode.selectedIndex = 1;
         simulate(select, 'change');
-        expect(metadata.get('slideshow')).toEqual({
+        expect(model.getMetadata('slideshow')).toEqual({
           slide_type: 'slide'
         });
       });
@@ -557,12 +557,12 @@ describe('@jupyterlab/notebook', () => {
         const select = tool.selectNode;
         expect(select.value).toBe('');
 
-        const metadata = notebookTools.activeCell!.model.metadata;
-        expect(metadata.get('raw_mimetype')).toBeUndefined();
+        const model = notebookTools.activeCell!.model;
+        expect(model.getMetadata('raw_mimetype')).toBeUndefined();
         simulate(select, 'focus');
         tool.selectNode.selectedIndex = 2;
         simulate(select, 'change');
-        expect(metadata.get('raw_mimetype')).toBe('text/restructuredtext');
+        expect(model.getMetadata('raw_mimetype')).toBe('text/restructuredtext');
       });
 
       it('should have no effect on a code cell', () => {

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -216,7 +216,7 @@ describe('@jupyter/notebook', () => {
         widget.modelContentChanged.connect(() => {
           called = true;
         });
-        widget.model!.metadata.set('foo', 1);
+        widget.model!.setMetadata('foo', 1);
         expect(called).toBe(true);
       });
     });
@@ -293,7 +293,7 @@ describe('@jupyter/notebook', () => {
         const widget = new LogStaticNotebook(options);
         const model = new NotebookModel();
         const value = { name: 'python', codemirror_mode: 'python' };
-        model.metadata.set('language_info', value);
+        model.setMetadata('language_info', value);
         widget.model = model;
         const child = widget.widgets[0];
         expect(child.model.mimeType).toBe('text/x-python');
@@ -325,7 +325,7 @@ describe('@jupyter/notebook', () => {
           const cell = widget.model!.cells.get(1);
           const child = widget.widgets[1];
           widget.model!.sharedModel.deleteCell(1);
-          expect(cell.isDisposed).toBe(false);
+          expect(cell.isDisposed).toBe(true);
           expect(child.isDisposed).toBe(true);
         });
 
@@ -417,7 +417,7 @@ describe('@jupyter/notebook', () => {
         const widget = new LogStaticNotebook(options);
         const model = new NotebookModel();
         const value = { name: 'python', codemirror_mode: 'python' };
-        model.metadata.set('language_info', value);
+        model.setMetadata('language_info', value);
         widget.model = model;
         expect(widget.codeMimetype).toBe('text/x-python');
       });
@@ -481,7 +481,7 @@ describe('@jupyter/notebook', () => {
     describe('#onMetadataChanged()', () => {
       it('should be called when the metadata on the notebook changes', () => {
         const widget = createWidget();
-        widget.model!.metadata.set('foo', 1);
+        widget.model!.setMetadata('foo', 1);
         expect(widget.methods).toEqual(
           expect.arrayContaining(['onMetadataChanged'])
         );
@@ -490,7 +490,7 @@ describe('@jupyter/notebook', () => {
       it('should update the `codeMimetype`', () => {
         const widget = createWidget();
         const value = { name: 'python', codemirror_mode: 'python' };
-        widget.model!.metadata.set('language_info', value);
+        widget.model!.setMetadata('language_info', value);
         expect(widget.methods).toEqual(
           expect.arrayContaining(['onMetadataChanged'])
         );
@@ -500,7 +500,7 @@ describe('@jupyter/notebook', () => {
       it('should update the cell widget mimetype', () => {
         const widget = createWidget();
         const value = { name: 'python', mimetype: 'text/x-python' };
-        widget.model!.metadata.set('language_info', value);
+        widget.model!.setMetadata('language_info', value);
         expect(widget.methods).toEqual(
           expect.arrayContaining(['onMetadataChanged'])
         );

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -83,11 +83,6 @@ class LogStaticNotebook extends StaticNotebook {
     this.methods.push('onCellInserted');
   }
 
-  protected onCellMoved(fromIndex: number, toIndex: number): void {
-    super.onCellMoved(fromIndex, toIndex);
-    this.methods.push('onCellMoved');
-  }
-
   protected onCellRemoved(index: number, cell: Cell): void {
     super.onCellRemoved(index, cell);
     this.methods.push('onCellRemoved');
@@ -127,11 +122,6 @@ class LogNotebook extends Notebook {
   protected onCellInserted(index: number, cell: Cell): void {
     super.onCellInserted(index, cell);
     this.methods.push('onCellInserted');
-  }
-
-  protected onCellMoved(fromIndex: number, toIndex: number): void {
-    super.onCellMoved(fromIndex, toIndex);
-    this.methods.push('onCellMoved');
   }
 
   protected onCellRemoved(index: number, cell: Cell): void {

--- a/packages/shared-models/src/api.ts
+++ b/packages/shared-models/src/api.ts
@@ -20,10 +20,7 @@ import type {
   JSONValue,
   PartialJSONValue
 } from '@lumino/coreutils';
-import type {
-  IDisposable,
-  IObservableDisposable
-} from '@lumino/disposable';
+import type { IDisposable, IObservableDisposable } from '@lumino/disposable';
 import type { ISignal } from '@lumino/signaling';
 
 /**

--- a/packages/shared-models/src/api.ts
+++ b/packages/shared-models/src/api.ts
@@ -20,7 +20,10 @@ import type {
   JSONValue,
   PartialJSONValue
 } from '@lumino/coreutils';
-import type { IDisposable } from '@lumino/disposable';
+import type {
+  IDisposable,
+  IObservableDisposable
+} from '@lumino/disposable';
 import type { ISignal } from '@lumino/signaling';
 
 /**
@@ -165,11 +168,6 @@ export interface ISharedNotebook extends ISharedDocument {
   readonly cells: ISharedCell[];
 
   /**
-   * Signal triggered when the cells list changes.
-   */
-  readonly cellsChanged: ISignal<this, IListChange>;
-
-  /**
    * Wether the undo/redo logic should be
    * considered on the full document across all cells.
    */
@@ -291,6 +289,11 @@ export interface ISharedNotebook extends ISharedDocument {
    * @param to: The end index of the range to remove (exclusive).
    */
   deleteCellRange(from: number, to: number): void;
+
+  /**
+   * Serialize the model to JSON.
+   */
+  toJSON(): nbformat.INotebookContent;
 }
 
 /**
@@ -356,7 +359,8 @@ export namespace SharedCell {
  */
 export interface ISharedBaseCell<
   Metadata extends nbformat.IBaseCellMetadata = nbformat.IBaseCellMetadata
-> extends ISharedText {
+> extends ISharedText,
+    IObservableDisposable {
   /**
    * The type of the cell.
    */
@@ -588,56 +592,6 @@ export type DocumentChange = {
    */
   stateChange?: StateChange<any>[];
 };
-
-/**
- * The change types which occur on a list.
- */
-export type ListChangeType =
-  /**
-   * Item(s) were added to the list.
-   */
-  | 'add'
-
-  /**
-   * Item(s) were removed from the list.
-   */
-  | 'remove';
-
-/**
- * The changed object which is emitted by a list.
- */
-export interface IListChange<T = any> {
-  /**
-   * The type of change undergone by the vector.
-   */
-  type: ListChangeType;
-
-  /**
-   * The new index associated with the change.
-   */
-  newIndex: number;
-
-  /**
-   * The new values associated with the change.
-   *
-   * #### Notes
-   * The values will be contiguous starting at the `newIndex`.
-   */
-  newValues: T[];
-
-  /**
-   * The old index associated with the change.
-   */
-  oldIndex: number;
-
-  /**
-   * The old values associated with the change.
-   *
-   * #### Notes
-   * The values will be contiguous starting at the `oldIndex`.
-   */
-  oldValues: T[];
-}
 
 /**
  * The change types which occur on an observable map.

--- a/packages/shared-models/src/api.ts
+++ b/packages/shared-models/src/api.ts
@@ -269,12 +269,18 @@ export interface ISharedNotebook extends ISharedDocument {
    * Move a cell.
    *
    * @param fromIndex: Index of the cell to move.
-   *
    * @param toIndex: New position of the cell.
+   */
+  moveCell(fromIndex: number, toIndex: number): void;
+
+  /**
+   * Move cells.
    *
+   * @param fromIndex: Index of the first cells to move.
+   * @param toIndex: New position of the first cell (in the current array).
    * @param n: Number of cells to move (default 1)
    */
-  moveCell(fromIndex: number, toIndex: number, n?: number): void;
+  moveCells(fromIndex: number, toIndex: number, n?: number): void;
 
   /**
    * Remove a cell.

--- a/packages/shared-models/src/api.ts
+++ b/packages/shared-models/src/api.ts
@@ -271,8 +271,10 @@ export interface ISharedNotebook extends ISharedDocument {
    * @param fromIndex: Index of the cell to move.
    *
    * @param toIndex: New position of the cell.
+   *
+   * @param n: Number of cells to move (default 1)
    */
-  moveCell(fromIndex: number, toIndex: number): void;
+  moveCell(fromIndex: number, toIndex: number, n?: number): void;
 
   /**
    * Remove a cell.

--- a/packages/shared-models/src/utils.ts
+++ b/packages/shared-models/src/utils.ts
@@ -35,7 +35,7 @@ export function convertYMapEventToMapChange(
  */
 export const createMutex = (): ((f: () => void) => void) => {
   let token = true;
-  return (f: any): void => {
+  return (f: () => void): void => {
     if (token) {
       token = false;
       try {

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -724,7 +724,8 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
    * @returns Cell metadata.
    */
   getMetadata(key?: string): Partial<Metadata> {
-    const metadata = this.ymodel.get('metadata');
+    // Transiently the metadata can be missing - like during destruction
+    const metadata = this.ymodel.get('metadata') ?? {};
 
     if (typeof key === 'string') {
       const value = metadata[key];

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -219,20 +219,11 @@ export class YFile
   implements ISharedFile, ISharedText, IYText
 {
   /**
-   * Instantiate a new shareable file.
+   * Create a new file
    *
-   * @param source The initial file content
-   *
-   * @returns The file model
+   * #### Notes
+   * The document is empty and must be populated
    */
-  static create(source?: string): YFile {
-    const model = new YFile();
-    if (source) {
-      model.source = source;
-    }
-    return model;
-  }
-
   constructor() {
     super();
     this.undoManager.addToScope(this.ysource);
@@ -1232,18 +1223,13 @@ export class YNotebook
   implements ISharedNotebook
 {
   /**
-   * Create a new YNotebook.
+   * Create a new notebook
+   *
+   * #### Notes
+   * The document is empty and must be populated
+   *
+   * @param options
    */
-  static create(options: ISharedNotebook.IOptions = {}): ISharedNotebook {
-    const notebook = new YNotebook(options);
-    notebook.nbformat = nbformat.MAJOR_VERSION;
-    notebook.nbformat_minor = nbformat.MINOR_VERSION;
-    if (!notebook.ymeta.get('metadata')) {
-      notebook.ymeta.set('metadata', {});
-    }
-    return notebook;
-  }
-
   constructor(options: ISharedNotebook.IOptions = {}) {
     super();
     this._disableDocumentWideUndoRedo =
@@ -1409,9 +1395,19 @@ export class YNotebook
    *
    * @param fromIndex: Index of the cell to move.
    * @param toIndex: New position of the cell.
-   * @param n: Number of cells to move
    */
-  moveCell(fromIndex: number, toIndex: number, n = 1): void {
+  moveCell(fromIndex: number, toIndex: number): void {
+    this.moveCells(fromIndex, toIndex);
+  }
+
+  /**
+   * Move cells.
+   *
+   * @param fromIndex: Index of the first cells to move.
+   * @param toIndex: New position of the first cell (in the current array).
+   * @param n: Number of cells to move (default 1)
+   */
+  moveCells(fromIndex: number, toIndex: number, n = 1): void {
     // FIXME we need to use yjs move feature to preserve undo history
     const clones = new Array(n)
       .fill(true)
@@ -1472,7 +1468,7 @@ export class YNotebook
    * @returns Notebook's metadata.
    */
   getMetadata(key?: string): nbformat.INotebookMetadata {
-    const meta = this.ymeta.get('metadata');
+    const meta = this.ymeta.get('metadata') ?? {};
 
     if (typeof key === 'string') {
       const value = meta[key];

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -1409,13 +1409,19 @@ export class YNotebook
    *
    * @param fromIndex: Index of the cell to move.
    * @param toIndex: New position of the cell.
+   * @param n: Number of cells to move
    */
-  moveCell(fromIndex: number, toIndex: number): void {
+  moveCell(fromIndex: number, toIndex: number, n = 1): void {
+    // FIXME we need to use yjs move feature to preserve undo history
+    const clones = new Array(n)
+      .fill(true)
+      .map((_, idx) => this.getCell(fromIndex + idx).toJSON());
     this.transact(() => {
-      // FIXME we need to use yjs move feature to preserve undo history
-      const clone = createCell(this.getCell(fromIndex).toJSON(), this);
-      this._ycells.delete(fromIndex, 1);
-      this._ycells.insert(toIndex, [clone.ymodel]);
+      this._ycells.delete(fromIndex, n);
+      this._ycells.insert(
+        fromIndex > toIndex ? toIndex : toIndex - n + 1,
+        clones.map(clone => createCell(clone, this).ymodel)
+      );
     });
   }
 

--- a/packages/shared-models/test/ymodels.spec.ts
+++ b/packages/shared-models/test/ymodels.spec.ts
@@ -1,28 +1,25 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import * as nbformat from '@jupyterlab/nbformat';
-
-import { IMapChange, NotebookChange, YCodeCell, YNotebook } from '../src';
+import {
+  IMapChange,
+  NotebookChange,
+  YCodeCell,
+  YNotebook
+} from '@jupyterlab/shared-models';
 
 describe('@jupyterlab/shared-models', () => {
   describe('YNotebook', () => {
     describe('#constructor', () => {
       it('should create a notebook without arguments', () => {
-        const notebook = YNotebook.create();
+        const notebook = new YNotebook();
         expect(notebook.cells.length).toBe(0);
-      });
-
-      it('should have the default nbformat', () => {
-        const notebook = YNotebook.create();
-        expect(notebook.nbformat).toEqual(nbformat.MAJOR_VERSION);
-        expect(notebook.nbformat_minor).toEqual(nbformat.MINOR_VERSION);
       });
     });
 
     describe('metadata', () => {
       it('should get metadata', () => {
-        const notebook = YNotebook.create();
+        const notebook = new YNotebook();
         const metadata = {
           orig_nbformat: 1,
           kernelspec: {
@@ -37,7 +34,7 @@ describe('@jupyterlab/shared-models', () => {
       });
 
       it('should get all metadata', () => {
-        const notebook = YNotebook.create();
+        const notebook = new YNotebook();
         const metadata = {
           orig_nbformat: 1,
           kernelspec: {
@@ -52,7 +49,7 @@ describe('@jupyterlab/shared-models', () => {
       });
 
       it('should get one metadata', () => {
-        const notebook = YNotebook.create();
+        const notebook = new YNotebook();
         const metadata = {
           orig_nbformat: 1,
           kernelspec: {
@@ -67,7 +64,7 @@ describe('@jupyterlab/shared-models', () => {
       });
 
       it('should set one metadata', () => {
-        const notebook = YNotebook.create();
+        const notebook = new YNotebook();
         const metadata = {
           orig_nbformat: 1,
           kernelspec: {
@@ -85,7 +82,7 @@ describe('@jupyterlab/shared-models', () => {
       it.each([null, undefined, 1, true, 'string', { a: 1 }, [1, 2]])(
         'should get single metadata %s',
         value => {
-          const nb = YNotebook.create();
+          const nb = new YNotebook();
           const metadata = {
             orig_nbformat: 1,
             kernelspec: {
@@ -102,7 +99,7 @@ describe('@jupyterlab/shared-models', () => {
       );
 
       it('should update metadata', () => {
-        const notebook = YNotebook.create();
+        const notebook = new YNotebook();
         const metadata = notebook.getMetadata();
         expect(metadata).toBeTruthy();
         metadata.orig_nbformat = 1;
@@ -127,7 +124,7 @@ describe('@jupyterlab/shared-models', () => {
       });
 
       it('should emit all metadata changes', () => {
-        const notebook = YNotebook.create();
+        const notebook = new YNotebook();
         const metadata = {
           orig_nbformat: 1,
           kernelspec: {
@@ -162,7 +159,7 @@ describe('@jupyterlab/shared-models', () => {
       });
 
       it('should emit a add metadata change', () => {
-        const notebook = YNotebook.create();
+        const notebook = new YNotebook();
         const metadata = {
           orig_nbformat: 1,
           kernelspec: {
@@ -187,7 +184,7 @@ describe('@jupyterlab/shared-models', () => {
       });
 
       it('should emit a delete metadata change', () => {
-        const notebook = YNotebook.create();
+        const notebook = new YNotebook();
         const metadata = {
           orig_nbformat: 1,
           kernelspec: {
@@ -219,7 +216,7 @@ describe('@jupyterlab/shared-models', () => {
       });
 
       it('should emit an update metadata change', () => {
-        const notebook = YNotebook.create();
+        const notebook = new YNotebook();
         const metadata = {
           orig_nbformat: 1,
           kernelspec: {
@@ -253,18 +250,18 @@ describe('@jupyterlab/shared-models', () => {
 
     describe('#insertCell', () => {
       it('should insert a cell', () => {
-        const notebook = YNotebook.create();
+        const notebook = new YNotebook();
         notebook.insertCell(0, { cell_type: 'code' });
         expect(notebook.cells.length).toBe(1);
       });
       it('should set cell source', () => {
-        const notebook = YNotebook.create();
+        const notebook = new YNotebook();
         const codeCell = notebook.insertCell(0, { cell_type: 'code' });
         codeCell.setSource('test');
         expect(notebook.cells[0].getSource()).toBe('test');
       });
       it('should update source', () => {
-        const notebook = YNotebook.create();
+        const notebook = new YNotebook();
         const codeCell = notebook.insertCell(0, { cell_type: 'code' });
         codeCell.setSource('test');
         codeCell.updateSource(0, 0, 'hello');
@@ -272,7 +269,7 @@ describe('@jupyterlab/shared-models', () => {
       });
 
       it('should emit a add cells change', () => {
-        const notebook = YNotebook.create();
+        const notebook = new YNotebook();
         const changes: NotebookChange[] = [];
         notebook.changed.connect((_, c) => {
           changes.push(c);
@@ -290,7 +287,7 @@ describe('@jupyterlab/shared-models', () => {
 
     describe('#deleteCell', () => {
       it('should emit a delete cells change', () => {
-        const notebook = YNotebook.create();
+        const notebook = new YNotebook();
         const changes: NotebookChange[] = [];
         const codeCell = notebook.insertCell(0, { cell_type: 'code' });
 
@@ -307,7 +304,7 @@ describe('@jupyterlab/shared-models', () => {
 
     describe('#moveCell', () => {
       it('should emit add and delete cells changes when moving a cell', () => {
-        const notebook = YNotebook.create();
+        const notebook = new YNotebook();
         const changes: NotebookChange[] = [];
         const codeCell = notebook.addCell({ cell_type: 'code' });
         notebook.addCell({ cell_type: 'markdown' });
@@ -419,7 +416,7 @@ describe('@jupyterlab/shared-models', () => {
     });
 
     it('should emit all metadata changes', () => {
-      const notebook = YNotebook.create();
+      const notebook = new YNotebook();
       const metadata = {
         collapsed: true,
         editable: false,


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Follow-up of #13168
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
- Remove modelDB from `CodeEditor.Model`
- Use directly metadata from YJS.
- `CellModel` and `AttachementCellModel` are now an abstract classes as the constructor does not need to access the cell type.
- Remove `onCellMoved` on `StaticNotebook` and `Notebook` as motion does not exist. A motion will always be a removal + an addition (even when we will use the yjs move feature as there is no event for motion).
- This also fixes the logic of cell selection when moving them.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
Break api for dealing with metadata for cells and notebook as it is not a observable json any longer.
`CellModel` and `AttachementCellModel` are now an abstract classes as the constructor does not need to access the cell type.