### PR TITLE
Include source in dists

### DIFF
--- a/builder/package.json
+++ b/builder/package.json
@@ -24,7 +24,8 @@
     "metadata_schema.json",
     "lib/*.d.ts",
     "lib/*.js.map",
-    "lib/*.js"
+    "lib/*.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc",

--- a/buildutils/package.json
+++ b/buildutils/package.json
@@ -31,7 +31,8 @@
     "template/package.json",
     "template/tsconfig.json",
     "template/src/index.ts",
-    "verdaccio.yml"
+    "verdaccio.yml",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc && cd template && npm run build",

--- a/buildutils/src/ensure-package.ts
+++ b/buildutils/src/ensure-package.ts
@@ -540,15 +540,17 @@ export async function ensurePackage(
       });
       anySourceMatch = anySourceMatch || found;
       if (!found) {
-        missingSourceMessages.push(`Source file ${basepath} not included in files`);
+        missingSourceMessages.push(
+          `Source file ${basepath} not included in files`
+        );
       }
     });
     if (srcFiles.length && !anySourceMatch) {
-      messages.push("Found no src file inclusion, adding src/**/*.{ts,tsx}");
+      messages.push('Found no src file inclusion, adding src/**/*.{ts,tsx}');
       if (!data.files) {
         data.files = [];
       }
-      data.files.push("src/**/*.{ts,tsx}");
+      data.files.push('src/**/*.{ts,tsx}');
     } else {
       messages.push(...missingSourceMessages);
     }

--- a/buildutils/src/ensure-package.ts
+++ b/buildutils/src/ensure-package.ts
@@ -486,70 +486,72 @@ export async function ensurePackage(
     return files;
   }
 
