### PR TITLE
Backport PR #11962 on branch 3.6.x (Do not load CSS of disabled federated extensions)

### DIFF
--- a/dev_mode/index.js
+++ b/dev_mode/index.js
@@ -87,6 +87,8 @@ export async function main() {
     PageConfig.getOption('federated_extensions')
   );
 
+  var futureSkipStylesForDisabled = (PageConfig.getOption('futureSkipStylesForDisabled') || '').toLowerCase() === 'true';
+
   const queuedFederated = [];
 
   extensions.forEach(data => {
@@ -98,7 +100,8 @@ export async function main() {
       queuedFederated.push(data.name);
       federatedMimeExtensionPromises.push(createModule(data.name, data.mimeExtension));
     }
-    if (data.style) {
+
+    if (data.style && (!futureSkipStylesForDisabled || !PageConfig.Extension.isDisabled(data.name))) {
       federatedStylePromises.push(createModule(data.name, data.style));
     }
   });

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -53,6 +53,13 @@ The involved packages are:
 
    * The ``ServiceManager`` class implements the optional property ``user`` from the ``IManager``.
 
+**Future changes:**
+Some of the behavior changes coming in JupyterLab 4.0 were made available behind a flag in JupyterLab 3.6:
+
+- In JupyterLab 3.x, the CSS for a _disabled_ prebuilt extensions is always loaded on the page.
+  This will no longer be the case in JupyterLab 4.0. To preview the impact of these changes on
+  your extension/theme start JupyterLab with ``--future-skip-styles-for-disabled`` flag.
+
 
 .. _extension_migration_3.0_3.1:
 

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -474,6 +474,12 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
         {"LabApp": {"collaborative": True}},
         "Whether to enable collaborative mode.",
     )
+    flags["future-skip-styles-for-disabled"] = (
+        {"LabApp": {"future_skip_styles_for_disabled": True}},
+        """Whether to skip loading styles for disabled prebuilt extensions.
+        This will be the default behavior starting with JupyterLab 4.0
+        (and this flag will be removed).""",
+    )
 
     subcommands = dict(
         build=(LabBuildApp, LabBuildApp.description.splitlines()[0]),
@@ -542,6 +548,14 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
         False,
         config=True,
         help="Whether to expose the global app instance to browser via window.jupyterlab",
+    )
+
+    future_skip_styles_for_disabled = Bool(
+        False,
+        config=True,
+        help="""Whether to skip loading styles for disabled prebuilt extensions.
+        This will be the default behavior starting with JupyterLab 4.0
+        (and this flag will be removed).""",
     )
 
     collaborative = Bool(False, config=True, help="Whether to enable collaborative mode.")
@@ -666,6 +680,7 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
         page_config["quitButton"] = self.serverapp.quit_button
         page_config["collaborative"] = self.collaborative
         page_config["allow_hidden_files"] = self.serverapp.contents_manager.allow_hidden
+        page_config["futureSkipStylesForDisabled"] = self.future_skip_styles_for_disabled
 
         # Client-side code assumes notebookVersion is a JSON-encoded string
         page_config["notebookVersion"] = json.dumps(jpserver_version_info)


### PR DESCRIPTION
Backport PR https://github.com/jupyterlab/jupyterlab/pull/11962 on branch 3.6.x (Do not load CSS of disabled federated extensions)" behind a `--future-skip-styles-for-disabled` flag.