### PR TITLE
Add jupyter-server-fileid

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - jupyterlab-link-share=0.2
+  - jupyter_server_fileid
   - jupyter-server-proxy
   - matplotlib-base
   - nodejs=14

--- a/binder/start
+++ b/binder/start
@@ -12,6 +12,8 @@ argv = sys.argv[1:] + [
     "--extensions-in-dev-mode",
     "--collaborative",
     "--ContentsManager.allow_hidden=True",
+    # Use advance file ID service for out of band rename support
+    "--FileIdExtension.file_id_manager_class=jupyter_server_fileid.manager.LocalFileIdManager",
     "--config",
     "binder/jupyter_notebook_config.py",
 ]


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Renaming a file in Binder on master is not working properly as in collaborative mode, we need a file ID service to be robust.
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

> Needs https://github.com/conda-forge/staged-recipes/pull/20986 

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Add the jupyter-server-fileid package to binder.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
More robust experience when renaming file.
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A