### PR TITLE
Add guards for browser globals accessed at import time

### DIFF
--- a/packages/apputils/src/windowresolver.ts
+++ b/packages/apputils/src/windowresolver.ts
@@ -110,6 +110,7 @@ namespace Private {
    * Start the storage event handler.
    */
   function initialize(): void {
+    if (typeof window === 'undefined') return;
     // Listen to all storage events for beacons and window names.
     window.addEventListener('storage', (event: StorageEvent) => {
       const { key, newValue } = event;

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -154,8 +154,10 @@ const SIDE_BY_SIDE_CLASS = 'jp-mod-sideBySide';
  * The interactivity modes for the notebook.
  */
 export type NotebookMode = 'command' | 'edit';
-
-if ((window as any).requestIdleCallback === undefined) {
+if (
+  typeof window !== 'undefined' &&
+  (window as any).requestIdleCallback === undefined
+) {
   // On Safari, requestIdleCallback is not available, so we use replacement functions for `idleCallbacks`
   // See: https://developer.mozilla.org/en-US/docs/Web/API/Background_Tasks_API#falling_back_to_settimeout
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/packages/ui-components/src/icon/labicon.tsx
+++ b/packages/ui-components/src/icon/labicon.tsx
@@ -424,6 +424,7 @@ export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
     this._svgReactAttrs = undefined;
 
     // update icon elements created using .element method
+    if (typeof document === 'undefined') return;
     document
       .querySelectorAll(`[data-icon-id="${uuidOld}"]`)
       .forEach(oldSvgElement => {


### PR DESCRIPTION
## References

This relates to issue #13429 and is meant to be illustrative / assist triage.

## Code changes

The code changes here are minimal and were required in order to build `thebe` in a web application built on `remix.run`. Remix has a closed `esbuild` based build process and performs SSR. The objective is here is not to enable SSR with jupyterlab components, but just to allow them to be built/packages by remix (or similar build processes/platforms) with minimum friction.

The code changes here may not be suitable for server side use of the components, as tsome code will not be called when `window` or `document` is not present.

The changes here stem from initialization of objects at import time / file scope instantiation of variables / objects -- so a longer term / better change would be to address how the classes / objects here are initialized and move that initialisaiton to happen at application start rather than import.

## User-facing changes

none

## Backwards-incompatible changes

Unknown, but there may be impact from not executing certain code when expected.
