### PR TITLE
Automated Changelog Entry for 3.6.0b0 on 3.6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.6.0b0
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.6.0a5...e59a4cf279c171a256e476bf82bd32e18c7a725a))
+
+### New features added
+
+- Add copy and paste commands to terminal context menu [#13535](https://github.com/jupyterlab/jupyterlab/pull/13535) ([@krassowski](https://github.com/krassowski))
+
+### Enhancements made
+
+- Sanitize notification message [#13510](https://github.com/jupyterlab/jupyterlab/pull/13510) ([@fcollonval](https://github.com/fcollonval))
+- Use more the contextual collaborative model attribute [#13564](https://github.com/jupyterlab/jupyterlab/pull/13564) ([@fcollonval](https://github.com/fcollonval))
+
+### Bugs fixed
+
+- use jupyter_config_dir instead of config_path[0] for workspaces, settings [#13589](https://github.com/jupyterlab/jupyterlab/pull/13589) ([@minrk](https://github.com/minrk))
+- Bump @lumino/application [#13590](https://github.com/jupyterlab/jupyterlab/pull/13590) ([@fcollonval](https://github.com/fcollonval))
+- Restores the appearance of the settingeditor's input focus [#13554](https://github.com/jupyterlab/jupyterlab/pull/13554) ([@brichet](https://github.com/brichet))
+- Fix a wrong argument when calling 'renderMimeVariable' [#13531](https://github.com/jupyterlab/jupyterlab/pull/13531) ([@brichet](https://github.com/brichet))
+- fix size of toc running indicator [#13568](https://github.com/jupyterlab/jupyterlab/pull/13568) ([@uenot](https://github.com/uenot))
+- Fixes backward-incompatible changes for 3.6 [#13560](https://github.com/jupyterlab/jupyterlab/pull/13560) ([@hbcarlos](https://github.com/hbcarlos))
+- Make focus visible (mostly CSS) [#13415](https://github.com/jupyterlab/jupyterlab/pull/13415) ([@gabalafou](https://github.com/gabalafou))
+
+### Documentation improvements
+
+- Copy edit for privacy policy docs [#13594](https://github.com/jupyterlab/jupyterlab/pull/13594) ([@jweill-aws](https://github.com/jweill-aws))
+- Sanitize notification message [#13510](https://github.com/jupyterlab/jupyterlab/pull/13510) ([@fcollonval](https://github.com/fcollonval))
+- Documentation RTC and user service (#13578) [#13591](https://github.com/jupyterlab/jupyterlab/pull/13591) ([@hbcarlos](https://github.com/hbcarlos))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-12-06&to=2022-12-16&type=c))
+
+[@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2022-12-06..2022-12-16&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-12-06..2022-12-16&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-12-06..2022-12-16&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-12-06..2022-12-16&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2022-12-06..2022-12-16&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-12-06..2022-12-16&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-12-06..2022-12-16&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-12-06..2022-12-16&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-12-06..2022-12-16&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-12-06..2022-12-16&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-12-06..2022-12-16&type=Issues) | [@uenot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Auenot+updated%3A2022-12-06..2022-12-16&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Avidartf+updated%3A2022-12-06..2022-12-16&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-12-06..2022-12-16&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.6.0a5
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.6.0a4...c3e7f3fefd5bf54bc8b9b54d140e379c25755657))
@@ -53,8 +90,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-11-18&to=2022-12-06&type=c))
 
 [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2022-11-18..2022-12-06&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-11-18..2022-12-06&type=Issues) | [@brichet](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abrichet+updated%3A2022-11-18..2022-12-06&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-11-18..2022-12-06&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-11-18..2022-12-06&type=Issues) | [@HaudinFlorence](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AHaudinFlorence+updated%3A2022-11-18..2022-12-06&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2022-11-18..2022-12-06&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-11-18..2022-12-06&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-11-18..2022-12-06&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-11-18..2022-12-06&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-11-18..2022-12-06&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-11-18..2022-12-06&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-11-18..2022-12-06&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-11-18..2022-12-06&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.6.0a4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ### Bugs fixed
 
-- use jupyter_config_dir instead of config_path[0] for workspaces, settings [#13589](https://github.com/jupyterlab/jupyterlab/pull/13589) ([@minrk](https://github.com/minrk))
+- use jupyter_config_dir instead of config_path\[0\] for workspaces, settings [#13589](https://github.com/jupyterlab/jupyterlab/pull/13589) ([@minrk](https://github.com/minrk))
 - Bump @lumino/application [#13590](https://github.com/jupyterlab/jupyterlab/pull/13590) ([@fcollonval](https://github.com/fcollonval))
 - Restores the appearance of the settingeditor's input focus [#13554](https://github.com/jupyterlab/jupyterlab/pull/13554) ([@brichet](https://github.com/brichet))
 - Fix a wrong argument when calling 'renderMimeVariable' [#13531](https://github.com/jupyterlab/jupyterlab/pull/13531) ([@brichet](https://github.com/brichet))


### PR DESCRIPTION
Automated Changelog Entry for 3.6.0b0 on 3.6.x
```
Python version: 3.6.0b0
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.6.0-beta.0
@jupyterlab/buildutils: 3.6.0-beta.0
@jupyterlab/template: 3.6.0-beta.0
@jupyterlab/application-top: 3.6.0-beta.0
@jupyterlab/example-app: 3.6.0-beta.0
@jupyterlab/example-cell: 3.6.0-beta.0
@jupyterlab/example-console: 3.6.0-beta.0
@jupyterlab/example-federated: 2.7.0-beta.0
@jupyterlab/example-federated-core: 2.7.0-beta.0
@jupyterlab/example-federated-md: 2.7.0-beta.0
@jupyterlab/example-federated-middle: 2.7.0-beta.0
@jupyterlab/example-federated-phosphor: 2.7.0-beta.0
@jupyterlab/example-filebrowser: 3.6.0-beta.0
@jupyterlab/example-notebook: 3.6.0-beta.0
@jupyterlab/example-terminal: 3.6.0-beta.0
@jupyterlab/galata: 4.5.0-beta.0
@jupyterlab/mock-extension: 3.6.0-beta.0
@jupyterlab/mock-consumer: 3.6.0-beta.0
@jupyterlab/mock-provider: 3.6.0-beta.0
@jupyterlab/mock-token: 3.6.0-beta.0
@jupyterlab/application: 3.6.0-beta.0
@jupyterlab/application-extension: 3.6.0-beta.0
@jupyterlab/apputils: 3.6.0-beta.0
@jupyterlab/apputils-extension: 3.6.0-beta.0
@jupyterlab/attachments: 3.6.0-beta.0
@jupyterlab/cell-toolbar: 3.6.0-beta.0
@jupyterlab/cell-toolbar-extension: 3.6.0-beta.0
@jupyterlab/cells: 3.6.0-beta.0
@jupyterlab/celltags: 3.6.0-beta.0
@jupyterlab/celltags-extension: 3.6.0-beta.0
@jupyterlab/codeeditor: 3.6.0-beta.0
@jupyterlab/codemirror: 3.6.0-beta.0
@jupyterlab/codemirror-extension: 3.6.0-beta.0
@jupyterlab/collaboration: 3.6.0-beta.0
@jupyterlab/collaboration-extension: 3.6.0-beta.0
@jupyterlab/completer: 3.6.0-beta.0
@jupyterlab/completer-extension: 3.6.0-beta.0
@jupyterlab/console: 3.6.0-beta.0
@jupyterlab/console-extension: 3.6.0-beta.0
@jupyterlab/coreutils: 5.6.0-beta.0
@jupyterlab/csvviewer: 3.6.0-beta.0
@jupyterlab/csvviewer-extension: 3.6.0-beta.0
@jupyterlab/debugger: 3.6.0-beta.0
@jupyterlab/debugger-extension: 3.6.0-beta.0
@jupyterlab/docmanager: 3.6.0-beta.0
@jupyterlab/docmanager-extension: 3.6.0-beta.0
@jupyterlab/docprovider: 3.6.0-beta.0
@jupyterlab/docprovider-extension: 3.6.0-beta.0
@jupyterlab/docregistry: 3.6.0-beta.0
@jupyterlab/documentsearch: 3.6.0-beta.0
@jupyterlab/documentsearch-extension: 3.6.0-beta.0
@jupyterlab/extensionmanager: 3.6.0-beta.0
@jupyterlab/extensionmanager-extension: 3.6.0-beta.0
@jupyterlab/filebrowser: 3.6.0-beta.0
@jupyterlab/filebrowser-extension: 3.6.0-beta.0
@jupyterlab/fileeditor: 3.6.0-beta.0
@jupyterlab/fileeditor-extension: 3.6.0-beta.0
@jupyterlab/help-extension: 3.6.0-beta.0
@jupyterlab/htmlviewer: 3.6.0-beta.0
@jupyterlab/htmlviewer-extension: 3.6.0-beta.0
@jupyterlab/hub-extension: 3.6.0-beta.0
@jupyterlab/imageviewer: 3.6.0-beta.0
@jupyterlab/imageviewer-extension: 3.6.0-beta.0
@jupyterlab/inspector: 3.6.0-beta.0
@jupyterlab/inspector-extension: 3.6.0-beta.0
@jupyterlab/javascript-extension: 3.6.0-beta.0
@jupyterlab/json-extension: 3.6.0-beta.0
@jupyterlab/launcher: 3.6.0-beta.0
@jupyterlab/launcher-extension: 3.6.0-beta.0
@jupyterlab/logconsole: 3.6.0-beta.0
@jupyterlab/logconsole-extension: 3.6.0-beta.0
@jupyterlab/mainmenu: 3.6.0-beta.0
@jupyterlab/mainmenu-extension: 3.6.0-beta.0
@jupyterlab/markdownviewer: 3.6.0-beta.0
@jupyterlab/markdownviewer-extension: 3.6.0-beta.0
@jupyterlab/mathjax2: 3.6.0-beta.0
@jupyterlab/mathjax2-extension: 3.6.0-beta.0
@jupyterlab/metapackage: 3.6.0-beta.0
@jupyterlab/nbconvert-css: 3.6.0-beta.0
@jupyterlab/nbformat: 3.6.0-beta.0
@jupyterlab/notebook: 3.6.0-beta.0
@jupyterlab/notebook-extension: 3.6.0-beta.0
@jupyterlab/observables: 4.6.0-beta.0
@jupyterlab/outputarea: 3.6.0-beta.0
@jupyterlab/pdf-extension: 3.6.0-beta.0
@jupyterlab/property-inspector: 3.6.0-beta.0
@jupyterlab/rendermime: 3.6.0-beta.0
@jupyterlab/rendermime-extension: 3.6.0-beta.0
@jupyterlab/rendermime-interfaces: 3.6.0-beta.0
@jupyterlab/running: 3.6.0-beta.0
@jupyterlab/running-extension: 3.6.0-beta.0
@jupyterlab/services: 6.6.0-beta.0
@jupyterlab/example-services-browser: 3.6.0-beta.0
node-example: 3.6.0-beta.0
@jupyterlab/example-services-outputarea: 3.6.0-beta.0
@jupyterlab/settingeditor: 3.6.0-beta.0
@jupyterlab/settingeditor-extension: 3.6.0-beta.0
@jupyterlab/settingregistry: 3.6.0-beta.0
@jupyterlab/shortcuts-extension: 3.6.0-beta.0
@jupyterlab/statedb: 3.6.0-beta.0
@jupyterlab/statusbar: 3.6.0-beta.0
@jupyterlab/statusbar-extension: 3.6.0-beta.0
@jupyterlab/terminal: 3.6.0-beta.0
@jupyterlab/terminal-extension: 3.6.0-beta.0
@jupyterlab/theme-dark-extension: 3.6.0-beta.0
@jupyterlab/theme-light-extension: 3.6.0-beta.0
@jupyterlab/toc: 5.6.0-beta.0
@jupyterlab/toc-extension: 5.6.0-beta.0
@jupyterlab/tooltip: 3.6.0-beta.0
@jupyterlab/tooltip-extension: 3.6.0-beta.0
@jupyterlab/translation: 3.6.0-beta.0
@jupyterlab/translation-extension: 3.6.0-beta.0
@jupyterlab/ui-components: 3.6.0-beta.0
@jupyterlab/ui-components-extension: 3.6.0-beta.0
@jupyterlab/vdom: 3.6.0-beta.0
@jupyterlab/vdom-extension: 3.6.0-beta.0
@jupyterlab/vega5-extension: 3.6.0-beta.0
@jupyterlab/testutils: 3.6.0-beta.0
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyterlab/jupyterlab/releases/tag/untagged-3e7cf917565ce91e7981  |
| Since | v3.6.0a5 |