### PR TITLE
Fixes using custom drives in RTC

### DIFF
--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -68,11 +68,11 @@ export class Context<
 
     this._model = this._factory.createNew(
       lang,
-      PageConfig.getOption('collaborative') === 'true'
-      //sharedModel ?? undefined
+      PageConfig.getOption('collaborative') === 'true',
+      sharedModel
     );
 
-    // TODO: remove for v4.0
+    // TODO: remove for v4.0?
     if (!sharedModel && options.docProviderFactory) {
       this._provider = options.docProviderFactory({
         path: this._path,
@@ -106,6 +106,7 @@ export class Context<
       path: this._path,
       contents: manager.contents
     });
+
     this.model.sharedModel.setState('path', this._path);
     this.model.sharedModel.changed.connect(this.onStateChanged, this);
   }
@@ -217,12 +218,6 @@ export class Context<
     this._model.dispose();
     this._provider.dispose();
     this._model.sharedModel.dispose();
-    if (this._manager.contents.close) {
-      this._manager.contents.close(this._path, {
-        type: this._factory.contentType,
-        format: this._factory.fileFormat
-      });
-    }
     this._disposed.emit(void 0);
     Signal.clearData(this);
   }
@@ -595,7 +590,8 @@ export class Context<
   private async _save(): Promise<void> {
     // if collaborative mode is enabled, saving happens in the back-end
     // after each change to the document
-    if (this._model.collaborative) {
+    const drive = this._manager.contents.driveName(this._path);
+    if (drive == '' && this._model.collaborative) {
       return;
     }
     this._saveState.emit('started');

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -24,8 +24,12 @@ export class DocumentModel
   /**
    * Construct a new document model.
    */
-  constructor(languagePreference?: string, collaborationEnabled?: boolean) {
-    super();
+  constructor(
+    languagePreference?: string,
+    collaborationEnabled?: boolean,
+    sharedModel?: ISharedFile
+  ) {
+    super({ sharedModel });
     this._defaultLang = languagePreference || '';
     this.sharedModel.changed.connect(this._onStateChanged, this);
     this._collaborationEnabled = !!collaborationEnabled;
@@ -254,9 +258,14 @@ export class TextModelFactory implements DocumentRegistry.CodeModelFactory {
    */
   createNew(
     languagePreference?: string,
-    collaborationEnabled?: boolean
+    collaborationEnabled?: boolean,
+    sharedModel?: ISharedFile
   ): DocumentRegistry.ICodeModel {
-    return new DocumentModel(languagePreference, collaborationEnabled);
+    return new DocumentModel(
+      languagePreference,
+      collaborationEnabled,
+      sharedModel
+    );
   }
 
   /**

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1177,7 +1177,11 @@ export namespace DocumentRegistry {
      *
      * @returns A new document model.
      */
-    createNew(languagePreference?: string, collaborationEnabled?: boolean): T;
+    createNew(
+      languagePreference?: string,
+      collaborationEnabled?: boolean,
+      sharedModel?: ISharedDocument
+    ): T;
 
     /**
      * Get the preferred kernel language given a file path.

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -101,9 +101,12 @@ export class NotebookModel implements INotebookModel {
    * Construct a new notebook model.
    */
   constructor(options: NotebookModel.IOptions = {}) {
-    const sharedModel = (this.sharedModel = new YNotebook({
-      disableDocumentWideUndoRedo: options.disableDocumentWideUndoRedo ?? false
-    }));
+    this.sharedModel =
+      options.sharedModel ??
+      new YNotebook({
+        disableDocumentWideUndoRedo:
+          options.disableDocumentWideUndoRedo ?? false
+      });
     this._cells = new CellList(this.sharedModel);
     this._trans = (options.translator || nullTranslator).load('jupyterlab');
     this._deletedCells = [];
@@ -112,6 +115,7 @@ export class NotebookModel implements INotebookModel {
     // Initialize the notebook
     // In collaboration mode, this will be overridden by the initialization coming
     // from the document provider.
+    const sharedModel = this.sharedModel as YNotebook;
     sharedModel.nbformat_minor = nbformat.MINOR_VERSION;
     sharedModel.nbformat = nbformat.MAJOR_VERSION;
     this._ensureMetadata(options.languagePreference ?? '');
@@ -520,5 +524,10 @@ export namespace NotebookModel {
      * Whether collaboration should be enabled for this document model.
      */
     collaborationEnabled?: boolean;
+
+    /**
+     * The shared document model.
+     */
+    sharedModel?: ISharedNotebook;
   }
 }

--- a/packages/notebook/src/modelfactory.ts
+++ b/packages/notebook/src/modelfactory.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import { ISharedNotebook } from '@jupyter/ydoc';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { Contents } from '@jupyterlab/services';
 import { INotebookModel, NotebookModel } from './model';
@@ -70,11 +71,13 @@ export class NotebookModelFactory
    */
   createNew(
     languagePreference?: string,
-    collaborationEnabled?: boolean
+    collaborationEnabled?: boolean,
+    sharedModel?: ISharedNotebook
   ): INotebookModel {
     return new NotebookModel({
       languagePreference,
       collaborationEnabled,
+      sharedModel,
       disableDocumentWideUndoRedo: this._disableDocumentWideUndoRedo
     });
   }

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -46,6 +46,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
+    "@jupyter/ydoc": "~0.2.2",
     "@jupyterlab/coreutils": "^6.0.0-alpha.16",
     "@jupyterlab/nbformat": "^4.0.0-alpha.16",
     "@jupyterlab/settingregistry": "^4.0.0-alpha.16",

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -3,8 +3,6 @@
 
 import { PathExt, URLExt } from '@jupyterlab/coreutils';
 
-import { ISharedDocument } from '@jupyter/ydoc';
-
 import { PartialJSONObject } from '@lumino/coreutils';
 
 import { IDisposable } from '@lumino/disposable';
@@ -137,21 +135,6 @@ export namespace Contents {
    * The options used to open a file.
    */
   export interface IOpenOptions {
-    /**
-     * The override file type for the request.
-     */
-    type: ContentType;
-
-    /**
-     * The override file format for the request.
-     */
-    format: FileFormat;
-  }
-
-  /**
-   * The options used to close a file.
-   */
-  export interface ICloseOptions {
     /**
      * The override file type for the request.
      */
@@ -322,17 +305,12 @@ export namespace Contents {
      * @param options: The options used to open the file.
      *
      * @returns A promise which resolves with the file content.
-     */
-    open?(path: string, options: Contents.IOpenOptions): ISharedDocument | void;
-
-    /**
-     * Close a file.
      *
-     * @param path: The path to the file.
-     *
-     * @returns A promise which resolves with the file content.
+     * Note: This is useful in real-time collaboration when the retrieval
+     * of the information goes through web sockets.
+     * This method can be use to stablish the connection.
      */
-    close?(path: string, options: Contents.ICloseOptions): Promise<void>;
+    open?(path: string, options: IOpenOptions): any;
 
     /**
      * Get a file or directory.
@@ -483,17 +461,12 @@ export namespace Contents {
      * @param options: The options used to open the file.
      *
      * @returns A promise which resolves with the file content.
-     */
-    open?(path: string, options: Contents.IOpenOptions): ISharedDocument | void;
-
-    /**
-     * Close a file.
      *
-     * @param path: The path to the file.
-     *
-     * @returns A promise which resolves with the file content.
+     * Note: This is useful in real-time collaboration when the retrieval
+     * of the information goes through web sockets.
+     * This method can be use to stablish the connection.
      */
-    close?(path: string, options: Contents.ICloseOptions): Promise<void>;
+    open?(path: string, options: IOpenOptions): any;
 
     /**
      * Get a file or directory.
@@ -756,30 +729,17 @@ export class ContentsManager implements Contents.IManager {
    * @param options: The options used to open the file.
    *
    * @returns A promise which resolves with the file content.
+   *
+   * Note: This is useful in real-time collaboration when the retrieval
+   * of the information goes through web sockets.
+   * This method can be use to stablish the connection.
    */
-  open(path: string, options: Contents.IOpenOptions): ISharedDocument | void {
+  open?(path: string, options: Contents.IOpenOptions): any {
     const [drive, localPath] = this._driveForPath(path);
     if (drive.open) {
       return drive.open(localPath, options);
     }
     return;
-  }
-
-  /**
-   * Close a file.
-   *
-   * @param path: The path to the file.
-   *
-   * @returns A promise which resolves with the file content.
-   */
-  close(path: string, options: Contents.ICloseOptions): Promise<void> {
-    const [drive, localPath] = this._driveForPath(path);
-    if (drive.close) {
-      return drive.close(localPath, options);
-    }
-    return Promise.reject(
-      `The current drive ${drive.name} doesn't support close.`
-    );
   }
 
   /**
@@ -1146,22 +1106,14 @@ export class Drive implements Contents.IDrive {
    * @param options: The options used to open the file.
    *
    * @returns A promise which resolves with the file content.
+   *
+   * Note: This is useful in real-time collaboration when the retrieval
+   * of the information goes through web sockets.
+   * This method can be use to stablish the connection.
    */
-  open(path: string, options: Contents.IOpenOptions): ISharedDocument | void {
-    // NO-OP
+  open?(path: string, options: Contents.IOpenOptions): any {
+    // NO OP
     return;
-  }
-
-  /**
-   * Close a file.
-   *
-   * @param path: The path to the file.
-   *
-   * @returns A promise which resolves with the file content.
-   */
-  close(path: string, options: Contents.ICloseOptions): Promise<void> {
-    // NO-OP
-    return Promise.resolve();
   }
 
   /**

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -3,6 +3,8 @@
 
 import { PathExt, URLExt } from '@jupyterlab/coreutils';
 
+import { ISharedDocument } from '@jupyter/ydoc';
+
 import { PartialJSONObject } from '@lumino/coreutils';
 
 import { IDisposable } from '@lumino/disposable';
@@ -130,6 +132,36 @@ export namespace Contents {
    * A contents file format.
    */
   export type FileFormat = 'json' | 'text' | 'base64' | null;
+
+  /**
+   * The options used to open a file.
+   */
+  export interface IOpenOptions {
+    /**
+     * The override file type for the request.
+     */
+    type: ContentType;
+
+    /**
+     * The override file format for the request.
+     */
+    format: FileFormat;
+  }
+
+  /**
+   * The options used to close a file.
+   */
+  export interface ICloseOptions {
+    /**
+     * The override file type for the request.
+     */
+    type: ContentType;
+
+    /**
+     * The override file format for the request.
+     */
+    format: FileFormat;
+  }
 
   /**
    * The options used to fetch a file.
@@ -283,6 +315,26 @@ export namespace Contents {
     driveName(path: string): string;
 
     /**
+     * Open a file.
+     *
+     * @param path: The path to the file.
+     *
+     * @param options: The options used to open the file.
+     *
+     * @returns A promise which resolves with the file content.
+     */
+    open?(path: string, options: Contents.IOpenOptions): ISharedDocument | void;
+
+    /**
+     * Close a file.
+     *
+     * @param path: The path to the file.
+     *
+     * @returns A promise which resolves with the file content.
+     */
+    close?(path: string, options: Contents.ICloseOptions): Promise<void>;
+
+    /**
      * Get a file or directory.
      *
      * @param path: The path to the file.
@@ -422,6 +474,26 @@ export namespace Contents {
      * A signal emitted when a file operation takes place.
      */
     fileChanged: ISignal<IDrive, IChangedArgs>;
+
+    /**
+     * Open a file.
+     *
+     * @param path: The path to the file.
+     *
+     * @param options: The options used to open the file.
+     *
+     * @returns A promise which resolves with the file content.
+     */
+    open?(path: string, options: Contents.IOpenOptions): ISharedDocument | void;
+
+    /**
+     * Close a file.
+     *
+     * @param path: The path to the file.
+     *
+     * @returns A promise which resolves with the file content.
+     */
+    close?(path: string, options: Contents.ICloseOptions): Promise<void>;
 
     /**
      * Get a file or directory.
@@ -674,6 +746,40 @@ export class ContentsManager implements Contents.IManager {
       return firstParts[0];
     }
     return '';
+  }
+
+  /**
+   * Open a file.
+   *
+   * @param path: The path to the file.
+   *
+   * @param options: The options used to open the file.
+   *
+   * @returns A promise which resolves with the file content.
+   */
+  open(path: string, options: Contents.IOpenOptions): ISharedDocument | void {
+    const [drive, localPath] = this._driveForPath(path);
+    if (drive.open) {
+      return drive.open(localPath, options);
+    }
+    return;
+  }
+
+  /**
+   * Close a file.
+   *
+   * @param path: The path to the file.
+   *
+   * @returns A promise which resolves with the file content.
+   */
+  close(path: string, options: Contents.ICloseOptions): Promise<void> {
+    const [drive, localPath] = this._driveForPath(path);
+    if (drive.close) {
+      return drive.close(localPath, options);
+    }
+    return Promise.reject(
+      `The current drive ${drive.name} doesn't support close.`
+    );
   }
 
   /**
@@ -1030,6 +1136,32 @@ export class Drive implements Contents.IDrive {
     }
     this._isDisposed = true;
     Signal.clearData(this);
+  }
+
+  /**
+   * Open a file.
+   *
+   * @param path: The path to the file.
+   *
+   * @param options: The options used to open the file.
+   *
+   * @returns A promise which resolves with the file content.
+   */
+  open(path: string, options: Contents.IOpenOptions): ISharedDocument | void {
+    // NO-OP
+    return;
+  }
+
+  /**
+   * Close a file.
+   *
+   * @param path: The path to the file.
+   *
+   * @returns A promise which resolves with the file content.
+   */
+  close(path: string, options: Contents.ICloseOptions): Promise<void> {
+    // NO-OP
+    return Promise.resolve();
   }
 
   /**


### PR DESCRIPTION
Fixes #13203

## References

## Code changes
Improves the Context not to block some of the requests to the contents API in collaborative mode.

## User-facing changes
It will work when installing an extension that registers a new drive in RTC.

## Backwards-incompatible changes
N/A