### PR TITLE
New multi line search

### DIFF
--- a/packages/documentsearch/src/searchmodel.ts
+++ b/packages/documentsearch/src/searchmodel.ts
@@ -321,7 +321,7 @@ namespace Private {
     regex: boolean,
     wholeWords: boolean
   ): RegExp | null {
-    const flag = caseSensitive ? 'g' : 'gi';
+    const flag = caseSensitive ? 'gm' : 'gim';
     // escape regex characters in query if its a string search
     let queryText = regex
       ? queryString

--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -140,7 +140,7 @@ function ReplaceEntry(props: IReplaceEntryProps): JSX.Element {
 
   return (
     <div className={REPLACE_WRAPPER_CLASS}>
-      <input
+      <textarea
         placeholder={trans.__('Replace')}
         className={REPLACE_ENTRY_CLASS}
         value={props.replaceText ?? ''}

--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -86,7 +86,7 @@ function SearchEntry(props: ISearchEntryProps): JSX.Element {
 
   return (
     <div className={wrapperClass}>
-      <input
+      <textarea
         placeholder={trans.__('Find')}
         className={INPUT_CLASS}
         value={props.searchText}

--- a/packages/fileeditor/src/searchprovider.ts
+++ b/packages/fileeditor/src/searchprovider.ts
@@ -73,7 +73,5 @@ export class FileEditorSearchProvider
       cm.state.selection.main.from,
       cm.state.selection.main.to
     );
-    // if there are newlines, just return empty string
-    return selection.search(/\r?\n|\r/g) === -1 ? selection : '';
   }
 }

--- a/packages/notebook/src/searchprovider.ts
+++ b/packages/notebook/src/searchprovider.ts
@@ -190,8 +190,6 @@ export class NotebookSearchProvider extends SearchProvider<NotebookPanel> {
       editor?.state.selection.main.from,
       editor?.state.selection.main.to
     );
-    // if there are newlines, just return empty string
-    return selection?.search(/\r?\n|\r/g) === -1 ? selection : '';
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
#13801 
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
At `packages/documentsearch/src/searchmodel.ts`, I added the `m` flag to  `const flag = caseSensitive ? 'g' : 'gi';`
forming: `const flag = caseSensitive ? 'gm' : 'gim';`. This will enable multi-line search, allowing the regular expression to match across multiple lines

At `packages/fileeditor/src/searchprovider.ts` and `packages/notebook/src/searchprovider.ts`, I removed the line ` return selection?.search(/\r?\n|\r/g) === -1 ? selection : ;''` By removing this line, the function will always return the selection regardless of whether it is a single-line or multi-line selection

At `packages/documentsearch/src/searchview.tsx`, I replaced `<input `with `<textarea`
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
