### PR TITLE
Caret operator in documentation

### DIFF
--- a/docs/source/extension/extension_dev.rst
+++ b/docs/source/extension/extension_dev.rst
@@ -284,6 +284,8 @@ for another example of an extension that uses settings.
 
 Please ensure that the schema files are included in the ``files`` metadata in ``package.json``.
 
+When declaring dependencies on JupyterLab packages, use the ``^`` operator before a package version so that the build system installs the newest patch version for a given major and minor version. For example, ``^4.0.0`` will install version 4.0.0, 4.0.1, 4.0.2, etc.
+
 A system administrator or user can override default values provided in a plugin's settings schema file with the :ref:`overrides.json <overridesjson>` file.
 
 .. _disabledExtensions:
@@ -675,11 +677,13 @@ the CSS files) are watched by the WebPack process. This means that if
 your extension is in TypeScript you'll have to run a ``jlpm run build``
 before the changes will be reflected in JupyterLab. To avoid this step
 you can also watch the TypeScript sources in your extension which is
-usually assigned to the ``tsc -w`` shortcut. If WebPack doesn't seem to
+usually assigned to the ``tsc -w`` shortcut. If webpack doesn't seem to
 detect the changes, this can be related to `the number of available watches <https://github.com/webpack/docs/wiki/troubleshooting#not-enough-watchers>`__.
 
 Note that the application is built against **released** versions of the
-core JupyterLab extensions. If your extension depends on JupyterLab
+core JupyterLab extensions. You should specify the version using the ``^``
+operator, such as ``^4.0.0``, so that the build system can use package
+versions with particular major and minor version. If your extension depends on JupyterLab
 packages, it should be compatible with the dependencies in the
 ``jupyterlab/static/package.json`` file.  Note that building will always use the latest JavaScript packages that meet the dependency requirements of JupyterLab itself and any installed extensions.  If you wish to test against a
 specific patch release of one of the core JupyterLab packages you can

--- a/docs/source/extension/extension_dev.rst
+++ b/docs/source/extension/extension_dev.rst
@@ -284,7 +284,7 @@ for another example of an extension that uses settings.
 
 Please ensure that the schema files are included in the ``files`` metadata in ``package.json``.
 
-When declaring dependencies on JupyterLab packages, use the ``^`` operator before a package version so that the build system installs the newest patch version for a given major and minor version. For example, ``^4.0.0`` will install version 4.0.0, 4.0.1, 4.0.2, etc.
+When declaring dependencies on JupyterLab packages, use the ``^`` operator before a package version so that the build system installs the newest patch or minor version for a given major version. For example, ``^4.0.0`` will install version 4.0.0, 4.0.1, 4.1.0, etc.
 
 A system administrator or user can override default values provided in a plugin's settings schema file with the :ref:`overrides.json <overridesjson>` file.
 
@@ -682,8 +682,8 @@ detect the changes, this can be related to `the number of available watches <htt
 
 Note that the application is built against **released** versions of the
 core JupyterLab extensions. You should specify the version using the ``^``
-operator, such as ``^4.0.0``, so that the build system can use patch
-versions of a package with a particular major and minor version.
+operator, such as ``^4.0.0``, so that the build system can use newer minor and patch
+versions of a package with a particular major version.
 If your extension depends on JupyterLab
 packages, it should be compatible with the dependencies in the
 ``jupyterlab/static/package.json`` file.  Note that building will always use the latest JavaScript packages that meet the dependency requirements of JupyterLab itself and any installed extensions.  If you wish to test against a

--- a/docs/source/extension/extension_dev.rst
+++ b/docs/source/extension/extension_dev.rst
@@ -682,8 +682,9 @@ detect the changes, this can be related to `the number of available watches <htt
 
 Note that the application is built against **released** versions of the
 core JupyterLab extensions. You should specify the version using the ``^``
-operator, such as ``^4.0.0``, so that the build system can use package
-versions with particular major and minor version. If your extension depends on JupyterLab
+operator, such as ``^4.0.0``, so that the build system can use patch
+versions of a package with a particular major and minor version.
+If your extension depends on JupyterLab
 packages, it should be compatible with the dependencies in the
 ``jupyterlab/static/package.json`` file.  Note that building will always use the latest JavaScript packages that meet the dependency requirements of JupyterLab itself and any installed extensions.  If you wish to test against a
 specific patch release of one of the core JupyterLab packages you can


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #6885. Mentions in the documentation that the `^` operator should be used when specifying dependencies on Jupyter packages from extensions' `package.json` files.

## Code changes

No code changes; docs only.

## User-facing changes

Modifies docs only.

## Backwards-incompatible changes

None.