### PR TITLE
Debugger: copy value of variable to clipboard

### DIFF
--- a/galata/playwright-documentation.config.js
+++ b/galata/playwright-documentation.config.js
@@ -18,6 +18,9 @@ module.exports = {
     launchOptions: {
       // Force slow motion
       slowMo: 30
+    },
+    contextOptions: {
+      permissions: ['clipboard-read', 'clipboard-write']
     }
   },
   // Switch to 'always' to keep raw assets for all tests

--- a/galata/test/documentation/debugger.test.ts
+++ b/galata/test/documentation/debugger.test.ts
@@ -178,6 +178,16 @@ test.describe('Debugger', () => {
     await page.locator('.lm-Menu-itemLabel:text("Copy to Clipboard")').click();
     expect(await page.evaluate(() => navigator.clipboard.readText())).toBe('2');
 
+    // Copy value entry is disabled for variables with empty value
+    await page
+      .locator('.jp-DebuggerVariables-toolbar select')
+      .selectOption('Globals');
+    await page
+      .locator('.jp-DebuggerVariables-body :text("special variables")')
+      .click({ button: 'right' });
+    await expect(
+      page.locator('li.lm-Menu-item[data-command="debugger:copy-to-clipboard"]')
+    ).toHaveAttribute('aria-disabled', 'true');
     await page.click('button[title^=Continue]');
   });
 

--- a/galata/test/documentation/debugger.test.ts
+++ b/galata/test/documentation/debugger.test.ts
@@ -160,11 +160,23 @@ test.describe('Debugger', () => {
     // Wait to be stopped on the breakpoint
     await page.debugger.waitForCallStack();
 
+    // Wait for the locals variables to be displayed
+    await expect(
+      page.locator('.jp-DebuggerVariables-toolbar select')
+    ).toHaveValue('Locals');
+
     expect(
       await page.screenshot({
         clip: { y: 58, x: 998, width: 280, height: 138 }
       })
     ).toMatchSnapshot('debugger_variables.png');
+
+    // Copy value to clipboard
+    await page
+      .locator('.jp-DebuggerVariables-body :text("b")')
+      .click({ button: 'right' });
+    await page.locator('.lm-Menu-itemLabel:text("Copy to Clipboard")').click();
+    expect(await page.evaluate(() => navigator.clipboard.readText())).toBe('2');
 
     await page.click('button[title^=Continue]');
   });

--- a/packages/debugger-extension/schema/main.json
+++ b/packages/debugger-extension/schema/main.json
@@ -30,6 +30,10 @@
       {
         "command": "debugger:render-mime-variable",
         "selector": ".jp-DebuggerVariables-body"
+      },
+      {
+        "command": "debugger:copy-to-clipboard",
+        "selector": ".jp-DebuggerVariables-body li:not(.jp-DebuggerVariables-noCopy)"
       }
     ]
   },

--- a/packages/debugger-extension/schema/main.json
+++ b/packages/debugger-extension/schema/main.json
@@ -33,7 +33,7 @@
       },
       {
         "command": "debugger:copy-to-clipboard",
-        "selector": ".jp-DebuggerVariables-body li:not(.jp-DebuggerVariables-emptyValue)"
+        "selector": ".jp-DebuggerVariables-body"
       }
     ]
   },

--- a/packages/debugger-extension/schema/main.json
+++ b/packages/debugger-extension/schema/main.json
@@ -33,7 +33,7 @@
       },
       {
         "command": "debugger:copy-to-clipboard",
-        "selector": ".jp-DebuggerVariables-body li:not(.jp-DebuggerVariables-noCopy)"
+        "selector": ".jp-DebuggerVariables-body li:not(.jp-DebuggerVariables-emptyValue)"
       }
     ]
   },

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -478,6 +478,19 @@ const variables: JupyterFrontEndPlugin<void> = {
         });
       }
     });
