### PR TITLE
Increase galata update timeouts

### DIFF
--- a/.github/workflows/galata-update.yml
+++ b/.github/workflows/galata-update.yml
@@ -12,7 +12,7 @@ jobs:
   update-galata-snapshots:
     name: Update Galata References
     if: ${{ github.event.issue.pull_request && (contains(github.event.comment.body, 'please update galata snapshots') || contains(github.event.comment.body, 'please update snapshots')) }}
-    timeout-minutes: 80
+    timeout-minutes: 120
     runs-on: ubuntu-22.04
 
     steps:
@@ -53,7 +53,7 @@ jobs:
   update-documentation-snapshots:
     name: Update Documentation Snapshots
     if: ${{ github.event.issue.pull_request && (contains(github.event.comment.body, 'please update documentation snapshots') || contains(github.event.comment.body, 'please update snapshots')) }}
-    timeout-minutes: 80
+    timeout-minutes: 120
     runs-on: ubuntu-22.04
 
     # Python version is frozen through strategy.matrix.python-version


### PR DESCRIPTION
Galata snapshots update job is timing out after 80 minutes, blocking https://github.com/jupyterlab/jupyterlab/pull/13884#issuecomment-1428620997.

This PR increases the timeouts to 120 minutes.