### PR TITLE
Move the toggle file browser logic to the widget

### DIFF
--- a/packages/filebrowser-extension/schema/browser.json
+++ b/packages/filebrowser-extension/schema/browser.json
@@ -24,10 +24,6 @@
         "id": "jp-mainmenu-view",
         "items": [
           {
-            "command": "filebrowser:toggle-main",
-            "rank": 1
-          },
-          {
             "command": "filebrowser:toggle-hidden-files",
             "rank": 9.95
           }
@@ -152,11 +148,6 @@
   "title": "File Browser",
   "description": "File Browser settings.",
   "jupyter.lab.shortcuts": [
-    {
-      "command": "filebrowser:toggle-main",
-      "keys": ["Accel Shift F"],
-      "selector": "body"
-    },
     {
       "command": "filebrowser:go-up",
       "keys": ["Backspace"],

--- a/packages/filebrowser-extension/schema/browser.json
+++ b/packages/filebrowser-extension/schema/browser.json
@@ -28,23 +28,6 @@
             "rank": 9.95
           }
         ]
-      },
-      {
-        "id": "jp-mainmenu-settings",
-        "items": [
-          {
-            "type": "separator",
-            "rank": 5
-          },
-          {
-            "command": "filebrowser:toggle-navigate-to-current-directory",
-            "rank": 5
-          },
-          {
-            "type": "separator",
-            "rank": 5
-          }
-        ]
       }
     ],
     "context": [

--- a/packages/filebrowser-extension/schema/widget.json
+++ b/packages/filebrowser-extension/schema/widget.json
@@ -22,6 +22,23 @@
             "rank": 1
           }
         ]
+      },
+      {
+        "id": "jp-mainmenu-settings",
+        "items": [
+          {
+            "type": "separator",
+            "rank": 5
+          },
+          {
+            "command": "filebrowser:toggle-navigate-to-current-directory",
+            "rank": 5
+          },
+          {
+            "type": "separator",
+            "rank": 5
+          }
+        ]
       }
     ]
   },

--- a/packages/filebrowser-extension/schema/widget.json
+++ b/packages/filebrowser-extension/schema/widget.json
@@ -12,6 +12,26 @@
       { "name": "refresh", "command": "filebrowser:refresh", "rank": 30 }
     ]
   },
+  "jupyter.lab.menus": {
+    "main": [
+      {
+        "id": "jp-mainmenu-view",
+        "items": [
+          {
+            "command": "filebrowser:toggle-main",
+            "rank": 1
+          }
+        ]
+      }
+    ]
+  },
+  "jupyter.lab.shortcuts": [
+    {
+      "command": "filebrowser:toggle-main",
+      "keys": ["Accel Shift F"],
+      "selector": "body"
+    }
+  ],
   "jupyter.lab.transform": true,
   "properties": {
     "toolbar": {

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -377,6 +377,7 @@ const browserWidget: JupyterFrontEndPlugin<void> = {
     toolbarRegistry: IToolbarWidgetRegistry,
     translator: ITranslator,
     labShell: ILabShell,
+    // Wait until file browser commands are ready before activating file browser widget
     fileBrowserCommands: null,
     commandPalette: ICommandPalette | null
   ): void => {


### PR DESCRIPTION
The `filebrowser:toggle-main` logic (*shortcut*, *menu entry* and *command*) is attached to the *browser* itself instead of the *widget*.

As the command relies only on commands attached to the *widget* (`filebrowser:activate` and `filebrowser:hide-main`), it seems logical to move it to the widget too.

For example Jupyter Notebook is using the *browser* but not the *widget*. The  `filebrowser:toggle-main` menu entry and command are created but unusable as the `filebrowser:activate` and `filebrowser:hide-main` are not.

## References

https://github.com/jupyter/notebook/pull/6588

## Code changes

- Move the menu entry and shortcut from `packages/filebrowser-extension/schema/browser.json` to `packages/filebrowser-extension/schema/widget.json`.

- Create the `filebrowser:toggle-main` command in `@jupyterlab/filebrowser-extension:widget` instead of `@jupyterlab/filebrowser-extension:browser`.

## User-facing changes

None

## Backwards-incompatible changes

None