### PR TITLE
Do not show side panel scrollbar when not needed

### DIFF
--- a/packages/ui-components/style/sidepanel.css
+++ b/packages/ui-components/style/sidepanel.css
@@ -7,7 +7,7 @@
   display: flex;
   flex-direction: column;
   min-width: var(--jp-sidebar-min-width);
-  overflow-y: scroll;
+  overflow-y: auto;
   color: var(--jp-ui-font-color1);
   background: var(--jp-layout-color1);
   font-size: var(--jp-ui-font-size1);


### PR DESCRIPTION
## References

Fixes #13252 for majority of cases

## Code changes

`overflow-y: auto;` over `overflow-y: scroll;`

## User-facing changes

No double scrollbar in file browser

## Backwards-incompatible changes

None