### PR TITLE
Automated Changelog Entry for 3.6.0a4 on 3.6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,22 +14,22 @@
 
 ### Enhancements made
 
-- Backport #12502 on branch 3.6.x (Add line history to Stdin cell outputs) [#13431](https://github.com/jupyterlab/jupyterlab/pull/13431) ([@fcollonval](https://github.com/fcollonval))
-- Backport #13413 on branch 3.6.x (Move configuration to jupyter-server-ydoc) [#13425](https://github.com/jupyterlab/jupyterlab/pull/13425) ([@fcollonval](https://github.com/fcollonval))
-- Backport #13341 on branch 3.6.x (Add user configuration for additional schemes for the sanitizer plugin) [#13419](https://github.com/jupyterlab/jupyterlab/pull/13419) ([@fcollonval](https://github.com/fcollonval))
-- Backport #13279 on branch 3.6.x (Define file or activity icons color as static) [#13408](https://github.com/jupyterlab/jupyterlab/pull/13408) ([@fcollonval](https://github.com/fcollonval))
+- Add line history to Stdin cell outputs [#13431](https://github.com/jupyterlab/jupyterlab/pull/13431) ([@fcollonval](https://github.com/fcollonval))
+- Move configuration to jupyter-server-ydoc [#13425](https://github.com/jupyterlab/jupyterlab/pull/13425) ([@fcollonval](https://github.com/fcollonval))
+- Add user configuration for additional schemes for the sanitizer plugin [#13419](https://github.com/jupyterlab/jupyterlab/pull/13419) ([@fcollonval](https://github.com/fcollonval))
+- Define file or activity icons color as static [#13408](https://github.com/jupyterlab/jupyterlab/pull/13408) ([@fcollonval](https://github.com/fcollonval))
 
 ### Maintenance and upkeep improvements
 
-- Backport #13434 on branch 3.6.x (Require jupyter_server_ydoc >=0.4.0) [#13437](https://github.com/jupyterlab/jupyterlab/pull/13437) ([@hbcarlos](https://github.com/hbcarlos))
-- Backport #13428 on branch 3.6.x (Use more consistent naming for user service) [#13435](https://github.com/jupyterlab/jupyterlab/pull/13435) ([@fcollonval](https://github.com/fcollonval))
-- Backport: Deprecate managing source extensions with `jupyter labextension` [#13424](https://github.com/jupyterlab/jupyterlab/pull/13424) ([@jtpio](https://github.com/jtpio))
-- Backport #13389 on branch 3.6.x (Extract @jupyterlab/shared-models to @jupyter-notebook/ydoc) [#13398](https://github.com/jupyterlab/jupyterlab/pull/13398) ([@fcollonval](https://github.com/fcollonval))
+- Require jupyter_server_ydoc >=0.4.0 [#13437](https://github.com/jupyterlab/jupyterlab/pull/13437) ([@hbcarlos](https://github.com/hbcarlos))
+- Use more consistent naming for user service [#13435](https://github.com/jupyterlab/jupyterlab/pull/13435) ([@fcollonval](https://github.com/fcollonval))
+- Deprecate managing source extensions with `jupyter labextension` [#13424](https://github.com/jupyterlab/jupyterlab/pull/13424) ([@jtpio](https://github.com/jtpio))
+- Extract @jupyterlab/shared-models to @jupyter-notebook/ydoc [#13398](https://github.com/jupyterlab/jupyterlab/pull/13398) ([@fcollonval](https://github.com/fcollonval))
 
 ### Documentation improvements
 
 - Remove broken URL [#13445](https://github.com/jupyterlab/jupyterlab/pull/13445) ([@fcollonval](https://github.com/fcollonval))
-- Backport #13413 on branch 3.6.x (Move configuration to jupyter-server-ydoc) [#13425](https://github.com/jupyterlab/jupyterlab/pull/13425) ([@fcollonval](https://github.com/fcollonval))
+- Move configuration to jupyter-server-ydoc [#13425](https://github.com/jupyterlab/jupyterlab/pull/13425) ([@fcollonval](https://github.com/fcollonval))
 - Update the tutorial to reflect the changes in the latest cookiecutter… [#13417](https://github.com/jupyterlab/jupyterlab/pull/13417) ([@frivas-at-navteca](https://github.com/frivas-at-navteca))
 
 ### Contributors to this release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.6.0a4
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.6.0a3...85627bd2edb6c6e15a1c30fd02ba82bcbc6d29f7))
+
+### Enhancements made
+
+- Backport #12502 on branch 3.6.x (Add line history to Stdin cell outputs) [#13431](https://github.com/jupyterlab/jupyterlab/pull/13431) ([@fcollonval](https://github.com/fcollonval))
+- Backport #13413 on branch 3.6.x (Move configuration to jupyter-server-ydoc) [#13425](https://github.com/jupyterlab/jupyterlab/pull/13425) ([@fcollonval](https://github.com/fcollonval))
+- Backport #13341 on branch 3.6.x (Add user configuration for additional schemes for the sanitizer plugin) [#13419](https://github.com/jupyterlab/jupyterlab/pull/13419) ([@fcollonval](https://github.com/fcollonval))
+- Backport #13279 on branch 3.6.x (Define file or activity icons color as static) [#13408](https://github.com/jupyterlab/jupyterlab/pull/13408) ([@fcollonval](https://github.com/fcollonval))
+
+### Maintenance and upkeep improvements
+
+- Backport #13434 on branch 3.6.x (Require jupyter_server_ydoc >=0.4.0) [#13437](https://github.com/jupyterlab/jupyterlab/pull/13437) ([@hbcarlos](https://github.com/hbcarlos))
+- Backport #13428 on branch 3.6.x (Use more consistent naming for user service) [#13435](https://github.com/jupyterlab/jupyterlab/pull/13435) ([@fcollonval](https://github.com/fcollonval))
+- Backport: Deprecate managing source extensions with `jupyter labextension` [#13424](https://github.com/jupyterlab/jupyterlab/pull/13424) ([@jtpio](https://github.com/jtpio))
+- Backport #13389 on branch 3.6.x (Extract @jupyterlab/shared-models to @jupyter-notebook/ydoc) [#13398](https://github.com/jupyterlab/jupyterlab/pull/13398) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+- Remove broken URL [#13445](https://github.com/jupyterlab/jupyterlab/pull/13445) ([@fcollonval](https://github.com/fcollonval))
+- Backport #13413 on branch 3.6.x (Move configuration to jupyter-server-ydoc) [#13425](https://github.com/jupyterlab/jupyterlab/pull/13425) ([@fcollonval](https://github.com/fcollonval))
+- Update the tutorial to reflect the changes in the latest cookiecutter… [#13417](https://github.com/jupyterlab/jupyterlab/pull/13417) ([@frivas-at-navteca](https://github.com/frivas-at-navteca))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-11-10&to=2022-11-18&type=c))
+
+[@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-11-10..2022-11-18&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2022-11-10..2022-11-18&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-11-10..2022-11-18&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-11-10..2022-11-18&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-11-10..2022-11-18&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-11-10..2022-11-18&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-11-10..2022-11-18&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-11-10..2022-11-18&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.6.0a3
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.6.0a2...00158c5b866ea54e51894dd59fa144643946066e))
@@ -27,8 +59,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-11-04&to=2022-11-10&type=c))
 
 [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-11-04..2022-11-10&type=Issues) | [@HaudinFlorence](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AHaudinFlorence+updated%3A2022-11-04..2022-11-10&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-11-04..2022-11-10&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-11-04..2022-11-10&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-11-04..2022-11-10&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-11-04..2022-11-10&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-11-04..2022-11-10&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.6.0a2
 


### PR DESCRIPTION
Automated Changelog Entry for 3.6.0a4 on 3.6.x
```
Python version: 3.6.0a4
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.6.0-alpha.4
@jupyterlab/buildutils: 3.6.0-alpha.4
@jupyterlab/template: 3.6.0-alpha.4
@jupyterlab/application-top: 3.6.0-alpha.4
@jupyterlab/example-app: 3.6.0-alpha.4
@jupyterlab/example-cell: 3.6.0-alpha.4
@jupyterlab/example-console: 3.6.0-alpha.4
@jupyterlab/example-federated: 2.7.0-alpha.4
@jupyterlab/example-federated-core: 2.7.0-alpha.4
@jupyterlab/example-federated-md: 2.7.0-alpha.4
@jupyterlab/example-federated-middle: 2.7.0-alpha.4
@jupyterlab/example-federated-phosphor: 2.7.0-alpha.4
@jupyterlab/example-filebrowser: 3.6.0-alpha.4
@jupyterlab/example-notebook: 3.6.0-alpha.4
@jupyterlab/example-terminal: 3.6.0-alpha.4
@jupyterlab/galata: 4.5.0-alpha.4
@jupyterlab/mock-extension: 3.6.0-alpha.4
@jupyterlab/mock-consumer: 3.6.0-alpha.4
@jupyterlab/mock-provider: 3.6.0-alpha.4
@jupyterlab/mock-token: 3.6.0-alpha.4
@jupyterlab/application: 3.6.0-alpha.4
@jupyterlab/application-extension: 3.6.0-alpha.4
@jupyterlab/apputils: 3.6.0-alpha.4
@jupyterlab/apputils-extension: 3.6.0-alpha.4
@jupyterlab/attachments: 3.6.0-alpha.4
@jupyterlab/cell-toolbar: 3.6.0-alpha.4
@jupyterlab/cell-toolbar-extension: 3.6.0-alpha.4
@jupyterlab/cells: 3.6.0-alpha.4
@jupyterlab/celltags: 3.6.0-alpha.4
@jupyterlab/celltags-extension: 3.6.0-alpha.4
@jupyterlab/codeeditor: 3.6.0-alpha.4
@jupyterlab/codemirror: 3.6.0-alpha.4
@jupyterlab/codemirror-extension: 3.6.0-alpha.4
@jupyterlab/collaboration: 3.6.0-alpha.4
@jupyterlab/collaboration-extension: 3.6.0-alpha.4
@jupyterlab/completer: 3.6.0-alpha.4
@jupyterlab/completer-extension: 3.6.0-alpha.4
@jupyterlab/console: 3.6.0-alpha.4
@jupyterlab/console-extension: 3.6.0-alpha.4
@jupyterlab/coreutils: 5.6.0-alpha.4
@jupyterlab/csvviewer: 3.6.0-alpha.4
@jupyterlab/csvviewer-extension: 3.6.0-alpha.4
@jupyterlab/debugger: 3.6.0-alpha.4
@jupyterlab/debugger-extension: 3.6.0-alpha.4
@jupyterlab/docmanager: 3.6.0-alpha.4
@jupyterlab/docmanager-extension: 3.6.0-alpha.4
@jupyterlab/docprovider: 3.6.0-alpha.4
@jupyterlab/docprovider-extension: 3.6.0-alpha.4
@jupyterlab/docregistry: 3.6.0-alpha.4
@jupyterlab/documentsearch: 3.6.0-alpha.4
@jupyterlab/documentsearch-extension: 3.6.0-alpha.4
@jupyterlab/extensionmanager: 3.6.0-alpha.4
@jupyterlab/extensionmanager-extension: 3.6.0-alpha.4
@jupyterlab/filebrowser: 3.6.0-alpha.4
@jupyterlab/filebrowser-extension: 3.6.0-alpha.4
@jupyterlab/fileeditor: 3.6.0-alpha.4
@jupyterlab/fileeditor-extension: 3.6.0-alpha.4
@jupyterlab/help-extension: 3.6.0-alpha.4
@jupyterlab/htmlviewer: 3.6.0-alpha.4
@jupyterlab/htmlviewer-extension: 3.6.0-alpha.4
@jupyterlab/hub-extension: 3.6.0-alpha.4
@jupyterlab/imageviewer: 3.6.0-alpha.4
@jupyterlab/imageviewer-extension: 3.6.0-alpha.4
@jupyterlab/inspector: 3.6.0-alpha.4
@jupyterlab/inspector-extension: 3.6.0-alpha.4
@jupyterlab/javascript-extension: 3.6.0-alpha.4
@jupyterlab/json-extension: 3.6.0-alpha.4
@jupyterlab/launcher: 3.6.0-alpha.4
@jupyterlab/launcher-extension: 3.6.0-alpha.4
@jupyterlab/logconsole: 3.6.0-alpha.4
@jupyterlab/logconsole-extension: 3.6.0-alpha.4
@jupyterlab/mainmenu: 3.6.0-alpha.4
@jupyterlab/mainmenu-extension: 3.6.0-alpha.4
@jupyterlab/markdownviewer: 3.6.0-alpha.4
@jupyterlab/markdownviewer-extension: 3.6.0-alpha.4
@jupyterlab/mathjax2: 3.6.0-alpha.4
@jupyterlab/mathjax2-extension: 3.6.0-alpha.4
@jupyterlab/metapackage: 3.6.0-alpha.4
@jupyterlab/nbconvert-css: 3.6.0-alpha.4
@jupyterlab/nbformat: 3.6.0-alpha.4
@jupyterlab/notebook: 3.6.0-alpha.4
@jupyterlab/notebook-extension: 3.6.0-alpha.4
@jupyterlab/observables: 4.6.0-alpha.4
@jupyterlab/outputarea: 3.6.0-alpha.4
@jupyterlab/pdf-extension: 3.6.0-alpha.4
@jupyterlab/property-inspector: 3.6.0-alpha.4
@jupyterlab/rendermime: 3.6.0-alpha.4
@jupyterlab/rendermime-extension: 3.6.0-alpha.4
@jupyterlab/rendermime-interfaces: 3.6.0-alpha.4
@jupyterlab/running: 3.6.0-alpha.4
@jupyterlab/running-extension: 3.6.0-alpha.4
@jupyterlab/services: 6.6.0-alpha.4
@jupyterlab/example-services-browser: 3.6.0-alpha.4
node-example: 3.6.0-alpha.4
@jupyterlab/example-services-outputarea: 3.6.0-alpha.4
@jupyterlab/settingeditor: 3.6.0-alpha.4
@jupyterlab/settingeditor-extension: 3.6.0-alpha.4
@jupyterlab/settingregistry: 3.6.0-alpha.4
@jupyterlab/shortcuts-extension: 3.6.0-alpha.4
@jupyterlab/statedb: 3.6.0-alpha.4
@jupyterlab/statusbar: 3.6.0-alpha.4
@jupyterlab/statusbar-extension: 3.6.0-alpha.4
@jupyterlab/terminal: 3.6.0-alpha.4
@jupyterlab/terminal-extension: 3.6.0-alpha.4
@jupyterlab/theme-dark-extension: 3.6.0-alpha.4
@jupyterlab/theme-light-extension: 3.6.0-alpha.4
@jupyterlab/toc: 5.6.0-alpha.4
@jupyterlab/toc-extension: 5.6.0-alpha.4
@jupyterlab/tooltip: 3.6.0-alpha.4
@jupyterlab/tooltip-extension: 3.6.0-alpha.4
@jupyterlab/translation: 3.6.0-alpha.4
@jupyterlab/translation-extension: 3.6.0-alpha.4
@jupyterlab/ui-components: 3.6.0-alpha.4
@jupyterlab/ui-components-extension: 3.6.0-alpha.4
@jupyterlab/vdom: 3.6.0-alpha.4
@jupyterlab/vdom-extension: 3.6.0-alpha.4
@jupyterlab/vega5-extension: 3.6.0-alpha.4
@jupyterlab/testutils: 3.6.0-alpha.4
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyterlab/jupyterlab/releases/tag/untagged-25dcb313f614568eaee0  |
| Since | v3.6.0a3 |