### PR TITLE
Use settings icons for 6 plugins

### DIFF
--- a/packages/apputils-extension/schema/palette.json
+++ b/packages/apputils-extension/schema/palette.json
@@ -1,6 +1,8 @@
 {
   "title": "Command Palette",
   "description": "Command palette settings.",
+  "jupyter.lab.setting-icon": "ui-components:palette",
+  "jupyter.lab.setting-icon-label": "Command Palette",
   "jupyter.lab.menus": {
     "main": [
       {

--- a/packages/csvviewer-extension/schema/csv.json
+++ b/packages/csvviewer-extension/schema/csv.json
@@ -1,6 +1,8 @@
 {
   "title": "CSV Viewer",
   "description": "CSV Viewer settings.",
+  "jupyter.lab.setting-icon": "ui-components:spreadsheet",
+  "jupyter.lab.setting-icon-label": "CSV Viewer",
   "jupyter.lab.toolbars": {
     "CSVTable": [{ "name": "delimiter", "rank": 10 }]
   },

--- a/packages/csvviewer-extension/schema/tsv.json
+++ b/packages/csvviewer-extension/schema/tsv.json
@@ -1,6 +1,8 @@
 {
   "title": "TSV Viewer",
   "description": "TSV Viewer settings.",
+  "jupyter.lab.setting-icon": "ui-components:spreadsheet",
+  "jupyter.lab.setting-icon-label": "TSV Viewer",
   "jupyter.lab.toolbars": {
     "TSVTable": [{ "name": "delimiter", "rank": 10 }]
   },

--- a/packages/documentsearch-extension/schema/plugin.json
+++ b/packages/documentsearch-extension/schema/plugin.json
@@ -1,6 +1,8 @@
 {
   "title": "Document Search",
   "description": "Document search plugin.",
+  "jupyter.lab.setting-icon": "ui-components:search",
+  "jupyter.lab.setting-icon-label": "Document Search",
   "jupyter.lab.menus": {
     "main": [
       {

--- a/packages/extensionmanager-extension/schema/plugin.json
+++ b/packages/extensionmanager-extension/schema/plugin.json
@@ -1,7 +1,7 @@
 {
   "title": "Extension Manager",
   "description": "Extension manager settings.",
-  "jupyter.lab.setting-icon": "ui-components:settings",
+  "jupyter.lab.setting-icon": "ui-components:extension",
   "jupyter.lab.setting-icon-label": "Extension Manager",
   "jupyter.lab.menus": {
     "main": [

--- a/packages/htmlviewer-extension/schema/plugin.json
+++ b/packages/htmlviewer-extension/schema/plugin.json
@@ -1,6 +1,8 @@
 {
   "title": "HTML Viewer",
   "description": "HTML Viewer settings.",
+  "jupyter.lab.setting-icon": "ui-components:html5",
+  "jupyter.lab.setting-icon-label": "HTML Viewer",
   "jupyter.lab.toolbars": {
     "HTML Viewer": [
       { "name": "refresh", "rank": 10 },


### PR DESCRIPTION
## References

It became a bit difficult to navigate the settings manager lately as too many entries have the generic cog icon. This PR sets icons for plugins which have an associated icon already (no new icons added).

Follow-up/good first issue would be adding icons for remaining entries (Language settings is a low-hanging fruit).

| Before | After |
|-----|---|
| ![Screenshot from 2022-10-23 19-22-31](https://user-images.githubusercontent.com/5832902/197409121-9aa51345-960b-4724-a8d9-c67187f21199.png) | ![Screenshot from 2022-10-23 19-23-05](https://user-images.githubusercontent.com/5832902/197409127-ecd6a137-697e-4120-bad4-55324b57c750.png) |


## Code changes

None

## User-facing changes

Easier to navigate settings.

## Backwards-incompatible changes

None