### PR TITLE
Set `isUntitled` to false on document path changes

### DIFF
--- a/galata/test/jupyterlab/save.test.ts
+++ b/galata/test/jupyterlab/save.test.ts
@@ -1,0 +1,77 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { expect, test } from '@jupyterlab/galata';
+
+const DEFAULT_NAME = 'untitled';
+const EXTENSION = {
+  Text: '.txt',
+  Notebook: '.ipynb',
+  Markdown: '.md'
+};
+
+for (const type of ['Text', 'Notebook', 'Markdown']) {
+  test(`Prompt to rename new ${type} file`, async ({ page }) => {
+    await page.menu.clickMenuItem(
+      type === 'Notebook' ? `File>New>${type}` : `File>New>${type} File`
+    );
+
+    await page.waitForSelector(
+      `[role="main"] >> text=${DEFAULT_NAME}${EXTENSION[type]}`
+    );
+
+    if (type === 'Notebook') {
+      // Select the kernel
+      await page.click('.jp-Dialog >> button >> text=Select');
+    }
+
+    await page.menu.clickMenuItem(
+      type === 'Markdown' ? `File>Save ${type} File` : `File>Save ${type}`
+    );
+
+    await page.waitForSelector('.jp-Dialog >> text=Rename file');
+
+    await expect(
+      page.locator('.jp-Dialog >> input[placeholder="File name"]')
+    ).toHaveValue(
+      type === 'Notebook'
+        ? `U${DEFAULT_NAME.slice(1)}${EXTENSION[type]}`
+        : `${DEFAULT_NAME}${EXTENSION[type]}`
+    );
+
+    await page.click('.jp-Dialog >> button >> text=Cancel');
+  });
+}
+
+for (const type of ['Text', 'Notebook', 'Markdown']) {
+  test(`Should not prompt to rename new renamed ${type} file`, async ({
+    page
+  }) => {
+    await page.menu.clickMenuItem(
+      type === 'Notebook' ? `File>New>${type}` : `File>New>${type} File`
+    );
+
+    await page.waitForSelector(
+      `[role="main"] >> text=${DEFAULT_NAME}${EXTENSION[type]}`
+    );
+
+    if (type === 'Notebook') {
+      // Select the kernel
+      await page.click('.jp-Dialog >> button >> text=Select');
+    }
+
+    await page.menu.clickMenuItem(
+      type === 'Markdown' ? `File>Rename ${type} File…` : `File>Rename ${type}…`
+    );
+
+    await page.fill('.jp-Dialog >> input', `dummy${EXTENSION[type]}`);
+
+    await page.click('.jp-Dialog >> button >> text=Rename');
+
+    await page.menu.clickMenuItem(
+      type === 'Markdown' ? `File>Save ${type} File` : `File>Save ${type}`
+    );
+
+    await expect(page.locator('.jp-Dialog')).toHaveCount(0);
+  });
+}

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -562,6 +562,8 @@ export class DocumentWidget<
     path: string
   ): void {
     this.title.label = PathExt.basename(sender.localPath);
+    // The document is not untitled any more.
+    this.isUntitled = false;
   }
 
   /**
@@ -591,6 +593,15 @@ export class DocumentWidget<
   }
 
   readonly context: DocumentRegistry.IContext<U>;
+
+  /**
+   * Whether the document has an auto-generated name or not.
+   *
+   * #### Notes
+   * A document has auto-generated name if its name is untitled and up
+   * to the instant the user saves it manually for the first time.
+   */
+  isUntitled?: boolean;
 }
 
 export namespace DocumentWidget {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fix #13263
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Set `isUntitled` to false as soon as the path changes

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Renaming an untitled file outside of the dialog prompt will avoid prompting for renaming at first save.
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A