### PR TITLE
Updates jupyter_ydoc

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -16,7 +16,7 @@
     "watch": "webpack --watch"
   },
   "resolutions": {
-    "@jupyter/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.2",
     "@jupyterlab/application": "~4.0.0-alpha.17",
     "@jupyterlab/application-extension": "~4.0.0-alpha.17",
     "@jupyterlab/apputils": "~4.0.0-alpha.17",


### PR DESCRIPTION
There is a small issue with the latest alpha published. The dependency `@jupyter/ydoc`, is a singleton package wich version should match the version used by an extension. The problem is that JupyterLab pins `@jupyter/ydoc` v0.2.0 but is using 0.2.2 and when loading an extension that uses `@jupyter/ydoc`, it fails saying the dependency is not in the shared context.

## References

## Code changes
Pins `@jupyter/ydoc` v0.2.2.

## User-facing changes

## Backwards-incompatible changes
