### PR TITLE
Increases timeout 

### DIFF
--- a/buildutils/src/local-repository.ts
+++ b/buildutils/src/local-repository.ts
@@ -96,8 +96,8 @@ packages:
 
   // Wait for Verdaccio to boot
   let content = '';
-  let delays = 0;
-  while (delays < 100) {
+  let delays = 12000;
+  while (delays > 0) {
     ps.stdout.write('.');
     if (content.indexOf('http address') !== -1) {
       break;
@@ -110,10 +110,11 @@ packages:
     if (fs.existsSync(log_file)) {
       content = fs.readFileSync(log_file, { encoding: 'utf-8' });
     }
-    delays += 1;
+    delays -= 100;
   }
-  if (delays === 100) {
-    console.error('Timed out!');
+  if (delays <= 0) {
+    console.error('Timed out!\nLOG:');
+    console.log(content);
     process.exit(1);
   }
   console.log('\nVerdaccio started');


### PR DESCRIPTION
This PR fixes the `release_test` by increasing the Verdaccio starting delay by 2 second.
It also displays the log if the timeout is reached, for a better understanding.

## Code changes

Increase the Verdaccio delay in  `buildutils/src.local-repository.ts`

## User-facing changes

None

## Backwards-incompatible changes

None