### PR TITLE
Drop the dependency on `@jupyterlab/buildutils` in `@jupyterlab/builder`

### DIFF
--- a/builder/package.json
+++ b/builder/package.json
@@ -33,7 +33,6 @@
     "watch": "tsc -w --listEmittedFiles"
   },
   "dependencies": {
-    "@jupyterlab/buildutils": "^4.0.0-alpha.17",
     "@lumino/algorithm": "^2.0.0-alpha.6",
     "@lumino/application": "^2.0.0-alpha.6",
     "@lumino/commands": "^2.0.0-alpha.6",

--- a/builder/src/build.ts
+++ b/builder/src/build.ts
@@ -10,7 +10,6 @@ import * as webpack from 'webpack';
 import * as fs from 'fs-extra';
 import * as glob from 'glob';
 import * as path from 'path';
-import { readJSONFile } from '@jupyterlab/buildutils';
 
 /**
  *  A namespace for JupyterLab build utilities.
@@ -138,7 +137,7 @@ export namespace Build {
         path.join(packagePath, 'package.json')
       );
       const packageDir = path.dirname(packageDataPath);
-      const data = readJSONFile(packageDataPath);
+      const data = fs.readJSONSync(packageDataPath);
       const name = data.name;
       const extension = normalizeExtension(data);
 
@@ -163,7 +162,7 @@ export namespace Build {
         if (fs.existsSync(destination)) {
           try {
             const oldPackagePath = path.join(destination, 'package.json.orig');
-            const oldPackageData = readJSONFile(oldPackagePath);
+            const oldPackageData = fs.readJSONSync(oldPackagePath);
             if (oldPackageData.version === data.version) {
               fs.removeSync(destination);
             }

--- a/builder/src/extensionConfig.ts
+++ b/builder/src/extensionConfig.ts
@@ -9,7 +9,6 @@ import { merge } from 'webpack-merge';
 import * as fs from 'fs-extra';
 import * as glob from 'glob';
 import Ajv from 'ajv';
-import { readJSONFile, writeJSONFile } from '@jupyterlab/buildutils';
 
 const baseConfig = require('./webpack.config.base');
 const { ModuleFederationPlugin } = webpack.container;
@@ -189,7 +188,7 @@ function generateConfig({
         }
 
         // Find the remoteEntry file and add it to the package.json metadata
-        const data = readJSONFile(path.join(outputPath, 'package.json'));
+        const data = fs.readJSONSync(path.join(outputPath, 'package.json'));
         const _build: any = {
           load: path.join('static', newEntry)
         };
@@ -203,7 +202,7 @@ function generateConfig({
           _build.style = './style';
         }
         data.jupyterlab._build = _build;
-        writeJSONFile(path.join(outputPath, 'package.json'), data);
+        fs.writeJSONSync(path.join(outputPath, 'package.json'), data);
       });
     }
   }

--- a/builder/src/extensionConfig.ts
+++ b/builder/src/extensionConfig.ts
@@ -202,7 +202,9 @@ function generateConfig({
           _build.style = './style';
         }
         data.jupyterlab._build = _build;
-        fs.writeJSONSync(path.join(outputPath, 'package.json'), data);
+        fs.writeJSONSync(path.join(outputPath, 'package.json'), data, {
+          spaces: 2
+        });
       });
     }
   }

--- a/builder/tsconfig.json
+++ b/builder/tsconfig.json
@@ -6,9 +6,5 @@
     "module": "commonjs"
   },
   "include": ["src/*"],
-  "references": [
-    {
-      "path": "../buildutils"
-    }
-  ]
+  "references": []
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/13740

This will help reduce the number of security vulnerabilities in downstream extensions and applications.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Drop dependency on `@jupyterlab/buildutils` in `@jupyterlab/builder`.

Replaces the uses of `readJSONFile` and `writeJSONFile` by the equivalent from `fs-extra`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