-  // Ensure style files are included by pattern.
-  const styleFiles = recurseDir(path.join(pkgPath, 'style'), []);
-  styleFiles.forEach(fpath => {
-    const basePath = fpath.slice(pkgPath.length + 1);
-    let found = false;
-    filePatterns.forEach(fpattern => {
-      if (minimatch.default(basePath, fpattern)) {
-        found = true;
-      }
-    });
-    if (!found && !isPrivate) {
-      messages.push(`File ${basePath} not included in files`);
-    }
-  });
-
-  // Ensure source TS files are included in lib (.js, .js.map, .d.ts)
-  const srcFiles = recurseDir(path.join(pkgPath, 'src'), []);
-  srcFiles.forEach(fpath => {
-    const basePath = fpath
-      .slice(pkgPath.length + 1)
-      .replace('src', 'lib')
-      .split(path.sep)
-      .join('/');
-    ['.js', '.js.map', '.d.ts'].forEach(ending => {
+  if (!isPrivate) {
+    // Ensure style files are included by pattern.
+    const styleFiles = recurseDir(path.join(pkgPath, 'style'), []);
+    styleFiles.forEach(fpath => {
+      const basePath = fpath.slice(pkgPath.length + 1);
       let found = false;
-      const targetPattern = basePath.replace(/\.tsx?$/g, ending);
       filePatterns.forEach(fpattern => {
-        if (minimatch.default(targetPattern, fpattern)) {
+        if (minimatch.default(basePath, fpattern)) {
           found = true;
         }
       });
-      if (!found && !isPrivate) {
-        messages.push(`File ${targetPattern} not included in files`);
+      if (!found) {
+        messages.push(`File ${basePath} not included in files`);
       }
     });
-  });
 
-  // Ensure source files are all included
-  let anySourceMatch = false;
-  const missingSourceMessages: string[] = [];
-  srcFiles.forEach(fpath => {
-    const basepath = fpath
-    .slice(pkgPath.length + 1)
-    .split(path.sep)
-    .join('/');
-    let found = false;
-    filePatterns.forEach(fpattern => {
-      if (minimatch.default(basepath, fpattern)) {
-        found = true;
+    // Ensure source TS files are included in lib (.js, .js.map, .d.ts)
+    const srcFiles = recurseDir(path.join(pkgPath, 'src'), []);
+    srcFiles.forEach(fpath => {
+      const basePath = fpath
+        .slice(pkgPath.length + 1)
+        .replace('src', 'lib')
+        .split(path.sep)
+        .join('/');
+      ['.js', '.js.map', '.d.ts'].forEach(ending => {
+        let found = false;
+        const targetPattern = basePath.replace(/\.tsx?$/g, ending);
+        filePatterns.forEach(fpattern => {
+          if (minimatch.default(targetPattern, fpattern)) {
+            found = true;
+          }
+        });
+        if (!found) {
+          messages.push(`File ${targetPattern} not included in files`);
+        }
+      });
+    });
+
+    // Ensure source files are all included
+    let anySourceMatch = false;
+    const missingSourceMessages: string[] = [];
+    srcFiles.forEach(fpath => {
+      const basepath = fpath
+        .slice(pkgPath.length + 1)
+        .split(path.sep)
+        .join('/');
+      let found = false;
+      filePatterns.forEach(fpattern => {
+        if (minimatch.default(basepath, fpattern)) {
+          found = true;
+        }
+      });
+      anySourceMatch = anySourceMatch || found;
+      if (!found) {
+        missingSourceMessages.push(`Source file ${basepath} not included in files`);
       }
     });
-    anySourceMatch = anySourceMatch || found;
-    if (!found && !isPrivate) {
-      missingSourceMessages.push(`Source file ${basepath} not included in files`);
+    if (srcFiles.length && !anySourceMatch) {
+      messages.push("Found no src file inclusion, adding src/**/*.{ts,tsx}");
+      if (!data.files) {
+        data.files = [];
+      }
+      data.files.push("src/**/*.{ts,tsx}");
+    } else {
+      messages.push(...missingSourceMessages);
     }
-  });
-  if (srcFiles.length && !anySourceMatch && !isPrivate) {
-    messages.push("Found no src file inclusion, adding src/**/*.{ts,tsx}");
-    if (!data.files) {
-      data.files = [];
-    }
-    data.files.push("src/**/*.{ts,tsx}");
-  } else {
-    messages.push(...missingSourceMessages);
   }
 
   // Ensure dependencies and dev dependencies.

--- a/buildutils/template/package.json
+++ b/buildutils/template/package.json
@@ -23,7 +23,8 @@
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "schema/*.json",
-    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
+    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/galata/package.json
+++ b/galata/package.json
@@ -20,7 +20,8 @@
   "files": [
     "lib/**/*.{js,ts,map}",
     "style/index.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "npm run build:extension && npm run build:galata",

--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -28,7 +28,8 @@
     "lib/*.js",
     "schema/*.json",
     "style/**/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -27,7 +27,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/apputils-extension/package.json
+++ b/packages/apputils-extension/package.json
@@ -28,7 +28,8 @@
     "style/*.css",
     "style/images/*.svg",
     "schema/*.json",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -30,7 +30,8 @@
   "files": [
     "lib/**/*.{d.ts,js,js.map}",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -27,7 +27,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/cell-toolbar-extension/package.json
+++ b/packages/cell-toolbar-extension/package.json
@@ -25,7 +25,8 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "schema/*.json",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/cell-toolbar/package.json
+++ b/packages/cell-toolbar/package.json
@@ -26,7 +26,8 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "schema/*.json",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -27,7 +27,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/celltags-extension/package.json
+++ b/packages/celltags-extension/package.json
@@ -30,7 +30,8 @@
   "files": [
     "lib/*.{d.ts,js,js.map}",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/celltags/package.json
+++ b/packages/celltags/package.json
@@ -31,7 +31,8 @@
     "lib/*.{d.ts,js,js.map}",
     "style/*.css",
     "static/*.svg",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -27,7 +27,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -28,7 +28,8 @@
     "lib/*.js",
     "schema/*.json",
     "style/**/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -25,7 +25,8 @@
     "lib/*.js",
     "style/*.css",
     "typings/codemirror/*.d.ts",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/completer-extension/package.json
+++ b/packages/completer-extension/package.json
@@ -28,7 +28,8 @@
     "lib/*.js",
     "schema/*.json",
     "style/**/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -30,7 +30,8 @@
     "lib/default/*.js.map",
     "lib/default/*.js",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/console-extension/package.json
+++ b/packages/console-extension/package.json
@@ -28,7 +28,8 @@
     "lib/*.js",
     "schema/*.json",
     "style/**/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -27,7 +27,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -25,7 +25,8 @@
     "lib/*.d.ts",
     "lib/*.js.map",
     "lib/*.js",
-    "lib/*.json"
+    "lib/*.json",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/csvviewer-extension/package.json
+++ b/packages/csvviewer-extension/package.json
@@ -28,7 +28,8 @@
     "lib/*.js",
     "schema/*.json",
     "style/**/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/csvviewer/package.json
+++ b/packages/csvviewer/package.json
@@ -27,7 +27,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/debugger-extension/package.json
+++ b/packages/debugger-extension/package.json
@@ -34,7 +34,8 @@
     "schema/*.json",
     "style/**/*.css",
     "style/**/*.svg",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -34,7 +34,8 @@
     "schema/*.json",
     "style/**/*.css",
     "style/**/*.svg",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -28,7 +28,8 @@
     "lib/*.js",
     "schema/*.json",
     "style/**/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/docmanager/package.json
+++ b/packages/docmanager/package.json
@@ -27,7 +27,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/**/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -27,7 +27,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/**/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/documentsearch-extension/package.json
+++ b/packages/documentsearch-extension/package.json
@@ -25,7 +25,8 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "schema/*.json",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/documentsearch/package.json
+++ b/packages/documentsearch/package.json
@@ -24,7 +24,8 @@
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/extensionmanager-extension/package.json
+++ b/packages/extensionmanager-extension/package.json
@@ -29,7 +29,8 @@
     "schema/*.json",
     "listing/*.json",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/extensionmanager/package.json
+++ b/packages/extensionmanager/package.json
@@ -27,7 +27,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/filebrowser-extension/package.json
+++ b/packages/filebrowser-extension/package.json
@@ -28,7 +28,8 @@
     "lib/*.js",
     "schema/*.json",
     "style/**/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -27,7 +27,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/fileeditor-extension/package.json
+++ b/packages/fileeditor-extension/package.json
@@ -28,7 +28,8 @@
     "lib/*.js",
     "schema/*.json",
     "style/**/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/fileeditor/package.json
+++ b/packages/fileeditor/package.json
@@ -25,7 +25,8 @@
   "files": [
     "lib/**/*.{d.ts,js,js.map}",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/help-extension/package.json
+++ b/packages/help-extension/package.json
@@ -28,7 +28,8 @@
     "lib/*.js",
     "schema/*.json",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/htmlviewer-extension/package.json
+++ b/packages/htmlviewer-extension/package.json
@@ -26,7 +26,8 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "schema/*.json",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/htmlviewer/package.json
+++ b/packages/htmlviewer/package.json
@@ -24,7 +24,8 @@
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/hub-extension/package.json
+++ b/packages/hub-extension/package.json
@@ -25,7 +25,8 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "schema/*.json",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/imageviewer-extension/package.json
+++ b/packages/imageviewer-extension/package.json
@@ -28,7 +28,8 @@
     "lib/*.js",
     "schema/*.json",
     "style/**/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/imageviewer/package.json
+++ b/packages/imageviewer/package.json
@@ -27,7 +27,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/inspector-extension/package.json
+++ b/packages/inspector-extension/package.json
@@ -28,7 +28,8 @@
     "lib/*.js",
     "schema/*.json",
     "style/**/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -27,7 +27,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/javascript-extension/package.json
+++ b/packages/javascript-extension/package.json
@@ -23,7 +23,8 @@
   },
   "files": [
     "lib/*.{d.ts,js,js.map}",
-    "style/*"
+    "style/*",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/json-extension/package.json
+++ b/packages/json-extension/package.json
@@ -23,7 +23,8 @@
   },
   "files": [
     "lib/*.{d.ts,js,js.map}",
-    "style/*"
+    "style/*",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/launcher-extension/package.json
+++ b/packages/launcher-extension/package.json
@@ -28,7 +28,8 @@
     "lib/*.js",
     "schema/*.json",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -27,7 +27,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/logconsole-extension/package.json
+++ b/packages/logconsole-extension/package.json
@@ -25,7 +25,8 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
     "schema/*.json",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/logconsole/package.json
+++ b/packages/logconsole/package.json
@@ -24,7 +24,8 @@
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/lsp-extension/package.json
+++ b/packages/lsp-extension/package.json
@@ -26,7 +26,8 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "schema/*.json",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/lsp/package.json
+++ b/packages/lsp/package.json
@@ -26,7 +26,8 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "schema/*.json",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/mainmenu-extension/package.json
+++ b/packages/mainmenu-extension/package.json
@@ -28,7 +28,8 @@
     "lib/*.js",
     "schema/*.json",
     "style/**/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/mainmenu/package.json
+++ b/packages/mainmenu/package.json
@@ -27,7 +27,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/**/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/markdownviewer-extension/package.json
+++ b/packages/markdownviewer-extension/package.json
@@ -28,7 +28,8 @@
     "lib/*.js",
     "schema/*.json",
     "style/**/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/markdownviewer/package.json
+++ b/packages/markdownviewer/package.json
@@ -27,7 +27,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/markedparser-extension/package.json
+++ b/packages/markedparser-extension/package.json
@@ -25,7 +25,8 @@
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/index.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/mathjax2-extension/package.json
+++ b/packages/mathjax2-extension/package.json
@@ -24,7 +24,8 @@
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/mathjax2/package.json
+++ b/packages/mathjax2/package.json
@@ -24,7 +24,8 @@
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/metadataform-extension/package.json
+++ b/packages/metadataform-extension/package.json
@@ -30,7 +30,8 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "schema/*.json",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/metadataform/package.json
+++ b/packages/metadataform/package.json
@@ -30,7 +30,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -21,7 +21,8 @@
   "files": [
     "lib/*.d.ts",
     "lib/*.js.map",
-    "lib/*.js"
+    "lib/*.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/nbformat/package.json
+++ b/packages/nbformat/package.json
@@ -23,7 +23,8 @@
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "schema/*.json",
-    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
+    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -27,7 +27,8 @@
     "lib/*.js",
     "schema/*.json",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -24,7 +24,8 @@
   "files": [
     "lib/*.{d.ts,js.map,js,json}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -25,7 +25,8 @@
     "lib/*.{d.ts,js.map,js,json}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
     "style/index.js",
-    "src/**/*.{ts,tsx}"
+    "src/**/*.{ts,tsx}",
+    "src/default.json"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/observables/package.json
+++ b/packages/observables/package.json
@@ -22,7 +22,8 @@
   },
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
-    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
+    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/outputarea/package.json
+++ b/packages/outputarea/package.json
@@ -27,7 +27,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/pdf-extension/package.json
+++ b/packages/pdf-extension/package.json
@@ -27,7 +27,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/property-inspector/package.json
+++ b/packages/property-inspector/package.json
@@ -25,7 +25,8 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "schema/*.json",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/rendermime-extension/package.json
+++ b/packages/rendermime-extension/package.json
@@ -24,7 +24,8 @@
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/rendermime-interfaces/package.json
+++ b/packages/rendermime-interfaces/package.json
@@ -21,7 +21,8 @@
   "files": [
     "lib/*.d.ts",
     "lib/*.js.map",
-    "lib/*.js"
+    "lib/*.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -27,7 +27,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/running-extension/package.json
+++ b/packages/running-extension/package.json
@@ -28,7 +28,8 @@
     "lib/*.js",
     "schema/*.json",
     "style/**/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/running/package.json
+++ b/packages/running/package.json
@@ -27,7 +27,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -30,7 +30,8 @@
     "lib/*.js",
     "lib/*.d.ts",
     "dist/*.js",
-    "dist/**/*.js"
+    "dist/**/*.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/settingeditor-extension/package.json
+++ b/packages/settingeditor-extension/package.json
@@ -28,7 +28,8 @@
     "lib/*.js",
     "schema/*.json",
     "style/**/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/settingeditor/package.json
+++ b/packages/settingeditor/package.json
@@ -27,7 +27,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/settingregistry/package.json
+++ b/packages/settingregistry/package.json
@@ -21,7 +21,8 @@
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "schema/*.json",
-    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
+    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/settingregistry/package.json
+++ b/packages/settingregistry/package.json
@@ -22,7 +22,8 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "schema/*.json",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "src/**/*.{ts,tsx}"
+    "src/**/*.{ts,tsx}",
+    "src/plugin-schema.json"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/shortcuts-extension/package.json
+++ b/packages/shortcuts-extension/package.json
@@ -26,7 +26,8 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
     "style/index.js",
-    "schema/*.json"
+    "schema/*.json",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/statedb/package.json
+++ b/packages/statedb/package.json
@@ -21,7 +21,8 @@
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "schema/*.json",
-    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
+    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/statusbar-extension/package.json
+++ b/packages/statusbar-extension/package.json
@@ -27,7 +27,8 @@
     "lib/**/*.js",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
     "schema/*.json",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/statusbar/package.json
+++ b/packages/statusbar/package.json
@@ -22,7 +22,8 @@
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/terminal-extension/package.json
+++ b/packages/terminal-extension/package.json
@@ -28,7 +28,8 @@
     "lib/*.js",
     "schema/*.json",
     "style/**/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -27,7 +27,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -18,7 +18,8 @@
     "lib": "lib/"
   },
   "files": [
-    "lib/**/*.{d.ts,js,js.map,json}"
+    "lib/**/*.{d.ts,js,js.map,json}",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/theme-dark-extension/package.json
+++ b/packages/theme-dark-extension/package.json
@@ -23,7 +23,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/theme-light-extension/package.json
+++ b/packages/theme-light-extension/package.json
@@ -23,7 +23,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/toc-extension/package.json
+++ b/packages/toc-extension/package.json
@@ -31,7 +31,8 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "schema/*.json",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/toc/package.json
+++ b/packages/toc/package.json
@@ -26,7 +26,8 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "schema/*.json",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/tooltip-extension/package.json
+++ b/packages/tooltip-extension/package.json
@@ -28,7 +28,8 @@
     "lib/*.js",
     "schema/*.json",
     "style/**/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -27,7 +27,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/translation-extension/package.json
+++ b/packages/translation-extension/package.json
@@ -28,7 +28,8 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "schema/**/*.{json,}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/translation/package.json
+++ b/packages/translation/package.json
@@ -23,7 +23,8 @@
     "lib": "lib/"
   },
   "files": [
-    "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}"
+    "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/ui-components-extension/package.json
+++ b/packages/ui-components-extension/package.json
@@ -23,7 +23,8 @@
   },
   "files": [
     "lib/*.{d.ts,js,js.map}",
-    "style/*"
+    "style/*",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -24,7 +24,8 @@
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/vega5-extension/package.json
+++ b/packages/vega5-extension/package.json
@@ -23,7 +23,8 @@
   },
   "files": [
     "lib/*.{d.ts,js,js.map}",
-    "style/*.*"
+    "style/*.*",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/testutils/package.json
+++ b/testutils/package.json
@@ -22,7 +22,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "default*.json",
-    "tsconfigtestbase.json"
+    "tsconfigtestbase.json",
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",


### PR DESCRIPTION

## References

Fixes #7851 .

## Code changes

Includes files in ./src in npm package dist, so that the relative paths in the built JS source maps can be resolved. Adds an integrity check for the same, so that it will also be enforced for packages in the future.

## User-facing changes

None (slightly larger dist on disk, but not loaded in browser unless debugging).

## Backwards-incompatible changes

None
