### PR TITLE
Restore partial border effect for menu

### DIFF
--- a/packages/application/style/menus.css
+++ b/packages/application/style/menus.css
@@ -27,7 +27,7 @@
 }
 
 .lm-MenuBar-menu {
-  transform: translateY(calc(-2 * var(--jp-border-width)));
+  top: calc(-2 * var(--jp-border-width));
 }
 
 .lm-MenuBar-item {
@@ -154,7 +154,7 @@
   border-top: var(--jp-border-width) solid var(--jp-layout-color2);
 }
 
-/* gray out icon/caret for disable menu items */
+/* gray out icon/caret for disabled menu items */
 .lm-Menu-item.lm-mod-disabled > .lm-Menu-itemIcon,
 .lm-Menu-item[data-type='submenu'].lm-mod-disabled > .lm-Menu-itemSubmenuIcon {
   opacity: 0.4;


### PR DESCRIPTION
## References

Fixer partial border styling of menu with menubar on 3.6.x reported in https://github.com/jupyterlab/jupyterlab/issues/13870

cherry-picked from 18c3af7de59f2eb44c45f58b98cb3c4d46afce72

## Code changes

This is a simple as switching from `transform` to `top` (the version for 4.x also requires strict containment relaxation, but we don't have containment on all size- managed widgets in 3.x so it does not apply to the backport)

## User-facing changes

Before vs after:

![comparison](https://user-images.githubusercontent.com/5832902/215346670-d1c444b4-5c0f-4d26-a403-6daa8a54d014.png)


## Backwards-incompatible changes

None