### PR TITLE
Avoids use of @deprecated to refer to a parameter

### DIFF
--- a/packages/ui-components/src/icon/labicon.tsx
+++ b/packages/ui-components/src/icon/labicon.tsx
@@ -91,7 +91,7 @@ export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
    * @param iconClass - optional, if the icon arg is not set, the iconClass arg
    * should be a CSS class associated with an existing CSS background-image
    *
-   * @deprecated fallback - don't use, optional, a LabIcon instance that will
+   * @param fallback - DEPRECATED, optional, a LabIcon instance that will
    * be used if neither icon nor iconClass are defined
    *
    * @param props - any additional args are passed though to the element method
@@ -133,7 +133,7 @@ export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
    * @param iconClass - optional, if the icon arg is not set, the iconClass arg
    * should be a CSS class associated with an existing CSS background-image
    *
-   * @deprecated fallback - don't use, optional, a LabIcon instance that will
+   * @param fallback - DEPRECATED, optional, a LabIcon instance that will
    * be used if neither icon nor iconClass are defined
    *
    * @param props - any additional args are passed though to the React component


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #12937.

## Code changes

Removes the `@deprecated` annotation in JSDoc, which was meant to indicate that a _parameter_ was deprecated, but actually caused the _function_ in question to be shown as deprecated in Visual Studio Code.

## User-facing changes

None.

## Backwards-incompatible changes

None.