### PR TITLE
Fix starting search with selected text (if any)

### DIFF
--- a/galata/test/jupyterlab/notebook-search.test.ts
+++ b/galata/test/jupyterlab/notebook-search.test.ts
@@ -35,6 +35,30 @@ test.describe('Notebook Search', () => {
     expect(await nbPanel.screenshot()).toMatchSnapshot('search.png');
   });
 
+  test('Search selected', async ({ page }) => {
+    // Enter first cell
+    await page.notebook.enterCellEditingMode(0);
+
+    // Got to first line
+    await page.keyboard.press('PageUp');
+
+    // Select first line
+    await page.keyboard.press('Shift+End');
+
+    // Open search box
+    await page.keyboard.press('Control+f');
+
+    // Expect it to be populated with first line
+    await page.waitForSelector(
+      '[placeholder="Find"][value="Test with one notebook withr"]'
+    );
+
+    // Expect both matches to be found (xfail)
+    // await page.waitForSelector('text=1/2');
+
+    await expect(page.locator('.jp-DocumentSearch-overlay')).toBeVisible();
+  });
+
   test('Close with Escape', async ({ page }) => {
     // Open search box
     await page.keyboard.press('Control+f');

--- a/galata/test/jupyterlab/notebook-search.test.ts
+++ b/galata/test/jupyterlab/notebook-search.test.ts
@@ -39,7 +39,7 @@ test.describe('Notebook Search', () => {
     // Enter first cell
     await page.notebook.enterCellEditingMode(0);
 
-    // Got to first line
+    // Go to first line
     await page.keyboard.press('PageUp');
 
     // Select first line

--- a/packages/documentsearch-extension/src/index.ts
+++ b/packages/documentsearch-extension/src/index.ts
@@ -232,6 +232,8 @@ const extension: JupyterFrontEndPlugin<ISearchProviderRegistry> = {
           const searchText = args['searchText'] as string;
           if (searchText) {
             searchWidget.setSearchText(searchText);
+          } else {
+            searchWidget.setSearchText(searchWidget.model.initialQuery);
           }
           searchWidget.focusSearchInput();
         }
@@ -247,6 +249,8 @@ const extension: JupyterFrontEndPlugin<ISearchProviderRegistry> = {
           const searchText = args['searchText'] as string;
           if (searchText) {
             searchWidget.setSearchText(searchText);
+          } else {
+            searchWidget.setSearchText(searchWidget.model.initialQuery);
           }
           const replaceText = args['replaceText'] as string;
           if (replaceText) {

--- a/packages/documentsearch/test/searchmodel.spec.ts
+++ b/packages/documentsearch/test/searchmodel.spec.ts
@@ -9,6 +9,7 @@ import { PromiseDelegate } from '@lumino/coreutils';
 
 class LogSearchProvider extends GenericSearchProvider {
   private _queryReceived: PromiseDelegate<RegExp | null>;
+  private _initialQuery: string = 'unset';
 
   constructor(widget: Widget) {
     super(widget);
@@ -21,6 +22,14 @@ class LogSearchProvider extends GenericSearchProvider {
   async startQuery(query: RegExp | null, filters = {}): Promise<void> {
     this._queryReceived.resolve(query);
     this._queryReceived = new PromiseDelegate();
+  }
+
+  set initialQuery(query: string) {
+    this._initialQuery = query;
+  }
+
+  getInitialQuery() {
+    return this._initialQuery;
   }
 }
 
@@ -49,6 +58,24 @@ describe('documentsearch/searchmodel', () => {
         query.lastIndex = 0;
         expect(query.test('test')).toEqual(false);
         query.lastIndex = 0;
+      });
+    });
+
+    describe('#initialQuery', () => {
+      it('should get query from search expression or provider', () => {
+        provider.initialQuery = 'provider-set-query';
+        expect(model.initialQuery).toEqual('provider-set-query');
+        model.searchExpression = 'query';
+        expect(model.initialQuery).toEqual('query');
+        model.searchExpression = '';
+        expect(model.initialQuery).toEqual('provider-set-query');
+      });
+      it('should remember last query', async () => {
+        provider.initialQuery = 'provider-set-query';
+        model.searchExpression = 'query';
+        expect(model.initialQuery).toEqual('query');
+        await model.endQuery();
+        expect(model.initialQuery).toEqual('query');
       });
     });
 


### PR DESCRIPTION
## References

Point (3) in https://github.com/jupyterlab/jupyterlab/issues/13756

## Code changes

Actually use `model.initialQuery` which was dead code, add tests

## User-facing changes

Selecting single-line text will now set it in the search box.

## X-fail

While it would be expected that the first match gets highlighted, the second gets highlighted and receives focus (destructive!). This is unexpected, but most likely unrelated to the changes in this PR - issues with focus management on 4.0 (after refactor for windowed notebooks) were previously documented:
- https://github.com/jupyterlab/jupyterlab/issues/13282
- https://github.com/jupyterlab/jupyterlab/issues/13283

The issues above are IMO blockers for 4.0.

## Backwards-incompatible changes

None