### PR TITLE
Revert "Write the browser open files for test"

### DIFF
--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -89,10 +89,6 @@ async def run_test_async(app, func):
     # since that uses a local HTML file to point the user at the app.
     if hasattr(app, "browser_open_file"):
         url = urljoin("file:", pathname2url(app.browser_open_file))
-        # Starting with jupyter-server 2.0.2, the open files are not written
-        # if open_browser = False
-        if not app.open_browser:
-            app.write_browser_open_files()
     else:
         url = app.display_url
 


### PR DESCRIPTION
Reverts jupyterlab/jupyterlab#13634

Fix was pushed upstream and released in jupyter-server 2.0.3: https://github.com/jupyter-server/jupyter_server/pull/1144