### PR TITLE
jupyter_server_ydoc>=0.6.0,<0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "jupyter_core",
     "jupyter-lsp>=1.5.1",
     "jupyter_server>=2.0.0rc3,<3",
-    "jupyter_server_ydoc>=0.5.1,<0.6.0",
+    "jupyter_server_ydoc>=0.6.0,<0.7.0",
     "jupyterlab_server>=2.16.0,<3",
     "notebook_shim>=0.2",
     "packaging",


### PR DESCRIPTION
## References

https://github.com/jupyter-server/jupyter_server_ydoc/pull/64
https://github.com/y-crdt/ypy-websocket/pull/57

## Code changes

Metadata is not stored anymore. It used to consist of a timestamp, which is now built-in the YStore, so no need to duplicate data.

## User-facing changes

Smaller YStore.

## Backwards-incompatible changes

YStore is incompatible.