### PR TITLE
Fix syntax highlighting for JSON viewer in Jupyter Notebook

### DIFF
--- a/packages/json-extension/package.json
+++ b/packages/json-extension/package.json
@@ -44,7 +44,8 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-highlighter": "^0.4.3",
-    "react-json-tree": "^0.16.1"
+    "react-json-tree": "^0.16.1",
+    "style-mod": "^4.0.0"
   },
   "devDependencies": {
     "@types/react": "^17.0.0",

--- a/packages/json-extension/src/component.tsx
+++ b/packages/json-extension/src/component.tsx
@@ -9,7 +9,7 @@ import { JSONArray, JSONExt, JSONObject, JSONValue } from '@lumino/coreutils';
 import * as React from 'react';
 import Highlight from 'react-highlighter';
 import { JSONTree } from 'react-json-tree';
-
+import { StyleModule } from 'style-mod';
 /**
  * The properties for the JSON tree component.
  */
@@ -37,6 +37,8 @@ export interface IState {
 function getStyle(tag: Tag): string {
   return jupyterHighlightStyle.style([tag]) ?? '';
 }
+
+StyleModule.mount(document, jupyterHighlightStyle.module as StyleModule);
 
 /**
  * A component that renders JSON data as a collapsible tree.

--- a/packages/json-extension/src/component.tsx
+++ b/packages/json-extension/src/component.tsx
@@ -38,8 +38,6 @@ function getStyle(tag: Tag): string {
   return jupyterHighlightStyle.style([tag]) ?? '';
 }
 
-StyleModule.mount(document, jupyterHighlightStyle.module as StyleModule);
-
 /**
  * A component that renders JSON data as a collapsible tree.
  */
@@ -47,6 +45,10 @@ export class Component extends React.Component<IProps, IState> {
   state = { filter: '', value: '' };
 
   timer: number = 0;
+
+  componentDidMount(): void {
+    StyleModule.mount(document, jupyterHighlightStyle.module as StyleModule);
+  }
 
   handleChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const { value } = event.target;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
This PR addresses https://github.com/jupyter/notebook/issues/6567 in Jupyter Notebook, by making an upstream change here in JupyterLab.
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

The changes are to the `json-extension` which mount `jupyterHighlightStyle` manually.

## User-facing changes
The users of Jupyter Notebook will see the same as what they see in JupyterLab when opening a JSON file.

### Before
![image](https://user-images.githubusercontent.com/73378227/203372694-45c4348a-53a9-4b2c-b86d-f8a46c8d5fe0.png)

### After
![image](https://user-images.githubusercontent.com/73378227/203372464-15127e65-503e-48af-a4f2-8cfa78555611.png)

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

No anticipated backwards incompatible changes.