### PR TITLE
Remove old completer API

### DIFF
--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -34,20 +34,7 @@ export class CompletionHandler implements IDisposable {
     this.completer = options.completer;
     this.completer.selected.connect(this.onCompletionSelected, this);
     this.completer.visibilityChanged.connect(this.onVisibilityChanged, this);
-    if (options.connector && options.reconciliator) {
-      console.warn(
-        'Both connector and reconciliator were passed; the connector will be ignored'
-      );
-    }
-    if (options.reconciliator) {
-      this._reconciliator = options.reconciliator;
-    } else if (options.connector) {
-      this._reconciliator = options.connector;
-    } else {
-      throw Error(
-        'At least one: connector or reconciliator needs to be provided'
-      );
-    }
+    this._reconciliator = options.reconciliator;
   }
 
   /**
@@ -57,13 +44,6 @@ export class CompletionHandler implements IDisposable {
 
   set reconciliator(reconciliator: IProviderReconciliator) {
     this._reconciliator = reconciliator;
-  }
-
-  /**
-   * @deprecated use `reconciliator` instead.
-   */
-  set connector(connector: CompletionHandler.ICompletionItemsConnector) {
-    this._reconciliator = connector;
   }
 
   /**
@@ -412,9 +392,7 @@ export class CompletionHandler implements IDisposable {
     return model;
   }
 
-  private _reconciliator:
-    | IProviderReconciliator
-    | CompletionHandler.ICompletionItemsConnector;
+  private _reconciliator: IProviderReconciliator;
   private _editor: CodeEditor.IEditor | null | undefined = null;
   private _enabled = false;
   private _isDisposed = false;
@@ -437,18 +415,7 @@ export namespace CompletionHandler {
     /**
      * The reconciliator that will fetch and merge completions from active providers.
      */
-    reconciliator?: IProviderReconciliator;
-
-    /**
-     * The data connector used to populate completion requests.
-     * #### Notes
-     * The only method of this connector that will ever be called is `fetch`, so
-     * it is acceptable for the other methods to be simple functions that return
-     * rejected promises.
-     *
-     * @deprecated use `reconciliator` instead.
-     */
-    connector?: CompletionHandler.ICompletionItemsConnector;
+    reconciliator: IProviderReconciliator;
   }
 
   /**
@@ -536,18 +503,6 @@ export namespace CompletionHandler {
      */
     items: Array<T>;
   }
-
-  /**
-   * @deprecated this is no longer required, use completion providers instead of custom connectors.
-   */
-  export interface ICompleterConnecterResponseType {
-    responseType: typeof ICompletionItemsResponseType;
-  }
-
-  /**
-   * @deprecated this is no longer required, use completion providers instead of custom connectors.
-   */
-  export const ICompletionItemsResponseType = 'ICompletionItemsReply' as const;
 
   /**
    * The details of a completion request.

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { map, StringExt } from '@lumino/algorithm';
+import { StringExt } from '@lumino/algorithm';
 import { JSONExt, ReadonlyPartialJSONArray } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 import { CompletionHandler } from './handler';
@@ -161,7 +161,7 @@ export class CompleterModel implements Completer.IModel {
    * #### Notes
    * This is a read-only property.
    */
