### PR TITLE
Fix notebook trust in RTC

### DIFF
--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -669,6 +669,12 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
     if (this._outputs) {
       this._outputs.trusted = args.newValue as boolean;
     }
+    if (args.newValue as boolean) {
+      const codeCell = this.sharedModel as models.YCodeCell;
+      const metadata = codeCell.getMetadata();
+      metadata.trusted = true;
+      codeCell.setMetadata(metadata);
+    }
     this.stateChanged.emit({
       name: 'trusted',
       oldValue: args.oldValue as boolean,

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -666,10 +666,11 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
     trusted: IObservableValue,
     args: ObservableValue.IChangedArgs
   ): void {
+    const newTrusted = args.newValue as boolean;
     if (this._outputs) {
-      this._outputs.trusted = args.newValue as boolean;
+      this._outputs.trusted = newTrusted;
     }
-    if (args.newValue as boolean) {
+    if (newTrusted) {
       const codeCell = this.sharedModel as models.YCodeCell;
       const metadata = codeCell.getMetadata();
       metadata.trusted = true;
@@ -678,7 +679,7 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
     this.stateChanged.emit({
       name: 'trusted',
       oldValue: args.oldValue as boolean,
-      newValue: args.newValue as boolean
+      newValue: newTrusted
     });
   }
 


### PR DESCRIPTION
## References

This is for JupyterLab v4.
See #12756.

## Code changes

Propagate cell trust to/from shared model.

## User-facing changes

The notebook trust mechanism now works in RTC.

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None.