### PR TITLE
Accessibility: role and aria-label

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -965,6 +965,7 @@ export class CodeCell extends Cell<ICodeCellModel> {
     const model = this.model;
     this.maxNumberOutputs = options.maxNumberOutputs;
 
+    this.node.setAttribute('role', 'textbox');
     // Note that modifying the below label warrants one to also modify
     // the same in this._outputLengthHandler. Ideally, this label must
     // have been a constant and used in both places but it is not done
@@ -1784,6 +1785,7 @@ export class MarkdownCell extends AttachmentsCell<IMarkdownCellModel> {
     this.addClass(MARKDOWN_CELL_CLASS);
     this.model.contentChanged.connect(this.onContentChanged, this);
     const trans = this.translator.load('jupyterlab');
+    this.node.setAttribute('role', 'textbox');
     this.node.setAttribute('aria-label', trans.__('Markdown Cell Content'));
     // Ensure we can resolve attachments:
     this._rendermime = options.rendermime.clone({

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -965,7 +965,6 @@ export class CodeCell extends Cell<ICodeCellModel> {
     const model = this.model;
     this.maxNumberOutputs = options.maxNumberOutputs;
 
-    this.node.setAttribute('role', 'textbox');
     // Note that modifying the below label warrants one to also modify
     // the same in this._outputLengthHandler. Ideally, this label must
     // have been a constant and used in both places but it is not done
@@ -1785,7 +1784,6 @@ export class MarkdownCell extends AttachmentsCell<IMarkdownCellModel> {
     this.addClass(MARKDOWN_CELL_CLASS);
     this.model.contentChanged.connect(this.onContentChanged, this);
     const trans = this.translator.load('jupyterlab');
-    this.node.setAttribute('role', 'textbox');
     this.node.setAttribute('aria-label', trans.__('Markdown Cell Content'));
     // Ensure we can resolve attachments:
     this._rendermime = options.rendermime.clone({

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -2165,8 +2165,6 @@ export namespace DirListing {
       translator?: ITranslator,
       hiddenColumns?: Set<DirListing.ToggleableColumn>
     ): void {
-      translator = translator || nullTranslator;
-
       fileType =
         fileType || DocumentRegistry.getDefaultTextFileType(translator);
       const { icon, iconClass, name } = fileType;
@@ -2256,9 +2254,13 @@ export namespace DirListing {
       );
       checkboxInput?.setAttribute(
         'aria-label',
-        `Select ${
-          fileType.contentType === 'directory' ? 'directory' : 'file'
-        } '${highlightedName}'`
+        trans.__(
+          trans.gettext(
+            "Select %1 '%2'",
+            fileType.contentType === 'directory' ? 'directory' : 'file',
+            highlightedName
+          )
+        )
       );
 
       let modText = '';

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -2260,11 +2260,11 @@ export namespace DirListing {
         let ariaLabel: string;
         if (fileType.contentType === 'directory') {
           ariaLabel = selected
-            ? trans.__('Unselect directory "%1"', highlightedName)
+            ? trans.__('Deselect directory "%1"', highlightedName)
             : trans.__('Select directory "%1"', highlightedName);
         } else {
           ariaLabel = selected
-            ? trans.__('Unselect file "%1"', highlightedName)
+            ? trans.__('Deselect file "%1"', highlightedName)
             : trans.__('Select file "%1"', highlightedName);
         }
         checkbox.setAttribute('aria-label', ariaLabel);

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1982,7 +1982,7 @@ export namespace DirListing {
         );
         checkboxInput?.setAttribute(
           'aria-label',
-          'Select all files and directories'
+          trans.__('Select all files and directories')
         );
         node.appendChild(checkboxWrapper);
       }
@@ -2254,13 +2254,9 @@ export namespace DirListing {
       );
       checkboxInput?.setAttribute(
         'aria-label',
-        trans.__(
-          trans.gettext(
-            "Select %1 '%2'",
-            fileType.contentType === 'directory' ? 'directory' : 'file',
-            highlightedName
-          )
-        )
+        fileType.contentType === 'directory'
+          ? trans.__('Select directory "%1"', highlightedName)
+          : trans.__('Select file "%1"', highlightedName)
       );
 
       let modText = '';

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -812,9 +812,9 @@ export class DirListing extends Widget {
       const trans = this.translator.load('jupyterlab');
       checkAllCheckbox?.setAttribute(
         'aria-label',
-        trans.__(
-          '%1 all files and directories',
-          allSelected || someSelected ? 'Unselect' : 'Select'
+        allSelected || someSelected
+            ? trans.__('Deselect all files and directories')
+            : trans.__('Select all files and directories')
         )
       );
     }

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1977,6 +1977,13 @@ export namespace DirListing {
         const checkboxWrapper = this.createCheckboxWrapperNode({
           alwaysVisible: true
         });
+        const checkboxInput = checkboxWrapper.querySelector(
+          'input[type="checkbox"]'
+        );
+        checkboxInput?.setAttribute(
+          'aria-label',
+          'Select all files and directories'
+        );
         node.appendChild(checkboxWrapper);
       }
       node.appendChild(name);
@@ -2237,11 +2244,22 @@ export namespace DirListing {
         node.removeAttribute('data-is-dot');
       }
       // If an item is being edited currently, its text node is unavailable.
+      const indices = !model.indices ? [] : model.indices;
+      let highlightedName = StringExt.highlight(model.name, indices, h.mark);
       if (text) {
-        const indices = !model.indices ? [] : model.indices;
-        let highlightedName = StringExt.highlight(model.name, indices, h.mark);
         VirtualDOM.render(h.span(highlightedName), text);
       }
+
+      // Adds an aria-label to the checkbox element.
+      const checkboxInput = checkboxWrapper.querySelector(
+        'input[type="checkbox"]'
+      );
+      checkboxInput?.setAttribute(
+        'aria-label',
+        `Select ${
+          fileType.contentType === 'directory' ? 'directory' : 'file'
+        } '${highlightedName}'`
+      );
 
       let modText = '';
       let modTitle = '';

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -813,9 +813,8 @@ export class DirListing extends Widget {
       checkAllCheckbox?.setAttribute(
         'aria-label',
         allSelected || someSelected
-            ? trans.__('Deselect all files and directories')
-            : trans.__('Select all files and directories')
-        )
+          ? trans.__('Deselect all files and directories')
+          : trans.__('Select all files and directories')
       );
     }
 
@@ -2258,20 +2257,17 @@ export namespace DirListing {
       ) as HTMLInputElement;
 
       if (checkbox) {
-        checkbox.setAttribute(
-          'aria-label',
-          fileType.contentType === 'directory'
-            ? trans.__(
-                '%1 directory "%2"',
-                selected ? 'Unselect' : 'Select',
-                highlightedName
-              )
-            : trans.__(
-                '%1 file "%2"',
-                selected ? 'Unselect' : 'Select',
-                highlightedName
-              )
-        );
+        let ariaLabel: string;
+        if (fileType.contentType === 'directory') {
+          ariaLabel = selected
+            ? trans.__('Unselect directory "%2"', highlightedName)
+            : trans.__('Select directory "%2"', highlightedName);
+        } else {
+          ariaLabel = selected
+            ? trans.__('Unselect file "%2"', highlightedName)
+            : trans.__('Select file "%2"', highlightedName);
+        }
+        checkbox.setAttribute('aria-label', ariaLabel);
         checkbox.checked = selected ?? false;
       }
 

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -2260,12 +2260,12 @@ export namespace DirListing {
         let ariaLabel: string;
         if (fileType.contentType === 'directory') {
           ariaLabel = selected
-            ? trans.__('Unselect directory "%2"', highlightedName)
-            : trans.__('Select directory "%2"', highlightedName);
+            ? trans.__('Unselect directory "%1"', highlightedName)
+            : trans.__('Select directory "%1"', highlightedName);
         } else {
           ariaLabel = selected
-            ? trans.__('Unselect file "%2"', highlightedName)
-            : trans.__('Select file "%2"', highlightedName);
+            ? trans.__('Unselect file "%1"', highlightedName)
+            : trans.__('Select file "%1"', highlightedName);
         }
         checkbox.setAttribute('aria-label', ariaLabel);
         checkbox.checked = selected ?? false;

--- a/packages/filebrowser/test/listing.spec.ts
+++ b/packages/filebrowser/test/listing.spec.ts
@@ -45,6 +45,12 @@ describe('filebrowser/listing', () => {
 
   describe('checkboxes', () => {
     let dirListing: TestDirListing;
+    let ariaSelectAll = 'Select all files and directories';
+    let ariaDeselectAll = 'Deselect all files and directories';
+    let ariaSelectFile = (filename: string | null) =>
+      `Select file "${filename}"`;
+    let ariaDeselectFile = (filename: string | null) =>
+      `Deselect file "${filename}"`;
 
     beforeEach(async () => {
       const options = createOptionsForConstructor();
@@ -81,9 +87,18 @@ describe('filebrowser/listing', () => {
           itemNode
         ) as HTMLInputElement;
         expect(checkbox.checked).toBe(false);
+        const nameNode = dirListing.renderer.getNameNode!(
+          itemNode
+        ) as HTMLElement;
+        expect(checkbox.getAttribute('aria-label')).toBe(
+          ariaSelectFile(nameNode.textContent)
+        );
         dirListing.selectNext();
         await signalToPromise(dirListing.updated);
         expect(checkbox.checked).toBe(true);
+        expect(checkbox.getAttribute('aria-label')).toBe(
+          ariaDeselectFile(nameNode.textContent)
+        );
       });
 
       it('should be unchecked after item is unselected', async () => {
@@ -91,13 +106,22 @@ describe('filebrowser/listing', () => {
         const checkbox = dirListing.renderer.getCheckboxNode!(
           itemNode
         ) as HTMLInputElement;
+        const nameNode = dirListing.renderer.getNameNode!(
+          itemNode
+        ) as HTMLElement;
         dirListing.selectNext();
         await signalToPromise(dirListing.updated);
         expect(checkbox.checked).toBe(true);
+        expect(checkbox.getAttribute('aria-label')).toBe(
+          ariaDeselectFile(nameNode.textContent)
+        );
         // Selecting the next item unselects the first.
         dirListing.selectNext();
         await signalToPromise(dirListing.updated);
         expect(checkbox.checked).toBe(false);
+        expect(checkbox.getAttribute('aria-label')).toBe(
+          ariaSelectFile(nameNode.textContent)
+        );
       });
 
       it('should allow selecting multiple items', async () => {
@@ -145,13 +169,24 @@ describe('filebrowser/listing', () => {
         const checkboxes = itemNodes.map(node =>
           dirListing.renderer.getCheckboxNode!(node)
         ) as HTMLInputElement[];
-        expect(checkboxes[0].checked).toBe(false);
-        expect(checkboxes[1].checked).toBe(false);
+        const nameNodes = itemNodes.map(node =>
+          dirListing.renderer.getNameNode!(node)
+        ) as HTMLElement[];
+        checkboxes.map((checkbox, index) => {
+          expect(checkbox.checked).toBe(false);
+          expect(checkbox.getAttribute('aria-label')).toBe(
+            ariaSelectFile(nameNodes[index].textContent)
+          );
+        });
         dirListing.selectNext();
         dirListing.selectNext(true); // true = keep existing selection
         await signalToPromise(dirListing.updated);
-        expect(checkboxes[0].checked).toBe(true);
-        expect(checkboxes[1].checked).toBe(true);
+        checkboxes.map((checkbox, index) => {
+          expect(checkbox.checked).toBe(true);
+          expect(checkbox.getAttribute('aria-label')).toBe(
+            ariaDeselectFile(nameNodes[index].textContent)
+          );
+        });
       });
 
       // A double click on the item should open the item; however, a double
@@ -233,6 +268,7 @@ describe('filebrowser/listing', () => {
           expect(headerCheckbox.checked).toBe(false);
           expect(headerCheckbox!.indeterminate).toBe(false);
           expect(Array.from(dirListing.selectedItems())).toHaveLength(0);
+          expect(headerCheckbox.getAttribute('aria-label')).toBe(ariaSelectAll);
         });
         it('should check all', async () => {
           const headerCheckbox = dirListing.renderer.getCheckboxNode!(
@@ -241,6 +277,9 @@ describe('filebrowser/listing', () => {
           simulate(headerCheckbox, 'click');
           await signalToPromise(dirListing.updated);
           expect(Array.from(dirListing.selectedItems())).toHaveLength(2);
+          expect(headerCheckbox.getAttribute('aria-label')).toBe(
+            ariaDeselectAll
+          );
         });
       });
 
@@ -255,6 +294,9 @@ describe('filebrowser/listing', () => {
           ) as HTMLInputElement;
           expect(headerCheckbox.indeterminate).toBe(true);
           expect(Array.from(dirListing.selectedItems())).toHaveLength(1);
+          expect(headerCheckbox.getAttribute('aria-label')).toBe(
+            ariaDeselectAll
+          );
         });
         it('should uncheck all', async () => {
           const headerCheckbox = dirListing.renderer.getCheckboxNode!(
@@ -263,6 +305,7 @@ describe('filebrowser/listing', () => {
           simulate(headerCheckbox, 'click');
           await signalToPromise(dirListing.updated);
           expect(Array.from(dirListing.selectedItems())).toHaveLength(0);
+          expect(headerCheckbox.getAttribute('aria-label')).toBe(ariaSelectAll);
         });
       });
 

--- a/packages/notebook/src/executionindicator.tsx
+++ b/packages/notebook/src/executionindicator.tsx
@@ -68,7 +68,8 @@ export function ExecutionIndicatorComponent(
       progress={percentage}
       width={16}
       height={24}
-      label={'Kernel status'}
+      label={trans.__('Kernel status')}
+      translator={translator}
     />
   );
   const titleFactory = (translatedStatus: string) =>

--- a/packages/notebook/src/executionindicator.tsx
+++ b/packages/notebook/src/executionindicator.tsx
@@ -64,7 +64,12 @@ export function ExecutionIndicatorComponent(
   }
 
   const progressBar = (percentage: number) => (
-    <ProgressCircle progress={percentage} width={16} height={24} />
+    <ProgressCircle
+      progress={percentage}
+      width={16}
+      height={24}
+      label={'Kernel status'}
+    />
   );
   const titleFactory = (translatedStatus: string) =>
     trans.__('Kernel status: %1', translatedStatus);

--- a/packages/notebook/src/executionindicator.tsx
+++ b/packages/notebook/src/executionindicator.tsx
@@ -69,7 +69,6 @@ export function ExecutionIndicatorComponent(
       width={16}
       height={24}
       label={trans.__('Kernel status')}
-      translator={translator}
     />
   );
   const titleFactory = (translatedStatus: string) =>

--- a/packages/statusbar/src/components/progressCircle.tsx
+++ b/packages/statusbar/src/components/progressCircle.tsx
@@ -17,9 +17,13 @@ export namespace ProgressCircle {
      * The aria-label for the widget
      */
     label?: string;
-
+    /**
+     * Element width
+     */
     width?: number;
-
+    /**
+     * Element height
+     */
     height?: number;
   }
 }
@@ -46,7 +50,7 @@ export function ProgressCircle(props: ProgressCircle.IProps): JSX.Element {
     <div
       className={'jp-Statusbar-ProgressCircle'}
       role="progressbar"
-      aria-label={props.label || 'Progress circle'}
+      aria-label={props.label || 'Unlabelled progress circle'}
       aria-valuemin={0}
       aria-valuemax={100}
       aria-valuenow={props.progress}

--- a/packages/statusbar/src/components/progressCircle.tsx
+++ b/packages/statusbar/src/components/progressCircle.tsx
@@ -13,6 +13,10 @@ export namespace ProgressCircle {
      * The current progress percentage, from 0 to 100
      */
     progress: number;
+    /**
+     * The aria-label for the widget
+     */
+    label?: string;
 
     width?: number;
 
@@ -42,6 +46,7 @@ export function ProgressCircle(props: ProgressCircle.IProps): JSX.Element {
     <div
       className={'jp-Statusbar-ProgressCircle'}
       role="progressbar"
+      aria-label={props.label || 'Progress circle'}
       aria-valuemin={0}
       aria-valuemax={100}
       aria-valuenow={props.progress}

--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { ITranslator } from '@jupyterlab/translation';
+import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { find, map, some } from '@lumino/algorithm';
 import { CommandRegistry } from '@lumino/commands';
 import { ReadonlyJSONObject } from '@lumino/coreutils';
@@ -961,13 +961,14 @@ class ToolbarPopupOpener extends ToolbarButton {
   /**
    *  Create a new popup opener
    */
-  constructor() {
+  constructor(props: ToolbarButtonComponent.IProps = {}) {
+    const trans = (props.translator || nullTranslator).load('jupyterlab');
     super({
       icon: ellipsesIcon,
       onClick: () => {
         this.handleClick();
       },
-      tooltip: 'More commands'
+      tooltip: trans.__('More commands')
     });
     this.addClass('jp-Toolbar-responsive-opener');
 

--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -966,9 +966,11 @@ class ToolbarPopupOpener extends ToolbarButton {
       icon: ellipsesIcon,
       onClick: () => {
         this.handleClick();
-      }
+      },
+      tooltip: 'More commands'
     });
     this.addClass('jp-Toolbar-responsive-opener');
+
     this.popup = new ToolbarPopup();
   }
 


### PR DESCRIPTION
This PR adds role, title or aria-label to several elements of the DOM:

- Adds a title to the responsive opener button
- ~~Adds a role to the Notebook cells~~
- Adds a label to the execution indicator
- Adds labels to the checkbox of the filebrowser


## References

- Related to https://github.com/jupyter/notebook/issues/6671

## Code changes

Adds  an option for the label to the the `ProgressCircle`.

## User-facing changes

None

## Backwards-incompatible changes

None