-  completionItems?(): CompletionHandler.ICompletionItems {
+  completionItems(): CompletionHandler.ICompletionItems {
     let query = this._query;
     if (query) {
       return this._markup(query);
@@ -173,7 +173,7 @@ export class CompleterModel implements Completer.IModel {
    * Set the list of visible items in the completer menu, and append any
    * new types to KNOWN_TYPES.
    */
-  setCompletionItems?(newValue: CompletionHandler.ICompletionItems): void {
+  setCompletionItems(newValue: CompletionHandler.ICompletionItems): void {
     if (
       JSONExt.deepEqual(
         newValue as unknown as ReadonlyPartialJSONArray,
@@ -187,24 +187,6 @@ export class CompleterModel implements Completer.IModel {
       this._completionItems
     );
     this._stateChanged.emit(undefined);
-  }
-
-  /**
-   * The list of visible items in the completer menu.
-   * @deprecated use `completionItems` instead
-   *
-   * #### Notes
-   * This is a read-only property.
-   */
-  items(): IterableIterator<Completer.IItem> {
-    return this._filter();
-  }
-
-  /**
-   * The unfiltered list of all available options in a completer menu.
-   */
-  options(): IterableIterator<string> {
-    return this._options[Symbol.iterator]();
   }
 
   /**
@@ -236,31 +218,6 @@ export class CompleterModel implements Completer.IModel {
    */
   orderedTypes(): string[] {
     return this._orderedTypes;
-  }
-
-  /**
-   * Set the available options in the completer menu.
-   */
-  setOptions(newValue: Iterable<string>, typeMap?: Completer.TypeMap): void {
-    const values = Array.from(newValue || []);
-    const types = typeMap || {};
-
-    if (
-      JSONExt.deepEqual(values, this._options) &&
-      JSONExt.deepEqual(types, this._typeMap)
-    ) {
-      return;
-    }
-    if (values.length) {
-      this._options = values;
-      this._typeMap = types;
-      this._orderedTypes = Private.findOrderedTypes(types);
-    } else {
-      this._options = [];
-      this._typeMap = {};
-      this._orderedTypes = [];
-    }
-    this._stateChanged.emit(undefined);
   }
 
   /**
@@ -422,33 +379,6 @@ export class CompleterModel implements Completer.IModel {
   }
 
   /**
-   * Apply the query to the complete options list to return the matching subset.
-   */
-  private _filter(): IterableIterator<Completer.IItem> {
-    const options = this._options || [];
-    const query = this._query;
-    if (!query) {
-      return map(options, option => ({ raw: option, text: option }));
-    }
-    const results: Private.IMatch[] = [];
-    for (const option of options) {
-      const match = StringExt.matchSumOfSquares(option, query);
-      if (match) {
-        const marked = StringExt.highlight(option, match.indices, Private.mark);
-        results.push({
-          raw: option,
-          score: match.score,
-          text: marked.join('')
-        });
-      }
-    }
-    return map(results.sort(Private.scoreCmp), result => ({
-      text: result.text,
-      raw: result.raw
-    }));
-  }
-
-  /**
    * Lazy load missing data of item at `activeIndex`.
    * @param {number} activeIndex - index of item
    * @return Return `undefined` if the completion item with `activeIndex` index can not be found.
@@ -509,7 +439,6 @@ export class CompleterModel implements Completer.IModel {
     this._current = null;
     this._cursor = null;
     this._completionItems = [];
-    this._options = [];
     this._original = null;
     this._query = '';
     this._subsetMatch = false;
@@ -521,7 +450,6 @@ export class CompleterModel implements Completer.IModel {
   private _cursor: Completer.ICursorSpan | null = null;
   private _isDisposed = false;
   private _completionItems: CompletionHandler.ICompletionItems = [];
-  private _options: string[] = [];
   private _original: Completer.ITextState | null = null;
   private _query = '';
   private _subsetMatch = false;

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -5,7 +5,7 @@ import { ISanitizer, Sanitizer } from '@jupyterlab/apputils';
 import { CodeEditor } from '@jupyterlab/codeeditor';
 import { renderText } from '@jupyterlab/rendermime';
 import { HoverBox, LabIcon } from '@jupyterlab/ui-components';
-import { JSONExt, JSONObject } from '@lumino/coreutils';
+import { JSONObject } from '@lumino/coreutils';
 import { IDisposable } from '@lumino/disposable';
 import { ElementExt } from '@lumino/domutils';
 import { Message } from '@lumino/messaging';
@@ -254,12 +254,9 @@ export class Completer extends Widget {
     }
 
     let node: HTMLElement | null = null;
-    let completionItemList = model.completionItems && model.completionItems();
-    if (completionItemList && completionItemList.length) {
-      node = this._createCompletionItemNode(model, completionItemList);
-    } else {
-      node = this._createIItemNode(model);
-    }
+    let completionItemList = model.completionItems();
+    node = this._createCompletionItemNode(model, completionItemList);
+
     if (!node) {
       return;
     }
@@ -326,54 +323,6 @@ export class Completer extends Widget {
         return null;
       }
       let li = this._renderer.createCompletionItemNode(item, orderedTypes);
-      ul.appendChild(li);
-    }
-    node.appendChild(ul);
-    return node;
-  }
-
-  private _createIItemNode(model: Completer.IModel): HTMLElement | null {
-    const items = Array.from(model.items());
-
-    // If there are no items, reset and bail.
-    if (!items || !items.length) {
-      this._resetFlag = true;
-      this.reset();
-      if (!this.isHidden) {
-        this.hide();
-        this._visibilityChanged.emit(undefined);
-      }
-      return null;
-    }
-
-    // If there is only one option, signal and bail.
-    // We don't test the filtered `items`, as that
-    // is too aggressive of completer behavior, it can
-    // lead to double typing of an option.
-    const options = Array.from(model.options());
-    if (options.length === 1) {
-      this._selected.emit(options[0]);
-      this.reset();
-      return null;
-    }
-
-    // Clear the node.
-    const node = this.node;
-    node.textContent = '';
-
-    // Compute an ordered list of all the types in the typeMap, this is computed
-    // once by the model each time new data arrives for efficiency.
-    const orderedTypes = model.orderedTypes();
-
-    // Populate the completer items.
-    let ul = document.createElement('ul');
-    ul.className = 'jp-Completer-list';
-    for (const item of items) {
-      const li = this._renderer.createItemNode(
-        item!,
-        model.typeMap(),
-        orderedTypes
-      );
       ul.appendChild(li);
     }
     node.appendChild(ul);
@@ -802,17 +751,12 @@ export namespace Completer {
     /**
      * Get the list of visible CompletionItems in the completer menu.
      */
-    completionItems?(): CompletionHandler.ICompletionItems;
+    completionItems(): CompletionHandler.ICompletionItems;
 
     /**
      * Set the list of visible CompletionItems in the completer menu.
      */
-    setCompletionItems?(items: CompletionHandler.ICompletionItems): void;
-
-    /**
-     * Get the of visible items in the completer menu.
-     */
-    items(): IterableIterator<IItem>;
+    setCompletionItems(items: CompletionHandler.ICompletionItems): void;
 
     /**
      * Lazy load missing data of item at `activeIndex`.
@@ -826,11 +770,6 @@ export namespace Completer {
     ): Promise<CompletionHandler.ICompletionItem | null> | undefined;
 
     /**
-     * Get the unfiltered options in a completer menu.
-     */
-    options(): IterableIterator<string>;
-
-    /**
      * The map from identifiers (`a.b`) to their types (function, module, class,
      * instance, etc.).
      */
@@ -840,11 +779,6 @@ export namespace Completer {
      * An ordered list of types used for visual encoding.
      */
     orderedTypes(): string[];
-
-    /**
-     * Set the available options in the completer menu.
-     */
-    setOptions(options: Iterable<string>, typeMap?: JSONObject): void;
 
     /**
      * Handle a cursor change.
@@ -890,21 +824,6 @@ export namespace Completer {
   }
 
   /**
-   * A completer menu item.
-   */
-  export interface IItem {
-    /**
-     * The highlighted, marked up text of a visible completer item.
-     */
-    text: string;
-
-    /**
-     * The raw text of a visible completer item.
-     */
-    raw: string;
-  }
-
-  /**
    * A cursor span.
    */
   export interface ICursorSpan extends JSONObject {
@@ -926,19 +845,10 @@ export namespace Completer {
     T extends CompletionHandler.ICompletionItem = CompletionHandler.ICompletionItem
   > {
     /**
-     * Create an item node (an `li` element)  from a ICompletionItem
+     * Create an item node (an `li` element) from a ICompletionItem
      * for a text completer menu.
      */
-    createCompletionItemNode?(item: T, orderedTypes: string[]): HTMLLIElement;
-
-    /**
-     * Create an item node (an `li` element) for a text completer menu.
-     */
-    createItemNode(
-      item: IItem,
-      typeMap: TypeMap,
-      orderedTypes: string[]
-    ): HTMLLIElement;
+    createCompletionItemNode(item: T, orderedTypes: string[]): HTMLLIElement;
 
     /**
      * Create a documentation node (a `pre` element by default) for
@@ -976,23 +886,6 @@ export namespace Completer {
         item.type,
         orderedTypes,
         item.icon
-      );
-    }
-
-    /**
-     * Create an item node for a text completer menu.
-     */
-    createItemNode(
-      item: IItem,
-      typeMap: TypeMap,
-      orderedTypes: string[]
-    ): HTMLLIElement {
-      return this._constructNode(
-        this._createBaseNode(item.raw),
-        this._createMatchNode(item.text),
-        !JSONExt.deepEqual(typeMap, {}),
-        typeMap[item.raw] || '',
-        orderedTypes
       );
     }
 

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -319,9 +319,6 @@ export class Completer extends Widget {
     let ul = document.createElement('ul');
     ul.className = 'jp-Completer-list';
     for (let item of items) {
-      if (!this._renderer.createCompletionItemNode) {
-        return null;
-      }
       let li = this._renderer.createCompletionItemNode(item, orderedTypes);
       ul.appendChild(li);
     }
@@ -400,7 +397,7 @@ export class Completer extends Widget {
           return;
         }
         // Autoinsert single completions on manual request (tab)
-        const items = model.completionItems && model.completionItems();
+        const items = model.completionItems();
         if (items && items.length === 1) {
           this._selected.emit(items[0].insertText || items[0].label);
           this.reset();

--- a/packages/completer/test/model.spec.ts
+++ b/packages/completer/test/model.spec.ts
@@ -6,7 +6,6 @@ import {
   CompleterModel,
   CompletionHandler
 } from '@jupyterlab/completer';
-import { JSONExt } from '@lumino/coreutils';
 
 function makeState(text: string): Completer.ITextState {
   return {
@@ -322,7 +321,7 @@ describe('completer/model', () => {
     describe('#dispose()', () => {
       it('should dispose of the model resources', () => {
         const model = new CompleterModel();
-        model.setOptions(['foo'], { foo: 'instance' });
+        model.setCompletionItems([{ label: 'foo' }]);
         expect(model.isDisposed).toBe(false);
         model.dispose();
         expect(model.isDisposed).toBe(true);

--- a/packages/completer/test/model.spec.ts
+++ b/packages/completer/test/model.spec.ts
@@ -30,20 +30,6 @@ describe('completer/model', () => {
     });
 
     describe('#stateChanged', () => {
-      it('should signal when model options have changed', () => {
-        const model = new CompleterModel();
-        let called = 0;
-        const listener = (sender: any, args: void) => {
-          called++;
-        };
-        model.stateChanged.connect(listener);
-        expect(called).toBe(0);
-        model.setOptions(['foo']);
-        expect(called).toBe(1);
-        model.setOptions(['foo'], { foo: 'instance' });
-        expect(called).toBe(2);
-      });
-
       it('should signal when model items have changed', () => {
         let model = new CompleterModel();
         let called = 0;
@@ -52,30 +38,11 @@ describe('completer/model', () => {
         };
         model.stateChanged.connect(listener);
         expect(called).toBe(0);
-        model.setCompletionItems!([{ label: 'foo' }]);
+        model.setCompletionItems([{ label: 'foo' }]);
         expect(called).toBe(1);
-        model.setCompletionItems!([{ label: 'foo' }]);
-        model.setCompletionItems!([{ label: 'foo' }, { label: 'bar' }]);
+        model.setCompletionItems([{ label: 'foo' }]);
+        model.setCompletionItems([{ label: 'foo' }, { label: 'bar' }]);
         expect(called).toBe(2);
-      });
-
-      it('should not signal when options have not changed', () => {
-        const model = new CompleterModel();
-        let called = 0;
-        const listener = (sender: any, args: void) => {
-          called++;
-        };
-        model.stateChanged.connect(listener);
-        expect(called).toBe(0);
-        model.setOptions(['foo']);
-        model.setOptions(['foo']);
-        expect(called).toBe(1);
-        model.setOptions(['foo'], { foo: 'instance' });
-        model.setOptions(['foo'], { foo: 'instance' });
-        expect(called).toBe(2);
-        model.setOptions([], {});
-        model.setOptions([], {});
-        expect(called).toBe(3);
       });
 
       it('should not signal when items have not changed', () => {
@@ -86,14 +53,14 @@ describe('completer/model', () => {
         };
         model.stateChanged.connect(listener);
         expect(called).toBe(0);
-        model.setCompletionItems!([{ label: 'foo' }]);
-        model.setCompletionItems!([{ label: 'foo' }]);
+        model.setCompletionItems([{ label: 'foo' }]);
+        model.setCompletionItems([{ label: 'foo' }]);
         expect(called).toBe(1);
-        model.setCompletionItems!([{ label: 'foo' }, { label: 'bar' }]);
-        model.setCompletionItems!([{ label: 'foo' }, { label: 'bar' }]);
+        model.setCompletionItems([{ label: 'foo' }, { label: 'bar' }]);
+        model.setCompletionItems([{ label: 'foo' }, { label: 'bar' }]);
         expect(called).toBe(2);
-        model.setCompletionItems!([]);
-        model.setCompletionItems!([]);
+        model.setCompletionItems([]);
+        model.setCompletionItems([]);
         expect(called).toBe(3);
       });
 
@@ -178,7 +145,7 @@ describe('completer/model', () => {
       it('should default to { items: [] }', () => {
         let model = new CompleterModel();
         let want: CompletionHandler.ICompletionItems = [];
-        expect(model.completionItems!()).toEqual(want);
+        expect(model.completionItems()).toEqual(want);
       });
 
       it('should return unmarked ICompletionItems if query is blank', () => {
@@ -188,25 +155,25 @@ describe('completer/model', () => {
           { label: 'bar' },
           { label: 'baz' }
         ];
-        model.setCompletionItems!([
+        model.setCompletionItems([
           { label: 'foo' },
           { label: 'bar' },
           { label: 'baz' }
         ]);
-        expect(model.completionItems!()).toEqual(want);
+        expect(model.completionItems()).toEqual(want);
       });
 
       it('should return a marked list of items if query is set', () => {
         let model = new CompleterModel();
         let want = '<mark>f</mark>oo';
-        model.setCompletionItems!([
+        model.setCompletionItems([
           { label: 'foo' },
           { label: 'bar' },
           { label: 'baz' }
         ]);
         model.query = 'f';
-        expect(model.completionItems!().length).toEqual(1);
-        expect(model.completionItems!()[0].label).toEqual(want);
+        expect(model.completionItems().length).toEqual(1);
+        expect(model.completionItems()[0].label).toEqual(want);
       });
 
       it('should order list based on score', () => {
@@ -215,7 +182,7 @@ describe('completer/model', () => {
           { insertText: 'qux', label: '<mark>qux</mark>' },
           { insertText: 'quux', label: '<mark>qu</mark>u<mark>x</mark>' }
         ];
-        model.setCompletionItems!([
+        model.setCompletionItems([
           { label: 'foo' },
           { label: 'bar' },
           { label: 'baz' },
@@ -223,7 +190,7 @@ describe('completer/model', () => {
           { label: 'qux' }
         ]);
         model.query = 'qux';
-        expect(model.completionItems!()).toEqual(want);
+        expect(model.completionItems()).toEqual(want);
       });
 
       it('should break ties in score by locale sort', () => {
@@ -232,7 +199,7 @@ describe('completer/model', () => {
           { insertText: 'quux', label: '<mark>qu</mark>ux' },
           { insertText: 'qux', label: '<mark>qu</mark>x' }
         ];
-        model.setCompletionItems!([
+        model.setCompletionItems([
           { label: 'foo' },
           { label: 'bar' },
           { label: 'baz' },
@@ -240,87 +207,19 @@ describe('completer/model', () => {
           { label: 'qux' }
         ]);
         model.query = 'qu';
-        expect(model.completionItems!()).toEqual(want);
+        expect(model.completionItems()).toEqual(want);
       });
 
       it('should return { items: [] } if reset', () => {
         let model = new CompleterModel();
         let want: CompletionHandler.ICompletionItems = [];
-        model.setCompletionItems!([
+        model.setCompletionItems([
           { label: 'foo' },
           { label: 'bar' },
           { label: 'baz' }
         ]);
         model.reset();
-        expect(model.completionItems!()).toEqual(want);
-      });
-    });
-
-    describe('#items()', () => {
-      it('should return an unfiltered list of items if query is blank', () => {
-        const model = new CompleterModel();
-        const want: Completer.IItem[] = [
-          { raw: 'foo', text: 'foo' },
-          { raw: 'bar', text: 'bar' },
-          { raw: 'baz', text: 'baz' }
-        ];
-        model.setOptions(['foo', 'bar', 'baz']);
-        expect(Array.from(model.items())).toEqual(want);
-      });
-
-      it('should return a filtered list of items if query is set', () => {
-        const model = new CompleterModel();
-        const want: Completer.IItem[] = [
-          { raw: 'foo', text: '<mark>f</mark>oo' }
-        ];
-        model.setOptions(['foo', 'bar', 'baz']);
-        model.query = 'f';
-        expect(Array.from(model.items())).toEqual(want);
-      });
-
-      it('should order list based on score', () => {
-        const model = new CompleterModel();
-        const want: Completer.IItem[] = [
-          { raw: 'qux', text: '<mark>qux</mark>' },
-          { raw: 'quux', text: '<mark>qu</mark>u<mark>x</mark>' }
-        ];
-        model.setOptions(['foo', 'bar', 'baz', 'quux', 'qux']);
-        model.query = 'qux';
-        expect(Array.from(model.items())).toEqual(want);
-      });
-
-      it('should break ties in score by locale sort', () => {
-        const model = new CompleterModel();
-        const want: Completer.IItem[] = [
-          { raw: 'quux', text: '<mark>qu</mark>ux' },
-          { raw: 'qux', text: '<mark>qu</mark>x' }
-        ];
-        model.setOptions(['foo', 'bar', 'baz', 'qux', 'quux']);
-        model.query = 'qu';
-        expect(Array.from(model.items())).toEqual(want);
-      });
-    });
-
-    describe('#options()', () => {
-      it('should default to an empty iterator', () => {
-        const model = new CompleterModel();
-        expect(model.options().next().done).toBe(true);
-      });
-
-      it('should return model options', () => {
-        const model = new CompleterModel();
-        const options = ['foo'];
-        model.setOptions(options, {});
-        expect(Array.from(model.options())).not.toBe(options);
-        expect(Array.from(model.options())).toEqual(options);
-      });
-
-      it('should return the typeMap', () => {
-        const model = new CompleterModel();
-        const options = ['foo'];
-        const typeMap = { foo: 'instance' };
-        model.setOptions(options, typeMap);
-        expect(JSONExt.deepEqual(model.typeMap(), typeMap)).toBeTruthy();
+        expect(model.completionItems()).toEqual(want);
       });
     });
 
@@ -390,7 +289,6 @@ describe('completer/model', () => {
         model.current = change;
         expect(model.current).toBeNull();
         expect(model.original).toBeNull();
-        expect(model.options().next().done).toBe(true);
       });
     });
 
@@ -515,12 +413,12 @@ describe('completer/model', () => {
 
       it('should return undefined if item index is out of range.', () => {
         const model = new CompleterModel();
-        model.setCompletionItems!([{ label: 'foo' }, { label: 'bar' }]);
+        model.setCompletionItems([{ label: 'foo' }, { label: 'bar' }]);
         expect(model.resolveItem(3)).toBeUndefined();
       });
       it('should return the original item if `resolve` is missing.', async () => {
         const model = new CompleterModel();
-        model.setCompletionItems!([{ label: 'foo' }, { label: 'bar' }]);
+        model.setCompletionItems([{ label: 'foo' }, { label: 'bar' }]);
         const resolved = await model.resolveItem(0);
         expect(resolved).toEqual({ label: 'foo' });
       });
@@ -531,7 +429,7 @@ describe('completer/model', () => {
           resolve: () =>
             Promise.resolve({ label: 'foo', documentation: 'Foo docs' })
         };
-        model.setCompletionItems!([item]);
+        model.setCompletionItems([item]);
         const resolved = await model.resolveItem(0);
         expect(resolved).toEqual({ label: 'foo', documentation: 'Foo docs' });
         expect(item).toEqual({

--- a/packages/completer/test/widget.spec.ts
+++ b/packages/completer/test/widget.spec.ts
@@ -42,16 +42,6 @@ class CustomRenderer extends Completer.Renderer {
     return li;
   }
 
-  createItemNode(
-    item: Completer.IItem,
-    typeMap: Completer.TypeMap,
-    orderedTypes: string[]
-  ): HTMLLIElement {
-    const li = super.createItemNode(item, typeMap, orderedTypes);
-    li.classList.add(TEST_ITEM_CLASS);
-    return li;
-  }
-
   createDocumentationNode(
     item: CompletionHandler.ICompletionItem
   ): HTMLElement {
@@ -103,32 +93,13 @@ describe('completer/widget', () => {
         expect(widget.model).toBe(options.model);
       });
 
-      it('should accept options with a renderer', () => {
-        const options: Completer.IOptions = {
-          editor: null,
-          model: new CompleterModel(),
-          renderer: new CustomRenderer()
-        };
-        options.model!.setOptions(['foo', 'bar']);
-
-        const widget = new Completer(options);
-        expect(widget).toBeInstanceOf(Completer);
-        MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-
-        const items = widget.node.querySelectorAll(`.${ITEM_CLASS}`);
-        expect(items).toHaveLength(2);
-        expect(Array.from(items[0].classList)).toEqual(
-          expect.arrayContaining([TEST_ITEM_CLASS])
-        );
-      });
-
-      it('should accept completion items with a renderer', async () => {
+      it('should accept options with a renderer', async () => {
         let options: Completer.IOptions = {
           editor: null,
           model: new CompleterModel(),
           renderer: new CustomRenderer()
         };
-        options.model!.setCompletionItems!([
+        options.model!.setCompletionItems([
           { label: 'foo', documentation: 'foo does bar' },
           { label: 'bar' }
         ]);
@@ -157,7 +128,7 @@ describe('completer/widget', () => {
           model: new CompleterModel(),
           renderer: new CustomRenderer()
         };
-        options.model!.setCompletionItems!([
+        options.model!.setCompletionItems([
           { label: 'foo', documentation: 'foo does bar' }
         ]);
 
@@ -173,7 +144,7 @@ describe('completer/widget', () => {
           editor: null,
           model: new CompleterModel()
         };
-        options.model!.setCompletionItems!([{ label: 'foo' }]);
+        options.model!.setCompletionItems([{ label: 'foo' }]);
         options.model!.resolveItem = jest.fn();
         const widget = new Completer(options);
         MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
@@ -185,7 +156,7 @@ describe('completer/widget', () => {
           editor: null,
           model: new CompleterModel()
         };
-        options.model!.setCompletionItems!([{ label: 'foo' }]);
+        options.model!.setCompletionItems([{ label: 'foo' }]);
         options.model!.resolveItem = jest.fn();
         const widget = new Completer(options);
         MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
@@ -195,20 +166,48 @@ describe('completer/widget', () => {
     });
 
     describe('#selected', () => {
-      it('should emit a signal when an item is selected', () => {
-        const anchor = createEditorWidget();
-        const options: Completer.IOptions = {
+      it('should emit the insert text if it is present', () => {
+        let anchor = createEditorWidget();
+        let options: Completer.IOptions = {
           editor: anchor.editor,
           model: new CompleterModel()
         };
         let value = '';
-        const listener = (sender: any, selected: string) => {
+        let listener = (sender: any, selected: string) => {
           value = selected;
         };
-        options.model!.setOptions(['foo', 'bar']);
+        options.model!.setCompletionItems([
+          { label: 'foo', insertText: 'bar' },
+          { label: 'baz' }
+        ]);
         Widget.attach(anchor, document.body);
 
-        const widget = new Completer(options);
+        let widget = new Completer(options);
+
+        widget.selected.connect(listener);
+        Widget.attach(widget, document.body);
+        MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
+        expect(value).toBe('');
+        widget.selectActive();
+        expect(value).toBe('bar');
+        widget.dispose();
+        anchor.dispose();
+      });
+
+      it('should emit the label if insert text is not present', () => {
+        let anchor = createEditorWidget();
+        let options: Completer.IOptions = {
+          editor: anchor.editor,
+          model: new CompleterModel()
+        };
+        let value = '';
+        let listener = (sender: any, selected: string) => {
+          value = selected;
+        };
+        options.model!.setCompletionItems([{ label: 'foo' }, { label: 'baz' }]);
+        Widget.attach(anchor, document.body);
+
+        let widget = new Completer(options);
 
         widget.selected.connect(listener);
         Widget.attach(widget, document.body);
@@ -219,118 +218,10 @@ describe('completer/widget', () => {
         widget.dispose();
         anchor.dispose();
       });
-
-      describe('#selected with completion items', () => {
-        it('should emit the insert text if it is present', () => {
-          let anchor = createEditorWidget();
-          let options: Completer.IOptions = {
-            editor: anchor.editor,
-            model: new CompleterModel()
-          };
-          let value = '';
-          let listener = (sender: any, selected: string) => {
-            value = selected;
-          };
-          options.model!.setCompletionItems!([
-            { label: 'foo', insertText: 'bar' },
-            { label: 'baz' }
-          ]);
-          Widget.attach(anchor, document.body);
-
-          let widget = new Completer(options);
-
-          widget.selected.connect(listener);
-          Widget.attach(widget, document.body);
-          MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-          expect(value).toBe('');
-          widget.selectActive();
-          expect(value).toBe('bar');
-          widget.dispose();
-          anchor.dispose();
-        });
-
-        it('should emit the label if insert text is not present', () => {
-          let anchor = createEditorWidget();
-          let options: Completer.IOptions = {
-            editor: anchor.editor,
-            model: new CompleterModel()
-          };
-          let value = '';
-          let listener = (sender: any, selected: string) => {
-            value = selected;
-          };
-          options.model!.setCompletionItems!([
-            { label: 'foo' },
-            { label: 'baz' }
-          ]);
-          Widget.attach(anchor, document.body);
-
-          let widget = new Completer(options);
-
-          widget.selected.connect(listener);
-          Widget.attach(widget, document.body);
-          MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-          expect(value).toBe('');
-          widget.selectActive();
-          expect(value).toBe('foo');
-          widget.dispose();
-          anchor.dispose();
-        });
-      });
     });
 
     describe('#visibilityChanged', () => {
       it('should emit a signal when completer visibility changes', async () => {
-        const panel = new Panel();
-        const code = createEditorWidget();
-        const editor = code.editor;
-        const model = new CompleterModel();
-        let called = false;
-
-        editor.model.sharedModel.setSource('a');
-        panel.node.style.position = 'absolute';
-        panel.node.style.top = '0px';
-        panel.node.style.left = '0px';
-        panel.node.style.height = '1000px';
-        code.node.style.height = '900px';
-        panel.addWidget(code);
-        Widget.attach(panel, document.body);
-        panel.node.scrollTop = 0;
-        document.body.scrollTop = 0;
-
-        const position = code.editor.getPositionAt(1)!;
-
-        editor.setCursorPosition(position);
-
-        const request: Completer.ITextState = {
-          column: position.column,
-          lineHeight: editor.lineHeight,
-          charWidth: editor.charWidth,
-          line: position.line,
-          text: 'a'
-        };
-
-        model.original = request;
-        model.cursor = { start: 0, end: 1 };
-        model.setOptions(['abc', 'abd', 'abe', 'abi']);
-
-        const widget = new Completer({ model, editor: code.editor });
-        widget.hide();
-        expect(called).toBe(false);
-        widget.visibilityChanged.connect(() => {
-          called = true;
-        });
-        Widget.attach(widget, document.body);
-        MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-
-        await framePromise();
-        expect(called).toBe(true);
-        widget.dispose();
-        code.dispose();
-        panel.dispose();
-      });
-
-      it('should emit a signal when completion items completer visibility changes', async () => {
         let panel = new Panel();
         let code = createEditorWidget();
         let editor = code.editor;
@@ -362,7 +253,7 @@ describe('completer/widget', () => {
 
         model.original = request;
         model.cursor = { start: 0, end: 1 };
-        model.setCompletionItems!([
+        model.setCompletionItems([
           { label: 'abc' },
           { label: 'abd' },
           { label: 'abe' },
@@ -451,37 +342,13 @@ describe('completer/widget', () => {
 
     describe('#reset()', () => {
       it('should reset the completer widget', () => {
-        const anchor = createEditorWidget();
-        const model = new CompleterModel();
-        const options: Completer.IOptions = {
-          editor: anchor.editor,
-          model
-        };
-        model.setOptions(['foo', 'bar'], { foo: 'instance', bar: 'function' });
-        Widget.attach(anchor, document.body);
-
-        const widget = new Completer(options);
-
-        Widget.attach(widget, document.body);
-        MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-        expect(widget.isHidden).toBe(false);
-        expect(model.options).toBeTruthy();
-        widget.reset();
-        MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-        expect(widget.isHidden).toBe(true);
-        expect(model.options().next().done).toBe(true);
-        widget.dispose();
-        anchor.dispose();
-      });
-
-      it('should reset the completer widget and its completion items', () => {
         let anchor = createEditorWidget();
         let model = new CompleterModel();
         let options: Completer.IOptions = {
           editor: anchor.editor,
           model
         };
-        model.setCompletionItems!([{ label: 'foo' }, { label: 'bar' }]);
+        model.setCompletionItems([{ label: 'foo' }, { label: 'bar' }]);
         Widget.attach(anchor, document.body);
 
         let widget = new Completer(options);
@@ -489,14 +356,14 @@ describe('completer/widget', () => {
         Widget.attach(widget, document.body);
         MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
         expect(widget.isHidden).toBe(false);
-        expect(model.completionItems!()).toEqual([
+        expect(model.completionItems()).toEqual([
           { label: 'foo' },
           { label: 'bar' }
         ]);
         widget.reset();
         MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
         expect(widget.isHidden).toBe(true);
-        expect(model.completionItems!()).toEqual([]);
+        expect(model.completionItems()).toEqual([]);
         widget.dispose();
         anchor.dispose();
       });
@@ -518,40 +385,13 @@ describe('completer/widget', () => {
 
       describe('keydown', () => {
         it('should reset if keydown is outside anchor', () => {
-          const model = new CompleterModel();
-          const anchor = createEditorWidget();
-          const options: Completer.IOptions = {
-            editor: anchor.editor,
-            model
-          };
-          model.setOptions(['foo', 'bar'], {
-            foo: 'instance',
-            bar: 'function'
-          });
-          Widget.attach(anchor, document.body);
-
-          const widget = new Completer(options);
-
-          Widget.attach(widget, document.body);
-          MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-          expect(widget.isHidden).toBe(false);
-          expect(model.options).toBeTruthy();
-          simulate(document.body, 'keydown', { keyCode: 70 }); // F
-          MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-          expect(widget.isHidden).toBe(true);
-          expect(model.options().next().done).toBe(true);
-          widget.dispose();
-          anchor.dispose();
-        });
-
-        it('should reset completion items if keydown is outside anchor', () => {
           let model = new CompleterModel();
           let anchor = createEditorWidget();
           let options: Completer.IOptions = {
             editor: anchor.editor,
             model
           };
-          model.setCompletionItems!([{ label: 'foo' }, { label: 'bar' }]);
+          model.setCompletionItems([{ label: 'foo' }, { label: 'bar' }]);
           Widget.attach(anchor, document.body);
 
           let widget = new Completer(options);
@@ -559,40 +399,40 @@ describe('completer/widget', () => {
           Widget.attach(widget, document.body);
           MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
           expect(widget.isHidden).toBe(false);
-          expect(model.completionItems!()).toEqual([
+          expect(model.completionItems()).toEqual([
             { label: 'foo' },
             { label: 'bar' }
           ]);
           simulate(document.body, 'keydown', { keyCode: 70 }); // F
           MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
           expect(widget.isHidden).toBe(true);
-          expect(model.completionItems!()).toEqual([]);
+          expect(model.completionItems()).toEqual([]);
           widget.dispose();
           anchor.dispose();
         });
 
         it('should select the item below and wrap to top past last (arrow keys)', () => {
-          const anchor = createEditorWidget();
-          const model = new CompleterModel();
-          const options: Completer.IOptions = {
+          let anchor = createEditorWidget();
+          let model = new CompleterModel();
+          let options: Completer.IOptions = {
             editor: anchor.editor,
             model
           };
-          model.setOptions(['foo', 'bar', 'baz'], {
-            foo: 'instance',
-            bar: 'function'
-          });
+          model.setCompletionItems([
+            { label: 'foo' },
+            { label: 'bar' },
+            { label: 'baz' }
+          ]);
           Widget.attach(anchor, document.body);
 
-          const widget = new Completer(options);
-          const target = document.createElement('div');
+          let widget = new Completer(options);
+          let target = document.createElement('div');
 
           anchor.node.appendChild(target);
           Widget.attach(widget, document.body);
           MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
 
-          const items = widget.node.querySelectorAll(`.${ITEM_CLASS}`);
-
+          let items = widget.node.querySelectorAll(`.${ITEM_CLASS}`);
           expect(Array.from(items[0].classList)).toEqual(
             expect.arrayContaining([ACTIVE_CLASS])
           );
@@ -637,143 +477,13 @@ describe('completer/widget', () => {
         });
 
         it('should select the item below and wrap to top past last (tab)', () => {
-          const anchor = createEditorWidget();
-          const model = new CompleterModel();
-          const options: Completer.IOptions = {
-            editor: anchor.editor,
-            model
-          };
-          model.setOptions(['foo', 'bar', 'baz'], {
-            foo: 'instance',
-            bar: 'function'
-          });
-          Widget.attach(anchor, document.body);
-
-          const widget = new Completer(options);
-          const target = document.createElement('div');
-
-          anchor.node.appendChild(target);
-          Widget.attach(widget, document.body);
-          MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-
-          const items = widget.node.querySelectorAll(`.${ITEM_CLASS}`);
-
-          expect(Array.from(items[0].classList)).toEqual(
-            expect.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[1].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[2].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          simulate(target, 'keydown', { keyCode: 9 }); // Tab
-          expect(Array.from(items[0].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[1].classList)).toEqual(
-            expect.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[2].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          simulate(target, 'keydown', { keyCode: 9 }); // Tab
-          expect(Array.from(items[0].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[1].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[2].classList)).toEqual(
-            expect.arrayContaining([ACTIVE_CLASS])
-          );
-          simulate(target, 'keydown', { keyCode: 9 }); // Tab
-          expect(Array.from(items[0].classList)).toEqual(
-            expect.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[1].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[2].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          widget.dispose();
-          anchor.dispose();
-        });
-
-        it('should select the completion item below and wrap to top past last (arrow keys)', () => {
           let anchor = createEditorWidget();
           let model = new CompleterModel();
           let options: Completer.IOptions = {
             editor: anchor.editor,
             model
           };
-          model.setCompletionItems!([
-            { label: 'foo' },
-            { label: 'bar' },
-            { label: 'baz' }
-          ]);
-          Widget.attach(anchor, document.body);
-
-          let widget = new Completer(options);
-          let target = document.createElement('div');
-
-          anchor.node.appendChild(target);
-          Widget.attach(widget, document.body);
-          MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-
-          let items = widget.node.querySelectorAll(`.${ITEM_CLASS}`);
-          expect(Array.from(items[0].classList)).toEqual(
-            expect.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[1].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[2].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          simulate(target, 'keydown', { keyCode: 40 }); // Down
-          expect(Array.from(items[0].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[1].classList)).toEqual(
-            expect.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[2].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          simulate(target, 'keydown', { keyCode: 40 }); // Down
-          expect(Array.from(items[0].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[1].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[2].classList)).toEqual(
-            expect.arrayContaining([ACTIVE_CLASS])
-          );
-          simulate(target, 'keydown', { keyCode: 40 }); // Down
-          expect(Array.from(items[0].classList)).toEqual(
-            expect.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[1].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[2].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          widget.dispose();
-          anchor.dispose();
-        });
-
-        it('should select the completion item below and wrap to top past last (tab)', () => {
-          let anchor = createEditorWidget();
-          let model = new CompleterModel();
-          let options: Completer.IOptions = {
-            editor: anchor.editor,
-            model
-          };
-          model.setCompletionItems!([
+          model.setCompletionItems([
             { label: 'foo' },
             { label: 'bar' },
             { label: 'baz' }
@@ -831,180 +541,14 @@ describe('completer/widget', () => {
           anchor.dispose();
         });
 
-        it('should select the item above and wrap to bottom past first (arrow keys)', () => {
-          const anchor = createEditorWidget();
-          const model = new CompleterModel();
-          const options: Completer.IOptions = {
-            editor: anchor.editor,
-            model
-          };
-          model.setOptions(['foo', 'bar', 'baz'], {
-            foo: 'instance',
-            bar: 'function'
-          });
-          Widget.attach(anchor, document.body);
-
-          const widget = new Completer(options);
-
-          Widget.attach(widget, document.body);
-          MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-
-          const items = widget.node.querySelectorAll(`.${ITEM_CLASS}`);
-
-          expect(Array.from(items[0].classList)).toEqual(
-            expect.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[1].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[2].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          simulate(anchor.node, 'keydown', { keyCode: 40 }); // Down
-          expect(Array.from(items[0].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[1].classList)).toEqual(
-            expect.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[2].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          simulate(anchor.node, 'keydown', { keyCode: 40 }); // Down
-          expect(Array.from(items[0].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[1].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[2].classList)).toEqual(
-            expect.arrayContaining([ACTIVE_CLASS])
-          );
-          simulate(anchor.node, 'keydown', { keyCode: 38 }); // Up
-          expect(Array.from(items[0].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[1].classList)).toEqual(
-            expect.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[2].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          simulate(anchor.node, 'keydown', { keyCode: 38 }); // Up
-          expect(Array.from(items[0].classList)).toEqual(
-            expect.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[1].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[2].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          simulate(anchor.node, 'keydown', { keyCode: 38 }); // Up
-          expect(Array.from(items[0].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[1].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[2].classList)).toEqual(
-            expect.arrayContaining([ACTIVE_CLASS])
-          );
-          widget.dispose();
-          anchor.dispose();
-        });
-
-        it('should select the item above and wrap to bottom past first (tab)', () => {
-          const anchor = createEditorWidget();
-          const model = new CompleterModel();
-          const options: Completer.IOptions = {
-            editor: anchor.editor,
-            model
-          };
-          model.setOptions(['foo', 'bar', 'baz'], {
-            foo: 'instance',
-            bar: 'function'
-          });
-          Widget.attach(anchor, document.body);
-
-          const widget = new Completer(options);
-
-          Widget.attach(widget, document.body);
-          MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-
-          const items = widget.node.querySelectorAll(`.${ITEM_CLASS}`);
-
-          expect(Array.from(items[0].classList)).toEqual(
-            expect.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[1].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[2].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          simulate(anchor.node, 'keydown', { keyCode: 9 }); // Tab
-          expect(Array.from(items[0].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[1].classList)).toEqual(
-            expect.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[2].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          simulate(anchor.node, 'keydown', { keyCode: 9 }); // Tab
-          expect(Array.from(items[0].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[1].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[2].classList)).toEqual(
-            expect.arrayContaining([ACTIVE_CLASS])
-          );
-          simulate(anchor.node, 'keydown', { keyCode: 9, shiftKey: true }); // Shift + Tab
-          expect(Array.from(items[0].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[1].classList)).toEqual(
-            expect.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[2].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          simulate(anchor.node, 'keydown', { keyCode: 9, shiftKey: true }); // Shift + Tab
-          expect(Array.from(items[0].classList)).toEqual(
-            expect.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[1].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[2].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          simulate(anchor.node, 'keydown', { keyCode: 9, shiftKey: true }); // Shift + Tab
-          expect(Array.from(items[0].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[1].classList)).toEqual(
-            expect.not.arrayContaining([ACTIVE_CLASS])
-          );
-          expect(Array.from(items[2].classList)).toEqual(
-            expect.arrayContaining([ACTIVE_CLASS])
-          );
-          widget.dispose();
-          anchor.dispose();
-        });
-
-        it('should select the completion item above and wrap to top past first (arrow keys)', () => {
+        it('should select the item above and wrap to top past first (arrow keys)', () => {
           let anchor = createEditorWidget();
           let model = new CompleterModel();
           let options: Completer.IOptions = {
             editor: anchor.editor,
             model
           };
-          model.setCompletionItems!([
+          model.setCompletionItems([
             { label: 'foo' },
             { label: 'bar' },
             { label: 'baz' }
@@ -1081,14 +625,14 @@ describe('completer/widget', () => {
           anchor.dispose();
         });
 
-        it('should select the completion item above and wrap to top past first (tab)', () => {
+        it('should select the item above and wrap to top past first (tab)', () => {
           let anchor = createEditorWidget();
           let model = new CompleterModel();
           let options: Completer.IOptions = {
             editor: anchor.editor,
             model
           };
-          model.setCompletionItems!([
+          model.setCompletionItems([
             { label: 'foo' },
             { label: 'bar' },
             { label: 'baz' }
@@ -1166,43 +710,6 @@ describe('completer/widget', () => {
         });
 
         it('should mark common subset on start and complete that subset on tab', async () => {
-          const anchor = createEditorWidget();
-          const model = new CompleterModel();
-          const options: Completer.IOptions = {
-            editor: anchor.editor,
-            model
-          };
-          let value = '';
-          const listener = (sender: any, selected: string) => {
-            value = selected;
-          };
-          model.setOptions(['fo', 'foo', 'foo', 'fooo'], {
-            foo: 'instance',
-            bar: 'function'
-          });
-          Widget.attach(anchor, document.body);
-
-          const widget = new Completer(options);
-
-          widget.selected.connect(listener);
-          Widget.attach(widget, document.body);
-          MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-          await framePromise();
-          const marked = widget.node.querySelectorAll(`.${ITEM_CLASS} mark`);
-          expect(Object.keys(value)).toHaveLength(0);
-          expect(marked).toHaveLength(4);
-          expect(marked[0].textContent).toBe('fo');
-          expect(marked[1].textContent).toBe('fo');
-          expect(marked[2].textContent).toBe('fo');
-          expect(marked[3].textContent).toBe('fo');
-          simulate(anchor.node, 'keydown', { keyCode: 9 }); // Tab key
-          MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-          expect(value).toBe('fo');
-          widget.dispose();
-          anchor.dispose();
-        });
-
-        it('should mark common subset of completion items on start and complete that subset on tab', async () => {
           let anchor = createEditorWidget();
           let model = new CompleterModel();
           let options: Completer.IOptions = {
@@ -1213,7 +720,7 @@ describe('completer/widget', () => {
           let listener = (sender: any, selected: string) => {
             value = selected;
           };
-          model.setCompletionItems!([
+          model.setCompletionItems([
             { label: 'fo' },
             { label: 'foo' },
             { label: 'foo' },
@@ -1253,7 +760,7 @@ describe('completer/widget', () => {
         const listener = (sender: any, selected: string) => {
           value = selected;
         };
-        model.setCompletionItems!([{ label: 'foo' }]);
+        model.setCompletionItems([{ label: 'foo' }]);
         Widget.attach(anchor, document.body);
 
         const widget = new Completer(options);
@@ -1278,7 +785,7 @@ describe('completer/widget', () => {
         const listener = (sender: any, selected: string) => {
           value = selected;
         };
-        model.setCompletionItems!([{ label: 'foo', insertText: 'bar' }]);
+        model.setCompletionItems([{ label: 'foo', insertText: 'bar' }]);
         Widget.attach(anchor, document.body);
 
         const widget = new Completer(options);
@@ -1294,40 +801,6 @@ describe('completer/widget', () => {
 
       describe('mousedown', () => {
         it('should trigger a selected signal on mouse down', () => {
-          const anchor = createEditorWidget();
-          const model = new CompleterModel();
-          const options: Completer.IOptions = {
-            editor: anchor.editor,
-            model
-          };
-          let value = '';
-          const listener = (sender: any, selected: string) => {
-            value = selected;
-          };
-          model.setOptions(['foo', 'bar', 'baz'], {
-            foo: 'instance',
-            bar: 'function'
-          });
-          model.query = 'b';
-          Widget.attach(anchor, document.body);
-
-          const widget = new Completer(options);
-
-          widget.selected.connect(listener);
-          Widget.attach(widget, document.body);
-          MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-
-          const item = widget.node.querySelectorAll(`.${ITEM_CLASS} mark`)[1];
-
-          simulate(anchor.node, 'keydown', { keyCode: 9 }); // Tab key
-          expect(model.query).toBe('ba');
-          simulate(item, 'mousedown');
-          expect(value).toBe('baz');
-          widget.dispose();
-          anchor.dispose();
-        });
-
-        it('should trigger a selected signal on mouse down of completion item', () => {
           let anchor = createEditorWidget();
           let model = new CompleterModel();
           let options: Completer.IOptions = {
@@ -1338,7 +811,7 @@ describe('completer/widget', () => {
           let listener = (sender: any, selected: string) => {
             value = selected;
           };
-          model.setCompletionItems!([
+          model.setCompletionItems([
             { label: 'foo' },
             { label: 'bar' },
             { label: 'baz' }
@@ -1363,32 +836,6 @@ describe('completer/widget', () => {
         });
 
         it('should ignore nonstandard mouse clicks (e.g., right click)', () => {
-          const anchor = createEditorWidget();
-          const model = new CompleterModel();
-          const options: Completer.IOptions = {
-            editor: anchor.editor,
-            model
-          };
-          let value = '';
-          const listener = (sender: any, selected: string) => {
-            value = selected;
-          };
-          model.setOptions(['foo', 'bar']);
-          Widget.attach(anchor, document.body);
-
-          const widget = new Completer(options);
-
-          widget.selected.connect(listener);
-          Widget.attach(widget, document.body);
-          MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-          expect(value).toBe('');
-          simulate(widget.node, 'mousedown', { button: 1 });
-          expect(value).toBe('');
-          widget.dispose();
-          anchor.dispose();
-        });
-
-        it('should ignore nonstandard mouse clicks (e.g., right click) on completion item', () => {
           let anchor = createEditorWidget();
           let model = new CompleterModel();
           let options: Completer.IOptions = {
@@ -1399,7 +846,7 @@ describe('completer/widget', () => {
           let listener = (sender: any, selected: string) => {
             value = selected;
           };
-          model.setCompletionItems!([{ label: 'foo' }, { label: 'bar' }]);
+          model.setCompletionItems([{ label: 'foo' }, { label: 'bar' }]);
           Widget.attach(anchor, document.body);
 
           let widget = new Completer(options);
@@ -1415,32 +862,6 @@ describe('completer/widget', () => {
         });
 
         it('should ignore a mouse down that misses an item', () => {
-          const anchor = createEditorWidget();
-          const model = new CompleterModel();
-          const options: Completer.IOptions = {
-            editor: anchor.editor,
-            model
-          };
-          let value = '';
-          const listener = (sender: any, selected: string) => {
-            value = selected;
-          };
-          model.setOptions(['foo', 'bar']);
-          Widget.attach(anchor, document.body);
-
-          const widget = new Completer(options);
-
-          widget.selected.connect(listener);
-          Widget.attach(widget, document.body);
-          MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-          expect(value).toBe('');
-          simulate(widget.node, 'mousedown');
-          expect(value).toBe('');
-          widget.dispose();
-          anchor.dispose();
-        });
-
-        it('should ignore a mouse down that misses a completion item', () => {
           let anchor = createEditorWidget();
           let model = new CompleterModel();
           let options: Completer.IOptions = {
@@ -1451,7 +872,7 @@ describe('completer/widget', () => {
           let listener = (sender: any, selected: string) => {
             value = selected;
           };
-          model.setCompletionItems!([{ label: 'foo' }, { label: 'bar' }]);
+          model.setCompletionItems([{ label: 'foo' }, { label: 'bar' }]);
           Widget.attach(anchor, document.body);
 
           let widget = new Completer(options);
@@ -1467,32 +888,6 @@ describe('completer/widget', () => {
         });
 
         it('should hide widget if mouse down misses it', () => {
-          const anchor = createEditorWidget();
-          const model = new CompleterModel();
-          const options: Completer.IOptions = {
-            editor: anchor.editor,
-            model
-          };
-          const listener = (sender: any, selected: string) => {
-            // no op
-          };
-          model.setOptions(['foo', 'bar']);
-          Widget.attach(anchor, document.body);
-
-          const widget = new Completer(options);
-
-          widget.selected.connect(listener);
-          Widget.attach(widget, document.body);
-          MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-          expect(widget.isHidden).toBe(false);
-          simulate(anchor.node, 'mousedown');
-          MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-          expect(widget.isHidden).toBe(true);
-          widget.dispose();
-          anchor.dispose();
-        });
-
-        it('should hide completion items widget if mouse down misses it', () => {
           let anchor = createEditorWidget();
           let model = new CompleterModel();
           let options: Completer.IOptions = {
@@ -1502,7 +897,7 @@ describe('completer/widget', () => {
           let listener = (sender: any, selected: string) => {
             // no op
           };
-          model.setCompletionItems!([{ label: 'foo' }, { label: 'bar' }]);
+          model.setCompletionItems([{ label: 'foo' }, { label: 'bar' }]);
           Widget.attach(anchor, document.body);
 
           let widget = new Completer(options);
@@ -1560,7 +955,12 @@ describe('completer/widget', () => {
 
           model.original = request;
           model.cursor = { start: text.length - 1, end: text.length };
-          model.setOptions(['abc', 'abd', 'abe', 'abi']);
+          model.setCompletionItems([
+            { label: 'abc' },
+            { label: 'abd' },
+            { label: 'abe' },
+            { label: 'abi' }
+          ]);
 
           const widget = new Completer({ model, editor: code.editor });
           Widget.attach(widget, document.body);
@@ -1605,7 +1005,7 @@ describe('completer/widget', () => {
 
         Widget.attach(anchor, document.body);
         model.original = request;
-        model.setOptions(['foo']);
+        model.setCompletionItems([{ label: 'foo' }]);
 
         const widget = new Completer(options);
         widget.selected.connect(listener);
@@ -1626,39 +1026,7 @@ describe('completer/widget', () => {
         );
       });
 
-      it('should un-hide widget if multiple options are available', () => {
-        const anchor = createEditorWidget();
-        const model = new CompleterModel();
-        const coords = { left: 0, right: 0, top: 100, bottom: 120 };
-        const request: Completer.ITextState = {
-          column: 0,
-          lineHeight: 0,
-          charWidth: 0,
-          line: 0,
-          coords,
-          text: 'f'
-        };
-
-        const options: Completer.IOptions = {
-          editor: anchor.editor,
-          model
-        };
-
-        Widget.attach(anchor, document.body);
-        model.original = request;
-        model.setOptions(['foo', 'bar', 'baz']);
-
-        const widget = new Completer(options);
-        widget.hide();
-        expect(widget.isHidden).toBe(true);
-        Widget.attach(widget, document.body);
-        MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-        expect(widget.isVisible).toBe(true);
-        widget.dispose();
-        anchor.dispose();
-      });
-
-      it('should un-hide widget if multiple completion items are available', () => {
+      it('should un-hide widget if multiple items are available', () => {
         let anchor = createEditorWidget();
         let model = new CompleterModel();
         let coords = { left: 0, right: 0, top: 100, bottom: 120 };
@@ -1678,7 +1046,7 @@ describe('completer/widget', () => {
 
         Widget.attach(anchor, document.body);
         model.original = request;
-        model.setCompletionItems!([
+        model.setCompletionItems([
           { label: 'foo' },
           { label: 'bar' },
           { label: 'baz' }

--- a/packages/completer/test/widget.spec.ts
+++ b/packages/completer/test/widget.spec.ts
@@ -981,43 +981,6 @@ describe('completer/widget', () => {
     });
 
     describe('#onUpdateRequest()', () => {
-      it('should emit a selection if there is only one match', () => {
-        const anchor = createEditorWidget();
-        const model = new CompleterModel();
-        const coords = { left: 0, right: 0, top: 100, bottom: 120 };
-        const request: Completer.ITextState = {
-          column: 0,
-          lineHeight: 0,
-          charWidth: 0,
-          line: 0,
-          coords,
-          text: 'f'
-        };
-
-        let value = '';
-        const options: Completer.IOptions = {
-          editor: anchor.editor,
-          model
-        };
-        const listener = (sender: any, selected: string) => {
-          value = selected;
-        };
-
-        Widget.attach(anchor, document.body);
-        model.original = request;
-        model.setCompletionItems([{ label: 'foo' }]);
-
-        const widget = new Completer(options);
-        widget.selected.connect(listener);
-        Widget.attach(widget, document.body);
-
-        expect(value).toBe('');
-        MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-        expect(value).toBe('foo');
-        widget.dispose();
-        anchor.dispose();
-      });
-
       it('should do nothing if a model does not exist', () => {
         const widget = new LogWidget({ editor: null });
         MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);


### PR DESCRIPTION
## References

partial for #9763

## Code changes

As in "Backwards-incompatible changes" section

## User-facing changes

None

## Backwards-incompatible changes

All completer extensions will need to be refactored for JupyterLab 4.0:
- `CompletionHandler.IOptions.connector` needs to be replaced by `CompletionHandler.IOptions.reconciliator`
- `items`, `setItems()`, `options` and `setOptions()` need to be replaced by `completionItems`, `setCompletionItems()` 
- `Renderer.createItemNode` → `Renderer.createCompletionItemNode`

We started signalling changes to these methods in 3.1 (#10348) but not everything was tagged and not everything has a replacement in 3.x so these are in general breaking changes that need to go into a major release.