### PR TITLE
Fix `FileEditor.ready`

### DIFF
--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -76,7 +76,7 @@ export class FileEditor extends Widget {
    * A promise that resolves when the file editor is ready.
    */
   get ready(): Promise<void> {
-    return this.ready;
+    return this._ready.promise;
   }
 
   /**

--- a/packages/fileeditor/test/widget.spec.ts
+++ b/packages/fileeditor/test/widget.spec.ts
@@ -159,6 +159,13 @@ describe('fileeditorcodewrapper', () => {
         expect(widget.editor.hasFocus()).toBe(true);
       });
     });
+
+    describe('#ready', () => {
+      it('should resolve after initialization', async () => {
+        await context.initialize(true);
+        return expect(widget.ready).resolves.toBe(undefined);
+      });
+    });
   });
 
   describe('FileEditorFactory', () => {


### PR DESCRIPTION
## References

Fixes regression introduced in https://github.com/jupyterlab/jupyterlab/pull/12439 which leads to:

```js
RangeError: Maximum call stack size exceeded
    at get ready [as ready] (widget.ts:79:17)
    at get ready [as ready] (widget.ts:79:17)
    at get ready [as ready] (widget.ts:79:17)
    ...
```

## Code changes

Add test case, correct copy-paste error.

## User-facing changes

Code relying on `.ready` will work.

## Backwards-incompatible changes

None
