### PR TITLE
`default` locale will use OS default locale

### DIFF
--- a/packages/translation-extension/schema/plugin.json
+++ b/packages/translation-extension/schema/plugin.json
@@ -33,8 +33,8 @@
     "locale": {
       "type": "string",
       "title": "Language locale",
-      "description": "Set the interface display language. Examples: 'es_CO', 'fr'.",
-      "default": "en"
+      "description": "Set the interface display language. Examples: 'es_CO', 'fr_FR'. Set 'default' to use the server default locale.",
+      "default": "default"
     },
     "stringsPrefix": {
       "type": "string",

--- a/packages/translation-extension/schema/plugin.json
+++ b/packages/translation-extension/schema/plugin.json
@@ -33,7 +33,7 @@
     "locale": {
       "type": "string",
       "title": "Language locale",
-      "description": "Set the interface display language. Examples: 'es_CO', 'fr_FR'. Set 'default' to use the server default locale.",
+      "description": "Set the interface display language. Examples: 'es_CO', 'fr_FR'. Set 'default' to use the server default locale. Requires corresponding language pack to be installed.",
       "default": "default"
     },
     "stringsPrefix": {

--- a/packages/translation/src/manager.ts
+++ b/packages/translation/src/manager.ts
@@ -26,9 +26,23 @@ export class TranslationManager implements ITranslator {
    * @param locale The language locale to use for translations.
    */
   async fetch(locale: string): Promise<void> {
-    this._currentLocale = locale;
     this._languageData = await this._connector.fetch({ language: locale });
-    this._domainData = this._languageData?.data || {};
+    if (this._languageData && locale === 'default') {
+      try {
+        for (const lang of Object.values(this._languageData.data ?? {})) {
+          this._currentLocale = (
+            (lang as any)['']['language'] as string
+          ).replace('_', '-');
+          break;
+        }
+      } catch (reason) {
+        this._currentLocale = 'en';
+      }
+    } else {
+      this._currentLocale = locale;
+    }
+
+    this._domainData = this._languageData?.data ?? {};
     const message: string = this._languageData?.message;
     if (message && locale !== 'en') {
       console.warn(message);

--- a/packages/translation/src/manager.ts
+++ b/packages/translation/src/manager.ts
@@ -30,12 +30,11 @@ export class TranslationManager implements ITranslator {
     if (this._languageData && locale === 'default') {
       try {
         for (const lang of Object.values(this._languageData.data ?? {})) {
-          this._currentLocale = (
+          this._currentLocale =
             // If the language is provided by the system set up, we need to retrieve the final
             // language. This is done through the `""` entry in `_languageData` that contains
             // language metadata.
-            (lang as any)['']['language'] as string
-          ).replace('_', '-');
+            ((lang as any)['']['language'] as string).replace('_', '-');
           break;
         }
       } catch (reason) {

--- a/packages/translation/src/manager.ts
+++ b/packages/translation/src/manager.ts
@@ -31,6 +31,9 @@ export class TranslationManager implements ITranslator {
       try {
         for (const lang of Object.values(this._languageData.data ?? {})) {
           this._currentLocale = (
+            // If the language is provided by the system set up, we need to retrieve the final
+            // language. This is done through the `""` entry in `_languageData` that contains
+            // language metadata.
             (lang as any)['']['language'] as string
           ).replace('_', '-');
           break;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "jupyter-lsp>=1.5.1",
     "jupyter_server>=2.0.1,<3",
     "jupyter_server_ydoc>=0.6.0,<0.7.0",
-    "jupyterlab_server>=2.16.0,<3",
+    "jupyterlab_server>=2.19.0,<3",
     "notebook_shim>=0.2",
     "packaging",
     "traitlets",


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fix #9672
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
New `default` value for language settings to use the default _locale_ (if the associated language pack is installed).

Requires https://github.com/jupyterlab/jupyterlab_server/pull/366

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
JupyterLab loads with the OS language by default (if the associated language pack is installed)
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None