### PR TITLE
Add a hover effect to plugin list entries

### DIFF
--- a/packages/settingeditor/style/base.css
+++ b/packages/settingeditor/style/base.css
@@ -438,6 +438,10 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
   white-space: nowrap;
 }
 
+.jp-PluginList-entry:hover {
+  background: var(--jp-layout-color1);
+}
+
 .jp-PluginList-entry li {
   margin-left: 27px;
   margin-top: 5px;


### PR DESCRIPTION
## References

Related to https://github.com/jupyterlab/jupyterlab/issues/11988. Currently there is no visual feedback when hovering over the entries in the plugin list. This PR adds a background change consistent with the change in sidebars to reduce the chance of mis-click.

## Code changes

Added one `:hover` style

## User-facing changes

After, light:

![Screenshot from 2022-11-05 14-04-02](https://user-images.githubusercontent.com/5832902/200123772-db728919-6b34-405a-af72-039881b52c97.png)

After, dark:

![Screenshot from 2022-11-05 14-03-49](https://user-images.githubusercontent.com/5832902/200123777-73bf4f84-933a-4036-824c-2ccd7fb37d07.png)

## Backwards-incompatible changes

None