### PR TITLE
Fix select wrapping in inputDialog

### DIFF
--- a/packages/apputils/src/inputdialog.ts
+++ b/packages/apputils/src/inputdialog.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { Styling } from '@jupyterlab/ui-components';
 import { Message } from '@lumino/messaging';
 import { Widget } from '@lumino/widgets';
 import { Dialog, showDialog } from './dialog';
@@ -442,7 +441,7 @@ class InputItemsDialog extends InputDialogBase<string> {
     } else {
       /* Use select directly */
       this._input.remove();
-      this.node.appendChild(Styling.wrapSelect(this._list));
+      this.node.appendChild(this._list);
     }
   }
 


### PR DESCRIPTION
The select input in `InputItemsDialog` is wrapped 2 times, manually when calling `Styling.wrapSelect` and automatically with `Styling.styleNodeByTag`. 

This PR remove the manual wrapper.

![image](https://user-images.githubusercontent.com/32258950/208461580-1e5c0c39-6148-4dc6-ae34-a703be3f74ad.png)

## User-facing changes

None

## Backwards-incompatible changes

None