### PR TITLE
Update plugin name to `@jupyterlab/filebrowser-extension:default-file-browser`

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -292,7 +292,7 @@ const factory: JupyterFrontEndPlugin<IFileBrowserFactory> = {
  * The default file browser factory provider.
  */
 const defaultFileBrowser: JupyterFrontEndPlugin<IDefaultFileBrowser> = {
-  id: '@jupyterlab/filebrowser-extension:defaultFileBrowser',
+  id: '@jupyterlab/filebrowser-extension:default-file-browser',
   provides: IDefaultFileBrowser,
   requires: [IFileBrowserFactory],
   optional: [IRouter, JupyterFrontEnd.ITreeResolver, ILabShell],


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/13786

Update the plugin name for the default file browser to `@jupyterlab/filebrowser-extension:default-file-browser` for consistency with the other plugins.

## Code changes

Update the name of a plugin.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes



<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
