### PR TITLE
Support sub-shells

### DIFF
--- a/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
+++ b/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
@@ -1430,6 +1430,12 @@
     "shortcuts": []
   },
   {
+    "id": "notebook:create-sub-console",
+    "label": "New Sub-Console for Notebook",
+    "caption": "",
+    "shortcuts": []
+  },
+  {
     "id": "notebook:create-new",
     "label": "Notebook",
     "caption": "Create a new notebook",

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -38,6 +38,7 @@ import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { consoleIcon } from '@jupyterlab/ui-components';
 import { find } from '@lumino/algorithm';
+import { KernelMessage } from '@jupyterlab/services';
 import {
   JSONExt,
   JSONObject,
@@ -348,6 +349,11 @@ async function activateConsole(
      * Its typical value is: a factory name or the widget id (if singleton)
      */
     type?: string;
+
+    /**
+     * Whether to create a sub-shell for this console
+     */
+    subshell?: boolean;
   }
 
   /**
@@ -379,6 +385,14 @@ async function activateConsole(
     await tracker.add(panel);
     panel.sessionContext.propertyChanged.connect(() => {
       void tracker.save(panel);
+    });
+    panel.sessionContext.ready.then(async () => {
+      if (options.subshell) {
+        const future = await panel.sessionContext.session!.kernel!.requestCreateSubshell({});
+        future.onReply = (msg: KernelMessage.ICreateSubshellReplyMsg): void => {
+          panel.sessionContext.session!.kernel!.shellId = msg.content.shell_id;
+        };
+      }
     });
 
     shell.add(panel, 'main', {

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -356,6 +356,11 @@
         "rank": 41
       },
       {
+        "command": "notebook:create-sub-console",
+        "selector": ".jp-Notebook",
+        "rank": 42
+      },
+      {
         "command": "notebook:create-new",
         "selector": ".jp-DirListing-content",
         "rank": 52,

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -130,6 +130,8 @@ namespace CommandIDs {
 
   export const createConsole = 'notebook:create-console';
 
+  export const createSubConsole = 'notebook:create-sub-console';
+
   export const createOutputView = 'notebook:create-output-view';
 
   export const clearAllOutputs = 'notebook:clear-all-cell-outputs';
@@ -1196,7 +1198,27 @@ function activateCodeConsole(
       return Private.createConsole(
         commands,
         current,
-        args['activate'] as boolean
+        args['activate'] as boolean,
+        false
+      );
+    },
+    isEnabled
+  });
+
+  commands.addCommand(CommandIDs.createSubConsole, {
+    label: trans.__('New Sub-Console for Notebook'),
+    execute: args => {
+      const current = tracker.currentWidget;
+
+      if (!current) {
+        return;
+      }
+
+      return Private.createConsole(
+        commands,
+        current,
+        args['activate'] as boolean,
+        true
       );
     },
     isEnabled
@@ -2965,6 +2987,7 @@ function populatePalette(
     CommandIDs.changeKernel,
     CommandIDs.reconnectToKernel,
     CommandIDs.createConsole,
+    CommandIDs.createSubConsole,
     CommandIDs.closeAndShutdown,
     CommandIDs.trust,
     CommandIDs.toggleCollapseCmd,
@@ -3070,9 +3093,15 @@ function populateMenus(
     isEnabled
   });
 
-  // Add a console creator the the Kernel menu
+  // Add a console creator to the Kernel menu
   mainMenu.fileMenu.consoleCreators.add({
     id: CommandIDs.createConsole,
+    isEnabled
+  });
+
+  // Add a console creator to the Kernel menu
+  mainMenu.fileMenu.consoleCreators.add({
+    id: CommandIDs.createSubConsole,
     isEnabled
   });
 
@@ -3146,12 +3175,14 @@ namespace Private {
   export function createConsole(
     commands: CommandRegistry,
     widget: NotebookPanel,
-    activate?: boolean
+    activate?: boolean,
+    subshell?: boolean,
   ): Promise<void> {
     const options = {
       path: widget.context.path,
       preferredLanguage: widget.context.model.defaultKernelLanguage,
       activate: activate,
+      subshell: subshell,
       ref: widget.id,
       insertMode: 'split-bottom',
       type: 'Linked Console'

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -68,6 +68,11 @@ export interface IKernelConnection extends IObservableDisposable {
   readonly clientId: string;
 
   /**
+   * The sub-shell ID, main shell has ID null.
+   */
+  shellId?: string | null;
+
+  /**
    * The current status of the kernel.
    */
   readonly status: KernelMessage.Status;
@@ -297,6 +302,25 @@ export interface IKernelConnection extends IObservableDisposable {
   ): IShellFuture<
     KernelMessage.IExecuteRequestMsg,
     KernelMessage.IExecuteReplyMsg
+  >;
+
+  /**
+   * Send an experimental `create_subshell_request` message.
+   *
+   * @hidden
+   *
+   * @param content - The content of the request.
+   *
+   * @param disposeOnDone - Whether to dispose of the future when done.
+   *
+   * @returns A kernel future.
+   */
+  requestCreateSubshell(
+    content: KernelMessage.ICreateSubshellRequestMsg['content'],
+    disposeOnDone?: boolean
+  ): IControlFuture<
+    KernelMessage.ICreateSubshellRequestMsg,
+    KernelMessage.ICreateSubshellReplyMsg
   >;
 
   /**
@@ -578,6 +602,11 @@ export namespace IKernelConnection {
      * The unique identifier for the kernel client.
      */
     clientId?: string;
+
+    /**
+     * The sub-shell ID talking to the kernel (main shell has ID null).
+     */
+    shellId?: string | null;
   }
 }
 


### PR DESCRIPTION
## References

This PR needs https://github.com/ipython/ipykernel/pull/1062.
There is a [JEP](https://github.com/jupyter/enhancement-proposals/pull/91) for sub-shell support.
Sub-shells allow to connect to a kernel and execute code even while the kernel is busy executing some (blocking) code. One use-case is to visualize intermediary results of a long-running computation.
In JupyterLab, the user will be able to attach a "sub-console" to a notebook. A visual indication will show that the console is not running in safe mode, because code executing through that console is run on a separate thread, potentially leading to state/data corruption.

## Code changes

TBD.

## User-facing changes

https://user-images.githubusercontent.com/4711805/211034032-e6464887-671c-4caa-98f3-98ae80b493a2.mp4

## Backwards-incompatible changes

TBD.