### PR TITLE
Fix environment activation on Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -25,6 +25,7 @@ tasks:
       source /workspace/bin/activate-env.sh
       micromamba config append channels conda-forge
       micromamba install -n base -y python=3.10 nodejs=14 yarn
+      source /workspace/bin/activate-env.sh
       python -m pip install -e ".[dev,docs,test]" && jlpm install && jlpm run build
       gp sync-done setup
     command: |


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

On Gitpod it looks like the environment should now be explicitly activated after installing the base dependencies.

This might have been a change in behavior with the mamba 1.0 release.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Gitpod setup.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
