### PR TITLE
Documentation RTC and user service

### DIFF
--- a/docs/source/extension/documents.rst
+++ b/docs/source/extension/documents.rst
@@ -39,9 +39,12 @@ communicate with each other.
 Models contain an instance of `ModelDB <../api/classes/observables.modeldb-1.html>`__
 that acts as data storage for the model's content. In JupyterLab 3.1, we introduced
 the package ``@jupyterlab/shared-models`` to swap ``ModelDB`` as a data storage
-to make 'documents' collaborative. We implemented these shared models using
-`Yjs <https://docs.yjs.dev>`_, a high-performance CRDT for building collaborative applications
-that automatically sync.
+to make 'documents' collaborative, and in JupyterLab 3.6 we moved this package to
+the `jupyter_ydoc <https://github.com/jupyter-server/jupyter_ydoc>`__ repository
+and renamed it as ``@jupyter/ydoc`` to keep in sync the front-end and back-end
+implementations of the shared models. We implemented these shared models using
+`Yjs <https://docs.yjs.dev>`_, a high-performance CRDT for building collaborative
+applications that automatically sync.
 At the moment, models contain both a ``ModelDB`` and a ``Shared Model`` instance, so it is
 possible to access ``ModelDB`` yet.
 
@@ -50,8 +53,8 @@ a view of a document model. There can be multiple document widgets associated wi
 a single document model, and they naturally stay in sync with each other since they
 are views on the same underlying data model.
 
-`Shared Models <../api/interfaces/shared_models.ishareddocument.html>`__ are models
-using Yjs’ shared types as a data structures instead of ``ModelDB``.
+`Shared Models <https://jupyter-ydoc.readthedocs.io/en/latest/api/interfaces/ISharedDocument.html>`__
+are models using Yjs’ shared types as a data structures instead of ``ModelDB``.
 
 The `Document Registry <../api/classes/docregistry.documentregistry-1.html>`__
 is where document types and factories are registered. Plugins can
@@ -141,10 +144,10 @@ between the document model and the wider application.
 Shared Models
 -------------
 
-The shared-models package contains an `ISharedNotebook
-<../api/interfaces/shared_models.isharednotebook.html>`_ and an `ISharedFile
-<../api/interfaces/shared_models.isharedfile.html>`_ which are the abstract
-interfaces to work against if you want to manipulate a notebook or a file.
+The YDoc package contains an `ISharedNotebook
+<https://jupyter-ydoc.readthedocs.io/en/latest/api/modules/ISharedNotebook.html>`_
+and an `ISharedFile <https://jupyter-ydoc.readthedocs.io/en/latest/api/interfaces/ISharedFile.html>`_
+which are the abstract interfaces to work against if you want to manipulate a notebook or a file.
 
 These models wrap a `Yjs document (Y.Doc) <https://docs.yjs.dev/api/y.doc>`_ which represents
 a shared document between clients and hold multiple shared objects. They enable you
@@ -155,6 +158,9 @@ types of collaborative applications.
 In addition, a shared model has an `Awareness <https://docs.yjs.dev/getting-started/adding-awareness>`_
 attribute. This attribute is linked to the *Y.Doc* which means there is one *Awareness* object per document and is
 used for sharing cursor locations and presence information.
+
+Please, check out the `YDoc documentation <https://jupyter-ydoc.readthedocs.io/en/latest>`_
+to know more about this package.
 
 Document Manager
 ----------------

--- a/docs/source/extension/extension_dev.rst
+++ b/docs/source/extension/extension_dev.rst
@@ -22,6 +22,7 @@ See the sections below for more detailed information, or browse the rest of this
    virtualdom
    ui_helpers
    internationalization
+   identity
    extension_tutorial
    extension_migration
 

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -158,6 +158,59 @@ Extension Development Changes
 - In JupyterLab 3.x, the CSS for a _disabled_ prebuilt extensions would still be loaded on the page.
   This is no longer the case in JupyterLab 4.0.
 
