### PR TITLE
Close search view on Escape

### DIFF
--- a/galata/test/jupyterlab/notebook-search.test.ts
+++ b/galata/test/jupyterlab/notebook-search.test.ts
@@ -35,27 +35,33 @@ test.describe('Notebook Search', () => {
     expect(await nbPanel.screenshot()).toMatchSnapshot('search.png');
   });
 
+  test('Close with Escape', async ({ page }) => {
+    // Open search box
+    await page.keyboard.press('Control+f');
+    await expect(page.locator('.jp-DocumentSearch-overlay')).toBeVisible();
+
+    // Close search box
+    await page.keyboard.press('Escape');
+    await expect(page.locator('.jp-DocumentSearch-overlay')).toBeHidden();
+  });
+
   test('Close with Escape from Notebook', async ({ page }) => {
     // Open search box
     await page.keyboard.press('Control+f');
-
-    await page.fill('[placeholder="Find"]', 'with');
-    expect(await page.isVisible('.jp-DocumentSearch-overlay')).toBeTruthy();
+    await expect(page.locator('.jp-DocumentSearch-overlay')).toBeVisible();
 
     // Enter first cell
     await page.notebook.enterCellEditingMode(0);
 
     // First escape should NOT close the search box (but leave the editing mode)
     await page.keyboard.press('Escape');
+    await page.waitForTimeout(250);
     expect(await page.notebook.isCellInEditingMode(0)).toBeFalsy();
     expect(await page.isVisible('.jp-DocumentSearch-overlay')).toBeTruthy();
 
     // Second escape should close the search box (even if it is not focused)
     await page.keyboard.press('Escape');
-    await page.waitForSelector('.jp-DocumentSearch-overlay', {
-      state: 'detached'
-    });
-    expect(await page.isHidden('.jp-DocumentSearch-overlay')).toBeTruthy();
+    await expect(page.locator('.jp-DocumentSearch-overlay')).toBeHidden();
   });
 
   test('Search within outputs', async ({ page }) => {

--- a/galata/test/jupyterlab/notebook-search.test.ts
+++ b/galata/test/jupyterlab/notebook-search.test.ts
@@ -35,6 +35,29 @@ test.describe('Notebook Search', () => {
     expect(await nbPanel.screenshot()).toMatchSnapshot('search.png');
   });
 
+  test('Close with Escape from Notebook', async ({ page }) => {
+    // Open search box
+    await page.keyboard.press('Control+f');
+
+    await page.fill('[placeholder="Find"]', 'with');
+    expect(await page.isVisible('.jp-DocumentSearch-overlay')).toBeTruthy();
+
+    // Enter first cell
+    await page.notebook.enterCellEditingMode(0);
+
+    // First escape should NOT close the search box (but leave the editing mode)
+    await page.keyboard.press('Escape');
+    expect(await page.notebook.isCellInEditingMode(0)).toBeFalsy();
+    expect(await page.isVisible('.jp-DocumentSearch-overlay')).toBeTruthy();
+
+    // Second escape should close the search box (even if it is not focused)
+    await page.keyboard.press('Escape');
+    await page.waitForSelector('.jp-DocumentSearch-overlay', {
+      state: 'detached'
+    });
+    expect(await page.isHidden('.jp-DocumentSearch-overlay')).toBeTruthy();
+  });
+
   test('Search within outputs', async ({ page }) => {
     // Open search box
     await page.keyboard.press('Control+f');

--- a/packages/codemirror/src/searchprovider.ts
+++ b/packages/codemirror/src/searchprovider.ts
@@ -617,17 +617,19 @@ export class CodeMirrorSearchHighlighter {
     this._currentIndex = null;
     this._matches = [];
 
-    this._cm!.editor.dispatch({
-      effects: this._highlightEffect.of({ matches: [] })
-    });
+    if (this._cm) {
+      this._cm.editor.dispatch({
+        effects: this._highlightEffect.of({ matches: [] })
+      });
 
-    const selection = this._cm!.state.selection.main;
-    const from = selection.from;
-    const to = selection.to;
-    // Setting a reverse selection to allow search-as-you-type to maintain the
-    // current selected match. See comment in _findNext for more details.
-    if (from !== to) {
-      this._cm!.editor.dispatch({ selection: { anchor: to, head: from } });
+      const selection = this._cm.state.selection.main;
+      const from = selection.from;
+      const to = selection.to;
+      // Setting a reverse selection to allow search-as-you-type to maintain the
+      // current selected match. See comment in _findNext for more details.
+      if (from !== to) {
+        this._cm.editor.dispatch({ selection: { anchor: to, head: from } });
+      }
     }
 
     return Promise.resolve();

--- a/packages/documentsearch-extension/schema/plugin.json
+++ b/packages/documentsearch-extension/schema/plugin.json
@@ -47,6 +47,11 @@
       "command": "documentsearch:highlightPrevious",
       "keys": ["Accel Shift G"],
       "selector": ".jp-mod-searchable"
+    },
+    {
+      "command": "documentsearch:end",
+      "keys": ["Escape"],
+      "selector": ".jp-mod-searchable"
     }
   ],
   "properties": {

--- a/packages/documentsearch/package.json
+++ b/packages/documentsearch/package.json
@@ -41,6 +41,7 @@
     "@jupyterlab/ui-components": "^4.0.0-alpha.30",
     "@lumino/coreutils": "^2.0.0-alpha.6",
     "@lumino/disposable": "^2.0.0-alpha.6",
+    "@lumino/messaging": "^2.0.0-alpha.6",
     "@lumino/polling": "^2.0.0-alpha.6",
     "@lumino/signaling": "^2.0.0-alpha.6",
     "@lumino/widgets": "^2.0.0-alpha.6",


### PR DESCRIPTION
## References

Closes #13311

## Code changes

- Uses lumino message loop close message to close the search view
-  Adds a galata test to ensure behaviour: closing search view when focused in notebook, but not when exiting a cell

## User-facing changes

- Allows to customise the hotkey used to close search
- Adds "End Search" command to command palette
- Allows to close search when focused on notebook (when not in edit mode)

## Backwards-incompatible changes

None