### PR TITLE
Define colour and background for filebrowser edit field

### DIFF
--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -282,6 +282,8 @@
   flex: 1 0 64px;
   outline: none;
   border: none;
+  color: var(--jp-ui-font-color1);
+  background-color: var(--jp-layout-color1);
 }
 
 .jp-DirListing-item.jp-mod-running .jp-DirListing-itemIcon::before {


### PR DESCRIPTION
## References

Fixes #13894

## Code changes

Defines a colour to prevent system `input` colour from interfering.

## User-facing changes

No changes in light theme. In dark theme:

| Before | After |
|---|---|
| ![Screenshot from 2023-01-30 23-45-48](https://user-images.githubusercontent.com/5832902/215622649-01023f67-fbea-4876-8cd1-659f9308e8ce.png) |  ![Screenshot from 2023-01-30 23-46-16](https://user-images.githubusercontent.com/5832902/215622636-e0c844ba-fc27-43e0-95f4-413d44a25b16.png) |


## Backwards-incompatible changes

None
