### PR TITLE
Remove metadata entries

### DIFF
--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -390,6 +390,7 @@ close the notebook without saving it.`,
     if (changes.metadataChange) {
       const metadata = changes.metadataChange.newValue as JSONObject;
       this._modelDBMutex(() => {
+        this.metadata.clear();
         Object.entries(metadata).forEach(([key, value]) => {
           this.metadata.set(key, value);
         });
@@ -402,7 +403,7 @@ close the notebook without saving it.`,
     change: IObservableMap.IChangedArgs<ReadonlyPartialJSONValue | undefined>
   ): void {
     this._modelDBMutex(() => {
-      this.sharedModel.updateMetadata(metadata.toJSON());
+      this.sharedModel.setMetadata(metadata.toJSON());
     });
     this.triggerContentChange();
   }


### PR DESCRIPTION
## References
Fixes #13301

## Code changes
When the metadata in the shared model changes, clear ModelDB's metadata and insert the new one.
When the metadata in ModelDB changes, it overwrites the metadata in the shared model.

## User-facing changes


## Backwards-incompatible changes

