### PR TITLE
More informative and specific titles for links and buttons

### DIFF
--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -47,7 +47,6 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
   if (entry.status && ['ok', 'warning', 'error'].indexOf(entry.status) !== -1) {
     flagClasses.push(`jp-extensionmanager-entry-${entry.status}`);
   }
-  const title = entry.name;
   const githubUser = canFetch ? getExtensionGitHubUser(entry) : null;
 
   if (!entry.allowed) {
@@ -57,7 +56,6 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
   return (
     <li
       className={`jp-extensionmanager-entry ${flagClasses.join(' ')}`}
-      title={title}
       style={{ display: 'flex' }}
     >
       <div style={{ marginRight: '8px' }}>
@@ -80,6 +78,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                 href={entry.homepage_url}
                 target="_blank"
                 rel="noopener noreferrer"
+                title={trans.__('%1 extension home page', entry.name)}
               >
                 {entry.name}
               </a>
@@ -91,7 +90,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
             <ToolbarButtonComponent
               icon={infoIcon}
               iconLabel={trans.__(
-                '%1 extension is not allowed any more. Please uninstall immediately or contact your administrator.',
+                '%1 extension is not allowed anymore. Please uninstall it immediately or contact your administrator.',
                 entry.name
               )}
               onClick={() =>
@@ -126,6 +125,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                       {ListModel.entryHasUpdate(entry) && (
                         <Button
                           onClick={() => props.performAction!('install', entry)}
+                          title={trans.__('Update "%1"', entry.name)}
                           minimal
                           small
                         >
@@ -134,6 +134,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                       )}
                       <Button
                         onClick={() => props.performAction!('uninstall', entry)}
+                        title={trans.__('Uninstall "%1"', entry.name)}
                         minimal
                         small
                       >
@@ -144,6 +145,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                   {entry.enabled ? (
                     <Button
                       onClick={() => props.performAction!('disable', entry)}
+                      title={trans.__('Disable "%1"', entry.name)}
                       minimal
                       small
                     >
@@ -152,6 +154,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                   ) : (
                     <Button
                       onClick={() => props.performAction!('enable', entry)}
+                      title={trans.__('Enable "%1"', entry.name)}
                       minimal
                       small
                     >
@@ -163,6 +166,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                 supportInstallation && (
                   <Button
                     onClick={() => props.performAction!('install', entry)}
+                    title={trans.__('Install "%1"', entry.name)}
                     minimal
                     small
                   >


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #13989

## Code changes

Adds informative titles to links and buttons for each extension in the extensionmanager. This improves compatibility with screen readers and other assistive technology.

## User-facing changes

Before, each extension had a single title and did not label links and buttons:

![non-specific link title](https://user-images.githubusercontent.com/93281816/218592662-616d216b-8e21-47e2-9757-57a5fa0cf585.png)

![non-specific button title](https://user-images.githubusercontent.com/93281816/218592733-3f67ba02-f082-4874-8b4d-35102534129b.png)

After, each extension no longer has a general title. Each link and button is labeled individually:

![specific link title](https://user-images.githubusercontent.com/93281816/219207992-cf81cafe-a31c-4a67-b91a-3d20b2d9b4ef.png)

![specific button title](https://user-images.githubusercontent.com/93281816/219208022-26b0c67c-7284-471b-9bd2-a62f27050c0f.png)


## Backwards-incompatible changes

None.
