### PR TITLE
Galata config helper should not set dev_mode

### DIFF
--- a/galata/jupyter_server_test_config.py
+++ b/galata/jupyter_server_test_config.py
@@ -4,6 +4,7 @@
 from jupyterlab.galata import configure_jupyter_server
 
 configure_jupyter_server(c)
+c.LabApp.dev_mode = True
 
 # Uncomment to set server log level to debug level
 # c.ServerApp.log_level = "DEBUG"

--- a/jupyterlab/galata/__init__.py
+++ b/jupyterlab/galata/__init__.py
@@ -25,7 +25,6 @@ def configure_jupyter_server(c):
     c.ServerApp.port = 8888
     c.ServerApp.port_retries = 0
     c.ServerApp.open_browser = False
-    c.LabApp.dev_mode = True
     # Add test helpers extension shipped with JupyterLab.
     # You can replace the following line by the two following one
     #   import jupyterlab


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Follow-up of https://github.com/jupyterlab/extension-cookiecutter-ts/pull/287
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
The server config helper should not set `dev_mode`

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Testing with galata starting the server with the helper method should work.
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None