### PR TITLE
Fixes toolbar button for Restart Kernel and Run All

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -154,7 +154,7 @@ bumped their major version (following semver convention). We want to point out p
      mode.
    * Added the property ``sharedModel`` to the interface ``NotebookModel.IOptions``.
    * The method ``NotebookModelFactory.createNew`` receives a parameter ``NotebookModelFactory.IModelOptions``.
-   * The default Notebook toolbar's ``restart-and-run`` button now refers to the command 
+   * The default Notebook toolbar's ``restart-and-run`` button now refers to the command
      ``notebook:restart-run-all`` instead of ``runmenu:restart-and-run-all``.
 - ``@jupyterlab/rendermime`` from 3.x to 4.x
   The markdown parser has been extracted to its own plugin ``@jupyterlab/markedparser-extension:plugin``

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -154,6 +154,8 @@ bumped their major version (following semver convention). We want to point out p
      mode.
    * Added the property ``sharedModel`` to the interface ``NotebookModel.IOptions``.
    * The method ``NotebookModelFactory.createNew`` receives a parameter ``NotebookModelFactory.IModelOptions``.
+   * The default Notebook toolbar's ``restart-and-run`` button now refers to the command 
+     ``notebook:restart-run-all`` instead of ``runmenu:restart-and-run-all``.
 - ``@jupyterlab/rendermime`` from 3.x to 4.x
   The markdown parser has been extracted to its own plugin ``@jupyterlab/markedparser-extension:plugin``
   that provides a new token ``IMarkdownParser`` (defined in ``@jupyterlab/rendermime``).

--- a/docs/source/extension/extension_points.rst
+++ b/docs/source/extension/extension_points.rst
@@ -869,7 +869,7 @@ mapping. For example for the notebook panel:
        { "name": "restart", "command": "kernelmenu:restart", "rank": 32 },
        {
          "name": "restart-and-run",
-         "command": "runmenu:restart-and-run-all",
+         "command": "notebook:restart-run-all",
          "rank": 33 // The default rank is 50
        },
        { "name": "cellType", "rank": 40 },

--- a/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
+++ b/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
@@ -1762,7 +1762,7 @@
   {
     "id": "notebook:restart-run-all",
     "label": "Restart Kernel and Run All Cells…",
-    "caption": "",
+    "caption": "Restart the kernel and run all cells",
     "shortcuts": []
   },
   {

--- a/packages/application/src/utils.ts
+++ b/packages/application/src/utils.ts
@@ -138,7 +138,7 @@ export function createSemanticCommand(
             .slice(undefined, -1)
             .map(l => l.replace(/…$/, ''))
             .join(', ');
-          const end = texts.slice(-1)[0] + (hasEllipsis ? '…' : '');
+          const end = texts.slice(-1)[0].replace(/…$/, '') + (hasEllipsis ? '…' : '');
           return trans.__('%1 and %2', main, end);
         }
       }

--- a/packages/application/src/utils.ts
+++ b/packages/application/src/utils.ts
@@ -138,7 +138,8 @@ export function createSemanticCommand(
             .slice(undefined, -1)
             .map(l => l.replace(/…$/, ''))
             .join(', ');
-          const end = texts.slice(-1)[0].replace(/…$/, '') + (hasEllipsis ? '…' : '');
+          const end =
+            texts.slice(-1)[0].replace(/…$/, '') + (hasEllipsis ? '…' : '');
           return trans.__('%1 and %2', main, end);
         }
       }

