### PR TITLE
Fix dirty propagation from shared model

### DIFF
--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -163,17 +163,17 @@ export class DocumentModel
     }
     if (changes.stateChange) {
       changes.stateChange.forEach(value => {
-        if (value.oldValue !== value.newValue) {
-          if (value.name === 'dirty') {
-            // Setting `dirty` will trigger the state change.
-            this.dirty = value.newValue;
-          } else {
-            this.triggerStateChange({
-              newValue: undefined,
-              oldValue: undefined,
-              ...value
-            });
-          }
+        if (value.name === 'dirty') {
+          // Setting `dirty` will trigger the state change.
+          // We always set `dirty` because the shared model state
+          // and the local attribute are synchronized one way shared model -> _dirty
+          this.dirty = value.newValue;
+        } else if (value.oldValue !== value.newValue) {
+          this.triggerStateChange({
+            newValue: undefined,
+            oldValue: undefined,
+            ...value
+          });
         }
       });
     }

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -362,17 +362,17 @@ close the notebook without saving it.`,
   ): void {
     if (changes.stateChange) {
       changes.stateChange.forEach(value => {
-        if (value.oldValue !== value.newValue) {
-          if (value.name === 'dirty') {
-            // Setting `dirty` will trigger the state change.
-            this.dirty = value.newValue;
-          } else {
-            this.triggerStateChange({
-              newValue: undefined,
-              oldValue: undefined,
-              ...value
-            });
-          }
+        if (value.name === 'dirty') {
+          // Setting `dirty` will trigger the state change.
+          // We always set `dirty` because the shared model state
+          // and the local attribute are synchronized one way shared model -> _dirty
+          this.dirty = value.newValue;
+        } else if (value.oldValue !== value.newValue) {
+          this.triggerStateChange({
+            newValue: undefined,
+            oldValue: undefined,
+            ...value
+          });
         }
       });
     }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Seen when working on https://github.com/jupyterlab/jupyterlab/pull/13364
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Ydocument `dirty` state and `DocumentModel.dirty` are synchronized one way:

`YDocument` -> `DocumentModel`. So we always propagate the update event from the YDocument for the dirty attribute.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Document dirty status is consistent
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A