### PR TITLE
Fixes notebook's metadata in collaborative mode

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -16,7 +16,7 @@
     "watch": "webpack --watch"
   },
   "resolutions": {
-    "@jupyter/ydoc": "~0.3.0",
+    "@jupyter/ydoc": "~0.3.1",
     "@jupyterlab/application": "~4.0.0-alpha.17",
     "@jupyterlab/application-extension": "~4.0.0-alpha.17",
     "@jupyterlab/apputils": "~4.0.0-alpha.17",

--- a/examples/cell/package.json
+++ b/examples/cell/package.json
@@ -7,7 +7,7 @@
     "clean": "rimraf build"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^0.3.0",
+    "@jupyter/ydoc": "^0.3.1",
     "@jupyterlab/application": "^4.0.0-alpha.17",
     "@jupyterlab/apputils": "^4.0.0-alpha.17",
     "@jupyterlab/cells": "^4.0.0-alpha.17",

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -36,7 +36,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^0.3.0",
+    "@jupyter/ydoc": "^0.3.1",
     "@jupyterlab/nbformat": "^4.0.0-alpha.17",
     "@jupyterlab/observables": "^5.0.0-alpha.17",
     "@jupyterlab/rendermime": "^4.0.0-alpha.17",

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -42,7 +42,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^0.3.0",
+    "@jupyter/ydoc": "^0.3.1",
     "@jupyterlab/apputils": "^4.0.0-alpha.17",
     "@jupyterlab/attachments": "^4.0.0-alpha.17",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.17",

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -41,7 +41,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^0.3.0",
+    "@jupyter/ydoc": "^0.3.1",
     "@jupyterlab/coreutils": "^6.0.0-alpha.17",
     "@jupyterlab/nbformat": "^4.0.0-alpha.17",
     "@jupyterlab/observables": "^5.0.0-alpha.17",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -59,7 +59,7 @@
     "@codemirror/search": "^6.0.0",
     "@codemirror/state": "^6.0.0",
     "@codemirror/view": "^6.0.0",
-    "@jupyter/ydoc": "^0.3.0",
+    "@jupyter/ydoc": "^0.3.1",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.17",
     "@jupyterlab/coreutils": "^6.0.0-alpha.17",
     "@jupyterlab/documentsearch": "^4.0.0-alpha.17",

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -44,7 +44,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^0.3.0",
+    "@jupyter/ydoc": "^0.3.1",
     "@jupyterlab/apputils": "^4.0.0-alpha.17",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.17",
     "@jupyterlab/coreutils": "^6.0.0-alpha.17",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -42,7 +42,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^0.3.0",
+    "@jupyter/ydoc": "^0.3.1",
     "@jupyterlab/apputils": "^4.0.0-alpha.17",
     "@jupyterlab/cells": "^4.0.0-alpha.17",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.17",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@codemirror/state": "^6.0.0",
     "@codemirror/view": "^6.0.0",
-    "@jupyter/ydoc": "^0.3.0",
+    "@jupyter/ydoc": "^0.3.1",
     "@jupyterlab/application": "^4.0.0-alpha.17",
     "@jupyterlab/apputils": "^4.0.0-alpha.17",
     "@jupyterlab/cells": "^4.0.0-alpha.17",

--- a/packages/docprovider/package.json
+++ b/packages/docprovider/package.json
@@ -38,7 +38,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^0.3.0",
+    "@jupyter/ydoc": "^0.3.1",
     "@jupyterlab/coreutils": "^6.0.0-alpha.17",
     "@jupyterlab/services": "^7.0.0-alpha.17",
     "@lumino/coreutils": "^2.0.0-alpha.6",

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -41,7 +41,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^0.3.0",
+    "@jupyter/ydoc": "^0.3.1",
     "@jupyterlab/apputils": "^4.0.0-alpha.17",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.17",
     "@jupyterlab/codemirror": "^4.0.0-alpha.17",

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -39,7 +39,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^0.3.0",
+    "@jupyter/ydoc": "^0.3.1",
     "@jupyterlab/apputils": "^4.0.0-alpha.17",
     "@jupyterlab/cells": "^4.0.0-alpha.17",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.17",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -45,7 +45,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^0.3.0",
+    "@jupyter/ydoc": "^0.3.1",
     "@jupyterlab/coreutils": "^6.0.0-alpha.17",
     "@jupyterlab/nbformat": "^4.0.0-alpha.17",
     "@jupyterlab/settingregistry": "^4.0.0-alpha.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1464,10 +1464,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@jupyter/ydoc@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@jupyter/ydoc/-/ydoc-0.3.0.tgz#52c1f1bac75236e1eb9b9b6c585864a91c9f1521"
-  integrity sha512-k50urcGPdGkeHrKDiXKnzS41o2LwBBgfNMaM5eTo5Jby4Etr3I4iWcI9dfunPhQrlNUc4tspu5XB57tyrfi1Nw==
+"@jupyter/ydoc@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@jupyter/ydoc/-/ydoc-0.3.1.tgz#d7859a9bb511f19571559ee8a4e12d2d2e50b64f"
+  integrity sha512-e7tzgNYJW3XhO0gf39cKQrXxw1/1Z7h950xsKauwUij06ngMluj464b+FK1/n3/p/jD1GMhx5RNkQYvX6V9tAg==
   dependencies:
     "@jupyterlab/nbformat" "^3.0.0 || ^4.0.0-alpha.15"
     "@lumino/coreutils" "^1.11.0 || ^2.0.0-alpha.6"


### PR DESCRIPTION
Updates `@jupyter/ydoc` pick [this fix](https://github.com/jupyter-server/jupyter_ydoc/pull/134).
It fixes the initialization of the notebook's metadata in collaborative mode.

## References
https://github.com/jupyter-server/jupyter_ydoc/pull/134

## Code changes
Updates `@jupyter/ydoc`.

## User-facing changesFixes the initialization of the notebook in RTC

## Backwards-incompatible changes
N/A
