### PR TITLE
Do not run galata in `.ipynb_checkpoints`

### DIFF
--- a/galata/playwright-documentation.config.js
+++ b/galata/playwright-documentation.config.js
@@ -9,7 +9,8 @@ module.exports = {
   projects: [
     {
       name: 'documentation',
-      testMatch: 'test/documentation/**'
+      testMatch: 'test/documentation/**',
+      testIgnore: '**/.ipynb_checkpoints/**'
     }
   ],
   use: {

--- a/galata/playwright.config.js
+++ b/galata/playwright.config.js
@@ -8,11 +8,13 @@ module.exports = {
   projects: [
     {
       name: 'galata',
-      testMatch: 'test/galata/**'
+      testMatch: 'test/galata/**',
+      testIgnore: '**/.ipynb_checkpoints/**'
     },
     {
       name: 'jupyterlab',
-      testMatch: 'test/jupyterlab/**'
+      testMatch: 'test/jupyterlab/**',
+      testIgnore: '**/.ipynb_checkpoints/**'
     }
   ],
   // Switch to 'always' to keep raw assets for all tests


### PR DESCRIPTION
## References

Related to #11757, excludes `.ipynb_checkpoints` from our galata test patterns so that when test files are edited from JupyterLab the checkpoints are not treated as tests.

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None