### PR TITLE
Require jupyter_server_ydoc>=0.5.0,<0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "jupyter_core",
     "jupyter-lsp>=1.5.1",
     "jupyter_server>=2.0.0rc3,<3",
-    "jupyter_server_ydoc>=0.4.0,<0.5.0",
+    "jupyter_server_ydoc>=0.5.0,<0.6.0",
     "jupyterlab_server>=2.16.0,<3",
     "notebook_shim>=0.2",
     "packaging",


### PR DESCRIPTION
## References

See https://github.com/jupyterlab/jupyterlab/issues/13463.

## Code changes

Require `jupyter_server_ydoc >=0.5.0,<0.6.0`.

## User-facing changes

Fix for non-local deployment.

## Backwards-incompatible changes

None.