### PR TITLE
Set fallback values for icons colors.

### DIFF
--- a/packages/ui-components/docs/source/labicon.rst
+++ b/packages/ui-components/docs/source/labicon.rst
@@ -151,7 +151,7 @@ Available icon classes
 
 .. raw:: html
 
-   <em>Icon-related CSS classes are defined in <a href="https://github.com/jupyterlab/jupyterlab/blob/f0153e0258b32674c9aec106383ddf7b618cebab/packages/ui-components/style/icons.css">ui-components/style/icons.css</a></em>
+   <em>Icon-related CSS classes are defined in <a href="https://github.com/jupyterlab/jupyterlab/blob/master/packages/ui-components/style/icons.css">ui-components/style/icons.css</a></em>
 
 |
 | All colors shown are for the standard light/dark theme, mouse over for hex values.
@@ -192,6 +192,24 @@ forth.
 For light/dark themes, ``jp-icon-accent0`` corresponds to the
 lightest/darkest background color, while ``jp-icon-accent1`` is somewhat
 darker/lighter, and so forth.
+
+Activity icons
+""""""""""""""
+
+Activity icons have their own set of CSS properties as it may not make sense to link them
+to a theme color. Here is a list of icons and the related properties:
+
+=========== ============================= =====================================
+   Icon             Primary color                    Secondary color
+=========== ============================= =====================================
+jupyter     ``jp-jupyter-icon-color``     None
+notebook    ``jp-notebook-icon-color``    None
+json        ``jp-json-icon-color``        None
+console     ``jp-console-icon-color``     ``jp-console-icon-background-color``
+terminal    ``jp-terminal-icon-color``    ``jp-terminal-icon-background-color``
+text editor ``jp-text-editor-icon-color`` None
+inspector   ``jp-inspector-icon-color``   None
+=========== ============================= =====================================
 
 Adding classes to a one-color icon
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/packages/ui-components/style/icons.css
+++ b/packages/ui-components/style/icons.css
@@ -206,39 +206,39 @@
 }
 
 .jp-jupyter-icon-color[fill] {
-  fill: var(--jp-jupyter-icon-color);
+  fill: var(--jp-jupyter-icon-color, var(--jp-warn-color0));
 }
 
 .jp-notebook-icon-color[fill] {
-  fill: var(--jp-notebook-icon-color);
+  fill: var(--jp-notebook-icon-color, var(--jp-warn-color0));
 }
 
 .jp-json-icon-color[fill] {
-  fill: var(--jp-json-icon-color);
+  fill: var(--jp-json-icon-color, var(--jp-warn-color1));
 }
 
 .jp-console-icon-color[fill] {
-  fill: var(--jp-console-icon-color);
+  fill: var(--jp-console-icon-color, white);
 }
 
 .jp-console-icon-background-color[fill] {
-  fill: var(--jp-console-icon-background-color);
+  fill: var(--jp-console-icon-background-color, var(--jp-brand-color1));
 }
 
 .jp-terminal-icon-color[fill] {
-  fill: var(--jp-terminal-icon-color);
+  fill: var(--jp-terminal-icon-color, var(--jp-layout-color2));
 }
 
 .jp-terminal-icon-background-color[fill] {
-  fill: var(--jp-terminal-icon-background-color);
+  fill: var(--jp-terminal-icon-background-color, var(--jp-inverse-layout2));
 }
 
 .jp-text-editor-icon-color[fill] {
-  fill: var(--jp-text-editor-icon-color);
+  fill: var(--jp-text-editor-icon-color) var(--jp-inverse-layout3);
 }
 
 .jp-inspector-icon-color[fill] {
-  fill: var(--jp-inspector-icon-color);
+  fill: var(--jp-inspector-icon-color) var(--jp-inverse-layout3);
 }
 
 /* CSS for icons in selected filebrowser listing items */

--- a/packages/ui-components/style/icons.css
+++ b/packages/ui-components/style/icons.css
@@ -234,11 +234,11 @@
 }
 
 .jp-text-editor-icon-color[fill] {
-  fill: var(--jp-text-editor-icon-color), var(--jp-inverse-layout3));
+  fill: var(--jp-text-editor-icon-color, var(--jp-inverse-layout3));
 }
 
 .jp-inspector-icon-color[fill] {
-  fill: var(--jp-inspector-icon-color), var(--jp-inverse-layout3));
+  fill: var(--jp-inspector-icon-color, var(--jp-inverse-layout3));
 }
 
 /* CSS for icons in selected filebrowser listing items */

--- a/packages/ui-components/style/icons.css
+++ b/packages/ui-components/style/icons.css
@@ -234,7 +234,7 @@
 }
 
 .jp-text-editor-icon-color[fill] {
-  fill: var(--jp-text-editor-icon-color) var(--jp-inverse-layout3);
+  fill: var(--jp-text-editor-icon-color), var(--jp-inverse-layout3));
 }
 
 .jp-inspector-icon-color[fill] {

--- a/packages/ui-components/style/icons.css
+++ b/packages/ui-components/style/icons.css
@@ -238,7 +238,7 @@
 }
 
 .jp-inspector-icon-color[fill] {
-  fill: var(--jp-inspector-icon-color) var(--jp-inverse-layout3);
+  fill: var(--jp-inspector-icon-color), var(--jp-inverse-layout3));
 }
 
 /* CSS for icons in selected filebrowser listing items */


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This PR is a follow up of PR https://github.com/jupyterlab/jupyterlab/pull/13279 and should fix issue https://github.com/jupyter/notebook/issues/6633 reporting that icons are not visible with the jupyterlab-night theme

## Code changes

In packages/ui-components/style/icons.css, add fallback values for the css variables related to the colors of the icons in the launcher.
## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
