### PR TITLE
Store document info in the state not in a separate context map out of the document interface.

### DIFF
--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -58,8 +58,7 @@
     "@lumino/disposable": "^2.0.0-alpha.6",
     "@lumino/messaging": "^2.0.0-alpha.6",
     "@lumino/signaling": "^2.0.0-alpha.6",
-    "@lumino/widgets": "^2.0.0-alpha.6",
-    "yjs": "^13.5.40"
+    "@lumino/widgets": "^2.0.0-alpha.6"
   },
   "devDependencies": {
     "@jupyterlab/testutils": "^4.0.0-alpha.15",

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -23,7 +23,7 @@ import {
   ServerConnection,
   ServiceManager
 } from '@jupyterlab/services';
-import * as ymodels from '@jupyterlab/shared-models';
+import { DocumentChange, ISharedDocument } from '@jupyterlab/shared-models';
 import {
   ITranslator,
   nullTranslator,
@@ -33,9 +33,7 @@ import { PartialJSONValue, PromiseDelegate } from '@lumino/coreutils';
 import { DisposableDelegate, IDisposable } from '@lumino/disposable';
 import { ISignal, Signal } from '@lumino/signaling';
 import { Widget } from '@lumino/widgets';
-import * as Y from 'yjs';
 import { DocumentRegistry } from './registry';
-import { DocumentChange, ISharedDocument } from '@jupyterlab/shared-models';
 
 /**
  * An implementation of a document context.
@@ -61,10 +59,6 @@ export class Context<
     const localPath = this._manager.contents.localPath(this._path);
     const lang = this._factory.preferredLanguage(PathExt.basename(localPath));
     this._model = this._factory.createNew(lang);
-    const ymodel = this._model.sharedModel as ymodels.YDocument<DocumentChange>; // translate to the concrete Yjs implementation
-    const ydoc = ymodel.ydoc;
-    this._ydoc = ydoc;
-    this._ycontext = ydoc.getMap('context');
     const docProviderFactory = options.docProviderFactory;
     this._provider = docProviderFactory
       ? docProviderFactory({
@@ -92,23 +86,11 @@ export class Context<
     this.sessionContext.propertyChanged.connect(this._onSessionChanged, this);
     manager.contents.fileChanged.connect(this._onFileChanged, this);
 
-    const urlResolver = (this.urlResolver = new RenderMimeRegistry.UrlResolver({
+    this.urlResolver = new RenderMimeRegistry.UrlResolver({
       path: this._path,
       contents: manager.contents
-    }));
-    this._ycontext.set('path', this._path);
-    this._ycontext.observe(event => {
-      const pathChanged = event.changes.keys.get('path');
-      if (pathChanged) {
-        const newPath = this._ycontext.get('path')!;
-        if (newPath && newPath !== pathChanged.oldValue) {
-          urlResolver.path = newPath;
-          this._path = newPath;
-          this._pathChanged.emit(this.path);
-          this.sessionContext.session?.setPath(newPath) as any;
-        }
-      }
     });
+    this.model.sharedModel.setState('path', this._path);
   }
 
   /**
@@ -218,7 +200,6 @@ export class Context<
     this._model.dispose();
     this._provider.dispose();
     this._model.sharedModel.dispose();
-    this._ydoc.destroy();
     this._disposed.emit(void 0);
     Signal.clearData(this);
   }
@@ -418,6 +399,20 @@ export class Context<
     });
   }
 
+  protected onStateChanged(sender: ISharedDocument, changes: DocumentChange) {
+    if (changes.stateChange) {
+      changes.stateChange.forEach(change => {
+        if (change.name === 'path' && change.newValue !== change.oldValue) {
+          (this.urlResolver as RenderMimeRegistry.UrlResolver).path =
+            change.newValue;
+          this._path = change.newValue;
+          this.sessionContext.session?.setPath(change.newValue) as any;
+          this._pathChanged.emit(this.path);
+        }
+      });
+    }
+  }
+
   /**
    * Handle a change on the contents manager.
    */
@@ -455,7 +450,7 @@ export class Context<
       const localPath = this._manager.contents.localPath(newPath);
       void this.sessionContext.session?.setName(PathExt.basename(localPath));
       this._updateContentsModel(updateModel as Contents.IModel);
-      this._ycontext.set('path', this._path);
+      this._model.sharedModel.setState('path', this._path);
     }
   }
 
@@ -469,7 +464,7 @@ export class Context<
     const path = this.sessionContext.session!.path;
     if (path !== this._path) {
       this._path = path;
-      this._ycontext.set('path', this._path);
+      this._model.sharedModel.setState('path', this._path);
     }
   }
 
@@ -492,7 +487,7 @@ export class Context<
     };
     const mod = this._contentsModel ? this._contentsModel.last_modified : null;
     this._contentsModel = newModel;
-    this._ycontext.set('last_modified', newModel.last_modified);
+    this._model.sharedModel.setState('last_modified', newModel.last_modified);
     if (!mod || newModel.last_modified !== mod) {
       this._fileChanged.emit(newModel);
     }
@@ -551,7 +546,7 @@ export class Context<
     await this.sessionContext.session?.setName(newName);
 
     this._path = newPath;
