### PR TITLE
use jupyter_config_dir instead of config_path[0] for workspaces, settings

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -26,7 +26,7 @@ from threading import Event
 from urllib.error import URLError
 from urllib.request import Request, quote, urljoin, urlopen
 
-from jupyter_core.paths import jupyter_config_path
+from jupyter_core.paths import jupyter_config_dir
 from jupyter_server.extension.serverextension import (
     GREEN_ENABLED,
     GREEN_OK,
@@ -139,14 +139,14 @@ def pjoin(*args):
 def get_user_settings_dir():
     """Get the configured JupyterLab user settings directory."""
     settings_dir = os.environ.get("JUPYTERLAB_SETTINGS_DIR")
-    settings_dir = settings_dir or pjoin(jupyter_config_path()[0], "lab", "user-settings")
+    settings_dir = settings_dir or pjoin(jupyter_config_dir(), "lab", "user-settings")
     return osp.abspath(settings_dir)
 
 
 def get_workspaces_dir():
     """Get the configured JupyterLab workspaces directory."""
     workspaces_dir = os.environ.get("JUPYTERLAB_WORKSPACES_DIR")
-    workspaces_dir = workspaces_dir or pjoin(jupyter_config_path()[0], "lab", "workspaces")
+    workspaces_dir = workspaces_dir or pjoin(jupyter_config_dir(), "lab", "workspaces")
     return osp.abspath(workspaces_dir)
 
 


### PR DESCRIPTION
avoids these being siloed in virtualenvs and conda envs, which is:

1. rarely desirable, I suspect (I'm sure some follks want this, but they can opt-in with $JUPYTER_CONFIG_DIR/WORKSPACES/etc.)
2. far more likely to be not writable than user dirs

## References

background: #13580
simpler alternative to #13581 

Related: https://github.com/jupyter/jupyter_core/issues/318

~~c l o s e s #13587~~
closes #13580

This doesn't add the writability check in #13581, but instead adds the explicit _requirement_ that `$JUPYTER_CONFIG_DIR` is writable, which I think is easier to manage and communicate than trying to track down env paths and inconsistent default behavior of jupyter-core described in https://github.com/jupyter/jupyter_core/issues/318. The current behavior is that jupyterlab has the requirement that _environments_ are writable, which is not a valid assumption.

## Code changes

use `jupyter_config_dir()` (always a user dir unless overridden explicitly) for workspaces/user-settings storage instead of `jupyter_config_path()[0]`. These are almost always the same, but if you are in a virtualenv or conda environment (including root), the latter will return a path in the env, which may not be writable. I also suspect deviating workspaces and user-settings persistence by env is not desirable by default (I know I would never want this).

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Default storage for workspaces, user-settings will change when jupyterlab is running in an environment with jupyter-core >= 5, from inside the environment to the standard user Jupyter config location. i.e. ~/.jupyter.

## Backwards-incompatible changes

Config storage path moving means that previously stored config will not be loaded. Not sure what level of deprecation/migration is considered appropriate here.

---
Edited: This does not fix the error seen on the example CI job.