### PR TITLE
Add support for showing the file size in the File Browser

### DIFF
--- a/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
+++ b/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
@@ -865,6 +865,12 @@
     "shortcuts": []
   },
   {
+    "id": "filebrowser:toggle-size",
+    "label": "Show Size Column",
+    "caption": "",
+    "shortcuts": []
+  },
+  {
     "id": "filebrowser:toggle-main",
     "label": "File Browser",
     "caption": "",

--- a/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
+++ b/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
@@ -865,8 +865,8 @@
     "shortcuts": []
   },
   {
-    "id": "filebrowser:toggle-size",
-    "label": "Show Size Column",
+    "id": "filebrowser:toggle-file-size",
+    "label": "Show File Size Column",
     "caption": "",
     "shortcuts": []
   },

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -43,19 +43,14 @@ test.describe('Sidebars', () => {
 
   test('File Browser has no unused rules', async ({ page }) => {
     await page.sidebar.openTab('filebrowser');
-    const contextmenu = await page.menu.openContextMenu(
-      '.jp-DirListing-headerItem'
-    );
-    const fileCheckboxesItem = await page.menu.getMenuItemInMenu(
-      contextmenu,
-      'Show File Checkboxes'
-    );
-    await fileCheckboxesItem.click();
-    const fileSizeColumnItem = await page.menu.getMenuItemInMenu(
-      contextmenu,
-      'Show File Size Column'
-    );
-    await fileSizeColumnItem.click();
+    ['Show File Checkboxes', 'Show File Size Column'].forEach(async command => {
+      const contextmenu = await page.menu.openContextMenu(
+        '.jp-DirListing-headerItem'
+      );
+      const item = await page.menu.getMenuItemInMenu(contextmenu, command);
+      await item.click();
+    });
+
     await page.notebook.createNew('notebook.ipynb');
 
     const unusedRules = await page.style.findUnusedStyleRules({

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -46,11 +46,16 @@ test.describe('Sidebars', () => {
     const contextmenu = await page.menu.openContextMenu(
       '.jp-DirListing-headerItem'
     );
-    const item = await page.menu.getMenuItemInMenu(
+    const fileCheckboxesItem = await page.menu.getMenuItemInMenu(
       contextmenu,
       'Show File Checkboxes'
     );
-    await item.click();
+    await fileCheckboxesItem.click();
+    const fileSizeColumnItem = await page.menu.getMenuItemInMenu(
+      contextmenu,
+      'Show File Size Column'
+    );
+    await fileSizeColumnItem.click();
     await page.notebook.createNew('notebook.ipynb');
 
     const unusedRules = await page.style.findUnusedStyleRules({

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -43,13 +43,15 @@ test.describe('Sidebars', () => {
 
   test('File Browser has no unused rules', async ({ page }) => {
     await page.sidebar.openTab('filebrowser');
-    ['Show File Checkboxes', 'Show File Size Column'].forEach(async command => {
+    const clickMenuItem = async (command): Promise<void> => {
       const contextmenu = await page.menu.openContextMenu(
         '.jp-DirListing-headerItem'
       );
       const item = await page.menu.getMenuItemInMenu(contextmenu, command);
       await item.click();
-    });
+    };
+    await clickMenuItem('Show File Checkboxes');
+    await clickMenuItem('Show File Size Column');
 
     await page.notebook.createNew('notebook.ipynb');
 

--- a/packages/filebrowser-extension/schema/browser.json
+++ b/packages/filebrowser-extension/schema/browser.json
@@ -102,14 +102,19 @@
         "rank": 14
       },
       {
-        "command": "filebrowser:toggle-file-checkboxes",
+        "command": "filebrowser:toggle-size",
         "selector": ".jp-DirListing-header",
         "rank": 15
       },
       {
+        "command": "filebrowser:toggle-file-checkboxes",
+        "selector": ".jp-DirListing-header",
+        "rank": 16
+      },
+      {
         "command": "filebrowser:share-main",
         "selector": ".jp-DirListing-item[data-isdir]",
-        "rank": 16
+        "rank": 17
       },
       {
         "type": "separator",
@@ -190,6 +195,12 @@
       "type": "boolean",
       "title": "Show last modified column",
       "description": "Whether to show the last modified column",
+      "default": true
+    },
+    "showSizeColumn": {
+      "type": "boolean",
+      "title": "Show size column",
+      "description": "Whether to show the size column",
       "default": true
     },
     "showHiddenFiles": {

--- a/packages/filebrowser-extension/schema/browser.json
+++ b/packages/filebrowser-extension/schema/browser.json
@@ -102,7 +102,7 @@
         "rank": 14
       },
       {
-        "command": "filebrowser:toggle-size",
+        "command": "filebrowser:toggle-file-size",
         "selector": ".jp-DirListing-header",
         "rank": 15
       },
@@ -197,11 +197,11 @@
       "description": "Whether to show the last modified column",
       "default": true
     },
-    "showSizeColumn": {
+    "showFileSizeColumn": {
       "type": "boolean",
-      "title": "Show size column",
-      "description": "Whether to show the size column",
-      "default": true
+      "title": "Show file size column",
+      "description": "Whether to show the file size column",
+      "default": false
     },
     "showHiddenFiles": {
       "type": "boolean",

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -208,7 +208,7 @@ const browser: JupyterFrontEndPlugin<void> = {
           const fileBrowserConfig = {
             navigateToCurrentDirectory: false,
             showLastModifiedColumn: true,
-            showFileSizeColumn: true,
+            showFileSizeColumn: false,
             useFuzzyFilter: true,
             showHiddenFiles: false,
             showFileCheckboxes: false

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -128,7 +128,7 @@ namespace CommandIDs {
 
   export const toggleLastModified = 'filebrowser:toggle-last-modified';
 
-  export const toggleSize = 'filebrowser:toggle-size';
+  export const toggleFileSize = 'filebrowser:toggle-file-size';
 
   export const search = 'filebrowser:search';
 
@@ -208,7 +208,7 @@ const browser: JupyterFrontEndPlugin<void> = {
           const fileBrowserConfig = {
             navigateToCurrentDirectory: false,
             showLastModifiedColumn: true,
-            showSizeColumn: true,
+            showFileSizeColumn: true,
             useFuzzyFilter: true,
             showHiddenFiles: false,
             showFileCheckboxes: false
@@ -1206,12 +1206,12 @@ function addCommands(
     }
   });
 
-  commands.addCommand(CommandIDs.toggleSize, {
-    label: trans.__('Show Size Column'),
-    isToggled: () => browser.showSizeColumn,
+  commands.addCommand(CommandIDs.toggleFileSize, {
+    label: trans.__('Show File Size Column'),
+    isToggled: () => browser.showFileSizeColumn,
     execute: () => {
-      const value = !browser.showSizeColumn;
-      const key = 'showSizeColumn';
+      const value = !browser.showFileSizeColumn;
+      const key = 'showFileSizeColumn';
       if (settingRegistry) {
         return settingRegistry
           .set(FILE_BROWSER_PLUGIN_ID, key, value)

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -128,6 +128,8 @@ namespace CommandIDs {
 
   export const toggleLastModified = 'filebrowser:toggle-last-modified';
 
+  export const toggleSize = 'filebrowser:toggle-size';
+
   export const search = 'filebrowser:search';
 
   export const toggleHiddenFiles = 'filebrowser:toggle-hidden-files';
@@ -206,6 +208,7 @@ const browser: JupyterFrontEndPlugin<void> = {
           const fileBrowserConfig = {
             navigateToCurrentDirectory: false,
             showLastModifiedColumn: true,
+            showSizeColumn: true,
             useFuzzyFilter: true,
             showHiddenFiles: false,
             showFileCheckboxes: false
@@ -1197,7 +1200,23 @@ function addCommands(
         return settingRegistry
           .set(FILE_BROWSER_PLUGIN_ID, key, value)
           .catch((reason: Error) => {
-            console.error(`Failed to set showLastModifiedColumn setting`);
+            console.error(`Failed to set ${key} setting`);
+          });
+      }
+    }
+  });
+
+  commands.addCommand(CommandIDs.toggleSize, {
+    label: trans.__('Show Size Column'),
+    isToggled: () => browser.showSizeColumn,
+    execute: () => {
+      const value = !browser.showSizeColumn;
+      const key = 'showSizeColumn';
+      if (settingRegistry) {
+        return settingRegistry
+          .set(FILE_BROWSER_PLUGIN_ID, key, value)
+          .catch((reason: Error) => {
+            console.error(`Failed to set ${key} setting`);
           });
       }
     }

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -156,14 +156,14 @@ export class FileBrowser extends SidePanel {
   /**
    * Whether to show the file size column
    */
-  get showSizeColumn(): boolean {
-    return this._showSizeColumn;
+  get showFileSizeColumn(): boolean {
+    return this._showFileSizeColumn;
   }
 
-  set showSizeColumn(value: boolean) {
+  set showFileSizeColumn(value: boolean) {
     if (this.listing.setColumnVisibility) {
-      this.listing.setColumnVisibility('size', value);
-      this._showSizeColumn = value;
+      this.listing.setColumnVisibility('file_size', value);
+      this._showFileSizeColumn = value;
     } else {
       console.warn('Listing does not support toggling column visibility');
     }
@@ -440,7 +440,7 @@ export class FileBrowser extends SidePanel {
   private _filePending: boolean;
   private _navigateToCurrentDirectory: boolean;
   private _showLastModifiedColumn: boolean = true;
-  private _showSizeColumn: boolean = true;
+  private _showFileSizeColumn: boolean = true;
   private _useFuzzyFilter: boolean = true;
   private _showHiddenFiles: boolean = false;
   private _showFileCheckboxes: boolean = false;

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -440,7 +440,7 @@ export class FileBrowser extends SidePanel {
   private _filePending: boolean;
   private _navigateToCurrentDirectory: boolean;
   private _showLastModifiedColumn: boolean = true;
-  private _showFileSizeColumn: boolean = true;
+  private _showFileSizeColumn: boolean = false;
   private _useFuzzyFilter: boolean = true;
   private _showHiddenFiles: boolean = false;
   private _showFileCheckboxes: boolean = false;

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -154,6 +154,22 @@ export class FileBrowser extends SidePanel {
   }
 
   /**
+   * Whether to show the file size column
+   */
+  get showSizeColumn(): boolean {
+    return this._showSizeColumn;
+  }
+
+  set showSizeColumn(value: boolean) {
+    if (this.listing.setColumnVisibility) {
+      this.listing.setColumnVisibility('size', value);
+      this._showSizeColumn = value;
+    } else {
+      console.warn('Listing does not support toggling column visibility');
+    }
+  }
+
+  /**
    * Whether to use fuzzy filtering on file names.
    */
   set useFuzzyFilter(value: boolean) {
@@ -424,6 +440,7 @@ export class FileBrowser extends SidePanel {
   private _filePending: boolean;
   private _navigateToCurrentDirectory: boolean;
   private _showLastModifiedColumn: boolean = true;
+  private _showSizeColumn: boolean = true;
   private _useFuzzyFilter: boolean = true;
   private _showHiddenFiles: boolean = false;
   private _showFileCheckboxes: boolean = false;

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1997,7 +1997,7 @@ export namespace DirListing {
       fileSize.classList.add(FILE_SIZE_ID_CLASS);
       narrow.classList.add(NARROW_ID_CLASS);
       narrow.textContent = '...';
-      if (!hiddenColumns?.has?.('is_selected')) {
+      if (!hiddenColumns?.has('is_selected')) {
         const checkboxWrapper = this.createCheckboxWrapperNode({
           alwaysVisible: true
         });
@@ -2008,13 +2008,13 @@ export namespace DirListing {
       node.appendChild(modified);
       node.appendChild(fileSize);
 
-      if (hiddenColumns?.has?.('last_modified')) {
+      if (hiddenColumns?.has('last_modified')) {
         modified.classList.add(MODIFIED_COLUMN_HIDDEN);
       } else {
         modified.classList.remove(MODIFIED_COLUMN_HIDDEN);
       }
 
-      if (hiddenColumns?.has?.('file_size')) {
+      if (hiddenColumns?.has('file_size')) {
         fileSize.classList.add(FILE_SIZE_COLUMN_HIDDEN);
       } else {
         fileSize.classList.remove(FILE_SIZE_COLUMN_HIDDEN);
@@ -2145,7 +2145,7 @@ export namespace DirListing {
       text.className = ITEM_TEXT_CLASS;
       modified.className = ITEM_MODIFIED_CLASS;
       fileSize.className = ITEM_FILE_SIZE_CLASS;
-      if (!hiddenColumns?.has?.('is_selected')) {
+      if (!hiddenColumns?.has('is_selected')) {
         const checkboxWrapper = this.createCheckboxWrapperNode();
         node.appendChild(checkboxWrapper);
       }
@@ -2160,13 +2160,13 @@ export namespace DirListing {
       // which conveniently deactivate irrelevant shortcuts.
       text.tabIndex = 0;
 
-      if (hiddenColumns?.has?.('last_modified')) {
+      if (hiddenColumns?.has('last_modified')) {
         modified.classList.add(MODIFIED_COLUMN_HIDDEN);
       } else {
         modified.classList.remove(MODIFIED_COLUMN_HIDDEN);
       }
 
-      if (hiddenColumns?.has?.('file_size')) {
+      if (hiddenColumns?.has('file_size')) {
         fileSize.classList.add(FILE_SIZE_COLUMN_HIDDEN);
       } else {
         fileSize.classList.remove(FILE_SIZE_COLUMN_HIDDEN);
@@ -2249,7 +2249,7 @@ export namespace DirListing {
         CHECKBOX_WRAPPER_CLASS
       );
 
-      const showFileCheckboxes = !hiddenColumns?.has?.('is_selected');
+      const showFileCheckboxes = !hiddenColumns?.has('is_selected');
       if (checkboxWrapper && !showFileCheckboxes) {
         node.removeChild(checkboxWrapper);
       } else if (showFileCheckboxes && !checkboxWrapper) {
@@ -2257,13 +2257,13 @@ export namespace DirListing {
         node.insertBefore(checkboxWrapper, iconContainer);
       }
 
-      if (hiddenColumns?.has?.('last_modified')) {
+      if (hiddenColumns?.has('last_modified')) {
         modified.classList.add(MODIFIED_COLUMN_HIDDEN);
       } else {
         modified.classList.remove(MODIFIED_COLUMN_HIDDEN);
       }
 
-      if (hiddenColumns?.has?.('file_size')) {
+      if (hiddenColumns?.has('file_size')) {
         fileSize.classList.add(FILE_SIZE_COLUMN_HIDDEN);
       } else {
         fileSize.classList.remove(FILE_SIZE_COLUMN_HIDDEN);

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1827,13 +1827,13 @@ export namespace DirListing {
     /**
      * The sort key.
      */
-    key: 'name' | 'last_modified' | 'size';
+    key: 'name' | 'last_modified' | 'file_size';
   }
 
   /**
    * Toggleable columns.
    */
-  export type ToggleableColumn = 'last_modified' | 'is_selected' | 'size';
+  export type ToggleableColumn = 'last_modified' | 'is_selected' | 'file_size';
 
   /**
    * A file contents model thunk.
@@ -1988,7 +1988,7 @@ export namespace DirListing {
       const name = this.createHeaderItemNode(trans.__('Name'));
       const narrow = document.createElement('div');
       const modified = this.createHeaderItemNode(trans.__('Last Modified'));
-      const size = this.createHeaderItemNode(trans.__('Size'));
+      const size = this.createHeaderItemNode(trans.__('File Size'));
       name.classList.add(NAME_ID_CLASS);
       name.classList.add(SELECTED_CLASS);
       modified.classList.add(MODIFIED_ID_CLASS);
@@ -2012,7 +2012,7 @@ export namespace DirListing {
         modified.classList.remove(MODIFIED_COLUMN_HIDDEN);
       }
 
-      if (hiddenColumns?.has?.('size')) {
+      if (hiddenColumns?.has?.('file_size')) {
         size.classList.add(SIZE_COLUMN_HIDDEN);
       } else {
         size.classList.remove(SIZE_COLUMN_HIDDEN);
@@ -2134,7 +2134,7 @@ export namespace DirListing {
         modified.classList.remove(MODIFIED_COLUMN_HIDDEN);
       }
 
-      if (hiddenColumns?.has?.('size')) {
+      if (hiddenColumns?.has?.('file_size')) {
         modified.classList.add(SIZE_COLUMN_HIDDEN);
       } else {
         modified.classList.remove(SIZE_COLUMN_HIDDEN);
@@ -2231,7 +2231,7 @@ export namespace DirListing {
         modified.classList.remove(MODIFIED_COLUMN_HIDDEN);
       }
 
-      if (hiddenColumns?.has?.('size')) {
+      if (hiddenColumns?.has?.('file_size')) {
         size.classList.add(SIZE_COLUMN_HIDDEN);
       } else {
         size.classList.remove(SIZE_COLUMN_HIDDEN);

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -2038,15 +2038,21 @@ export namespace DirListing {
     handleHeaderClick(node: HTMLElement, event: MouseEvent): ISortState | null {
       const name = DOMUtils.findElement(node, NAME_ID_CLASS);
       const modified = DOMUtils.findElement(node, MODIFIED_ID_CLASS);
+      const fileSize = DOMUtils.findElement(node, FILE_SIZE_ID_CLASS);
       const state: ISortState = { direction: 'ascending', key: 'name' };
       const target = event.target as HTMLElement;
-      if (name.contains(target)) {
-        const modifiedIcon = DOMUtils.findElement(
-          modified,
-          HEADER_ITEM_ICON_CLASS
-        );
-        const nameIcon = DOMUtils.findElement(name, HEADER_ITEM_ICON_CLASS);
 
+      const modifiedIcon = DOMUtils.findElement(
+        modified,
+        HEADER_ITEM_ICON_CLASS
+      );
+      const fileSizeIcon = DOMUtils.findElement(
+        fileSize,
+        HEADER_ITEM_ICON_CLASS
+      );
+      const nameIcon = DOMUtils.findElement(name, HEADER_ITEM_ICON_CLASS);
+
+      if (name.contains(target)) {
         if (name.classList.contains(SELECTED_CLASS)) {
           if (!name.classList.contains(DESCENDING_CLASS)) {
             state.direction = 'descending';
@@ -2063,16 +2069,13 @@ export namespace DirListing {
         name.classList.add(SELECTED_CLASS);
         modified.classList.remove(SELECTED_CLASS);
         modified.classList.remove(DESCENDING_CLASS);
+        fileSize.classList.remove(SELECTED_CLASS);
+        fileSize.classList.remove(DESCENDING_CLASS);
         Private.updateCaret(modifiedIcon, 'left');
+        Private.updateCaret(fileSizeIcon, 'left');
         return state;
       }
       if (modified.contains(target)) {
-        const modifiedIcon = DOMUtils.findElement(
-          modified,
-          HEADER_ITEM_ICON_CLASS
-        );
-        const nameIcon = DOMUtils.findElement(name, HEADER_ITEM_ICON_CLASS);
-
         state.key = 'last_modified';
         if (modified.classList.contains(SELECTED_CLASS)) {
           if (!modified.classList.contains(DESCENDING_CLASS)) {
@@ -2090,7 +2093,34 @@ export namespace DirListing {
         modified.classList.add(SELECTED_CLASS);
         name.classList.remove(SELECTED_CLASS);
         name.classList.remove(DESCENDING_CLASS);
+        fileSize.classList.remove(SELECTED_CLASS);
+        fileSize.classList.remove(DESCENDING_CLASS);
         Private.updateCaret(nameIcon, 'right');
+        Private.updateCaret(fileSizeIcon, 'right');
+        return state;
+      }
+      if (fileSize.contains(target)) {
+        state.key = 'file_size';
+        if (fileSize.classList.contains(SELECTED_CLASS)) {
+          if (!fileSize.classList.contains(DESCENDING_CLASS)) {
+            state.direction = 'descending';
+            fileSize.classList.add(DESCENDING_CLASS);
+            Private.updateCaret(fileSizeIcon, 'left', 'down');
+          } else {
+            fileSize.classList.remove(DESCENDING_CLASS);
+            Private.updateCaret(fileSizeIcon, 'left', 'up');
+          }
+        } else {
+          fileSize.classList.remove(DESCENDING_CLASS);
+          Private.updateCaret(fileSizeIcon, 'left', 'up');
+        }
+        fileSize.classList.add(SELECTED_CLASS);
+        name.classList.remove(SELECTED_CLASS);
+        name.classList.remove(DESCENDING_CLASS);
+        modified.classList.remove(SELECTED_CLASS);
+        modified.classList.remove(DESCENDING_CLASS);
+        Private.updateCaret(nameIcon, 'right');
+        Private.updateCaret(modifiedIcon, 'right');
         return state;
       }
       return state;
@@ -2495,6 +2525,14 @@ namespace Private {
         const valB = new Date(b.last_modified).getTime();
 
         return t1 - t2 || (valA - valB) * reverse;
+      });
+    } else if (state.key === 'file_size') {
+      // Sort by size (grouping directories first)
+      copy.sort((a, b) => {
+        const t1 = a.type === 'directory' ? 0 : 1;
+        const t2 = b.type === 'directory' ? 0 : 1;
+
+        return t1 - t2 || ((a.size ?? 0) - (b.size ?? 0)) * reverse;
       });
     } else {
       // Sort by name (grouping directories first)

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -228,6 +228,8 @@ export class DirListing extends Widget {
     this._renderer = options.renderer || DirListing.defaultRenderer;
 
     const headerNode = DOMUtils.findElement(this.node, HEADER_CLASS);
+    // hide the file size column by default
+    this._hiddenColumns.add('file_size');
     this._renderer.populateHeaderNode(
       headerNode,
       this.translator,

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -2250,10 +2250,14 @@ export namespace DirListing {
 
       // add file size to pop up if its available
       if (model.size !== null && model.size !== undefined) {
+        const fileSize = Private.formatFileSize(model.size, 1, 1024);
+        size.textContent = fileSize;
         hoverText += trans.__(
           '\nSize: %1',
           Private.formatFileSize(model.size, 1, 1024)
         );
+      } else {
+        size.textContent = '';
       }
       if (model.path) {
         const dirname = PathExt.dirname(model.path);
@@ -2275,9 +2279,6 @@ export namespace DirListing {
           '\nModified: %1',
           Time.format(new Date(model.last_modified))
         );
-      }
-      if (model.size) {
-        hoverText += trans.__('\nSize: %1', model.size);
       }
       hoverText += trans.__('\nWritable: %1', model.writable);
 
@@ -2323,9 +2324,6 @@ export namespace DirListing {
       }
       modified.textContent = modText;
       modified.title = modTitle;
-
-      // TODO: handle units
-      size.textContent = model.size ? model.size.toString() : '';
     }
 
     /**

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -87,9 +87,9 @@ const ITEM_ICON_CLASS = 'jp-DirListing-itemIcon';
 const ITEM_MODIFIED_CLASS = 'jp-DirListing-itemModified';
 
 /**
- * The class name added to the listing item size cell.
+ * The class name added to the listing item file size cell.
  */
-const ITEM_SIZE_CLASS = 'jp-DirListing-itemSize';
+const ITEM_FILE_SIZE_CLASS = 'jp-DirListing-itemFileSize';
 
 /**
  * The class name added to the label element that wraps each item's checkbox and
@@ -113,9 +113,9 @@ const NAME_ID_CLASS = 'jp-id-name';
 const MODIFIED_ID_CLASS = 'jp-id-modified';
 
 /**
- * The class name added to the size column header cell.
+ * The class name added to the file size column header cell.
  */
-const SIZE_ID_CLASS = 'jp-id-size';
+const FILE_SIZE_ID_CLASS = 'jp-id-filesize';
 
 /**
  * The class name added to the narrow column header cell.
@@ -130,7 +130,7 @@ const MODIFIED_COLUMN_HIDDEN = 'jp-LastModified-hidden';
 /**
  * The class name added to the size column header cell and size item cell when hidden.
  */
-const SIZE_COLUMN_HIDDEN = 'jp-Size-hidden';
+const FILE_SIZE_COLUMN_HIDDEN = 'jp-FileSize-hidden';
 
 /**
  * The mime type for a contents drag object.
@@ -1988,11 +1988,11 @@ export namespace DirListing {
       const name = this.createHeaderItemNode(trans.__('Name'));
       const narrow = document.createElement('div');
       const modified = this.createHeaderItemNode(trans.__('Last Modified'));
-      const size = this.createHeaderItemNode(trans.__('File Size'));
+      const fileSize = this.createHeaderItemNode(trans.__('File Size'));
       name.classList.add(NAME_ID_CLASS);
       name.classList.add(SELECTED_CLASS);
       modified.classList.add(MODIFIED_ID_CLASS);
-      size.classList.add(SIZE_ID_CLASS);
+      fileSize.classList.add(FILE_SIZE_ID_CLASS);
       narrow.classList.add(NARROW_ID_CLASS);
       narrow.textContent = '...';
       if (!hiddenColumns?.has?.('is_selected')) {
@@ -2004,7 +2004,7 @@ export namespace DirListing {
       node.appendChild(name);
       node.appendChild(narrow);
       node.appendChild(modified);
-      node.appendChild(size);
+      node.appendChild(fileSize);
 
       if (hiddenColumns?.has?.('last_modified')) {
         modified.classList.add(MODIFIED_COLUMN_HIDDEN);
@@ -2013,9 +2013,9 @@ export namespace DirListing {
       }
 
       if (hiddenColumns?.has?.('file_size')) {
-        size.classList.add(SIZE_COLUMN_HIDDEN);
+        fileSize.classList.add(FILE_SIZE_COLUMN_HIDDEN);
       } else {
-        size.classList.remove(SIZE_COLUMN_HIDDEN);
+        fileSize.classList.remove(FILE_SIZE_COLUMN_HIDDEN);
       }
 
       // set the initial caret icon
@@ -2108,11 +2108,11 @@ export namespace DirListing {
       const icon = document.createElement('span');
       const text = document.createElement('span');
       const modified = document.createElement('span');
-      const size = document.createElement('span');
+      const fileSize = document.createElement('span');
       icon.className = ITEM_ICON_CLASS;
       text.className = ITEM_TEXT_CLASS;
       modified.className = ITEM_MODIFIED_CLASS;
-      size.className = ITEM_SIZE_CLASS;
+      fileSize.className = ITEM_FILE_SIZE_CLASS;
       if (!hiddenColumns?.has?.('is_selected')) {
         const checkboxWrapper = this.createCheckboxWrapperNode();
         node.appendChild(checkboxWrapper);
@@ -2120,7 +2120,7 @@ export namespace DirListing {
       node.appendChild(icon);
       node.appendChild(text);
       node.appendChild(modified);
-      node.appendChild(size);
+      node.appendChild(fileSize);
 
       // Make the text note focusable so that it receives keyboard events;
       // text node was specifically chosen to receive shortcuts because
@@ -2135,9 +2135,9 @@ export namespace DirListing {
       }
 
       if (hiddenColumns?.has?.('file_size')) {
-        modified.classList.add(SIZE_COLUMN_HIDDEN);
+        modified.classList.add(FILE_SIZE_COLUMN_HIDDEN);
       } else {
-        modified.classList.remove(SIZE_COLUMN_HIDDEN);
+        modified.classList.remove(FILE_SIZE_COLUMN_HIDDEN);
       }
 
       return node;
@@ -2211,7 +2211,7 @@ export namespace DirListing {
       const iconContainer = DOMUtils.findElement(node, ITEM_ICON_CLASS);
       const text = DOMUtils.findElement(node, ITEM_TEXT_CLASS);
       const modified = DOMUtils.findElement(node, ITEM_MODIFIED_CLASS);
-      const size = DOMUtils.findElement(node, ITEM_SIZE_CLASS);
+      const fileSize = DOMUtils.findElement(node, ITEM_FILE_SIZE_CLASS);
       const checkboxWrapper = DOMUtils.findElement(
         node,
         CHECKBOX_WRAPPER_CLASS
@@ -2232,9 +2232,9 @@ export namespace DirListing {
       }
 
       if (hiddenColumns?.has?.('file_size')) {
-        size.classList.add(SIZE_COLUMN_HIDDEN);
+        fileSize.classList.add(FILE_SIZE_COLUMN_HIDDEN);
       } else {
-        size.classList.remove(SIZE_COLUMN_HIDDEN);
+        fileSize.classList.remove(FILE_SIZE_COLUMN_HIDDEN);
       }
 
       // render the file item's icon
@@ -2250,14 +2250,14 @@ export namespace DirListing {
 
       // add file size to pop up if its available
       if (model.size !== null && model.size !== undefined) {
-        const fileSize = Private.formatFileSize(model.size, 1, 1024);
-        size.textContent = fileSize;
+        const fileSizeText = Private.formatFileSize(model.size, 1, 1024);
+        fileSize.textContent = fileSizeText;
         hoverText += trans.__(
           '\nSize: %1',
           Private.formatFileSize(model.size, 1, 1024)
         );
       } else {
-        size.textContent = '';
+        fileSize.textContent = '';
       }
       if (model.path) {
         const dirname = PathExt.dirname(model.path);

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -2165,9 +2165,9 @@ export namespace DirListing {
       }
 
       if (hiddenColumns?.has?.('file_size')) {
-        modified.classList.add(FILE_SIZE_COLUMN_HIDDEN);
+        fileSize.classList.add(FILE_SIZE_COLUMN_HIDDEN);
       } else {
-        modified.classList.remove(FILE_SIZE_COLUMN_HIDDEN);
+        fileSize.classList.remove(FILE_SIZE_COLUMN_HIDDEN);
       }
 
       return node;

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -2096,7 +2096,7 @@ export namespace DirListing {
         fileSize.classList.remove(SELECTED_CLASS);
         fileSize.classList.remove(DESCENDING_CLASS);
         Private.updateCaret(nameIcon, 'right');
-        Private.updateCaret(fileSizeIcon, 'right');
+        Private.updateCaret(fileSizeIcon, 'left');
         return state;
       }
       if (fileSize.contains(target)) {
@@ -2120,7 +2120,7 @@ export namespace DirListing {
         modified.classList.remove(SELECTED_CLASS);
         modified.classList.remove(DESCENDING_CLASS);
         Private.updateCaret(nameIcon, 'right');
-        Private.updateCaret(modifiedIcon, 'right');
+        Private.updateCaret(modifiedIcon, 'left');
         return state;
       }
       return state;

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -2533,10 +2533,10 @@ namespace Private {
   ): string {
     // https://www.codexworld.com/how-to/convert-file-size-bytes-kb-mb-gb-javascript/
     if (bytes === 0) {
-      return '0 Bytes';
+      return '0 B';
     }
     const dm = decimalPoint || 2;
-    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+    const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
     const i = Math.floor(Math.log(bytes) / Math.log(k));
     if (i >= 0 && i < sizes.length) {
       return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -87,6 +87,11 @@ const ITEM_ICON_CLASS = 'jp-DirListing-itemIcon';
 const ITEM_MODIFIED_CLASS = 'jp-DirListing-itemModified';
 
 /**
+ * The class name added to the listing item size cell.
+ */
+const ITEM_SIZE_CLASS = 'jp-DirListing-itemSize';
+
+/**
  * The class name added to the label element that wraps each item's checkbox and
  * the header's check-all checkbox.
  */
@@ -108,6 +113,11 @@ const NAME_ID_CLASS = 'jp-id-name';
 const MODIFIED_ID_CLASS = 'jp-id-modified';
 
 /**
+ * The class name added to the size column header cell.
+ */
+const SIZE_ID_CLASS = 'jp-id-size';
+
+/**
  * The class name added to the narrow column header cell.
  */
 const NARROW_ID_CLASS = 'jp-id-narrow';
@@ -116,6 +126,11 @@ const NARROW_ID_CLASS = 'jp-id-narrow';
  * The class name added to the modified column header cell and modified item cell when hidden.
  */
 const MODIFIED_COLUMN_HIDDEN = 'jp-LastModified-hidden';
+
+/**
+ * The class name added to the size column header cell and size item cell when hidden.
+ */
+const SIZE_COLUMN_HIDDEN = 'jp-Size-hidden';
 
 /**
  * The mime type for a contents drag object.
@@ -1812,13 +1827,13 @@ export namespace DirListing {
     /**
      * The sort key.
      */
-    key: 'name' | 'last_modified';
+    key: 'name' | 'last_modified' | 'size';
   }
 
   /**
    * Toggleable columns.
    */
-  export type ToggleableColumn = 'last_modified' | 'is_selected';
+  export type ToggleableColumn = 'last_modified' | 'is_selected' | 'size';
 
   /**
    * A file contents model thunk.
@@ -1973,9 +1988,11 @@ export namespace DirListing {
       const name = this.createHeaderItemNode(trans.__('Name'));
       const narrow = document.createElement('div');
       const modified = this.createHeaderItemNode(trans.__('Last Modified'));
+      const size = this.createHeaderItemNode(trans.__('Size'));
       name.classList.add(NAME_ID_CLASS);
       name.classList.add(SELECTED_CLASS);
       modified.classList.add(MODIFIED_ID_CLASS);
+      size.classList.add(SIZE_ID_CLASS);
       narrow.classList.add(NARROW_ID_CLASS);
       narrow.textContent = '...';
       if (!hiddenColumns?.has?.('is_selected')) {
@@ -1987,11 +2004,18 @@ export namespace DirListing {
       node.appendChild(name);
       node.appendChild(narrow);
       node.appendChild(modified);
+      node.appendChild(size);
 
       if (hiddenColumns?.has?.('last_modified')) {
         modified.classList.add(MODIFIED_COLUMN_HIDDEN);
       } else {
         modified.classList.remove(MODIFIED_COLUMN_HIDDEN);
+      }
+
+      if (hiddenColumns?.has?.('size')) {
+        size.classList.add(SIZE_COLUMN_HIDDEN);
+      } else {
+        size.classList.remove(SIZE_COLUMN_HIDDEN);
       }
 
       // set the initial caret icon
@@ -2084,9 +2108,11 @@ export namespace DirListing {
       const icon = document.createElement('span');
       const text = document.createElement('span');
       const modified = document.createElement('span');
+      const size = document.createElement('span');
       icon.className = ITEM_ICON_CLASS;
       text.className = ITEM_TEXT_CLASS;
       modified.className = ITEM_MODIFIED_CLASS;
+      size.className = ITEM_SIZE_CLASS;
       if (!hiddenColumns?.has?.('is_selected')) {
         const checkboxWrapper = this.createCheckboxWrapperNode();
         node.appendChild(checkboxWrapper);
@@ -2094,6 +2120,7 @@ export namespace DirListing {
       node.appendChild(icon);
       node.appendChild(text);
       node.appendChild(modified);
+      node.appendChild(size);
 
       // Make the text note focusable so that it receives keyboard events;
       // text node was specifically chosen to receive shortcuts because
@@ -2106,6 +2133,13 @@ export namespace DirListing {
       } else {
         modified.classList.remove(MODIFIED_COLUMN_HIDDEN);
       }
+
+      if (hiddenColumns?.has?.('size')) {
+        modified.classList.add(SIZE_COLUMN_HIDDEN);
+      } else {
+        modified.classList.remove(SIZE_COLUMN_HIDDEN);
+      }
+
       return node;
     }
 
@@ -2177,6 +2211,7 @@ export namespace DirListing {
       const iconContainer = DOMUtils.findElement(node, ITEM_ICON_CLASS);
       const text = DOMUtils.findElement(node, ITEM_TEXT_CLASS);
       const modified = DOMUtils.findElement(node, ITEM_MODIFIED_CLASS);
+      const size = DOMUtils.findElement(node, ITEM_SIZE_CLASS);
       const checkboxWrapper = DOMUtils.findElement(
         node,
         CHECKBOX_WRAPPER_CLASS
@@ -2194,6 +2229,12 @@ export namespace DirListing {
         modified.classList.add(MODIFIED_COLUMN_HIDDEN);
       } else {
         modified.classList.remove(MODIFIED_COLUMN_HIDDEN);
+      }
+
+      if (hiddenColumns?.has?.('size')) {
+        size.classList.add(SIZE_COLUMN_HIDDEN);
+      } else {
+        size.classList.remove(SIZE_COLUMN_HIDDEN);
       }
 
       // render the file item's icon
@@ -2234,6 +2275,9 @@ export namespace DirListing {
           '\nModified: %1',
           Time.format(new Date(model.last_modified))
         );
+      }
+      if (model.size) {
+        hoverText += trans.__('\nSize: %1', model.size);
       }
       hoverText += trans.__('\nWritable: %1', model.writable);
 
@@ -2279,6 +2323,9 @@ export namespace DirListing {
       }
       modified.textContent = modText;
       modified.title = modTitle;
+
+      // TODO: handle units
+      size.textContent = model.size ? model.size.toString() : '';
     }
 
     /**

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -68,7 +68,6 @@ export class FileBrowserModel implements IDisposable {
       writable: false,
       created: 'unknown',
       last_modified: 'unknown',
-      size: 0,
       mimetype: 'text/plain',
       format: 'text'
     };

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -68,6 +68,7 @@ export class FileBrowserModel implements IDisposable {
       writable: false,
       created: 'unknown',
       last_modified: 'unknown',
+      size: 0,
       mimetype: 'text/plain',
       format: 'text'
     };
@@ -581,6 +582,7 @@ export class FileBrowserModel implements IDisposable {
       writable: contents.writable,
       created: contents.created,
       last_modified: contents.last_modified,
+      size: contents.size,
       mimetype: contents.mimetype,
       format: contents.format
     };

--- a/packages/filebrowser/src/opendialog.ts
+++ b/packages/filebrowser/src/opendialog.ts
@@ -194,7 +194,6 @@ class OpenDialog
           writable: false,
           created: 'unknown',
           last_modified: 'unknown',
-          size: 0,
           mimetype: 'text/plain',
           format: 'text'
         }

--- a/packages/filebrowser/src/opendialog.ts
+++ b/packages/filebrowser/src/opendialog.ts
@@ -194,6 +194,7 @@ class OpenDialog
           writable: false,
           created: 'unknown',
           last_modified: 'unknown',
+          size: 0,
           mimetype: 'text/plain',
           format: 'text'
         }

--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -92,7 +92,7 @@
   display: none;
 }
 
-.jp-Size-hidden {
+.jp-FileSize-hidden {
   display: none;
 }
 
@@ -288,7 +288,7 @@
   text-align: right;
 }
 
-.jp-DirListing-itemSize {
+.jp-DirListing-itemFileSize {
   flex: 0 0 72px;
   text-align: right;
 }

--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -153,8 +153,8 @@
   text-align: right;
 }
 
-.jp-DirListing-headerItem.jp-id-size {
-  flex: 0 0 56px;
+.jp-DirListing-headerItem.jp-id-filesize {
+  flex: 0 0 70px;
   border-left: var(--jp-border-width) solid var(--jp-border-color2);
   text-align: right;
 }
@@ -289,7 +289,7 @@
 }
 
 .jp-DirListing-itemFileSize {
-  flex: 0 0 72px;
+  flex: 0 0 84px;
   text-align: right;
 }
 

--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -92,6 +92,10 @@
   display: none;
 }
 
+.jp-Size-hidden {
+  display: none;
+}
+
 .jp-FileBrowser-filterBox {
   padding: 0;
   flex: 0 0 auto;
@@ -285,7 +289,7 @@
 }
 
 .jp-DirListing-itemSize {
-  flex: 0 0 62px;
+  flex: 0 0 72px;
   text-align: right;
 }
 

--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -150,7 +150,7 @@
 .jp-DirListing-headerItem.jp-id-modified {
   flex: 0 0 112px;
   border-left: var(--jp-border-width) solid var(--jp-border-color2);
-  text-align: center;
+  text-align: right;
 }
 
 .jp-DirListing-headerItem.jp-id-size {

--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -154,7 +154,7 @@
 }
 
 .jp-DirListing-headerItem.jp-id-filesize {
-  flex: 0 0 70px;
+  flex: 0 0 75px;
   border-left: var(--jp-border-width) solid var(--jp-border-color2);
   text-align: right;
 }

--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -289,7 +289,7 @@
 }
 
 .jp-DirListing-itemFileSize {
-  flex: 0 0 84px;
+  flex: 0 0 90px;
   text-align: right;
 }
 

--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -146,6 +146,12 @@
 .jp-DirListing-headerItem.jp-id-modified {
   flex: 0 0 112px;
   border-left: var(--jp-border-width) solid var(--jp-border-color2);
+  text-align: center;
+}
+
+.jp-DirListing-headerItem.jp-id-size {
+  flex: 0 0 56px;
+  border-left: var(--jp-border-width) solid var(--jp-border-color2);
   text-align: right;
 }
 
@@ -275,6 +281,11 @@
 
 .jp-DirListing-itemModified {
   flex: 0 0 125px;
+  text-align: right;
+}
+
+.jp-DirListing-itemSize {
+  flex: 0 0 62px;
   text-align: right;
 }
 


### PR DESCRIPTION

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/14042


## Code changes

Follow the same logic as for the last modified column.

A follow-up would be to make the handling of hidden columns more generic but that might require extra refactoring work and delay delivering this feature before 4.0.

- [x] Make the "File Size" column hidden by default
- [x] Make it possible to show the "File Size" column via the settings and the context menu
- [x] Use `B` instead of `Bytes` for consistency
- [x] Allow sorting on the file size

## User-facing changes

Users will be able to show the file size column (opt-in):

https://user-images.githubusercontent.com/591645/220101734-72768e0f-1146-4c5c-b093-91f4303448a5.mp4

Downstream applications like Notebook 7 can then enable the column by default: https://github.com/jupyter/notebook/issues/6397

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
