### PR TITLE
Switch to one-based editor

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -2094,7 +2094,7 @@ export class MarkdownCell extends AttachmentsCell<IMarkdownCellModel> {
       if (numHashAtStart > 0) {
         this.inputArea!.editor.setCursorPosition({
           column: numHashAtStart + 1,
-          line: 0
+          line: 1
         });
       }
     }

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -19,7 +19,7 @@ import { ISignal, Signal } from '@lumino/signaling';
  */
 export namespace CodeEditor {
   /**
-   * A zero-based position in the editor.
+   * A one-based position in the editor.
    */
   export interface IPosition extends JSONObject {
     /**
@@ -484,7 +484,7 @@ export namespace CodeEditor {
     /**
      * Reveals the given selection in the editor.
      *
-     * @param position - The desired selection to reveal.
+     * @param selection - The desired selection to reveal.
      */
     revealSelection(selection: IRange): void;
 

--- a/packages/codeeditor/src/jsoneditor.ts
+++ b/packages/codeeditor/src/jsoneditor.ts
@@ -316,7 +316,7 @@ export class JSONEditor extends Widget {
       this._originalValue = content;
       // Move the cursor to within the brace.
       if (value.length > 1 && value[0] === '{') {
-        this.editor.setCursorPosition({ line: 0, column: 1 });
+        this.editor.setCursorPosition({ line: 1, column: 2 });
       }
     }
     this._changeGuard = false;

--- a/packages/codeeditor/src/lineCol.tsx
+++ b/packages/codeeditor/src/lineCol.tsx
@@ -295,7 +295,7 @@ export class LineCol extends VDomRenderer<LineCol.Model> {
    * Handle submission for the widget.
    */
   private _handleSubmit(value: number): void {
-    this.model!.editor!.setCursorPosition({ line: value - 1, column: 0 });
+    this.model!.editor!.setCursorPosition({ line: value, column: 1 });
     this._popup!.dispose();
     this.model!.editor!.focus();
   }
@@ -333,8 +333,8 @@ export namespace LineCol {
         this._editor.model.selections.changed.connect(this._onSelectionChanged);
 
         const pos = this._editor.getCursorPosition();
-        this._column = pos.column + 1;
-        this._line = pos.line + 1;
+        this._column = pos.column;
+        this._line = pos.line;
       }
 
       this._triggerChange(oldState, this._getAllState());
@@ -360,8 +360,8 @@ export namespace LineCol {
     private _onSelectionChanged = () => {
       const oldState = this._getAllState();
       const pos = this.editor!.getCursorPosition();
-      this._line = pos.line + 1;
-      this._column = pos.column + 1;
+      this._line = pos.line;
+      this._column = pos.column;
 
       this._triggerChange(oldState, this._getAllState());
     };

--- a/packages/codeeditor/src/widget.ts
+++ b/packages/codeeditor/src/widget.ts
@@ -155,7 +155,7 @@ export class CodeEditorWrapper extends Widget {
       if (
         this.editor
           .getLine(end.line)!
-          .slice(0, end.column)
+          .slice(0, end.column - 1)
           .match(leadingWhitespaceRe)
       ) {
         this.addClass(HAS_IN_LEADING_WHITESPACE_CLASS);

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -378,8 +378,8 @@ function activateEditorCommands(
       const column = args['column'] as number | undefined;
       if (line !== undefined || column !== undefined) {
         editor.setCursorPosition({
-          line: (line ?? 1) - 1,
-          column: (column ?? 1) - 1
+          line: line ?? 1,
+          column: column ?? 1
         });
       } else {
         editor.execCommand(gotoLine);

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -407,8 +407,6 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
    * Returns the content for the given line number.
    */
   getLine(line: number): string | undefined {
-    // TODO: CM6 remove +1 when CM6 first line number has propagated
-    line = line + 1;
     return line <= this.doc.lines ? this.doc.line(line).text : undefined;
   }
 
@@ -416,17 +414,15 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
    * Find an offset for the given position.
    */
   getOffsetAt(position: CodeEditor.IPosition): number {
-    // TODO: CM6 remove +1 when CM6 first line number has propagated
-    return this.doc.line(position.line + 1).from + position.column;
+    return this.doc.line(position.line).from + position.column - 1;
   }
 
   /**
    * Find a position for the given offset.
    */
   getPositionAt(offset: number): CodeEditor.IPosition {
-    // TODO: CM6 remove -1 when CM6 first line number has propagated
     const line = this.doc.lineAt(offset);
-    return { line: line.number - 1, column: offset - line.from };
+    return { line: line.number, column: offset - line.from + 1 };
   }
 
   /**
@@ -484,12 +480,11 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
   }
 
   firstLine(): number {
-    // TODO: return 1 when CM6 first line number has propagated
-    return 0;
+    return 1;
   }
 
   lastLine(): number {
-    return this.doc.lines - 1;
+    return this.doc.lines;
   }
 
   cursorCoords(

--- a/packages/codemirror/test/editor.spec.ts
+++ b/packages/codemirror/test/editor.spec.ts
@@ -182,9 +182,9 @@ describe('CodeMirrorEditor', () => {
   describe('#getLine()', () => {
     it('should get a line of text', () => {
       model.sharedModel.setSource('foo\nbar');
-      expect(editor.getLine(0)).toBe('foo');
-      expect(editor.getLine(1)).toBe('bar');
-      expect(editor.getLine(2)).toBeUndefined();
+      expect(editor.getLine(1)).toBe('foo');
+      expect(editor.getLine(2)).toBe('bar');
+      expect(editor.getLine(3)).toBeUndefined();
     });
   });
 
@@ -192,13 +192,13 @@ describe('CodeMirrorEditor', () => {
     it('should get the offset for a given position', () => {
       model.sharedModel.setSource('foo\nbar');
       let pos = {
-        column: 2,
-        line: 1
+        column: 3,
+        line: 2
       };
       expect(editor.getOffsetAt(pos)).toBe(6);
       pos = {
-        column: 2,
-        line: 5
+        column: 3,
+        line: 6
       };
       expect(() => {
         editor.getOffsetAt(pos);
@@ -210,8 +210,8 @@ describe('CodeMirrorEditor', () => {
     it('should get the position for a given offset', () => {
       model.sharedModel.setSource('foo\nbar');
       let pos = editor.getPositionAt(6);
-      expect(pos.column).toBe(2);
-      expect(pos.line).toBe(1);
+      expect(pos.column).toBe(3);
+      expect(pos.line).toBe(2);
       expect(() => {
         pos = editor.getPositionAt(101);
       }).toThrow(RangeError);
@@ -310,7 +310,7 @@ describe('CodeMirrorEditor', () => {
   describe('#revealPosition()', () => {
     it('should reveal the given position in the editor', () => {
       model.sharedModel.setSource(TEXT);
-      editor.revealPosition({ line: 50, column: 0 });
+      editor.revealPosition({ line: 50, column: 1 });
       expect(editor).toBeTruthy();
     });
   });
@@ -318,8 +318,8 @@ describe('CodeMirrorEditor', () => {
   describe('#revealSelection()', () => {
     it('should reveal the given selection in the editor', () => {
       model.sharedModel.setSource(TEXT);
-      const start = { line: 50, column: 0 };
-      const end = { line: 52, column: 0 };
+      const start = { line: 50, column: 1 };
+      const end = { line: 52, column: 1 };
       editor.setSelection({ start, end });
       editor.revealSelection(editor.getSelection());
       expect(editor).toBeTruthy();
@@ -330,8 +330,8 @@ describe('CodeMirrorEditor', () => {
     it('should get the primary position of the cursor', () => {
       model.sharedModel.setSource(TEXT);
       let pos = editor.getCursorPosition();
-      expect(pos.line).toBe(0);
-      expect(pos.column).toBe(0);
+      expect(pos.line).toBe(1);
+      expect(pos.column).toBe(1);
 
       editor.setCursorPosition({ line: 12, column: 3 });
       pos = editor.getCursorPosition();
@@ -353,16 +353,16 @@ describe('CodeMirrorEditor', () => {
   describe('#getSelection()', () => {
     it('should get the primary selection of the editor', () => {
       const selection = editor.getSelection();
-      expect(selection.start.line).toBe(0);
-      expect(selection.end.line).toBe(0);
+      expect(selection.start.line).toBe(1);
+      expect(selection.end.line).toBe(1);
     });
   });
 
   describe('#setSelection()', () => {
     it('should set the primary selection of the editor', () => {
       model.sharedModel.setSource(TEXT);
-      const start = { line: 50, column: 0 };
-      const end = { line: 52, column: 0 };
+      const start = { line: 50, column: 1 };
+      const end = { line: 52, column: 1 };
       editor.setSelection({ start, end });
       expect(editor.getSelection().start).toEqual(start);
       expect(editor.getSelection().end).toEqual(end);
@@ -371,12 +371,12 @@ describe('CodeMirrorEditor', () => {
     it('should remove any secondary cursors', () => {
       model.sharedModel.setSource(TEXT);
       const range0 = {
-        start: { line: 50, column: 0 },
-        end: { line: 52, column: 0 }
+        start: { line: 50, column: 1 },
+        end: { line: 52, column: 1 }
       };
       const range1 = {
-        start: { line: 53, column: 0 },
-        end: { line: 54, column: 0 }
+        start: { line: 53, column: 1 },
+        end: { line: 54, column: 1 }
       };
       editor.setSelections([range0, range1]);
       editor.setSelection(range1);
@@ -388,12 +388,12 @@ describe('CodeMirrorEditor', () => {
     it('should get the selections for all the cursors', () => {
       model.sharedModel.setSource(TEXT);
       const range0 = {
-        start: { line: 50, column: 0 },
-        end: { line: 52, column: 0 }
+        start: { line: 50, column: 1 },
+        end: { line: 52, column: 1 }
       };
       const range1 = {
-        start: { line: 53, column: 0 },
-        end: { line: 54, column: 0 }
+        start: { line: 53, column: 1 },
+        end: { line: 54, column: 1 }
       };
       editor.setSelections([range0, range1]);
       const selections = editor.getSelections();
@@ -406,12 +406,12 @@ describe('CodeMirrorEditor', () => {
     it('should set the selections for all the cursors', () => {
       model.sharedModel.setSource(TEXT);
       const range0 = {
-        start: { line: 50, column: 0 },
-        end: { line: 52, column: 0 }
+        start: { line: 50, column: 1 },
+        end: { line: 52, column: 1 }
       };
       const range1 = {
-        start: { line: 53, column: 0 },
-        end: { line: 54, column: 0 }
+        start: { line: 53, column: 1 },
+        end: { line: 54, column: 1 }
       };
       editor.setSelections([range0, range1]);
       const selections = editor.getSelections();
@@ -423,8 +423,8 @@ describe('CodeMirrorEditor', () => {
       model.sharedModel.setSource(TEXT);
       editor.setSelections([]);
       const selection = editor.getSelection();
-      expect(selection.start.line).toBe(0);
-      expect(selection.end.line).toBe(0);
+      expect(selection.start.line).toBe(1);
+      expect(selection.end.line).toBe(1);
     });
   });
 

--- a/packages/completer/test/handler.spec.ts
+++ b/packages/completer/test/handler.spec.ts
@@ -190,7 +190,7 @@ describe('@jupyterlab/completer', () => {
           expect.not.arrayContaining(['handleTextChange'])
         );
         editor.model.sharedModel.setSource('bar');
-        editor.setCursorPosition({ line: 0, column: 2 });
+        editor.setCursorPosition({ line: 1, column: 3 });
         // This signal is emitted (again) because the cursor position that
         // a natural user would create need to be recreated here.
         // (editor.model.value.changed as any).emit({ type: 'set', value: 'bar' }); @todo remove?
@@ -239,8 +239,8 @@ describe('@jupyterlab/completer', () => {
         const editor = createEditorWidget().editor;
         const text = 'eggs\nfoo # comment\nbaz';
         const want = 'eggs\nfoobar # comment\nbaz';
-        const line = 1;
-        const column = 5; // this sets the cursor after the "#" sign - not in the mid of the replaced word
+        const line = 2;
+        const column = 6; // this sets the cursor after the "#" sign - not in the mid of the replaced word
         const request: Completer.ITextState = {
           column,
           line,
@@ -271,8 +271,8 @@ describe('@jupyterlab/completer', () => {
         const editor = createEditorWidget().editor;
         const text = 'eggs\nfoo # comment\nbaz';
         const want = 'eggs\nfoobar # comment\nbaz';
-        const line = 1;
-        const column = 5;
+        const line = 2;
+        const column = 6;
         const request: Completer.ITextState = {
           column,
           line,
@@ -320,8 +320,8 @@ describe('@jupyterlab/completer', () => {
       const editor = createEditorWidget().editor;
       const text = 'eggs\n  # comment\nbaz';
       const want = 'eggs\n foobar # comment\nbaz';
-      const line = 1;
-      const column = 1;
+      const line = 2;
+      const column = 2;
       const request: Completer.ITextState = {
         column: column,
         line,

--- a/packages/console/src/history.ts
+++ b/packages/console/src/history.ts
@@ -266,12 +266,12 @@ export class ConsoleHistory implements IConsoleHistory {
         }
         this._setByHistory = true;
         sharedModel.setSource(value);
-        let columnPos = 0;
-        columnPos = value.indexOf('\n');
-        if (columnPos < 0) {
+        let columnPos = 1;
+        columnPos = value.indexOf('\n') + 1;
+        if (columnPos < 1) {
           columnPos = value.length;
         }
-        editor.setCursorPosition({ line: 0, column: columnPos });
+        editor.setCursorPosition({ line: 1, column: columnPos });
       });
     } else {
       void this.forward(source).then(value => {

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -852,8 +852,8 @@ const main: JupyterFrontEndPlugin<void> = {
             results.forEach(editor => {
               void editor.reveal().then(() => {
                 editor.get()?.revealPosition({
-                  line: (breakpoint.line as number) - 1,
-                  column: breakpoint.column || 0
+                  line: breakpoint.line ?? 1,
+                  column: breakpoint.column ?? 1
                 });
               });
             });

--- a/packages/fileeditor/src/toc/factory.ts
+++ b/packages/fileeditor/src/toc/factory.ts
@@ -57,7 +57,7 @@ export abstract class EditorTableOfContentsFactory extends TableOfContentsFactor
       if (heading) {
         widget.content.editor.setCursorPosition({
           line: heading.line,
-          column: 0
+          column: 1
         });
       }
     };

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1266,7 +1266,7 @@ function activateCodeConsole(
             if (curLine < lastLine) {
               // we find a block of complete statement containing the current line, great!
               while (
-                lastLine < editor.lineCount &&
+                lastLine <= editor.lineCount &&
                 !srcLines[lastLine].replace(/\s/g, '').length
               ) {
                 lastLine += 1;

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1985,8 +1985,8 @@ export class Notebook extends StaticNotebook {
       if (this.activeCellIndex < prev) {
         const editor = this.activeCell!.editor;
         if (editor) {
-          const lastLine = editor.lineCount - 1;
-          editor.setCursorPosition({ line: lastLine, column: 0 });
+          const lastLine = editor.lineCount;
+          editor.setCursorPosition({ line: lastLine, column: 1 });
         }
       }
     } else if (location === 'bottom') {
@@ -1995,7 +1995,7 @@ export class Notebook extends StaticNotebook {
       if (this.activeCellIndex > prev) {
         const editor = this.activeCell!.editor;
         if (editor) {
-          editor.setCursorPosition({ line: 0, column: 0 });
+          editor.setCursorPosition({ line: 1, column: 1 });
         }
       }
     }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Part of https://github.com/jupyterlab/jupyterlab/issues/10380

This switch from {line: 0, col: 0} based to {line: 1, col: 1}.
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Switch to a (1, 1) base rather than (0, 0) base.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
Cursor position is switched 1 (for line and column).