### PR TITLE
fix size of toc running indicator

### DIFF
--- a/packages/toc/style/base.css
+++ b/packages/toc/style/base.css
@@ -406,6 +406,7 @@
   margin: 2px;
   background: none;
   border: none;
+  flex: auto 0 0;
 }
 
 .toc-entry-holder[data-running='0']::after {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Addresses issue #13545 
<!-- Note any other pull requests that address this issue and how this pull request is different. -->
Fix from earlier PR to wrong branch #13566

## Code changes

<!-- Describe the code changes and how they address the issue. -->
As described in the issue, added `flex: auto 0 0` to the selector `.toc-entry-holder::after`. This prevents the running indicators in the table of contents from warping when long titles are added.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->
Before:
<img width="248" alt="Screen Shot 2022-12-09 at 4 43 40 PM" src="https://user-images.githubusercontent.com/61431157/206800856-b185a823-9ad6-4ebc-9fd5-350058eea44f.png">

After:
<img width="252" alt="Screen Shot 2022-12-09 at 4 40 50 PM" src="https://user-images.githubusercontent.com/61431157/206800964-3bd8719b-6526-4f3d-b4cf-acbfa3e24afd.png">

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None