### PR TITLE
Automated Changelog Entry for 3.6.0a0 on 3.6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,51 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.6.x/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.6.0a0
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/d3316552294b1667d809805a1829f33c62701cc8...a960bd68b83d392a8697019adbffa748fda1be0a))
+
+### Enhancements made
+
+- Backport PR #13284: Use settings icons for 6 plugins [#13298](https://github.com/jupyterlab/jupyterlab/pull/13298) ([@krassowski](https://github.com/krassowski))
+- Backport PR #13286: Do not run galata in `.ipynb_checkpoints` [#13297](https://github.com/jupyterlab/jupyterlab/pull/13297) ([@krassowski](https://github.com/krassowski))
+- Optimize text mimerenderer: ansi vs autolink  [#13202](https://github.com/jupyterlab/jupyterlab/pull/13202) ([@vidartf](https://github.com/vidartf))
+- Remove Yjs locking mechanism [#13222](https://github.com/jupyterlab/jupyterlab/pull/13222) ([@davidbrochart](https://github.com/davidbrochart))
+
+### Bugs fixed
+
+- Set `isUntitled` to false on document path changes [#13268](https://github.com/jupyterlab/jupyterlab/pull/13268) ([@fcollonval](https://github.com/fcollonval))
+- Remove some unused CSS styles and fix icon alignment in plugin list [#13255](https://github.com/jupyterlab/jupyterlab/pull/13255) ([@krassowski](https://github.com/krassowski))
+- Fix notebook trust in RTC [#13274](https://github.com/jupyterlab/jupyterlab/pull/13274) ([@davidbrochart](https://github.com/davidbrochart))
+- Don't dispose the notebook metadata editor on active cell change [#13259](https://github.com/jupyterlab/jupyterlab/pull/13259) ([@fcollonval](https://github.com/fcollonval))
+
+### Maintenance and upkeep improvements
+
+- Fix memory leaks [#13229](https://github.com/jupyterlab/jupyterlab/pull/13229) ([@fcollonval](https://github.com/fcollonval))
+- Update branch configuration [#13220](https://github.com/jupyterlab/jupyterlab/pull/13220) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+- Backporting IUser/Collaboration PRs [#13242](https://github.com/jupyterlab/jupyterlab/pull/13242) ([@martinRenou](https://github.com/martinRenou))
+- Update example documentation: `lab -> app` [#13223](https://github.com/jupyterlab/jupyterlab/pull/13223) ([@davidbrochart](https://github.com/davidbrochart))
+- Remove Yjs locking mechanism [#13222](https://github.com/jupyterlab/jupyterlab/pull/13222) ([@davidbrochart](https://github.com/davidbrochart))
+- Update branch configuration [#13220](https://github.com/jupyterlab/jupyterlab/pull/13220) ([@fcollonval](https://github.com/fcollonval))
+
+### API and Breaking Changes
+
+- Remove Yjs locking mechanism [#13222](https://github.com/jupyterlab/jupyterlab/pull/13222) ([@davidbrochart](https://github.com/davidbrochart))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2000-03-05&to=2022-10-25&type=c))
+
+[@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2000-03-05..2022-10-25&type=Issues) | [@agoose77](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aagoose77+updated%3A2000-03-05..2022-10-25&type=Issues) | [@aiqc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aaiqc+updated%3A2000-03-05..2022-10-25&type=Issues) | [@ajbozarth](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aajbozarth+updated%3A2000-03-05..2022-10-25&type=Issues) | [@andrewfulton9](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aandrewfulton9+updated%3A2000-03-05..2022-10-25&type=Issues) | [@athornton](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aathornton+updated%3A2000-03-05..2022-10-25&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2000-03-05..2022-10-25&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2000-03-05..2022-10-25&type=Issues) | [@brichet](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abrichet+updated%3A2000-03-05..2022-10-25&type=Issues) | [@damianavila](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adamianavila+updated%3A2000-03-05..2022-10-25&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2000-03-05..2022-10-25&type=Issues) | [@dlqqq](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adlqqq+updated%3A2000-03-05..2022-10-25&type=Issues) | [@dmonad](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Admonad+updated%3A2000-03-05..2022-10-25&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2000-03-05..2022-10-25&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2000-03-05..2022-10-25&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2000-03-05..2022-10-25&type=Issues) | [@firai](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afirai+updated%3A2000-03-05..2022-10-25&type=Issues) | [@fperez](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afperez+updated%3A2000-03-05..2022-10-25&type=Issues) | [@gabalafou](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agabalafou+updated%3A2000-03-05..2022-10-25&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2000-03-05..2022-10-25&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2000-03-05..2022-10-25&type=Issues) | [@isabela-pf](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aisabela-pf+updated%3A2000-03-05..2022-10-25&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2000-03-05..2022-10-25&type=Issues) | [@jess-x](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajess-x+updated%3A2000-03-05..2022-10-25&type=Issues) | [@JohanMabille](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AJohanMabille+updated%3A2000-03-05..2022-10-25&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2000-03-05..2022-10-25&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2000-03-05..2022-10-25&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2000-03-05..2022-10-25&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2000-03-05..2022-10-25&type=Issues) | [@malemburg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Amalemburg+updated%3A2000-03-05..2022-10-25&type=Issues) | [@marthacryan](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Amarthacryan+updated%3A2000-03-05..2022-10-25&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AmartinRenou+updated%3A2000-03-05..2022-10-25&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2000-03-05..2022-10-25&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2000-03-05..2022-10-25&type=Issues) | [@mlucool](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Amlucool+updated%3A2000-03-05..2022-10-25&type=Issues) | [@rccern](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Arccern+updated%3A2000-03-05..2022-10-25&type=Issues) | [@schmidi314](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aschmidi314+updated%3A2000-03-05..2022-10-25&type=Issues) | [@siddartha-10](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Asiddartha-10+updated%3A2000-03-05..2022-10-25&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASylvainCorlay+updated%3A2000-03-05..2022-10-25&type=Issues) | [@thesinepainter](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Athesinepainter+updated%3A2000-03-05..2022-10-25&type=Issues) | [@trallard](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrallard+updated%3A2000-03-05..2022-10-25&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrungleduc+updated%3A2000-03-05..2022-10-25&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2000-03-05..2022-10-25&type=Issues) | [@williamstein](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awilliamstein+updated%3A2000-03-05..2022-10-25&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ayuvipanda+updated%3A2000-03-05..2022-10-25&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AZsailer+updated%3A2000-03-05..2022-10-25&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.5.0b0
 
 No merged PRs
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.5.0a0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.6.x/CHANGELOG.md'
 
 - Use settings icons for 6 plugins [#13298](https://github.com/jupyterlab/jupyterlab/pull/13298) ([@krassowski](https://github.com/krassowski))
 - Do not run galata in `.ipynb_checkpoints` [#13297](https://github.com/jupyterlab/jupyterlab/pull/13297) ([@krassowski](https://github.com/krassowski))
-- Optimize text mimerenderer: ansi vs autolink  [#13202](https://github.com/jupyterlab/jupyterlab/pull/13202) ([@vidartf](https://github.com/vidartf))
+- Optimize text mimerenderer: ansi vs autolink [#13202](https://github.com/jupyterlab/jupyterlab/pull/13202) ([@vidartf](https://github.com/vidartf))
 - Remove Yjs locking mechanism [#13222](https://github.com/jupyterlab/jupyterlab/pull/13222) ([@davidbrochart](https://github.com/davidbrochart))
 
 ### Bugs fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.6.x/CHANGELOG.md'
 
 # JupyterLab Changelog
 
-## v3.5
+## v3.6
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
@@ -18,8 +18,8 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.6.x/CHANGELOG.md'
 
 ### Enhancements made
 
-- Backport PR #13284: Use settings icons for 6 plugins [#13298](https://github.com/jupyterlab/jupyterlab/pull/13298) ([@krassowski](https://github.com/krassowski))
-- Backport PR #13286: Do not run galata in `.ipynb_checkpoints` [#13297](https://github.com/jupyterlab/jupyterlab/pull/13297) ([@krassowski](https://github.com/krassowski))
+- Use settings icons for 6 plugins [#13298](https://github.com/jupyterlab/jupyterlab/pull/13298) ([@krassowski](https://github.com/krassowski))
+- Do not run galata in `.ipynb_checkpoints` [#13297](https://github.com/jupyterlab/jupyterlab/pull/13297) ([@krassowski](https://github.com/krassowski))
 - Optimize text mimerenderer: ansi vs autolink  [#13202](https://github.com/jupyterlab/jupyterlab/pull/13202) ([@vidartf](https://github.com/vidartf))
 - Remove Yjs locking mechanism [#13222](https://github.com/jupyterlab/jupyterlab/pull/13222) ([@davidbrochart](https://github.com/davidbrochart))
 
@@ -54,36 +54,43 @@ github_url: 'https://github.com/jupyterlab/jupyterlab/blob/3.6.x/CHANGELOG.md'
 
 <!-- <END NEW CHANGELOG ENTRY> -->
 
-## 3.5.0b0
+## v3.5
 
-No merged PRs
+## 3.5.0
 
-## 3.5.0a0
-
-([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.4.8...a2e4a9a7e867e34ed664d97a672cdae8a9ea2b02))
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.4.8...225e7ab0844a0284bf50a567de505eb4650ec122))
 
 ### Enhancements made
 
+- Optimize text mimerenderer: ansi vs autolink [#13202](https://github.com/jupyterlab/jupyterlab/pull/13202) ([@vidartf](https://github.com/vidartf))
 - Collapse debugger panel when disabling debugger [#13088](https://github.com/jupyterlab/jupyterlab/pull/13088) ([@yanmulin](https://github.com/yanmulin))
 - File Browser: add support for filtering directories on search [#12342](https://github.com/jupyterlab/jupyterlab/pull/12342) ([@jtpio](https://github.com/jtpio))
 - Prompt for renaming at first manual save [#12953](https://github.com/jupyterlab/jupyterlab/pull/12953) ([@fcollonval](https://github.com/fcollonval))
-- Raise ceiling on jupyter_server dependency to < 3 [#13068](https://github.com/jupyterlab/jupyterlab/pull/13068) ([@Zsailer](https://github.com/Zsailer))
+- Raise ceiling on `jupyter_server` dependency to < 3 [#13068](https://github.com/jupyterlab/jupyterlab/pull/13068) ([@Zsailer](https://github.com/Zsailer))
+
+### Bugs fixed
+
+- Set `isUntitled` to false on document path changes [#13268](https://github.com/jupyterlab/jupyterlab/pull/13268) ([@fcollonval](https://github.com/fcollonval))
+- Don't dispose the notebook metadata editor on active cell change [#13259](https://github.com/jupyterlab/jupyterlab/pull/13259) ([@fcollonval](https://github.com/fcollonval))
+- Use keystroke format consistent with menus [#13200](https://github.com/jupyterlab/jupyterlab/pull/13200) ([@fcollonval](https://github.com/fcollonval))
 
 ### Maintenance and upkeep improvements
 
-- Bump to latest Lumino 1.x [#13190](https://github.com/jupyterlab/jupyterlab/pull/13190) ([@fcollonval](https://github.com/fcollonval))
+- Fix memory leaks [#13229](https://github.com/jupyterlab/jupyterlab/pull/13229) ([@fcollonval](https://github.com/fcollonval))
+- Bump to the latest Lumino 1.x [#13190](https://github.com/jupyterlab/jupyterlab/pull/13190) ([@fcollonval](https://github.com/fcollonval))
 - Update branch configuration [#13184](https://github.com/jupyterlab/jupyterlab/pull/13184) ([@fcollonval](https://github.com/fcollonval))
 
 ### Documentation improvements
 
+- Update example documentation: `lab -> app` [#13223](https://github.com/jupyterlab/jupyterlab/pull/13223) ([@davidbrochart](https://github.com/davidbrochart))
 - Prompt for renaming at first manual save [#12953](https://github.com/jupyterlab/jupyterlab/pull/12953) ([@fcollonval](https://github.com/fcollonval))
 - Update branch configuration [#13184](https://github.com/jupyterlab/jupyterlab/pull/13184) ([@fcollonval](https://github.com/fcollonval))
 
 ### Contributors to this release
 
-([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-10-04&to=2022-10-06&type=c))
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-10-04&to=2022-10-24&type=c))
 
-[@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-10-04..2022-10-06&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-10-04..2022-10-06&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-10-04..2022-10-06&type=Issues)
+[@Carreau](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ACarreau+updated%3A2022-10-04..2022-10-24&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2022-10-04..2022-10-24&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2022-10-04..2022-10-24&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-10-04..2022-10-24&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2022-10-04..2022-10-24&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-10-04..2022-10-24&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-10-04..2022-10-24&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-10-04..2022-10-24&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-10-04..2022-10-24&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-10-04..2022-10-24&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-10-04..2022-10-24&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASylvainCorlay+updated%3A2022-10-04..2022-10-24&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrungleduc+updated%3A2022-10-04..2022-10-24&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-10-04..2022-10-24&type=Issues)
 
 ## v3.4
 


### PR DESCRIPTION
Automated Changelog Entry for 3.6.0a0 on 3.6.x
```
Python version: 3.6.0a0
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.6.0-alpha.0
@jupyterlab/buildutils: 3.6.0-alpha.0
@jupyterlab/template: 3.6.0-alpha.0
@jupyterlab/application-top: 3.6.0-alpha.0
@jupyterlab/example-app: 3.6.0-alpha.0
@jupyterlab/example-cell: 3.6.0-alpha.0
@jupyterlab/example-console: 3.6.0-alpha.0
@jupyterlab/example-federated: 2.7.0-alpha.0
@jupyterlab/example-federated-core: 2.7.0-alpha.0
@jupyterlab/example-federated-md: 2.7.0-alpha.0
@jupyterlab/example-federated-middle: 2.7.0-alpha.0
@jupyterlab/example-federated-phosphor: 2.7.0-alpha.0
@jupyterlab/example-filebrowser: 3.6.0-alpha.0
@jupyterlab/example-notebook: 3.6.0-alpha.0
@jupyterlab/example-terminal: 3.6.0-alpha.0
@jupyterlab/galata: 4.5.0-alpha.0
@jupyterlab/mock-extension: 3.6.0-alpha.0
@jupyterlab/mock-consumer: 3.6.0-alpha.0
@jupyterlab/mock-provider: 3.6.0-alpha.0
@jupyterlab/mock-token: 3.6.0-alpha.0
@jupyterlab/application: 3.6.0-alpha.0
@jupyterlab/application-extension: 3.6.0-alpha.0
@jupyterlab/apputils: 3.6.0-alpha.0
@jupyterlab/apputils-extension: 3.6.0-alpha.0
@jupyterlab/attachments: 3.6.0-alpha.0
@jupyterlab/cell-toolbar: 3.6.0-alpha.0
@jupyterlab/cell-toolbar-extension: 3.6.0-alpha.0
@jupyterlab/cells: 3.6.0-alpha.0
@jupyterlab/celltags: 3.6.0-alpha.0
@jupyterlab/celltags-extension: 3.6.0-alpha.0
@jupyterlab/codeeditor: 3.6.0-alpha.0
@jupyterlab/codemirror: 3.6.0-alpha.0
@jupyterlab/codemirror-extension: 3.6.0-alpha.0
@jupyterlab/collaboration: 3.6.0-alpha.0
@jupyterlab/collaboration-extension: 3.6.0-alpha.0
@jupyterlab/completer: 3.6.0-alpha.0
@jupyterlab/completer-extension: 3.6.0-alpha.0
@jupyterlab/console: 3.6.0-alpha.0
@jupyterlab/console-extension: 3.6.0-alpha.0
@jupyterlab/coreutils: 5.6.0-alpha.0
@jupyterlab/csvviewer: 3.6.0-alpha.0
@jupyterlab/csvviewer-extension: 3.6.0-alpha.0
@jupyterlab/debugger: 3.6.0-alpha.0
@jupyterlab/debugger-extension: 3.6.0-alpha.0
@jupyterlab/docmanager: 3.6.0-alpha.0
@jupyterlab/docmanager-extension: 3.6.0-alpha.0
@jupyterlab/docprovider: 3.6.0-alpha.0
@jupyterlab/docprovider-extension: 3.6.0-alpha.0
@jupyterlab/docregistry: 3.6.0-alpha.0
@jupyterlab/documentsearch: 3.6.0-alpha.0
@jupyterlab/documentsearch-extension: 3.6.0-alpha.0
@jupyterlab/extensionmanager: 3.6.0-alpha.0
@jupyterlab/extensionmanager-extension: 3.6.0-alpha.0
@jupyterlab/filebrowser: 3.6.0-alpha.0
@jupyterlab/filebrowser-extension: 3.6.0-alpha.0
@jupyterlab/fileeditor: 3.6.0-alpha.0
@jupyterlab/fileeditor-extension: 3.6.0-alpha.0
@jupyterlab/help-extension: 3.6.0-alpha.0
@jupyterlab/htmlviewer: 3.6.0-alpha.0
@jupyterlab/htmlviewer-extension: 3.6.0-alpha.0
@jupyterlab/hub-extension: 3.6.0-alpha.0
@jupyterlab/imageviewer: 3.6.0-alpha.0
@jupyterlab/imageviewer-extension: 3.6.0-alpha.0
@jupyterlab/inspector: 3.6.0-alpha.0
@jupyterlab/inspector-extension: 3.6.0-alpha.0
@jupyterlab/javascript-extension: 3.6.0-alpha.0
@jupyterlab/json-extension: 3.6.0-alpha.0
@jupyterlab/launcher: 3.6.0-alpha.0
@jupyterlab/launcher-extension: 3.6.0-alpha.0
@jupyterlab/logconsole: 3.6.0-alpha.0
@jupyterlab/logconsole-extension: 3.6.0-alpha.0
@jupyterlab/mainmenu: 3.6.0-alpha.0
@jupyterlab/mainmenu-extension: 3.6.0-alpha.0
@jupyterlab/markdownviewer: 3.6.0-alpha.0
@jupyterlab/markdownviewer-extension: 3.6.0-alpha.0
@jupyterlab/mathjax2: 3.6.0-alpha.0
@jupyterlab/mathjax2-extension: 3.6.0-alpha.0
@jupyterlab/metapackage: 3.6.0-alpha.0
@jupyterlab/nbconvert-css: 3.6.0-alpha.0
@jupyterlab/nbformat: 3.6.0-alpha.0
@jupyterlab/notebook: 3.6.0-alpha.0
@jupyterlab/notebook-extension: 3.6.0-alpha.0
@jupyterlab/observables: 4.6.0-alpha.0
@jupyterlab/outputarea: 3.6.0-alpha.0
@jupyterlab/pdf-extension: 3.6.0-alpha.0
@jupyterlab/property-inspector: 3.6.0-alpha.0
@jupyterlab/rendermime: 3.6.0-alpha.0
@jupyterlab/rendermime-extension: 3.6.0-alpha.0
@jupyterlab/rendermime-interfaces: 3.6.0-alpha.0
@jupyterlab/running: 3.6.0-alpha.0
@jupyterlab/running-extension: 3.6.0-alpha.0
@jupyterlab/services: 6.6.0-alpha.0
@jupyterlab/example-services-browser: 3.6.0-alpha.0
node-example: 3.6.0-alpha.0
@jupyterlab/example-services-outputarea: 3.6.0-alpha.0
@jupyterlab/settingeditor: 3.6.0-alpha.0
@jupyterlab/settingeditor-extension: 3.6.0-alpha.0
@jupyterlab/settingregistry: 3.6.0-alpha.0
@jupyterlab/shared-models: 3.6.0-alpha.0
@jupyterlab/shortcuts-extension: 3.6.0-alpha.0
@jupyterlab/statedb: 3.6.0-alpha.0
@jupyterlab/statusbar: 3.6.0-alpha.0
@jupyterlab/statusbar-extension: 3.6.0-alpha.0
@jupyterlab/terminal: 3.6.0-alpha.0
@jupyterlab/terminal-extension: 3.6.0-alpha.0
@jupyterlab/theme-dark-extension: 3.6.0-alpha.0
@jupyterlab/theme-light-extension: 3.6.0-alpha.0
@jupyterlab/toc: 5.6.0-alpha.0
@jupyterlab/toc-extension: 5.6.0-alpha.0
@jupyterlab/tooltip: 3.6.0-alpha.0
@jupyterlab/tooltip-extension: 3.6.0-alpha.0
@jupyterlab/translation: 3.6.0-alpha.0
@jupyterlab/translation-extension: 3.6.0-alpha.0
@jupyterlab/ui-components: 3.6.0-alpha.0
@jupyterlab/ui-components-extension: 3.6.0-alpha.0
@jupyterlab/vdom: 3.6.0-alpha.0
@jupyterlab/vdom-extension: 3.6.0-alpha.0
@jupyterlab/vega5-extension: 3.6.0-alpha.0
@jupyterlab/testutils: 3.6.0-alpha.0
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyterlab/jupyterlab/releases/tag/untagged-ebe82187ff2e57ac501a  |
| Since | 3.5.0 |