### PR TITLE
Fix `RunningTerminal` access before initialization

### DIFF
--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -289,20 +289,6 @@ function addRunningSessionManager(
   const trans = translator.load('jupyterlab');
   const manager = app.serviceManager.terminals;
 
-  managers.add({
-    name: trans.__('Terminals'),
-    running: () =>
-      Array.from(manager.running()).map(model => new RunningTerminal(model)),
-    shutdownAll: () => manager.shutdownAll(),
-    refreshRunning: () => manager.refreshRunning(),
-    runningChanged: manager.runningChanged,
-    shutdownLabel: trans.__('Shut Down'),
-    shutdownAllLabel: trans.__('Shut Down All'),
-    shutdownAllConfirmationText: trans.__(
-      'Are you sure you want to permanently shut down all running terminals?'
-    )
-  });
-
   class RunningTerminal implements IRunningSessions.IRunningItem {
     constructor(model: Terminal.IModel) {
       this._model = model;
@@ -322,6 +308,20 @@ function addRunningSessionManager(
 
     private _model: Terminal.IModel;
   }
+
+  managers.add({
+    name: trans.__('Terminals'),
+    running: () =>
+      Array.from(manager.running()).map(model => new RunningTerminal(model)),
+    shutdownAll: () => manager.shutdownAll(),
+    refreshRunning: () => manager.refreshRunning(),
+    runningChanged: manager.runningChanged,
+    shutdownLabel: trans.__('Shut Down'),
+    shutdownAllLabel: trans.__('Shut Down All'),
+    shutdownAllConfirmationText: trans.__(
+      'Are you sure you want to permanently shut down all running terminals?'
+    )
+  });
 }
 
 /**


### PR DESCRIPTION
## References

Fixes #13570

## Code changes

Move class definition up.

## User-facing changes

Terminals section works

## Backwards-incompatible changes

None
