### PR TITLE
Update `jupyter_server_ydoc` as 0.6.2 is yanked

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "jupyter_server>=2.0.1,<3",
     "jupyterlab_server>=2.19.0,<3",
     "jupyter_ydoc>=0.3.0,<0.4.0",
-    "jupyter_server_ydoc>=0.6.2,<0.7.0",
+    "jupyter_server_ydoc>=0.7.0,<0.8.0",
     "notebook_shim>=0.2",
     "packaging",
     "traitlets",


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Follow-up of https://github.com/jupyterlab/jupyterlab/pull/13854
`jupyter-ydoc` 0.6.2 has been yanked in favor of 0.7.0

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
None

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None