-    this._ycontext.set('path', this._path);
+    this._model.sharedModel.setState('path', this._path);
   }
 
   /**
@@ -736,8 +731,10 @@ export class Context<
         // (our last save)
         // In some cases the filesystem reports an inconsistent time, so we allow buffer when comparing.
         const lastModifiedCheckMargin = this._lastModifiedCheckMargin;
-        const ycontextModified = this._ycontext.get('last_modified');
-        // prefer using the timestamp from ycontext because it is more up to date
+        const ycontextModified = this._model.sharedModel.getState(
+          'last_modified'
+        ) as string;
+        // prefer using the timestamp from the state because it is more up to date
         const modified = ycontextModified || this.contentsModel?.last_modified;
         const tClient = modified ? new Date(modified) : new Date();
         const tDisk = new Date(model.last_modified);
@@ -889,7 +886,8 @@ or load the version on disk (revert)?`,
     this._path = newPath;
     await this.sessionContext.session?.setPath(newPath);
     await this.sessionContext.session?.setName(newPath.split('/').pop()!);
-    this._ycontext.set('path', this._path);
+    // we must rename the document before saving with the new path
+    this._model.sharedModel.setState('path', this._path);
     await this.save();
     await this._maybeCheckpoint(true);
   }
@@ -917,8 +915,6 @@ or load the version on disk (revert)?`,
   private _disposed = new Signal<this, void>(this);
   private _dialogs: ISessionContext.IDialogs;
   private _provider: IDocumentProvider;
-  private _ydoc: Y.Doc;
-  private _ycontext: Y.Map<string>;
   private _lastModifiedCheckMargin = 500;
   private _timeConflictModalIsOpen = false;
 }

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -91,6 +91,7 @@ export class Context<
       contents: manager.contents
     });
     this.model.sharedModel.setState('path', this._path);
+    this.model.sharedModel.changed.connect(this.onStateChanged, this);
   }
 
   /**

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -158,11 +158,7 @@ export class DocumentModel
     sender: models.ISharedFile,
     changes: models.DocumentChange
   ): void {
-    if (
-      (changes.stateChange &&
-        changes.stateChange.find(change => change.name === 'path')) ||
-      (changes as models.FileChange).sourceChange
-    ) {
+    if ((changes as models.FileChange).sourceChange) {
       this.triggerContentChange();
     }
     if (changes.stateChange) {

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -167,13 +167,17 @@ export class DocumentModel
     }
     if (changes.stateChange) {
       changes.stateChange.forEach(value => {
-        if (value.name !== 'dirty' || this._dirty !== value.newValue) {
-          this._dirty = value.newValue;
-          this.triggerStateChange({
-            newValue: undefined,
-            oldValue: undefined,
-            ...value
-          });
+        if (value.oldValue !== value.newValue) {
+          if (value.name === 'dirty') {
+            // Setting `dirty` will trigger the state change.
+            this.dirty = value.newValue;
+          } else {
+            this.triggerStateChange({
+              newValue: undefined,
+              oldValue: undefined,
+              ...value
+            });
+          }
         }
       });
     }

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -156,9 +156,13 @@ export class DocumentModel
 
   private _onStateChanged(
     sender: models.ISharedFile,
-    changes: models.NotebookChange | models.FileChange
+    changes: models.DocumentChange
   ): void {
-    if (changes.contextChange || (changes as models.FileChange).sourceChange) {
+    if (
+      (changes.stateChange &&
+        changes.stateChange.find(change => change.name === 'path')) ||
+      (changes as models.FileChange).sourceChange
+    ) {
       this.triggerContentChange();
     }
     if (changes.stateChange) {

--- a/packages/shared-models/src/api.ts
+++ b/packages/shared-models/src/api.ts
@@ -15,7 +15,11 @@
  */
 
 import type * as nbformat from '@jupyterlab/nbformat';
-import type { PartialJSONValue } from '@lumino/coreutils';
+import type {
+  JSONObject,
+  JSONValue,
+  PartialJSONValue
+} from '@lumino/coreutils';
 import type { IDisposable } from '@lumino/disposable';
 import type { ISignal } from '@lumino/signaling';
 
@@ -67,6 +71,26 @@ export interface ISharedBase extends IDisposable {
  * This is used by, for example, docregistry to share the file-path of the edited content.
  */
 export interface ISharedDocument extends ISharedBase {
+  /**
+   * Document state
+   */
+  readonly state: JSONObject;
+
+  /**
+   * Get the value for a state attribute
+   *
+   * @param key Key to get
+   */
+  getState(key: string): JSONValue | undefined;
+
+  /**
+   * Set the value of a state attribute
+   *
+   * @param key Key to set
+   * @param value New attribute value
+   */
+  setState(key: string, value: JSONValue): void;
+
   /**
    * The changed signal.
    */
@@ -559,11 +583,6 @@ export type StateChange<T> = {
  * Generic document change
  */
 export type DocumentChange = {
-  /**
-   * The context a map => should be part of the document state map
-   */
-  // FIXME to remove at some point
-  contextChange?: MapChange;
   /**
    * Change occurring in the document state.
    */


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
To deal with path renaming, a out of interface map was added to the document. It is a bad practice to add new map to the document outside of shared models. So this uses the existing state map for storing those information.

It also extends ISharedDocument interface to access and modify the state.
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
- Use state Y.Map to store the document `path` and `last_modified` information
- Remove adding out of the model a new map to the document.

The expected side effect is that y-js is only required in `shared-models`, `codemirror` (for the editor binding) and `collaboration` (as it uses a global awarness).

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

You need to listen to `stateChange` instead of `contextChange` on a `ISharedDocument`.