### PR TITLE
Automated Changelog Entry for 4.0.0a34 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,90 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 4.0.0a34
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v4.0.0a33...ba3913a982ef82665a448c2ffa0c06ca79e3412b))
+
+### Enhancements made
+
+- Update to ajv 8 and react-json-schema-form 5 [#13924](https://github.com/jupyterlab/jupyterlab/pull/13924) ([@bollwyvl](https://github.com/bollwyvl))
+- Notify command explicitly [#13915](https://github.com/jupyterlab/jupyterlab/pull/13915) ([@fcollonval](https://github.com/fcollonval))
+- Improve Galata [#13909](https://github.com/jupyterlab/jupyterlab/pull/13909) ([@fcollonval](https://github.com/fcollonval))
+- Move RTC packages to an extension [#13907](https://github.com/jupyterlab/jupyterlab/pull/13907) ([@hbcarlos](https://github.com/hbcarlos))
+- Caret operator in documentation [#13856](https://github.com/jupyterlab/jupyterlab/pull/13856) ([@JasonWeill](https://github.com/JasonWeill))
+- Improve kernels pane in running sidebar [#13851](https://github.com/jupyterlab/jupyterlab/pull/13851) ([@afshin](https://github.com/afshin))
+- Add languages to the command palette [#13815](https://github.com/jupyterlab/jupyterlab/pull/13815) ([@jtpio](https://github.com/jtpio))
+- Expose `contentVisibility` widget hiding mode [#13652](https://github.com/jupyterlab/jupyterlab/pull/13652) ([@krassowski](https://github.com/krassowski))
+
+### Bugs fixed
+
+- Use node 18 for benchmark [#13982](https://github.com/jupyterlab/jupyterlab/pull/13982) ([@fcollonval](https://github.com/fcollonval))
+- Dispose properly objects [#13960](https://github.com/jupyterlab/jupyterlab/pull/13960) ([@fcollonval](https://github.com/fcollonval))
+- Fixes toolbar button for Restart Kernel and Run All [#13939](https://github.com/jupyterlab/jupyterlab/pull/13939) ([@JasonWeill](https://github.com/JasonWeill))
+- Fix LSP adapter errors on tab close [#13918](https://github.com/jupyterlab/jupyterlab/pull/13918) ([@afshin](https://github.com/afshin))
+- Define colour and background for filebrowser edit field [#13895](https://github.com/jupyterlab/jupyterlab/pull/13895) ([@krassowski](https://github.com/krassowski))
+- Fix searching backwards in notebook [#13883](https://github.com/jupyterlab/jupyterlab/pull/13883) ([@krassowski](https://github.com/krassowski))
+- Waits for panel reveal before measuring first cell for cell toolbar  [#13876](https://github.com/jupyterlab/jupyterlab/pull/13876) ([@JasonWeill](https://github.com/JasonWeill))
+- Reset execution indicator state when kernel restarts [#13832](https://github.com/jupyterlab/jupyterlab/pull/13832) ([@krassowski](https://github.com/krassowski))
+
+### Maintenance and upkeep improvements
+
+- Increase galata update timeouts [#13985](https://github.com/jupyterlab/jupyterlab/pull/13985) ([@krassowski](https://github.com/krassowski))
+- Use node 18 for benchmark [#13982](https://github.com/jupyterlab/jupyterlab/pull/13982) ([@fcollonval](https://github.com/fcollonval))
+- Add back `@types/react` as a dependency of `@jupyterlab/apputils` [#13981](https://github.com/jupyterlab/jupyterlab/pull/13981) ([@jtpio](https://github.com/jtpio))
+- Bump jupyterlab-language-pack-zh-cn from 3.5.post4 to 3.6.post0 [#13979](https://github.com/jupyterlab/jupyterlab/pull/13979) ([@dependabot](https://github.com/dependabot))
+- Bump actions/cache from 2 to 3 [#13977](https://github.com/jupyterlab/jupyterlab/pull/13977) ([@dependabot](https://github.com/dependabot))
+- Bump tj-actions/changed-files from 35.5.0 to 35.5.2 [#13976](https://github.com/jupyterlab/jupyterlab/pull/13976) ([@dependabot](https://github.com/dependabot))
+- Relax memory-leak action [#13974](https://github.com/jupyterlab/jupyterlab/pull/13974) ([@fcollonval](https://github.com/fcollonval))
+- Fix yarn.lock [#13963](https://github.com/jupyterlab/jupyterlab/pull/13963) ([@fcollonval](https://github.com/fcollonval))
+- Remove rtc documentation [#13952](https://github.com/jupyterlab/jupyterlab/pull/13952) ([@hbcarlos](https://github.com/hbcarlos))
+- Report benchmark status even in case of failure [#13950](https://github.com/jupyterlab/jupyterlab/pull/13950) ([@fcollonval](https://github.com/fcollonval))
+- Remove vdom packages [#13949](https://github.com/jupyterlab/jupyterlab/pull/13949) ([@fcollonval](https://github.com/fcollonval))
+- Import directly from jupyter_server [#13942](https://github.com/jupyterlab/jupyterlab/pull/13942) ([@fcollonval](https://github.com/fcollonval))
+- Use Python 3.11 for js-debugger tests [#13941](https://github.com/jupyterlab/jupyterlab/pull/13941) ([@fcollonval](https://github.com/fcollonval))
+- Update plugin name to `@jupyterlab/filebrowser-extension:default-file-browser` [#13936](https://github.com/jupyterlab/jupyterlab/pull/13936) ([@jtpio](https://github.com/jtpio))
+- Bump ipython from 8.0.0 to 8.9.0 [#13935](https://github.com/jupyterlab/jupyterlab/pull/13935) ([@dependabot](https://github.com/dependabot))
+- Bump black[jupyter] from 22.12.0 to 23.1.0 [#13934](https://github.com/jupyterlab/jupyterlab/pull/13934) ([@dependabot](https://github.com/dependabot))
+- Bump ruff from 0.0.238 to 0.0.241 [#13933](https://github.com/jupyterlab/jupyterlab/pull/13933) ([@dependabot](https://github.com/dependabot))
+- Bump tj-actions/changed-files from 35.4.4 to 35.5.0 [#13932](https://github.com/jupyterlab/jupyterlab/pull/13932) ([@dependabot](https://github.com/dependabot))
+- Fix UI tests [#13931](https://github.com/jupyterlab/jupyterlab/pull/13931) ([@fcollonval](https://github.com/fcollonval))
+- Bump http-cache-semantics from 4.1.0 to 4.1.1 [#13922](https://github.com/jupyterlab/jupyterlab/pull/13922) ([@dependabot](https://github.com/dependabot))
+- Rename `@jupyterlab/completer-extension:tracker` to `@jupyterlab/completer-extension:manager` [#13910](https://github.com/jupyterlab/jupyterlab/pull/13910) ([@fcollonval](https://github.com/fcollonval))
+- Improve Galata [#13909](https://github.com/jupyterlab/jupyterlab/pull/13909) ([@fcollonval](https://github.com/fcollonval))
+- Lint fixes [#13905](https://github.com/jupyterlab/jupyterlab/pull/13905) ([@JasonWeill](https://github.com/JasonWeill))
+- Switch to VEGALITE5_MIME_TYPE [#13893](https://github.com/jupyterlab/jupyterlab/pull/13893) ([@ChristopherDavisUCI](https://github.com/ChristopherDavisUCI))
+- Bump altair from 4.2.0 to 4.2.2 [#13892](https://github.com/jupyterlab/jupyterlab/pull/13892) ([@dependabot](https://github.com/dependabot))
+- Add more linting [#13882](https://github.com/jupyterlab/jupyterlab/pull/13882) ([@blink1073](https://github.com/blink1073))
+- Bump lumino packages to `2.0.0-beta.0` [#13828](https://github.com/jupyterlab/jupyterlab/pull/13828) ([@krassowski](https://github.com/krassowski))
+- Bump ipywidgets from 7.6.6 to 8.0.4 [#13820](https://github.com/jupyterlab/jupyterlab/pull/13820) ([@dependabot](https://github.com/dependabot))
+
+### Documentation improvements
+
+- Mention how to fix pixman, cairo missing library errors that occur while running tests in readthedocs [#13956](https://github.com/jupyterlab/jupyterlab/pull/13956) ([@andrii-i](https://github.com/andrii-i))
+- Remove rtc documentation [#13952](https://github.com/jupyterlab/jupyterlab/pull/13952) ([@hbcarlos](https://github.com/hbcarlos))
+- Remove vdom packages [#13949](https://github.com/jupyterlab/jupyterlab/pull/13949) ([@fcollonval](https://github.com/fcollonval))
+- Fixes toolbar button for Restart Kernel and Run All [#13939](https://github.com/jupyterlab/jupyterlab/pull/13939) ([@JasonWeill](https://github.com/JasonWeill))
+- Improve Galata [#13909](https://github.com/jupyterlab/jupyterlab/pull/13909) ([@fcollonval](https://github.com/fcollonval))
+- Move RTC packages to an extension [#13907](https://github.com/jupyterlab/jupyterlab/pull/13907) ([@hbcarlos](https://github.com/hbcarlos))
+- Fix minor typo in urls.rst [#13902](https://github.com/jupyterlab/jupyterlab/pull/13902) ([@chbrandt](https://github.com/chbrandt))
+- Add more linting [#13882](https://github.com/jupyterlab/jupyterlab/pull/13882) ([@blink1073](https://github.com/blink1073))
+- Update language-packs workflow [#13874](https://github.com/jupyterlab/jupyterlab/pull/13874) ([@fcollonval](https://github.com/fcollonval))
+- Caret operator in documentation [#13856](https://github.com/jupyterlab/jupyterlab/pull/13856) ([@JasonWeill](https://github.com/JasonWeill))
+
+### API and Breaking Changes
+
+- Remove vdom packages [#13949](https://github.com/jupyterlab/jupyterlab/pull/13949) ([@fcollonval](https://github.com/fcollonval))
+- Fix LSP adapter errors on tab close [#13918](https://github.com/jupyterlab/jupyterlab/pull/13918) ([@afshin](https://github.com/afshin))
+- Switch to VEGALITE5_MIME_TYPE [#13893](https://github.com/jupyterlab/jupyterlab/pull/13893) ([@ChristopherDavisUCI](https://github.com/ChristopherDavisUCI))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2023-01-27&to=2023-02-14&type=c))
+
+[@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2023-01-27..2023-02-14&type=Issues) | [@andrii-i](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aandrii-i+updated%3A2023-01-27..2023-02-14&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2023-01-27..2023-02-14&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2023-01-27..2023-02-14&type=Issues) | [@chbrandt](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Achbrandt+updated%3A2023-01-27..2023-02-14&type=Issues) | [@ChristopherDavisUCI](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AChristopherDavisUCI+updated%3A2023-01-27..2023-02-14&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adependabot+updated%3A2023-01-27..2023-02-14&type=Issues) | [@domoritz](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adomoritz+updated%3A2023-01-27..2023-02-14&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2023-01-27..2023-02-14&type=Issues) | [@fperez](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afperez+updated%3A2023-01-27..2023-02-14&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2023-01-27..2023-02-14&type=Issues) | [@HaudinFlorence](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AHaudinFlorence+updated%3A2023-01-27..2023-02-14&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2023-01-27..2023-02-14&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2023-01-27..2023-02-14&type=Issues) | [@JasonWeill](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AJasonWeill+updated%3A2023-01-27..2023-02-14&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2023-01-27..2023-02-14&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2023-01-27..2023-02-14&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2023-01-27..2023-02-14&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2023-01-27..2023-02-14&type=Issues) | [@pre-commit-ci](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Apre-commit-ci+updated%3A2023-01-27..2023-02-14&type=Issues) | [@psychemedia](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Apsychemedia+updated%3A2023-01-27..2023-02-14&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrungleduc+updated%3A2023-01-27..2023-02-14&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2023-01-27..2023-02-14&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 4.0.0a33
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v4.0.0a32...bd8ef2d398e0612aad334e4feafb853836b05a07))
@@ -114,8 +198,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2023-01-05&to=2023-01-27&type=c))
 
 [@3coins](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3A3coins+updated%3A2023-01-05..2023-01-27&type=Issues) | [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aafshin+updated%3A2023-01-05..2023-01-27&type=Issues) | [@andrii-i](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aandrii-i+updated%3A2023-01-05..2023-01-27&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ablink1073+updated%3A2023-01-05..2023-01-27&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abollwyvl+updated%3A2023-01-05..2023-01-27&type=Issues) | [@brichet](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abrichet+updated%3A2023-01-05..2023-01-27&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adavidbrochart+updated%3A2023-01-05..2023-01-27&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Adependabot+updated%3A2023-01-05..2023-01-27&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2023-01-05..2023-01-27&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2023-01-05..2023-01-27&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2023-01-05..2023-01-27&type=Issues) | [@HaudinFlorence](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AHaudinFlorence+updated%3A2023-01-05..2023-01-27&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2023-01-05..2023-01-27&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajasongrout+updated%3A2023-01-05..2023-01-27&type=Issues) | [@JasonWeill](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AJasonWeill+updated%3A2023-01-05..2023-01-27&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2023-01-05..2023-01-27&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2023-01-05..2023-01-27&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2023-01-05..2023-01-27&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksdev+updated%3A2023-01-05..2023-01-27&type=Issues) | [@pre-commit-ci](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Apre-commit-ci+updated%3A2023-01-05..2023-01-27&type=Issues) | [@psychemedia](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Apsychemedia+updated%3A2023-01-05..2023-01-27&type=Issues) | [@RRosio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ARRosio+updated%3A2023-01-05..2023-01-27&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3ASylvainCorlay+updated%3A2023-01-05..2023-01-27&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atrungleduc+updated%3A2023-01-05..2023-01-27&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2023-01-05..2023-01-27&type=Issues) | [@yczhangsjtu](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ayczhangsjtu+updated%3A2023-01-05..2023-01-27&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 4.0.0a32
 


### PR DESCRIPTION
Automated Changelog Entry for 4.0.0a34 on master
```
Python version: 4.0.0a34
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 4.0.0-alpha.19
@jupyterlab/buildutils: 4.0.0-alpha.19
@jupyterlab/template: 4.0.0-alpha.19
@jupyterlab/application-top: 4.0.0-alpha.19
@jupyterlab/example-app: 4.0.0-alpha.19
@jupyterlab/example-cell: 4.0.0-alpha.19
@jupyterlab/example-console: 4.0.0-alpha.19
@jupyterlab/example-federated: 3.0.0-alpha.19
@jupyterlab/example-federated-core: 3.0.0-alpha.19
@jupyterlab/example-federated-md: 3.0.0-alpha.19
@jupyterlab/example-federated-middle: 3.0.0-alpha.19
@jupyterlab/example-filebrowser: 4.0.0-alpha.19
@jupyterlab/example-notebook: 4.0.0-alpha.19
@jupyterlab/example-terminal: 4.0.0-alpha.19
@jupyterlab/galata: 5.0.0-alpha.19
@jupyterlab/galata-extension: 5.0.0-alpha.17
@jupyterlab/mock-extension: 4.0.0-alpha.19
@jupyterlab/mock-consumer: 4.0.0-alpha.19
@jupyterlab/mock-provider: 4.0.0-alpha.19
@jupyterlab/mock-token: 4.0.0-alpha.19
@jupyterlab/application: 4.0.0-alpha.19
@jupyterlab/application-extension: 4.0.0-alpha.19
@jupyterlab/apputils: 4.0.0-alpha.19
@jupyterlab/apputils-extension: 4.0.0-alpha.19
@jupyterlab/attachments: 4.0.0-alpha.19
@jupyterlab/cell-toolbar: 4.0.0-alpha.19
@jupyterlab/cell-toolbar-extension: 4.0.0-alpha.19
@jupyterlab/cells: 4.0.0-alpha.19
@jupyterlab/celltags: 4.0.0-alpha.19
@jupyterlab/celltags-extension: 4.0.0-alpha.19
@jupyterlab/codeeditor: 4.0.0-alpha.19
@jupyterlab/codemirror: 4.0.0-alpha.19
@jupyterlab/codemirror-extension: 4.0.0-alpha.19
@jupyterlab/completer: 4.0.0-alpha.19
@jupyterlab/completer-extension: 4.0.0-alpha.19
@jupyterlab/console: 4.0.0-alpha.19
@jupyterlab/console-extension: 4.0.0-alpha.19
@jupyterlab/coreutils: 6.0.0-alpha.19
@jupyterlab/csvviewer: 4.0.0-alpha.19
@jupyterlab/csvviewer-extension: 4.0.0-alpha.19
@jupyterlab/debugger: 4.0.0-alpha.19
@jupyterlab/debugger-extension: 4.0.0-alpha.19
@jupyterlab/docmanager: 4.0.0-alpha.19
@jupyterlab/docmanager-extension: 4.0.0-alpha.19
@jupyterlab/docregistry: 4.0.0-alpha.19
@jupyterlab/documentsearch: 4.0.0-alpha.19
@jupyterlab/documentsearch-extension: 4.0.0-alpha.19
@jupyterlab/extensionmanager: 4.0.0-alpha.19
@jupyterlab/extensionmanager-extension: 4.0.0-alpha.19
@jupyterlab/filebrowser: 4.0.0-alpha.19
@jupyterlab/filebrowser-extension: 4.0.0-alpha.19
@jupyterlab/fileeditor: 4.0.0-alpha.19
@jupyterlab/fileeditor-extension: 4.0.0-alpha.19
@jupyterlab/help-extension: 4.0.0-alpha.19
@jupyterlab/htmlviewer: 4.0.0-alpha.19
@jupyterlab/htmlviewer-extension: 4.0.0-alpha.19
@jupyterlab/hub-extension: 4.0.0-alpha.19
@jupyterlab/imageviewer: 4.0.0-alpha.19
@jupyterlab/imageviewer-extension: 4.0.0-alpha.19
@jupyterlab/inspector: 4.0.0-alpha.19
@jupyterlab/inspector-extension: 4.0.0-alpha.19
@jupyterlab/javascript-extension: 4.0.0-alpha.19
@jupyterlab/json-extension: 4.0.0-alpha.19
@jupyterlab/launcher: 4.0.0-alpha.19
@jupyterlab/launcher-extension: 4.0.0-alpha.19
@jupyterlab/logconsole: 4.0.0-alpha.19
@jupyterlab/logconsole-extension: 4.0.0-alpha.19
@jupyterlab/lsp: 4.0.0-alpha.19
@jupyterlab/lsp-extension: 4.0.0-alpha.19
@jupyterlab/mainmenu: 4.0.0-alpha.19
@jupyterlab/mainmenu-extension: 4.0.0-alpha.19
@jupyterlab/markdownviewer: 4.0.0-alpha.19
@jupyterlab/markdownviewer-extension: 4.0.0-alpha.19
@jupyterlab/markedparser-extension: 4.0.0-alpha.19
@jupyterlab/mathjax2: 4.0.0-alpha.19
@jupyterlab/mathjax2-extension: 4.0.0-alpha.19
@jupyterlab/metadataform: 4.0.0-alpha.19
@jupyterlab/metadataform-extension: 4.0.0-alpha.19
@jupyterlab/metapackage: 4.0.0-alpha.19
@jupyterlab/nbconvert-css: 4.0.0-alpha.19
@jupyterlab/nbformat: 4.0.0-alpha.19
@jupyterlab/notebook: 4.0.0-alpha.19
@jupyterlab/notebook-extension: 4.0.0-alpha.19
@jupyterlab/observables: 5.0.0-alpha.19
@jupyterlab/outputarea: 4.0.0-alpha.19
@jupyterlab/pdf-extension: 4.0.0-alpha.19
@jupyterlab/property-inspector: 4.0.0-alpha.19
@jupyterlab/rendermime: 4.0.0-alpha.19
@jupyterlab/rendermime-extension: 4.0.0-alpha.19
@jupyterlab/rendermime-interfaces: 3.8.0-alpha.19
@jupyterlab/running: 4.0.0-alpha.19
@jupyterlab/running-extension: 4.0.0-alpha.19
@jupyterlab/services: 7.0.0-alpha.19
@jupyterlab/example-services-browser: 4.0.0-alpha.19
node-example: 4.0.0-alpha.19
@jupyterlab/example-services-outputarea: 4.0.0-alpha.19
@jupyterlab/settingeditor: 4.0.0-alpha.19
@jupyterlab/settingeditor-extension: 4.0.0-alpha.19
@jupyterlab/settingregistry: 4.0.0-alpha.19
@jupyterlab/shortcuts-extension: 4.0.0-alpha.19
@jupyterlab/statedb: 4.0.0-alpha.19
@jupyterlab/statusbar: 4.0.0-alpha.19
@jupyterlab/statusbar-extension: 4.0.0-alpha.19
@jupyterlab/terminal: 4.0.0-alpha.19
@jupyterlab/terminal-extension: 4.0.0-alpha.19
@jupyterlab/testing: 4.0.0-alpha.19
@jupyterlab/theme-dark-extension: 4.0.0-alpha.19
@jupyterlab/theme-light-extension: 4.0.0-alpha.19
@jupyterlab/toc: 6.0.0-alpha.19
@jupyterlab/toc-extension: 6.0.0-alpha.19
@jupyterlab/tooltip: 4.0.0-alpha.19
@jupyterlab/tooltip-extension: 4.0.0-alpha.19
@jupyterlab/translation: 4.0.0-alpha.19
@jupyterlab/translation-extension: 4.0.0-alpha.19
@jupyterlab/ui-components: 4.0.0-alpha.34
@jupyterlab/example-simple-list: 4.0.0-alpha.17
@jupyterlab/ui-components-extension: 4.0.0-alpha.19
@jupyterlab/vega5-extension: 4.0.0-alpha.19
@jupyterlab/testutils: 4.0.0-alpha.19
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyterlab/jupyterlab/releases/tag/untagged-ac8e0fca3d004495edc8  |
| Since | v4.0.0a33 |