### PR TITLE
Automated Changelog Entry for 3.6.0a2 on 3.6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.6.0a2
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.6.0a1...7199ab64466ab27890e9b24f991c9c930f81f702))
+
+### Enhancements made
+
+- Bump Lumino 1.x [#13378](https://github.com/jupyterlab/jupyterlab/pull/13378) ([@fcollonval](https://github.com/fcollonval))
+- Store original path as returned from contents API in the `Contents.IModel` [#13216](https://github.com/jupyterlab/jupyterlab/pull/13216) ([@krassowski](https://github.com/krassowski))
+- Backport document dirty logic [#13364](https://github.com/jupyterlab/jupyterlab/pull/13364) ([@davidbrochart](https://github.com/davidbrochart))
+- Add notification queue and display using toast [#12959](https://github.com/jupyterlab/jupyterlab/pull/12959) ([@telamonian](https://github.com/telamonian))
+
+### Bugs fixed
+
+- Fix key name for nbformat minor version [#13377](https://github.com/jupyterlab/jupyterlab/pull/13377) ([@fcollonval](https://github.com/fcollonval))
+- Remove metadata entries [#13371](https://github.com/jupyterlab/jupyterlab/pull/13371) ([@hbcarlos](https://github.com/hbcarlos))
+
+### Maintenance and upkeep improvements
+
+- Integrity check does not clean style import when emptied [#13367](https://github.com/jupyterlab/jupyterlab/pull/13367) ([@fcollonval](https://github.com/fcollonval))
+- Fix the examples with jupyter-server v2 [#13336](https://github.com/jupyterlab/jupyterlab/pull/13336) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+- Add notification queue and display using toast [#12959](https://github.com/jupyterlab/jupyterlab/pull/12959) ([@telamonian](https://github.com/telamonian))
+
+### API and Breaking Changes
+
+- Backport document dirty logic [#13364](https://github.com/jupyterlab/jupyterlab/pull/13364) ([@davidbrochart](https://github.com/davidbrochart))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-10-31&to=2022-11-04&type=c))
+
+[@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2022-10-31..2022-11-04&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-10-31..2022-11-04&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-10-31..2022-11-04&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-10-31..2022-11-04&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-10-31..2022-11-04&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.6.0a1
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.6.0a0...fb72792f7fb8b1310477763874979934d38334bf))
@@ -53,8 +90,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-10-26&to=2022-10-31&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-10-26..2022-10-31&type=Issues) | [@brichet](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abrichet+updated%3A2022-10-26..2022-10-31&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2022-10-26..2022-10-31&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-10-26..2022-10-31&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-10-26..2022-10-31&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-10-26..2022-10-31&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AmartinRenou+updated%3A2022-10-26..2022-10-31&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-10-26..2022-10-31&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-10-26..2022-10-31&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASylvainCorlay+updated%3A2022-10-26..2022-10-31&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-10-26..2022-10-31&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.6.0a0
 


### PR DESCRIPTION
Automated Changelog Entry for 3.6.0a2 on 3.6.x
```
Python version: 3.6.0a2
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.6.0-alpha.2
@jupyterlab/buildutils: 3.6.0-alpha.2
@jupyterlab/template: 3.6.0-alpha.2
@jupyterlab/application-top: 3.6.0-alpha.2
@jupyterlab/example-app: 3.6.0-alpha.2
@jupyterlab/example-cell: 3.6.0-alpha.2
@jupyterlab/example-console: 3.6.0-alpha.2
@jupyterlab/example-federated: 2.7.0-alpha.2
@jupyterlab/example-federated-core: 2.7.0-alpha.2
@jupyterlab/example-federated-md: 2.7.0-alpha.2
@jupyterlab/example-federated-middle: 2.7.0-alpha.2
@jupyterlab/example-federated-phosphor: 2.7.0-alpha.2
@jupyterlab/example-filebrowser: 3.6.0-alpha.2
@jupyterlab/example-notebook: 3.6.0-alpha.2
@jupyterlab/example-terminal: 3.6.0-alpha.2
@jupyterlab/galata: 4.5.0-alpha.2
@jupyterlab/mock-extension: 3.6.0-alpha.2
@jupyterlab/mock-consumer: 3.6.0-alpha.2
@jupyterlab/mock-provider: 3.6.0-alpha.2
@jupyterlab/mock-token: 3.6.0-alpha.2
@jupyterlab/application: 3.6.0-alpha.2
@jupyterlab/application-extension: 3.6.0-alpha.2
@jupyterlab/apputils: 3.6.0-alpha.2
@jupyterlab/apputils-extension: 3.6.0-alpha.2
@jupyterlab/attachments: 3.6.0-alpha.2
@jupyterlab/cell-toolbar: 3.6.0-alpha.2
@jupyterlab/cell-toolbar-extension: 3.6.0-alpha.2
@jupyterlab/cells: 3.6.0-alpha.2
@jupyterlab/celltags: 3.6.0-alpha.2
@jupyterlab/celltags-extension: 3.6.0-alpha.2
@jupyterlab/codeeditor: 3.6.0-alpha.2
@jupyterlab/codemirror: 3.6.0-alpha.2
@jupyterlab/codemirror-extension: 3.6.0-alpha.2
@jupyterlab/collaboration: 3.6.0-alpha.2
@jupyterlab/collaboration-extension: 3.6.0-alpha.2
@jupyterlab/completer: 3.6.0-alpha.2
@jupyterlab/completer-extension: 3.6.0-alpha.2
@jupyterlab/console: 3.6.0-alpha.2
@jupyterlab/console-extension: 3.6.0-alpha.2
@jupyterlab/coreutils: 5.6.0-alpha.2
@jupyterlab/csvviewer: 3.6.0-alpha.2
@jupyterlab/csvviewer-extension: 3.6.0-alpha.2
@jupyterlab/debugger: 3.6.0-alpha.2
@jupyterlab/debugger-extension: 3.6.0-alpha.2
@jupyterlab/docmanager: 3.6.0-alpha.2
@jupyterlab/docmanager-extension: 3.6.0-alpha.2
@jupyterlab/docprovider: 3.6.0-alpha.2
@jupyterlab/docprovider-extension: 3.6.0-alpha.2
@jupyterlab/docregistry: 3.6.0-alpha.2
@jupyterlab/documentsearch: 3.6.0-alpha.2
@jupyterlab/documentsearch-extension: 3.6.0-alpha.2
@jupyterlab/extensionmanager: 3.6.0-alpha.2
@jupyterlab/extensionmanager-extension: 3.6.0-alpha.2
@jupyterlab/filebrowser: 3.6.0-alpha.2
@jupyterlab/filebrowser-extension: 3.6.0-alpha.2
@jupyterlab/fileeditor: 3.6.0-alpha.2
@jupyterlab/fileeditor-extension: 3.6.0-alpha.2
@jupyterlab/help-extension: 3.6.0-alpha.2
@jupyterlab/htmlviewer: 3.6.0-alpha.2
@jupyterlab/htmlviewer-extension: 3.6.0-alpha.2
@jupyterlab/hub-extension: 3.6.0-alpha.2
@jupyterlab/imageviewer: 3.6.0-alpha.2
@jupyterlab/imageviewer-extension: 3.6.0-alpha.2
@jupyterlab/inspector: 3.6.0-alpha.2
@jupyterlab/inspector-extension: 3.6.0-alpha.2
@jupyterlab/javascript-extension: 3.6.0-alpha.2
@jupyterlab/json-extension: 3.6.0-alpha.2
@jupyterlab/launcher: 3.6.0-alpha.2
@jupyterlab/launcher-extension: 3.6.0-alpha.2
@jupyterlab/logconsole: 3.6.0-alpha.2
@jupyterlab/logconsole-extension: 3.6.0-alpha.2
@jupyterlab/mainmenu: 3.6.0-alpha.2
@jupyterlab/mainmenu-extension: 3.6.0-alpha.2
@jupyterlab/markdownviewer: 3.6.0-alpha.2
@jupyterlab/markdownviewer-extension: 3.6.0-alpha.2
@jupyterlab/mathjax2: 3.6.0-alpha.2
@jupyterlab/mathjax2-extension: 3.6.0-alpha.2
@jupyterlab/metapackage: 3.6.0-alpha.2
@jupyterlab/nbconvert-css: 3.6.0-alpha.2
@jupyterlab/nbformat: 3.6.0-alpha.2
@jupyterlab/notebook: 3.6.0-alpha.2
@jupyterlab/notebook-extension: 3.6.0-alpha.2
@jupyterlab/observables: 4.6.0-alpha.2
@jupyterlab/outputarea: 3.6.0-alpha.2
@jupyterlab/pdf-extension: 3.6.0-alpha.2
@jupyterlab/property-inspector: 3.6.0-alpha.2
@jupyterlab/rendermime: 3.6.0-alpha.2
@jupyterlab/rendermime-extension: 3.6.0-alpha.2
@jupyterlab/rendermime-interfaces: 3.6.0-alpha.2
@jupyterlab/running: 3.6.0-alpha.2
@jupyterlab/running-extension: 3.6.0-alpha.2
@jupyterlab/services: 6.6.0-alpha.2
@jupyterlab/example-services-browser: 3.6.0-alpha.2
node-example: 3.6.0-alpha.2
@jupyterlab/example-services-outputarea: 3.6.0-alpha.2
@jupyterlab/settingeditor: 3.6.0-alpha.2
@jupyterlab/settingeditor-extension: 3.6.0-alpha.2
@jupyterlab/settingregistry: 3.6.0-alpha.2
@jupyterlab/shared-models: 3.6.0-alpha.2
@jupyterlab/shortcuts-extension: 3.6.0-alpha.2
@jupyterlab/statedb: 3.6.0-alpha.2
@jupyterlab/statusbar: 3.6.0-alpha.2
@jupyterlab/statusbar-extension: 3.6.0-alpha.2
@jupyterlab/terminal: 3.6.0-alpha.2
@jupyterlab/terminal-extension: 3.6.0-alpha.2
@jupyterlab/theme-dark-extension: 3.6.0-alpha.2
@jupyterlab/theme-light-extension: 3.6.0-alpha.2
@jupyterlab/toc: 5.6.0-alpha.2
@jupyterlab/toc-extension: 5.6.0-alpha.2
@jupyterlab/tooltip: 3.6.0-alpha.2
@jupyterlab/tooltip-extension: 3.6.0-alpha.2
@jupyterlab/translation: 3.6.0-alpha.2
@jupyterlab/translation-extension: 3.6.0-alpha.2
@jupyterlab/ui-components: 3.6.0-alpha.2
@jupyterlab/ui-components-extension: 3.6.0-alpha.2
@jupyterlab/vdom: 3.6.0-alpha.2
@jupyterlab/vdom-extension: 3.6.0-alpha.2
@jupyterlab/vega5-extension: 3.6.0-alpha.2
@jupyterlab/testutils: 3.6.0-alpha.2
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyterlab/jupyterlab/releases/tag/untagged-3ba36030eecc73cdf77d  |
| Since | v3.6.0a1 |