### PR TITLE
Fix TOC running marker resizing

### DIFF
--- a/packages/toc/style/base.css
+++ b/packages/toc/style/base.css
@@ -406,6 +406,7 @@
   margin: 2px;
   background: none;
   border: none;
+  flex: auto 0 0;
 }
 
 .toc-entry-holder[data-running='0']::after {

--- a/tsconfigdoc.json
+++ b/tsconfigdoc.json
@@ -56,6 +56,12 @@
       "path": "./packages/codemirror-extension"
     },
     {
+      "path": "./packages/collaboration"
+    },
+    {
+      "path": "./packages/collaboration-extension"
+    },
+    {
       "path": "./packages/completer"
     },
     {
@@ -164,6 +170,12 @@
       "path": "./packages/logconsole-extension"
     },
     {
+      "path": "./packages/lsp"
+    },
+    {
+      "path": "./packages/lsp-extension"
+    },
+    {
       "path": "./packages/mainmenu"
     },
     {
@@ -174,6 +186,9 @@
     },
     {
       "path": "./packages/markdownviewer-extension"
+    },
+    {
+      "path": "./packages/markedparser-extension"
     },
     {
       "path": "./packages/mathjax2"

--- a/tsconfigdoc.json
+++ b/tsconfigdoc.json
@@ -56,12 +56,6 @@
       "path": "./packages/codemirror-extension"
     },
     {
-      "path": "./packages/collaboration"
-    },
-    {
-      "path": "./packages/collaboration-extension"
-    },
-    {
       "path": "./packages/completer"
     },
     {
@@ -170,12 +164,6 @@
       "path": "./packages/logconsole-extension"
     },
     {
-      "path": "./packages/lsp"
-    },
-    {
-      "path": "./packages/lsp-extension"
-    },
-    {
       "path": "./packages/mainmenu"
     },
     {
@@ -186,9 +174,6 @@
     },
     {
       "path": "./packages/markdownviewer-extension"
-    },
-    {
-      "path": "./packages/markedparser-extension"
     },
     {
       "path": "./packages/mathjax2"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Addresses issue #13545

This is an update to version 3.5.x.
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
As described in the issue, added `flex: auto 0 0` to the selector `.toc-entry-holder::after`. This prevents the running indicators in the table of contents from warping when long titles are added.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->
Before:
<img width="248" alt="Screen Shot 2022-12-09 at 4 43 40 PM" src="https://user-images.githubusercontent.com/61431157/206800856-b185a823-9ad6-4ebc-9fd5-350058eea44f.png">

After:
<img width="252" alt="Screen Shot 2022-12-09 at 4 40 50 PM" src="https://user-images.githubusercontent.com/61431157/206800964-3bd8719b-6526-4f3d-b4cf-acbfa3e24afd.png">


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None
