### PR TITLE
Define css variables for the font colors of inactive elements

### DIFF
--- a/packages/application/style/menus.css
+++ b/packages/application/style/menus.css
@@ -79,7 +79,7 @@
   z-index: 10000;
   padding: 4px 0;
   background: var(--jp-layout-color0);
-  color: var(--jp-menu-active-font-color);
+  color: var(--jp-menu-enabled-font-color);
   border: var(--jp-border-width) solid var(--jp-border-color1);
   font-size: var(--jp-ui-font-size1);
   box-shadow: var(--jp-elevation-z6);
@@ -97,7 +97,7 @@
 }
 
 .lm-Menu-item.lm-mod-disabled {
-  color: var(--jp-menu-inactive-font-color);
+  color: var(--jp-menu-disabled-font-color);
 }
 
 .lm-Menu-itemIcon {

--- a/packages/application/style/menus.css
+++ b/packages/application/style/menus.css
@@ -79,7 +79,7 @@
   z-index: 10000;
   padding: 4px 0;
   background: var(--jp-layout-color0);
-  color: var(--jp-menu-enabled-font-color);
+  color: var(--jp-ui-font-color0);
   border: var(--jp-border-width) solid var(--jp-border-color1);
   font-size: var(--jp-ui-font-size1);
   box-shadow: var(--jp-elevation-z6);
@@ -93,11 +93,11 @@
 }
 
 .lm-Menu-item.lm-mod-active {
-  background: var(--jp-layout-color2);
+  background: var(--jp-layout-color3);
 }
 
 .lm-Menu-item.lm-mod-disabled {
-  color: var(--jp-menu-disabled-font-color);
+  color: var(--jp-ui-font-disabled-color0);
 }
 
 .lm-Menu-itemIcon {

--- a/packages/application/style/menus.css
+++ b/packages/application/style/menus.css
@@ -79,7 +79,7 @@
   z-index: 10000;
   padding: 4px 0;
   background: var(--jp-layout-color0);
-  color: var(--jp-ui-font-color1);
+  color: var(--jp-menu-active-font-color);
   border: var(--jp-border-width) solid var(--jp-border-color1);
   font-size: var(--jp-ui-font-size1);
   box-shadow: var(--jp-elevation-z6);
@@ -97,7 +97,7 @@
 }
 
 .lm-Menu-item.lm-mod-disabled {
-  color: var(--jp-ui-font-color3);
+  color: var(--jp-menu-inactive-font-color);
 }
 
 .lm-Menu-itemIcon {

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -125,6 +125,13 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-ui-font-color1: rgba(255, 255, 255, 0.87);
   --jp-ui-font-color2: rgba(255, 255, 255, 0.54);
   --jp-ui-font-color3: rgba(255, 255, 255, 0.38);
+  --jp-ui-font-color4: rgba(255, 255, 255, 0.24);
+  --jp-ui-font-color5: rgba(255, 255, 255, 0.12);
+
+  /* Font colors for disabled items like for instance in the menu */
+  --jp-ui-font-disabled-color0: var(--jp-ui-font-color3);
+  --jp-ui-font-disabled-color1: var(--jp-ui-font-color4);
+  --jp-ui-font-disabled-color2: var(--jp-ui-font-color5);
 
   /*
    * Use these against the brand/accent/warn/error colors.
@@ -436,8 +443,4 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-switch-color: var(--md-grey-400);
   --jp-switch-true-position-color: var(--md-orange-700);
   --jp-switch-cursor-color: rgba(0, 0, 0, 0.8);
-
-  /* Variables for the menu font color : to highlight the active items */
-  --jp-menu-enabled-font-color: rgba(255, 255, 255, 1);
-  --jp-menu-disabled-font-color: rgba(255, 255, 255, 0.38);
 }

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -438,6 +438,6 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-switch-cursor-color: rgba(0, 0, 0, 0.8);
 
   /* Variables for the menu font color : to highlight the active items */
-  --jp-menu-enabled-font-color: var(--jp-ui-font-color0);
-  --jp-menu-disabled-font-color: var(--jp-ui-font-color3);
+  --jp-menu-enabled-font-color: rgba(255, 255, 255, 1);
+  --jp-menu-disabled-font-color: rgba(255, 255, 255, 0.38);
 }

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -437,7 +437,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-switch-true-position-color: var(--md-orange-700);
   --jp-switch-cursor-color: rgba(0, 0, 0, 0.8);
 
