### PR TITLE
Check if `contentHeader` is not disposed before accessing widgets

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -311,6 +311,7 @@ export const toggleHeader: JupyterFrontEndPlugin<void> = {
       label: trans.__('Show Header Above Content'),
       isEnabled: () =>
         app.shell.currentWidget instanceof MainAreaWidget &&
+        !app.shell.currentWidget.contentHeader.isDisposed &&
         app.shell.currentWidget.contentHeader.widgets.length > 0,
       isToggled: () => {
         const widget = app.shell.currentWidget;


### PR DESCRIPTION
## References

When disposed widget gets attached to the main area the error message is misleading for extension developer as it fails on `contentHeader` (see https://github.com/jupyterlab/jupyterlab/issues/13439). This PR fixes that message which surfaces more useful errors.

## Code changes

Check if `contentHeader` is not disposed before accessing `contentHeader.widgets.length`

## User-facing changes

None

## Backwards-incompatible changes

None
