### PR TITLE
Fix notebook trust in RTC

### DIFF
--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -430,8 +430,9 @@ export class CellModel extends CodeEditor.Model implements ICellModel {
           this.metadata.set('tags', metadata.tags);
           break;
         case 'trusted':
-          this.metadata.set('trusted', metadata.trusted);
-          this.trusted = metadata.trusted as boolean;
+          const trusted = metadata.trusted as boolean;
+          this.metadata.set('trusted', trusted);
+          this.trusted = trusted;
           break;
         default:
           // The default is applied for custom metadata that are not
@@ -795,10 +796,11 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
     trusted: IObservableValue,
     args: ObservableValue.IChangedArgs
   ): void {
+    const newTrusted = args.newValue as boolean;
     if (this._outputs) {
-      this._outputs.trusted = args.newValue as boolean;
+      this._outputs.trusted = newTrusted;
     }
-    if (args.newValue as boolean) {
+    if (newTrusted) {
       const codeCell = this.sharedModel as models.YCodeCell;
       const metadata = codeCell.getMetadata();
       metadata.trusted = true;
@@ -807,7 +809,7 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
     this.stateChanged.emit({
       name: 'trusted',
       oldValue: args.oldValue,
-      newValue: args.newValue
+      newValue: newTrusted
     });
   }
 

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -431,6 +431,7 @@ export class CellModel extends CodeEditor.Model implements ICellModel {
           break;
         case 'trusted':
           this.metadata.set('trusted', metadata.trusted);
+          this.trusted = metadata.trusted as boolean;
           break;
         default:
           // The default is applied for custom metadata that are not
@@ -796,6 +797,12 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
   ): void {
     if (this._outputs) {
       this._outputs.trusted = args.newValue as boolean;
+    }
+    if (args.newValue as boolean) {
+      const codeCell = this.sharedModel as models.YCodeCell;
+      const metadata = codeCell.getMetadata();
+      metadata.trusted = true;
+      codeCell.setMetadata(metadata);
     }
     this.stateChanged.emit({
       name: 'trusted',


### PR DESCRIPTION
## References

This is for JupyterLab v3.
See #12756.

## Code changes

Propagate cell trust to/from shared model.

## User-facing changes

The notebook trust mechanism now works in RTC.

## Backwards-incompatible changes

None.