### PR TITLE
Fix execution indicator in RTC mode

### DIFF
--- a/packages/notebook/src/executionindicator.tsx
+++ b/packages/notebook/src/executionindicator.tsx
@@ -466,7 +466,10 @@ export namespace ExecutionIndicator {
      */
     private _startTimer(nb: Notebook) {
       const state = this._notebookExecutionProgress.get(nb);
-      if (state) {
+      if (!state) {
+        return;
+      }
+      if (state.scheduledCell.size > 0) {
         if (state.executionStatus !== 'busy') {
           state.executionStatus = 'busy';
           clearTimeout(state.timeout);
@@ -475,6 +478,8 @@ export namespace ExecutionIndicator {
             this._tick(state);
           }, 1000);
         }
+      } else {
+        this._resetTime(state);
       }
     }
 

--- a/packages/notebook/style/executionindicator.css
+++ b/packages/notebook/style/executionindicator.css
@@ -23,8 +23,8 @@
 .jp-Notebook-ExecutionIndicator-tooltip {
   visibility: hidden;
   height: auto;
-  width: fit-content;
-  width: -moz-fit-content;
+  width: max-content;
+  width: -moz-max-content;
   background-color: var(--jp-layout-color2);
   color: var(--jp-ui-font-color1);
   text-align: justify;


### PR DESCRIPTION


## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/13690

New behavior:

![fixed](https://user-images.githubusercontent.com/4451292/210249959-039e68bc-e991-4ca1-ad73-f0f0fffde674.gif)

## Code changes

- Update the logic for detecting the start and end of execution.
- Fix the CSS issue with `fit-content` in Chome.

## User-facing changes

N/A

## Backwards-incompatible changes

N/A
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
