### PR TITLE
Minor trust improvements

### DIFF
--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -380,7 +380,9 @@ close the notebook without saving it.`,
 
     // Ensure there is at least one cell
     if ((copy.cells?.length ?? 0) === 0) {
-      copy['cells'] = [{ cell_type: 'code', source: '', metadata: {} }];
+      copy['cells'] = [
+        { cell_type: 'code', source: '', metadata: { trusted: true } }
+      ];
     }
     this.sharedModel.fromJSON(copy);
 

--- a/packages/notebook/test/empty.json
+++ b/packages/notebook/test/empty.json
@@ -1,0 +1,25 @@
+{
+  "cells": [],
+  "metadata": {
+    "anaconda-cloud": {},
+    "kernelspec": {
+      "display_name": "Python [default]",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.5.2"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/packages/notebook/test/model.spec.ts
+++ b/packages/notebook/test/model.spec.ts
@@ -275,6 +275,23 @@ describe('@jupyterlab/notebook', () => {
         expect(data.cells.length).toBe(7);
         expect(data.cells[0].id).toBe('cell_1');
       });
+      it('should only include `trusted` metadata in code cells', () => {
+        const model = new NotebookModel();
+        model.fromJSON(utils.DEFAULT_CONTENT_45);
+
+        [...model.cells].map(cell => (cell.trusted = true));
+        expect(model.cells.get(0).type).toBe('code');
+        expect(model.cells.get(1).type).toBe('markdown');
+        expect(model.cells.get(2).type).toBe('raw');
+
+        const data = model.toJSON();
+        // code cell trust should be preserved
+        expect(data.cells[0].metadata.trusted).toBe(true);
+        // markdown cell should have no trusted entry
+        expect(data.cells[1].metadata.trusted).toBeUndefined();
+        // raw cell should have no trusted entry
+        expect(data.cells[2].metadata.trusted).toBeUndefined();
+      });
     });
 
     describe('#fromJSON()', () => {
@@ -301,6 +318,13 @@ describe('@jupyterlab/notebook', () => {
         model.dirty = false;
         model.fromJSON(utils.DEFAULT_CONTENT);
         expect(model.dirty).toBe(true);
+      });
+
+      it('should populate empty notebook with empty trusted code cell', () => {
+        const model = new NotebookModel();
+        model.fromJSON(utils.EMPTY_CONTENT);
+        const cell = model.cells.get(0);
+        expect(cell.trusted).toBe(true);
       });
     });
 

--- a/packages/notebook/test/utils.ts
+++ b/packages/notebook/test/utils.ts
@@ -11,9 +11,11 @@ import {
 } from '@jupyterlab/notebook';
 import { NBTestUtils } from '@jupyterlab/notebook/lib/testutils';
 import * as defaultContent45 from './default-45.json';
+import * as emptyContent from './empty.json';
 
 export { DEFAULT_CONTENT } from '@jupyterlab/notebook/lib/testutils';
 export const DEFAULT_CONTENT_45: INotebookContent = defaultContent45;
+export const EMPTY_CONTENT: INotebookContent = emptyContent;
 
 /**
  * Local versions of the NBTestUtils that import from `src` instead of `lib`.


### PR DESCRIPTION
## References

- https://github.com/jupyterlab/jupyterlab/issues/14025
- https://github.com/jupyterlab/jupyterlab/issues/12889
- https://github.com/jupyterlab/jupyterlab/issues/9765


## Code changes

Done:
- [x] Empty notebook gets populated with a **trusted** code cell
- [x] Test that serialization does not include `trusted` for non-code cells

In follow-up:
- [ ] Set user-created cells as trusted (but not if pasting untrusted cells)

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
