### PR TITLE
Correct starting docs: working directory path sample code

### DIFF
--- a/docs/source/getting_started/starting.rst
+++ b/docs/source/getting_started/starting.rst
@@ -21,9 +21,9 @@ Example:
 .. code:: bash
 
     #Windows Example
-    jupyter lab --app_dir=E:/ --preferred_dir E:/Documents/Somewhere/Else
+    jupyter lab --notebook-dir=E:/ --preferred-dir E:/Documents/Somewhere/Else
     #Linux Example
-    jupyter lab --app_dir=/var/ --preferred_dir /var/www/html/example-app/
+    jupyter lab --notebook-dir=/var/ --preferred-dir /var/www/html/example-app/
 
 You may access JupyterLab by entering the notebook server's :ref:`URL <urls>`
 into the browser. JupyterLab sessions always reside in a


### PR DESCRIPTION
## References

Addresses the confusion apparent in issue #11723

No currently open PRs address this mistake in the docs.

## Code changes

Corrects the sample code given for passing a working directory path

## User-facing changes

Docs-only

## Backwards-incompatible changes

n/a
