### PR TITLE
Automated Changelog Entry for 3.5.3 on 3.5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.5.3
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.5.2...6d5a96fa9595a86f8b87ef62b9be9bfbf288a8e1))
+
+### Bugs fixed
+
+- Write the browser open files for test [#13634](https://github.com/jupyterlab/jupyterlab/pull/13634) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-12-19&to=2022-12-21&type=c))
+
+[@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-12-19..2022-12-21&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-12-19..2022-12-21&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-12-19..2022-12-21&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-12-19..2022-12-21&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-12-19..2022-12-21&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.5.2
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.5.1...d309941e9019ada44d1124956dff9a3ec1a54c48))
@@ -25,8 +41,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-12-05&to=2022-12-19&type=c))
 
 [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2022-12-05..2022-12-19&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-12-05..2022-12-19&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-12-05..2022-12-19&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-12-05..2022-12-19&type=Issues) | [@HaudinFlorence](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AHaudinFlorence+updated%3A2022-12-05..2022-12-19&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-12-05..2022-12-19&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-12-05..2022-12-19&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-12-05..2022-12-19&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-12-05..2022-12-19&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-12-05..2022-12-19&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-12-05..2022-12-19&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Avidartf+updated%3A2022-12-05..2022-12-19&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-12-05..2022-12-19&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.5.1
 


### PR DESCRIPTION
Automated Changelog Entry for 3.5.3 on 3.5.x
```
Python version: 3.5.3
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.5.3
@jupyterlab/buildutils: 3.5.3
@jupyterlab/template: 3.5.3
@jupyterlab/application-top: 3.5.3
@jupyterlab/example-app: 3.5.3
@jupyterlab/example-cell: 3.5.3
@jupyterlab/example-console: 3.5.3
@jupyterlab/example-federated: 2.6.3
@jupyterlab/example-federated-core: 2.6.3
@jupyterlab/example-federated-md: 2.6.3
@jupyterlab/example-federated-middle: 2.6.3
@jupyterlab/example-federated-phosphor: 2.6.3
@jupyterlab/example-filebrowser: 3.5.3
@jupyterlab/example-notebook: 3.5.3
@jupyterlab/example-terminal: 3.5.3
@jupyterlab/galata: 4.4.3
@jupyterlab/mock-extension: 3.5.3
@jupyterlab/mock-consumer: 3.5.3
@jupyterlab/mock-provider: 3.5.3
@jupyterlab/mock-token: 3.5.3
@jupyterlab/application: 3.5.3
@jupyterlab/application-extension: 3.5.3
@jupyterlab/apputils: 3.5.3
@jupyterlab/apputils-extension: 3.5.3
@jupyterlab/attachments: 3.5.3
@jupyterlab/cell-toolbar: 3.5.3
@jupyterlab/cell-toolbar-extension: 3.5.3
@jupyterlab/cells: 3.5.3
@jupyterlab/celltags: 3.5.3
@jupyterlab/celltags-extension: 3.5.3
@jupyterlab/codeeditor: 3.5.3
@jupyterlab/codemirror: 3.5.3
@jupyterlab/codemirror-extension: 3.5.3
@jupyterlab/completer: 3.5.3
@jupyterlab/completer-extension: 3.5.3
@jupyterlab/console: 3.5.3
@jupyterlab/console-extension: 3.5.3
@jupyterlab/coreutils: 5.5.3
@jupyterlab/csvviewer: 3.5.3
@jupyterlab/csvviewer-extension: 3.5.3
@jupyterlab/debugger: 3.5.3
@jupyterlab/debugger-extension: 3.5.3
@jupyterlab/docmanager: 3.5.3
@jupyterlab/docmanager-extension: 3.5.3
@jupyterlab/docprovider: 3.5.3
@jupyterlab/docprovider-extension: 3.5.3
@jupyterlab/docregistry: 3.5.3
@jupyterlab/documentsearch: 3.5.3
@jupyterlab/documentsearch-extension: 3.5.3
@jupyterlab/extensionmanager: 3.5.3
@jupyterlab/extensionmanager-extension: 3.5.3
@jupyterlab/filebrowser: 3.5.3
@jupyterlab/filebrowser-extension: 3.5.3
@jupyterlab/fileeditor: 3.5.3
@jupyterlab/fileeditor-extension: 3.5.3
@jupyterlab/help-extension: 3.5.3
@jupyterlab/htmlviewer: 3.5.3
@jupyterlab/htmlviewer-extension: 3.5.3
@jupyterlab/hub-extension: 3.5.3
@jupyterlab/imageviewer: 3.5.3
@jupyterlab/imageviewer-extension: 3.5.3
@jupyterlab/inspector: 3.5.3
@jupyterlab/inspector-extension: 3.5.3
@jupyterlab/javascript-extension: 3.5.3
@jupyterlab/json-extension: 3.5.3
@jupyterlab/launcher: 3.5.3
@jupyterlab/launcher-extension: 3.5.3
@jupyterlab/logconsole: 3.5.3
@jupyterlab/logconsole-extension: 3.5.3
@jupyterlab/mainmenu: 3.5.3
@jupyterlab/mainmenu-extension: 3.5.3
@jupyterlab/markdownviewer: 3.5.3
@jupyterlab/markdownviewer-extension: 3.5.3
@jupyterlab/mathjax2: 3.5.3
@jupyterlab/mathjax2-extension: 3.5.3
@jupyterlab/metapackage: 3.5.3
@jupyterlab/nbconvert-css: 3.5.3
@jupyterlab/nbformat: 3.5.3
@jupyterlab/notebook: 3.5.3
@jupyterlab/notebook-extension: 3.5.3
@jupyterlab/observables: 4.5.3
@jupyterlab/outputarea: 3.5.3
@jupyterlab/pdf-extension: 3.5.3
@jupyterlab/property-inspector: 3.5.3
@jupyterlab/rendermime: 3.5.3
@jupyterlab/rendermime-extension: 3.5.3
@jupyterlab/rendermime-interfaces: 3.5.3
@jupyterlab/running: 3.5.3
@jupyterlab/running-extension: 3.5.3
@jupyterlab/services: 6.5.3
@jupyterlab/example-services-browser: 3.5.3
node-example: 3.5.3
@jupyterlab/example-services-outputarea: 3.5.3
@jupyterlab/settingeditor: 3.5.3
@jupyterlab/settingeditor-extension: 3.5.3
@jupyterlab/settingregistry: 3.5.3
@jupyterlab/shared-models: 3.5.3
@jupyterlab/shortcuts-extension: 3.5.3
@jupyterlab/statedb: 3.5.3
@jupyterlab/statusbar: 3.5.3
@jupyterlab/statusbar-extension: 3.5.3
@jupyterlab/terminal: 3.5.3
@jupyterlab/terminal-extension: 3.5.3
@jupyterlab/theme-dark-extension: 3.5.3
@jupyterlab/theme-light-extension: 3.5.3
@jupyterlab/toc: 5.5.3
@jupyterlab/toc-extension: 5.5.3
@jupyterlab/tooltip: 3.5.3
@jupyterlab/tooltip-extension: 3.5.3
@jupyterlab/translation: 3.5.3
@jupyterlab/translation-extension: 3.5.3
@jupyterlab/ui-components: 3.5.3
@jupyterlab/ui-components-extension: 3.5.3
@jupyterlab/vdom: 3.5.3
@jupyterlab/vdom-extension: 3.5.3
@jupyterlab/vega5-extension: 3.5.3
@jupyterlab/testutils: 3.5.3
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyterlab/jupyterlab/releases/tag/untagged-1498e9ff001c098537f5  |
| Since | v3.5.2 |