### PR TITLE
enable document model specific collaboration

### DIFF
--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -611,12 +611,6 @@ function addCommands(
       return false;
     }
     const context = docManager.contextForWidget(currentWidget);
-    console.log({
-      context,
-      writable: !!context?.writable,
-      // @ts-ignore
-      collaborative: context?._collaborative
-    });
     return !!context?.writable;
   };
 

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -191,7 +191,6 @@ const manager: JupyterFrontEndPlugin<IDocumentManager> = {
       setBusy: (status && (() => status.setBusy())) ?? undefined,
       sessionDialogs: sessionDialogs || undefined,
       translator: translator ?? nullTranslator,
-      collaborative: true,
       docProviderFactory: docProviderFactory ?? undefined,
       isConnectedCallback: () => {
         if (info) {
@@ -612,11 +611,13 @@ function addCommands(
       return false;
     }
     const context = docManager.contextForWidget(currentWidget);
-    return !!(
-      context &&
-      context.contentsModel &&
-      context.contentsModel.writable
-    );
+    console.log({
+      context,
+      writable: !!context?.writable,
+      // @ts-ignore
+      collaborative: context?._collaborative
+    });
+    return !!context?.writable;
   };
 
   // If inside a rich application like JupyterLab, add additional functionality.

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -611,7 +611,7 @@ function addCommands(
       return false;
     }
     const context = docManager.contextForWidget(currentWidget);
-    return !!context?.writable;
+    return !!context?.contentsModel?.writable;
   };
 
   // If inside a rich application like JupyterLab, add additional functionality.

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -39,7 +39,6 @@ export class DocumentManager implements IDocumentManager {
     this.translator = options.translator || nullTranslator;
     this.registry = options.registry;
     this.services = options.manager;
-    this._collaborative = !!options.collaborative;
     this._dialogs = options.sessionDialogs || sessionContextDialogs;
     this._docProviderFactory = options.docProviderFactory;
     this._isConnectedCallback = options.isConnectedCallback || (() => true);
@@ -513,7 +512,6 @@ export class DocumentManager implements IDocumentManager {
       kernelPreference,
       setBusy: this._setBusy,
       sessionDialogs: this._dialogs,
-      collaborative: this._collaborative,
       docProviderFactory: this._docProviderFactory,
       lastModifiedCheckMargin: this._lastModifiedCheckMargin,
       translator: this.translator
@@ -651,7 +649,6 @@ export class DocumentManager implements IDocumentManager {
   private _setBusy: (() => IDisposable) | undefined;
   private _dialogs: ISessionContext.IDialogs;
   private _docProviderFactory: IDocumentProviderFactory | undefined;
-  private _collaborative: boolean;
   private _isConnectedCallback: () => boolean;
 }
 
@@ -702,12 +699,6 @@ export namespace DocumentManager {
      * A factory method for the document provider.
      */
     docProviderFactory?: IDocumentProviderFactory;
-
-    /**
-     * Whether the context should be collaborative.
-     * If true, the context will connect through yjs_ws_server to share information if possible.
-     */
-    collaborative?: boolean;
 
     /**
      * Autosaving should be paused while this callback function returns `false`.

--- a/packages/docprovider-extension/src/index.ts
+++ b/packages/docprovider-extension/src/index.ts
@@ -9,7 +9,7 @@ import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
-import { PageConfig, URLExt } from '@jupyterlab/coreutils';
+import { URLExt } from '@jupyterlab/coreutils';
 import {
   IDocumentProvider,
   IDocumentProviderFactory,
@@ -28,12 +28,10 @@ const docProviderPlugin: JupyterFrontEndPlugin<IDocumentProviderFactory> = {
   activate: (app: JupyterFrontEnd): IDocumentProviderFactory => {
     const server = ServerConnection.makeSettings();
     const url = URLExt.join(server.wsUrl, 'api/yjs');
-    const collaborative =
-      PageConfig.getOption('collaborative') == 'true' ? true : false;
     const factory = (
       options: IDocumentProviderFactory.IOptions<YDocument<DocumentChange>>
     ): IDocumentProvider => {
-      return collaborative
+      return options.collaborative
         ? new WebSocketProvider({
             ...options,
             url,

--- a/packages/docprovider/src/tokens.ts
+++ b/packages/docprovider/src/tokens.ts
@@ -55,8 +55,13 @@ export namespace IDocumentProviderFactory {
     format: string;
 
     /**
-     * The document model
+     * The shared model
      */
     model: T;
+
+    /**
+     * Whether the document provider should be collaborative.
+     */
+    collaborative: boolean;
   }
 }

--- a/packages/docprovider/src/tokens.ts
+++ b/packages/docprovider/src/tokens.ts
@@ -62,6 +62,6 @@ export namespace IDocumentProviderFactory {
     /**
      * Whether the document provider should be collaborative.
      */
-    collaborative: boolean;
+    collaborative?: boolean;
   }
 }

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -58,10 +58,9 @@ export class Context<
     this._lastModifiedCheckMargin = options.lastModifiedCheckMargin || 500;
     const localPath = this._manager.contents.localPath(this._path);
     const lang = this._factory.preferredLanguage(PathExt.basename(localPath));
-    this._model = this._factory.createNew(lang);
-    this._collaborative = !!(
-      PageConfig.getOption('collaborative') === 'true' &&
-      this._model.collaborative
+    this._model = this._factory.createNew(
+      lang,
+      PageConfig.getOption('collaborative') === 'true'
     );
     const docProviderFactory = options.docProviderFactory;
     this._provider = docProviderFactory
@@ -70,7 +69,7 @@ export class Context<
           contentType: this._factory.contentType,
           format: this._factory.fileFormat!,
           model: this._model.sharedModel,
-          collaborative: this._collaborative
+          collaborative: this._model.collaborative
         })
       : new ProviderMock();
 
