### PR TITLE
Move configuration to jupyter-server-ydoc

### DIFF
--- a/docs/source/user/rtc.rst
+++ b/docs/source/user/rtc.rst
@@ -65,17 +65,17 @@ There are a number of settings that you can change:
 
 .. code-block:: bash
 
-  $ # The delay of inactivity (in seconds) after which a document is saved to disk (default: 1).
-  $ # If None, the document will never be saved.
-  $ jupyter lab --collaborative --YDocExtension.document_save_delay=0.5
-  $
-  $ # The period (in seconds) to check for file changes on disk (default: 1).
-  $ # If 0, file changes will only be checked when saving.
-  $ jupyter lab --collaborative --YDocExtension.file_poll_interval=2
-  $
-  $ # The delay (in seconds) to keep a document in memory in the back-end after all clients disconnect (default: 60).
-  $ # If None, the document will be kept in memory forever.
-  $ jupyter lab --collaborative --YDocExtension.document_cleanup_delay=100
-  $
-  $ # The YStore class to use for storing Y updates (default: JupyterSQLiteYStore).
-  $ jupyter lab --collaborative --YDocExtension.ystore_class=ypy_websocket.ystore.TempFileYStore
+  # The delay of inactivity (in seconds) after which a document is saved to disk (default: 1).
+  # If None, the document will never be saved.
+  jupyter lab --collaborative --YDocExtension.document_save_delay=0.5
+  
+  # The period (in seconds) to check for file changes on disk (default: 1).
+  # If 0, file changes will only be checked when saving.
+  jupyter lab --collaborative --YDocExtension.file_poll_interval=2
+  
+  # The delay (in seconds) to keep a document in memory in the back-end after all clients disconnect (default: 60).
+  # If None, the document will be kept in memory forever.
+  jupyter lab --collaborative --YDocExtension.document_cleanup_delay=100
+  
+  # The YStore class to use for storing Y updates (default: JupyterSQLiteYStore).
+  jupyter lab --collaborative --YDocExtension.ystore_class=ypy_websocket.ystore.TempFileYStore

--- a/docs/source/user/rtc.rst
+++ b/docs/source/user/rtc.rst
@@ -68,14 +68,14 @@ There are a number of settings that you can change:
   # The delay of inactivity (in seconds) after which a document is saved to disk (default: 1).
   # If None, the document will never be saved.
   jupyter lab --collaborative --YDocExtension.document_save_delay=0.5
-  
+
   # The period (in seconds) to check for file changes on disk (default: 1).
   # If 0, file changes will only be checked when saving.
   jupyter lab --collaborative --YDocExtension.file_poll_interval=2
-  
+
   # The delay (in seconds) to keep a document in memory in the back-end after all clients disconnect (default: 60).
   # If None, the document will be kept in memory forever.
   jupyter lab --collaborative --YDocExtension.document_cleanup_delay=100
-  
+
   # The YStore class to use for storing Y updates (default: JupyterSQLiteYStore).
   jupyter lab --collaborative --YDocExtension.ystore_class=ypy_websocket.ystore.TempFileYStore

--- a/docs/source/user/rtc.rst
+++ b/docs/source/user/rtc.rst
@@ -31,7 +31,7 @@ for what is essential, the document's content.
 
 A nice improvement from Real Time Collaboration (RTC) is that you don't need to worry
 about saving a document anymore. It is automatically taken care of: each change made by
-any user to a document is saved after one second. You can see it with the dirty indicator
+any user to a document is saved after one second by default. You can see it with the dirty indicator
 being set after a change, and cleared after saving. This even works if the file is modified
 outside of JupyterLab's editor, for instance in the back-end with a third-party editor or
 after changing branch in a version control system such as ``git``. In this case, the file is
