### PR TITLE
Sets whether the model is collaborative or not when registering its factory

### DIFF
--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -201,6 +201,13 @@ export class DocumentModel
  */
 export class TextModelFactory implements DocumentRegistry.CodeModelFactory {
   /**
+   * Instantiates a TextModelFactory.
+   */
+  constructor(collaborative?: boolean) {
+    this._collaborative = collaborative ?? true;
+  }
+
+  /**
    * The name of the model type.
    *
    * #### Notes
@@ -230,6 +237,13 @@ export class TextModelFactory implements DocumentRegistry.CodeModelFactory {
   }
 
   /**
+   * Whether the model is collaborative or not.
+   */
+  get collaborative(): boolean {
+    return this._collaborative;
+  }
+
+  /**
    * Get whether the model factory has been disposed.
    */
   get isDisposed(): boolean {
@@ -256,7 +270,8 @@ export class TextModelFactory implements DocumentRegistry.CodeModelFactory {
     languagePreference?: string,
     collaborationEnabled?: boolean
   ): DocumentRegistry.ICodeModel {
-    return new DocumentModel(languagePreference, collaborationEnabled);
+    const collaborative = collaborationEnabled && this.collaborative;
+    return new DocumentModel(languagePreference, collaborative);
   }
 
   /**
@@ -268,6 +283,7 @@ export class TextModelFactory implements DocumentRegistry.CodeModelFactory {
   }
 
   private _isDisposed = false;
+  private _collaborative: boolean;
 }
 
 /**

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -49,7 +49,7 @@ export class DocumentRegistry implements IDisposable {
     if (factory && factory.name !== 'text') {
       throw new Error('Text model factory must have the name `text`');
     }
-    this._modelFactories['text'] = factory || new TextModelFactory();
+    this._modelFactories['text'] = factory || new TextModelFactory(true);
 
     const fts =
       options.initialFileTypes ||
@@ -1169,6 +1169,11 @@ export namespace DocumentRegistry {
      * The format of the file (defaults to `"text"`).
      */
     readonly fileFormat: Contents.FileFormat;
+
+    /**
+     * Whether the model is collaborative or not.
+     */
+    readonly collaborative?: boolean;
 
     /**
      * Create a new model for a given path.

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1519,7 +1519,8 @@ function activateNotebookHandler(
   const registry = app.docRegistry;
   const modelFactory = new NotebookModelFactory({
     disableDocumentWideUndoRedo:
-      factory.notebookConfig.disableDocumentWideUndoRedo
+      factory.notebookConfig.disableDocumentWideUndoRedo,
+    collaborative: true
   });
   registry.addModelFactory(modelFactory);
 

--- a/packages/notebook/src/modelfactory.ts
+++ b/packages/notebook/src/modelfactory.ts
@@ -17,6 +17,7 @@ export class NotebookModelFactory
   constructor(options: NotebookModelFactory.IOptions) {
     this._disableDocumentWideUndoRedo =
       options.disableDocumentWideUndoRedo || false;
+    this._collaborative = options.collaborative ?? true;
   }
 
   /**
@@ -48,6 +49,13 @@ export class NotebookModelFactory
   }
 
   /**
+   * Whether the model is collaborative or not.
+   */
+  get collaborative(): boolean {
+    return this._collaborative;
+  }
+
+  /**
    * Get whether the model factory has been disposed.
    */
   get isDisposed(): boolean {
@@ -74,7 +82,7 @@ export class NotebookModelFactory
   ): INotebookModel {
     return new NotebookModel({
       languagePreference,
-      collaborationEnabled,
+      collaborationEnabled: collaborationEnabled && this.collaborative,
       disableDocumentWideUndoRedo: this._disableDocumentWideUndoRedo
     });
   }
@@ -91,6 +99,7 @@ export class NotebookModelFactory
    */
   private _disableDocumentWideUndoRedo: boolean;
   private _disposed = false;
+  private _collaborative: boolean;
 }
 
 /**
@@ -101,6 +110,11 @@ export namespace NotebookModelFactory {
    * The options used to initialize a NotebookModelFactory.
    */
   export interface IOptions {
+    /**
+     * Whether the model is collaborative or not.
+     */
+    collaborative?: boolean;
+
     /**
      * Defines if the document can be undo/redo.
      */


### PR DESCRIPTION
Follow-up #13458 

Hi @dlqqq, @ellisonbg and @fcollonval .

I like the idea of specifying whether the document is collaborative or not. Furthermore, I believe we should make it more robust by setting it as collaborative when registering the model factory.

## References

## Code changes

## User-facing changes

## Backwards-incompatible changes
