### PR TITLE
Write the browser open files for test

### DIFF
--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -92,7 +92,7 @@ async def run_test_async(app, func):
         # Starting with jupyter-server 2.0.2, the open files are not written
         # if open_browser = False
         if not app.open_browser:
-            app.serverapp.write_browser_open_files()
+            app.write_browser_open_files()
     else:
         url = app.display_url
 

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -89,6 +89,10 @@ async def run_test_async(app, func):
     # since that uses a local HTML file to point the user at the app.
     if hasattr(app, "browser_open_file"):
         url = urljoin("file:", pathname2url(app.browser_open_file))
+        # Starting with jupyter-server 2.0.2, the open files are not written
+        # if open_browser = False
+        if not app.open_browser:
+            app.serverapp.write_browser_open_files()
     else:
         url = app.display_url
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #13633
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Force writing the browser open files for browser testing

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Fix CI error when using `jupyterlab.browser_check` and jupyter-server >= 2.0.2
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A