### PR TITLE
Automated Changelog Entry for 3.6.0rc1 on 3.6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,48 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.6.0rc1
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.6.0rc0...f19aec68ac3de836aaa4fd4149ec9dd51f8d8221))
+
+### Enhancements made
+
+- Backport #13652 on branch 3.6.x (Expose contentVisibility widget hiding mode) [#13860](https://github.com/jupyterlab/jupyterlab/pull/13860) ([@fcollonval](https://github.com/fcollonval))
+- `default` locale will use OS default locale [#13721](https://github.com/jupyterlab/jupyterlab/pull/13721) ([@fcollonval](https://github.com/fcollonval))
+- Enable strict CSS containment for `MainAreaWidget` [#13811](https://github.com/jupyterlab/jupyterlab/pull/13811) ([@krassowski](https://github.com/krassowski))
+- Turn terminal links into anchors using xterm addon [#13645](https://github.com/jupyterlab/jupyterlab/pull/13645) ([@mgcth](https://github.com/mgcth))
+
+### Bugs fixed
+
+- Pin `jupyter_ydoc` [#13863](https://github.com/jupyterlab/jupyterlab/pull/13863) ([@fcollonval](https://github.com/fcollonval))
+- Fix `preferred_dir` for examples [#13788](https://github.com/jupyterlab/jupyterlab/pull/13788) ([@fcollonval](https://github.com/fcollonval))
+- Bump canvas to version with nodejs 18 binaries [#13783](https://github.com/jupyterlab/jupyterlab/pull/13783) ([@fcollonval](https://github.com/fcollonval))
+- Explain why cell model may be missing in cell toolbar [#13763](https://github.com/jupyterlab/jupyterlab/pull/13763) ([@krassowski](https://github.com/krassowski))
+- Fix handling of `settingEditorType` [#13761](https://github.com/jupyterlab/jupyterlab/pull/13761) ([@jtpio](https://github.com/jtpio))
+- Force jupyter-server v1 to check against notebook v6 [#13716](https://github.com/jupyterlab/jupyterlab/pull/13716) ([@fcollonval](https://github.com/fcollonval))
+
+### Maintenance and upkeep improvements
+
+- Bump `@lumino/widgets` to 1.37.1 on 3.6 branch [#13829](https://github.com/jupyterlab/jupyterlab/pull/13829) ([@krassowski](https://github.com/krassowski))
+- Clean examples [#13812](https://github.com/jupyterlab/jupyterlab/pull/13812) ([@fcollonval](https://github.com/fcollonval))
+- Added config to link ts source maps [#13765](https://github.com/jupyterlab/jupyterlab/pull/13765) ([@3coins](https://github.com/3coins))
+- Fix `preferred_dir` for examples [#13788](https://github.com/jupyterlab/jupyterlab/pull/13788) ([@fcollonval](https://github.com/fcollonval))
+- Bump canvas to version with nodejs 18 binaries [#13783](https://github.com/jupyterlab/jupyterlab/pull/13783) ([@fcollonval](https://github.com/fcollonval))
+- Drop the dependency on `@jupyterlab/buildutils` in `@jupyterlab/builder` [#13741](https://github.com/jupyterlab/jupyterlab/pull/13741) ([@jtpio](https://github.com/jtpio))
+
+### Documentation improvements
+
+- Force jupyter-server v1 to check against notebook v6 [#13716](https://github.com/jupyterlab/jupyterlab/pull/13716) ([@fcollonval](https://github.com/fcollonval))
+- Bug fixes/revisions for the Lab extension tutorial [#13593](https://github.com/jupyterlab/jupyterlab/pull/13593) ([@ericsnekbytes](https://github.com/ericsnekbytes))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2023-01-11&to=2023-01-26&type=c))
+
+[@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2023-01-11..2023-01-26&type=Issues) | [@andrii-i](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aandrii-i+updated%3A2023-01-11..2023-01-26&type=Issues) | [@brichet](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abrichet+updated%3A2023-01-11..2023-01-26&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2023-01-11..2023-01-26&type=Issues) | [@ericsnekbytes](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aericsnekbytes+updated%3A2023-01-11..2023-01-26&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2023-01-11..2023-01-26&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2023-01-11..2023-01-26&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2023-01-11..2023-01-26&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2023-01-11..2023-01-26&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2023-01-11..2023-01-26&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2023-01-11..2023-01-26&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2023-01-11..2023-01-26&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2023-01-11..2023-01-26&type=Issues) | [@psychemedia](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Apsychemedia+updated%3A2023-01-11..2023-01-26&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASylvainCorlay+updated%3A2023-01-11..2023-01-26&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2023-01-11..2023-01-26&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.6.0rc0
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.4.8...d535914e4a9d5998b1f63d9ce166e4983a152dd1))
@@ -142,8 +184,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2022-10-04&to=2023-01-10&type=c))
 
 [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2022-10-04..2023-01-10&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2022-10-04..2023-01-10&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2022-10-04..2023-01-10&type=Issues) | [@brichet](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abrichet+updated%3A2022-10-04..2023-01-10&type=Issues) | [@Carreau](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ACarreau+updated%3A2022-10-04..2023-01-10&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2022-10-04..2023-01-10&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2022-10-04..2023-01-10&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2022-10-04..2023-01-10&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2022-10-04..2023-01-10&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2022-10-04..2023-01-10&type=Issues) | [@HaudinFlorence](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AHaudinFlorence+updated%3A2022-10-04..2023-01-10&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2022-10-04..2023-01-10&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2022-10-04..2023-01-10&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2022-10-04..2023-01-10&type=Issues) | [@jupyterlab-dev-mode](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-dev-mode+updated%3A2022-10-04..2023-01-10&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2022-10-04..2023-01-10&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2022-10-04..2023-01-10&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AmartinRenou+updated%3A2022-10-04..2023-01-10&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2022-10-04..2023-01-10&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2022-10-04..2023-01-10&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASylvainCorlay+updated%3A2022-10-04..2023-01-10&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrungleduc+updated%3A2022-10-04..2023-01-10&type=Issues) | [@uenot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Auenot+updated%3A2022-10-04..2023-01-10&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Avidartf+updated%3A2022-10-04..2023-01-10&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2022-10-04..2023-01-10&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## v3.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Enhancements made
 
-- Backport #13652 on branch 3.6.x (Expose contentVisibility widget hiding mode) [#13860](https://github.com/jupyterlab/jupyterlab/pull/13860) ([@fcollonval](https://github.com/fcollonval))
+- Expose contentVisibility widget hiding mode [#13860](https://github.com/jupyterlab/jupyterlab/pull/13860) ([@fcollonval](https://github.com/fcollonval))
 - `default` locale will use OS default locale [#13721](https://github.com/jupyterlab/jupyterlab/pull/13721) ([@fcollonval](https://github.com/fcollonval))
 - Enable strict CSS containment for `MainAreaWidget` [#13811](https://github.com/jupyterlab/jupyterlab/pull/13811) ([@krassowski](https://github.com/krassowski))
 - Turn terminal links into anchors using xterm addon [#13645](https://github.com/jupyterlab/jupyterlab/pull/13645) ([@mgcth](https://github.com/mgcth))


### PR DESCRIPTION
Automated Changelog Entry for 3.6.0rc1 on 3.6.x
```
Python version: 3.6.0rc1
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.6.0-rc.1
@jupyterlab/buildutils: 3.6.0-rc.1
@jupyterlab/template: 3.6.0-rc.1
@jupyterlab/application-top: 3.6.0-rc.1
@jupyterlab/example-app: 3.6.0-rc.1
@jupyterlab/example-cell: 3.6.0-rc.1
@jupyterlab/example-console: 3.6.0-rc.1
@jupyterlab/example-federated: 2.7.0-rc.1
@jupyterlab/example-federated-core: 2.7.0-rc.1
@jupyterlab/example-federated-md: 2.7.0-rc.1
@jupyterlab/example-federated-middle: 2.7.0-rc.1
@jupyterlab/example-federated-phosphor: 2.7.0-rc.1
@jupyterlab/example-filebrowser: 3.6.0-rc.1
@jupyterlab/example-notebook: 3.6.0-rc.1
@jupyterlab/example-terminal: 3.6.0-rc.1
@jupyterlab/galata: 4.5.0-rc.1
@jupyterlab/mock-extension: 3.6.0-rc.1
@jupyterlab/mock-consumer: 3.6.0-rc.1
@jupyterlab/mock-provider: 3.6.0-rc.1
@jupyterlab/mock-token: 3.6.0-rc.1
@jupyterlab/application: 3.6.0-rc.1
@jupyterlab/application-extension: 3.6.0-rc.1
@jupyterlab/apputils: 3.6.0-rc.1
@jupyterlab/apputils-extension: 3.6.0-rc.1
@jupyterlab/attachments: 3.6.0-rc.1
@jupyterlab/cell-toolbar: 3.6.0-rc.1
@jupyterlab/cell-toolbar-extension: 3.6.0-rc.1
@jupyterlab/cells: 3.6.0-rc.1
@jupyterlab/celltags: 3.6.0-rc.1
@jupyterlab/celltags-extension: 3.6.0-rc.1
@jupyterlab/codeeditor: 3.6.0-rc.1
@jupyterlab/codemirror: 3.6.0-rc.1
@jupyterlab/codemirror-extension: 3.6.0-rc.1
@jupyterlab/collaboration: 3.6.0-rc.1
@jupyterlab/collaboration-extension: 3.6.0-rc.1
@jupyterlab/completer: 3.6.0-rc.1
@jupyterlab/completer-extension: 3.6.0-rc.1
@jupyterlab/console: 3.6.0-rc.1
@jupyterlab/console-extension: 3.6.0-rc.1
@jupyterlab/coreutils: 5.6.0-rc.1
@jupyterlab/csvviewer: 3.6.0-rc.1
@jupyterlab/csvviewer-extension: 3.6.0-rc.1
@jupyterlab/debugger: 3.6.0-rc.1
@jupyterlab/debugger-extension: 3.6.0-rc.1
@jupyterlab/docmanager: 3.6.0-rc.1
@jupyterlab/docmanager-extension: 3.6.0-rc.1
@jupyterlab/docprovider: 3.6.0-rc.1
@jupyterlab/docprovider-extension: 3.6.0-rc.1
@jupyterlab/docregistry: 3.6.0-rc.1
@jupyterlab/documentsearch: 3.6.0-rc.1
@jupyterlab/documentsearch-extension: 3.6.0-rc.1
@jupyterlab/extensionmanager: 3.6.0-rc.1
@jupyterlab/extensionmanager-extension: 3.6.0-rc.1
@jupyterlab/filebrowser: 3.6.0-rc.1
@jupyterlab/filebrowser-extension: 3.6.0-rc.1
@jupyterlab/fileeditor: 3.6.0-rc.1
@jupyterlab/fileeditor-extension: 3.6.0-rc.1
@jupyterlab/help-extension: 3.6.0-rc.1
@jupyterlab/htmlviewer: 3.6.0-rc.1
@jupyterlab/htmlviewer-extension: 3.6.0-rc.1
@jupyterlab/hub-extension: 3.6.0-rc.1
@jupyterlab/imageviewer: 3.6.0-rc.1
@jupyterlab/imageviewer-extension: 3.6.0-rc.1
@jupyterlab/inspector: 3.6.0-rc.1
@jupyterlab/inspector-extension: 3.6.0-rc.1
@jupyterlab/javascript-extension: 3.6.0-rc.1
@jupyterlab/json-extension: 3.6.0-rc.1
@jupyterlab/launcher: 3.6.0-rc.1
@jupyterlab/launcher-extension: 3.6.0-rc.1
@jupyterlab/logconsole: 3.6.0-rc.1
@jupyterlab/logconsole-extension: 3.6.0-rc.1
@jupyterlab/mainmenu: 3.6.0-rc.1
@jupyterlab/mainmenu-extension: 3.6.0-rc.1
@jupyterlab/markdownviewer: 3.6.0-rc.1
@jupyterlab/markdownviewer-extension: 3.6.0-rc.1
@jupyterlab/mathjax2: 3.6.0-rc.1
@jupyterlab/mathjax2-extension: 3.6.0-rc.1
@jupyterlab/metapackage: 3.6.0-rc.1
@jupyterlab/nbconvert-css: 3.6.0-rc.1
@jupyterlab/nbformat: 3.6.0-rc.1
@jupyterlab/notebook: 3.6.0-rc.1
@jupyterlab/notebook-extension: 3.6.0-rc.1
@jupyterlab/observables: 4.6.0-rc.1
@jupyterlab/outputarea: 3.6.0-rc.1
@jupyterlab/pdf-extension: 3.6.0-rc.1
@jupyterlab/property-inspector: 3.6.0-rc.1
@jupyterlab/rendermime: 3.6.0-rc.1
@jupyterlab/rendermime-extension: 3.6.0-rc.1
@jupyterlab/rendermime-interfaces: 3.6.0-rc.1
@jupyterlab/running: 3.6.0-rc.1
@jupyterlab/running-extension: 3.6.0-rc.1
@jupyterlab/services: 6.6.0-rc.1
@jupyterlab/example-services-browser: 3.6.0-rc.1
node-example: 3.6.0-rc.1
@jupyterlab/example-services-outputarea: 3.6.0-rc.1
@jupyterlab/settingeditor: 3.6.0-rc.1
@jupyterlab/settingeditor-extension: 3.6.0-rc.1
@jupyterlab/settingregistry: 3.6.0-rc.1
@jupyterlab/shortcuts-extension: 3.6.0-rc.1
@jupyterlab/statedb: 3.6.0-rc.1
@jupyterlab/statusbar: 3.6.0-rc.1
@jupyterlab/statusbar-extension: 3.6.0-rc.1
@jupyterlab/terminal: 3.6.0-rc.1
@jupyterlab/terminal-extension: 3.6.0-rc.1
@jupyterlab/theme-dark-extension: 3.6.0-rc.1
@jupyterlab/theme-light-extension: 3.6.0-rc.1
@jupyterlab/toc: 5.6.0-rc.1
@jupyterlab/toc-extension: 5.6.0-rc.1
@jupyterlab/tooltip: 3.6.0-rc.1
@jupyterlab/tooltip-extension: 3.6.0-rc.1
@jupyterlab/translation: 3.6.0-rc.1
@jupyterlab/translation-extension: 3.6.0-rc.1
@jupyterlab/ui-components: 3.6.0-rc.1
@jupyterlab/ui-components-extension: 3.6.0-rc.1
@jupyterlab/vdom: 3.6.0-rc.1
@jupyterlab/vdom-extension: 3.6.0-rc.1
@jupyterlab/vega5-extension: 3.6.0-rc.1
@jupyterlab/testutils: 3.6.0-rc.1
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyterlab/jupyterlab/releases/tag/untagged-3279df620b62732359a5  |
| Since | v3.6.0rc0 |