### PR TITLE
Fix `replaceSelection`, add unit test

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -660,10 +660,17 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
   /**
    * Replaces the current selection with the given text.
    *
+   * Behaviour for multiple selections is undefined.
+   *
    * @param text The text to be inserted.
    */
   replaceSelection(text: string): void {
-    this.state.replaceSelection(text);
+    const firstSelection = this.getSelections()[0];
+    this.model.sharedModel.updateSource(
+      this.getOffsetAt(firstSelection.start),
+      this.getOffsetAt(firstSelection.end),
+      text
+    );
   }
 
   /**

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -671,6 +671,10 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
       this.getOffsetAt(firstSelection.end),
       text
     );
+    const newPosition = this.getPositionAt(
+      this.getOffsetAt(firstSelection.start) + text.length
+    );
+    this.setSelection({ start: newPosition, end: newPosition });
   }
 
   /**

--- a/packages/codemirror/test/editor.spec.ts
+++ b/packages/codemirror/test/editor.spec.ts
@@ -493,4 +493,21 @@ describe('CodeMirrorEditor', () => {
       ]);
     });
   });
+
+  describe('#replaceSelection()', () => {
+    it('should set text in empty editor', () => {
+      model.sharedModel.setSource('');
+      editor.replaceSelection('text');
+      expect(model.sharedModel.source).toBe('text');
+    });
+
+    it('should replace from start to end of selection', () => {
+      model.sharedModel.setSource('axxc');
+      const start = { line: 0, column: 1 };
+      const end = { line: 0, column: 3 };
+      editor.setSelection({ start, end });
+      editor.replaceSelection('b');
+      expect(model.sharedModel.source).toBe('abc');
+    });
+  });
 });

--- a/packages/codemirror/test/editor.spec.ts
+++ b/packages/codemirror/test/editor.spec.ts
@@ -499,6 +499,7 @@ describe('CodeMirrorEditor', () => {
       model.sharedModel.setSource('');
       editor.replaceSelection('text');
       expect(model.sharedModel.source).toBe('text');
+      expect(editor.getSelection().end.column).toBe(4);
     });
 
     it('should replace from start to end of selection', () => {


### PR DESCRIPTION
## References

Fixes #13656

## Code changes

Modifies text by using `model.sharedModel.updateSource` rather than CodeMirror's `state.replaceSelection`.

## User-facing changes

Commands for replacing text which users use for snippets work again in 4.0 alpha

## Backwards-incompatible changes

None.