### PR TITLE
Explain why cell model may be missing in cell toolbar

### DIFF
--- a/packages/cell-toolbar/src/celltoolbartracker.ts
+++ b/packages/cell-toolbar/src/celltoolbartracker.ts
@@ -63,7 +63,8 @@ export class CellToolbarTracker implements IDisposable {
   }
 
   _onActiveCellChanged(notebook: Notebook): void {
-    if (this._previousActiveCell?.model) {
+    if (this._previousActiveCell && !this._previousActiveCell.isDisposed) {
+      // Disposed cells do not have model anymore.
       this._removeToolbar(this._previousActiveCell.model);
     }
 


### PR DESCRIPTION
## References

https://github.com/jupyterlab/jupyterlab/issues/13728 (should fix on backport, master is not affected as it has a check already)

## Code changes

Previously we were checking for cell model presence on master and doing nothing on 3.x. This PR intends to document why we the model may be missing (disposed cell) and upon backporting harmonise the behaviour.


## User-facing changes

None for master.

## Backwards-incompatible changes

None
