### PR TITLE
Reduce ILayoutRestorer API surface area

### DIFF
--- a/packages/application/src/layoutrestorer.ts
+++ b/packages/application/src/layoutrestorer.ts
@@ -36,27 +36,9 @@ export interface ILayoutRestorer extends IRestorer {
   restored: Promise<void>;
 
   /**
-   * Whether full layout restoration is deferred and is currently incomplete.
-   *
-   * #### Notes
-   * This flag is useful for tracking when the application has started in
-   * 'single-document' mode and the main area has not yet been restored.
-   */
-  isDeferred: boolean;
-
-  /**
    * Add a widget to be tracked by the layout restorer.
    */
   add(widget: Widget, name: string): void;
-
-  /**
-   * Fetch the layout state for the application.
-   *
-   * #### Notes
-   * Fetching the layout relies on all widget restoration to be complete, so
-   * calls to `fetch` are guaranteed to return after restoration is complete.
-   */
-  fetch(): Promise<ILabShell.ILayout>;
 
   /**
    * Restore the widgets of a particular widget tracker.
@@ -69,15 +51,6 @@ export interface ILayoutRestorer extends IRestorer {
     tracker: WidgetTracker<T>,
     options: IRestorer.IOptions<T>
   ): Promise<any>;
-
-  /**
-   * Restore the main area layout on demand.
-   * This happens when the application has started in 'single-document' mode
-   * (no main area widget loaded) and is switching to 'multiple-document' mode.
-   *
-   * @returns - the rehydrated main area.
-   */
-  restoreDeferred(): Promise<ILabShell.IMainArea | null>;
 }
 
 /**

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -30,7 +30,7 @@ import {
   Widget
 } from '@lumino/widgets';
 import { JupyterFrontEnd } from './frontend';
-import { ILayoutRestorer } from './layoutrestorer';
+import { LayoutRestorer } from './layoutrestorer';
 
 /**
  * The class name added to AppShell instances.
@@ -1062,7 +1062,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
    */
   async restoreLayout(
     mode: DockPanel.Mode,
-    layoutRestorer: ILayoutRestorer,
+    layoutRestorer: LayoutRestorer,
     configuration: {
       [m: string]: ILabShell.IUserLayout;
     } = {}
@@ -1717,7 +1717,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
   };
   private _delayedWidget = new Array<ILabShell.IDelayedWidget>();
   private _translator: ITranslator;
-  private _layoutRestorer: ILayoutRestorer;
+  private _layoutRestorer: LayoutRestorer;
 }
 
 namespace Private {

--- a/packages/apputils/src/widgettracker.ts
+++ b/packages/apputils/src/widgettracker.ts
@@ -340,7 +340,8 @@ export class WidgetTracker<T extends Widget = Widget>
    *
    * ### Notes
    * This function is useful when starting the shell in 'single-document' mode,
-   * to avoid restoring all useless widgets.
+   * to avoid restoring all useless widgets. It should not ordinarily be called
+   * by client code.
    */
   defer(options: IRestorable.IOptions<T>): void {
     this._deferred = options;


### PR DESCRIPTION
This PR reduces the API surface area of `ILayoutRestorer` that was added in #13037 while still keeping the deferred restoration feature, as suggested by @brichet.

## References
Follow on to https://github.com/jupyterlab/jupyterlab/pull/13037

## User-facing changes
N/A

## Backwards-incompatible changes
N/A