### PR TITLE
Don't dispose the notebook metadata editor on active cell change

### DIFF
--- a/packages/notebook/src/notebooktools.ts
+++ b/packages/notebook/src/notebooktools.ts
@@ -535,7 +535,7 @@ export namespace NotebookTools {
 
       this._editorFactory = editorFactory;
       this._editorLabel = options.label || 'Edit Metadata';
-      this._createEditor();
+      this.createEditor();
       const titleNode = new Widget({ node: document.createElement('label') });
       titleNode.node.textContent = options.label || 'Edit Metadata';
       layout.addWidget(titleNode);
@@ -555,21 +555,11 @@ export namespace NotebookTools {
     protected onActiveNotebookPanelChanged(msg: Message): void {
       this.editor.dispose();
       if (this.notebookTools.activeNotebookPanel) {
-        this._createEditor();
+        this.createEditor();
       }
     }
 
-    /**
-     * Handle a change to the notebook.
-     */
-    protected onActiveCellChanged(msg: Message): void {
-      this.editor.dispose();
-      if (this.notebookTools.activeCell) {
-        this._createEditor();
-      }
-    }
-
-    private _createEditor() {
+    protected createEditor() {
       this._editor = new JSONEditor({
         editorFactory: this._editorFactory
       });
@@ -662,7 +652,10 @@ export namespace NotebookTools {
      * Handle a change to the active cell.
      */
     protected onActiveCellChanged(msg: Message): void {
-      super.onActiveCellChanged(msg);
+      this.editor.dispose();
+      if (this.notebookTools.activeCell) {
+        this.createEditor();
+      }
       this._update();
     }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->
Follow-up of https://github.com/jupyterlab/jupyterlab/pull/13229

The metadata editor is disposed before loading new values (to avoid polluting undo history). But the changes are disposing the notebook metadata editor on active cell changes (what should not be the case). 

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Don't dispose the notebook metadata editor on active cell changes.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Notebook metadata editor are not cleared when active cell changes
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A