### PR TITLE
Reduce CI test flake due to kernel switching to busy

### DIFF
--- a/galata/test/documentation/debugger.test.ts
+++ b/galata/test/documentation/debugger.test.ts
@@ -21,6 +21,11 @@ test.describe('Debugger', () => {
 
     await createNotebook(page);
 
+    // Wait for kernel to settle on idle
+    await page.waitForSelector('#jp-main-statusbar >> text=Idle');
+    await page.waitForSelector('#jp-main-statusbar >> text=Busy');
+    await page.waitForSelector('#jp-main-statusbar >> text=Idle');
+
     expect(
       await page.screenshot({
         clip: { x: 1050, y: 62, width: 190, height: 28 }


### PR DESCRIPTION
## References

An attempt to tackle documentation snapshot failures seen in #13284 and elsewhere earlier.

## Code changes

Await for the Idle > Busy > Idle steps to complete. Ideally we would not have this jitter at all, but that's a bigger undertaking.

## User-facing changes

None

## Backwards-incompatible changes

None