### PR TITLE
Restores the appearance of the settingeditor's input focus

### DIFF
--- a/packages/settingeditor/style/base.css
+++ b/packages/settingeditor/style/base.css
@@ -227,8 +227,12 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
 }
 
 /** copy of `input.jp-mod-styled:focus` style */
-.jp-SettingsPanel fieldset input:focus {
-  border: var(--jp-border-width) solid var(--md-blue-500);
+.jp-SettingsPanel fieldset input:focus,
+.jp-SettingsPanel fieldset select:focus,
+.jp-SettingsPanel fieldset textarea:focus {
+  -moz-outline-radius: unset;
+  outline: var(--jp-border-width) solid var(--md-blue-500);
+  outline-offset: -1px;
   box-shadow: inset 0 0 4px var(--md-blue-300);
 }
 


### PR DESCRIPTION
Unintentionally, https://github.com/jupyterlab/jupyterlab/pull/13415 changes the appearance of `settingseditor`'s input:focus, similar to the following diff (new appearance on left):

<img src="https://user-images.githubusercontent.com/32258950/206226669-3dbff0a9-2b64-45dd-8a73-332ae38b37b6.png" width="250px">

This PR restores the previous appearance.

## References

https://github.com/jupyterlab/jupyterlab/pull/13415#discussion_r1022094877

## Code changes

Adds styles to `base.css` of *settingseditor*, to handle input focus.

## User-facing changes

Restore previous state.



cc @gabalafou 