### PR TITLE
enable filetype-specific collaboration

### DIFF
--- a/packages/apputils-extension/src/workspacesplugin.ts
+++ b/packages/apputils-extension/src/workspacesplugin.ts
@@ -71,7 +71,8 @@ export const workspacesPlugin: JupyterFrontEndPlugin<void> = {
       displayName: trans.__('JupyterLab workspace File'),
       extensions: [WORKSPACE_EXT],
       mimeTypes: ['text/json'],
-      iconClass: ICON_NAME
+      iconClass: ICON_NAME,
+      collaborative: true
     });
     app.docRegistry.addWidgetFactory(factory);
     app.commands.addCommand(CommandIDs.saveWorkspaceAs, {

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -191,7 +191,6 @@ const manager: JupyterFrontEndPlugin<IDocumentManager> = {
       setBusy: (status && (() => status.setBusy())) ?? undefined,
       sessionDialogs: sessionDialogs || undefined,
       translator: translator ?? nullTranslator,
-      collaborative: true,
       docProviderFactory: docProviderFactory ?? undefined,
       isConnectedCallback: () => {
         if (info) {
@@ -612,11 +611,7 @@ function addCommands(
       return false;
     }
     const context = docManager.contextForWidget(currentWidget);
-    return !!(
-      context &&
-      context.contentsModel &&
-      context.contentsModel.writable
-    );
+    return !!context?.writable;
   };
 
   // If inside a rich application like JupyterLab, add additional functionality.

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { ISessionContext, sessionContextDialogs } from '@jupyterlab/apputils';
-import { PathExt } from '@jupyterlab/coreutils';
+import { PageConfig, PathExt } from '@jupyterlab/coreutils';
 import { IDocumentProviderFactory } from '@jupyterlab/docprovider';
 import {
   Context,
@@ -39,7 +39,6 @@ export class DocumentManager implements IDocumentManager {
     this.translator = options.translator || nullTranslator;
     this.registry = options.registry;
     this.services = options.manager;
-    this._collaborative = !!options.collaborative;
     this._dialogs = options.sessionDialogs || sessionContextDialogs;
     this._docProviderFactory = options.docProviderFactory;
     this._isConnectedCallback = options.isConnectedCallback || (() => true);
@@ -487,7 +486,8 @@ export class DocumentManager implements IDocumentManager {
   private _createContext(
     path: string,
     factory: DocumentRegistry.ModelFactory,
-    kernelPreference?: ISessionContext.IKernelPreference
+    kernelPreference: ISessionContext.IKernelPreference | undefined,
+    collaborative: boolean | undefined
   ): Private.IContext {
     // TODO: Make it impossible to open two different contexts for the same
     // path. Or at least prompt the closing of all widgets associated with the
@@ -513,7 +513,7 @@ export class DocumentManager implements IDocumentManager {
       kernelPreference,
       setBusy: this._setBusy,
       sessionDialogs: this._dialogs,
-      collaborative: this._collaborative,
+      collaborative,
       docProviderFactory: this._docProviderFactory,
       lastModifiedCheckMargin: this._lastModifiedCheckMargin,
       translator: this.translator
@@ -584,6 +584,21 @@ export class DocumentManager implements IDocumentManager {
       return undefined;
     }
 
+    let fileType: DocumentRegistry.IFileType | undefined = undefined;
+    for (const ft of this.registry.fileTypes()) {
+      if (ft.name === modelName) {
+        fileType = ft;
+        break;
+      }
+    }
+
+    // determine whether this collaborative mode should be enabled for this
+    // DocumentContext. collaborative mode must be enabled globally and the file
+    // type must support collaboration.
+    const globalCollab = PageConfig.getOption('collaborative') === 'true';
+    const fileTypeSupportsCollab = fileType?.collaborative;
+    const collaborative = globalCollab && fileTypeSupportsCollab;
+
     // Handle the kernel preference.
     const preference = this.registry.getKernelPreference(
       path,
@@ -599,13 +614,13 @@ export class DocumentManager implements IDocumentManager {
       // Use an existing context if available.
       context = this._findContext(path, factory.name) || null;
       if (!context) {
-        context = this._createContext(path, factory, preference);
+        context = this._createContext(path, factory, preference, collaborative);
         // Populate the model, either from disk or a
         // model backend.
         ready = this._when.then(() => context!.initialize(false));
       }
     } else if (which === 'create') {
-      context = this._createContext(path, factory, preference);
+      context = this._createContext(path, factory, preference, collaborative);
       // Immediately save the contents to disk.
       ready = this._when.then(() => context!.initialize(true));
     } else {
@@ -651,7 +666,6 @@ export class DocumentManager implements IDocumentManager {
   private _setBusy: (() => IDisposable) | undefined;
   private _dialogs: ISessionContext.IDialogs;
   private _docProviderFactory: IDocumentProviderFactory | undefined;
-  private _collaborative: boolean;
   private _isConnectedCallback: () => boolean;
 }
 
@@ -702,12 +716,6 @@ export namespace DocumentManager {
      * A factory method for the document provider.
      */
     docProviderFactory?: IDocumentProviderFactory;
-
-    /**
-     * Whether the context should be collaborative.
-     * If true, the context will connect through yjs_ws_server to share information if possible.
-     */
-    collaborative?: boolean;
 
     /**
      * Autosaving should be paused while this callback function returns `false`.

--- a/packages/docprovider-extension/src/index.ts
+++ b/packages/docprovider-extension/src/index.ts
@@ -9,7 +9,7 @@ import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
-import { PageConfig, URLExt } from '@jupyterlab/coreutils';
+import { URLExt } from '@jupyterlab/coreutils';
 import {
   IDocumentProvider,
   IDocumentProviderFactory,
@@ -28,12 +28,10 @@ const docProviderPlugin: JupyterFrontEndPlugin<IDocumentProviderFactory> = {
   activate: (app: JupyterFrontEnd): IDocumentProviderFactory => {
     const server = ServerConnection.makeSettings();
     const url = URLExt.join(server.wsUrl, 'api/yjs');
-    const collaborative =
-      PageConfig.getOption('collaborative') == 'true' ? true : false;
     const factory = (
       options: IDocumentProviderFactory.IOptions<YDocument<DocumentChange>>
     ): IDocumentProvider => {
-      return collaborative
+      return options.collaborative
         ? new WebSocketProvider({
             ...options,
             url,

--- a/packages/docprovider/src/tokens.ts
+++ b/packages/docprovider/src/tokens.ts
@@ -58,5 +58,11 @@ export namespace IDocumentProviderFactory {
      * The document model
      */
     model: T;
+
+    /**
+     * Whether collaboration is enabled globally and the current document file
+     * type supports collaboration.
+     */
+    collaborative: boolean;
   }
 }

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1310,7 +1310,8 @@ export namespace DocumentRegistry {
       extensions: ['.ipynb'],
       contentType: 'notebook',
       fileFormat: 'json',
-      icon: notebookIcon
+      icon: notebookIcon,
+      collaborative: true
     };
   }
 

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -933,6 +933,12 @@ export namespace DocumentRegistry {
     readonly ready: Promise<void>;
 
     /**
+     * Returns whether this document context is writable. True only if the
+     * contents model is writable and collaboration is disabled.
+     */
+    readonly writable: boolean;
+
+    /**
      * Rename the document.
      */
     rename(newName: string): Promise<void>;
@@ -1207,6 +1213,12 @@ export namespace DocumentRegistry {
      * The format of the new file.
      */
     readonly fileFormat: Contents.FileFormat;
+
+    /**
+     * Whether this file type supports collaboration. `DocumentContext`
+     * defines the default if this value is `undefined`.
+     */
+    readonly collaborative?: boolean;
   }
 
   /**
@@ -1272,7 +1284,8 @@ export namespace DocumentRegistry {
       displayName: trans.__('Text'),
       mimeTypes: ['text/plain'],
       extensions: ['.txt'],
-      icon: fileIcon
+      icon: fileIcon,
+      collaborative: true
     };
   }
 
@@ -1347,63 +1360,72 @@ export namespace DocumentRegistry {
         displayName: trans.__('Markdown File'),
         extensions: ['.md'],
         mimeTypes: ['text/markdown'],
-        icon: markdownIcon
+        icon: markdownIcon,
+        collaborative: true
       },
       {
         name: 'PDF',
         displayName: trans.__('PDF File'),
         extensions: ['.pdf'],
         mimeTypes: ['application/pdf'],
-        icon: pdfIcon
+        icon: pdfIcon,
+        collaborative: true
       },
       {
         name: 'python',
         displayName: trans.__('Python File'),
         extensions: ['.py'],
         mimeTypes: ['text/x-python'],
-        icon: pythonIcon
+        icon: pythonIcon,
+        collaborative: true
       },
       {
         name: 'json',
         displayName: trans.__('JSON File'),
         extensions: ['.json'],
         mimeTypes: ['application/json'],
-        icon: jsonIcon
+        icon: jsonIcon,
+        collaborative: true
       },
       {
         name: 'julia',
         displayName: trans.__('Julia File'),
         extensions: ['.jl'],
         mimeTypes: ['text/x-julia'],
-        icon: juliaIcon
+        icon: juliaIcon,
+        collaborative: true
       },
       {
         name: 'csv',
         displayName: trans.__('CSV File'),
         extensions: ['.csv'],
         mimeTypes: ['text/csv'],
-        icon: spreadsheetIcon
+        icon: spreadsheetIcon,
+        collaborative: true
       },
       {
         name: 'tsv',
         displayName: trans.__('TSV File'),
         extensions: ['.tsv'],
         mimeTypes: ['text/csv'],
-        icon: spreadsheetIcon
+        icon: spreadsheetIcon,
+        collaborative: true
       },
       {
         name: 'r',
         displayName: trans.__('R File'),
         mimeTypes: ['text/x-rsrc'],
         extensions: ['.R'],
-        icon: rKernelIcon
+        icon: rKernelIcon,
+        collaborative: true
       },
       {
         name: 'yaml',
         displayName: trans.__('YAML File'),
         mimeTypes: ['text/x-yaml', 'text/yaml'],
         extensions: ['.yaml', '.yml'],
-        icon: yamlIcon
+        icon: yamlIcon,
+        collaborative: true
       },
       {
         name: 'svg',
@@ -1411,7 +1433,8 @@ export namespace DocumentRegistry {
         mimeTypes: ['image/svg+xml'],
         extensions: ['.svg'],
         icon: imageIcon,
-        fileFormat: 'base64'
+        fileFormat: 'base64',
+        collaborative: true
       },
       {
         name: 'tiff',

--- a/packages/htmlviewer-extension/src/index.tsx
+++ b/packages/htmlviewer-extension/src/index.tsx
@@ -104,7 +104,8 @@ function activateHTMLViewer(
     displayName: trans.__('HTML File'),
     extensions: ['.html'],
     mimeTypes: ['text/html'],
-    icon: html5Icon
+    icon: html5Icon,
+    collaborative: true
   };
   app.docRegistry.addFileType(ft);
 

--- a/packages/vdom-extension/src/index.ts
+++ b/packages/vdom-extension/src/index.ts
@@ -79,7 +79,8 @@ const plugin: JupyterFrontEndPlugin<IVDOMTracker> = {
       name: 'vdom',
       mimeTypes: [MIME_TYPE],
       extensions: ['.vdom', '.vdom.json'],
-      icon: reactIcon
+      icon: reactIcon,
+      collaborative: true
     });
 
     const trans = (translator || nullTranslator).load('jupyterlab');


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

cc @ellisonbg @3coins @davidbrochart 

## References

- https://github.com/jupyterlab/jupyterlab/issues/13440

## Code changes

Forces collaboration to explicitly enabled per file type, even when the collaboration global flag is enabled. This prevents custom extensions that add file types to the document registry from breaking, and forces extension developers to be explicit about enabling collaboration for their widgets.

### Testing

1. Run JupyterLab with the collaboration flag and verify RTC + autosave still works for files.
2. Remove the `collaborative: true` line from `getDefaultNotebookFileType()` in `docregistry/src/registry.ts`.
3. Rebuild JupyterLab and restart the server.
4. Verify that RTC is enabled for text files but not for notebook files.

## User-facing changes

None known.

## Backwards-incompatible changes

None known.