-  /* Variables for the menu font color : to highlight the active items */
-  --jp-menu-active-font-color: var(--jp-ui-font-color0);
-  --jp-menu-inactive-font-color: var(--jp-ui-font-color3);
+  /* Variables for the menu font color */
+  --jp-menu-enabled-font-color: var(--jp-ui-font-color0);
+  --jp-menu-disabled-font-color: var(--jp-ui-font-color3);
 }

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -436,4 +436,8 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-switch-color: var(--md-grey-400);
   --jp-switch-true-position-color: var(--md-orange-700);
   --jp-switch-cursor-color: rgba(0, 0, 0, 0.8);
+
+  /* Variables for the menu font color : to highlight the active items */
+  --jp-menu-active-font-color: var(--jp-ui-font-color0);
+  --jp-menu-inactive-font-color: var(--jp-ui-font-color3);
 }

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -437,7 +437,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-switch-true-position-color: var(--md-orange-700);
   --jp-switch-cursor-color: rgba(0, 0, 0, 0.8);
 
-  /* Variables for the menu font color */
+  /* Variables for the menu font color : to highlight the active items */
   --jp-menu-enabled-font-color: var(--jp-ui-font-color0);
   --jp-menu-disabled-font-color: var(--jp-ui-font-color3);
 }

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -423,6 +423,6 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-switch-cursor-color: rgba(255, 255, 255, 1);
 
   /* Variables for the menu font color : to highlight the active items */
-  --jp-menu-enabled-font-color: var(--jp-ui-font-color0);
-  --jp-menu-disabled-font-color: var(--jp-ui-font-color3);
+  --jp-menu-enabled-font-color: rgba(255, 255, 255, 1);
+  --jp-menu-disabled-font-color: rgba(255, 255, 255, 0.38);
 }

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -123,6 +123,8 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-ui-font-color1: rgba(0, 0, 0, 0.87);
   --jp-ui-font-color2: rgba(0, 0, 0, 0.54);
   --jp-ui-font-color3: rgba(0, 0, 0, 0.38);
+  --jp-ui-font-color4: rgba(0, 0, 0, 0.24);
+  --jp-ui-font-color5: rgba(0, 0, 0, 0.12);
 
   /*
    * Use these against the brand/accent/warn/error colors.
@@ -133,6 +135,12 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-ui-inverse-font-color1: rgba(255, 255, 255, 1);
   --jp-ui-inverse-font-color2: rgba(255, 255, 255, 0.7);
   --jp-ui-inverse-font-color3: rgba(255, 255, 255, 0.5);
+  --jp-ui-inverse-font-color4: rgba(255, 255, 255, 0.3);
+
+  /* Font colors for disabled items like for instance in the menu */
+  --jp-ui-font-disabled-color0: var(--jp-ui-font-color3);
+  --jp-ui-font-disabled-color1: var(--jp-ui-font-color4);
+  --jp-ui-font-disabled-color2: var(--jp-ui-font-color5);
 
   /* Content Fonts
    *
@@ -421,8 +429,4 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-switch-color: var(--md-grey-400);
   --jp-switch-true-position-color: var(--md-orange-700);
   --jp-switch-cursor-color: rgba(255, 255, 255, 1);
-
-  /* Variables for the menu font color : to highlight the active items */
-  --jp-menu-enabled-font-color: rgba(255, 255, 255, 1);
-  --jp-menu-disabled-font-color: rgba(255, 255, 255, 0.38);
 }

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -421,4 +421,8 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-switch-color: var(--md-grey-400);
   --jp-switch-true-position-color: var(--md-orange-700);
   --jp-switch-cursor-color: rgba(255, 255, 255, 1);
+
+  /* Variables for the menu font color */
+  --jp-menu-active-font-color: var(--jp-ui-font-color0);
+  --jp-menu-inactive-font-color: var(--jp-ui-font-color3);
 }

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -422,7 +422,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-switch-true-position-color: var(--md-orange-700);
   --jp-switch-cursor-color: rgba(255, 255, 255, 1);
 
-  /* Variables for the menu font color */
-  --jp-menu-active-font-color: var(--jp-ui-font-color0);
-  --jp-menu-inactive-font-color: var(--jp-ui-font-color3);
+  /* Variables for the menu font color : to highlight the active items */
+  --jp-menu-enabled-font-color: var(--jp-ui-font-color0);
+  --jp-menu-disabled-font-color: var(--jp-ui-font-color3);
 }


### PR DESCRIPTION
Define css variables for the inactive elements like some of the menu.

This PR is the follow up of PR  #13276 that did not take into account the color font of the menu : the logics applied in PR #13276 is to have the same index in the css variables for the background color and the font color in the interface but it was not applicable to the menu with a satisfying rendering. All these changes are proposed in a perspective of making it easier to change the theme in an automatic way.


## References



## Code changes

In variable.css, new css variables are defined for both the dark and light theme, then used menu.css.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
