### PR TITLE
Add user configuration for additional schemes for the sanitizer plugin

### DIFF
--- a/packages/apputils-extension/schema/sanitizer.json
+++ b/packages/apputils-extension/schema/sanitizer.json
@@ -1,0 +1,17 @@
+{
+  "title": "HTML Sanitizer",
+  "description": "HTML Sanitizer settings.",
+  "jupyter.lab.setting-icon": "ui-components:html5",
+  "additionalProperties": false,
+  "properties": {
+    "additionalSchemes": {
+      "title": "Additional Scheme",
+      "description": "Add an additional scheme to the sanitizer.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "type": "object"
+}

--- a/packages/apputils/src/sanitizer.ts
+++ b/packages/apputils/src/sanitizer.ts
@@ -447,6 +447,12 @@ export class Sanitizer implements ISanitizer {
     return sanitize(dirty, { ...this._options, ...(options || {}) });
   }
 
+  addScheme(scheme: string): void {
+    if (Array.isArray(this._options.allowedSchemes)) {
+      this._options.allowedSchemes.push(scheme);
+    }
+  }
+
   private _options: sanitize.IOptions = {
     // HTML tags that are allowed to be used. Tags were extracted from Google Caja
     allowedTags: [
@@ -952,7 +958,8 @@ export class Sanitizer implements ISanitizer {
     // 'src' Attributes are validated to be URIs, which does not allow for embedded (image) data.
     // Since embedded data is no longer deemed to be a threat, validation can be skipped.
     // See https://github.com/jupyterlab/jupyterlab/issues/5183
-    allowedSchemesAppliedToAttributes: ['href', 'cite']
+    allowedSchemesAppliedToAttributes: ['href', 'cite'],
+    allowedSchemes: []
   };
 }
 

--- a/packages/apputils/src/tokens.ts
+++ b/packages/apputils/src/tokens.ts
@@ -206,6 +206,7 @@ export interface ISanitizer {
    * @returns The sanitized string.
    */
   sanitize(dirty: string, options?: ISanitizer.IOptions): string;
+  addScheme?(scheme: string): void;
 }
 
 /**


### PR DESCRIPTION
## References
This looks to close out #7384 by adding user configuration for the sanitizer plugin for the purpose of adding additional schemes to the sanitizer.

## Code changes

* Add settings to the sanitizer plugin
* Add function to default sanitizer to add user configuration to additional schemes

## User-facing changes

A new option in the advanced settings allowing users to add additional schemes.

![localhost_8817_lab](https://user-images.githubusercontent.com/73378227/198895555-55dbcc6b-86fe-4d47-ab21-dbcc5348ab6e.png)

## Backwards-incompatible changes

No backwards-incompatible changes anticipated.
