### PR TITLE
Remove not needed `Completer.IRenderer.sanitizer`

### DIFF
--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -852,11 +852,6 @@ export namespace Completer {
      * documentation panel.
      */
     createDocumentationNode?(activeItem: T): HTMLElement;
-
-    /**
-     * The sanitizer used to sanitize untrusted html inputs.
-     */
-    readonly sanitizer: ISanitizer;
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Link to https://github.com/jupyterlab/jupyterlab/pull/13663
It removes a not-needed attribute from the interface `Completer.IRenderer` introduced in https://github.com/jupyterlab/jupyterlab/pull/13341 (not yet release if this is backported to 3.6.0).
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Remove not needed `Completer.IRenderer.sanitizer`

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None if backported before releasing 3.6.0