### PR TITLE
tomllib is in stdlib in Python 3.11+

### DIFF
--- a/jupyterlab/federated_labextensions.py
+++ b/jupyterlab/federated_labextensions.py
@@ -29,7 +29,10 @@ from jupyter_core.paths import ENV_JUPYTER_PATH, SYSTEM_JUPYTER_PATH, jupyter_da
 from jupyter_core.utils import ensure_dir_exists
 from jupyter_server.extension.serverextension import ArgumentConflict
 from jupyterlab_server.config import get_federated_extensions
-from tomli import load
+try:
+    from tomllib import load  # Python 3.11+
+except ImportError:
+    from tomli import load
 
 from .commands import _test_overlap
 

--- a/jupyterlab/federated_labextensions.py
+++ b/jupyterlab/federated_labextensions.py
@@ -29,6 +29,7 @@ from jupyter_core.paths import ENV_JUPYTER_PATH, SYSTEM_JUPYTER_PATH, jupyter_da
 from jupyter_core.utils import ensure_dir_exists
 from jupyter_server.extension.serverextension import ArgumentConflict
 from jupyterlab_server.config import get_federated_extensions
+
 try:
     from tomllib import load  # Python 3.11+
 except ImportError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "packaging",
     "traitlets",
     "tornado>=6.1.0",
-    "tomli",
+    "tomli;python_version<\"3.11\"",
     "ypy-websocket",
 ]
 dynamic = [


### PR DESCRIPTION
## References

There is no issue for that. It's not publicly-facing change.

## Code changes

This change removes one dependency from the project with Python 3.11+.

## User-facing changes

None

## Backwards-incompatible changes

None