### PR TITLE
Fix searching backwards in notebook

### DIFF
--- a/packages/cells/src/searchprovider.ts
+++ b/packages/cells/src/searchprovider.ts
@@ -658,7 +658,9 @@ class MarkdownCellSearchProvider extends CellSearchProvider {
     if (cell.rendered && this.matchesCount > 0) {
       // Unrender the cell if there are matches within the cell
       this._unrenderedByHighligh = true;
+      const waitForRendered = signalToPromise(cell.renderedChanged);
       cell.rendered = false;
+      await waitForRendered;
     }
 
     match = await super.highlightPrevious();

--- a/packages/notebook/src/searchprovider.ts
+++ b/packages/notebook/src/searchprovider.ts
@@ -540,34 +540,18 @@ export class NotebookSearchProvider extends SearchProvider<NotebookPanel> {
           this._currentProviderIndex + (reverse ? -1 : 1);
 
         if (loop) {
-          // We loop on all cells, not hit found
-          if (this._currentProviderIndex === startIndex) {
-            break;
-          }
-
           this._currentProviderIndex =
             (this._currentProviderIndex + this._searchProviders.length) %
             this._searchProviders.length;
         }
       }
     } while (
-      0 <= this._currentProviderIndex &&
-      this._currentProviderIndex < this._searchProviders.length
+      loop
+        ? // We looped on all cells, no hit found
+          this._currentProviderIndex !== startIndex
+        : 0 <= this._currentProviderIndex &&
+          this._currentProviderIndex < this._searchProviders.length
     );
-
-    if (loop) {
-      // Search a last time in the first provider as it may contain more
-      // than one matches
-      const searchEngine = this._searchProviders[this._currentProviderIndex];
-      const match = reverse
-        ? await searchEngine.highlightPrevious()
-        : await searchEngine.highlightNext();
-
-      if (match) {
-        await activateNewMatch();
-        return match;
-      }
-    }
 
     this._currentProviderIndex = null;
     return null;

--- a/packages/notebook/src/searchprovider.ts
+++ b/packages/notebook/src/searchprovider.ts
@@ -495,6 +495,10 @@ export class NotebookSearchProvider extends SearchProvider<NotebookPanel> {
       if (this.widget.content.activeCellIndex !== this._currentProviderIndex!) {
         this.widget.content.activeCellIndex = this._currentProviderIndex!;
       }
+      if (this.widget.content.activeCellIndex === -1) {
+        console.warn('No active cell (no cells or no model), aborting search');
+        return;
+      }
       const activeCell = this.widget.content.activeCell!;
 
       if (!activeCell.inViewport) {

--- a/packages/notebook/test/searchprovider.spec.ts
+++ b/packages/notebook/test/searchprovider.spec.ts
@@ -69,6 +69,16 @@ describe('@jupyterlab/notebook', () => {
         expect(provider.currentMatchIndex).toBe(0);
         await provider.endQuery();
       });
+
+      it('should do nothing if there are no cells', async () => {
+        await provider.startQuery(/test/, undefined);
+        for (let _ of panel.model!.sharedModel.cells) {
+          panel.model!.sharedModel.deleteCell(0);
+        }
+        await provider.highlightNext();
+        expect(provider.currentMatchIndex).toBe(null);
+        await provider.endQuery();
+      });
     });
 
     describe('#highlightPrevious()', () => {

--- a/packages/notebook/test/searchprovider.spec.ts
+++ b/packages/notebook/test/searchprovider.spec.ts
@@ -1,0 +1,100 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  INotebookModel,
+  NotebookPanel,
+  NotebookSearchProvider
+} from '@jupyterlab/notebook';
+import { Context } from '@jupyterlab/docregistry';
+import { initNotebookContext } from '@jupyterlab/notebook/lib/testutils';
+import { JupyterServer } from '@jupyterlab/testing';
+import * as utils from './utils';
+
+const server = new JupyterServer();
+
+beforeAll(async () => {
+  await server.start();
+}, 30000);
+
+afterAll(async () => {
+  await server.shutdown();
+});
+
+describe('@jupyterlab/notebook', () => {
+  describe('NotebookSearchProvider', () => {
+    let context: Context<INotebookModel>;
+    let panel: NotebookPanel;
+    let provider: NotebookSearchProvider;
+
+    beforeEach(async () => {
+      context = await initNotebookContext();
+      panel = utils.createNotebookPanel(context);
+      provider = new NotebookSearchProvider(panel);
+      panel.model!.sharedModel.insertCells(0, [
+        { cell_type: 'markdown', source: 'test test' },
+        { cell_type: 'code', source: 'test' }
+      ]);
+    });
+
+    afterEach(() => {
+      context.dispose();
+    });
+
+    describe('#matchesCount', () => {
+      it('should return number of matches', async () => {
+        await provider.startQuery(/test/, undefined);
+        expect(provider.matchesCount).toBe(3);
+      });
+    });
+
+    describe('#highlightNext()', () => {
+      it('should highlight next match', async () => {
+        await provider.startQuery(/test/, undefined);
+        await provider.highlightNext();
+        expect(provider.currentMatchIndex).toBe(0);
+        await provider.highlightNext();
+        expect(provider.currentMatchIndex).toBe(1);
+        await provider.highlightNext();
+        expect(provider.currentMatchIndex).toBe(2);
+        await provider.endQuery();
+      });
+
+      it('should loop back to first match', async () => {
+        panel.content.activeCellIndex = 1;
+        await provider.startQuery(/test/, undefined);
+        await provider.highlightNext();
+        expect(provider.currentMatchIndex).toBe(2);
+        await provider.highlightNext();
+        expect(provider.currentMatchIndex).toBe(0);
+        await provider.endQuery();
+      });
+    });
+
+    describe('#highlightPrevious()', () => {
+      it('should highlight previous match', async () => {
+        panel.content.activeCellIndex = 1;
+        await provider.startQuery(/tes/, undefined);
+        await provider.highlightNext();
+        expect(provider.currentMatchIndex).toBe(2);
+        expect(panel.content.activeCellIndex).toBe(1);
+        await provider.highlightPrevious();
+        expect(panel.content.activeCellIndex).toBe(0);
+        expect(provider.currentMatchIndex).toBe(1);
+        await provider.highlightPrevious();
+        expect(panel.content.activeCellIndex).toBe(0);
+        expect(provider.currentMatchIndex).toBe(0);
+        await provider.endQuery();
+      });
+
+      it('should loop back to last match', async () => {
+        await provider.startQuery(/test/, undefined);
+        await provider.highlightNext();
+        expect(provider.currentMatchIndex).toBe(0);
+        await provider.highlightPrevious();
+        expect(provider.currentMatchIndex).toBe(2);
+        await provider.endQuery();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## References

Fixes #13880

## Code changes

- `highlightPrevious` in cell search provider now has previously missing renderer signal handler block which was already present in `highlightNext`
- the logic in the do-while loop was corrected

## User-facing changes

Search in notebook is usable again.

## Backwards-incompatible changes

N/A