### PR TITLE
Depend on `@jupyter/ydoc` instead of `@jupyter-notebook/ydoc`

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -16,7 +16,7 @@
     "watch": "webpack --watch"
   },
   "resolutions": {
-    "@jupyter-notebook/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.0",
     "@jupyterlab/application": "~4.0.0-alpha.16",
     "@jupyterlab/application-extension": "~4.0.0-alpha.16",
     "@jupyterlab/apputils": "~4.0.0-alpha.16",
@@ -266,7 +266,7 @@
     "buildDir": "./static",
     "outputDir": ".",
     "singletonPackages": [
-      "@jupyter-notebook/ydoc",
+      "@jupyter/ydoc",
       "@jupyterlab/application",
       "@jupyterlab/apputils",
       "@jupyterlab/cell-toolbar",

--- a/examples/cell/package.json
+++ b/examples/cell/package.json
@@ -7,7 +7,7 @@
     "clean": "rimraf build"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.2",
     "@jupyterlab/application": "^4.0.0-alpha.16",
     "@jupyterlab/apputils": "^4.0.0-alpha.16",
     "@jupyterlab/cells": "^4.0.0-alpha.16",

--- a/examples/cell/package.json
+++ b/examples/cell/package.json
@@ -7,7 +7,7 @@
     "clean": "rimraf build"
   },
   "dependencies": {
-    "@jupyter-notebook/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.0",
     "@jupyterlab/application": "^4.0.0-alpha.16",
     "@jupyterlab/apputils": "^4.0.0-alpha.16",
     "@jupyterlab/cells": "^4.0.0-alpha.16",

--- a/jupyterlab/staging/package.json
+++ b/jupyterlab/staging/package.json
@@ -16,7 +16,7 @@
     "watch": "webpack --watch"
   },
   "resolutions": {
-    "@jupyter/ydoc": "~0.2.0",
+    "@jupyter-notebook/ydoc": "~0.2.0",
     "@jupyterlab/application": "~4.0.0-alpha.16",
     "@jupyterlab/application-extension": "~4.0.0-alpha.16",
     "@jupyterlab/apputils": "~4.0.0-alpha.16",
@@ -266,7 +266,7 @@
     "buildDir": "./build",
     "outputDir": "..",
     "singletonPackages": [
-      "@jupyter/ydoc",
+      "@jupyter-notebook/ydoc",
       "@jupyterlab/application",
       "@jupyterlab/apputils",
       "@jupyterlab/cell-toolbar",

--- a/jupyterlab/staging/package.json
+++ b/jupyterlab/staging/package.json
@@ -16,7 +16,7 @@
     "watch": "webpack --watch"
   },
   "resolutions": {
-    "@jupyter-notebook/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.0",
     "@jupyterlab/application": "~4.0.0-alpha.16",
     "@jupyterlab/application-extension": "~4.0.0-alpha.16",
     "@jupyterlab/apputils": "~4.0.0-alpha.16",
@@ -266,7 +266,7 @@
     "buildDir": "./build",
     "outputDir": "..",
     "singletonPackages": [
-      "@jupyter-notebook/ydoc",
+      "@jupyter/ydoc",
       "@jupyterlab/application",
       "@jupyterlab/apputils",
       "@jupyterlab/cell-toolbar",

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -36,7 +36,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.2",
     "@jupyterlab/nbformat": "^4.0.0-alpha.16",
     "@jupyterlab/observables": "^5.0.0-alpha.16",
     "@jupyterlab/rendermime": "^4.0.0-alpha.16",

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -36,7 +36,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter-notebook/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.0",
     "@jupyterlab/nbformat": "^4.0.0-alpha.16",
     "@jupyterlab/observables": "^5.0.0-alpha.16",
     "@jupyterlab/rendermime": "^4.0.0-alpha.16",

--- a/packages/attachments/src/model.ts
+++ b/packages/attachments/src/model.ts
@@ -15,7 +15,7 @@ import {
 import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 import { IDisposable } from '@lumino/disposable';
 import { ISignal, Signal } from '@lumino/signaling';
-import { ISharedMarkdownCell, ISharedRawCell } from '@jupyter-notebook/ydoc';
+import { ISharedMarkdownCell, ISharedRawCell } from '@jupyter/ydoc';
 
 /**
  * The model for attachments.

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -42,7 +42,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.2",
     "@jupyterlab/apputils": "^4.0.0-alpha.16",
     "@jupyterlab/attachments": "^4.0.0-alpha.16",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.16",

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -42,7 +42,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter-notebook/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.0",
     "@jupyterlab/apputils": "^4.0.0-alpha.16",
     "@jupyterlab/attachments": "^4.0.0-alpha.16",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.16",

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -27,7 +27,7 @@ import {
   ISharedMarkdownCell,
   ISharedRawCell,
   YCodeCell
-} from '@jupyter-notebook/ydoc';
+} from '@jupyter/ydoc';
 
 const globalModelDBMutex = createMutex();
 

--- a/packages/cells/src/searchprovider.ts
+++ b/packages/cells/src/searchprovider.ts
@@ -15,7 +15,7 @@ import {
   TextSearchEngine
 } from '@jupyterlab/documentsearch';
 import { OutputArea } from '@jupyterlab/outputarea';
-import { CellChange, ISharedBaseCell } from '@jupyter-notebook/ydoc';
+import { CellChange, ISharedBaseCell } from '@jupyter/ydoc';
 import { ISignal, Signal } from '@lumino/signaling';
 import { ICellModel } from './model';
 import { Cell, CodeCell, MarkdownCell } from './widget';

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -33,7 +33,7 @@ import {
 
 import { Kernel, KernelMessage } from '@jupyterlab/services';
 
-import { IMapChange } from '@jupyter-notebook/ydoc';
+import { IMapChange } from '@jupyter/ydoc';
 
 import { TableOfContentsUtils } from '@jupyterlab/toc';
 

--- a/packages/cells/test/model.spec.ts
+++ b/packages/cells/test/model.spec.ts
@@ -22,7 +22,7 @@ import {
   YCodeCell,
   YMarkdownCell,
   YRawCell
-} from '@jupyter-notebook/ydoc';
+} from '@jupyter/ydoc';
 
 class TestModel extends CellModel {
   get type(): 'raw' {

--- a/packages/cells/test/widget.spec.ts
+++ b/packages/cells/test/widget.spec.ts
@@ -19,7 +19,7 @@ import {
 import { CodeEditor, CodeEditorWrapper } from '@jupyterlab/codeeditor';
 import { OutputArea, OutputPrompt } from '@jupyterlab/outputarea';
 import { IExecuteReplyMsg } from '@jupyterlab/services/lib/kernel/messages';
-import { createStandaloneCell, YCodeCell } from '@jupyter-notebook/ydoc';
+import { createStandaloneCell, YCodeCell } from '@jupyter/ydoc';
 import {
   createSessionContext,
   framePromise,

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -41,7 +41,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter-notebook/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.0",
     "@jupyterlab/coreutils": "^6.0.0-alpha.16",
     "@jupyterlab/nbformat": "^4.0.0-alpha.16",
     "@jupyterlab/observables": "^5.0.0-alpha.16",

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -41,7 +41,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.2",
     "@jupyterlab/coreutils": "^6.0.0-alpha.16",
     "@jupyterlab/nbformat": "^4.0.0-alpha.16",
     "@jupyterlab/observables": "^5.0.0-alpha.16",

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -3,7 +3,7 @@
 
 import { IChangedArgs } from '@jupyterlab/coreutils';
 import { IObservableMap, ObservableMap } from '@jupyterlab/observables';
-import { ISharedText, YFile } from '@jupyter-notebook/ydoc';
+import { ISharedText, YFile } from '@jupyter/ydoc';
 import { ITranslator } from '@jupyterlab/translation';
 import { JSONObject } from '@lumino/coreutils';
 import { IDisposable } from '@lumino/disposable';

--- a/packages/codeeditor/src/jsoneditor.ts
+++ b/packages/codeeditor/src/jsoneditor.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { IObservableJSON } from '@jupyterlab/observables';
-import { ISharedText, SourceChange } from '@jupyter-notebook/ydoc';
+import { ISharedText, SourceChange } from '@jupyter/ydoc';
 import {
   ITranslator,
   nullTranslator,

--- a/packages/codeeditor/test/editor.spec.ts
+++ b/packages/codeeditor/test/editor.spec.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { CodeEditor } from '@jupyterlab/codeeditor';
-import { ISharedText, SourceChange, YFile } from '@jupyter-notebook/ydoc';
+import { ISharedText, SourceChange, YFile } from '@jupyter/ydoc';
 
 describe('CodeEditor.Model', () => {
   let model: CodeEditor.Model;

--- a/packages/codeeditor/test/widget.spec.ts
+++ b/packages/codeeditor/test/widget.spec.ts
@@ -3,7 +3,7 @@
 
 import { CodeEditor, CodeEditorWrapper } from '@jupyterlab/codeeditor';
 import { CodeMirrorEditor } from '@jupyterlab/codemirror';
-import { YFile } from '@jupyter-notebook/ydoc';
+import { YFile } from '@jupyter/ydoc';
 import { Message, MessageLoop } from '@lumino/messaging';
 import { Widget } from '@lumino/widgets';
 import { simulate } from 'simulate-event';

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -59,7 +59,7 @@
     "@codemirror/search": "^6.0.0",
     "@codemirror/state": "^6.0.0",
     "@codemirror/view": "^6.0.0",
-    "@jupyter-notebook/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.0",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.16",
     "@jupyterlab/coreutils": "^6.0.0-alpha.16",
     "@jupyterlab/documentsearch": "^4.0.0-alpha.16",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -59,7 +59,7 @@
     "@codemirror/search": "^6.0.0",
     "@codemirror/state": "^6.0.0",
     "@codemirror/view": "^6.0.0",
-    "@jupyter/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.2",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.16",
     "@jupyterlab/coreutils": "^6.0.0-alpha.16",
     "@jupyterlab/documentsearch": "^4.0.0-alpha.16",

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -6,7 +6,7 @@
 
 import { CodeEditor } from '@jupyterlab/codeeditor';
 import { ICollaborator, IObservableMap } from '@jupyterlab/observables';
-import { IYText } from '@jupyter-notebook/ydoc';
+import { IYText } from '@jupyter/ydoc';
 import {
   ITranslator,
   nullTranslator,

--- a/packages/codemirror/test/editor.spec.ts
+++ b/packages/codemirror/test/editor.spec.ts
@@ -3,7 +3,7 @@
 
 import { CodeEditor } from '@jupyterlab/codeeditor';
 import { CodeMirrorEditor } from '@jupyterlab/codemirror';
-import { YFile } from '@jupyter-notebook/ydoc';
+import { YFile } from '@jupyter/ydoc';
 import { generate, simulate } from 'simulate-event';
 
 const UP_ARROW = 38;

--- a/packages/codemirror/test/factory.spec.ts
+++ b/packages/codemirror/test/factory.spec.ts
@@ -6,7 +6,7 @@ import {
   CodeMirrorEditor,
   CodeMirrorEditorFactory
 } from '@jupyterlab/codemirror';
-import { YFile } from '@jupyter-notebook/ydoc';
+import { YFile } from '@jupyter/ydoc';
 
 import { indentSelection } from '@codemirror/commands';
 

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -44,7 +44,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter-notebook/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.0",
     "@jupyterlab/apputils": "^4.0.0-alpha.16",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.16",
     "@jupyterlab/coreutils": "^6.0.0-alpha.16",

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -44,7 +44,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.2",
     "@jupyterlab/apputils": "^4.0.0-alpha.16",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.16",
     "@jupyterlab/coreutils": "^6.0.0-alpha.16",

--- a/packages/completer/src/connectorproxy.ts
+++ b/packages/completer/src/connectorproxy.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { SourceChange } from '@jupyter-notebook/ydoc';
+import { SourceChange } from '@jupyter/ydoc';
 import { CompletionHandler } from './handler';
 import {
   ICompletionContext,

--- a/packages/completer/src/default/kernelprovider.ts
+++ b/packages/completer/src/default/kernelprovider.ts
@@ -3,7 +3,7 @@
 
 import { Text } from '@jupyterlab/coreutils';
 import { KernelMessage } from '@jupyterlab/services';
-import { SourceChange } from '@jupyter-notebook/ydoc';
+import { SourceChange } from '@jupyter/ydoc';
 import { JSONObject } from '@lumino/coreutils';
 import { CompletionHandler } from '../handler';
 import { ICompletionContext, ICompletionProvider } from '../tokens';

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -3,7 +3,7 @@
 
 import { CodeEditor } from '@jupyterlab/codeeditor';
 import { Text } from '@jupyterlab/coreutils';
-import { ISharedText, SourceChange } from '@jupyter-notebook/ydoc';
+import { ISharedText, SourceChange } from '@jupyter/ydoc';
 import { IDataConnector } from '@jupyterlab/statedb';
 import { LabIcon } from '@jupyterlab/ui-components';
 import { ReadonlyJSONObject } from '@lumino/coreutils';

--- a/packages/completer/src/tokens.ts
+++ b/packages/completer/src/tokens.ts
@@ -4,7 +4,7 @@
 import { ISanitizer } from '@jupyterlab/apputils';
 import { CodeEditor } from '@jupyterlab/codeeditor';
 import { Session } from '@jupyterlab/services';
-import { SourceChange } from '@jupyter-notebook/ydoc';
+import { SourceChange } from '@jupyter/ydoc';
 import { Token } from '@lumino/coreutils';
 import { ISignal } from '@lumino/signaling';
 import { Widget } from '@lumino/widgets';

--- a/packages/completer/test/handler.spec.ts
+++ b/packages/completer/test/handler.spec.ts
@@ -10,7 +10,7 @@ import {
   CompletionHandler,
   ConnectorProxy
 } from '@jupyterlab/completer';
-import { ISharedText, SourceChange, YFile } from '@jupyter-notebook/ydoc';
+import { ISharedText, SourceChange, YFile } from '@jupyter/ydoc';
 import { createSessionContext } from '@jupyterlab/testutils';
 
 function createEditorWidget(): CodeEditorWrapper {

--- a/packages/completer/test/manager.spec.ts
+++ b/packages/completer/test/manager.spec.ts
@@ -16,7 +16,7 @@ import {
 import { Context } from '@jupyterlab/docregistry';
 import { INotebookModel, NotebookModelFactory } from '@jupyterlab/notebook';
 import { ServiceManager } from '@jupyterlab/services';
-import { createStandaloneCell } from '@jupyter-notebook/ydoc';
+import { createStandaloneCell } from '@jupyter/ydoc';
 
 import { createSessionContext } from '@jupyterlab/testutils';
 import { NBTestUtils } from '@jupyterlab/testutils';

--- a/packages/completer/test/widget.spec.ts
+++ b/packages/completer/test/widget.spec.ts
@@ -8,7 +8,7 @@ import {
   CompleterModel,
   CompletionHandler
 } from '@jupyterlab/completer';
-import { YFile } from '@jupyter-notebook/ydoc';
+import { YFile } from '@jupyter/ydoc';
 import { framePromise, sleep } from '@jupyterlab/testutils';
 import { Message, MessageLoop } from '@lumino/messaging';
 import { Panel, Widget } from '@lumino/widgets';

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -42,7 +42,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter-notebook/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.0",
     "@jupyterlab/apputils": "^4.0.0-alpha.16",
     "@jupyterlab/cells": "^4.0.0-alpha.16",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.16",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -42,7 +42,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.2",
     "@jupyterlab/apputils": "^4.0.0-alpha.16",
     "@jupyterlab/cells": "^4.0.0-alpha.16",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.16",

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -19,7 +19,7 @@ import * as nbformat from '@jupyterlab/nbformat';
 import { IObservableList, ObservableList } from '@jupyterlab/observables';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { KernelMessage } from '@jupyterlab/services';
-import { createStandaloneCell, ISharedRawCell } from '@jupyter-notebook/ydoc';
+import { createStandaloneCell, ISharedRawCell } from '@jupyter/ydoc';
 import { JSONObject, MimeData } from '@lumino/coreutils';
 import { Drag } from '@lumino/dragdrop';
 import { Message } from '@lumino/messaging';

--- a/packages/console/test/history.spec.ts
+++ b/packages/console/test/history.spec.ts
@@ -5,7 +5,7 @@ import { ISessionContext } from '@jupyterlab/apputils';
 import { CodeEditor } from '@jupyterlab/codeeditor';
 import { CodeMirrorEditor } from '@jupyterlab/codemirror';
 import { KernelMessage } from '@jupyterlab/services';
-import { createStandaloneCell } from '@jupyter-notebook/ydoc';
+import { createStandaloneCell } from '@jupyter/ydoc';
 import { createSessionContext, signalToPromise } from '@jupyterlab/testutils';
 import { ConsoleHistory } from '../src';
 

--- a/packages/console/test/widget.spec.ts
+++ b/packages/console/test/widget.spec.ts
@@ -8,7 +8,7 @@ import {
   RawCell,
   RawCellModel
 } from '@jupyterlab/cells';
-import { createStandaloneCell, YCodeCell } from '@jupyter-notebook/ydoc';
+import { createStandaloneCell, YCodeCell } from '@jupyter/ydoc';
 import { createSessionContext, NBTestUtils } from '@jupyterlab/testutils';
 import { Message, MessageLoop } from '@lumino/messaging';
 import { Widget } from '@lumino/widgets';

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@codemirror/state": "^6.0.0",
     "@codemirror/view": "^6.0.0",
-    "@jupyter-notebook/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.0",
     "@jupyterlab/application": "^4.0.0-alpha.16",
     "@jupyterlab/apputils": "^4.0.0-alpha.16",
     "@jupyterlab/cells": "^4.0.0-alpha.16",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@codemirror/state": "^6.0.0",
     "@codemirror/view": "^6.0.0",
-    "@jupyter/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.2",
     "@jupyterlab/application": "^4.0.0-alpha.16",
     "@jupyterlab/apputils": "^4.0.0-alpha.16",
     "@jupyterlab/cells": "^4.0.0-alpha.16",

--- a/packages/debugger/src/handlers/editor.ts
+++ b/packages/debugger/src/handlers/editor.ts
@@ -11,7 +11,7 @@ import { IDisposable } from '@lumino/disposable';
 
 import { Signal } from '@lumino/signaling';
 
-import { ISharedText, SourceChange } from '@jupyter-notebook/ydoc';
+import { ISharedText, SourceChange } from '@jupyter/ydoc';
 
 import {
   Compartment,

--- a/packages/debugger/src/tokens.ts
+++ b/packages/debugger/src/tokens.ts
@@ -5,7 +5,7 @@ import { CodeEditor, CodeEditorWrapper } from '@jupyterlab/codeeditor';
 
 import { KernelMessage, Session } from '@jupyterlab/services';
 
-import { ISharedText } from '@jupyter-notebook/ydoc';
+import { ISharedText } from '@jupyter/ydoc';
 
 import { ReadonlyJSONObject, Token } from '@lumino/coreutils';
 

--- a/packages/docprovider-extension/package.json
+++ b/packages/docprovider-extension/package.json
@@ -34,7 +34,7 @@
     "watch": "tsc -w --listEmittedFiles"
   },
   "dependencies": {
-    "@jupyter-notebook/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.0",
     "@jupyterlab/application": "^4.0.0-alpha.16",
     "@jupyterlab/coreutils": "^6.0.0-alpha.16",
     "@jupyterlab/docprovider": "^4.0.0-alpha.16",

--- a/packages/docprovider-extension/package.json
+++ b/packages/docprovider-extension/package.json
@@ -34,7 +34,7 @@
     "watch": "tsc -w --listEmittedFiles"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.2",
     "@jupyterlab/application": "^4.0.0-alpha.16",
     "@jupyterlab/coreutils": "^6.0.0-alpha.16",
     "@jupyterlab/docprovider": "^4.0.0-alpha.16",

--- a/packages/docprovider-extension/src/index.ts
+++ b/packages/docprovider-extension/src/index.ts
@@ -17,7 +17,7 @@ import {
   WebSocketProvider
 } from '@jupyterlab/docprovider';
 import { ServerConnection } from '@jupyterlab/services';
-import { DocumentChange, YDocument } from '@jupyter-notebook/ydoc';
+import { DocumentChange, YDocument } from '@jupyter/ydoc';
 
 /**
  * The default document provider plugin

--- a/packages/docprovider/package.json
+++ b/packages/docprovider/package.json
@@ -38,7 +38,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter-notebook/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.0",
     "@jupyterlab/coreutils": "^6.0.0-alpha.16",
     "@jupyterlab/services": "^7.0.0-alpha.16",
     "@lumino/coreutils": "^2.0.0-alpha.6",

--- a/packages/docprovider/package.json
+++ b/packages/docprovider/package.json
@@ -38,7 +38,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.2",
     "@jupyterlab/coreutils": "^6.0.0-alpha.16",
     "@jupyterlab/services": "^7.0.0-alpha.16",
     "@lumino/coreutils": "^2.0.0-alpha.6",

--- a/packages/docprovider/src/tokens.ts
+++ b/packages/docprovider/src/tokens.ts
@@ -3,7 +3,7 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-import { ISharedDocument } from '@jupyter-notebook/ydoc';
+import { ISharedDocument } from '@jupyter/ydoc';
 import { Token } from '@lumino/coreutils';
 import { IDisposable } from '@lumino/disposable';
 

--- a/packages/docprovider/src/yprovider.ts
+++ b/packages/docprovider/src/yprovider.ts
@@ -5,7 +5,7 @@
 
 import { URLExt } from '@jupyterlab/coreutils';
 import { ServerConnection, User } from '@jupyterlab/services';
-import { DocumentChange, YDocument } from '@jupyter-notebook/ydoc';
+import { DocumentChange, YDocument } from '@jupyter/ydoc';
 import { PromiseDelegate } from '@lumino/coreutils';
 import { Signal } from '@lumino/signaling';
 import { Awareness } from 'y-protocols/awareness';

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -41,7 +41,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.2",
     "@jupyterlab/apputils": "^4.0.0-alpha.16",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.16",
     "@jupyterlab/codemirror": "^4.0.0-alpha.16",

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -41,7 +41,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter-notebook/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.0",
     "@jupyterlab/apputils": "^4.0.0-alpha.16",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.16",
     "@jupyterlab/codemirror": "^4.0.0-alpha.16",

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -23,7 +23,7 @@ import {
   ServerConnection,
   ServiceManager
 } from '@jupyterlab/services';
-import { DocumentChange, ISharedDocument } from '@jupyter-notebook/ydoc';
+import { DocumentChange, ISharedDocument } from '@jupyter/ydoc';
 import {
   ITranslator,
   nullTranslator,

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -11,7 +11,7 @@ import {
   DocumentChange,
   FileChange,
   ISharedFile
-} from '@jupyter-notebook/ydoc';
+} from '@jupyter/ydoc';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { PartialJSONValue } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -7,11 +7,7 @@ import { Mode } from '@jupyterlab/codemirror';
 import { IChangedArgs, PathExt } from '@jupyterlab/coreutils';
 import { IObservableList } from '@jupyterlab/observables';
 import { Contents } from '@jupyterlab/services';
-import {
-  DocumentChange,
-  FileChange,
-  ISharedFile
-} from '@jupyter/ydoc';
+import { DocumentChange, FileChange, ISharedFile } from '@jupyter/ydoc';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { PartialJSONValue } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -10,7 +10,7 @@ import {
 import { IObservableList } from '@jupyterlab/observables';
 import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 import { Contents, Kernel } from '@jupyterlab/services';
-import { ISharedDocument, ISharedFile } from '@jupyter-notebook/ydoc';
+import { ISharedDocument, ISharedFile } from '@jupyter/ydoc';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import {
   fileIcon,

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -41,7 +41,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter-notebook/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.0",
     "@jupyterlab/apputils": "^4.0.0-alpha.16",
     "@jupyterlab/cells": "^4.0.0-alpha.16",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.16",

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -41,7 +41,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.2",
     "@jupyterlab/apputils": "^4.0.0-alpha.16",
     "@jupyterlab/cells": "^4.0.0-alpha.16",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.16",

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -20,7 +20,7 @@ import {
 import { signalToPromise } from '@jupyterlab/coreutils';
 import * as nbformat from '@jupyterlab/nbformat';
 import { KernelMessage } from '@jupyterlab/services';
-import { ISharedAttachmentsCell } from '@jupyter-notebook/ydoc';
+import { ISharedAttachmentsCell } from '@jupyter/ydoc';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { every, findIndex } from '@lumino/algorithm';
 import { JSONExt, JSONObject } from '@lumino/coreutils';

--- a/packages/notebook/src/celllist.ts
+++ b/packages/notebook/src/celllist.ts
@@ -16,7 +16,7 @@ import {
   ISharedNotebook,
   ISharedRawCell,
   NotebookChange
-} from '@jupyter-notebook/ydoc';
+} from '@jupyter/ydoc';
 import { ISignal, Signal } from '@lumino/signaling';
 
 /**

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -12,7 +12,7 @@ import {
   ISharedNotebook,
   NotebookChange,
   YNotebook
-} from '@jupyter-notebook/ydoc';
+} from '@jupyter/ydoc';
 import {
   ITranslator,
   nullTranslator,

--- a/packages/notebook/src/notebooktools.ts
+++ b/packages/notebook/src/notebooktools.ts
@@ -11,7 +11,7 @@ import { CodeEditor, JSONEditor } from '@jupyterlab/codeeditor';
 import { Mode } from '@jupyterlab/codemirror';
 import * as nbformat from '@jupyterlab/nbformat';
 import { ObservableJSON } from '@jupyterlab/observables';
-import { IMapChange, ISharedText } from '@jupyter-notebook/ydoc';
+import { IMapChange, ISharedText } from '@jupyter/ydoc';
 import {
   ITranslator,
   nullTranslator,

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -16,7 +16,7 @@ import { IChangedArgs, PageConfig } from '@jupyterlab/coreutils';
 import * as nbformat from '@jupyterlab/nbformat';
 import { IObservableList } from '@jupyterlab/observables';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
-import type { IMapChange } from '@jupyter-notebook/ydoc';
+import type { IMapChange } from '@jupyter/ydoc';
 import { TableOfContentsUtils } from '@jupyterlab/toc';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { WindowedList } from '@jupyterlab/ui-components';

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -6,7 +6,7 @@ import { CodeCell, MarkdownCell, RawCell } from '@jupyterlab/cells';
 import { CodeEditor } from '@jupyterlab/codeeditor';
 import { CellType, IMimeBundle } from '@jupyterlab/nbformat';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
-import { ISharedCodeCell } from '@jupyter-notebook/ydoc';
+import { ISharedCodeCell } from '@jupyter/ydoc';
 import {
   acceptDialog,
   createSessionContext,

--- a/testutils/src/jest-config.ts
+++ b/testutils/src/jest-config.ts
@@ -7,7 +7,7 @@ import path from 'path';
 
 const esModules = [
   '@codemirror',
-  '@jupyter-notebook/ydoc',
+  '@jupyter/ydoc',
   'lib0',
   'vscode-ws-jsonrpc',
   'y-protocols',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1424,10 +1424,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@jupyter-notebook/ydoc@~0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@jupyter-notebook/ydoc/-/ydoc-0.2.0.tgz#0febf91cd80dd2206f668c60e8ee20f4983cca99"
-  integrity sha512-R8iHKwU+8OvdYwtgNj9dh3vv0OrAyHLNDmXjaSu6CJ1w10OP7MuQasvD18DAgTjqlHEUgnPoSJA2j0UlflSC1Q==
+"@jupyter/ydoc@~0.2.0":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@jupyter/ydoc/-/ydoc-0.2.2.tgz#a2be83d2a0e076cef7ed77302e69153a0a4d6c16"
+  integrity sha512-UtU7ZxpL0k+QF9So4wtGxaS2C+nno58dig7sQUaBn48wlQDiuypzKgUmF7I37srpu6f/ywon3JBuEjxuL1CIBQ==
   dependencies:
     "@jupyterlab/nbformat" "^3.0.0 || ^4.0.0-alpha.15"
     "@lumino/coreutils" "^1.11.0 || ^2.0.0-alpha.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1424,7 +1424,7 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@jupyter/ydoc@~0.2.0":
+"@jupyter/ydoc@~0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@jupyter/ydoc/-/ydoc-0.2.2.tgz#a2be83d2a0e076cef7ed77302e69153a0a4d6c16"
   integrity sha512-UtU7ZxpL0k+QF9So4wtGxaS2C+nno58dig7sQUaBn48wlQDiuypzKgUmF7I37srpu6f/ywon3JBuEjxuL1CIBQ==


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyter-server/jupyter_ydoc/pull/97

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Depend on `jupyter/ydoc` instead of `jupyter-notebook/ydoc` now that the package has been renamed and published.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

A different package will be in the shared scope, but this should only affect alpha releases of 4.0 and 3.6.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
