### PR TITLE
Automated Changelog Entry for 3.6.0rc0 on 3.6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,45 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.6.0rc0
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.6.0b0...d535914e4a9d5998b1f63d9ce166e4983a152dd1))
+
+### Enhancements made
+
+- User defined default viewer take precedence for rendered factory [#11541](https://github.com/jupyterlab/jupyterlab/pull/11541) ([@fcollonval](https://github.com/fcollonval))
+- Remove not needed `Completer.IRenderer.sanitizer` [#13700](https://github.com/jupyterlab/jupyterlab/pull/13700) ([@fcollonval](https://github.com/fcollonval))
+- Contain the tabs within the tabbar (do not use translation transform) [#13671](https://github.com/jupyterlab/jupyterlab/pull/13671) ([@krassowski](https://github.com/krassowski))
+
+### Bugs fixed
+
+- Fix execution indicator in RTC mode [#13693](https://github.com/jupyterlab/jupyterlab/pull/13693) ([@trungleduc](https://github.com/trungleduc))
+- Write the browser open files for test [#13634](https://github.com/jupyterlab/jupyterlab/pull/13634) ([@fcollonval](https://github.com/fcollonval))
+- Add the `scaleFactor` value from the embed options when creating the PNG representation for a Vega-based chart [#13610](https://github.com/jupyterlab/jupyterlab/pull/13610) ([@joaopalmeiro](https://github.com/joaopalmeiro))
+- Does not prevent default behavior when shift-clicking [#13616](https://github.com/jupyterlab/jupyterlab/pull/13616) ([@jmk89](https://github.com/jmk89))
+- Do not load CSS of disabled federated extensions [#11962](https://github.com/jupyterlab/jupyterlab/pull/11962) ([@jtpio](https://github.com/jtpio))
+
+### Maintenance and upkeep improvements
+
+- Remove empty button in the notebook toolbar [#13691](https://github.com/jupyterlab/jupyterlab/pull/13691) ([@trungleduc](https://github.com/trungleduc))
+- Pin check release action without pyproject validation [#13714](https://github.com/jupyterlab/jupyterlab/pull/13714) ([@fcollonval](https://github.com/fcollonval))
+- Update copyright date to 2023 in the about dialog [#13708](https://github.com/jupyterlab/jupyterlab/pull/13708) ([@jtpio](https://github.com/jtpio))
+- Fix links in `CHANGELOG.md` [#13698](https://github.com/jupyterlab/jupyterlab/pull/13698) ([@jtpio](https://github.com/jtpio))
+- Write the browser open files for test [#13634](https://github.com/jupyterlab/jupyterlab/pull/13634) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+- Fix links in `CHANGELOG.md` [#13698](https://github.com/jupyterlab/jupyterlab/pull/13698) ([@jtpio](https://github.com/jtpio))
+- Do not load CSS of disabled federated extensions [#11962](https://github.com/jupyterlab/jupyterlab/pull/11962) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-12-17&to=2023-01-10&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-12-17..2023-01-10&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2022-12-17..2023-01-10&type=Issues) | [@brichet](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abrichet+updated%3A2022-12-17..2023-01-10&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-12-17..2023-01-10&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-12-17..2023-01-10&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2022-12-17..2023-01-10&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-12-17..2023-01-10&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-12-17..2023-01-10&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-12-17..2023-01-10&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-12-17..2023-01-10&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-12-17..2023-01-10&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-12-17..2023-01-10&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-12-17..2023-01-10&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.6.0b0
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.6.0a5...e59a4cf279c171a256e476bf82bd32e18c7a725a))
@@ -42,8 +81,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-12-06&to=2022-12-16&type=c))
 
 [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2022-12-06..2022-12-16&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-12-06..2022-12-16&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-12-06..2022-12-16&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-12-06..2022-12-16&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2022-12-06..2022-12-16&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-12-06..2022-12-16&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-12-06..2022-12-16&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-12-06..2022-12-16&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-12-06..2022-12-16&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-12-06..2022-12-16&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-12-06..2022-12-16&type=Issues) | [@uenot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Auenot+updated%3A2022-12-06..2022-12-16&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Avidartf+updated%3A2022-12-06..2022-12-16&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-12-06..2022-12-16&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.6.0a5
 


### PR DESCRIPTION
Automated Changelog Entry for 3.6.0rc0 on 3.6.x
```
Python version: 3.6.0rc0
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.6.0-rc.0
@jupyterlab/buildutils: 3.6.0-rc.0
@jupyterlab/template: 3.6.0-rc.0
@jupyterlab/application-top: 3.6.0-rc.0
@jupyterlab/example-app: 3.6.0-rc.0
@jupyterlab/example-cell: 3.6.0-rc.0
@jupyterlab/example-console: 3.6.0-rc.0
@jupyterlab/example-federated: 2.7.0-rc.0
@jupyterlab/example-federated-core: 2.7.0-rc.0
@jupyterlab/example-federated-md: 2.7.0-rc.0
@jupyterlab/example-federated-middle: 2.7.0-rc.0
@jupyterlab/example-federated-phosphor: 2.7.0-rc.0
@jupyterlab/example-filebrowser: 3.6.0-rc.0
@jupyterlab/example-notebook: 3.6.0-rc.0
@jupyterlab/example-terminal: 3.6.0-rc.0
@jupyterlab/galata: 4.5.0-rc.0
@jupyterlab/mock-extension: 3.6.0-rc.0
@jupyterlab/mock-consumer: 3.6.0-rc.0
@jupyterlab/mock-provider: 3.6.0-rc.0
@jupyterlab/mock-token: 3.6.0-rc.0
@jupyterlab/application: 3.6.0-rc.0
@jupyterlab/application-extension: 3.6.0-rc.0
@jupyterlab/apputils: 3.6.0-rc.0
@jupyterlab/apputils-extension: 3.6.0-rc.0
@jupyterlab/attachments: 3.6.0-rc.0
@jupyterlab/cell-toolbar: 3.6.0-rc.0
@jupyterlab/cell-toolbar-extension: 3.6.0-rc.0
@jupyterlab/cells: 3.6.0-rc.0
@jupyterlab/celltags: 3.6.0-rc.0
@jupyterlab/celltags-extension: 3.6.0-rc.0
@jupyterlab/codeeditor: 3.6.0-rc.0
@jupyterlab/codemirror: 3.6.0-rc.0
@jupyterlab/codemirror-extension: 3.6.0-rc.0
@jupyterlab/collaboration: 3.6.0-rc.0
@jupyterlab/collaboration-extension: 3.6.0-rc.0
@jupyterlab/completer: 3.6.0-rc.0
@jupyterlab/completer-extension: 3.6.0-rc.0
@jupyterlab/console: 3.6.0-rc.0
@jupyterlab/console-extension: 3.6.0-rc.0
@jupyterlab/coreutils: 5.6.0-rc.0
@jupyterlab/csvviewer: 3.6.0-rc.0
@jupyterlab/csvviewer-extension: 3.6.0-rc.0
@jupyterlab/debugger: 3.6.0-rc.0
@jupyterlab/debugger-extension: 3.6.0-rc.0
@jupyterlab/docmanager: 3.6.0-rc.0
@jupyterlab/docmanager-extension: 3.6.0-rc.0
@jupyterlab/docprovider: 3.6.0-rc.0
@jupyterlab/docprovider-extension: 3.6.0-rc.0
@jupyterlab/docregistry: 3.6.0-rc.0
@jupyterlab/documentsearch: 3.6.0-rc.0
@jupyterlab/documentsearch-extension: 3.6.0-rc.0
@jupyterlab/extensionmanager: 3.6.0-rc.0
@jupyterlab/extensionmanager-extension: 3.6.0-rc.0
@jupyterlab/filebrowser: 3.6.0-rc.0
@jupyterlab/filebrowser-extension: 3.6.0-rc.0
@jupyterlab/fileeditor: 3.6.0-rc.0
@jupyterlab/fileeditor-extension: 3.6.0-rc.0
@jupyterlab/help-extension: 3.6.0-rc.0
@jupyterlab/htmlviewer: 3.6.0-rc.0
@jupyterlab/htmlviewer-extension: 3.6.0-rc.0
@jupyterlab/hub-extension: 3.6.0-rc.0
@jupyterlab/imageviewer: 3.6.0-rc.0
@jupyterlab/imageviewer-extension: 3.6.0-rc.0
@jupyterlab/inspector: 3.6.0-rc.0
@jupyterlab/inspector-extension: 3.6.0-rc.0
@jupyterlab/javascript-extension: 3.6.0-rc.0
@jupyterlab/json-extension: 3.6.0-rc.0
@jupyterlab/launcher: 3.6.0-rc.0
@jupyterlab/launcher-extension: 3.6.0-rc.0
@jupyterlab/logconsole: 3.6.0-rc.0
@jupyterlab/logconsole-extension: 3.6.0-rc.0
@jupyterlab/mainmenu: 3.6.0-rc.0
@jupyterlab/mainmenu-extension: 3.6.0-rc.0
@jupyterlab/markdownviewer: 3.6.0-rc.0
@jupyterlab/markdownviewer-extension: 3.6.0-rc.0
@jupyterlab/mathjax2: 3.6.0-rc.0
@jupyterlab/mathjax2-extension: 3.6.0-rc.0
@jupyterlab/metapackage: 3.6.0-rc.0
@jupyterlab/nbconvert-css: 3.6.0-rc.0
@jupyterlab/nbformat: 3.6.0-rc.0
@jupyterlab/notebook: 3.6.0-rc.0
@jupyterlab/notebook-extension: 3.6.0-rc.0
@jupyterlab/observables: 4.6.0-rc.0
@jupyterlab/outputarea: 3.6.0-rc.0
@jupyterlab/pdf-extension: 3.6.0-rc.0
@jupyterlab/property-inspector: 3.6.0-rc.0
@jupyterlab/rendermime: 3.6.0-rc.0
@jupyterlab/rendermime-extension: 3.6.0-rc.0
@jupyterlab/rendermime-interfaces: 3.6.0-rc.0
@jupyterlab/running: 3.6.0-rc.0
@jupyterlab/running-extension: 3.6.0-rc.0
@jupyterlab/services: 6.6.0-rc.0
@jupyterlab/example-services-browser: 3.6.0-rc.0
node-example: 3.6.0-rc.0
@jupyterlab/example-services-outputarea: 3.6.0-rc.0
@jupyterlab/settingeditor: 3.6.0-rc.0
@jupyterlab/settingeditor-extension: 3.6.0-rc.0
@jupyterlab/settingregistry: 3.6.0-rc.0
@jupyterlab/shortcuts-extension: 3.6.0-rc.0
@jupyterlab/statedb: 3.6.0-rc.0
@jupyterlab/statusbar: 3.6.0-rc.0
@jupyterlab/statusbar-extension: 3.6.0-rc.0
@jupyterlab/terminal: 3.6.0-rc.0
@jupyterlab/terminal-extension: 3.6.0-rc.0
@jupyterlab/theme-dark-extension: 3.6.0-rc.0
@jupyterlab/theme-light-extension: 3.6.0-rc.0
@jupyterlab/toc: 5.6.0-rc.0
@jupyterlab/toc-extension: 5.6.0-rc.0
@jupyterlab/tooltip: 3.6.0-rc.0
@jupyterlab/tooltip-extension: 3.6.0-rc.0
@jupyterlab/translation: 3.6.0-rc.0
@jupyterlab/translation-extension: 3.6.0-rc.0
@jupyterlab/ui-components: 3.6.0-rc.0
@jupyterlab/ui-components-extension: 3.6.0-rc.0
@jupyterlab/vdom: 3.6.0-rc.0
@jupyterlab/vdom-extension: 3.6.0-rc.0
@jupyterlab/vega5-extension: 3.6.0-rc.0
@jupyterlab/testutils: 3.6.0-rc.0
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyterlab/jupyterlab/releases/tag/untagged-7cae54a80065e1c6c8a0  |
| Since | v3.6.0b0 |