### PR TITLE
Fix Binder for jupyter-server v2

### DIFF
--- a/.github/jupyterlab-probot.yml
+++ b/.github/jupyterlab-probot.yml
@@ -1,3 +1,3 @@
-binderUrlSuffix: "?urlpath=lab-dev"
+binderUrlSuffix: "?urlpath=lab"
 addBinderLink: true
 triageLabel: "status:Needs Triage"

--- a/binder/README.md
+++ b/binder/README.md
@@ -7,7 +7,7 @@ https://mybinder.org/v2/gh/jupyterlab/jupyterlab/master?urlpath=lab
 To check out a different version, just replace "master" with the desired
 branch/tag name or commit hash.
 
-If there is an error with the launched application, you can look at 
+If there is an error with the launched application, you can look at
 `~/jupyterlab-dev.log` in a terminal to see the log.
 
 Please note that this setup is developer focused.

--- a/binder/README.md
+++ b/binder/README.md
@@ -2,13 +2,13 @@ This directory holds configuration files for https://mybinder.org/.
 
 A Binder instance can be launched by visiting this URL:
 
-https://mybinder.org/v2/gh/jupyterlab/jupyterlab/master?urlpath=lab-dev
+https://mybinder.org/v2/gh/jupyterlab/jupyterlab/master?urlpath=lab
 
 To check out a different version, just replace "master" with the desired
 branch/tag name or commit hash.
 
-If there is an error with the launched application, you can append
-`edit/jupyterlab-dev.log` to the URL (after `lab-dev/`) to see the server logs.
+If there is an error with the launched application, you can look at 
+`~/jupyterlab-dev.log` in a terminal to see the log.
 
 Please note that this setup is developer focused.
 For a more user-focused Binder use this URL:

--- a/binder/jupyter_notebook_config.py
+++ b/binder/jupyter_notebook_config.py
@@ -12,19 +12,6 @@ common = [
     "--ServerApp.allow_remote_access=True",
 ]
 
-lab_command = " ".join(
-    [
-        "jupyter",
-        "lab",
-        "--dev-mode",
-        "--extensions-in-dev-mode",
-        "--collaborative",
-        "--ServerApp.base_url={base_url}lab-dev",
-    ]
-    + common
-    + [">jupyterlab-dev.log 2>&1"]
-)
-
 
 lab_splice_command = " ".join(
     [
@@ -47,7 +34,6 @@ lab_splice_command = " ".join(
 
 
 c.ServerProxy.servers = {
-    "lab-dev": {"command": ["/bin/bash", "-c", lab_command], "timeout": 60, "absolute_url": True},
     "lab-spliced": {
         "command": ["/bin/bash", "-c", lab_splice_command],
         "timeout": 300,
@@ -55,8 +41,6 @@ c.ServerProxy.servers = {
     },
 }
 
-c.NotebookApp.default_url = "/lab-dev"
-
 import logging
 
-c.NotebookApp.log_level = logging.DEBUG
+c.ServerApp.log_level = logging.DEBUG

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,8 +1,6 @@
 #!/bin/bash
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
 set -euo pipefail
 
 pip install -e .[dev]
-
-jlpm
-
-jlpm build

--- a/binder/start
+++ b/binder/start
@@ -17,6 +17,7 @@ argv = sys.argv[1:] + [
 ]
 print(argv)
 
+
 # Convert from jupyter-notebook based to jupyter-lab based start-up
 def nb2jps(s):
     return s.replace("jupyter-notebook", "jupyter-lab").replace("--NotebookApp.", "--ServerApp.")

--- a/binder/start
+++ b/binder/start
@@ -1,14 +1,30 @@
 #!/usr/bin/env python3
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 import sys
 import shutil
 import os
 
-# using jupyter_notebook_config.py for now since Binder is still starting the
-# classic notebook server
-argv = sys.argv[1:] + ["--config", "binder/jupyter_notebook_config.py"]
+argv = sys.argv[1:] + [
+    "--debug",
+    "--dev-mode",
+    "--extensions-in-dev-mode",
+    "--collaborative",
+    "--ContentsManager.allow_hidden=True",
+    "--config",
+    "binder/jupyter_notebook_config.py"
+]
 print(argv)
 
-with open("startup_args.txt", "w") as fid:
-    fid.write(str(argv))
+# Convert from jupyter-notebook based to jupyter-lab based start-up
+def nb2jps(s):
+    return s.replace("jupyter-notebook", "jupyter-lab").replace("--NotebookApp.", "--ServerApp.")
 
-os.execv(shutil.which(argv[0]), argv)
+new_argv = list(map(nb2jps, argv.copy()))
+print(new_argv)
+
+with open(".startup_args.txt", "w") as fid:
+    fid.write(str(new_argv))
+
+os.execv(shutil.which(new_argv[0]), new_argv)

--- a/binder/start
+++ b/binder/start
@@ -13,13 +13,14 @@ argv = sys.argv[1:] + [
     "--collaborative",
     "--ContentsManager.allow_hidden=True",
     "--config",
-    "binder/jupyter_notebook_config.py"
+    "binder/jupyter_notebook_config.py",
 ]
 print(argv)
 
 # Convert from jupyter-notebook based to jupyter-lab based start-up
 def nb2jps(s):
     return s.replace("jupyter-notebook", "jupyter-lab").replace("--NotebookApp.", "--ServerApp.")
+
 
 new_argv = list(map(nb2jps, argv.copy()))
 print(new_argv)


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Follow-up of https://github.com/jupyterlab/jupyterlab/pull/12926

jupyter-server v2 is not compatible with Binder. This fixes it.
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Start JupyterLab with Jupyter Server and not via Jupyter Notebook in Binder.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A