### PR TITLE
Deprecate managing source extensions with `jupyter labextension`

### DIFF
--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -204,8 +204,7 @@ class InstallLabExtensionApp(BaseExtensionApp):
         self.deprecation_warning(
             """Installing extensions with the jupyter labextension install command is now deprecated and will be removed in a future major version of JupyterLab.
 
-Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to
-distribute their extensions as Python packages.
+Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to distribute their extensions as Python packages.
 """
         )
         pinned_versions = self.pin.split(",")
@@ -334,8 +333,7 @@ class UpdateLabExtensionApp(BaseExtensionApp):
         self.deprecation_warning(
             """Updating extensions with the jupyter labextension update command is now deprecated and will be removed in a future major version of JupyterLab.
 
-Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to
-distribute their extensions as Python packages.
+Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to distribute their extensions as Python packages.
 """
         )
         if not self.all and not self.extra_args:
@@ -399,8 +397,7 @@ class UninstallLabExtensionApp(BaseExtensionApp):
         self.deprecation_warning(
             """Uninstalling extensions with the jupyter labextension uninstall command is now deprecated and will be removed in a future major version of JupyterLab.
 
-Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to
-distribute their extensions as Python packages.
+Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to distribute their extensions as Python packages.
 """
         )
         self.extra_args = self.extra_args or [os.getcwd()]

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -204,7 +204,7 @@ class InstallLabExtensionApp(BaseExtensionApp):
         self.deprecation_warning(
             """Installing extensions with the jupyter labextension install command is now deprecated and will be removed in a future major version of JupyterLab.
 
-Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to distribute their extensions as Python packages.
+Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to distribute their extensions as prebuilt packages.
 """
         )
         pinned_versions = self.pin.split(",")
@@ -333,7 +333,7 @@ class UpdateLabExtensionApp(BaseExtensionApp):
         self.deprecation_warning(
             """Updating extensions with the jupyter labextension update command is now deprecated and will be removed in a future major version of JupyterLab.
 
-Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to distribute their extensions as Python packages.
+Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to distribute their extensions as prebuilt packages.
 """
         )
         if not self.all and not self.extra_args:
@@ -397,7 +397,7 @@ class UninstallLabExtensionApp(BaseExtensionApp):
         self.deprecation_warning(
             """Uninstalling extensions with the jupyter labextension uninstall command is now deprecated and will be removed in a future major version of JupyterLab.
 
-Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to distribute their extensions as Python packages.
+Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to distribute their extensions as prebuilt packages.
 """
         )
         self.extra_args = self.extra_args or [os.getcwd()]

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -41,7 +41,10 @@ flags["no-build"] = (
     {"BaseExtensionApp": {"should_build": False}},
     "Defer building the app after the action.",
 )
