### PR TITLE
Automated Changelog Entry for 3.6.0a1 on 3.6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,54 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.6.0a1
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.6.0a0...fb72792f7fb8b1310477763874979934d38334bf))
+
+### Enhancements made
+
+- Store document info in the state not in a separate context map out of the document interface. [#13317](https://github.com/jupyterlab/jupyterlab/pull/13317) ([@fcollonval](https://github.com/fcollonval))
+- Use file ID [#13246](https://github.com/jupyterlab/jupyterlab/pull/13246) ([@davidbrochart](https://github.com/davidbrochart))
+- Relax doc provider API [#13214](https://github.com/jupyterlab/jupyterlab/pull/13214) ([@fcollonval](https://github.com/fcollonval))
+- User service [#12926](https://github.com/jupyterlab/jupyterlab/pull/12926) ([@hbcarlos](https://github.com/hbcarlos))
+- Backport PRs #13037 and #13300 [#13314](https://github.com/jupyterlab/jupyterlab/pull/13314) ([@brichet](https://github.com/brichet))
+- Fix illegible white on yellow text of stacktrace in dark theme [#13249](https://github.com/jupyterlab/jupyterlab/pull/13249) ([@NikolayXHD](https://github.com/NikolayXHD))
+- Backport of "Allow empty notebook" (#13141) [#13296](https://github.com/jupyterlab/jupyterlab/pull/13296) ([@martinRenou](https://github.com/martinRenou))
+
+### Bugs fixed
+
+- Updates JSONEditor's source only when there is an active cell or an active notebook panel [#13308](https://github.com/jupyterlab/jupyterlab/pull/13308) ([@hbcarlos](https://github.com/hbcarlos))
+- Avoids use of @deprecated to refer to a parameter [#13309](https://github.com/jupyterlab/jupyterlab/pull/13309) ([@jweill-aws](https://github.com/jweill-aws))
+- Fix border-radius does not follow css variable [#13289](https://github.com/jupyterlab/jupyterlab/pull/13289) ([@vthinkxie](https://github.com/vthinkxie))
+
+### Maintenance and upkeep improvements
+
+- Check a core path is actually a package [#13346](https://github.com/jupyterlab/jupyterlab/pull/13346) ([@fcollonval](https://github.com/fcollonval))
+- Removes empty requires list  [#13334](https://github.com/jupyterlab/jupyterlab/pull/13334) ([@hbcarlos](https://github.com/hbcarlos))
+- Fix Binder for jupyter-server v2 [#13344](https://github.com/jupyterlab/jupyterlab/pull/13344) ([@fcollonval](https://github.com/fcollonval))
+- Switch to releaser v2 [#13322](https://github.com/jupyterlab/jupyterlab/pull/13322) ([@blink1073](https://github.com/blink1073))
+
+### Documentation improvements
+
+- Fix Binder for jupyter-server v2 [#13344](https://github.com/jupyterlab/jupyterlab/pull/13344) ([@fcollonval](https://github.com/fcollonval))
+- Correct starting docs: working directory path sample code [#13261](https://github.com/jupyterlab/jupyterlab/pull/13261) ([@hugetim](https://github.com/hugetim))
+
+### API and Breaking Changes
+
+- Store document info in the state not in a separate context map out of the document interface. [#13317](https://github.com/jupyterlab/jupyterlab/pull/13317) ([@fcollonval](https://github.com/fcollonval))
+
+### Other merged PRs
+
+- Update README.md [#13257](https://github.com/jupyterlab/jupyterlab/pull/13257) ([@liliyao2022](https://github.com/liliyao2022))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-10-26&to=2022-10-31&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-10-26..2022-10-31&type=Issues) | [@brichet](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abrichet+updated%3A2022-10-26..2022-10-31&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2022-10-26..2022-10-31&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-10-26..2022-10-31&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-10-26..2022-10-31&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-10-26..2022-10-31&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AmartinRenou+updated%3A2022-10-26..2022-10-31&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-10-26..2022-10-31&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-10-26..2022-10-31&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASylvainCorlay+updated%3A2022-10-26..2022-10-31&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-10-26..2022-10-31&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.6.0a0
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/d3316552294b1667d809805a1829f33c62701cc8...a960bd68b83d392a8697019adbffa748fda1be0a))
@@ -47,8 +95,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2000-03-05&to=2022-10-25&type=c))
 
 [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2000-03-05..2022-10-25&type=Issues) | [@agoose77](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aagoose77+updated%3A2000-03-05..2022-10-25&type=Issues) | [@aiqc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aaiqc+updated%3A2000-03-05..2022-10-25&type=Issues) | [@ajbozarth](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aajbozarth+updated%3A2000-03-05..2022-10-25&type=Issues) | [@andrewfulton9](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aandrewfulton9+updated%3A2000-03-05..2022-10-25&type=Issues) | [@athornton](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aathornton+updated%3A2000-03-05..2022-10-25&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2000-03-05..2022-10-25&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2000-03-05..2022-10-25&type=Issues) | [@brichet](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abrichet+updated%3A2000-03-05..2022-10-25&type=Issues) | [@damianavila](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adamianavila+updated%3A2000-03-05..2022-10-25&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2000-03-05..2022-10-25&type=Issues) | [@dlqqq](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adlqqq+updated%3A2000-03-05..2022-10-25&type=Issues) | [@dmonad](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Admonad+updated%3A2000-03-05..2022-10-25&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2000-03-05..2022-10-25&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2000-03-05..2022-10-25&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2000-03-05..2022-10-25&type=Issues) | [@firai](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afirai+updated%3A2000-03-05..2022-10-25&type=Issues) | [@fperez](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afperez+updated%3A2000-03-05..2022-10-25&type=Issues) | [@gabalafou](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agabalafou+updated%3A2000-03-05..2022-10-25&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2000-03-05..2022-10-25&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2000-03-05..2022-10-25&type=Issues) | [@isabela-pf](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aisabela-pf+updated%3A2000-03-05..2022-10-25&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2000-03-05..2022-10-25&type=Issues) | [@jess-x](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajess-x+updated%3A2000-03-05..2022-10-25&type=Issues) | [@JohanMabille](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AJohanMabille+updated%3A2000-03-05..2022-10-25&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2000-03-05..2022-10-25&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2000-03-05..2022-10-25&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajweill-aws+updated%3A2000-03-05..2022-10-25&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2000-03-05..2022-10-25&type=Issues) | [@malemburg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Amalemburg+updated%3A2000-03-05..2022-10-25&type=Issues) | [@marthacryan](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Amarthacryan+updated%3A2000-03-05..2022-10-25&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AmartinRenou+updated%3A2000-03-05..2022-10-25&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2000-03-05..2022-10-25&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2000-03-05..2022-10-25&type=Issues) | [@mlucool](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Amlucool+updated%3A2000-03-05..2022-10-25&type=Issues) | [@rccern](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Arccern+updated%3A2000-03-05..2022-10-25&type=Issues) | [@schmidi314](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aschmidi314+updated%3A2000-03-05..2022-10-25&type=Issues) | [@siddartha-10](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Asiddartha-10+updated%3A2000-03-05..2022-10-25&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASylvainCorlay+updated%3A2000-03-05..2022-10-25&type=Issues) | [@thesinepainter](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Athesinepainter+updated%3A2000-03-05..2022-10-25&type=Issues) | [@trallard](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrallard+updated%3A2000-03-05..2022-10-25&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrungleduc+updated%3A2000-03-05..2022-10-25&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2000-03-05..2022-10-25&type=Issues) | [@williamstein](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awilliamstein+updated%3A2000-03-05..2022-10-25&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ayuvipanda+updated%3A2000-03-05..2022-10-25&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AZsailer+updated%3A2000-03-05..2022-10-25&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## v3.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@
 - Use file ID [#13246](https://github.com/jupyterlab/jupyterlab/pull/13246) ([@davidbrochart](https://github.com/davidbrochart))
 - Relax doc provider API [#13214](https://github.com/jupyterlab/jupyterlab/pull/13214) ([@fcollonval](https://github.com/fcollonval))
 - User service [#12926](https://github.com/jupyterlab/jupyterlab/pull/12926) ([@hbcarlos](https://github.com/hbcarlos))
-- Backport PRs #13037 and #13300 [#13314](https://github.com/jupyterlab/jupyterlab/pull/13314) ([@brichet](https://github.com/brichet))
+- Avoids restoring widget in dock panel when first loading in 'single-document' mode [#13314](https://github.com/jupyterlab/jupyterlab/pull/13314) ([@brichet](https://github.com/brichet))
 - Fix illegible white on yellow text of stacktrace in dark theme [#13249](https://github.com/jupyterlab/jupyterlab/pull/13249) ([@NikolayXHD](https://github.com/NikolayXHD))
-- Backport of "Allow empty notebook" (#13141) [#13296](https://github.com/jupyterlab/jupyterlab/pull/13296) ([@martinRenou](https://github.com/martinRenou))
+- Allow empty notebook [#13296](https://github.com/jupyterlab/jupyterlab/pull/13296) ([@martinRenou](https://github.com/martinRenou))
 
 ### Bugs fixed
 


### PR DESCRIPTION
Automated Changelog Entry for 3.6.0a1 on 3.6.x
```
Python version: 3.6.0a1
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.6.0-alpha.1
@jupyterlab/buildutils: 3.6.0-alpha.1
@jupyterlab/template: 3.6.0-alpha.1
@jupyterlab/application-top: 3.6.0-alpha.1
@jupyterlab/example-app: 3.6.0-alpha.1
@jupyterlab/example-cell: 3.6.0-alpha.1
@jupyterlab/example-console: 3.6.0-alpha.1
@jupyterlab/example-federated: 2.7.0-alpha.1
@jupyterlab/example-federated-core: 2.7.0-alpha.1
@jupyterlab/example-federated-md: 2.7.0-alpha.1
@jupyterlab/example-federated-middle: 2.7.0-alpha.1
@jupyterlab/example-federated-phosphor: 2.7.0-alpha.1
@jupyterlab/example-filebrowser: 3.6.0-alpha.1
@jupyterlab/example-notebook: 3.6.0-alpha.1
@jupyterlab/example-terminal: 3.6.0-alpha.1
@jupyterlab/galata: 4.5.0-alpha.1
@jupyterlab/mock-extension: 3.6.0-alpha.1
@jupyterlab/mock-consumer: 3.6.0-alpha.1
@jupyterlab/mock-provider: 3.6.0-alpha.1
@jupyterlab/mock-token: 3.6.0-alpha.1
@jupyterlab/application: 3.6.0-alpha.1
@jupyterlab/application-extension: 3.6.0-alpha.1
@jupyterlab/apputils: 3.6.0-alpha.1
@jupyterlab/apputils-extension: 3.6.0-alpha.1
@jupyterlab/attachments: 3.6.0-alpha.1
@jupyterlab/cell-toolbar: 3.6.0-alpha.1
@jupyterlab/cell-toolbar-extension: 3.6.0-alpha.1
@jupyterlab/cells: 3.6.0-alpha.1
@jupyterlab/celltags: 3.6.0-alpha.1
@jupyterlab/celltags-extension: 3.6.0-alpha.1
@jupyterlab/codeeditor: 3.6.0-alpha.1
@jupyterlab/codemirror: 3.6.0-alpha.1
@jupyterlab/codemirror-extension: 3.6.0-alpha.1
@jupyterlab/collaboration: 3.6.0-alpha.1
@jupyterlab/collaboration-extension: 3.6.0-alpha.1
@jupyterlab/completer: 3.6.0-alpha.1
@jupyterlab/completer-extension: 3.6.0-alpha.1
@jupyterlab/console: 3.6.0-alpha.1
@jupyterlab/console-extension: 3.6.0-alpha.1
@jupyterlab/coreutils: 5.6.0-alpha.1
@jupyterlab/csvviewer: 3.6.0-alpha.1
@jupyterlab/csvviewer-extension: 3.6.0-alpha.1
@jupyterlab/debugger: 3.6.0-alpha.1
@jupyterlab/debugger-extension: 3.6.0-alpha.1
@jupyterlab/docmanager: 3.6.0-alpha.1
@jupyterlab/docmanager-extension: 3.6.0-alpha.1
@jupyterlab/docprovider: 3.6.0-alpha.1
@jupyterlab/docprovider-extension: 3.6.0-alpha.1
@jupyterlab/docregistry: 3.6.0-alpha.1
@jupyterlab/documentsearch: 3.6.0-alpha.1
@jupyterlab/documentsearch-extension: 3.6.0-alpha.1
@jupyterlab/extensionmanager: 3.6.0-alpha.1
@jupyterlab/extensionmanager-extension: 3.6.0-alpha.1
@jupyterlab/filebrowser: 3.6.0-alpha.1
@jupyterlab/filebrowser-extension: 3.6.0-alpha.1
@jupyterlab/fileeditor: 3.6.0-alpha.1
@jupyterlab/fileeditor-extension: 3.6.0-alpha.1
@jupyterlab/help-extension: 3.6.0-alpha.1
@jupyterlab/htmlviewer: 3.6.0-alpha.1
@jupyterlab/htmlviewer-extension: 3.6.0-alpha.1
@jupyterlab/hub-extension: 3.6.0-alpha.1
@jupyterlab/imageviewer: 3.6.0-alpha.1
@jupyterlab/imageviewer-extension: 3.6.0-alpha.1
@jupyterlab/inspector: 3.6.0-alpha.1
@jupyterlab/inspector-extension: 3.6.0-alpha.1
@jupyterlab/javascript-extension: 3.6.0-alpha.1
@jupyterlab/json-extension: 3.6.0-alpha.1
@jupyterlab/launcher: 3.6.0-alpha.1
@jupyterlab/launcher-extension: 3.6.0-alpha.1
@jupyterlab/logconsole: 3.6.0-alpha.1
@jupyterlab/logconsole-extension: 3.6.0-alpha.1
@jupyterlab/mainmenu: 3.6.0-alpha.1
@jupyterlab/mainmenu-extension: 3.6.0-alpha.1
@jupyterlab/markdownviewer: 3.6.0-alpha.1
@jupyterlab/markdownviewer-extension: 3.6.0-alpha.1
@jupyterlab/mathjax2: 3.6.0-alpha.1
@jupyterlab/mathjax2-extension: 3.6.0-alpha.1
@jupyterlab/metapackage: 3.6.0-alpha.1
@jupyterlab/nbconvert-css: 3.6.0-alpha.1
@jupyterlab/nbformat: 3.6.0-alpha.1
@jupyterlab/notebook: 3.6.0-alpha.1
@jupyterlab/notebook-extension: 3.6.0-alpha.1
@jupyterlab/observables: 4.6.0-alpha.1
@jupyterlab/outputarea: 3.6.0-alpha.1
@jupyterlab/pdf-extension: 3.6.0-alpha.1
@jupyterlab/property-inspector: 3.6.0-alpha.1
@jupyterlab/rendermime: 3.6.0-alpha.1
@jupyterlab/rendermime-extension: 3.6.0-alpha.1
@jupyterlab/rendermime-interfaces: 3.6.0-alpha.1
@jupyterlab/running: 3.6.0-alpha.1
@jupyterlab/running-extension: 3.6.0-alpha.1
@jupyterlab/services: 6.6.0-alpha.1
@jupyterlab/example-services-browser: 3.6.0-alpha.1
node-example: 3.6.0-alpha.1
@jupyterlab/example-services-outputarea: 3.6.0-alpha.1
@jupyterlab/settingeditor: 3.6.0-alpha.1
@jupyterlab/settingeditor-extension: 3.6.0-alpha.1
@jupyterlab/settingregistry: 3.6.0-alpha.1
@jupyterlab/shared-models: 3.6.0-alpha.1
@jupyterlab/shortcuts-extension: 3.6.0-alpha.1
@jupyterlab/statedb: 3.6.0-alpha.1
@jupyterlab/statusbar: 3.6.0-alpha.1
@jupyterlab/statusbar-extension: 3.6.0-alpha.1
@jupyterlab/terminal: 3.6.0-alpha.1
@jupyterlab/terminal-extension: 3.6.0-alpha.1
@jupyterlab/theme-dark-extension: 3.6.0-alpha.1
@jupyterlab/theme-light-extension: 3.6.0-alpha.1
@jupyterlab/toc: 5.6.0-alpha.1
@jupyterlab/toc-extension: 5.6.0-alpha.1
@jupyterlab/tooltip: 3.6.0-alpha.1
@jupyterlab/tooltip-extension: 3.6.0-alpha.1
@jupyterlab/translation: 3.6.0-alpha.1
@jupyterlab/translation-extension: 3.6.0-alpha.1
@jupyterlab/ui-components: 3.6.0-alpha.1
@jupyterlab/ui-components-extension: 3.6.0-alpha.1
@jupyterlab/vdom: 3.6.0-alpha.1
@jupyterlab/vdom-extension: 3.6.0-alpha.1
@jupyterlab/vega5-extension: 3.6.0-alpha.1
@jupyterlab/testutils: 3.6.0-alpha.1
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyterlab/jupyterlab/releases/tag/untagged-404ee09ebaeaa230734e  |
| Since | v3.6.0a0 |