### PR TITLE
use singleton boolean type for codemirror `lineWiseCopyCut` setting

### DIFF
--- a/packages/codemirror-extension/schema/commands.json
+++ b/packages/codemirror-extension/schema/commands.json
@@ -153,7 +153,7 @@
       "default": false
     },
     "lineWiseCopyCut": {
-      "type": ["boolean"],
+      "type": "boolean",
       "title": "Line-wise Ctrl-C",
       "description": "When enabled, which is the default, doing copy or cut when there is no selection will copy or cut the whole lines that have cursors on them.",
       "default": true


### PR DESCRIPTION
## References

- follow-on to #13924
- discovered on binder with #14038

Fixes #14011

## Code changes

- replaces use of `["boolean"]` as a `type` in schema

## User-facing changes

- when opening `CodeMirror` in _Advanced Settings Editor_ it _shouldn't_  go to the classic "react snowstorm"

## Backwards-incompatible changes

- n/a