### PR TITLE
Revert target to ES2017

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -12,13 +12,13 @@ AsyncIterable Support
 ^^^^^^^^^^^^^^^^^^^^^
 
 For the events service, we are using a JavaScript feature introduced in ES2018. If your code is
-using TypeScript with ES2017 target (as JupyterLab 3.6), you will have either to update your
-target to ES2018 or to add ``"ES2018"`` to `TypeScript lib option <https://www.typescriptlang.org/tsconfig#lib>`_.
+using TypeScript with ES2017 target (as JupyterLab 3.6), you will either need to update your
+target to ES2018 or add ``"ES2018"`` to the `TypeScript lib option <https://www.typescriptlang.org/tsconfig#lib>`_.
 
 .. note::
 
-    JupyterLab 3.6.0 was released with an updated target "ES2018". We strongly advice updating to 3.6.1
-    that revert the target to "ES2017".
+    JupyterLab 3.6.0 was released with an updated target "ES2018". We strongly advise updating to 3.6.1,
+    which reverts the target back to "ES2017".
 
 Real-Time Collaboration
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -1,12 +1,24 @@
 .. _extension_migration:
 
 Extension Migration Guide
-================================================
+=========================
 
 .. _extension_migration_3.5_3.6:
 
 JupyterLab 3.5 to 3.6
 ---------------------
+
+AsyncIterable Support
+^^^^^^^^^^^^^^^^^^^^^
+
+For the events service, we are using a JavaScript feature introduced in ES2018. If your code is
+using TypeScript with ES2017 target (as JupyterLab 3.6), you will have either to update your
+target to ES2018 or to add ``"ES2018"`` to `TypeScript lib option <https://www.typescriptlang.org/tsconfig#lib>`_.
+
+.. note::
+
+    JupyterLab 3.6.0 was released with an updated target "ES2018". We strongly advice updating to 3.6.1
+    that revert the target to "ES2017".
 
 Real-Time Collaboration
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -1588,7 +1588,7 @@ namespace Private {
       let selectedIndex = 0;
       if (currentKernelDisplayName) {
         // Select current kernel by default.
-        selectedIndex = [...node.options].findIndex(
+        selectedIndex = Array.from(node.options).findIndex(
           option => option.text === currentKernelDisplayName
         );
         selectedIndex = Math.max(selectedIndex, 0);

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1646,7 +1646,7 @@ export class MarkdownCell extends AttachmentsCell<IMarkdownCellModel> {
         } cell${this._numberChildNodes > 1 ? 's' : ''} hidden`;
         // If the heading isn't collapsed, remove the button
       } else {
-        for (const el of expandButton) {
+        for (const el of Array.from(expandButton)) {
           this.node.removeChild(el);
         }
       }

--- a/packages/toc/src/generators/notebook/get_rendered_html_heading.ts
+++ b/packages/toc/src/generators/notebook/get_rendered_html_heading.ts
@@ -51,7 +51,7 @@ function getRenderedHTMLHeadings(
     );
   }
   let headings: INotebookHeading[] = [];
-  for (const el of nodes) {
+  for (const el of Array.from(nodes)) {
     if (el.classList.contains('jp-toc-ignore')) {
       // skip this element if a special class name is included
       continue;

--- a/tsconfigbase.json
+++ b/tsconfigbase.json
@@ -7,6 +7,7 @@
     "esModuleInterop": true,
     "incremental": true,
     "jsx": "react",
+    "lib": ["DOM", "ES2018"],
     "module": "esnext",
     "moduleResolution": "node",
     "noEmitOnError": true,
@@ -16,7 +17,7 @@
     "resolveJsonModule": true,
     "sourceMap": true,
     "strictNullChecks": true,
-    "target": "es2018",
+    "target": "es2017",
     "types": []
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/3.6.x/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fix #13913
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Revert TypeScript target to "ES2017" and add a migration note.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None - the emitted type will still include `AsyncIterable` and require downstream consumer to either add it to TypeScript lib or bump their target to ES2018.