### PR TITLE
Backport document dirty logic

### DIFF
--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -30,7 +30,6 @@ export class DocumentModel
     this.switchSharedModel(filemodel, true);
     this.value.changed.connect(this.triggerContentChange, this);
 
-    (this.sharedModel as models.YFile).dirty = false;
     this.sharedModel.changed.connect(this._onStateChanged, this);
   }
 
@@ -52,13 +51,19 @@ export class DocumentModel
    * The dirty state of the document.
    */
   get dirty(): boolean {
-    return this.sharedModel.dirty;
+    return this._dirty;
   }
   set dirty(newValue: boolean) {
-    if (newValue === this.dirty) {
+    const oldValue = this._dirty;
+    if (newValue === oldValue) {
       return;
     }
-    (this.sharedModel as models.YFile).dirty = newValue;
+    this._dirty = newValue;
+    this.triggerStateChange({
+      name: 'dirty',
+      oldValue,
+      newValue
+    });
   }
 
   /**
@@ -162,7 +167,12 @@ export class DocumentModel
     if (changes.stateChange) {
       changes.stateChange.forEach(value => {
         if (value.oldValue !== value.newValue) {
-          this.triggerStateChange(value);
+          if (value.name === 'dirty') {
+            // Setting `dirty` will trigger the state change.
+            this.dirty = value.newValue;
+          } else {
+            this.triggerStateChange(value);
+          }
         }
       });
     }
@@ -173,6 +183,7 @@ export class DocumentModel
    */
   readonly sharedModel: models.ISharedFile;
   private _defaultLang = '';
+  private _dirty = false;
   private _readOnly = false;
   private _contentChanged = new Signal<this, void>(this);
   private _stateChanged = new Signal<this, IChangedArgs<any>>(this);

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -166,13 +166,13 @@ export class DocumentModel
     }
     if (changes.stateChange) {
       changes.stateChange.forEach(value => {
-        if (value.oldValue !== value.newValue) {
-          if (value.name === 'dirty') {
-            // Setting `dirty` will trigger the state change.
-            this.dirty = value.newValue;
-          } else {
-            this.triggerStateChange(value);
-          }
+        if (value.name === 'dirty') {
+          // Setting `dirty` will trigger the state change.
+          // We always set `dirty` because the shared model state
+          // and the local attribute are synchronized one way shared model -> _dirty
+          this.dirty = value.newValue;
+        } else if (value.oldValue !== value.newValue) {
+          this.triggerStateChange(value);
         }
       });
     }

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -430,13 +430,13 @@ close the notebook without saving it.`,
   ): void {
     if (changes.stateChange) {
       changes.stateChange.forEach(value => {
-        if (value.oldValue !== value.newValue) {
-          if (value.name === 'dirty') {
-            // Setting `dirty` will trigger the state change.
-            this.dirty = value.newValue;
-          } else {
-            this.triggerStateChange(value);
-          }
+        if (value.name === 'dirty') {
+          // Setting `dirty` will trigger the state change.
+          // We always set `dirty` because the shared model state
+          // and the local attribute are synchronized one way shared model -> _dirty
+          this.dirty = value.newValue;
+        } else if (value.oldValue !== value.newValue) {
+          this.triggerStateChange(value);
         }
       });
     }

--- a/packages/shared-models/src/api.ts
+++ b/packages/shared-models/src/api.ts
@@ -63,11 +63,6 @@ export interface ISharedBase extends IDisposable {
  */
 export interface ISharedDocument extends ISharedBase {
   /**
-   * Whether the document is saved to disk or not.
-   */
-  readonly dirty: boolean;
-
-  /**
    * Document state
    */
   readonly state: JSONObject;
@@ -501,6 +496,11 @@ export type NotebookChange = {
   metadataChange?: {
     oldValue: nbformat.INotebookMetadata;
     newValue: nbformat.INotebookMetadata | undefined;
+  };
+  nbformatChanged?: {
+    key: string;
+    oldValue: number | undefined;
+    newValue: number | undefined;
   };
   contextChange?: MapChange;
   stateChange?: Array<{

--- a/packages/shared-models/src/api.ts
+++ b/packages/shared-models/src/api.ts
@@ -537,7 +537,6 @@ export type CellChange<MetadataType> = {
 };
 
 export type DocumentChange = {
-  contextChange?: MapChange;
   stateChange?: Array<{
     name: string;
     oldValue: any;

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -25,7 +25,8 @@ export interface IYText extends models.ISharedText {
 
 export type YCellType = YRawCell | YCodeCell | YMarkdownCell;
 
-export class YDocument<T extends DocumentChange> implements models.ISharedDocument {
+export class YDocument<T extends DocumentChange>
+  implements models.ISharedDocument {
   /**
    * Perform a transaction. While the function f is called, all changes to the shared
    * document are bundled into a single event.

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -9,7 +9,7 @@ import { ISignal, Signal } from '@lumino/signaling';
 import { Awareness } from 'y-protocols/awareness';
 import * as Y from 'yjs';
 import * as models from './api';
-import { Delta, ISharedNotebook } from './api';
+import { Delta, DocumentChange, ISharedNotebook } from './api';
 
 const deepCopy = (o: any) => JSON.parse(JSON.stringify(o));
 
@@ -25,7 +25,7 @@ export interface IYText extends models.ISharedText {
 
 export type YCellType = YRawCell | YCodeCell | YMarkdownCell;
 
-export class YDocument<T> implements models.ISharedDocument {
+export class YDocument<T extends DocumentChange> implements models.ISharedDocument {
   /**
    * Perform a transaction. While the function f is called, all changes to the shared
    * document are bundled into a single event.

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -711,7 +711,7 @@ export class YBaseCell<Metadata extends models.ISharedBaseCellMetadata>
   /**
    * Handle a change to the ymodel.
    */
-  private _modelObserver = (events: Y.YEvent<any>[]) => {
+  private _modelObserver = (events: Y.YEvent[]) => {
     const changes: models.CellChange<Metadata> = {};
     const sourceEvent = events.find(
       event => event.target === this.ymodel.get('source')

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -26,16 +26,6 @@ export interface IYText extends models.ISharedText {
 export type YCellType = YRawCell | YCodeCell | YMarkdownCell;
 
 export class YDocument<T> implements models.ISharedDocument {
-  get dirty(): boolean {
-    return this.ystate.get('dirty');
-  }
-
-  set dirty(value: boolean) {
-    this.transact(() => {
-      this.ystate.set('dirty', value);
-    }, false);
-  }
-
   /**
    * Perform a transaction. While the function f is called, all changes to the shared
    * document are bundled into a single event.
@@ -254,27 +244,27 @@ export class YNotebook
       return this._ycellMapping.get(ycell) as YCellType;
     });
 
-    this.ymeta.observe(this._onMetadataChanged);
+    this.ymeta.observe(this._onMetaChanged);
     this.ystate.observe(this._onStateChanged);
   }
 
   get nbformat(): number {
-    return this.ystate.get('nbformat');
+    return this.ymeta.get('nbformat');
   }
 
   set nbformat(value: number) {
     this.transact(() => {
-      this.ystate.set('nbformat', value);
+      this.ymeta.set('nbformat', value);
     }, false);
   }
 
   get nbformat_minor(): number {
-    return this.ystate.get('nbformatMinor');
+    return this.ymeta.get('nbformatMinor');
   }
 
   set nbformat_minor(value: number) {
     this.transact(() => {
-      this.ystate.set('nbformatMinor', value);
+      this.ymeta.set('nbformatMinor', value);
     }, false);
   }
 
@@ -283,7 +273,7 @@ export class YNotebook
    */
   dispose(): void {
     this.ycells.unobserve(this._onYCellsChanged);
-    this.ymeta.unobserve(this._onMetadataChanged);
+    this.ymeta.unobserve(this._onMetaChanged);
     this.ystate.unobserve(this._onStateChanged);
   }
 
@@ -470,7 +460,7 @@ export class YNotebook
   /**
    * Handle a change to the ystate.
    */
-  private _onMetadataChanged = (event: Y.YMapEvent<any>) => {
+  private _onMetaChanged = (event: Y.YMapEvent<any>) => {
     if (event.keysChanged.has('metadata')) {
       const change = event.changes.keys.get('metadata');
       const metadataChange = {
@@ -478,6 +468,26 @@ export class YNotebook
         newValue: this.getMetadata()
       };
       this._changed.emit({ metadataChange });
+    }
+
+    if (event.keysChanged.has('nbformat')) {
+      const change = event.changes.keys.get('nbformat');
+      const nbformatChanged = {
+        key: 'nbformat',
+        oldValue: change?.oldValue ? change!.oldValue : undefined,
+        newValue: this.nbformat
+      };
+      this._changed.emit({ nbformatChanged });
+    }
+
+    if (event.keysChanged.has('nbformat_minor')) {
+      const change = event.changes.keys.get('nbformat_minor');
+      const nbformatChanged = {
+        key: 'nbformat_minor',
+        oldValue: change?.oldValue ? change!.oldValue : undefined,
+        newValue: this.nbformat_minor
+      };
+      this._changed.emit({ nbformatChanged });
     }
   };
 
@@ -701,7 +711,7 @@ export class YBaseCell<Metadata extends models.ISharedBaseCellMetadata>
   /**
    * Handle a change to the ymodel.
    */
-  private _modelObserver = (events: Y.YEvent[]) => {
+  private _modelObserver = (events: Y.YEvent<any>[]) => {
     const changes: models.CellChange<Metadata> = {};
     const sourceEvent = events.find(
       event => event.target === this.ymodel.get('source')


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Backport the refactoring of the `dirty` state handling missing in https://github.com/jupyterlab/jupyterlab/pull/13222

> This backport will align the behavior in collaboration mode of 3.6.0 and master.
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
The state `dirty` of a Y-backed document should only be set by the backend not the frontend.

This removes the public `dirty` attribute from the shared document API.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
