### PR TITLE
Restore blueprint focus overrides on 3.x branch

### DIFF
--- a/packages/ui-components/style/base.css
+++ b/packages/ui-components/style/base.css
@@ -51,6 +51,13 @@ a:hover {
   color: unset;
 }
 
+/* Override Blueprint's _accessibility.scss styles */
+:focus {
+  outline: unset;
+  outline-offset: unset;
+  -moz-outline-radius: unset;
+}
+
 /* Styles for ui-components */
 .jp-Button {
   border-radius: var(--jp-border-radius);


### PR DESCRIPTION
## References

Together with https://github.com/jupyterlab/jupyterlab/pull/13878 will fix #13870.

## Code changes

Restore blueprint override removed in backport (https://github.com/jupyterlab/jupyterlab/pull/13543) of https://github.com/jupyterlab/jupyterlab/pull/13415.

It was ok to remove it on 4.0 branch as it does not use blueprint, but on 3.x we still depend on blueprint.

## User-facing changes

No extra blue outline on context menus and other menus, as it was before

## Backwards-incompatible changes

None
