### PR TITLE
Fix propagating the sanitizer to the completer renderer

### DIFF
--- a/packages/completer/src/manager.ts
+++ b/packages/completer/src/manager.ts
@@ -217,7 +217,8 @@ export class CompletionProviderManager implements ICompletionProviderManager {
       model = new CompleterModel();
     }
 
-    const completer = new Completer({ model, renderer });
+    const { sanitizer } = completerContext;
+    const completer = new Completer({ model, renderer, sanitizer });
     completer.showDocsPanel = this._showDoc;
     completer.hide();
     Widget.attach(completer, document.body);

--- a/packages/completer/src/manager.ts
+++ b/packages/completer/src/manager.ts
@@ -206,10 +206,9 @@ export class CompletionProviderManager implements ICompletionProviderManager {
     const firstProvider = [...this._activeProviders][0];
     const provider = this._providers.get(firstProvider);
 
-    let renderer = provider?.renderer;
-    if (!renderer) {
-      renderer = Completer.defaultRenderer;
-    }
+    let renderer =
+      provider?.renderer ??
+      Completer.getDefaultRenderer(completerContext.sanitizer);
     const modelFactory = provider?.modelFactory;
     let model: Completer.IModel;
     if (modelFactory) {

--- a/packages/completer/src/tokens.ts
+++ b/packages/completer/src/tokens.ts
@@ -32,6 +32,9 @@ export interface ICompletionContext {
    */
   session?: Session.ISessionConnection | null;
 
+  /**
+   * The sanitizer used to sanitize untrusted html inputs.
+   */
   sanitizer?: ISanitizer;
 }
 

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -61,7 +61,8 @@ export class Completer extends Widget {
   constructor(options: Completer.IOptions) {
     super({ node: document.createElement('div') });
     this.sanitizer = options.sanitizer ?? new Sanitizer();
-    this._renderer = options.renderer ?? Completer.getDefaultRenderer(this.sanitizer);
+    this._renderer =
+      options.renderer ?? Completer.getDefaultRenderer(this.sanitizer);
     this.model = options.model ?? null;
     this.editor = options.editor ?? null;
     this.addClass('jp-Completer');
@@ -673,7 +674,8 @@ export class Completer extends Widget {
           let node: HTMLElement;
           const nodeRenderer =
             this._renderer.createDocumentationNode ??
-            Completer.getDefaultRenderer(this.sanitizer).createDocumentationNode;
+            Completer.getDefaultRenderer(this.sanitizer)
+              .createDocumentationNode;
           node = nodeRenderer(activeItem);
           docPanel!.textContent = '';
           docPanel!.appendChild(node);
@@ -954,7 +956,7 @@ export namespace Completer {
    * The default implementation of an `IRenderer`.
    */
   export class Renderer implements IRenderer {
-    constructor(readonly sanitizer: ISanitizer = new Sanitizer()) {};
+    constructor(readonly sanitizer: ISanitizer = new Sanitizer()) {}
 
     /**
      * Create an item node from an ICompletionItem for a text completer menu.
@@ -1101,10 +1103,10 @@ export namespace Completer {
       !_defaultRenderer ||
       (sanitizer && _defaultRenderer.sanitizer !== sanitizer)
     ) {
-      _defaultRenderer = new Renderer(sanitizer)
+      _defaultRenderer = new Renderer(sanitizer);
     }
     return this._defaultRenderer;
-  };
+  }
 }
 
 /**

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -1093,7 +1093,7 @@ export namespace Completer {
   /**
    * Default renderer
    */
-  let _defaultRenderer: IRenderer;
+  let _defaultRenderer: Renderer;
 
   /**
    * The default `IRenderer` instance.
@@ -1105,7 +1105,7 @@ export namespace Completer {
     ) {
       _defaultRenderer = new Renderer(sanitizer);
     }
-    return this._defaultRenderer;
+    return _defaultRenderer;
   }
 }
 

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -60,12 +60,11 @@ export class Completer extends Widget {
    */
   constructor(options: Completer.IOptions) {
     super({ node: document.createElement('div') });
-    this._renderer = options.renderer || Completer.defaultRenderer;
-
-    this.model = options.model || null;
-    this.editor = options.editor || null;
-    this.addClass('jp-Completer');
     this.sanitizer = options.sanitizer ?? new Sanitizer();
+    this._renderer = options.renderer ?? Completer.getDefaultRenderer(this.sanitizer);
+    this.model = options.model ?? null;
+    this.editor = options.editor ?? null;
+    this.addClass('jp-Completer');
   }
 
   /**
@@ -674,7 +673,7 @@ export class Completer extends Widget {
           let node: HTMLElement;
           const nodeRenderer =
             this._renderer.createDocumentationNode ??
-            Completer.defaultRenderer.createDocumentationNode;
+            Completer.getDefaultRenderer(this.sanitizer).createDocumentationNode;
           node = nodeRenderer(activeItem);
           docPanel!.textContent = '';
           docPanel!.appendChild(node);
@@ -731,7 +730,7 @@ export namespace Completer {
     /**
      * Sanitizer used to sanitize html strings
      */
-    sanitizer?: Sanitizer;
+    sanitizer?: ISanitizer;
   }
 
   /**
@@ -948,14 +947,15 @@ export namespace Completer {
     /**
      * The sanitizer used to sanitize untrusted html inputs.
      */
-    sanitizer: Sanitizer;
+    readonly sanitizer: ISanitizer;
   }
 
   /**
    * The default implementation of an `IRenderer`.
    */
   export class Renderer implements IRenderer {
-    sanitizer: Sanitizer = new Sanitizer();
+    constructor(readonly sanitizer: ISanitizer = new Sanitizer()) {};
+
     /**
      * Create an item node from an ICompletionItem for a text completer menu.
      */
@@ -1089,9 +1089,22 @@ export namespace Completer {
   }
 
   /**
+   * Default renderer
+   */
+  let _defaultRenderer: IRenderer;
+
+  /**
    * The default `IRenderer` instance.
    */
-  export const defaultRenderer = new Renderer();
+  export function getDefaultRenderer(sanitizer?: ISanitizer): IRenderer {
+    if (
+      !_defaultRenderer ||
+      (sanitizer && _defaultRenderer.sanitizer !== sanitizer)
+    ) {
+      _defaultRenderer = new Renderer(sanitizer)
+    }
+    return this._defaultRenderer;
+  };
 }
 
 /**

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -1096,7 +1096,7 @@ export namespace Completer {
   /**
    * The default `IRenderer` instance.
    */
-  export function getDefaultRenderer(sanitizer?: ISanitizer): IRenderer {
+  export function getDefaultRenderer(sanitizer?: ISanitizer): Renderer {
     if (
       !_defaultRenderer ||
       (sanitizer && _defaultRenderer.sanitizer !== sanitizer)


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Follow up of #13341 seen when backporting it to 3.6.x.
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Fix propagating the sanitizer to the completer renderer
Correct interface to use ISanitizer instead of Sanitizer

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Sanitization of completer renderer should be consistent with application sanitizer.
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A