### PR TITLE
Fix Python test dependencies

### DIFF
--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -79,7 +79,7 @@ jobs:
 
   test_minimum_versions:
     name: Test Minimum Versions
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -79,7 +79,7 @@ jobs:
 
   test_minimum_versions:
     name: Test Minimum Versions
-    timeout-minutes: 60
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/conftest.py
+++ b/conftest.py
@@ -6,7 +6,7 @@
 import pytest
 
 pytest_plugins = [
-    "jupyter_server.pytest_plugin",
+    "pytest_jupyter.jupyter_server",
     "jupyterlab_server.pytest_plugin",
     "jupyterlab.pytest_plugin",
 ]

--- a/jupyterlab/pytest_plugin.py
+++ b/jupyterlab/pytest_plugin.py
@@ -96,7 +96,7 @@ def labapp(jp_serverapp, make_lab_app):
 
 
 @pytest.fixture
-def fetch_long(http_server_client, jp_auth_header, jp_base_url):
+def fetch_long(jp_http_server_client, jp_auth_header, jp_base_url):
     """fetch fixture that handles auth, base_url, and path"""
 
     def client_fetch(*parts, headers=None, params=None, **kwargs):
@@ -109,6 +109,6 @@ def fetch_long(http_server_client, jp_auth_header, jp_base_url):
         headers = headers or {}
         headers.update(jp_auth_header)
         # Make request.
-        return http_server_client.fetch(url, headers=headers, request_timeout=250, **kwargs)
+        return jp_http_server_client.fetch(url, headers=headers, request_timeout=250, **kwargs)
 
     return client_fetch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ test = [
     "pytest-check-links>=0.7",
     "pytest-console-scripts",
     "pytest-cov",
-    "pytest-jupyter[server]",
+    "pytest-jupyter",
     "pytest-timeout",
     "pytest-tornasync",
     "requests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ test = [
     "pytest-check-links>=0.7",
     "pytest-console-scripts",
     "pytest-cov",
+    "pytest-jupyter[server]",
     "pytest-timeout",
     "pytest-tornasync",
     "requests",
@@ -111,7 +112,6 @@ test = [
     "virtualenv",
 ]
 dev = ["build", "pre-commit", "pytest-cov", "coverage", "hatch", "bump2version"]
-ui-tests = ["build"]
 
 [tool.hatch.version]
 path = "jupyterlab/_version.py"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Pytest fixtures for Jupyter are now part of a separate package [pytest-jupyter](https://github.com/jupyter-server/pytest-jupyter).
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Add the new test dependency
Remove unused `ui-tests` optional group dependency

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A