### PR TITLE
Add an input dialog for multiple selection

### DIFF
--- a/packages/apputils/src/inputdialog.ts
+++ b/packages/apputils/src/inputdialog.ts
@@ -163,6 +163,40 @@ export namespace InputDialog {
   }
 
   /**
+   * Constructor options for item selection input dialogs
+   */
+  export interface IMultipleItemsOptions extends IOptions {
+    /**
+     * List of choices
+     */
+    items: Array<string>;
+    /**
+     * Default choices
+     */
+    defaults?: string[];
+  }
+
+  /**
+   * Create and show a input dialog for a choice.
+   *
+   * @param options - The dialog setup options.
+   *
+   * @returns A promise that resolves with whether the dialog was accepted
+   */
+  export function getMultipleItems(
+    options: IMultipleItemsOptions
+  ): Promise<Dialog.IResult<string[]>> {
+    return showDialog({
+      ...options,
+      body: new InputMultipleItemsDialog(options),
+      buttons: [
+        Dialog.cancelButton({ label: options.cancelLabel }),
+        Dialog.okButton({ label: options.okLabel })
+      ]
+    });
+  }
+
+  /**
    * Constructor options for text input dialogs
    */
   export interface ITextOptions extends IOptions {
@@ -458,4 +492,64 @@ class InputItemsDialog extends InputDialogBase<string> {
 
   private _list: HTMLSelectElement;
   private _editable: boolean;
+}
+
+/**
+ * Widget body for input list dialog
+ */
+class InputMultipleItemsDialog extends InputDialogBase<string> {
+  /**
+   * InputMultipleItemsDialog constructor
+   *
+   * @param options Constructor options
+   */
+  constructor(options: InputDialog.IMultipleItemsOptions) {
+    super(options.label);
+
+    let defaults = options.defaults || [];
+
+    this._list = document.createElement('select');
+
+    // Add an hidden option, otherwise the first one is selected by default
+    let option = document.createElement('option');
+    option.value = '';
+    option.classList.add('hidden');
+    this._list.appendChild(option);
+
+    options.items.forEach(item => {
+      const option = document.createElement('option');
+      option.value = item;
+      option.textContent = item;
+      this._list.appendChild(option);
+    });
+
+    // use the select
+    this._input.remove();
+    this._list.setAttribute('multiple', '');
+    this.node.appendChild(this._list);
+
+    // select the current ones
+    const htmlOptions = this._list.options;
+    for (let i: number = 0; i < htmlOptions.length; i++) {
+      const option = htmlOptions[i];
+      if (defaults.includes(option.value)) {
+        option.selected = true;
+      }
+    }
+  }
+
+  /**
+   * Get the user choices
+   */
+  getValue(): string[] {
+    let result = [];
+    for (let opt of this._list.options) {
+      if (opt.selected && !opt.classList.contains('hidden')) {
+        result.push(opt.value || opt.text);
+      }
+    }
+    return result;
+  }
+
+  private _list: HTMLSelectElement;
 }

--- a/packages/apputils/src/inputdialog.ts
+++ b/packages/apputils/src/inputdialog.ts
@@ -509,12 +509,7 @@ class InputMultipleItemsDialog extends InputDialogBase<string> {
     let defaults = options.defaults || [];
 
     this._list = document.createElement('select');
-
-    // Add an hidden option, otherwise the first one is selected by default
-    let option = document.createElement('option');
-    option.value = '';
-    option.classList.add('hidden');
-    this._list.appendChild(option);
+    this._list.setAttribute('multiple', '');
 
     options.items.forEach(item => {
       const option = document.createElement('option');
@@ -525,7 +520,6 @@ class InputMultipleItemsDialog extends InputDialogBase<string> {
 
     // use the select
     this._input.remove();
-    this._list.setAttribute('multiple', '');
     this.node.appendChild(this._list);
 
     // select the current ones
@@ -534,6 +528,8 @@ class InputMultipleItemsDialog extends InputDialogBase<string> {
       const option = htmlOptions[i];
       if (defaults.includes(option.value)) {
         option.selected = true;
+      } else {
+        option.selected = false;
       }
     }
   }

--- a/packages/apputils/test/inputdialog.spec.ts
+++ b/packages/apputils/test/inputdialog.spec.ts
@@ -169,7 +169,7 @@ describe('@jupyterlab/apputils', () => {
         expect(result.value).toStrictEqual([]);
       });
 
-      it('should accept option "currents"', async () => {
+      it('should accept option "defaults"', async () => {
         const dialog = InputDialog.getMultipleItems({
           label: 'list',
           items: ['item1', 'item2', 'item3'],

--- a/packages/apputils/test/inputdialog.spec.ts
+++ b/packages/apputils/test/inputdialog.spec.ts
@@ -144,6 +144,48 @@ describe('@jupyterlab/apputils', () => {
       });
     });
 
+    describe('getMultipleItems()', () => {
+      it('should accept at least two arguments', async () => {
+        const dialog = InputDialog.getMultipleItems({
+          title: 'list',
+          items: ['item1']
+        });
+
+        await dismissDialog();
+        expect((await dialog).button.accept).toBe(false);
+      });
+
+      it('should return empty list if none is selected', async () => {
+        const dialog = InputDialog.getMultipleItems({
+          items: ['item1', 'item2'],
+          title: 'Pick a choice'
+        });
+
+        await acceptDialog();
+
+        const result = await dialog;
+
+        expect(result.button.accept).toBe(true);
+        expect(result.value).toStrictEqual([]);
+      });
+
+      it('should accept option "currents"', async () => {
+        const dialog = InputDialog.getMultipleItems({
+          label: 'list',
+          items: ['item1', 'item2', 'item3'],
+          defaults: ['item1', 'item3'],
+          title: 'Pick a choice'
+        });
+
+        await acceptDialog();
+
+        const result = await dialog;
+
+        expect(result.button.accept).toBe(true);
+        expect(result.value).toStrictEqual(['item1', 'item3']);
+      });
+    });
+
     describe('getText()', () => {
       it('should accept at least one argument', async () => {
         const dialog = InputDialog.getText({

--- a/packages/ui-components/src/components/styling.ts
+++ b/packages/ui-components/src/components/styling.ts
@@ -39,7 +39,8 @@ export namespace Styling {
       node.classList.add('jp-mod-styled');
     }
     if (node.localName === 'select') {
-      wrapSelect(node as HTMLSelectElement);
+      const multiple = node.hasAttribute('multiple');
+      wrapSelect(node as HTMLSelectElement, multiple);
     }
     const nodes = node.getElementsByTagName(tagName);
     for (let i = 0; i < nodes.length; i++) {
@@ -49,7 +50,8 @@ export namespace Styling {
         child.classList.add(className);
       }
       if (tagName === 'select') {
-        wrapSelect(child as HTMLSelectElement);
+        const multiple = child.hasAttribute('multiple');
+        wrapSelect(child as HTMLSelectElement, multiple);
       }
     }
   }
@@ -57,7 +59,10 @@ export namespace Styling {
   /**
    * Wrap a select node.
    */
-  export function wrapSelect(node: HTMLSelectElement): HTMLElement {
+  export function wrapSelect(
+    node: HTMLSelectElement,
+    multiple?: boolean
+  ): HTMLElement {
     const wrapper = document.createElement('div');
     wrapper.classList.add('jp-select-wrapper');
     node.addEventListener('focus', Private.onFocus);
@@ -68,16 +73,20 @@ export namespace Styling {
     }
     wrapper.appendChild(node);
 
-    // add the icon node
-    wrapper.appendChild(
-      caretDownEmptyIcon.element({
-        tag: 'span',
-        stylesheet: 'select',
-        right: '8px',
-        top: '5px',
-        width: '18px'
-      })
-    );
+    if (multiple) {
+      wrapper.classList.add('multiple');
+    } else {
+      // add the icon node
+      wrapper.appendChild(
+        caretDownEmptyIcon.element({
+          tag: 'span',
+          stylesheet: 'select',
+          right: '8px',
+          top: '5px',
+          width: '18px'
+        })
+      );
+    }
 
     return wrapper;
   }

--- a/packages/ui-components/style/styling.css
+++ b/packages/ui-components/style/styling.css
@@ -53,9 +53,12 @@ input.jp-mod-styled:focus {
   flex-direction: column;
   padding: 1px;
   background-color: var(--jp-layout-color1);
-  height: 28px;
   box-sizing: border-box;
   margin-bottom: 12px;
+}
+
+.jp-select-wrapper:not(.multiple) {
+  height: 28px;
 }
 
 .jp-select-wrapper.jp-mod-focused select.jp-mod-styled {
@@ -73,7 +76,6 @@ select.jp-mod-styled:hover {
 
 select.jp-mod-styled {
   flex: 1 1 auto;
-  height: 32px;
   width: 100%;
   font-size: var(--jp-ui-font-size2);
   background: var(--jp-input-background);
@@ -85,4 +87,17 @@ select.jp-mod-styled {
   appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
+}
+
+select.jp-mod-styled:not([multiple]) {
+  height: 32;
+}
+
+select.jp-mod-styled[multiple] {
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+option.hidden {
+  display: none;
 }

--- a/packages/ui-components/style/styling.css
+++ b/packages/ui-components/style/styling.css
@@ -90,7 +90,7 @@ select.jp-mod-styled {
 }
 
 select.jp-mod-styled:not([multiple]) {
-  height: 32;
+  height: 32px;
 }
 
 select.jp-mod-styled[multiple] {

--- a/packages/ui-components/style/styling.css
+++ b/packages/ui-components/style/styling.css
@@ -97,7 +97,3 @@ select.jp-mod-styled[multiple] {
   max-height: 200px;
   overflow-y: auto;
 }
-
-option.hidden {
-  display: none;
-}


### PR DESCRIPTION
This PR add an input dialog for multiple selection.

<img src='https://user-images.githubusercontent.com/32258950/208455687-beb2bc20-8e4a-44fd-b4ee-4c44a5492a0f.png' width=300px>

## Reference

This is useful for commands with multiple values as  argument, as it will be in https://github.com/jupyterlab/jupyterlab/pull/13601

## Code changes

- Adds a `InputMultipleItemsDialog` class in `apputils/src/inputdialog.ts`.
- Modifies `apputils/src/inputdialog.ts` and `ui-components/style/styling.css` to display a multi select input as a list and not a select input.
- Adds tests on it.

## User-facing changes

None

## Backwards-incompatible changes

None