-flags["dev-build"] = ({"BaseExtensionApp": {"dev_build": True}}, "Build in development mode.")
+flags["dev-build"] = (
+    {"BaseExtensionApp": {"dev_build": True}},
+    "Build in development mode.",
+)
 flags["no-minimize"] = (
     {"BaseExtensionApp": {"minimize": False}},
     "Do not minimize a production build.",
@@ -62,13 +65,22 @@ check_flags["installed"] = (
 )
 
 develop_flags = copy(flags)
-develop_flags["overwrite"] = ({"DevelopLabExtensionApp": {"overwrite": True}}, "Overwrite files")
+develop_flags["overwrite"] = (
+    {"DevelopLabExtensionApp": {"overwrite": True}},
+    "Overwrite files",
+)
 
 update_flags = copy(flags)
-update_flags["all"] = ({"UpdateLabExtensionApp": {"all": True}}, "Update all extensions")
+update_flags["all"] = (
+    {"UpdateLabExtensionApp": {"all": True}},
+    "Update all extensions",
+)
 
 uninstall_flags = copy(flags)
-uninstall_flags["all"] = ({"UninstallLabExtensionApp": {"all": True}}, "Uninstall all extensions")
+uninstall_flags["all"] = (
+    {"UninstallLabExtensionApp": {"all": True}},
+    "Uninstall all extensions",
+)
 
 aliases = dict(base_aliases)
 aliases["app-dir"] = "BaseExtensionApp.app_dir"
@@ -109,7 +121,9 @@ class BaseExtensionApp(JupyterApp, DebugLogFileMixin):
     )
 
     minimize = Bool(
-        True, config=True, help="Whether to minimize a production build (defaults to True)."
+        True,
+        config=True,
+        help="Whether to minimize a production build (defaults to True).",
     )
 
     should_clean = Bool(
@@ -121,7 +135,8 @@ class BaseExtensionApp(JupyterApp, DebugLogFileMixin):
     splice_source = Bool(False, config=True, help="Splice source packages into app directory.")
 
     labextensions_path = List(
-        Unicode(), help="The standard paths to look in for prebuilt JupyterLab extensions"
+        Unicode(),
+        help="The standard paths to look in for prebuilt JupyterLab extensions",
     )
 
     @default("labextensions_path")
@@ -162,6 +177,9 @@ class BaseExtensionApp(JupyterApp, DebugLogFileMixin):
         """A default format for messages"""
         return "%(message)s"
 
+    def deprecate_warning(self, msg):
+        return self.log.warning("\033[33m(Deprecated) %s \033[0m", msg)
+
 
 class InstallLabExtensionApp(BaseExtensionApp):
     description = """Install labextension(s)
@@ -183,6 +201,13 @@ class InstallLabExtensionApp(BaseExtensionApp):
     pin = Unicode("", config=True, help="Pin this version with a certain alias")
 
     def run_task(self):
+        self.deprecate_warning(
+            """Installing extensions with the jupyter labextension install command is now deprecated and will be removed in a future major version of JupyterLab.
+
+Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to
+distribute their extensions as Python packages.
+"""
+        )
         pinned_versions = self.pin.split(",")
         self.extra_args = self.extra_args or [os.getcwd()]
         return any(
@@ -213,7 +238,9 @@ class DevelopLabExtensionApp(BaseExtensionApp):
     symlink = Bool(True, config=False, help="Whether to use a symlink")
 
     labextensions_dir = Unicode(
-        "", config=True, help="Full path to labextensions dir (probably use prefix or user)"
+        "",
+        config=True,
+        help="Full path to labextensions dir (probably use prefix or user)",
     )
 
     def run_task(self):
@@ -304,6 +331,13 @@ class UpdateLabExtensionApp(BaseExtensionApp):
     all = Bool(False, config=True, help="Whether to update all extensions")
 
     def run_task(self):
+        self.deprecate_warning(
+            """Updating extensions with the jupyter labextension update command is now deprecated and will be removed in a future major version of JupyterLab.
+
+Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to
+distribute their extensions as Python packages.
+"""
+        )
         if not self.all and not self.extra_args:
             self.log.warning(
                 "Specify an extension to update, or use --all to update all extensions"
@@ -362,6 +396,13 @@ class UninstallLabExtensionApp(BaseExtensionApp):
     all = Bool(False, config=True, help="Whether to uninstall all extensions")
 
     def run_task(self):
+        self.deprecate_warning(
+            """Uninstalling extensions with the jupyter labextension uninstall command is now deprecated and will be removed in a future major version of JupyterLab.
+
+Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to
+distribute their extensions as Python packages.
+"""
+        )
         self.extra_args = self.extra_args or [os.getcwd()]
 
         options = AppOptions(
@@ -439,7 +480,9 @@ class CheckLabExtensionsApp(BaseExtensionApp):
     flags = check_flags
 
     should_check_installed_only = Bool(
-        False, config=True, help="Whether it should check only if the extensions is installed"
+        False,
+        config=True,
+        help="Whether it should check only if the extensions is installed",
     )
 
     def run_task(self):

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -99,6 +99,8 @@ disable_aliases["level"] = "DisableLabExtensionsApp.level"
 
 VERSION = get_app_version()
 
+LABEXTENSION_COMMAND_WARNING = "Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to distribute their extensions as prebuilt packages"
+
 
 class BaseExtensionApp(JupyterApp, DebugLogFileMixin):
     version = VERSION
@@ -174,7 +176,9 @@ class BaseExtensionApp(JupyterApp, DebugLogFileMixin):
         pass
 
     def deprecation_warning(self, msg):
-        return self.log.warning("\033[33m(Deprecated) %s \033[0m", msg)
+        return self.log.warning(
+            "\033[33m(Deprecated) %s\n\n%s \033[0m", msg, LABEXTENSION_COMMAND_WARNING
+        )
 
     def _log_format_default(self):
         """A default format for messages"""
@@ -202,10 +206,7 @@ class InstallLabExtensionApp(BaseExtensionApp):
 
     def run_task(self):
         self.deprecation_warning(
-            """Installing extensions with the jupyter labextension install command is now deprecated and will be removed in a future major version of JupyterLab.
-
-Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to distribute their extensions as prebuilt packages.
-"""
+            "Installing extensions with the jupyter labextension install command is now deprecated and will be removed in a future major version of JupyterLab."
         )
         pinned_versions = self.pin.split(",")
         self.extra_args = self.extra_args or [os.getcwd()]
@@ -331,10 +332,7 @@ class UpdateLabExtensionApp(BaseExtensionApp):
 
     def run_task(self):
         self.deprecation_warning(
-            """Updating extensions with the jupyter labextension update command is now deprecated and will be removed in a future major version of JupyterLab.
-
-Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to distribute their extensions as prebuilt packages.
-"""
+            "Updating extensions with the jupyter labextension update command is now deprecated and will be removed in a future major version of JupyterLab."
         )
         if not self.all and not self.extra_args:
             self.log.warning(
@@ -395,10 +393,7 @@ class UninstallLabExtensionApp(BaseExtensionApp):
 
     def run_task(self):
         self.deprecation_warning(
-            """Uninstalling extensions with the jupyter labextension uninstall command is now deprecated and will be removed in a future major version of JupyterLab.
-
-Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to distribute their extensions as prebuilt packages.
-"""
+            "Uninstalling extensions with the jupyter labextension uninstall command is now deprecated and will be removed in a future major version of JupyterLab."
         )
         self.extra_args = self.extra_args or [os.getcwd()]
 

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -173,12 +173,12 @@ class BaseExtensionApp(JupyterApp, DebugLogFileMixin):
     def run_task(self):
         pass
 
+    def deprecation_warning(self, msg):
+        return self.log.warning("\033[33m(Deprecated) %s \033[0m", msg)
+
     def _log_format_default(self):
         """A default format for messages"""
         return "%(message)s"
-
-    def deprecate_warning(self, msg):
-        return self.log.warning("\033[33m(Deprecated) %s \033[0m", msg)
 
 
 class InstallLabExtensionApp(BaseExtensionApp):
@@ -201,7 +201,7 @@ class InstallLabExtensionApp(BaseExtensionApp):
     pin = Unicode("", config=True, help="Pin this version with a certain alias")
 
     def run_task(self):
-        self.deprecate_warning(
+        self.deprecation_warning(
             """Installing extensions with the jupyter labextension install command is now deprecated and will be removed in a future major version of JupyterLab.
 
 Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to
@@ -331,7 +331,7 @@ class UpdateLabExtensionApp(BaseExtensionApp):
     all = Bool(False, config=True, help="Whether to update all extensions")
 
     def run_task(self):
-        self.deprecate_warning(
+        self.deprecation_warning(
             """Updating extensions with the jupyter labextension update command is now deprecated and will be removed in a future major version of JupyterLab.
 
 Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to
@@ -396,7 +396,7 @@ class UninstallLabExtensionApp(BaseExtensionApp):
     all = Bool(False, config=True, help="Whether to uninstall all extensions")
 
     def run_task(self):
-        self.deprecate_warning(
+        self.deprecation_warning(
             """Uninstalling extensions with the jupyter labextension uninstall command is now deprecated and will be removed in a future major version of JupyterLab.
 
 Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/12386

## Code changes

Log a deprecation warning to the console when using the following commands:

- `jupyter labextension install`
- `jupyter labextension update`
- `jupyter labextension uninstall`

Also includes other formatting changes since `black` was run on the file.

## User-facing changes

Users managing extensions via the command line with the `jupyter labextension` commands will get the following warning:

![image](https://user-images.githubusercontent.com/591645/198115779-60af62e0-f798-4c37-a851-e0ec3caf15a3.png)

## Backwards-incompatible changes

None