### PR TITLE
Correct `dirty` handling in notebook model

### DIFF
--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -362,13 +362,17 @@ close the notebook without saving it.`,
   ): void {
     if (changes.stateChange) {
       changes.stateChange.forEach(value => {
-        if (value.name !== 'dirty' || this._dirty !== value.newValue) {
-          this._dirty = value.newValue;
-          this.triggerStateChange({
-            newValue: undefined,
-            oldValue: undefined,
-            ...value
-          });
+        if (value.oldValue !== value.newValue) {
+          if (value.name === 'dirty') {
+            // Setting `dirty` will trigger the state change.
+            this.dirty = value.newValue;
+          } else {
+            this.triggerStateChange({
+              newValue: undefined,
+              oldValue: undefined,
+              ...value
+            });
+          }
         }
       });
     }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Follow-up of #13317
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
`NotebookModel.dirty` is not properly set when the state changes.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A