### PR TITLE
Backport PRs #13037 and #13300

### DIFF
--- a/galata/test/jupyterlab/workspace.test.ts
+++ b/galata/test/jupyterlab/workspace.test.ts
@@ -126,12 +126,16 @@ test.describe('Workspace', () => {
     tmpPath
   }) => {
     await Promise.all([
-      // Wait for the workspace to be saved
+      // Wait for the workspace to be saved.
+      // The document opened from URL should not be saved in workspace,
+      // to not change the workspace for 'multiple-document' mode.
       page.waitForResponse(
         response =>
           response.request().method() === 'PUT' &&
           /api\/workspaces/.test(response.request().url()) &&
-          response.request().postDataJSON().data[`editor:${tmpPath}/${mdFile}`]
+          response.request().postDataJSON().data['layout-restorer:data'][
+            'main'
+          ] === null
       ),
       page.goto(`${baseURL}/doc/tree/${tmpPath}/${mdFile}`)
     ]);
@@ -223,5 +227,142 @@ test.describe('Workspace', () => {
     );
     await expect(page.locator(`[role="main"] >> text=${mdFile}`)).toBeVisible();
     await expect(page.locator(`[role="main"] >> text=${nbFile}`)).toBeVisible();
+  });
+});
+
+test.describe('Workspace in doc mode', () => {
+  test.beforeAll(async ({ request, tmpPath }) => {
+    const contents = galata.newContentsHelper(request);
+    await contents.uploadFile(
+      path.resolve(__dirname, `./notebooks/${nbFile}`),
+      `${tmpPath}/${nbFile}`
+    );
+    await contents.uploadFile(
+      path.resolve(__dirname, `./notebooks/${mdFile}`),
+      `${tmpPath}/${mdFile}`
+    );
+  });
+
+  test.afterAll(async ({ request, tmpPath }) => {
+    const contents = galata.newContentsHelper(request);
+    await contents.deleteDirectory(tmpPath);
+  });
+
+  // Use non-default state to have the running session panel displayed
+  test.use({
+    mockState: {
+      'layout-restorer:data': {
+        main: {
+          dock: {
+            type: 'tab-area',
+            currentIndex: 0,
+            widgets: ['notebook:workspace-test/simple_notebook.ipynb']
+          }
+        },
+        down: {
+          size: 0,
+          widgets: []
+        },
+        left: {
+          collapsed: false,
+          visible: true,
+          current: 'filebrowser',
+          widgets: [
+            'filebrowser',
+            'running-sessions',
+            '@jupyterlab/toc:plugin',
+            'extensionmanager.main-view'
+          ]
+        },
+        right: {
+          collapsed: true,
+          visible: true,
+          widgets: []
+        },
+        relativeSizes: [0.4, 0.6, 0],
+        top: {
+          simpleVisibility: true
+        }
+      },
+      'file-browser-filebrowser:cwd': {
+        path: 'workspace-test'
+      },
+      'notebook:workspace-test/simple_notebook.ipynb': {
+        data: {
+          path: 'workspace-test/simple_notebook.ipynb',
+          factory: 'Notebook'
+        }
+      }
+    } as any
+  });
+
+  test('should restore workspace when switching back to lab mode', async ({
+    baseURL,
+    page,
+    tmpPath
+  }) => {
+    // Open the browser in doc mode.
+    // This should not change the saved workspace's main area information,
+    // the document opened from URL should not be saved in workspace.
+    await Promise.all([
+      // Wait for the workspace to be saved.
+      page.waitForRequest(request => {
+        let restorerData = {};
+        let mainRestorerWidgets = [];
+        if (request.postDataJSON() && request.postDataJSON().data) {
+          restorerData = request.postDataJSON().data['layout-restorer:data'];
+          mainRestorerWidgets = restorerData['main']['dock']['widgets'];
+        }
+        return (
+          request.method() === 'PUT' &&
+          /api\/workspaces/.test(request.url()) &&
+          mainRestorerWidgets.length === 1 &&
+          mainRestorerWidgets[0] ===
+            'notebook:workspace-test/simple_notebook.ipynb'
+        );
+      }),
+      page.goto(`${baseURL}/doc/tree/${tmpPath}/${mdFile}`)
+    ]);
+
+    // Ensure that there is only the document opened, no matter the workspace content.
+    await expect(
+      page.locator('#jp-main-dock-panel .jp-MainAreaWidget .jp-FileEditor')
+    ).toHaveCount(1);
+
+    await expect(
+      page.locator('#jp-main-dock-panel .jp-MainAreaWidget')
+    ).toHaveCount(1);
+
+    // Switch to lab mode, which should restore the loaded workspace.
+    await Promise.all([
+      // Wait for the workspace to be saved.
+      // Expect the saved main area to remain unchanged.
+      page.waitForRequest(request => {
+        let restorerData = {};
+        let mainRestorerWidgets = [];
+        if (request.postDataJSON() && request.postDataJSON().data) {
+          restorerData = request.postDataJSON().data['layout-restorer:data'];
+          mainRestorerWidgets = restorerData['main']['dock']['widgets'];
+        }
+        return (
+          request.method() === 'PUT' &&
+          /api\/workspaces/.test(request.url()) &&
+          mainRestorerWidgets.length === 1 &&
+          mainRestorerWidgets[0] ===
+            'notebook:workspace-test/simple_notebook.ipynb'
+        );
+      }),
+      page.url() === `${baseURL}/lab`,
+      page.click('button.jp-switch[role="switch"]')
+    ]);
+
+    // Ensure that the document opened by URL is closed, and that the one from workspace file is restored.
+    await expect(
+      page.locator('#jp-main-dock-panel .jp-MainAreaWidget .jp-Notebook')
+    ).toHaveCount(1);
+
+    await expect(
+      page.locator('#jp-main-dock-panel .jp-MainAreaWidget')
+    ).toHaveCount(1);
   });
 });

