### PR TITLE
Add commands without shortcuts

### DIFF
--- a/packages/shortcuts-extension/src/components/TopNav.tsx
+++ b/packages/shortcuts-extension/src/components/TopNav.tsx
@@ -26,6 +26,7 @@ export interface ISymbolsProps {}
 /** All external actions, setting commands, getting command list ... */
 export interface IShortcutUIexternal {
   translator: ITranslator;
+  getAllCommands: () => string[];
   getAllShortCutSettings: () => Promise<ISettingRegistry.ISettings>;
   removeShortCut: (key: string) => Promise<void>;
   createMenu: () => Menu;

--- a/packages/shortcuts-extension/src/index.ts
+++ b/packages/shortcuts-extension/src/index.ts
@@ -36,6 +36,7 @@ function getExternalForJupyterLab(
   const shortcutPluginLocation = '@jupyterlab/shortcuts-extension:shortcuts';
   return {
     translator,
+    getAllCommands: () => commands.listCommands(),
     getAllShortCutSettings: () =>
       settingRegistry.reload(shortcutPluginLocation),
     removeShortCut: (key: string) =>


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fix #13705

> as of now, it does not work as expected because a selector cannot be defined in the UI.
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Add the commands without shortcuts defined

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Can add a shortcut on commands without it
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None