### PR TITLE
Reduces the context of the form used in metadataform

### DIFF
--- a/packages/metadataform/src/form.tsx
+++ b/packages/metadataform/src/form.tsx
@@ -37,11 +37,15 @@ export class FormWidget extends ReactWidget {
    * @returns - The rendered form
    */
   render(): JSX.Element {
+    const formContext = {
+      settings: this._props.settings,
+      updateMetadata: this._props.metadataFormWidget.updateMetadata
+    };
     return (
       <Form
         schema={this._props.properties as JSONSchema7}
         formData={this._props.formData}
-        formContext={this._props}
+        formContext={formContext}
         FieldTemplate={this._templateFactory.fieldTemplate}
         ArrayFieldTemplate={this._templateFactory.arrayTemplate}
         ObjectFieldTemplate={this._templateFactory.objectTemplate}

--- a/packages/metadataform/src/metadataform.ts
+++ b/packages/metadataform/src/metadataform.ts
@@ -140,8 +140,9 @@ export class MetadataFormWidget
    * the whole root object must be updated.
    * This function build an object with all the root object to update
    * in metadata before performing update.
+   * It uses an arrow function to allow using 'this' properly when called from a custom field.
    */
-  updateMetadata(formData: ReadonlyPartialJSONObject, reload?: boolean) {
+  updateMetadata = (formData: ReadonlyPartialJSONObject, reload?: boolean) => {
     if (this.notebookTools == undefined) return;
 
     const notebook = this.notebookTools.activeNotebookPanel;
@@ -284,7 +285,7 @@ export class MetadataFormWidget
     if (reload) {
       this._update();
     }
-  }
+  };
 
   /**
    * Set the content of the widget.


### PR DESCRIPTION
The `formContext` passed when using the `metadataform` contains all the `props` of the parent widget.

Only some of the `props` are necessary, the *settings* and the function to update the metadata.

This PR reduce this `formContext` to strictly necessary attributes.

## Code changes

- the content of the `formContext` of the from used in *FormWidget* of metadataform package.
- the function `updateMetadata()` in *MetadataFormWidget* becomes an arrow function to keep the reference to `this`.

## User-facing changes

None

## Backwards-incompatible changes

Changes the path to use the function `updateMetadata()` from a custom fields:
~~props.formContext.metadataFormWidget.updateMetadata()~~ &rarr; props.formContext.updateMetadata()

... which is probably not used yet, as the package is pretty new.

cc @fcollonval (good catch BTW)