### PR TITLE
Backport #13428 on branch 3.6.x (Use more consistent naming for user service)

### DIFF
--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -4,7 +4,6 @@
 import { CommandLinker } from '@jupyterlab/apputils';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { ServiceManager } from '@jupyterlab/services';
-import { UserManager } from '@jupyterlab/services/src/user';
 import { ContextMenuSvg } from '@jupyterlab/ui-components';
 import { IIterator } from '@lumino/algorithm';
 import { Application, IPlugin } from '@lumino/application';

--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -4,6 +4,7 @@
 import { CommandLinker } from '@jupyterlab/apputils';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { ServiceManager } from '@jupyterlab/services';
+import { UserManager } from '@jupyterlab/services/src/user';
 import { ContextMenuSvg } from '@jupyterlab/ui-components';
 import { IIterator } from '@lumino/algorithm';
 import { Application, IPlugin } from '@lumino/application';

--- a/packages/collaboration-extension/src/index.ts
+++ b/packages/collaboration-extension/src/index.ts
@@ -59,7 +59,7 @@ const menuBarPlugin: JupyterFrontEndPlugin<void> = {
     const { shell } = app;
     const { user } = app.serviceManager;
 
-    if (PageConfig.getOption('collaborative') !== 'true') {
+    if (PageConfig.getOption('collaborative') !== 'true' || !user) {
       return;
     }
 

--- a/packages/collaboration/src/collaboratorspanel.tsx
+++ b/packages/collaboration/src/collaboratorspanel.tsx
@@ -9,7 +9,7 @@ import { Panel } from '@lumino/widgets';
 
 import { ReactWidget } from '@jupyterlab/apputils';
 
-import { UserManager } from '@jupyterlab/services';
+import { User } from '@jupyterlab/services';
 
 import { PathExt } from '@jupyterlab/coreutils';
 
@@ -36,12 +36,12 @@ const CLICKABLE_COLLABORATOR_CLASS = 'jp-ClickableCollaborator';
 const COLLABORATOR_ICON_CLASS = 'jp-CollaboratorIcon';
 
 export class CollaboratorsPanel extends Panel {
-  private _currentUser: UserManager.IManager;
+  private _currentUser: User.IManager;
   private _awareness: Awareness;
   private _body: CollaboratorsBody;
 
   constructor(
-    currentUser: UserManager.IManager,
+    currentUser: User.IManager,
     awareness: Awareness,
     fileopener: (path: string) => void
   ) {

--- a/packages/collaboration/src/menu.ts
+++ b/packages/collaboration/src/menu.ts
@@ -102,7 +102,7 @@ export class RendererUserMenu extends MenuBar.Renderer {
  * Custom lumino Menu for the user menu.
  */
 export class UserMenu extends Menu {
-  private _user: User.IManager;
+  private _user?: User.IManager;
 
   constructor(options: UserMenu.IOptions) {
     super(options);
@@ -114,7 +114,7 @@ export class UserMenu extends Menu {
 
     this._user?.ready
       .then(() => {
-        this.title.label = this._user.identity!.display_name;
+        this.title.label = this._user!.identity!.display_name;
       })
       .catch(e => console.error(e));
 

--- a/packages/collaboration/src/menu.ts
+++ b/packages/collaboration/src/menu.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { caretDownIcon, userIcon } from '@jupyterlab/ui-components';
-import { User, UserManager } from '@jupyterlab/services';
+import { User } from '@jupyterlab/services';
 import { Menu, MenuBar } from '@lumino/widgets';
 import { h, VirtualElement } from '@lumino/virtualdom';
 
@@ -10,14 +10,14 @@ import { h, VirtualElement } from '@lumino/virtualdom';
  * Custom renderer for the user menu.
  */
 export class RendererUserMenu extends MenuBar.Renderer {
-  private _user: UserManager.IManager;
+  private _user: User.IManager;
 
   /**
    * Constructor of the class RendererUserMenu.
    *
    * @argument user Current user object.
    */
-  constructor(user: UserManager.IManager) {
+  constructor(user: User.IManager) {
     super();
     this._user = user;
   }
@@ -102,7 +102,7 @@ export class RendererUserMenu extends MenuBar.Renderer {
  * Custom lumino Menu for the user menu.
  */
 export class UserMenu extends Menu {
-  private _user: UserManager.IManager;
+  private _user: User.IManager;
 
   constructor(options: UserMenu.IOptions) {
     super(options);
@@ -112,20 +112,20 @@ export class UserMenu extends Menu {
     this.title.icon = caretDownIcon;
     this.title.iconClass = 'jp-UserMenu-caretDownIcon';
 
-    this._user.ready
+    this._user?.ready
       .then(() => {
         this.title.label = this._user.identity!.display_name;
       })
       .catch(e => console.error(e));
 
-    this._user.userChanged.connect(this._updateLabel, this);
+    this._user?.userChanged.connect(this._updateLabel, this);
   }
 
   dispose() {
-    this._user.userChanged.disconnect(this._updateLabel, this);
+    this._user?.userChanged.disconnect(this._updateLabel, this);
   }
 
-  private _updateLabel(sender: UserManager.IManager, user: User.IUser): void {
+  private _updateLabel(sender: User.IManager, user: User.IUser): void {
     this.title.label = user.identity.display_name;
     this.update();
   }
@@ -142,6 +142,6 @@ export namespace UserMenu {
     /**
      * Current user manager.
      */
-    user: UserManager.IManager;
+    user?: User.IManager;
   }
 }

--- a/packages/collaboration/src/userinfopanel.tsx
+++ b/packages/collaboration/src/userinfopanel.tsx
@@ -3,7 +3,7 @@
 
 import { ReactWidget } from '@jupyterlab/apputils';
 
-import { User, UserManager } from '@jupyterlab/services';
+import { User } from '@jupyterlab/services';
 
 import { Panel } from '@lumino/widgets';
 
@@ -12,10 +12,10 @@ import * as React from 'react';
 import { UserIconComponent } from './components';
 
 export class UserInfoPanel extends Panel {
-  private _profile: UserManager.IManager;
+  private _profile: User.IManager;
   private _body: UserInfoBody;
 
-  constructor(user: UserManager.IManager) {
+  constructor(user: User.IManager) {
     super({});
     this.addClass('jp-UserInfoPanel');
 

--- a/packages/docprovider/src/yprovider.ts
+++ b/packages/docprovider/src/yprovider.ts
@@ -4,7 +4,7 @@
 |----------------------------------------------------------------------------*/
 
 import { URLExt } from '@jupyterlab/coreutils';
-import { ServerConnection, UserManager } from '@jupyterlab/services';
+import { ServerConnection, User } from '@jupyterlab/services';
 import { DocumentChange, YDocument } from '@jupyter-notebook/ydoc';
 import { PromiseDelegate } from '@lumino/coreutils';
 import { Signal } from '@lumino/signaling';
@@ -42,12 +42,12 @@ export class WebSocketProvider implements IDocumentProvider {
 
     const user = options.user;
 
-    user.ready
+    user?.ready
       .then(() => {
         this._onUserChanged(user);
       })
       .catch(e => console.error(e));
-    user.userChanged.connect(this._onUserChanged, this);
+    user?.userChanged.connect(this._onUserChanged, this);
 
     const serverSettings = ServerConnection.makeSettings();
     const url = URLExt.join(
@@ -106,7 +106,7 @@ export class WebSocketProvider implements IDocumentProvider {
     Signal.clearData(this);
   }
 
-  private _onUserChanged(user: UserManager.IManager): void {
+  private _onUserChanged(user: User.IManager): void {
     this._awareness.setLocalStateField('user', user.identity);
   }
 
@@ -138,6 +138,6 @@ export namespace WebSocketProvider {
     /**
      * The user data
      */
-    user: UserManager.IManager;
+    user?: User.IManager;
   }
 }

--- a/packages/services/src/manager.ts
+++ b/packages/services/src/manager.ts
@@ -25,7 +25,7 @@ import { Terminal, TerminalManager } from './terminal';
 
 import { ServerConnection } from './serverconnection';
 
-import { UserManager } from './user';
+import { User, UserManager } from './user';
 
 import { Workspace, WorkspaceManager } from './workspace';
 
@@ -141,7 +141,7 @@ export class ServiceManager implements ServiceManager.IManager {
   /**
    * Get the user manager instance.
    */
-  readonly user: UserManager.IManager;
+  readonly user: User.IManager;
 
   /**
    * Get the workspace manager instance.
@@ -233,7 +233,7 @@ export namespace ServiceManager {
     /**
      * The user manager for the manager.
      */
-    readonly user: UserManager.IManager;
+    readonly user?: User.IManager;
 
     /**
      * The workspace manager for the manager.

--- a/packages/services/src/user/index.ts
+++ b/packages/services/src/user/index.ts
@@ -25,7 +25,7 @@ const SERVICE_USER_URL = 'api/me';
 /**
  * The user API service manager.
  */
-export class UserManager extends BaseManager implements UserManager.IManager {
+export class UserManager extends BaseManager implements User.IManager {
   private _isReady = false;
   private _ready: Promise<void>;
   private _pollSpecs: Poll;
@@ -207,46 +207,6 @@ export namespace UserManager {
      */
     standby?: Poll.Standby | (() => boolean | Poll.Standby);
   }
-
-  /**
-   * Object which manages user's identity.
-   *
-   * #### Notes
-   * The manager is responsible for maintaining the state of the user.
-   */
-  export interface IManager extends IBaseManager {
-    /**
-     * A signal emitted when the user changes.
-     */
-    userChanged: ISignal<this, User.IUser>;
-
-    /**
-     * User's identity.
-     *
-     * #### Notes
-     * The value will be null until the manager is ready.
-     */
-    readonly identity: User.IIdentity | null;
-
-    /**
-     * User's permissions.
-     *
-     * #### Notes
-     * The value will be null until the manager is ready.
-     */
-    readonly permissions: ReadonlyJSONObject | null;
-
-    /**
-     * Force a refresh of user's identity from the server.
-     *
-     * @returns A promise that resolves when the identity is fetched.
-     *
-     * #### Notes
-     * This is intended to be called only in response to a user action,
-     * since the manager maintains its internal state.
-     */
-    refreshUser(): Promise<void>;
-  }
 }
 
 /**
@@ -297,6 +257,46 @@ export namespace User {
      * The url to the user's image for the icon.
      */
     readonly avatar_url?: string;
+  }
+
+  /**
+   * Object which manages user's identity.
+   *
+   * #### Notes
+   * The manager is responsible for maintaining the state of the user.
+   */
+  export interface IManager extends IBaseManager {
+    /**
+     * A signal emitted when the user changes.
+     */
+    userChanged: ISignal<this, User.IUser>;
+
+    /**
+     * User's identity.
+     *
+     * #### Notes
+     * The value will be null until the manager is ready.
+     */
+    readonly identity: User.IIdentity | null;
+
+    /**
+     * User's permissions.
+     *
+     * #### Notes
+     * The value will be null until the manager is ready.
+     */
+    readonly permissions: ReadonlyJSONObject | null;
+
+    /**
+     * Force a refresh of user's identity from the server.
+     *
+     * @returns A promise that resolves when the identity is fetched.
+     *
+     * #### Notes
+     * This is intended to be called only in response to a user action,
+     * since the manager maintains its internal state.
+     */
+    refreshUser(): Promise<void>;
   }
 }
 

--- a/testutils/src/user.ts
+++ b/testutils/src/user.ts
@@ -12,9 +12,7 @@ import {
 /**
  * The user API service manager.
  */
-export class FakeUserManager
-  extends BaseManager
-  implements UserManager.IManager {
+export class FakeUserManager extends BaseManager implements User.IManager {
   private _isReady = false;
   private _ready: Promise<void>;
 


### PR DESCRIPTION
Backport #13428

Make `ServiceManager.IManager.user` optional to be backward compatible (if not define it will break collaborative features).