### PR TITLE
Enable strict CSS containment for `MainAreaWidget`

### DIFF
--- a/packages/apputils/style/mainareawidget.css
+++ b/packages/apputils/style/mainareawidget.css
@@ -23,3 +23,7 @@
   white-space: pre-wrap;
   word-wrap: break-word;
 }
+
+.jp-MainAreaWidget {
+  contain: strict;
+}


### PR DESCRIPTION
## References

Relates to https://github.com/jupyterlab/lumino/issues/504

This is a smaller version of https://github.com/jupyterlab/lumino/pull/506 which I hope can be backported and included in 3.x.

This PR is not needed on 4.x once https://github.com/jupyterlab/lumino/pull/506 is merged and released (but I am making it against 4.x to trigger visual tests and discuss if we want to backport).

## Code changes

Addition of:

```css
.jp-MainAreaWidget {
  contain: strict;
}
```

## User-facing changes

- Notebook outputs producing html elements with `transform: translate*` styles will not be drawn outside of the notebook boundaries.
- Substantial performance boost (reduction in layout cost) on Chromium browsers

## Backwards-incompatible changes

As above.