### PR TITLE
Added collaborative_document_save_delay trait

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -580,6 +580,14 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
         document will be kept in memory forever.""",
     )
 
+    collaborative_document_save_delay = Int(
+        1,
+        allow_none=True,
+        config=True,
+        help="""The delay in seconds to wait after a change is made to a document before saving it
+        (relevant only in collaborative mode). Defaults to 1s, if None then the document will never be saved.""",
+    )
+
     collaborative_ystore_class = Type(
         default_value=JupyterSQLiteYStore,
         klass=BaseYStore,
@@ -816,6 +824,7 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
                 "page_config_data": page_config,
                 "collaborative_file_poll_interval": self.collaborative_file_poll_interval,
                 "collaborative_document_cleanup_delay": self.collaborative_document_cleanup_delay,
+                "collaborative_document_save_delay": self.collaborative_document_save_delay,
                 "collaborative_ystore_class": self.collaborative_ystore_class,
             }
         )

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -21,7 +21,7 @@ from jupyterlab_server import (
     WorkspaceListApp,
 )
 from notebook_shim.shim import NotebookConfigShimMixin
-from traitlets import Bool, Instance, Int, Type, Unicode, default
+from traitlets import Bool, Float, Instance, Int, Type, Unicode, default
 from ypy_websocket.ystore import BaseYStore
 
 from ._version import __version__
@@ -580,7 +580,7 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
         document will be kept in memory forever.""",
     )
 
-    collaborative_document_save_delay = Int(
+    collaborative_document_save_delay = Float(
         1,
         allow_none=True,
         config=True,


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Closes https://github.com/jupyter-server/jupyter_server_ydoc/issues/47.

## Code changes

Add `collaborative_document_save_delay` trait.

## User-facing changes

The delay before saving a document after a document change is parameterizable in collaborative mode (default to 1 second).

## Backwards-incompatible changes

None.