### PR TITLE
Address some additional translation holes

### DIFF
--- a/packages/console/src/panel.ts
+++ b/packages/console/src/panel.ts
@@ -81,7 +81,8 @@ export class ConsolePanel extends MainAreaWidget<Panel> {
       sessionContext: sessionContext,
       mimeTypeService,
       contentFactory,
-      modelFactory
+      modelFactory,
+      translator
     });
     this.content.addWidget(this.console);
 

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -26,6 +26,7 @@ import { Message } from '@lumino/messaging';
 import { ISignal, Signal } from '@lumino/signaling';
 import { Panel, PanelLayout, Widget } from '@lumino/widgets';
 import { ConsoleHistory, IConsoleHistory } from './history';
+import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 
 /**
  * The data attribute added to a widget that has an active kernel.
@@ -90,6 +91,7 @@ export class CodeConsole extends Widget {
    */
   constructor(options: CodeConsole.IOptions) {
     super();
+    this._translator = options.translator ?? nullTranslator;
     this.addClass(CONSOLE_CLASS);
     this.node.dataset[KERNEL_USER] = 'true';
     this.node.dataset[CODE_RUNNER] = 'true';
@@ -732,7 +734,8 @@ export class CodeConsole extends Widget {
       rendermime,
       contentFactory,
       editorConfig,
-      placeholder: false
+      placeholder: false,
+      translator: this._translator
     };
   }
 
@@ -840,6 +843,7 @@ export class CodeConsole extends Widget {
   } | null = null;
   private _drag: Drag | null = null;
   private _focusedCell: Cell | null = null;
+  private _translator: ITranslator;
 }
 
 /**
@@ -874,6 +878,11 @@ export namespace CodeConsole {
      * The service used to look up mime types.
      */
     mimeTypeService: IEditorMimeTypeService;
+
+    /**
+     * The application language translator.
+     */
+    translator?: ITranslator;
   }
 
   /**

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -1004,7 +1004,7 @@ namespace Private {
 
     const saveBtn = Dialog.okButton({ label: trans.__('Save'), accept: true });
     return showDialog({
-      title: trans.__('Save File As..'),
+      title: trans.__('Save File As…'),
       body: new SaveWidget(path),
       buttons: [Dialog.cancelButton(), saveBtn]
     }).then(result => {

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -361,11 +361,7 @@ export namespace Commands {
     commands.addCommand(CommandIDs.changeTabs, {
       label: args => {
         if (args.insertSpaces) {
-          return trans._n(
-            'Spaces: %1',
-            'Spaces: %1',
-            (args.size as number) ?? 0
-          );
+          return trans.__('Spaces: %1', (args.size as number) ?? 0);
         } else {
           return trans.__('Indent with Tab');
         }
@@ -434,7 +430,7 @@ export namespace Commands {
             console.error(`Failed to set ${id}: ${reason.message}`);
           });
       },
-      label: trans.__('Auto Close Brackets for Text Editor'),
+      label: trans.__('Auto Close Brackets in Text Editor'),
       isToggled: () => config.autoClosingBrackets
     });
 

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -124,7 +124,7 @@ export const tabSpaceStatus: JupyterFrontEndPlugin<void> = {
       const args: JSONObject = {
         insertSpaces: true,
         size,
-        name: trans._n('Spaces: %1', 'Spaces: %1', size)
+        name: trans.__('Spaces: %1', size)
       };
       menu.addItem({ command, args });
     }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes https://github.com/jupyterlab/language-packs/issues/12
Xref https://github.com/jupyterlab/jupyterlab/issues/10737 (Stdin placeholder for console)

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
- Use ellipsis instead of `..` in save as dialog
- Pass translator object to console so the Stdin placeholder are translated (and any other thing in code cell requiring translation).  
  That required to add an optional `translator` to `CodeConsole.IOptions` (similarly to notebook).
- Use singular translation for `Spaces: %1` in editor indentation command and status bar widget

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Improved translation
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None