### PR TITLE
Upgrade to TypeScript 5.0 beta

### DIFF
--- a/builder/package.json
+++ b/builder/package.json
@@ -70,7 +70,7 @@
     "@types/node": "^18.11.18",
     "@types/supports-color": "^5.3.0",
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/buildutils/package.json
+++ b/buildutils/package.json
@@ -46,7 +46,7 @@
     "dependency-graph": "^0.11.0",
     "fs-extra": "^10.1.0",
     "glob": "~7.1.6",
-    "inquirer": "^7.1.0",
+    "inquirer": "^9.1.4",
     "minimatch": "~3.0.4",
     "os": "~0.1.1",
     "package-json": "^7.0.0",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@types/fs-extra": "^9.0.1",
     "@types/glob": "^7.1.1",
-    "@types/inquirer": "^7.3.1",
+    "@types/inquirer": "^9.0.3",
     "@types/node": "^18.11.18",
     "@types/prettier": "~2.6.0",
     "rimraf": "~3.0.0"

--- a/buildutils/package.json
+++ b/buildutils/package.json
@@ -54,7 +54,7 @@
     "process": "^0.11.10",
     "semver": "^7.3.2",
     "sort-package-json": "~1.53.1",
-    "typescript": "~4.7.3",
+    "typescript": "~5.0.0-beta",
     "verdaccio": "^5.20.1"
   },
   "devDependencies": {

--- a/buildutils/src/create-package.ts
+++ b/buildutils/src/create-package.ts
@@ -20,8 +20,9 @@ const questions: inquirer.Question[] = [
     message: 'description: '
   }
 ];
+const prompt = inquirer.createPromptModule();
 