@@ -60,3 +60,22 @@ on the same document.
     looses connection and goes offline for a while. You should never have to touch it, and it is
     fine to just ignore it, including in your version control system (don't commit this file). If
     you happen to delete it, there shouldn't be any serious consequence either.
+
+There are a number of settings that you can change:
+
+.. code-block:: bash
+
+  $ # The delay of inactivity (in seconds) after which a document is saved to disk (default: 1).
+  $ # If None, the document will never be saved.
+  $ jupyter lab --collaborative --YDocExtension.document_save_delay=0.5
+  $
+  $ # The period (in seconds) to check for file changes on disk (default: 1).
+  $ # If 0, file changes will only be checked when saving.
+  $ jupyter lab --collaborative --YDocExtension.file_poll_interval=2
+  $
+  $ # The delay (in seconds) to keep a document in memory in the back-end after all clients disconnect (default: 60).
+  $ # If None, the document will be kept in memory forever.
+  $ jupyter lab --collaborative --YDocExtension.document_cleanup_delay=100
+  $
+  $ # The YStore class to use for storing Y updates (default: JupyterSQLiteYStore).
+  $ jupyter lab --collaborative --YDocExtension.ystore_class=ypy_websocket.ystore.TempFileYStore

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -12,7 +12,6 @@ from jupyter_core.application import JupyterApp, NoStart, base_aliases, base_fla
 from jupyter_server._version import version_info as jpserver_version_info
 from jupyter_server.serverapp import flags
 from jupyter_server.utils import url_path_join as ujoin
-from jupyter_server_ydoc.ydoc import JupyterSQLiteYStore
 from jupyterlab_server import (
     LabServerApp,
     LicensesApp,
@@ -21,7 +20,7 @@ from jupyterlab_server import (
     WorkspaceListApp,
 )
 from notebook_shim.shim import NotebookConfigShimMixin
-from traitlets import Bool, Float, Instance, Int, Type, Unicode, default
+from traitlets import Bool, Instance, Unicode, default
 from ypy_websocket.ystore import BaseYStore
 
 from ._version import __version__
@@ -563,40 +562,6 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
 
     collaborative = Bool(False, config=True, help="Whether to enable collaborative mode.")
 
-    collaborative_file_poll_interval = Int(
-        1,
-        config=True,
-        help="""The period in seconds to check for file changes on disk (relevant only
-        in collaborative mode). Defaults to 1s, if 0 then file changes will only be checked when
-        saving changes from the front-end.""",
-    )
-
-    collaborative_document_cleanup_delay = Int(
-        60,
-        allow_none=True,
-        config=True,
-        help="""The delay in seconds to keep a document in memory in the back-end after all clients
-        disconnect (relevant only in collaborative mode). Defaults to 60s, if None then the
-        document will be kept in memory forever.""",
-    )
-
-    collaborative_document_save_delay = Float(
-        1,
-        allow_none=True,
-        config=True,
-        help="""The delay in seconds to wait after a change is made to a document before saving it
-        (relevant only in collaborative mode). Defaults to 1s, if None then the document will never be saved.""",
-    )
-
-    collaborative_ystore_class = Type(
-        default_value=JupyterSQLiteYStore,
-        klass=BaseYStore,
-        config=True,
-        help="""The YStore class to use for storing Y updates (relevant only in collaborative mode).
-        Defaults to JupyterSQLiteYStore, which stores Y updates in a '.jupyter_ystore.db' SQLite
-        database in the current directory.""",
-    )
-
     @default("app_dir")
     def _default_app_dir(self):
         app_dir = get_app_dir()
@@ -819,15 +784,7 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
             page_config["token"] = ""
 
         # Update Jupyter Server's webapp settings with jupyterlab settings.
-        self.serverapp.web_app.settings.update(
-            {
-                "page_config_data": page_config,
-                "collaborative_file_poll_interval": self.collaborative_file_poll_interval,
-                "collaborative_document_cleanup_delay": self.collaborative_document_cleanup_delay,
-                "collaborative_document_save_delay": self.collaborative_document_save_delay,
-                "collaborative_ystore_class": self.collaborative_ystore_class,
-            }
-        )
+        self.serverapp.web_app.settings["page_config_data"] = page_config
 
         # Extend Server handlers with jupyterlab handlers.
         self.handlers.extend(handlers)

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -21,7 +21,6 @@ from jupyterlab_server import (
 )
 from notebook_shim.shim import NotebookConfigShimMixin
 from traitlets import Bool, Instance, Unicode, default
-from ypy_websocket.ystore import BaseYStore
 
 from ._version import __version__
 from .commands import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "jupyter-lsp>=1.5.1",
     "jupyter_server>=2.0.0rc3,<3",
     "jupyter_ydoc>=0.2.2,<0.3.0",
-    "jupyter_server_ydoc>=0.1.14,<0.2.0",
+    "jupyter_server_ydoc>=0.3.0,<0.4.0",
     "jupyterlab_server>=2.16.0,<3",
     "notebook_shim>=0.2",
     "packaging",


### PR DESCRIPTION
## References

Needs https://github.com/jupyter-server/jupyter_server_ydoc/pull/54.
See https://github.com/jupyter-server/jupyter_server_ydoc/issues/53.

## Code changes

Configuration of [jupyter-server-ydoc](https://github.com/jupyter-server/jupyter_server_ydoc) is moved there.

## User-facing changes

The configuration must now point to the `jupyter-server-ydoc` extension, e.g.:
```console
jupyter lab --collaborative --YDocExtension.document_save_delay=0.2
```

## Backwards-incompatible changes

See above.