### PR TITLE
Backport #13399 on branch 3.6.x (tomllib is in stdlib in Python 3.11+)

### DIFF
--- a/jupyterlab/federated_labextensions.py
+++ b/jupyterlab/federated_labextensions.py
@@ -24,7 +24,11 @@ from jupyter_core.paths import ENV_JUPYTER_PATH, SYSTEM_JUPYTER_PATH, jupyter_da
 from jupyter_core.utils import ensure_dir_exists
 from jupyter_server.extension.serverextension import ArgumentConflict
 from jupyterlab_server.config import get_federated_extensions
-from tomli import load
+
+try:
+    from tomllib import load  # Python 3.11+
+except ImportError:
+    from tomli import load
 
 from .commands import _test_overlap
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     nbclassic
     notebook<7
     jinja2>=2.1
-    tomli
+    tomli;python_version<"3.11"
 
 [options.extras_require]
 test =


### PR DESCRIPTION
Backport #13399