### PR TITLE
Require jupyter-server-ydoc >=0.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "jupyter_core",
     "jupyter-lsp>=1.5.1",
     "jupyter_server>=2.0.0rc3,<3",
-    "jupyter_server_ydoc>=0.4.0,<0.5.0",
+    "jupyter_server_ydoc>=0.5.1,<0.6.0",
     "jupyterlab_server>=2.16.0,<3",
     "notebook_shim>=0.2",
     "packaging",


### PR DESCRIPTION
## Code changes

Require `jupyter_server_ydoc>=0.5.1,<0.6.0`, which in turn requires `ypy-websocket>=0.7.0,<8`.

## User-facing changes

The `SQLiteYStore` now implements "time to live" for documents, which squashes updates into a single update after some time.
YStores are now versioned, which allows for checking compatibility and by default creates a new YStore if the current one is not compatible.

## Backwards-incompatible changes

YStore is incompatible.