### PR TITLE
Updates JSONEditor's source only when there is an active cell or an active notebook panel

### DIFF
--- a/packages/notebook/src/notebooktools.ts
+++ b/packages/notebook/src/notebooktools.ts
@@ -619,7 +619,9 @@ export namespace NotebookTools {
      */
     protected onActiveNotebookPanelChanged(msg: Message): void {
       super.onActiveNotebookPanelChanged(msg);
-      this._update();
+      if (this.notebookTools.activeNotebookPanel) {
+        this._update();
+      }
     }
 
     /**
@@ -655,8 +657,8 @@ export namespace NotebookTools {
       this.editor.dispose();
       if (this.notebookTools.activeCell) {
         this.createEditor();
+        this._update();
       }
-      this._update();
     }
 
     /**


### PR DESCRIPTION
## References
Follow-up of #13259

## Code changes

Updates JSONEditor's source only when there is an active cell or an active notebook panel.

When removing a cell or closing a notebook, the active cell or active notebook panel changes and the editor tries to set a new source into a disposed editor.

## User-facing changes

## Backwards-incompatible changes
