### PR TITLE
Use `DocumentWidgetOpenerMock`

### DIFF
--- a/packages/filebrowser/test/listing.spec.ts
+++ b/packages/filebrowser/test/listing.spec.ts
@@ -3,6 +3,7 @@
 
 import { DocumentManager } from '@jupyterlab/docmanager';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
+import { DocumentWidgetOpenerMock } from '@jupyterlab/docregistry/lib/testutils';
 import { ServiceManagerMock } from '@jupyterlab/services/lib/testutils';
 import { signalToPromise } from '@jupyterlab/testing';
 import { Signal } from '@lumino/signaling';
@@ -16,11 +17,7 @@ const createOptionsForConstructor: () => DirListing.IOptions = () => ({
   model: new FilterFileBrowserModel({
     manager: new DocumentManager({
       registry: new DocumentRegistry(),
-      opener: {
-        open: () => {
-          /* noop */
-        }
-      } as any,
+      opener: new DocumentWidgetOpenerMock(),
       manager: new ServiceManagerMock()
     })
   })


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Follow-up of https://github.com/jupyterlab/jupyterlab/pull/12495#discussion_r1060624166
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
In filebrowser listing test use the `DocumentWidgetOpenerMock` instead of a custom mock

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None