### PR TITLE
Added config to link ts source maps

### DIFF
--- a/builder/package.json
+++ b/builder/package.json
@@ -56,6 +56,7 @@
     "mini-svg-data-uri": "^1.4.4",
     "path-browserify": "^1.0.0",
     "process": "^0.11.10",
+    "source-map-loader": "~1.0.2",
     "style-loader": "~3.3.1",
     "supports-color": "^7.2.0",
     "terser-webpack-plugin": "^5.3.6",

--- a/builder/src/extensionConfig.ts
+++ b/builder/src/extensionConfig.ts
@@ -251,6 +251,16 @@ function generateConfig({
     filename += '?v=[contenthash]';
   }
 
+  const rules: any = [{ test: /\.html$/, type: 'asset/resource' }];
+
+  if (mode === 'development') {
+    rules.push({
+      test: /\.js$/,
+      enforce: 'pre',
+      use: ['source-map-loader']
+    });
+  }
+
   const config = [
     merge(
       baseConfig,
@@ -268,7 +278,7 @@ function generateConfig({
       webpackConfig,
       {
         module: {
-          rules: [{ test: /\.html$/, type: 'asset/resource' }]
+          rules
         }
       }
     )

--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -77,7 +77,8 @@ const UNUSED: Dict<string[]> = {
     'style-loader',
     'terser-webpack-plugin',
     'webpack-cli',
-    'worker-loader'
+    'worker-loader',
+    'source-map-loader'
   ],
   '@jupyterlab/buildutils': ['verdaccio'],
   '@jupyterlab/codemirror': [


### PR DESCRIPTION
## Problem

The current extension dev build does not link the typescript source files, this causes the debugger in browser to only show the compiled JS files which makes it harder to find the exact line of code during debug sessions. 

## Solution
For extension builds, added configuration to load source maps from compiled JS files. This correctly links the source maps to the original typescript source code during debugging sessions.


<img width="988" alt="Screen Shot 2023-01-13 at 8 48 40 PM" src="https://user-images.githubusercontent.com/289369/212454238-9e39cd05-99e2-4e13-9526-aab271327589.png">