--- a/galata/test/jupyterlab/workspace.test.ts
+++ b/galata/test/jupyterlab/workspace.test.ts
@@ -231,8 +231,8 @@ test.describe('Workspace', () => {
 });
 
 test.describe('Workspace in doc mode', () => {
-  test.beforeAll(async ({ request, tmpPath }) => {
-    const contents = galata.newContentsHelper(request);
+  test.beforeAll(async ({ baseURL, tmpPath }) => {
+    const contents = galata.newContentsHelper(baseURL);
     await contents.uploadFile(
       path.resolve(__dirname, `./notebooks/${nbFile}`),
       `${tmpPath}/${nbFile}`
@@ -243,8 +243,8 @@ test.describe('Workspace in doc mode', () => {
     );
   });
 
-  test.afterAll(async ({ request, tmpPath }) => {
-    const contents = galata.newContentsHelper(request);
+  test.afterAll(async ({ baseURL, tmpPath }) => {
+    const contents = galata.newContentsHelper(baseURL);
     await contents.deleteDirectory(tmpPath);
   });
 

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -637,16 +637,21 @@ const layout: JupyterFrontEndPlugin<ILayoutRestorer> = {
   ) => {
     const first = app.started;
     const registry = app.commands;
-    const restorer = new LayoutRestorer({ connector: state, first, registry });
 
-    void restorer.fetch().then(saved => {
-      labShell.restoreLayout(
-        PageConfig.getOption('mode') as DockPanel.Mode,
-        saved
-      );
+    const mode = PageConfig.getOption('mode') as DockPanel.Mode;
+    const restorer = new LayoutRestorer({
+      connector: state,
+      first,
+      registry,
+      mode
+    });
+
+    // Restore the layout.
+    void labShell.restoreLayout(mode, restorer).then(saved => {
       labShell.layoutModified.connect(() => {
         void restorer.save(labShell.saveLayout());
       });
+
       Private.activateSidebarSwitcher(
         app,
         labShell,

--- a/packages/application/src/layoutrestorer.ts
+++ b/packages/application/src/layoutrestorer.ts
@@ -115,6 +115,9 @@ export class LayoutRestorer implements ILayoutRestorer {
     this._connector = options.connector;
     this._first = options.first;
     this._registry = options.registry;
+    if (options.mode) {
+      this._mode = options.mode;
+    }
 
     void this._first
       .then(() => {
@@ -130,6 +133,17 @@ export class LayoutRestorer implements ILayoutRestorer {
       .then(() => {
         this._restored.resolve(void 0);
       });
+  }
+
+  /**
+   * Whether full layout restoration is deferred and is currently incomplete.
+   *
+   * #### Notes
+   * This flag is useful for tracking when the application has started in
+   * 'single-document' mode and the main area has not yet been restored.
+   */
+  get isDeferred(): boolean {
+    return this._deferred.length > 0;
   }
 
   /**
@@ -185,7 +199,12 @@ export class LayoutRestorer implements ILayoutRestorer {
       const fresh = false;
 
       // Rehydrate main area.
-      const mainArea = this._rehydrateMainArea(main);
+      let mainArea: ILabShell.IMainArea | null = null;
+      if (this._mode === 'multiple-document') {
+        mainArea = this._rehydrateMainArea(main);
+      } else {
+        this._deferredMainArea = main;
+      }
 
       // Rehydrate down area.
       const downArea = this._rehydrateDownArea(down);
@@ -216,22 +235,17 @@ export class LayoutRestorer implements ILayoutRestorer {
    *
    * @param options - The restoration options.
    */
-  restore(
+  async restore(
     tracker: WidgetTracker,
     options: IRestorer.IOptions<Widget>
   ): Promise<any> {
-    const warning = 'restore() can only be called before `first` has resolved.';
-
     if (this._firstDone) {
-      console.warn(warning);
-      return Promise.reject(warning);
+      throw new Error('restore() must be called before `first` has resolved.');
     }
 
     const { namespace } = tracker;
     if (this._trackers.has(namespace)) {
-      const warning = `A tracker namespaced ${namespace} was already restored.`;
-      console.warn(warning);
-      return Promise.reject(warning);
+      throw new Error(`The tracker "${namespace}" is already restored.`);
     }
 
     const { args, command, name, when } = options;
@@ -258,21 +272,54 @@ export class LayoutRestorer implements ILayoutRestorer {
     });
 
     const first = this._first;
-    const promise = tracker
-      .restore({
-        args: args || (() => JSONExt.emptyObject),
-        command,
-        connector: this._connector,
-        name,
-        registry: this._registry,
-        when: when ? [first].concat(when) : first
-      })
-      .catch(error => {
-        console.error(error);
-      });
+    if (this._mode == 'multiple-document') {
+      const promise = tracker
+        .restore({
+          args: args || (() => JSONExt.emptyObject),
+          command,
+          connector: this._connector,
+          name,
+          registry: this._registry,
+          when: when ? [first].concat(when) : first
+        })
+        .catch(error => {
+          console.error(error);
+        });
 
-    this._promises.push(promise);
-    return promise;
+      this._promises.push(promise);
+
+      return promise;
+    }
+
+    tracker.defer({
+      args: args || (() => JSONExt.emptyObject),
+      command,
+      connector: this._connector,
+      name,
+      registry: this._registry,
+      when: when ? [first].concat(when) : first
+    });
+    this._deferred.push(tracker);
+  }
+
+  /**
+   * Restore the application layout if its restoration has been deferred.
+   *
+   * @returns - the rehydrated main area.
+   */
+  async restoreDeferred(): Promise<ILabShell.IMainArea | null> {
+    if (!this.isDeferred) {
+      return null;
+    }
+
+    // Empty the deferred list and wait for all trackers to restore.
+    const wait = Promise.resolve();
+    const promises = this._deferred.map(t => wait.then(() => t.restore()));
+    this._deferred.length = 0;
+    await Promise.all(promises);
+
+    // Rehydrate the main area layout.
+    return this._rehydrateMainArea(this._deferredMainArea);
   }
 
   /**
@@ -287,7 +334,10 @@ export class LayoutRestorer implements ILayoutRestorer {
     }
 
     const dehydrated: Private.ILayout = {};
-    dehydrated.main = this._dehydrateMainArea(data.mainArea);
+    // Save the cached main area layout if restoration is deferred.
+    dehydrated.main = this.isDeferred
+      ? this._deferredMainArea
+      : this._dehydrateMainArea(data.mainArea);
     dehydrated.down = this._dehydrateDownArea(data.downArea);
     dehydrated.left = this._dehydrateSideArea(data.leftArea);
     dehydrated.right = this._dehydrateSideArea(data.rightArea);
@@ -453,6 +503,8 @@ export class LayoutRestorer implements ILayoutRestorer {
   }
 
   private _connector: IDataConnector<ReadonlyPartialJSONValue>;
+  private _deferred = new Array<WidgetTracker>();
+  private _deferredMainArea?: Private.IMainArea | null = null;
   private _first: Promise<any>;
   private _firstDone = false;
   private _promisesDone = false;
@@ -461,6 +513,7 @@ export class LayoutRestorer implements ILayoutRestorer {
   private _registry: CommandRegistry;
   private _trackers = new Set<string>();
   private _widgets = new Map<string, Widget>();
+  private _mode: DockPanel.Mode = 'multiple-document';
 }
 
 /**
@@ -488,6 +541,11 @@ export namespace LayoutRestorer {
      * The application command registry.
      */
     registry: CommandRegistry;
+
+    /**
+     * The DockPanel mode.
+     */
+    mode?: DockPanel.Mode;
   }
 }
 

--- a/packages/application/test/shell.spec.ts
+++ b/packages/application/test/shell.spec.ts
@@ -1,9 +1,11 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { LabShell } from '@jupyterlab/application';
+import { LabShell, LayoutRestorer } from '@jupyterlab/application';
+import { StateDB } from '@jupyterlab/statedb';
 import { framePromise } from '@jupyterlab/testutils';
 import { toArray } from '@lumino/algorithm';
+import { CommandRegistry } from '@lumino/commands';
 import { Message } from '@lumino/messaging';
 import { DockPanel, Widget } from '@lumino/widgets';
 import { simulate } from 'simulate-event';
@@ -116,11 +118,15 @@ describe('LabShell', () => {
   });
 
   describe('#restored', () => {
-    it('should resolve when the app is restored for the first time', () => {
-      const state = shell.saveLayout();
+    it('should resolve when the app is restored for the first time', async () => {
+      const restorer = new LayoutRestorer({
+        connector: new StateDB(),
+        first: Promise.resolve<void>(void 0),
+        registry: new CommandRegistry()
+      });
       const mode: DockPanel.Mode = 'multiple-document';
-      shell.restoreLayout(mode, state);
-      return shell.restored;
+      await shell.restoreLayout(mode, restorer);
+      await expect(shell.restored).resolves.not.toThrow();
     });
   });
 
@@ -426,11 +432,15 @@ describe('LabShell', () => {
   });
 
   describe('#restoreLayout', () => {
-    it('should restore the layout of the shell', () => {
-      const state = shell.saveLayout();
+    it('should restore the layout of the shell', async () => {
+      const restorer = new LayoutRestorer({
+        connector: new StateDB(),
+        first: Promise.resolve<void>(void 0),
+        registry: new CommandRegistry()
+      });
       const mode: DockPanel.Mode = 'multiple-document';
       shell.mode = 'single-document';
-      shell.restoreLayout(mode, state);
+      await shell.restoreLayout(mode, restorer);
       expect(shell.mode).toBe('multiple-document');
     });
   });

--- a/packages/apputils/src/widgettracker.ts
+++ b/packages/apputils/src/widgettracker.ts
@@ -176,7 +176,11 @@ export class WidgetTracker<T extends Widget = Widget>
    * A promise resolved when the tracker has been restored.
    */
   get restored(): Promise<void> {
-    return this._pool.restored;
+    if (this._deferred) {
+      return Promise.resolve();
+    } else {
+      return this._pool.restored;
+    }
   }
 
   /**
@@ -316,8 +320,30 @@ export class WidgetTracker<T extends Widget = Widget>
    * This function should not typically be invoked by client code.
    * Its primary use case is to be invoked by a restorer.
    */
-  async restore(options: IRestorable.IOptions<T>): Promise<any> {
-    return this._pool.restore(options);
+  async restore(options?: IRestorable.IOptions<T>): Promise<any> {
+    const deferred = this._deferred;
+    if (deferred) {
+      this._deferred = null;
+      return this._pool.restore(deferred);
+    }
+    if (options) {
+      return this._pool.restore(options);
+    }
+    console.warn('No options provided to restore the tracker.');
+  }
+
+  /**
+   * Save the restore options for this tracker, but do not restore yet.
+   *
+   * @param options - The configuration options that describe restoration.
+   *
+   * ### Notes
+   * This function is useful when starting the shell in 'single-document' mode,
+   * to avoid restoring all useless widgets. It should not ordinarily be called
+   * by client code.
+   */
+  defer(options: IRestorable.IOptions<T>): void {
+    this._deferred = options;
   }
 
   /**
@@ -340,6 +366,7 @@ export class WidgetTracker<T extends Widget = Widget>
   }
 
   private _currentChanged = new Signal<this, T | null>(this);
+  private _deferred: IRestorable.IOptions<T> | null = null;
   private _focusTracker: FocusTracker<T>;
   private _pool: RestorablePool<T>;
   private _isDisposed = false;

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -498,8 +498,6 @@ const browserWidget: JupyterFrontEndPlugin<void> = {
           }
         }
       });
-
-      maybeCreate();
     });
   }
 };

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -1333,8 +1333,8 @@ namespace Private {
       }
       browser.removeClass(restoring);
 
-      if (labShell?.isEmpty('main')) {
-        void commands.execute('launcher:create');
+      if (labShell?.isEmpty('main') && commands.hasCommand('launcher:create')) {
+        void Private.createLauncher(commands, browser);
       }
     };
     router.routed.connect(listener);

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -258,14 +258,15 @@ const factory: JupyterFrontEndPlugin<IFileBrowserFactory> = {
   id: '@jupyterlab/filebrowser-extension:factory',
   provides: IFileBrowserFactory,
   requires: [IDocumentManager, ITranslator],
-  optional: [IStateDB, IRouter, JupyterFrontEnd.ITreeResolver],
+  optional: [IStateDB, IRouter, JupyterFrontEnd.ITreeResolver, ILabShell],
   activate: async (
     app: JupyterFrontEnd,
     docManager: IDocumentManager,
     translator: ITranslator,
     state: IStateDB | null,
     router: IRouter | null,
-    tree: JupyterFrontEnd.ITreeResolver | null
+    tree: JupyterFrontEnd.ITreeResolver | null,
+    labShell: ILabShell | null
   ): Promise<IFileBrowserFactory> => {
     const { commands } = app;
     const tracker = new WidgetTracker<FileBrowser>({ namespace });
@@ -298,8 +299,14 @@ const factory: JupyterFrontEndPlugin<IFileBrowserFactory> = {
       auto: false,
       restore: false
     });
-    void Private.restoreBrowser(defaultBrowser, commands, router, tree);
-
+    void Private.restoreBrowser(
+      defaultBrowser,
+      commands,
+      router,
+      tree,
+      app,
+      labShell
+    );
     return { createFileBrowser, defaultBrowser, tracker };
   }
 };
@@ -1288,7 +1295,9 @@ namespace Private {
     browser: FileBrowser,
     commands: CommandRegistry,
     router: IRouter | null,
-    tree: JupyterFrontEnd.ITreeResolver | null
+    tree: JupyterFrontEnd.ITreeResolver | null,
+    app: JupyterFrontEnd,
+    labShell: ILabShell | null
   ): Promise<void> {
     const restoring = 'jp-mod-restoring';
 
@@ -1325,6 +1334,10 @@ namespace Private {
         await browser.model.refresh();
       }
       browser.removeClass(restoring);
+
+      if (labShell?.isEmpty('main')) {
+        void commands.execute('launcher:create');
+      }
     };
     router.routed.connect(listener);
   }


### PR DESCRIPTION
## References

Backport 2 PRs
- [#13037](https://github.com/jupyterlab/jupyterlab/pull/13037): Avoids restoring widget in dock panel when first loading in 'single-document' mode
- [#13300](https://github.com/jupyterlab/jupyterlab/pull/13300): Reduce ILayoutRestorer API surface area