### PR TITLE
Check a core path is actually a package

### DIFF
--- a/buildutils/src/utils.ts
+++ b/buildutils/src/utils.ts
@@ -63,7 +63,16 @@ export function getLernaPaths(basePath = '.'): string[] {
  */
 export function getCorePaths(): string[] {
   const spec = path.resolve(path.join('.', 'packages', '*'));
-  return glob.sync(spec);
+  return (
+    glob
+      .sync(spec)
+      // Git versioned only files - so we check for package.json
+      // to ensure a package really exists and is not a ghost from
+      // another branch
+      .filter(packagePath =>
+        fs.existsSync(path.join(packagePath, 'package.json'))
+      )
+  );
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
This will fix the issue for maintainer that an empty folder is added to `tsconfigdoc.json` although it should not like when switching between Git branches (that only cares about files and not folders).
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Check that a `package.json` file exists in a folder to consider it as a core path.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A