### PR TITLE
Require jupyter_server_ydoc >=0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
     "jupyter_core",
     "jupyter-lsp>=1.5.1",
     "jupyter_server>=2.0.0rc3,<3",
-    "jupyter_ydoc>=0.2.2,<0.3.0",
     "jupyter_server_ydoc>=0.4.0,<0.5.0",
     "jupyterlab_server>=2.16.0,<3",
     "notebook_shim>=0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "jupyter-lsp>=1.5.1",
     "jupyter_server>=2.0.0rc3,<3",
     "jupyter_ydoc>=0.2.2,<0.3.0",
-    "jupyter_server_ydoc>=0.3.0,<0.4.0",
+    "jupyter_server_ydoc>=0.4.0,<0.5.0",
     "jupyterlab_server>=2.16.0,<3",
     "notebook_shim>=0.2",
     "packaging",


### PR DESCRIPTION
## References

We need https://github.com/y-crdt/ypy-websocket/pull/42, through https://github.com/jupyter-server/jupyter_server_ydoc/pull/58.

## Code changes

Bug fixed in RTC.

## User-facing changes

Better RTC experience.

## Backwards-incompatible changes

`YStore` database format is incompatible.