### PR TITLE
Wrap kernel message binary buffers in DataView

### DIFF
--- a/packages/services/src/kernel/serialize.ts
+++ b/packages/services/src/kernel/serialize.ts
@@ -75,9 +75,9 @@ namespace Private {
     let buffers = [];
     for (let i = 5; i < offsets.length; i++) {
       if (i == offsets.length - 1) {
-        buffers.push(binMsg.slice(offsets[i]));
+        buffers.push(new DataView(binMsg.slice(offsets[i])));
       } else {
-        buffers.push(binMsg.slice(offsets[i], offsets[i + 1]));
+        buffers.push(new DataView(binMsg.slice(offsets[i], offsets[i + 1])));
       }
     }
     msg = {


### PR DESCRIPTION
## References

Closes https://github.com/martinRenou/ipycanvas/issues/311.

## Code changes

Kernel message binary buffers used to be deserialized as `DataView`s, prior to https://github.com/jupyterlab/jupyterlab/pull/11841 where they are `ArrayBuffer`s. This change restores the original type.

## User-facing changes

None.

## Backwards-incompatible changes

None.