### PR TITLE
Add copy and paste commands to terminal context menu

### DIFF
--- a/packages/terminal-extension/schema/plugin.json
+++ b/packages/terminal-extension/schema/plugin.json
@@ -4,9 +4,19 @@
   "jupyter.lab.menus": {
     "context": [
       {
-        "command": "terminal:refresh",
+        "command": "terminal:copy",
         "selector": ".jp-Terminal",
         "rank": 1
+      },
+      {
+        "command": "terminal:paste",
+        "selector": ".jp-Terminal",
+        "rank": 2
+      },
+      {
+        "command": "terminal:refresh",
+        "selector": ".jp-Terminal",
+        "rank": 3
       }
     ]
   },

--- a/packages/terminal/src/tokens.ts
+++ b/packages/terminal/src/tokens.ts
@@ -44,6 +44,21 @@ export namespace ITerminal {
      * Refresh the terminal session.
      */
     refresh(): Promise<void>;
+
+    /**
+     * Check if terminal has any text selected.
+     */
+    hasSelection(): boolean;
+
+    /**
+     * Paste text into terminal.
+     */
+    paste(data: string): void;
+
+    /**
+     * Get selected text from terminal.
+     */
+    getSelection(): string | null;
   }
   /**
    * Options for the terminal widget.

--- a/packages/terminal/src/widget.ts
+++ b/packages/terminal/src/widget.ts
@@ -199,6 +199,35 @@ export class Terminal extends Widget implements ITerminal.ITerminal {
   }
 
   /**
+   * Check if terminal has any text selected.
+   */
+  hasSelection(): boolean {
+    if (!this.isDisposed) {
+      return this._term.hasSelection();
+    }
+    return false;
+  }
+
+  /**
+   * Paste text into terminal.
+   */
+  paste(data: string): void {
+    if (!this.isDisposed) {
+      return this._term.paste(data);
+    }
+  }
+
+  /**
+   * Get selected text from terminal.
+   */
+  getSelection(): string | null {
+    if (!this.isDisposed) {
+      return this._term.getSelection();
+    }
+    return null;
+  }
+
+  /**
    * Process a message sent to the widget.
    *
    * @param msg - The message sent to the widget.


### PR DESCRIPTION
## References

Closes #3011

Re-uses the same interface to Clipboard API that we use in `FileEditor`'s context menu for over two years now (#8425, JupyterLab 2.2).

## Code changes

- add new methods to `ITerminal` interface: `getSelection`,  `hasSelection` and `paste` following the underlying naming of `xterjm.js` implementation
- implement the new methods in `Terminal` by passing them over to `xterm.js` methods
- add new commands: `terminal:paste` and `terminal:copy`
- add the new commands to context menu

## User-facing changes

- 'Refresh terminal' command now uses refresh icon when in context menu
- 'Copy' and 'Paste' context menu actions added

![Screenshot from 2022-12-04 14-44-37](https://user-images.githubusercontent.com/5832902/205497293-fe3059c0-f463-4d23-893b-3f0088330ab1.png)

When pasting for the first time the browser may (depending on browser/settings) ask for confirmation to allow access to the clipboard:

![Screenshot from 2022-12-04 14-51-32](https://user-images.githubusercontent.com/5832902/205497586-b0367592-e19d-438e-9992-7e50f5607ff9.png)


All the caveats of this not working if browser restricts Clipboard API apply, see [browser compatibility table](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard#browser_compatibility).

<details>

For example, Firefox does not permit copy in non-secure contexts (`https` is ok) and does not allow paste at all. This is also the case for file editor, so this is not new. Ideally we would detect support and disable the command if support is not available but this is tricky for browsers which allow support after user consent.

</details>

## Backwards-incompatible changes

Adds new non-optional methods to the interface.

If would like to backport to 3.6 if time permits, making the new methods optional in backport (but required for 4.0).