### PR TITLE
Fix undefined css variables

### DIFF
--- a/packages/ui-components/style/icons.css
+++ b/packages/ui-components/style/icons.css
@@ -230,15 +230,18 @@
 }
 
 .jp-terminal-icon-background-color[fill] {
-  fill: var(--jp-terminal-icon-background-color, var(--jp-inverse-layout2));
+  fill: var(
+    --jp-terminal-icon-background-color,
+    var(--jp-inverse-layout-color2)
+  );
 }
 
 .jp-text-editor-icon-color[fill] {
-  fill: var(--jp-text-editor-icon-color, var(--jp-inverse-layout3));
+  fill: var(--jp-text-editor-icon-color, var(--jp-inverse-layout-color3));
 }
 
 .jp-inspector-icon-color[fill] {
-  fill: var(--jp-inspector-icon-color, var(--jp-inverse-layout3));
+  fill: var(--jp-inspector-icon-color, var(--jp-inverse-layout-color3));
 }
 
 /* CSS for icons in selected filebrowser listing items */

--- a/packages/ui-components/style/rjsfTemplates.css
+++ b/packages/ui-components/style/rjsfTemplates.css
@@ -92,7 +92,7 @@ form.rjsf button[type='submit'] {
   color: var(--jp-ui-font-color0);
   flex-basis: 100%;
   padding: 4px 0;
-  font-weight: var(--jp-content-header-font-weight);
+  font-weight: var(--jp-content-heading-font-weight);
   border-bottom: 1px solid var(--jp-border-color2);
 }
 


### PR DESCRIPTION
Fix undefined css variables.

Fixes #13799 

## References

This PR fixes issue #13799 for the undefined css variables  `--jp-inverse-layout2`, `--jp-inverse-layout3` and `--jp-content-header-font-weight`. 

## Code changes

Minor changes in `packages/ui-components/style/icons.css`and in `packages/ui-components/style/rjsfTemplates.css`

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
