### PR TITLE
Forbid using RTC mode without Jupyter Server v2.

### DIFF
--- a/docs/source/user/rtc.rst
+++ b/docs/source/user/rtc.rst
@@ -9,7 +9,12 @@ Real Time Collaboration
 From JupyterLab 3.1, file documents and notebooks have collaborative
 editing using the `Yjs shared editing framework <https://github.com/yjs/yjs>`_.
 Editors are not collaborative by default; to activate it, start JupyterLab
-with the ``--collaborative`` flag.
+with the ``--collaborative`` flag and you need to upgrade Jupyter Server to 
+version 2.0.0 or later. To install it with pip for example:
+
+.. code-block:: bash
+
+    python -m pip install "jupyter_server>=2.0.0"
 
 To share a document with other users, you can copy the URL and send it, or you
 can install a helpful extension called

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -6,6 +6,7 @@
 
 import json
 import os
+import sys
 from os.path import join as pjoin
 
 from jupyter_core.application import JupyterApp, NoStart, base_aliases, base_flags
@@ -763,6 +764,16 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
     def initialize(self, argv=None):
         """Subclass because the ExtensionApp.initialize() method does not take arguments"""
         super().initialize()
+
+        if self.collaborative and jpserver_version_info < (2, 0, 0):
+            jpserver_version = ".".join(filter(lambda p: p, map(lambda p: str(p), jpserver_version_info)))
+            self.log.critical(f"""To enable real-time collaboration, you must install Jupyter Server v2 (current version is {jpserver_version}).
+
+You can install it using pip for example:
+
+  python -m pip install "jupyter_server>=2.0.0"
+""")
+            sys.exit(1)
 
 
 # -----------------------------------------------------------------------------

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -766,7 +766,7 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
         super().initialize()
 
         if self.collaborative and jpserver_version_info < (2, 0, 0):
-            jpserver_version = ".".join(filter(lambda p: p, map(lambda p: str(p), jpserver_version_info)))
+            jpserver_version = ".".join(filter(lambda p: len(p) > 0, map(lambda p: str(p), jpserver_version_info)))
             self.log.critical(f"""To enable real-time collaboration, you must install Jupyter Server v2 (current version is {jpserver_version}).
 
 You can install it using pip for example:

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -766,7 +766,7 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
         super().initialize()
 
         if self.collaborative and jpserver_version_info < (2, 0, 0):
-            jpserver_version = ".".join(filter(lambda p: len(p) > 0, map(lambda p: str(p), jpserver_version_info)))
+            jpserver_version = ".".join(filter(lambda p: len(p) > 0, map(str, jpserver_version_info)))
             self.log.critical(f"""To enable real-time collaboration, you must install Jupyter Server v2 (current version is {jpserver_version}).
 
 You can install it using pip for example:


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/3.6.x/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Follow-up of RTC rework for 3.x

It will resolve https://github.com/jupyterlab/jupyterlab/issues/13463
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Stop initialization of the server in collaborative mode if Jupyter Server is not v2+

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Forbid using RTC mode without Jupyter Server v2.
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
Collaboration is conditioned on a new dependency (that don't break other features in non-RTC mode).