+
+.. _extension_migration_3.5_3.6:
+
+JupyterLab 3.5 to 3.6
+---------------------
+
+Real-Time Collaboration
+^^^^^^^^^^^^^^^^^^^^^^^
+In JupyterLab v3.6, it is necessary to install Jupyter Server v2.0 to use real-time collaboration.
+This requirement was introduced to take advantage of the new identity API in Jupyter Server v2.0.
+
+On the other side, we also changed how JupyterLab loads documents. Instead of using the content
+API, now the provider opens a WebSocket connection to the YDocWebSocketHandler, which is implemented
+in an external `jupyter server extension <https://github.com/jupyter-server/jupyter_server_ydoc>`__.
+
+In addition, the shared models' package was moved to an external package called `@jupyter/ydoc
+<https://github.com/jupyter-server/jupyter_ydoc>`__. All the extensions that depend on
+``@jupyterlab/shared-models`` will need to update to depend in ``@jupyter/ydoc``; the API should
+be the same.
+
+**API Changes:**
+To be able to fix RTC and make it stable. It was necessary to change the API and make a few breaking changes.
+These changes should not affect the vast majority of extensions. They will only affect a couple
+of extensions focused on RTC.
+
+It was necessary to change the paradigm of how JupyterLab loads documents and replace the locking mechanism
+in the back-end. Instead of identifying the first client to open the document, it now centralizes
+the process by instantiating a YDoc client in the back-end. This client is the only one that loads
+the content of the document into memory and shares it with every other client connected.
+
+The involved packages are:
+
+- ``@jupyterlab/docprovider``:
+   * The interface ``IDocumentProvider``, now extends from ``IDisposable``.
+     Removed: ``acquireLock``, ``releaseLock``, ``setPath``, ``destroy``, ``requestInitialContent`` and ``putInitializedState``.
+     Added: ``ready`` and ``isDisposed``.
+
+   * ``IDocumentProviderFactory.IOptions`` is now templated with ``T extends ISharedDocument``.
+     And the ``ymodel`` attribute has been renamed ``model`` typed ``T`` (relaxing typing from ``YDocument`` to ``ISharedDocument``).
+
+   * ``WebSocketProviderWithLocks`` has been renamed to ``WebSocketProvider``.
+     It does not extend ``WebSocketProvider`` from ``y-websocket`` anymore.
+
+   * ``WebSocketProvider.IOptions`` has a new optional attribute, ``user``.
+
+- ``@jupyterlab/services``:
+   * The interface ``IManager`` has a new optional property, ``user``.
+
+   * The ``ServiceManager`` class implements the optional property ``user`` from the ``IManager``.
+
+
+.. _extension_migration_3.0_3.1:
+
 JupyterLab 3.0 to 3.1
 ---------------------
 

--- a/docs/source/extension/identity.rst
+++ b/docs/source/extension/identity.rst
@@ -1,0 +1,36 @@
+.. Copyright (c) Jupyter Development Team.
+.. Distributed under the terms of the Modified BSD License.
+
+.. _identity:
+
+Identity
+========
+
+JupyterLab v3.6 includes user identity build on top of the ``IdentityProvider`` and the endpoint ``/api/me``
+introduced in Jupyter Server v2 as part of the authentication. The ``/api/me`` endpoint returns a dictionary
+with the user's identity their permissions. Please check out its
+`documentation <https://jupyter-server.readthedocs.io/en/latest/operators/security.html#identity-model>`_
+to know more about the identity model implemented in Jupyter Server.
+
+The user identity API was included in JupyterLab as part of the service package by adding a new service called
+``UserManager`` to the ``ServiceManager``. This new service periodically requests the user identity to the
+``/api/me`` endpoint and keeps the information in memory until the next request. Nevertheless, it is always
+possible to refresh the information manually by calling the ``refreshUser`` method. Once the service is ready,
+it is possible to access the user's identity through the property ``identity`` or listen for changes by subscribing
+to the signal ``userChanged``.
+
+**Example:**
+
+.. code:: typescript
+
+    const extension: JupyterFrontEndPlugin<void> = {
+      id: 'jupyterlab-extension',
+      autoStart: true,
+      activate: (app: JupyterFrontEnd) => {
+         const user = app.services.user;
+         user.ready.then(() => {
+            console.debug("Identity:", user.identity);
+            console.debug("Permissions:", user.permissions);
+         });
+      }
+    };


### PR DESCRIPTION
- [X] Migration guide
- [X] Update RTC documentation
- [X] User service documentation

## References
Fixes #13463
Fixes #13551
Fixes #13332
Fixes #13333

## Code changes
Adds a migration guide for Lab v3.6, updates the RTC documentation and adds documentation about identity.

## User-facing changes

## Backwards-incompatible changes
