### PR TITLE
Use more consistent naming for user service

### DIFF
--- a/packages/collaboration/src/collaboratorspanel.tsx
+++ b/packages/collaboration/src/collaboratorspanel.tsx
@@ -9,7 +9,7 @@ import { Panel } from '@lumino/widgets';
 
 import { ReactWidget } from '@jupyterlab/apputils';
 
-import { UserManager } from '@jupyterlab/services';
+import { User } from '@jupyterlab/services';
 
 import { PathExt } from '@jupyterlab/coreutils';
 
@@ -36,12 +36,12 @@ const CLICKABLE_COLLABORATOR_CLASS = 'jp-ClickableCollaborator';
 const COLLABORATOR_ICON_CLASS = 'jp-CollaboratorIcon';
 
 export class CollaboratorsPanel extends Panel {
-  private _currentUser: UserManager.IManager;
+  private _currentUser: User.IManager;
   private _awareness: Awareness;
   private _body: CollaboratorsBody;
 
   constructor(
-    currentUser: UserManager.IManager,
+    currentUser: User.IManager,
     awareness: Awareness,
     fileopener: (path: string) => void
   ) {

--- a/packages/collaboration/src/menu.ts
+++ b/packages/collaboration/src/menu.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { caretDownIcon, userIcon } from '@jupyterlab/ui-components';
-import { User, UserManager } from '@jupyterlab/services';
+import { User } from '@jupyterlab/services';
 import { Menu, MenuBar } from '@lumino/widgets';
 import { h, VirtualElement } from '@lumino/virtualdom';
 
@@ -10,14 +10,14 @@ import { h, VirtualElement } from '@lumino/virtualdom';
  * Custom renderer for the user menu.
  */
 export class RendererUserMenu extends MenuBar.Renderer {
-  private _user: UserManager.IManager;
+  private _user: User.IManager;
 
   /**
    * Constructor of the class RendererUserMenu.
    *
    * @argument user Current user object.
    */
-  constructor(user: UserManager.IManager) {
+  constructor(user: User.IManager) {
     super();
     this._user = user;
   }
@@ -92,7 +92,7 @@ export class RendererUserMenu extends MenuBar.Renderer {
  * Custom lumino Menu for the user menu.
  */
 export class UserMenu extends Menu {
-  private _user: UserManager.IManager;
+  private _user: User.IManager;
 
   constructor(options: UserMenu.IOptions) {
     super(options);
@@ -115,7 +115,7 @@ export class UserMenu extends Menu {
     this._user.userChanged.disconnect(this._updateLabel, this);
   }
 
-  private _updateLabel(sender: UserManager.IManager, user: User.IUser): void {
+  private _updateLabel(sender: User.IManager, user: User.IUser): void {
     this.title.label = user.identity.display_name;
     this.update();
   }
@@ -132,6 +132,6 @@ export namespace UserMenu {
     /**
      * Current user manager.
      */
-    user: UserManager.IManager;
+    user: User.IManager;
   }
 }

--- a/packages/collaboration/src/userinfopanel.tsx
+++ b/packages/collaboration/src/userinfopanel.tsx
@@ -3,7 +3,7 @@
 
 import { ReactWidget } from '@jupyterlab/apputils';
 
-import { User, UserManager } from '@jupyterlab/services';
+import { User } from '@jupyterlab/services';
 
 import { Panel } from '@lumino/widgets';
 
@@ -12,10 +12,10 @@ import * as React from 'react';
 import { UserIconComponent } from './components';
 
 export class UserInfoPanel extends Panel {
-  private _profile: UserManager.IManager;
+  private _profile: User.IManager;
   private _body: UserInfoBody;
 
-  constructor(user: UserManager.IManager) {
+  constructor(user: User.IManager) {
     super({});
     this.addClass('jp-UserInfoPanel');
 

--- a/packages/docprovider/src/yprovider.ts
+++ b/packages/docprovider/src/yprovider.ts
@@ -4,7 +4,7 @@
 |----------------------------------------------------------------------------*/
 
 import { URLExt } from '@jupyterlab/coreutils';
-import { ServerConnection, UserManager } from '@jupyterlab/services';
+import { ServerConnection, User } from '@jupyterlab/services';
 import { DocumentChange, YDocument } from '@jupyter-notebook/ydoc';
 import { PromiseDelegate } from '@lumino/coreutils';
 import { Signal } from '@lumino/signaling';
@@ -106,7 +106,7 @@ export class WebSocketProvider implements IDocumentProvider {
     Signal.clearData(this);
   }
 
-  private _onUserChanged(user: UserManager.IManager): void {
+  private _onUserChanged(user: User.IManager): void {
     this._awareness.setLocalStateField('user', user.identity);
   }
 
@@ -138,6 +138,6 @@ export namespace WebSocketProvider {
     /**
      * The user data
      */
-    user: UserManager.IManager;
+    user: User.IManager;
   }
 }

--- a/packages/services/src/manager.ts
+++ b/packages/services/src/manager.ts
@@ -25,7 +25,7 @@ import { Setting, SettingManager } from './setting';
 
 import { Terminal, TerminalManager } from './terminal';
 
-import { UserManager } from './user';
+import { User, UserManager } from './user';
 
 import { Workspace, WorkspaceManager } from './workspace';
 
@@ -143,7 +143,7 @@ export class ServiceManager implements ServiceManager.IManager {
   /**
    * Get the user manager instance.
    */
-  readonly user: UserManager.IManager;
+  readonly user: User.IManager;
 
   /**
    * Get the workspace manager instance.
@@ -272,7 +272,7 @@ export namespace ServiceManager {
     /**
      * The user manager for the manager.
      */
-    readonly user: UserManager.IManager;
+    readonly user: User.IManager;
 
     /**
      * The workspace manager for the manager.

--- a/packages/services/src/user/index.ts
+++ b/packages/services/src/user/index.ts
@@ -25,7 +25,7 @@ const SERVICE_USER_URL = 'api/me';
 /**
  * The user API service manager.
  */
-export class UserManager extends BaseManager implements UserManager.IManager {
+export class UserManager extends BaseManager implements User.IManager {
   private _isReady = false;
   private _ready: Promise<void>;
   private _pollSpecs: Poll;
@@ -208,46 +208,6 @@ export namespace UserManager {
      */
     standby?: Poll.Standby | (() => boolean | Poll.Standby);
   }
-
-  /**
-   * Object which manages user's identity.
-   *
-   * #### Notes
-   * The manager is responsible for maintaining the state of the user.
-   */
-  export interface IManager extends IBaseManager {
-    /**
-     * A signal emitted when the user changes.
-     */
-    userChanged: ISignal<this, User.IUser>;
-
-    /**
-     * User's identity.
-     *
-     * #### Notes
-     * The value will be null until the manager is ready.
-     */
-    readonly identity: User.IIdentity | null;
-
-    /**
-     * User's permissions.
-     *
-     * #### Notes
-     * The value will be null until the manager is ready.
-     */
-    readonly permissions: ReadonlyJSONObject | null;
-
-    /**
-     * Force a refresh of user's identity from the server.
-     *
-     * @returns A promise that resolves when the identity is fetched.
-     *
-     * #### Notes
-     * This is intended to be called only in response to a user action,
-     * since the manager maintains its internal state.
-     */
-    refreshUser(): Promise<void>;
-  }
 }
 
 /**
@@ -298,6 +258,46 @@ export namespace User {
      * The url to the user's image for the icon.
      */
     readonly avatar_url?: string;
+  }
+
+  /**
+   * Object which manages user's identity.
+   *
+   * #### Notes
+   * The manager is responsible for maintaining the state of the user.
+   */
+  export interface IManager extends IBaseManager {
+    /**
+     * A signal emitted when the user changes.
+     */
+    userChanged: ISignal<this, User.IUser>;
+
+    /**
+     * User's identity.
+     *
+     * #### Notes
+     * The value will be null until the manager is ready.
+     */
+    readonly identity: User.IIdentity | null;
+
+    /**
+     * User's permissions.
+     *
+     * #### Notes
+     * The value will be null until the manager is ready.
+     */
+    readonly permissions: ReadonlyJSONObject | null;
+
+    /**
+     * Force a refresh of user's identity from the server.
+     *
+     * @returns A promise that resolves when the identity is fetched.
+     *
+     * #### Notes
+     * This is intended to be called only in response to a user action,
+     * since the manager maintains its internal state.
+     */
+    refreshUser(): Promise<void>;
   }
 }
 

--- a/testutils/src/user.ts
+++ b/testutils/src/user.ts
@@ -12,10 +12,7 @@ import {
 /**
  * The user API service manager.
  */
-export class FakeUserManager
-  extends BaseManager
-  implements UserManager.IManager
-{
+export class FakeUserManager extends BaseManager implements User.IManager {
   private _isReady = false;
   private _ready: Promise<void>;
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Follow-up from comments in https://github.com/jupyterlab/jupyterlab/pull/13337
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Rename `UserManager.IManager` to `User.IManager` to align with other services.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
Ok as not yet published