### PR TITLE
Automated Changelog Entry for 3.6.0a5 on 3.6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Add lumino with support for plugin deactivation [#13541](https://github.com/jupyterlab/jupyterlab/pull/13541) ([@fcollonval](https://github.com/fcollonval))
 - Sets whether the model is collaborative or not when registering its factory [#13526](https://github.com/jupyterlab/jupyterlab/pull/13526) ([@hbcarlos](https://github.com/hbcarlos))
 - RTC: Move user name to user panel [#13517](https://github.com/jupyterlab/jupyterlab/pull/13517) ([@martinRenou](https://github.com/martinRenou))
-- Backport #13492 on branch 3.6.x (jupyter_server_ydoc>=0.6.0,<0.7.0) [#13499](https://github.com/jupyterlab/jupyterlab/pull/13499) ([@fcollonval](https://github.com/fcollonval))
+- Backport #13492 on branch 3.6.x (jupyter_server_ydoc>=0.6.0,\<0.7.0) [#13499](https://github.com/jupyterlab/jupyterlab/pull/13499) ([@fcollonval](https://github.com/fcollonval))
 - Backport #13433 (Allows to pause the execution during debug) [#13494](https://github.com/jupyterlab/jupyterlab/pull/13494) ([@brichet](https://github.com/brichet))
 - Backport #13267 on branch 3.6.x (Ask confirmation when closing a document) [#13489](https://github.com/jupyterlab/jupyterlab/pull/13489) ([@fcollonval](https://github.com/fcollonval))
 - Backport #12667 on branch 3.6.x (Add events service) [#13465](https://github.com/jupyterlab/jupyterlab/pull/13465) ([@fcollonval](https://github.com/fcollonval))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,11 @@
 - Add lumino with support for plugin deactivation [#13541](https://github.com/jupyterlab/jupyterlab/pull/13541) ([@fcollonval](https://github.com/fcollonval))
 - Sets whether the model is collaborative or not when registering its factory [#13526](https://github.com/jupyterlab/jupyterlab/pull/13526) ([@hbcarlos](https://github.com/hbcarlos))
 - RTC: Move user name to user panel [#13517](https://github.com/jupyterlab/jupyterlab/pull/13517) ([@martinRenou](https://github.com/martinRenou))
-- Backport #13492 on branch 3.6.x (jupyter_server_ydoc>=0.6.0,\<0.7.0) [#13499](https://github.com/jupyterlab/jupyterlab/pull/13499) ([@fcollonval](https://github.com/fcollonval))
-- Backport #13433 (Allows to pause the execution during debug) [#13494](https://github.com/jupyterlab/jupyterlab/pull/13494) ([@brichet](https://github.com/brichet))
-- Backport #13267 on branch 3.6.x (Ask confirmation when closing a document) [#13489](https://github.com/jupyterlab/jupyterlab/pull/13489) ([@fcollonval](https://github.com/fcollonval))
-- Backport #12667 on branch 3.6.x (Add events service) [#13465](https://github.com/jupyterlab/jupyterlab/pull/13465) ([@fcollonval](https://github.com/fcollonval))
-- Backport #13365 on branch 3.6.x (Add announcements) [#13444](https://github.com/jupyterlab/jupyterlab/pull/13444) ([@fcollonval](https://github.com/fcollonval))
+- jupyter_server_ydoc>=0.6.0,\<0.7.0 [#13499](https://github.com/jupyterlab/jupyterlab/pull/13499) ([@fcollonval](https://github.com/fcollonval))
+- Allows to pause the execution during debug [#13494](https://github.com/jupyterlab/jupyterlab/pull/13494) ([@brichet](https://github.com/brichet))
+- Ask confirmation when closing a document [#13489](https://github.com/jupyterlab/jupyterlab/pull/13489) ([@fcollonval](https://github.com/fcollonval))
+- Add events service [#13465](https://github.com/jupyterlab/jupyterlab/pull/13465) ([@fcollonval](https://github.com/fcollonval))
+- Add announcements [#13444](https://github.com/jupyterlab/jupyterlab/pull/13444) ([@fcollonval](https://github.com/fcollonval))
 
 ### Bugs fixed
 
@@ -29,7 +29,7 @@
 - Default `IDocumentProviderFactory.IOptions` generic to ISharedDocument [#13490](https://github.com/jupyterlab/jupyterlab/pull/13490) ([@jtpio](https://github.com/jtpio))
 - Use same key for saving user info in local store [#13482](https://github.com/jupyterlab/jupyterlab/pull/13482) ([@hbcarlos](https://github.com/hbcarlos))
 - Set fallback values for icons colors. [#13468](https://github.com/jupyterlab/jupyterlab/pull/13468) ([@HaudinFlorence](https://github.com/HaudinFlorence))
-- Backport #13458 on branch 3.6.x (Enable document model specific collaboration) [#13480](https://github.com/jupyterlab/jupyterlab/pull/13480) ([@fcollonval](https://github.com/fcollonval))
+- Enable document model specific collaboration [#13480](https://github.com/jupyterlab/jupyterlab/pull/13480) ([@fcollonval](https://github.com/fcollonval))
 - Share attachments [#13450](https://github.com/jupyterlab/jupyterlab/pull/13450) ([@hbcarlos](https://github.com/hbcarlos))
 
 ### Maintenance and upkeep improvements
@@ -37,16 +37,16 @@
 - Bump sanitize-html to 2.7.3 [#13509](https://github.com/jupyterlab/jupyterlab/pull/13509) ([@fcollonval](https://github.com/fcollonval))
 - Depend on `@jupyter/ydoc` instead of `@jupyter-notebook/ydoc` [#13506](https://github.com/jupyterlab/jupyterlab/pull/13506) ([@jtpio](https://github.com/jtpio))
 - Fix Python test dependencies [#13508](https://github.com/jupyterlab/jupyterlab/pull/13508) ([@fcollonval](https://github.com/fcollonval))
-- Backport #13478 on branch 3.6.x (Require jupyter-server-ydoc >=0.5.1) [#13479](https://github.com/jupyterlab/jupyterlab/pull/13479) ([@fcollonval](https://github.com/fcollonval))
+- Require jupyter-server-ydoc >=0.5.1 [#13479](https://github.com/jupyterlab/jupyterlab/pull/13479) ([@fcollonval](https://github.com/fcollonval))
 
 ### Documentation improvements
 
 - Forbid using RTC mode without Jupyter Server v2. [#13472](https://github.com/jupyterlab/jupyterlab/pull/13472) ([@fcollonval](https://github.com/fcollonval))
-- Backport #13365 on branch 3.6.x (Add announcements) [#13444](https://github.com/jupyterlab/jupyterlab/pull/13444) ([@fcollonval](https://github.com/fcollonval))
+- Add announcements [#13444](https://github.com/jupyterlab/jupyterlab/pull/13444) ([@fcollonval](https://github.com/fcollonval))
 
 ### API and Breaking Changes
 
-- Backport #13458 on branch 3.6.x (Enable document model specific collaboration) [#13480](https://github.com/jupyterlab/jupyterlab/pull/13480) ([@fcollonval](https://github.com/fcollonval))
+- Enable document model specific collaboration [#13480](https://github.com/jupyterlab/jupyterlab/pull/13480) ([@fcollonval](https://github.com/fcollonval))
 
 ### Contributors to this release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,54 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.6.0a5
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.6.0a4...c3e7f3fefd5bf54bc8b9b54d140e379c25755657))
+
+### Enhancements made
+
+- Add lumino with support for plugin deactivation [#13541](https://github.com/jupyterlab/jupyterlab/pull/13541) ([@fcollonval](https://github.com/fcollonval))
+- Sets whether the model is collaborative or not when registering its factory [#13526](https://github.com/jupyterlab/jupyterlab/pull/13526) ([@hbcarlos](https://github.com/hbcarlos))
+- RTC: Move user name to user panel [#13517](https://github.com/jupyterlab/jupyterlab/pull/13517) ([@martinRenou](https://github.com/martinRenou))
+- Backport #13492 on branch 3.6.x (jupyter_server_ydoc>=0.6.0,<0.7.0) [#13499](https://github.com/jupyterlab/jupyterlab/pull/13499) ([@fcollonval](https://github.com/fcollonval))
+- Backport #13433 (Allows to pause the execution during debug) [#13494](https://github.com/jupyterlab/jupyterlab/pull/13494) ([@brichet](https://github.com/brichet))
+- Backport #13267 on branch 3.6.x (Ask confirmation when closing a document) [#13489](https://github.com/jupyterlab/jupyterlab/pull/13489) ([@fcollonval](https://github.com/fcollonval))
+- Backport #12667 on branch 3.6.x (Add events service) [#13465](https://github.com/jupyterlab/jupyterlab/pull/13465) ([@fcollonval](https://github.com/fcollonval))
+- Backport #13365 on branch 3.6.x (Add announcements) [#13444](https://github.com/jupyterlab/jupyterlab/pull/13444) ([@fcollonval](https://github.com/fcollonval))
+
+### Bugs fixed
+
+- Set corrections to icons and switch colors [#13500](https://github.com/jupyterlab/jupyterlab/pull/13500) ([@HaudinFlorence](https://github.com/HaudinFlorence))
+- Default `IDocumentProviderFactory.IOptions` generic to ISharedDocument [#13490](https://github.com/jupyterlab/jupyterlab/pull/13490) ([@jtpio](https://github.com/jtpio))
+- Use same key for saving user info in local store [#13482](https://github.com/jupyterlab/jupyterlab/pull/13482) ([@hbcarlos](https://github.com/hbcarlos))
+- Set fallback values for icons colors. [#13468](https://github.com/jupyterlab/jupyterlab/pull/13468) ([@HaudinFlorence](https://github.com/HaudinFlorence))
+- Backport #13458 on branch 3.6.x (Enable document model specific collaboration) [#13480](https://github.com/jupyterlab/jupyterlab/pull/13480) ([@fcollonval](https://github.com/fcollonval))
+- Share attachments [#13450](https://github.com/jupyterlab/jupyterlab/pull/13450) ([@hbcarlos](https://github.com/hbcarlos))
+
+### Maintenance and upkeep improvements
+
+- Bump sanitize-html to 2.7.3 [#13509](https://github.com/jupyterlab/jupyterlab/pull/13509) ([@fcollonval](https://github.com/fcollonval))
+- Depend on `@jupyter/ydoc` instead of `@jupyter-notebook/ydoc` [#13506](https://github.com/jupyterlab/jupyterlab/pull/13506) ([@jtpio](https://github.com/jtpio))
+- Fix Python test dependencies [#13508](https://github.com/jupyterlab/jupyterlab/pull/13508) ([@fcollonval](https://github.com/fcollonval))
+- Backport #13478 on branch 3.6.x (Require jupyter-server-ydoc >=0.5.1) [#13479](https://github.com/jupyterlab/jupyterlab/pull/13479) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+- Forbid using RTC mode without Jupyter Server v2. [#13472](https://github.com/jupyterlab/jupyterlab/pull/13472) ([@fcollonval](https://github.com/fcollonval))
+- Backport #13365 on branch 3.6.x (Add announcements) [#13444](https://github.com/jupyterlab/jupyterlab/pull/13444) ([@fcollonval](https://github.com/fcollonval))
+
+### API and Breaking Changes
+
+- Backport #13458 on branch 3.6.x (Enable document model specific collaboration) [#13480](https://github.com/jupyterlab/jupyterlab/pull/13480) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-11-18&to=2022-12-06&type=c))
+
+[@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2022-11-18..2022-12-06&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-11-18..2022-12-06&type=Issues) | [@brichet](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abrichet+updated%3A2022-11-18..2022-12-06&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-11-18..2022-12-06&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-11-18..2022-12-06&type=Issues) | [@HaudinFlorence](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AHaudinFlorence+updated%3A2022-11-18..2022-12-06&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2022-11-18..2022-12-06&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-11-18..2022-12-06&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-11-18..2022-12-06&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-11-18..2022-12-06&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-11-18..2022-12-06&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-11-18..2022-12-06&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-11-18..2022-12-06&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-11-18..2022-12-06&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.6.0a4
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.6.0a3...85627bd2edb6c6e15a1c30fd02ba82bcbc6d29f7))
@@ -37,8 +85,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-11-10&to=2022-11-18&type=c))
 
 [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-11-10..2022-11-18&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2022-11-10..2022-11-18&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-11-10..2022-11-18&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-11-10..2022-11-18&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-11-10..2022-11-18&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-11-10..2022-11-18&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-11-10..2022-11-18&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-11-10..2022-11-18&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.6.0a3
 


### PR DESCRIPTION
Automated Changelog Entry for 3.6.0a5 on 3.6.x
```
Python version: 3.6.0a5
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.6.0-alpha.5
@jupyterlab/buildutils: 3.6.0-alpha.5
@jupyterlab/template: 3.6.0-alpha.5
@jupyterlab/application-top: 3.6.0-alpha.5
@jupyterlab/example-app: 3.6.0-alpha.5
@jupyterlab/example-cell: 3.6.0-alpha.5
@jupyterlab/example-console: 3.6.0-alpha.5
@jupyterlab/example-federated: 2.7.0-alpha.5
@jupyterlab/example-federated-core: 2.7.0-alpha.5
@jupyterlab/example-federated-md: 2.7.0-alpha.5
@jupyterlab/example-federated-middle: 2.7.0-alpha.5
@jupyterlab/example-federated-phosphor: 2.7.0-alpha.5
@jupyterlab/example-filebrowser: 3.6.0-alpha.5
@jupyterlab/example-notebook: 3.6.0-alpha.5
@jupyterlab/example-terminal: 3.6.0-alpha.5
@jupyterlab/galata: 4.5.0-alpha.5
@jupyterlab/mock-extension: 3.6.0-alpha.5
@jupyterlab/mock-consumer: 3.6.0-alpha.5
@jupyterlab/mock-provider: 3.6.0-alpha.5
@jupyterlab/mock-token: 3.6.0-alpha.5
@jupyterlab/application: 3.6.0-alpha.5
@jupyterlab/application-extension: 3.6.0-alpha.5
@jupyterlab/apputils: 3.6.0-alpha.5
@jupyterlab/apputils-extension: 3.6.0-alpha.5
@jupyterlab/attachments: 3.6.0-alpha.5
@jupyterlab/cell-toolbar: 3.6.0-alpha.5
@jupyterlab/cell-toolbar-extension: 3.6.0-alpha.5
@jupyterlab/cells: 3.6.0-alpha.5
@jupyterlab/celltags: 3.6.0-alpha.5
@jupyterlab/celltags-extension: 3.6.0-alpha.5
@jupyterlab/codeeditor: 3.6.0-alpha.5
@jupyterlab/codemirror: 3.6.0-alpha.5
@jupyterlab/codemirror-extension: 3.6.0-alpha.5
@jupyterlab/collaboration: 3.6.0-alpha.5
@jupyterlab/collaboration-extension: 3.6.0-alpha.5
@jupyterlab/completer: 3.6.0-alpha.5
@jupyterlab/completer-extension: 3.6.0-alpha.5
@jupyterlab/console: 3.6.0-alpha.5
@jupyterlab/console-extension: 3.6.0-alpha.5
@jupyterlab/coreutils: 5.6.0-alpha.5
@jupyterlab/csvviewer: 3.6.0-alpha.5
@jupyterlab/csvviewer-extension: 3.6.0-alpha.5
@jupyterlab/debugger: 3.6.0-alpha.5
@jupyterlab/debugger-extension: 3.6.0-alpha.5
@jupyterlab/docmanager: 3.6.0-alpha.5
@jupyterlab/docmanager-extension: 3.6.0-alpha.5
@jupyterlab/docprovider: 3.6.0-alpha.5
@jupyterlab/docprovider-extension: 3.6.0-alpha.5
@jupyterlab/docregistry: 3.6.0-alpha.5
@jupyterlab/documentsearch: 3.6.0-alpha.5
@jupyterlab/documentsearch-extension: 3.6.0-alpha.5
@jupyterlab/extensionmanager: 3.6.0-alpha.5
@jupyterlab/extensionmanager-extension: 3.6.0-alpha.5
@jupyterlab/filebrowser: 3.6.0-alpha.5
@jupyterlab/filebrowser-extension: 3.6.0-alpha.5
@jupyterlab/fileeditor: 3.6.0-alpha.5
@jupyterlab/fileeditor-extension: 3.6.0-alpha.5
@jupyterlab/help-extension: 3.6.0-alpha.5
@jupyterlab/htmlviewer: 3.6.0-alpha.5
@jupyterlab/htmlviewer-extension: 3.6.0-alpha.5
@jupyterlab/hub-extension: 3.6.0-alpha.5
@jupyterlab/imageviewer: 3.6.0-alpha.5
@jupyterlab/imageviewer-extension: 3.6.0-alpha.5
@jupyterlab/inspector: 3.6.0-alpha.5
@jupyterlab/inspector-extension: 3.6.0-alpha.5
@jupyterlab/javascript-extension: 3.6.0-alpha.5
@jupyterlab/json-extension: 3.6.0-alpha.5
@jupyterlab/launcher: 3.6.0-alpha.5
@jupyterlab/launcher-extension: 3.6.0-alpha.5
@jupyterlab/logconsole: 3.6.0-alpha.5
@jupyterlab/logconsole-extension: 3.6.0-alpha.5
@jupyterlab/mainmenu: 3.6.0-alpha.5
@jupyterlab/mainmenu-extension: 3.6.0-alpha.5
@jupyterlab/markdownviewer: 3.6.0-alpha.5
@jupyterlab/markdownviewer-extension: 3.6.0-alpha.5
@jupyterlab/mathjax2: 3.6.0-alpha.5
@jupyterlab/mathjax2-extension: 3.6.0-alpha.5
@jupyterlab/metapackage: 3.6.0-alpha.5
@jupyterlab/nbconvert-css: 3.6.0-alpha.5
@jupyterlab/nbformat: 3.6.0-alpha.5
@jupyterlab/notebook: 3.6.0-alpha.5
@jupyterlab/notebook-extension: 3.6.0-alpha.5
@jupyterlab/observables: 4.6.0-alpha.5
@jupyterlab/outputarea: 3.6.0-alpha.5
@jupyterlab/pdf-extension: 3.6.0-alpha.5
@jupyterlab/property-inspector: 3.6.0-alpha.5
@jupyterlab/rendermime: 3.6.0-alpha.5
@jupyterlab/rendermime-extension: 3.6.0-alpha.5
@jupyterlab/rendermime-interfaces: 3.6.0-alpha.5
@jupyterlab/running: 3.6.0-alpha.5
@jupyterlab/running-extension: 3.6.0-alpha.5
@jupyterlab/services: 6.6.0-alpha.5
@jupyterlab/example-services-browser: 3.6.0-alpha.5
node-example: 3.6.0-alpha.5
@jupyterlab/example-services-outputarea: 3.6.0-alpha.5
@jupyterlab/settingeditor: 3.6.0-alpha.5
@jupyterlab/settingeditor-extension: 3.6.0-alpha.5
@jupyterlab/settingregistry: 3.6.0-alpha.5
@jupyterlab/shortcuts-extension: 3.6.0-alpha.5
@jupyterlab/statedb: 3.6.0-alpha.5
@jupyterlab/statusbar: 3.6.0-alpha.5
@jupyterlab/statusbar-extension: 3.6.0-alpha.5
@jupyterlab/terminal: 3.6.0-alpha.5
@jupyterlab/terminal-extension: 3.6.0-alpha.5
@jupyterlab/theme-dark-extension: 3.6.0-alpha.5
@jupyterlab/theme-light-extension: 3.6.0-alpha.5
@jupyterlab/toc: 5.6.0-alpha.5
@jupyterlab/toc-extension: 5.6.0-alpha.5
@jupyterlab/tooltip: 3.6.0-alpha.5
@jupyterlab/tooltip-extension: 3.6.0-alpha.5
@jupyterlab/translation: 3.6.0-alpha.5
@jupyterlab/translation-extension: 3.6.0-alpha.5
@jupyterlab/ui-components: 3.6.0-alpha.5
@jupyterlab/ui-components-extension: 3.6.0-alpha.5
@jupyterlab/vdom: 3.6.0-alpha.5
@jupyterlab/vdom-extension: 3.6.0-alpha.5
@jupyterlab/vega5-extension: 3.6.0-alpha.5
@jupyterlab/testutils: 3.6.0-alpha.5
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyterlab/jupyterlab/releases/tag/untagged-0ee2f042ae815c9e757c  |
| Since | v3.6.0a4 |