+
+    commands.addCommand(CommandIDs.copyToClipboard, {
+      label: 'Copy to Clipboard',
+      caption: trans.__('Copy value to clipboard'),
+      isEnabled: () => !!service.session?.isStarted,
+      isVisible: () => handler.activeWidget instanceof NotebookPanel,
+      execute: async () => {
+        const value = service.model.variables.selectedVariable!.value;
+        if (value) {
+          navigator.clipboard.writeText(value);
+        }
+      }
+    });
   }
 };
 

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -484,19 +484,10 @@ const variables: JupyterFrontEndPlugin<void> = {
       label: trans.__('Copy to Clipboard'),
       caption: trans.__('Copy text representation of the value to clipboard'),
       isEnabled: () => {
-        const test = (node: HTMLElement) => {
-          const treeTest = !(
-            node
-              .closest('.jp-DebuggerVariables-body li')
-              ?.classList.contains('jp-DebuggerVariables-emptyValue') ?? true
-          );
-          const gridTest = !!node.closest(
-            '.jp-DebuggerVariables-body .jp-DebuggerVariables-grid canvas'
-          );
-          return treeTest || gridTest;
-        };
-        const node = app.contextMenuHitTest(test);
-        return !!service.session?.isStarted && !!node;
+        return (
+          !!service.session?.isStarted &&
+          !!service.model.variables.selectedVariable?.value
+        );
       },
       isVisible: () => handler.activeWidget instanceof NotebookPanel,
       execute: async () => {

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -487,7 +487,7 @@ const variables: JupyterFrontEndPlugin<void> = {
       execute: async () => {
         const value = service.model.variables.selectedVariable!.value;
         if (value) {
-          navigator.clipboard.writeText(value);
+          await navigator.clipboard.writeText(value);
         }
       }
     });

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -483,7 +483,21 @@ const variables: JupyterFrontEndPlugin<void> = {
     commands.addCommand(CommandIDs.copyToClipboard, {
       label: trans.__('Copy to Clipboard'),
       caption: trans.__('Copy text representation of the value to clipboard'),
-      isEnabled: () => !!service.session?.isStarted,
+      isEnabled: () => {
+        const test = (node: HTMLElement) => {
+          const treeTest = !(
+            node
+              .closest('.jp-DebuggerVariables-body li')
+              ?.classList.contains('jp-DebuggerVariables-emptyValue') ?? true
+          );
+          const gridTest = !!node.closest(
+            '.jp-DebuggerVariables-body .jp-DebuggerVariables-grid canvas'
+          );
+          return treeTest || gridTest;
+        };
+        const node = app.contextMenuHitTest(test);
+        return !!service.session?.isStarted && !!node;
+      },
       isVisible: () => handler.activeWidget instanceof NotebookPanel,
       execute: async () => {
         const value = service.model.variables.selectedVariable!.value;

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -480,7 +480,7 @@ const variables: JupyterFrontEndPlugin<void> = {
     });
 
     commands.addCommand(CommandIDs.copyToClipboard, {
-      label: 'Copy to Clipboard',
+      label: trans.__('Copy to Clipboard'),
       caption: trans.__('Copy value to clipboard'),
       isEnabled: () => !!service.session?.isStarted,
       isVisible: () => handler.activeWidget instanceof NotebookPanel,

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -12,6 +12,7 @@ import {
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 import {
+  Clipboard,
   ICommandPalette,
   IThemeManager,
   MainAreaWidget,
@@ -481,13 +482,13 @@ const variables: JupyterFrontEndPlugin<void> = {
 
     commands.addCommand(CommandIDs.copyToClipboard, {
       label: trans.__('Copy to Clipboard'),
-      caption: trans.__('Copy value to clipboard'),
+      caption: trans.__('Copy text representation of the value to clipboard'),
       isEnabled: () => !!service.session?.isStarted,
       isVisible: () => handler.activeWidget instanceof NotebookPanel,
       execute: async () => {
         const value = service.model.variables.selectedVariable!.value;
         if (value) {
-          await navigator.clipboard.writeText(value);
+          Clipboard.copyToSystem(value);
         }
       }
     });

--- a/packages/debugger/src/debugger.ts
+++ b/packages/debugger/src/debugger.ts
@@ -121,6 +121,8 @@ export namespace Debugger {
     export const restartDebug = 'debugger:restart-debug';
 
     export const pauseOnExceptions = 'debugger:pause-on-exceptions';
+
+    export const copyToClipboard = 'debugger:copy-to-clipboard';
   }
 
   /**

--- a/packages/debugger/src/panels/variables/tree.tsx
+++ b/packages/debugger/src/panels/variables/tree.tsx
@@ -224,6 +224,7 @@ const VariableComponent = (props: IVariableComponentProps): JSX.Element => {
 
   const trans = (translator ?? nullTranslator).load('jupyterlab');
 
+  const value = variable.value;
   const onVariableClicked = async (e: React.MouseEvent): Promise<void> => {
     if (!expandable) {
       return;
@@ -239,9 +240,11 @@ const VariableComponent = (props: IVariableComponentProps): JSX.Element => {
   return (
     <li
       onClick={(e): Promise<void> => onVariableClicked(e)}
-      onMouseDown={() => {
+      onMouseDown={e => {
+        e.stopPropagation();
         onSelection(variable);
       }}
+      className={value ? '' : 'jp-DebuggerVariables-noCopy'}
     >
       <caretDownEmptyIcon.react
         visibility={expandable ? 'visible' : 'hidden'}
@@ -299,6 +302,7 @@ const VariableComponent = (props: IVariableComponentProps): JSX.Element => {
           service={service}
           filter={filter}
           translator={translator}
+          handleSelectVariable={onSelect}
         />
       )}
     </li>

--- a/packages/debugger/src/panels/variables/tree.tsx
+++ b/packages/debugger/src/panels/variables/tree.tsx
@@ -224,7 +224,6 @@ const VariableComponent = (props: IVariableComponentProps): JSX.Element => {
 
   const trans = (translator ?? nullTranslator).load('jupyterlab');
 
-  const value = variable.value;
   const onVariableClicked = async (e: React.MouseEvent): Promise<void> => {
     if (!expandable) {
       return;
@@ -244,7 +243,6 @@ const VariableComponent = (props: IVariableComponentProps): JSX.Element => {
         e.stopPropagation();
         onSelection(variable);
       }}
-      className={value ? '' : 'jp-DebuggerVariables-emptyValue'}
     >
       <caretDownEmptyIcon.react
         visibility={expandable ? 'visible' : 'hidden'}

--- a/packages/debugger/src/panels/variables/tree.tsx
+++ b/packages/debugger/src/panels/variables/tree.tsx
@@ -244,7 +244,7 @@ const VariableComponent = (props: IVariableComponentProps): JSX.Element => {
         e.stopPropagation();
         onSelection(variable);
       }}
-      className={value ? '' : 'jp-DebuggerVariables-noCopy'}
+      className={value ? '' : 'jp-DebuggerVariables-emptyValue'}
     >
       <caretDownEmptyIcon.react
         visibility={expandable ? 'visible' : 'hidden'}


### PR DESCRIPTION
Adds *copy to clipboard* feature for the value of the variables in the debugger's variables panel.
It's available with a new context menu entry.

<img src="https://user-images.githubusercontent.com/32258950/209646260-72b9f12d-06a4-49c7-92ab-9b02c01a24d0.png" width="200px">

## References

- https://github.com/jupyterlab/jupyterlab/issues/10139

## Code changes

- Adds a new command
- Changes the tree widget to be able to copy a nested variable
- Adds a test in *galata / documentation / debugger*

## User-facing changes

Adds a context menu entry in the debugger variables panel.

## Backwards-incompatible changes

None