--- a/packages/application/src/utils.ts
+++ b/packages/application/src/utils.ts
@@ -125,10 +125,13 @@ export function createSemanticCommand(
     attribute: 'label' | 'caption'
   ): string | CommandRegistry.CommandFunc<string> | undefined {
     return () => {
-      const texts = reduceAttribute(attribute);
+      // If a command has constituent commands with no defined label/caption,
+      // fall back to the default label/caption.
+      const texts = reduceAttribute(attribute).filter(text => text !== '');
+
       switch (texts.length) {
         case 0:
-          return defaultValues.label ?? '';
+          return defaultValues[attribute] ?? '';
         case 1:
           return texts[0];
         default: {

--- a/packages/application/src/utils.ts
+++ b/packages/application/src/utils.ts
@@ -125,9 +125,7 @@ export function createSemanticCommand(
     attribute: 'label' | 'caption'
   ): string | CommandRegistry.CommandFunc<string> | undefined {
     return () => {
-      // If a command has constituent commands with no defined label/caption,
-      // fall back to the default label/caption.
-      const texts = reduceAttribute(attribute).filter(text => text !== '');
+      const texts = reduceAttribute(attribute);
 
       switch (texts.length) {
         case 0:

--- a/packages/application/test/utils.spec.ts
+++ b/packages/application/test/utils.spec.ts
@@ -190,7 +190,10 @@ describe('@jupyterlab/application', () => {
     ])(
       'labels/captions %j, and default %s has label/caption %s',
       (values, defaultValue, expected) => {
+        let myCommands: SemanticCommand[] = [];
+
         for (let i = 0; i < values.length; i++) {
+          semanticCmd = new SemanticCommand();
           const id = `command-${i}`;
           const label = values[i];
           const caption = label.replace('label', 'caption');
@@ -201,6 +204,7 @@ describe('@jupyterlab/application', () => {
           });
 
           semanticCmd.add({ id });
+          myCommands.push(semanticCmd);
         }
 
         const semanticCommandId = 'my-semantic-command';
@@ -208,7 +212,7 @@ describe('@jupyterlab/application', () => {
           semanticCommandId,
           createSemanticCommand(
             app,
-            semanticCmd,
+            myCommands,
             {
               label: defaultValue,
               caption: defaultValue?.replace('label', 'caption')

--- a/packages/application/test/utils.spec.ts
+++ b/packages/application/test/utils.spec.ts
@@ -141,5 +141,46 @@ describe('@jupyterlab/application', () => {
 
       expect(contextualCommand.isVisible?.call({})).toEqual(expected);
     });
+
+    // Command IDs, labels, defaultLabel, expected
+    it.each([
+      [[], [], undefined, ''],
+      [[], [], 'default', 'default'],
+      [['a'], [''], 'default', ''],
+      [['a'], ['label a'], 'default', 'label a'],
+      [['a', 'b'], ['label a', 'label b'], 'default', 'label a and label b'],
+      [['a', 'b'], ['label a', 'label b…'], 'default', 'label a and label b…'],
+      [['a', 'b'], ['label a…', 'label b'], 'default', 'label a and label b…'],
+      [['a', 'b'], ['label a…', 'label b…'], 'default', 'label a and label b…'],
+      [['a', 'b', 'c'], ['label a', 'label b', 'label c'], 'default', 'label a, label b and label c'],
+      [['a', 'b', 'c'], ['label a…', 'label b…', 'label c'], 'default', 'label a, label b and label c…'],
+      [['a', 'b', 'c'], ['label a…', 'label b', 'label c…'], 'default', 'label a, label b and label c…'],
+      [['a', 'b', 'c'], ['label a…', 'label b…', 'label c…'], 'default', 'label a, label b and label c…'],
+      [['a', 'b', 'c'], ['label a', 'label b…', 'label c'], 'default', 'label a, label b and label c…'],
+      [['a', 'b', 'c'], ['label a', 'label b…', 'label c…'], 'default', 'label a, label b and label c…'],
+      [['a', 'b', 'c'], ['label a', 'label b', 'label c…'], 'default', 'label a, label b and label c…']
+    ])('commands %j, labels %j, and default %s has label %s', (subCommands, labels, defaultLabel, expectedLabel) => {
+      for (let i = 0; i < subCommands.length; i++) {
+        const id = subCommands[i];
+        const label = labels[i];
+        commands.addCommand(id, {
+          execute: () => null,
+          label: label
+        });
+
+        semanticCmd.add({ id });
+      }
+
+      const contextualCommand = createSemanticCommand(
+        app,
+        semanticCmd,
+        {
+          label: defaultLabel
+        },
+        translator.load('jupyterlab')
+      );
+
+      expect(contextualCommand.label).toEqual(expectedLabel);
+    });
   });
 });

--- a/packages/application/test/utils.spec.ts
+++ b/packages/application/test/utils.spec.ts
@@ -152,35 +152,73 @@ describe('@jupyterlab/application', () => {
       [['a', 'b'], ['label a', 'label b…'], 'default', 'label a and label b…'],
       [['a', 'b'], ['label a…', 'label b'], 'default', 'label a and label b…'],
       [['a', 'b'], ['label a…', 'label b…'], 'default', 'label a and label b…'],
-      [['a', 'b', 'c'], ['label a', 'label b', 'label c'], 'default', 'label a, label b and label c'],
-      [['a', 'b', 'c'], ['label a…', 'label b…', 'label c'], 'default', 'label a, label b and label c…'],
-      [['a', 'b', 'c'], ['label a…', 'label b', 'label c…'], 'default', 'label a, label b and label c…'],
-      [['a', 'b', 'c'], ['label a…', 'label b…', 'label c…'], 'default', 'label a, label b and label c…'],
-      [['a', 'b', 'c'], ['label a', 'label b…', 'label c'], 'default', 'label a, label b and label c…'],
-      [['a', 'b', 'c'], ['label a', 'label b…', 'label c…'], 'default', 'label a, label b and label c…'],
-      [['a', 'b', 'c'], ['label a', 'label b', 'label c…'], 'default', 'label a, label b and label c…']
-    ])('commands %j, labels %j, and default %s has label %s', (subCommands, labels, defaultLabel, expectedLabel) => {
-      for (let i = 0; i < subCommands.length; i++) {
-        const id = subCommands[i];
-        const label = labels[i];
-        commands.addCommand(id, {
-          execute: () => null,
-          label: label
-        });
+      [
+        ['a', 'b', 'c'],
+        ['label a', 'label b', 'label c'],
+        'default',
+        'label a, label b and label c'
+      ],
+      [
+        ['a', 'b', 'c'],
+        ['label a…', 'label b…', 'label c'],
+        'default',
+        'label a, label b and label c…'
+      ],
+      [
+        ['a', 'b', 'c'],
+        ['label a…', 'label b', 'label c…'],
+        'default',
+        'label a, label b and label c…'
+      ],
+      [
+        ['a', 'b', 'c'],
+        ['label a…', 'label b…', 'label c…'],
+        'default',
+        'label a, label b and label c…'
+      ],
+      [
+        ['a', 'b', 'c'],
+        ['label a', 'label b…', 'label c'],
+        'default',
+        'label a, label b and label c…'
+      ],
+      [
+        ['a', 'b', 'c'],
+        ['label a', 'label b…', 'label c…'],
+        'default',
+        'label a, label b and label c…'
+      ],
+      [
+        ['a', 'b', 'c'],
+        ['label a', 'label b', 'label c…'],
+        'default',
+        'label a, label b and label c…'
+      ]
+    ])(
+      'commands %j, labels %j, and default %s has label %s',
+      (subCommands, labels, defaultLabel, expectedLabel) => {
+        for (let i = 0; i < subCommands.length; i++) {
+          const id = subCommands[i];
+          const label = labels[i];
+          commands.addCommand(id, {
+            execute: () => null,
+            label: label
+          });
 
-        semanticCmd.add({ id });
+          semanticCmd.add({ id });
+        }
+
+        const contextualCommand = createSemanticCommand(
+          app,
+          semanticCmd,
+          {
+            label: defaultLabel
+          },
+          translator.load('jupyterlab')
+        );
+
+        expect(contextualCommand.label).toEqual(expectedLabel);
       }
-
-      const contextualCommand = createSemanticCommand(
-        app,
-        semanticCmd,
-        {
-          label: defaultLabel
-        },
-        translator.load('jupyterlab')
-      );
-
-      expect(contextualCommand.label).toEqual(expectedLabel);
-    });
+    );
   });
 });

--- a/packages/application/test/utils.spec.ts
+++ b/packages/application/test/utils.spec.ts
@@ -223,7 +223,7 @@ describe('@jupyterlab/application', () => {
 
         expect(commands.label(semanticCommandId)).toEqual(expected);
         expect(commands.caption(semanticCommandId)).toEqual(
-          expected.replace('label', 'caption')
+          expected.replace(/label/g, 'caption')
         );
       }
     );

--- a/packages/application/test/utils.spec.ts
+++ b/packages/application/test/utils.spec.ts
@@ -142,82 +142,85 @@ describe('@jupyterlab/application', () => {
       expect(contextualCommand.isVisible?.call({})).toEqual(expected);
     });
 
-    // Command IDs, labels, defaultLabel, expected
+    // Labels/captions, defaultLabel/defaultCaption, expected
     it.each([
-      [[], [], undefined, ''],
-      [[], [], 'default', 'default'],
-      [['a'], [''], 'default', ''],
-      [['a'], ['label a'], 'default', 'label a'],
-      [['a', 'b'], ['label a', 'label b'], 'default', 'label a and label b'],
-      [['a', 'b'], ['label a', 'label b…'], 'default', 'label a and label b…'],
-      [['a', 'b'], ['label a…', 'label b'], 'default', 'label a and label b…'],
-      [['a', 'b'], ['label a…', 'label b…'], 'default', 'label a and label b…'],
+      [[], undefined, ''],
+      [[], 'default', 'default'],
+      [[''], 'default', ''],
+      [['label a'], 'default', 'label a'],
+      [['label a', 'label b'], 'default', 'label a and label b'],
+      [['label a', 'label b…'], 'default', 'label a and label b…'],
+      [['label a…', 'label b'], 'default', 'label a and label b…'],
+      [['label a…', 'label b…'], 'default', 'label a and label b…'],
       [
-        ['a', 'b', 'c'],
         ['label a', 'label b', 'label c'],
         'default',
         'label a, label b and label c'
       ],
       [
-        ['a', 'b', 'c'],
         ['label a…', 'label b…', 'label c'],
         'default',
         'label a, label b and label c…'
       ],
       [
-        ['a', 'b', 'c'],
         ['label a…', 'label b', 'label c…'],
         'default',
         'label a, label b and label c…'
       ],
       [
-        ['a', 'b', 'c'],
         ['label a…', 'label b…', 'label c…'],
         'default',
         'label a, label b and label c…'
       ],
       [
-        ['a', 'b', 'c'],
         ['label a', 'label b…', 'label c'],
         'default',
         'label a, label b and label c…'
       ],
       [
-        ['a', 'b', 'c'],
         ['label a', 'label b…', 'label c…'],
         'default',
         'label a, label b and label c…'
       ],
       [
-        ['a', 'b', 'c'],
         ['label a', 'label b', 'label c…'],
         'default',
         'label a, label b and label c…'
       ]
     ])(
-      'commands %j, labels %j, and default %s has label %s',
-      (subCommands, labels, defaultLabel, expectedLabel) => {
-        for (let i = 0; i < subCommands.length; i++) {
-          const id = subCommands[i];
-          const label = labels[i];
+      'labels/captions %j, and default %s has label/caption %s',
+      (values, defaultValue, expected) => {
+        for (let i = 0; i < values.length; i++) {
+          const id = `command-${i}`;
+          const label = values[i];
+          const caption = label.replace('label', 'caption');
           commands.addCommand(id, {
             execute: () => null,
-            label: label
+            label: label,
+            caption: caption
           });
 
           semanticCmd.add({ id });
         }
 
-        const contextualCommand = createSemanticCommand(
-          app,
-          semanticCmd,
-          {
-            label: defaultLabel
-          },
-          translator.load('jupyterlab')
+        const semanticCommandId = 'my-semantic-command';
+        commands.addCommand(
+          semanticCommandId,
+          createSemanticCommand(
+            app,
+            semanticCmd,
+            {
+              label: defaultValue,
+              caption: defaultValue?.replace('label', 'caption')
+            },
+            translator.load('jupyterlab')
+          )
         );
 
-        expect(contextualCommand.label).toEqual(expectedLabel);
+        expect(commands.label(semanticCommandId)).toEqual(expected);
+        expect(commands.caption(semanticCommandId)).toEqual(
+          expected.replace('label', 'caption')
+        );
       }
     );
   });

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -35,7 +35,6 @@ import { ServerConnection } from '@jupyterlab/services';
 import { ISettingRegistry, SettingRegistry } from '@jupyterlab/settingregistry';
 import { ITranslator, TranslationBundle } from '@jupyterlab/translation';
 import {
-  fastForwardIcon,
   refreshIcon,
   runIcon,
   stopIcon
@@ -645,8 +644,7 @@ export function createRunMenu(
         caption: trans.__('Restart Kernel and Run All')
       },
       trans
-    ),
-    icon: args => (args.toolbar ? fastForwardIcon : undefined)
+    )
   });
 }
 

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -34,11 +34,7 @@ import {
 import { ServerConnection } from '@jupyterlab/services';
 import { ISettingRegistry, SettingRegistry } from '@jupyterlab/settingregistry';
 import { ITranslator, TranslationBundle } from '@jupyterlab/translation';
-import {
-  refreshIcon,
-  runIcon,
-  stopIcon
-} from '@jupyterlab/ui-components';
+import { refreshIcon, runIcon, stopIcon } from '@jupyterlab/ui-components';
 import { find } from '@lumino/algorithm';
 import { JSONExt } from '@lumino/coreutils';
 import { IDisposable } from '@lumino/disposable';

--- a/packages/notebook-extension/schema/panel.json
+++ b/packages/notebook-extension/schema/panel.json
@@ -18,7 +18,7 @@
       { "name": "restart", "command": "kernelmenu:restart", "rank": 32 },
       {
         "name": "restart-and-run",
-        "command": "runmenu:restart-and-run-all",
+        "command": "notebook:restart-run-all",
         "rank": 33
       },
       { "name": "cellType", "rank": 40 },

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -85,6 +85,7 @@ import {
   copyIcon,
   cutIcon,
   duplicateIcon,
+  fastForwardIcon,
   moveDownIcon,
   moveUpIcon,
   notebookIcon,
@@ -1912,6 +1913,7 @@ function addCommands(
 
   commands.addCommand(CommandIDs.runAndAdvance, {
     label: trans.__('Run Selected Cells'),
+    caption: trans.__('Run the selected cells'),
     execute: args => {
       const current = getCurrent(tracker, shell, args);
 
@@ -1925,6 +1927,7 @@ function addCommands(
   });
   commands.addCommand(CommandIDs.run, {
     label: trans.__('Run Selected Cells and Do not Advance'),
+    caption: trans.__('Run the selected cells and do not advance'),
     execute: args => {
       const current = getCurrent(tracker, shell, args);
 
@@ -1951,6 +1954,7 @@ function addCommands(
   });
   commands.addCommand(CommandIDs.runAll, {
     label: trans.__('Run All Cells'),
+    caption: trans.__('Run all cells'),
     execute: args => {
       const current = getCurrent(tracker, shell, args);
 
@@ -2019,6 +2023,7 @@ function addCommands(
   });
   commands.addCommand(CommandIDs.restart, {
     label: trans.__('Restart Kernel…'),
+    caption: trans.__('Restart the kernel'),
     execute: args => {
       const current = getCurrent(tracker, shell, args);
 
@@ -2112,6 +2117,7 @@ function addCommands(
   });
   commands.addCommand(CommandIDs.restartRunAll, {
     label: trans.__('Restart Kernel and Run All Cells…'),
+    caption: trans.__('Restart the kernel and run all cells'),
     execute: async () => {
       const restarted: boolean = await commands.execute(CommandIDs.restart, {
         activate: false
@@ -2120,7 +2126,8 @@ function addCommands(
         await commands.execute(CommandIDs.runAll);
       }
     },
-    isEnabled
+    isEnabled,
+    icon: fastForwardIcon
   });
   commands.addCommand(CommandIDs.clearAllOutputs, {
     label: trans.__('Clear Outputs of All Cells'),
@@ -2148,6 +2155,7 @@ function addCommands(
   });
   commands.addCommand(CommandIDs.interrupt, {
     label: trans.__('Interrupt Kernel'),
+    caption: trans.__('Interrupt the kernel'),
     execute: args => {
       const current = getCurrent(tracker, shell, args);
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #11898.
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Falls back to default label/caption if all labels/captions of subcommands in a semanticCommand are empty strings


## User-facing changes

Before the change, the ⏩ toolbar button had the caption " and " (with leading/trailing spaces):

![before change](https://user-images.githubusercontent.com/93281816/150036186-8a5bc180-e564-4dd0-9e94-662362946e76.png)

After the change, the "Restart the kernel and run all cells" notebook toolbar button has an appropriate caption:

![after change](https://user-images.githubusercontent.com/93281816/217668737-f3c36544-b092-4083-b0d1-11a70da7b638.png)

Other toolbar buttons also have captions in sentence case (only the first word is capitalized) with definite articles used ("Interrupt Kernel" becomes "Interrupt the kernel").

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None.