-void inquirer.prompt(questions).then(answers => {
+void prompt(questions).then(answers => {
   let { name, description } = answers;
   const dest = path.resolve(path.join('.', 'packages', name));
   if (fs.existsSync(dest)) {

--- a/buildutils/template/package.json
+++ b/buildutils/template/package.json
@@ -39,7 +39,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/examples/cell/package.json
+++ b/examples/cell/package.json
@@ -27,7 +27,7 @@
     "mini-svg-data-uri": "^1.4.4",
     "rimraf": "~3.0.0",
     "style-loader": "~3.3.1",
-    "typescript": "~4.7.3",
+    "typescript": "~5.0.0-beta",
     "webpack": "^5.72.0",
     "webpack-cli": "^5.0.0",
     "whatwg-fetch": "^3.0.0"

--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -23,7 +23,7 @@
     "mini-css-extract-plugin": "^2.7.0",
     "rimraf": "~3.0.0",
     "style-loader": "~3.3.1",
-    "typescript": "~4.7.3",
+    "typescript": "~5.0.0-beta",
     "webpack": "^5.72.0",
     "webpack-cli": "^5.0.0",
     "whatwg-fetch": "^3.0.0"

--- a/examples/filebrowser/package.json
+++ b/examples/filebrowser/package.json
@@ -28,7 +28,7 @@
     "mini-svg-data-uri": "^1.4.4",
     "rimraf": "~3.0.0",
     "style-loader": "~3.3.1",
-    "typescript": "~4.7.3",
+    "typescript": "~5.0.0-beta",
     "webpack": "^5.72.0",
     "webpack-cli": "^5.0.0",
     "whatwg-fetch": "^3.0.0"

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -30,7 +30,7 @@
     "mini-svg-data-uri": "^1.4.4",
     "rimraf": "~3.0.0",
     "style-loader": "~3.3.1",
-    "typescript": "~4.7.3",
+    "typescript": "~5.0.0-beta",
     "webpack": "^5.72.0",
     "webpack-cli": "^5.0.0",
     "whatwg-fetch": "^3.0.0"

--- a/examples/terminal/package.json
+++ b/examples/terminal/package.json
@@ -20,7 +20,7 @@
     "mini-svg-data-uri": "^1.4.4",
     "rimraf": "~3.0.0",
     "style-loader": "~3.3.1",
-    "typescript": "~4.7.3",
+    "typescript": "~5.0.0-beta",
     "webpack": "^5.72.0",
     "webpack-cli": "^5.0.0",
     "whatwg-fetch": "^3.0.0"

--- a/galata/extension/package.json
+++ b/galata/extension/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@jupyterlab/builder": "^4.0.0-alpha.19",
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "jupyterlab": {
     "extension": true,

--- a/galata/package.json
+++ b/galata/package.json
@@ -59,7 +59,7 @@
     "path": "~0.12.7",
     "systeminformation": "^5.8.6",
     "vega": "^5.20.0",
-    "vega-lite": "^5.6.1-next.1",
+    "vega-lite": "^5.6.1",
     "vega-statistics": "^1.7.9"
   },
   "devDependencies": {

--- a/galata/package.json
+++ b/galata/package.json
@@ -59,7 +59,7 @@
     "path": "~0.12.7",
     "systeminformation": "^5.8.6",
     "vega": "^5.20.0",
-    "vega-lite": "^5.1.0",
+    "vega-lite": "^5.6.1-next.1",
     "vega-statistics": "^1.7.9"
   },
   "devDependencies": {

--- a/galata/package.json
+++ b/galata/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
+++ b/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
@@ -880,7 +880,7 @@
   },
   {
     "id": "fileeditor:change-font-size",
-    "label": "",
+    "label": "Decrease Font Size",
     "caption": "",
     "shortcuts": []
   },

--- a/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
+++ b/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
@@ -880,7 +880,7 @@
   },
   {
     "id": "fileeditor:change-font-size",
-    "label": "Decrease Font Size",
+    "label": "",
     "caption": "",
     "shortcuts": []
   },

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
   },
   "devDependencies": {
     "lerna": "^6.4.1",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "yarn": "1.22.19"
   }
 }

--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -67,7 +67,7 @@
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -66,7 +66,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/apputils-extension/package.json
+++ b/packages/apputils-extension/package.json
@@ -62,7 +62,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/apputils-extension/package.json
+++ b/packages/apputils-extension/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -71,7 +71,7 @@
     "@types/jest": "^29.2.0",
     "@types/sanitize-html": "^2.3.1",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -72,7 +72,7 @@
     "@types/sanitize-html": "^2.3.1",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/cell-toolbar-extension/package.json
+++ b/packages/cell-toolbar-extension/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cell-toolbar/package.json
+++ b/packages/cell-toolbar/package.json
@@ -55,7 +55,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -74,7 +74,7 @@
     "@types/jest": "^29.2.0",
     "@types/react": "^18.0.26",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -75,7 +75,7 @@
     "@types/react": "^18.0.26",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/celltags-extension/package.json
+++ b/packages/celltags-extension/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/celltags/package.json
+++ b/packages/celltags/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -60,7 +60,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -61,7 +61,7 @@
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -87,7 +87,7 @@
     "@lezer/lr": "^1.0.0",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -88,7 +88,7 @@
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/completer-extension/package.json
+++ b/packages/completer-extension/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/completer-extension/package.json
+++ b/packages/completer-extension/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -65,7 +65,7 @@
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -64,7 +64,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/console-extension/package.json
+++ b/packages/console-extension/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/console-extension/package.json
+++ b/packages/console-extension/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -65,7 +65,7 @@
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -64,7 +64,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -57,7 +57,7 @@
     "jest-junit": "^15.0.0",
     "rimraf": "~3.0.0",
     "ts-jest": "^29.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -58,7 +58,7 @@
     "rimraf": "~3.0.0",
     "ts-jest": "^29.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/csvviewer-extension/package.json
+++ b/packages/csvviewer-extension/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/csvviewer-extension/package.json
+++ b/packages/csvviewer-extension/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/csvviewer/package.json
+++ b/packages/csvviewer/package.json
@@ -59,7 +59,7 @@
     "csv-spectrum": "^1.0.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/csvviewer/package.json
+++ b/packages/csvviewer/package.json
@@ -58,7 +58,7 @@
     "canvas": "^2.9.1",
     "csv-spectrum": "^1.0.0",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/debugger-extension/package.json
+++ b/packages/debugger-extension/package.json
@@ -63,7 +63,7 @@
     "@types/jest": "^29.2.0",
     "@types/react-dom": "^18.0.9",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/debugger-extension/package.json
+++ b/packages/debugger-extension/package.json
@@ -64,7 +64,7 @@
     "@types/react-dom": "^18.0.9",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -349,9 +349,11 @@ const variables: JupyterFrontEndPlugin<void> = {
       caption: trans.__('Inspect Variable'),
       isEnabled: args =>
         !!service.session?.isStarted &&
-        (args.variableReference ??
-          service.model.variables.selectedVariable?.variablesReference ??
-          0) > 0,
+        Number(
+          args.variableReference ??
+            service.model.variables.selectedVariable?.variablesReference ??
+            0
+        ) > 0,
       execute: async args => {
         let { variableReference, name } = args as {
           variableReference?: number;

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -84,7 +84,7 @@
     "canvas": "^2.9.1",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -83,7 +83,7 @@
     "@types/jest": "^29.2.0",
     "canvas": "^2.9.1",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/debugger/src/handler.ts
+++ b/packages/debugger/src/handler.ts
@@ -150,7 +150,6 @@ export class DebuggerHandler implements DebuggerHandler.IHandler {
       msg: KernelMessage.IIOPubMessage
     ): void => {
       if (
-        msg.parent_header != {} &&
         (msg.parent_header as KernelMessage.IHeader).msg_type ==
           'execute_request' &&
         this._service.isStarted &&

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/docmanager/package.json
+++ b/packages/docmanager/package.json
@@ -61,7 +61,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/docmanager/package.json
+++ b/packages/docmanager/package.json
@@ -62,7 +62,7 @@
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -65,7 +65,7 @@
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -64,7 +64,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/documentsearch-extension/package.json
+++ b/packages/documentsearch-extension/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/documentsearch/package.json
+++ b/packages/documentsearch/package.json
@@ -51,7 +51,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/extensionmanager-extension/package.json
+++ b/packages/extensionmanager-extension/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/extensionmanager-extension/package.json
+++ b/packages/extensionmanager-extension/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/extensionmanager/package.json
+++ b/packages/extensionmanager/package.json
@@ -53,7 +53,7 @@
     "@types/react-paginate": "^6.2.1",
     "@types/semver": "^7.3.3",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/extensionmanager/package.json
+++ b/packages/extensionmanager/package.json
@@ -54,7 +54,7 @@
     "@types/semver": "^7.3.3",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/filebrowser-extension/package.json
+++ b/packages/filebrowser-extension/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/filebrowser-extension/package.json
+++ b/packages/filebrowser-extension/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -67,7 +67,7 @@
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -66,7 +66,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/fileeditor-extension/package.json
+++ b/packages/fileeditor-extension/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/fileeditor-extension/package.json
+++ b/packages/fileeditor-extension/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -274,7 +274,13 @@ export namespace Commands {
           });
       },
       label: args => {
-        if ((args.delta ?? 0) > 0) {
+        const delta = Number(args['delta']);
+        if (Number.isNaN(delta)) {
+          throw new Error(
+            `${CommandIDs.changeFontSize}: delta arg must be a number`
+          );
+        }
+        if (delta > 0) {
           return args.isMenu
             ? trans.__('Increase Text Editor Font Size')
             : trans.__('Increase Font Size');

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -276,7 +276,7 @@ export namespace Commands {
       label: args => {
         const delta = Number(args['delta']);
         if (Number.isNaN(delta)) {
-          throw new Error(
+          console.error(
             `${CommandIDs.changeFontSize}: delta arg must be a number`
           );
         }

--- a/packages/fileeditor/package.json
+++ b/packages/fileeditor/package.json
@@ -60,7 +60,7 @@
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/fileeditor/package.json
+++ b/packages/fileeditor/package.json
@@ -59,7 +59,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/help-extension/package.json
+++ b/packages/help-extension/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/help-extension/package.json
+++ b/packages/help-extension/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/htmlviewer-extension/package.json
+++ b/packages/htmlviewer-extension/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/htmlviewer/package.json
+++ b/packages/htmlviewer/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/hub-extension/package.json
+++ b/packages/hub-extension/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/imageviewer-extension/package.json
+++ b/packages/imageviewer-extension/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/imageviewer-extension/package.json
+++ b/packages/imageviewer-extension/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/imageviewer/package.json
+++ b/packages/imageviewer/package.json
@@ -53,7 +53,7 @@
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/imageviewer/package.json
+++ b/packages/imageviewer/package.json
@@ -52,7 +52,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/inspector-extension/package.json
+++ b/packages/inspector-extension/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/inspector-extension/package.json
+++ b/packages/inspector-extension/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -59,7 +59,7 @@
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -58,7 +58,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/javascript-extension/package.json
+++ b/packages/javascript-extension/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/javascript-extension/package.json
+++ b/packages/javascript-extension/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/json-extension/package.json
+++ b/packages/json-extension/package.json
@@ -52,7 +52,7 @@
     "@types/react-dom": "^18.0.9",
     "@types/react-highlighter": "^0.3.4",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/json-extension/package.json
+++ b/packages/json-extension/package.json
@@ -53,7 +53,7 @@
     "@types/react-highlighter": "^0.3.4",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/launcher-extension/package.json
+++ b/packages/launcher-extension/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/launcher-extension/package.json
+++ b/packages/launcher-extension/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@types/react": "^18.0.26",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -51,7 +51,7 @@
     "@types/react": "^18.0.26",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/logconsole-extension/package.json
+++ b/packages/logconsole-extension/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/logconsole/package.json
+++ b/packages/logconsole/package.json
@@ -53,7 +53,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/lsp-extension/package.json
+++ b/packages/lsp-extension/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/lsp/package.json
+++ b/packages/lsp/package.json
@@ -63,7 +63,7 @@
     "@types/lodash.mergewith": "^4.6.1",
     "json-schema-to-typescript": "^8.0.0",
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mainmenu-extension/package.json
+++ b/packages/mainmenu-extension/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mainmenu-extension/package.json
+++ b/packages/mainmenu-extension/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/mainmenu/package.json
+++ b/packages/mainmenu/package.json
@@ -54,7 +54,7 @@
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mainmenu/package.json
+++ b/packages/mainmenu/package.json
@@ -53,7 +53,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/markdownviewer-extension/package.json
+++ b/packages/markdownviewer-extension/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/markdownviewer-extension/package.json
+++ b/packages/markdownviewer-extension/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/markdownviewer/package.json
+++ b/packages/markdownviewer/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/markdownviewer/package.json
+++ b/packages/markdownviewer/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/markedparser-extension/package.json
+++ b/packages/markedparser-extension/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@types/marked": "^4.0.3",
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mathjax2-extension/package.json
+++ b/packages/mathjax2-extension/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/mathjax2-extension/package.json
+++ b/packages/mathjax2-extension/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mathjax2/package.json
+++ b/packages/mathjax2/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mathjax2/package.json
+++ b/packages/mathjax2/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/metadataform-extension/package.json
+++ b/packages/metadataform-extension/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/metadataform/package.json
+++ b/packages/metadataform/package.json
@@ -64,7 +64,7 @@
     "@types/react": "^18.0.26",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/metadataform/package.json
+++ b/packages/metadataform/package.json
@@ -63,7 +63,7 @@
     "@types/jest": "^29.2.0",
     "@types/react": "^18.0.26",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -136,7 +136,7 @@
     "json-to-html": "~0.1.2",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -135,7 +135,7 @@
     "fs-extra": "^10.1.0",
     "json-to-html": "~0.1.2",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/nbformat/package.json
+++ b/packages/nbformat/package.json
@@ -43,7 +43,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -72,7 +72,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -73,7 +73,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -74,7 +74,7 @@
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -73,7 +73,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/observables/package.json
+++ b/packages/observables/package.json
@@ -46,7 +46,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/observables/package.json
+++ b/packages/observables/package.json
@@ -47,7 +47,7 @@
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/outputarea/package.json
+++ b/packages/outputarea/package.json
@@ -60,7 +60,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/outputarea/package.json
+++ b/packages/outputarea/package.json
@@ -61,7 +61,7 @@
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/pdf-extension/package.json
+++ b/packages/pdf-extension/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/pdf-extension/package.json
+++ b/packages/pdf-extension/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/property-inspector/package.json
+++ b/packages/property-inspector/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/rendermime-extension/package.json
+++ b/packages/rendermime-extension/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/rendermime-extension/package.json
+++ b/packages/rendermime-extension/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/rendermime-interfaces/package.json
+++ b/packages/rendermime-interfaces/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/rendermime-interfaces/package.json
+++ b/packages/rendermime-interfaces/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -61,7 +61,7 @@
     "fs-extra": "^10.1.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -60,7 +60,7 @@
     "@types/lodash.escape": "^4.0.6",
     "fs-extra": "^10.1.0",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/running-extension/package.json
+++ b/packages/running-extension/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/running-extension/package.json
+++ b/packages/running-extension/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/running/package.json
+++ b/packages/running/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/running/package.json
+++ b/packages/running/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/services/examples/browser/package.json
+++ b/packages/services/examples/browser/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3",
+    "typescript": "~5.0.0-beta",
     "webpack": "^5.72.0",
     "webpack-cli": "^5.0.0"
   }

--- a/packages/services/examples/typescript-browser-with-output/package.json
+++ b/packages/services/examples/typescript-browser-with-output/package.json
@@ -25,7 +25,7 @@
     "css-loader": "^6.7.1",
     "rimraf": "~3.0.0",
     "style-loader": "~3.3.1",
-    "typescript": "~4.7.3",
+    "typescript": "~5.0.0-beta",
     "webpack": "^5.72.0",
     "webpack-cli": "^5.0.0"
   },

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -62,7 +62,7 @@
     "@types/jest": "^29.2.0",
     "@types/ws": "^8.5.3",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta",
     "webpack": "^5.72.0",
     "webpack-cli": "^5.0.0"

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -63,7 +63,7 @@
     "@types/ws": "^8.5.3",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3",
+    "typescript": "~5.0.0-beta",
     "webpack": "^5.72.0",
     "webpack-cli": "^5.0.0"
   },

--- a/packages/settingeditor-extension/package.json
+++ b/packages/settingeditor-extension/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/settingeditor-extension/package.json
+++ b/packages/settingeditor-extension/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/settingeditor/package.json
+++ b/packages/settingeditor/package.json
@@ -63,7 +63,7 @@
     "@types/react": "^18.0.26",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/settingeditor/package.json
+++ b/packages/settingeditor/package.json
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@types/react": "^18.0.26",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/settingregistry/package.json
+++ b/packages/settingregistry/package.json
@@ -49,7 +49,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/shortcuts-extension/package.json
+++ b/packages/shortcuts-extension/package.json
@@ -58,7 +58,7 @@
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/shortcuts-extension/package.json
+++ b/packages/shortcuts-extension/package.json
@@ -57,7 +57,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/statedb/package.json
+++ b/packages/statedb/package.json
@@ -46,7 +46,7 @@
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/statedb/package.json
+++ b/packages/statedb/package.json
@@ -45,7 +45,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/statusbar-extension/package.json
+++ b/packages/statusbar-extension/package.json
@@ -46,7 +46,7 @@
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/statusbar-extension/package.json
+++ b/packages/statusbar-extension/package.json
@@ -47,7 +47,7 @@
     "@types/react-dom": "^18.0.9",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/statusbar/package.json
+++ b/packages/statusbar/package.json
@@ -49,7 +49,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/terminal-extension/package.json
+++ b/packages/terminal-extension/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@types/webpack-env": "^1.14.1",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/terminal-extension/package.json
+++ b/packages/terminal-extension/package.json
@@ -53,7 +53,7 @@
     "@types/webpack-env": "^1.14.1",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -59,7 +59,7 @@
     "@types/jest": "^29.2.0",
     "canvas": "^2.9.1",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -60,7 +60,7 @@
     "canvas": "^2.9.1",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -53,7 +53,7 @@
     "@types/node": "^18.11.18",
     "@types/node-fetch": "^2.6.2",
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/theme-dark-extension/package.json
+++ b/packages/theme-dark-extension/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/theme-dark-extension/package.json
+++ b/packages/theme-dark-extension/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/theme-light-extension/package.json
+++ b/packages/theme-light-extension/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/theme-light-extension/package.json
+++ b/packages/theme-light-extension/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/toc-extension/package.json
+++ b/packages/toc-extension/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/toc-extension/package.json
+++ b/packages/toc-extension/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/toc/package.json
+++ b/packages/toc/package.json
@@ -59,7 +59,7 @@
     "@types/jest": "^29.2.0",
     "@types/react": "^18.0.26",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/toc/package.json
+++ b/packages/toc/package.json
@@ -60,7 +60,7 @@
     "@types/react": "^18.0.26",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tooltip-extension/package.json
+++ b/packages/tooltip-extension/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/tooltip-extension/package.json
+++ b/packages/tooltip-extension/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/translation-extension/package.json
+++ b/packages/translation-extension/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/translation/package.json
+++ b/packages/translation/package.json
@@ -49,7 +49,7 @@
     "@jupyterlab/testing": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-components-extension/package.json
+++ b/packages/ui-components-extension/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/ui-components-extension/package.json
+++ b/packages/ui-components-extension/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-components/examples/simple-windowed-list/package.json
+++ b/packages/ui-components/examples/simple-windowed-list/package.json
@@ -23,7 +23,7 @@
     "mini-svg-data-uri": "^1.4.4",
     "rimraf": "~3.0.0",
     "style-loader": "~3.3.1",
-    "typescript": "~4.7.3",
+    "typescript": "~5.0.0-beta",
     "webpack": "^5.72.0",
     "webpack-cli": "^5.0.0"
   },

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -66,7 +66,7 @@
     "@types/react": "^18.0.26",
     "rimraf": "~3.0.0",
     "svgo": "^3.0.1",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "peerDependencies": {

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -67,7 +67,7 @@
     "rimraf": "~3.0.0",
     "svgo": "^3.0.1",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "peerDependencies": {
     "react": "^18.2.0"

--- a/packages/vega5-extension/package.json
+++ b/packages/vega5-extension/package.json
@@ -42,7 +42,7 @@
     "@lumino/widgets": "^2.0.0-beta.1",
     "vega": "^5.20.0",
     "vega-embed": "^6.2.1",
-    "vega-lite": "^5.1.0"
+    "vega-lite": "^5.6.1-next.1"
   },
   "devDependencies": {
     "@jupyterlab/testutils": "^4.0.0-alpha.19",

--- a/packages/vega5-extension/package.json
+++ b/packages/vega5-extension/package.json
@@ -50,7 +50,7 @@
     "@types/webpack-env": "^1.14.1",
     "jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
+    "typedoc": "~0.23.25",
     "typescript": "~5.0.0-beta"
   },
   "publishConfig": {

--- a/packages/vega5-extension/package.json
+++ b/packages/vega5-extension/package.json
@@ -51,7 +51,7 @@
     "jest": "^29.2.0",
     "rimraf": "~3.0.0",
     "typedoc": "~0.22.10",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/testutils/package.json
+++ b/testutils/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.0-beta"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11686,10 +11686,20 @@ typedoc@~0.22.10:
     minimatch "^5.1.0"
     shiki "^0.10.1"
 
-"typescript@^3 || ^4", typescript@~4.7.3:
+"typescript@^3 || ^4":
+  version "4.9.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
+  integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
+
+typescript@~4.7.3:
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+
+typescript@~5.0.0-beta:
+  version "5.0.0-dev.20230204"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.0-dev.20230204.tgz#ed40e18638c4d6e539f37361b0d49d39fe040650"
+  integrity sha512-+7FKfJ6M6n0mveLqxFzi6z1ZJfqUX5QDJFBJqS0r1WP76v32AwGoZRBaYalyd7l8ph4k5qXoMmDCexrF/sVnyQ==
 
 typestyle@^2.0.4:
   version "2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11705,6 +11705,11 @@ tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@~2.4.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
 
+tslib@~2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+
 tsscmp@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"
@@ -12214,6 +12219,22 @@ vega-label@~1.2.0:
     vega-dataflow "^5.7.3"
     vega-scenegraph "^4.9.2"
     vega-util "^1.15.2"
+
+vega-lite@^5.6.1:
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/vega-lite/-/vega-lite-5.6.1.tgz#538e50f6cd90a7c267f48acd06a2c1d29acf413a"
+  integrity sha512-Dij2OkJcmK+/2pIcLambjV/vWmhP11ypL3YqDVryBfJxP1m+ZgZU+8/SOEP3B2R1MhmmT7JDYQUtiNcGi1/2ig==
+  dependencies:
+    "@types/clone" "~2.1.1"
+    clone "~2.1.2"
+    fast-deep-equal "~3.1.3"
+    fast-json-stable-stringify "~2.1.0"
+    json-stringify-pretty-compact "~3.0.0"
+    tslib "~2.5.0"
+    vega-event-selector "~3.0.0"
+    vega-expression "~5.0.0"
+    vega-util "~1.17.0"
+    yargs "~17.6.2"
 
 vega-lite@^5.6.1-next.1:
   version "5.6.1-next.1"
@@ -12998,7 +13019,7 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.3.1, yargs@^17.6.2, yargs@~17.6.0:
+yargs@^17.3.1, yargs@^17.6.2, yargs@~17.6.0, yargs@~17.6.2:
   version "17.6.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.6.2.tgz#2e23f2944e976339a1ee00f18c77fedee8332541"
   integrity sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -11856,11 +11856,6 @@ typedoc@~0.23.25:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
   integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
-typescript@~4.7.3:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
-
 typescript@~5.0.0-beta:
   version "5.0.0-dev.20230204"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.0-dev.20230204.tgz#ed40e18638c4d6e539f37361b0d49d39fe040650"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3262,13 +3262,13 @@
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz#0ea7b61496902b95890dc4c3a116b60cb8dae812"
   integrity sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==
 
-"@types/inquirer@^7.3.1":
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/@types/inquirer/-/inquirer-7.3.3.tgz#92e6676efb67fa6925c69a2ee638f67a822952ac"
-  integrity sha512-HhxyLejTHMfohAuhRun4csWigAMjXTmRyiJTU1Y/I1xmggikFMkOUoMQRlFm+zQcPEGHSs3io/0FAmNZf8EymQ==
+"@types/inquirer@^9.0.3":
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/@types/inquirer/-/inquirer-9.0.3.tgz#dc99da4f2f6de9d26c284b4f6aaab4d98c456db1"
+  integrity sha512-CzNkWqQftcmk2jaCWdBTf9Sm7xSw4rkI1zpU/Udw3HX5//adEZUIm9STtoRP1qgWj0CWQtJ9UTvqmO2NNjhMJw==
   dependencies:
     "@types/through" "*"
-    rxjs "^6.4.0"
+    rxjs "^7.2.0"
 
 "@types/is-glob@^4.0.1":
   version "4.0.2"
@@ -4011,6 +4011,13 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.21.3"
 
+ansi-escapes@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-6.0.0.tgz#68c580e87a489f6df3d761028bb93093fde6bd8a"
+  integrity sha512-IG23inYII3dWlU2EyiAiGj6Bwal5GzsgPMwjYGvc1HPE2dgbj4ZB5ToWBKSquKw74nB3TIuOwaI6/jSULzfgrw==
+  dependencies:
+    type-fest "^3.0.0"
+
 ansi-regex@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -4020,6 +4027,11 @@ ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
+ansi-regex@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
+  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
 ansi-styles@^3.2.1:
   version "3.2.1"
@@ -4039,6 +4051,11 @@ ansi-styles@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
+ansi-styles@^6.1.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
+  integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 
 any-promise@^1.0.0:
   version "1.3.0"
@@ -4355,6 +4372,15 @@ bl@^4.0.3, bl@^4.1.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
+bl@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-5.1.0.tgz#183715f678c7188ecef9fe475d90209400624273"
+  integrity sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==
+  dependencies:
+    buffer "^6.0.3"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
+
 blacklist@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/blacklist/-/blacklist-1.1.4.tgz#b2dd09d6177625b2caa69835a37b28995fa9a2f2"
@@ -4446,6 +4472,14 @@ buffer@^5.5.0:
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
+
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 builtins@^1.0.3:
   version "1.0.3"
@@ -4621,6 +4655,11 @@ chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^5.0.0, chalk@^5.1.2:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.2.0.tgz#249623b7d66869c673699fb66d65723e54dfcfb3"
+  integrity sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==
+
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
@@ -4714,15 +4753,32 @@ cli-cursor@3.1.0, cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
-cli-spinners@2.6.1, cli-spinners@^2.5.0:
+cli-cursor@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-4.0.0.tgz#3cecfe3734bf4fe02a8361cbdc0f6fe28c6a57ea"
+  integrity sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==
+  dependencies:
+    restore-cursor "^4.0.0"
+
+cli-spinners@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.6.1.tgz#adc954ebe281c37a6319bfa401e6dd2488ffb70d"
   integrity sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==
+
+cli-spinners@^2.5.0, cli-spinners@^2.6.1:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.7.0.tgz#f815fd30b5f9eaac02db604c7a231ed7cb2f797a"
+  integrity sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==
 
 cli-width@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
+
+cli-width@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-4.0.0.tgz#a5622f6a3b0a9e3e711a25f099bf2399f608caf6"
+  integrity sha512-ZksGS2xpa/bYkNzN3BAw1wEjsLV/ZKOf/CCrJ/QOBsxx6fOARIkwTutxp1XIOIohi6HKmOFjMoK/XaqDVUpEEw==
 
 clipanion@3.2.0-rc.14:
   version "3.2.0-rc.14"
@@ -5752,6 +5808,11 @@ duplicate-package-checker-webpack-plugin@^3.0.0:
     lodash "^4.17.4"
     semver "^5.4.1"
 
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -5793,6 +5854,11 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+emoji-regex@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
+  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
 emojis-list@^3.0.0:
   version "3.0.0"
@@ -5977,6 +6043,11 @@ escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
+escape-string-regexp@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
+  integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
 
 escodegen@^2.0.0:
   version "2.0.0"
@@ -6350,6 +6421,14 @@ figures@3.2.0, figures@^3.0.0:
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
   dependencies:
     escape-string-regexp "^1.0.5"
+
+figures@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-5.0.0.tgz#126cd055052dea699f8a54e8c9450e6ecfc44d5f"
+  integrity sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==
+  dependencies:
+    escape-string-regexp "^5.0.0"
+    is-unicode-supported "^1.2.0"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -7178,7 +7257,7 @@ identity-obj-proxy@^3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ieee754@^1.1.13:
+ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -7267,25 +7346,6 @@ init-package-json@^3.0.2:
     validate-npm-package-license "^3.0.4"
     validate-npm-package-name "^4.0.0"
 
-inquirer@^7.1.0:
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
-  integrity sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==
-  dependencies:
-    ansi-escapes "^4.2.1"
-    chalk "^4.1.0"
-    cli-cursor "^3.1.0"
-    cli-width "^3.0.0"
-    external-editor "^3.0.3"
-    figures "^3.0.0"
-    lodash "^4.17.19"
-    mute-stream "0.0.8"
-    run-async "^2.4.0"
-    rxjs "^6.6.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-    through "^2.3.6"
-
 inquirer@^8.2.4:
   version "8.2.5"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.5.tgz#d8654a7542c35a9b9e069d27e2df4858784d54f8"
@@ -7306,6 +7366,27 @@ inquirer@^8.2.4:
     strip-ansi "^6.0.0"
     through "^2.3.6"
     wrap-ansi "^7.0.0"
+
+inquirer@^9.1.4:
+  version "9.1.4"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-9.1.4.tgz#482da8803670a64bd942bc5166a9547a19d41474"
+  integrity sha512-9hiJxE5gkK/cM2d1mTEnuurGTAoHebbkX0BYl3h7iEg7FYfuNIom+nDfBCSWtvSnoSrWCeBxqqBZu26xdlJlXA==
+  dependencies:
+    ansi-escapes "^6.0.0"
+    chalk "^5.1.2"
+    cli-cursor "^4.0.0"
+    cli-width "^4.0.0"
+    external-editor "^3.0.3"
+    figures "^5.0.0"
+    lodash "^4.17.21"
+    mute-stream "0.0.8"
+    ora "^6.1.2"
+    run-async "^2.4.0"
+    rxjs "^7.5.7"
+    string-width "^5.1.2"
+    strip-ansi "^7.0.1"
+    through "^2.3.6"
+    wrap-ansi "^8.0.1"
 
 internal-slot@^1.0.3:
   version "1.0.4"
@@ -7426,6 +7507,11 @@ is-interactive@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
   integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
 
+is-interactive@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-2.0.0.tgz#40c57614593826da1100ade6059778d597f16e90"
+  integrity sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==
+
 is-lambda@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-lambda/-/is-lambda-1.0.1.tgz#3d9877899e6a53efc0160504cde15f82e6f061d5"
@@ -7542,6 +7628,11 @@ is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
+
+is-unicode-supported@^1.1.0, is-unicode-supported@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz#d824984b616c292a2e198207d4a609983842f714"
+  integrity sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==
 
 is-weakref@^1.0.2:
   version "1.0.2"
@@ -8513,7 +8604,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
-lodash@4, lodash@4.17.21, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.7.0:
+lodash@4, lodash@4.17.21, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -8525,6 +8616,14 @@ log-symbols@^4.1.0:
   dependencies:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
+
+log-symbols@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-5.1.0.tgz#a20e3b9a5f53fac6aeb8e2bb22c07cf2c8f16d93"
+  integrity sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==
+  dependencies:
+    chalk "^5.0.0"
+    is-unicode-supported "^1.1.0"
 
 loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
@@ -9458,6 +9557,21 @@ ora@^5.4.1:
     is-unicode-supported "^0.1.0"
     log-symbols "^4.1.0"
     strip-ansi "^6.0.0"
+    wcwidth "^1.0.1"
+
+ora@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-6.1.2.tgz#7b3c1356b42fd90fb1dad043d5dbe649388a0bf5"
+  integrity sha512-EJQ3NiP5Xo94wJXIzAyOtSb0QEIAUu7m8t6UZ9krbz0vAJqr92JpcK/lEXg91q6B9pEGqrykkd2EQplnifDSBw==
+  dependencies:
+    bl "^5.0.0"
+    chalk "^5.0.0"
+    cli-cursor "^4.0.0"
+    cli-spinners "^2.6.1"
+    is-interactive "^2.0.0"
+    is-unicode-supported "^1.1.0"
+    log-symbols "^5.1.0"
+    strip-ansi "^7.0.1"
     wcwidth "^1.0.1"
 
 os-tmpdir@~1.0.2:
@@ -10532,6 +10646,14 @@ restore-cursor@^3.1.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
 
+restore-cursor@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-4.0.0.tgz#519560a4318975096def6e609d44100edaa4ccb9"
+  integrity sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==
+  dependencies:
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
+
 retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
@@ -10578,12 +10700,12 @@ rw@1:
   resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
   integrity sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==
 
-rxjs@^6.4.0, rxjs@^6.6.0:
-  version "6.6.7"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
-  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
+rxjs@^7.2.0, rxjs@^7.5.7:
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.0.tgz#90a938862a82888ff4c7359811a595e14e1e09a4"
+  integrity sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==
   dependencies:
-    tslib "^1.9.0"
+    tslib "^2.1.0"
 
 rxjs@^7.5.5:
   version "7.6.0"
@@ -11068,6 +11190,15 @@ string-length@^4.0.1:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
+string-width@^5.0.1, string-width@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
+  dependencies:
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
+
 string.prototype.matchall@^4.0.6:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz#3bf85722021816dcd1bf38bb714915887ca79fd3"
@@ -11113,6 +11244,13 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
+
+strip-ansi@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.0.1.tgz#61740a08ce36b61e50e65653f07060d000975fb2"
+  integrity sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==
+  dependencies:
+    ansi-regex "^6.0.1"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -11557,7 +11695,7 @@ tsconfig-paths@^4.1.2:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -11644,6 +11782,11 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^3.0.0:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.5.5.tgz#43e96a3c6306e46cfd36e85c57a03fb7e2b34b48"
+  integrity sha512-Nudle2CLcCaf9/1bVQunwzX1/ZH4Z6mvP8hkWWZCbKrxtnN52QwD5Xn/mo68aofQhGU4be1GlEC6LQCTKGXkRw==
 
 type-is@~1.6.18:
   version "1.6.18"
@@ -12072,10 +12215,10 @@ vega-label@~1.2.0:
     vega-scenegraph "^4.9.2"
     vega-util "^1.15.2"
 
-vega-lite@^5.1.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/vega-lite/-/vega-lite-5.6.0.tgz#0f0adfc8b86f5eea071df186b2877d828c870c11"
-  integrity sha512-aTjQk//SzL9ctHY4ItA8yZSGflHMWPJmCXEs8LeRlixuOaAbamZmeL8xNMbQpS/vAZQeFAqjcJ32Fuztz/oGww==
+vega-lite@^5.6.1-next.1:
+  version "5.6.1-next.1"
+  resolved "https://registry.yarnpkg.com/vega-lite/-/vega-lite-5.6.1-next.1.tgz#6264a5aaba3f866c7932be1ccf6b80f2de44a418"
+  integrity sha512-46Vz8hRz5vRQP4LVQM44IuOO1Lb5q6h6oiTptWymmQjkfCgyjads+75N/nfpwKykgUOl3+W16mXk6Nodq9AHmw==
   dependencies:
     "@types/clone" "~2.1.1"
     clone "~2.1.2"
@@ -12668,6 +12811,15 @@ wrap-ansi@^7.0.0:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
+
+wrap-ansi@^8.0.1:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
+  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
+  dependencies:
+    ansi-styles "^6.1.0"
+    string-width "^5.0.1"
+    strip-ansi "^7.0.1"
 
 wrappy@1:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4033,6 +4033,11 @@ ansi-regex@^6.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
   integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
+ansi-sequence-parser@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz#4d790f31236ac20366b23b3916b789e1bde39aed"
+  integrity sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -6851,7 +6856,7 @@ glob@^7.1.3, glob@^7.1.4, glob@~7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^8.0.1, glob@^8.0.3:
+glob@^8.0.1:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
   integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
@@ -8292,7 +8297,7 @@ json5@^2.1.2, json5@^2.2.1, json5@^2.2.2, json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsonc-parser@3.2.0, jsonc-parser@^3.0.0:
+jsonc-parser@3.2.0, jsonc-parser@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
   integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
@@ -8745,10 +8750,15 @@ map-obj@^4.0.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
-marked@^4.0.16, marked@^4.0.17:
+marked@^4.0.17:
   version "4.0.18"
   resolved "https://registry.npmjs.org/marked/-/marked-4.0.18.tgz"
   integrity sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw==
+
+marked@^4.2.12:
+  version "4.2.12"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.2.12.tgz#d69a64e21d71b06250da995dcd065c11083bebb5"
+  integrity sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==
 
 mathml-tag-names@^2.1.3:
   version "2.1.3"
@@ -8915,10 +8925,17 @@ minimatch@3.1.2, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1, minimatch@^5.1.0:
+minimatch@^5.0.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.1.tgz#6c9dffcf9927ff2a31e74b5af11adf8b9604b022"
   integrity sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^6.1.6:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-6.2.0.tgz#2b70fd13294178c69c04dfc05aebdb97a4e79e42"
+  integrity sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==
   dependencies:
     brace-expansion "^2.0.1"
 
@@ -10888,14 +10905,15 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shiki@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.10.1.tgz#6f9a16205a823b56c072d0f1a0bcd0f2646bef14"
-  integrity sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==
+shiki@^0.14.1:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.14.1.tgz#9fbe082d0a8aa2ad63df4fbf2ee11ec924aa7ee1"
+  integrity sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==
   dependencies:
-    jsonc-parser "^3.0.0"
-    vscode-oniguruma "^1.6.1"
-    vscode-textmate "5.2.0"
+    ansi-sequence-parser "^1.1.0"
+    jsonc-parser "^3.2.0"
+    vscode-oniguruma "^1.7.0"
+    vscode-textmate "^8.0.0"
 
 side-channel@^1.0.4:
   version "1.0.4"
@@ -11823,16 +11841,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typedoc@~0.22.10:
-  version "0.22.18"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.22.18.tgz#1d000c33b66b88fd8cdfea14a26113a83b7e6591"
-  integrity sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==
+typedoc@~0.23.25:
+  version "0.23.25"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.23.25.tgz#5f8f1850fd044c4d15d453117affddf11a265610"
+  integrity sha512-O1he153qVyoCgJYSvIyY3bPP1wAJTegZfa6tL3APinSZhJOf8CSd8F/21M6ex8pUY/fuY6n0jAsT4fIuMGA6sA==
   dependencies:
-    glob "^8.0.3"
     lunr "^2.3.9"
-    marked "^4.0.16"
-    minimatch "^5.1.0"
-    shiki "^0.10.1"
+    marked "^4.2.12"
+    minimatch "^6.1.6"
+    shiki "^0.14.1"
 
 "typescript@^3 || ^4":
   version "4.9.4"
@@ -12566,15 +12583,15 @@ vscode-languageserver-types@3.17.2:
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz#b2c2e7de405ad3d73a883e91989b850170ffc4f2"
   integrity sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==
 
-vscode-oniguruma@^1.6.1:
+vscode-oniguruma@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz#439bfad8fe71abd7798338d1cd3dc53a8beea94b"
   integrity sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==
 
-vscode-textmate@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.2.0.tgz#01f01760a391e8222fe4f33fbccbd1ad71aed74e"
-  integrity sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==
+vscode-textmate@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-8.0.0.tgz#2c7a3b1163ef0441097e0b5d6389cd5504b59e5d"
+  integrity sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==
 
 vscode-ws-jsonrpc@~1.0.2:
   version "1.0.2"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This carries forward work done in #13028 to update Typescript, this time to version 5.0 beta, as suggested in #13872.

The Typescript 5 [timeline](https://github.com/microsoft/TypeScript/issues/51362) indicates that 5.0 final is expected on 14 March, so during the bugfix phase of JupyterLab 4.0.

## Code changes

Upgrade Typescript to 5.0 beta.

## User-facing changes

Should be little to none.

## Backwards-incompatible changes

This upgrade seemed rather painless (thanks to the work from @jtpio and others in #13028!), so hopefully there are little if any backwards incompatibilities for us.