@@ -229,7 +228,7 @@ export class Context<
    * contents model is writable and collaboration is disabled.
    */
   get writable(): boolean {
-    return !!(this._contentsModel?.writable && !this._collaborative);
+    return !!(this._contentsModel?.writable && !this._model.collaborative);
   }
 
   /**

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -28,10 +28,11 @@ export class DocumentModel
   /**
    * Construct a new document model.
    */
-  constructor(languagePreference?: string) {
+  constructor(languagePreference?: string, collaborationEnabled?: boolean) {
     super();
     this._defaultLang = languagePreference || '';
     this.sharedModel.changed.connect(this._onStateChanged, this);
+    this._collaborationEnabled = !!collaborationEnabled;
   }
 
   /**
@@ -102,8 +103,11 @@ export class DocumentModel
     return this._defaultLang;
   }
 
+  /**
+   * Whether the model is collaborative or not.
+   */
   get collaborative(): boolean {
-    return true;
+    return this._collaborationEnabled;
   }
 
   /**
@@ -193,6 +197,7 @@ export class DocumentModel
   private _readOnly = false;
   private _contentChanged = new Signal<this, void>(this);
   private _stateChanged = new Signal<this, IChangedArgs<any>>(this);
+  private _collaborationEnabled: boolean;
 }
 
 /**
@@ -251,8 +256,11 @@ export class TextModelFactory implements DocumentRegistry.CodeModelFactory {
    *
    * @returns A new document model.
    */
-  createNew(languagePreference?: string): DocumentRegistry.ICodeModel {
-    return new DocumentModel(languagePreference);
+  createNew(
+    languagePreference?: string,
+    collaborationEnabled?: boolean
+  ): DocumentRegistry.ICodeModel {
+    return new DocumentModel(languagePreference, collaborationEnabled);
   }
 
   /**

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -102,6 +102,10 @@ export class DocumentModel
     return this._defaultLang;
   }
 
+  get collaborative(): boolean {
+    return true;
+  }
+
   /**
    * Serialize the model to a string.
    */

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1183,7 +1183,7 @@ export namespace DocumentRegistry {
      *
      * @returns A new document model.
      */
-    createNew(languagePreference?: string): T;
+    createNew(languagePreference?: string, collaborationEnabled?: boolean): T;
 
     /**
      * Get the preferred kernel language given a file path.

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -824,6 +824,12 @@ export namespace DocumentRegistry {
     readonly sharedModel: ISharedDocument;
 
     /**
+     * Whether this document model supports collaboration when the collaborative
+     * flag is enabled globally. Defaults to `false`.
+     */
+    readonly collaborative?: boolean;
+
+    /**
      * Serialize the model to a string.
      */
     toString(): string;
@@ -931,6 +937,12 @@ export namespace DocumentRegistry {
      * A promise that is fulfilled when the context is ready.
      */
     readonly ready: Promise<void>;
+
+    /**
+     * Returns whether this document context is writable. True only if the
+     * contents model is writable and collaboration is disabled.
+     */
+    readonly writable: boolean;
 
     /**
      * Rename the document.

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -939,12 +939,6 @@ export namespace DocumentRegistry {
     readonly ready: Promise<void>;
 
     /**
-     * Returns whether this document context is writable. True only if the
-     * contents model is writable and collaboration is disabled.
-     */
-    readonly writable: boolean;
-
-    /**
      * Rename the document.
      */
     rename(newName: string): Promise<void>;

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -107,6 +107,7 @@ export class NotebookModel implements INotebookModel {
     this._cells = new CellList(this.sharedModel);
     this._trans = (options.translator || nullTranslator).load('jupyterlab');
     this._deletedCells = [];
+    this._collaborationEnabled = !!options?.collaborationEnabled;
 
     // Initialize the notebook
     // In collaboration mode, this will be overridden by the initialization coming
@@ -231,8 +232,11 @@ export class NotebookModel implements INotebookModel {
     return info?.name ?? '';
   }
 
+  /**
+   * Whether the model is collaborative or not.
+   */
   get collaborative(): boolean {
-    return true;
+    return this._collaborationEnabled;
   }
 
   /**
@@ -481,6 +485,7 @@ close the notebook without saving it.`,
   private _deletedCells: string[];
   private _isDisposed = false;
   private _metadataChanged = new Signal<NotebookModel, IMapChange>(this);
+  private _collaborationEnabled: boolean;
 }
 
 /**
@@ -510,5 +515,10 @@ export namespace NotebookModel {
      * Defines if the document can be undo/redo.
      */
     disableDocumentWideUndoRedo?: boolean;
+
+    /**
+     * Whether collaboration should be enabled for this document model.
+     */
+    collaborationEnabled?: boolean;
   }
 }

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -231,6 +231,10 @@ export class NotebookModel implements INotebookModel {
     return info?.name ?? '';
   }
 
+  get collaborative(): boolean {
+    return true;
+  }
+
   /**
    * Dispose of the resources held by the model.
    */

--- a/packages/notebook/src/modelfactory.ts
+++ b/packages/notebook/src/modelfactory.ts
@@ -68,9 +68,13 @@ export class NotebookModelFactory
    *
    * @returns A new document model.
    */
-  createNew(languagePreference?: string): INotebookModel {
+  createNew(
+    languagePreference?: string,
+    collaborationEnabled?: boolean
+  ): INotebookModel {
     return new NotebookModel({
       languagePreference,
+      collaborationEnabled,
       disableDocumentWideUndoRedo: this._disableDocumentWideUndoRedo
     });
   }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

cc @ellisonbg @3coins @davidbrochart 

## References

- https://github.com/jupyterlab/jupyterlab/issues/13440

## Code changes

Forces collaboration to explicitly enabled per document model, even when the collaboration global flag is enabled. This prevents custom extensions that add document models to the document registry from providing a broken experience by default when RTC is enabled globally, and forces extension developers to be explicit about enabling collaboration for their document models.

### Testing

1. Run JupyterLab with the `--collaborative` flag and verify RTC + autosave still works for files.
2. Comment out the `get collaborative()` method in `packages/notebook/src/model.ts`.
3. Rebuild JupyterLab and restart the server.
4. Verify that RTC is enabled for text files but not for notebook files.

## User-facing changes

None known.

## Backwards-incompatible changes

None known.