### PR TITLE
Fix non-document wide undo stack

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -56,4 +56,4 @@ dependencies:
   # extra conda stuff
   - jsonschema-with-format-nongpl
   - pip:
-    - jupyter-collaboration >=1.0.0a1
+    - jupyter-collaboration >=1.0.0a3

--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -17,7 +17,7 @@
     "watch": "webpack --watch"
   },
   "resolutions": {
-    "@jupyter/ydoc": "~0.3.1",
+    "@jupyter/ydoc": "~0.3.4",
     "@jupyterlab/application": "~4.0.0-alpha.20",
     "@jupyterlab/application-extension": "~4.0.0-alpha.20",
     "@jupyterlab/apputils": "~4.0.0-alpha.20",

--- a/examples/cell/package.json
+++ b/examples/cell/package.json
@@ -7,7 +7,7 @@
     "clean": "rimraf build"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^0.3.1",
+    "@jupyter/ydoc": "^0.3.4",
     "@jupyterlab/application": "^4.0.0-alpha.20",
     "@jupyterlab/apputils": "^4.0.0-alpha.20",
     "@jupyterlab/cells": "^4.0.0-alpha.20",

--- a/packages/cell-toolbar/package.json
+++ b/packages/cell-toolbar/package.json
@@ -40,7 +40,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^0.3.1",
+    "@jupyter/ydoc": "^0.3.4",
     "@jupyterlab/apputils": "^4.0.0-alpha.20",
     "@jupyterlab/cells": "^4.0.0-alpha.20",
     "@jupyterlab/docregistry": "^4.0.0-alpha.20",

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@codemirror/state": "^6.2.0",
     "@codemirror/view": "^6.7.0",
-    "@jupyter/ydoc": "^0.3.1",
+    "@jupyter/ydoc": "^0.3.4",
     "@jupyterlab/apputils": "^4.0.0-alpha.20",
     "@jupyterlab/attachments": "^4.0.0-alpha.20",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.20",

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1198,7 +1198,7 @@ export class CodeCell extends Cell<ICodeCellModel> {
       } else {
         this.model.deleteMetadata('collapsed');
       }
-    });
+    }, false);
   }
 
   /**
@@ -1437,7 +1437,7 @@ export namespace CodeCell {
     if (!code.trim() || !sessionContext.session?.kernel) {
       model.sharedModel.transact(() => {
         model.clearExecution();
-      });
+      }, false);
       return;
     }
     const cellId = { cellId: model.sharedModel.getId() };
@@ -1450,7 +1450,7 @@ export namespace CodeCell {
     model.sharedModel.transact(() => {
       model.clearExecution();
       cell.outputHidden = false;
-    });
+    }, false);
     cell.setPrompt('*');
     model.trusted = true;
     let future:

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@codemirror/state": "^6.2.0",
-    "@jupyter/ydoc": "^0.3.1",
+    "@jupyter/ydoc": "^0.3.4",
     "@jupyterlab/coreutils": "^6.0.0-alpha.20",
     "@jupyterlab/nbformat": "^4.0.0-alpha.20",
     "@jupyterlab/observables": "^5.0.0-alpha.20",

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -38,7 +38,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^0.3.1",
+    "@jupyter/ydoc": "^0.3.4",
     "@jupyterlab/application": "^4.0.0-alpha.20",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.20",
     "@jupyterlab/codemirror": "^4.0.0-alpha.20",

--- a/packages/codemirror-extension/src/services.tsx
+++ b/packages/codemirror-extension/src/services.tsx
@@ -212,7 +212,10 @@ export const bindingPlugin: JupyterFrontEndPlugin<void> = {
       factory: options => {
         const sharedModel = options.model.sharedModel as IYText;
         return EditorExtensionRegistry.createImmutableExtension(
-          ybinding(sharedModel.ysource)
+          ybinding({
+            ytext: sharedModel.ysource,
+            undoManager: sharedModel.undoManager ?? undefined
+          })
         );
       }
     });

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -58,7 +58,7 @@
     "@codemirror/search": "^6.2.0",
     "@codemirror/state": "^6.2.0",
     "@codemirror/view": "^6.7.0",
-    "@jupyter/ydoc": "^0.3.1",
+    "@jupyter/ydoc": "^0.3.4",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.20",
     "@jupyterlab/coreutils": "^6.0.0-alpha.20",
     "@jupyterlab/documentsearch": "^4.0.0-alpha.20",

--- a/packages/codemirror/test/editor.spec.ts
+++ b/packages/codemirror/test/editor.spec.ts
@@ -63,7 +63,7 @@ describe('CodeMirrorEditor', () => {
       model,
       languages,
       // Binding between the editor and the Yjs model
-      extensions: [ybinding(sharedModel.ysource)]
+      extensions: [ybinding({ ytext: sharedModel.ysource })]
     });
   });
 

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -45,7 +45,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^0.3.1",
+    "@jupyter/ydoc": "^0.3.4",
     "@jupyterlab/apputils": "^4.0.0-alpha.20",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.20",
     "@jupyterlab/coreutils": "^6.0.0-alpha.20",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@codemirror/state": "^6.2.0",
     "@codemirror/view": "^6.7.0",
-    "@jupyter/ydoc": "^0.3.1",
+    "@jupyter/ydoc": "^0.3.4",
     "@jupyterlab/apputils": "^4.0.0-alpha.20",
     "@jupyterlab/cells": "^4.0.0-alpha.20",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.20",

--- a/packages/console/test/history.spec.ts
+++ b/packages/console/test/history.spec.ts
@@ -170,7 +170,7 @@ describe('console/history', () => {
         const editor = new CodeMirrorEditor({
           model,
           host,
-          extensions: [ybinding((model.sharedModel as any).ysource)]
+          extensions: [ybinding({ ytext: (model.sharedModel as any).ysource })]
         });
         history.editor = editor;
         model.sharedModel.setSource('foo');
@@ -193,7 +193,7 @@ describe('console/history', () => {
         const editor = new CodeMirrorEditor({
           model,
           host,
-          extensions: [ybinding((model.sharedModel as any).ysource)]
+          extensions: [ybinding({ ytext: (model.sharedModel as any).ysource })]
         });
         history.editor = editor;
         history.push('foo');

--- a/packages/console/test/utils.ts
+++ b/packages/console/test/utils.ts
@@ -20,7 +20,7 @@ const extensions = (() => {
     factory: ({ model }) => {
       const sharedModel = model.sharedModel as IYText;
       return EditorExtensionRegistry.createImmutableExtension([
-        ybinding(sharedModel.ysource)
+        ybinding({ ytext: sharedModel.ysource })
       ]);
     }
   });

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@codemirror/state": "^6.2.0",
     "@codemirror/view": "^6.7.0",
-    "@jupyter/ydoc": "^0.3.1",
+    "@jupyter/ydoc": "^0.3.4",
     "@jupyterlab/application": "^4.0.0-alpha.20",
     "@jupyterlab/apputils": "^4.0.0-alpha.20",
     "@jupyterlab/cells": "^4.0.0-alpha.20",

--- a/packages/debugger/test/debugger.spec.ts
+++ b/packages/debugger/test/debugger.spec.ts
@@ -68,7 +68,7 @@ describe('Debugger', () => {
     factory: ({ model }) => {
       const m = model.sharedModel as IYText;
       return EditorExtensionRegistry.createImmutableExtension(
-        ybinding(m.ysource)
+        ybinding({ ytext: m.ysource })
       );
     }
   });

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -42,7 +42,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^0.3.1",
+    "@jupyter/ydoc": "^0.3.4",
     "@jupyterlab/apputils": "^4.0.0-alpha.20",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.20",
     "@jupyterlab/coreutils": "^6.0.0-alpha.20",

--- a/packages/fileeditor/test/searchprovider.spec.ts
+++ b/packages/fileeditor/test/searchprovider.spec.ts
@@ -37,7 +37,7 @@ describe('@jupyterlab/fileeditor', () => {
       name: 'binding',
       factory: ({ model }) => {
         return EditorExtensionRegistry.createImmutableExtension(
-          ybinding((model.sharedModel as any).ysource)
+          ybinding({ ytext: (model.sharedModel as any).ysource })
         );
       }
     });

--- a/packages/metapackage/test/completer/handler.spec.ts
+++ b/packages/metapackage/test/completer/handler.spec.ts
@@ -17,7 +17,10 @@ function createEditorWidget(): CodeEditorWrapper {
   const model = new CodeEditor.Model({ sharedModel: new YFile() });
   const factory = (options: CodeEditor.IOptions) => {
     const m = options.model.sharedModel as any;
-    options.extensions = [...(options.extensions ?? []), ybinding(m.ysource)];
+    options.extensions = [
+      ...(options.extensions ?? []),
+      ybinding({ ytext: m.ysource })
+    ];
     return new CodeMirrorEditor(options);
   };
   return new CodeEditorWrapper({ factory, model });

--- a/packages/metapackage/test/completer/manager.spec.ts
+++ b/packages/metapackage/test/completer/manager.spec.ts
@@ -26,9 +26,7 @@ const SAMPLE_PROVIDER_ID = 'CompletionProvider:sample';
 
 function contextFactory(): Context<INotebookModel> {
   const serviceManager = new ServiceManager({ standby: 'never' });
-  const factory = new NotebookModelFactory({
-    disableDocumentWideUndoRedo: false
-  });
+  const factory = new NotebookModelFactory();
   const context = new Context({
     manager: serviceManager,
     factory,

--- a/packages/metapackage/test/completer/reconciliator.spec.ts
+++ b/packages/metapackage/test/completer/reconciliator.spec.ts
@@ -16,9 +16,7 @@ import { NBTestUtils } from '@jupyterlab/notebook/lib/testutils';
 
 function contextFactory(): Context<INotebookModel> {
   const serviceManager = new ServiceManager({ standby: 'never' });
-  const factory = new NotebookModelFactory({
-    disableDocumentWideUndoRedo: false
-  });
+  const factory = new NotebookModelFactory();
   const context = new Context({
     manager: serviceManager,
     factory,

--- a/packages/metapackage/test/completer/widget.spec.ts
+++ b/packages/metapackage/test/completer/widget.spec.ts
@@ -28,7 +28,10 @@ function createEditorWidget(): CodeEditorWrapper {
   const model = new CodeEditor.Model({ sharedModel: new YFile() });
   const factory = (options: CodeEditor.IOptions) => {
     const m = options.model.sharedModel as any;
-    options.extensions = [...(options.extensions ?? []), ybinding(m.ysource)];
+    options.extensions = [
+      ...(options.extensions ?? []),
+      ybinding({ ytext: m.ysource })
+    ];
     return new CodeMirrorEditor(options);
   };
   return new CodeEditorWrapper({ factory, model });

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -37,7 +37,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^0.3.1",
+    "@jupyter/ydoc": "^0.3.4",
     "@jupyterlab/application": "^4.0.0-alpha.20",
     "@jupyterlab/apputils": "^4.0.0-alpha.20",
     "@jupyterlab/cells": "^4.0.0-alpha.20",

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -748,7 +748,7 @@
     },
     "documentWideUndoRedo": {
       "title": "Enable undo/redo actions at the notebook document level.",
-      "description": "Enables the undo/redo actions at the notebook document level; aka undoing within a cell may undo the latest notebook change that happen in another cell.",
+      "description": "Enables the undo/redo actions at the notebook document level; aka undoing within a cell may undo the latest notebook change that happen in another cell. This is deprecated and will be removed in 5.0.0.",
       "type": "boolean",
       "default": false
     },

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -746,9 +746,9 @@
         "showProgress": true
       }
     },
-    "experimentalEnableDocumentWideUndoRedo": {
-      "title": "Enable the undo/redo on the notebook document level.",
-      "description": "Experimental settings that enables the undo/redo at the notebook document level; aka undoing within a cell may undo the latest notebook change that happen in another cell.",
+    "documentWideUndoRedo": {
+      "title": "Enable undo/redo actions at the notebook document level.",
+      "description": "Enables the undo/redo actions at the notebook document level; aka undoing within a cell may undo the latest notebook change that happen in another cell.",
       "type": "boolean",
       "default": false
     },

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -746,9 +746,9 @@
         "showProgress": true
       }
     },
-    "experimentalDisableDocumentWideUndoRedo": {
-      "title": "Experimental settings to enable the undo/redo on the notebook document level.",
-      "description": "Disable the undo/redo on the notebook document level, so actions independent cells can have their own history. The undo/redo never applies on the outputs, in other words, outputs don't have history. A moved cell completely looses history capability for now.",
+    "experimentalEnableDocumentWideUndoRedo": {
+      "title": "Enable the undo/redo on the notebook document level.",
+      "description": "Experimental settings that enables the undo/redo at the notebook document level; aka undoing within a cell may undo the latest notebook change that happen in another cell.",
       "type": "boolean",
       "default": false
     },

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1734,9 +1734,8 @@ function activateNotebookHandler(
       showEditorForReadOnlyMarkdown: settings.get(
         'showEditorForReadOnlyMarkdown'
       ).composite as boolean,
-      disableDocumentWideUndoRedo: !settings.get(
-        'experimentalEnableDocumentWideUndoRedo'
-      ).composite as boolean,
+      disableDocumentWideUndoRedo: !settings.get('documentWideUndoRedo')
+        .composite as boolean,
       renderingLayout: settings.get('renderingLayout').composite as
         | 'default'
         | 'side-by-side',
@@ -1769,7 +1768,7 @@ function activateNotebookHandler(
       .composite as boolean;
 
     modelFactory.disableDocumentWideUndoRedo = !settings.get(
-      'experimentalEnableDocumentWideUndoRedo'
+      'documentWideUndoRedo'
     ).composite as boolean;
 
     updateTracker({

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -2744,7 +2744,11 @@ function addCommands(
       const current = getCurrent(tracker, shell, args);
 
       if (current) {
-        return current.content.activeCell?.editor?.redo();
+        const cell = current.content.activeCell;
+        if (cell) {
+          cell.inputHidden = false;
+          return cell.editor?.redo();
+        }
       }
     }
   });
@@ -2754,7 +2758,11 @@ function addCommands(
       const current = getCurrent(tracker, shell, args);
 
       if (current) {
-        return current.content.activeCell?.editor?.undo();
+        const cell = current.content.activeCell;
+        if (cell) {
+          cell.inputHidden = false;
+          return cell.editor?.undo();
+        }
       }
     }
   });

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1734,8 +1734,8 @@ function activateNotebookHandler(
       showEditorForReadOnlyMarkdown: settings.get(
         'showEditorForReadOnlyMarkdown'
       ).composite as boolean,
-      disableDocumentWideUndoRedo: settings.get(
-        'experimentalDisableDocumentWideUndoRedo'
+      disableDocumentWideUndoRedo: !settings.get(
+        'experimentalEnableDocumentWideUndoRedo'
       ).composite as boolean,
       renderingLayout: settings.get('renderingLayout').composite as
         | 'default'
@@ -1768,8 +1768,8 @@ function activateNotebookHandler(
     factory.shutdownOnClose = settings.get('kernelShutdown')
       .composite as boolean;
 
-    modelFactory.disableDocumentWideUndoRedo = settings.get(
-      'experimentalDisableDocumentWideUndoRedo'
+    modelFactory.disableDocumentWideUndoRedo = !settings.get(
+      'experimentalEnableDocumentWideUndoRedo'
     ).composite as boolean;
 
     updateTracker({

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -41,7 +41,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^0.3.1",
+    "@jupyter/ydoc": "^0.3.4",
     "@jupyterlab/apputils": "^4.0.0-alpha.20",
     "@jupyterlab/cells": "^4.0.0-alpha.20",
     "@jupyterlab/codeeditor": "^4.0.0-alpha.20",

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1243,7 +1243,7 @@ export namespace NotebookActions {
    * @param notebook - The target notebook widget.
    *
    * #### Notes
-   * This is a no-op if if there are no cell actions to undo.
+   * This is a no-op if there are no cell actions to undo.
    */
   export function undo(notebook: Notebook): void {
     if (!notebook.model) {
@@ -1332,7 +1332,7 @@ export namespace NotebookActions {
         cell.sharedModel.transact(() => {
           (cell as ICodeCellModel).clearExecution();
           (child as CodeCell).outputHidden = false;
-        });
+        }, false);
       }
     }
     Private.handleState(notebook, state, true);
@@ -1360,7 +1360,7 @@ export namespace NotebookActions {
         cell.sharedModel.transact(() => {
           (cell as ICodeCellModel).clearExecution();
           (child as CodeCell).outputHidden = false;
-        });
+        }, false);
       }
     }
     Private.handleState(notebook, state, true);
@@ -2246,7 +2246,7 @@ namespace Private {
         }
         cell.model.sharedModel.transact(() => {
           (cell.model as ICodeCellModel).clearExecution();
-        });
+        }, false);
         break;
       default:
         break;

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -108,7 +108,7 @@ export class NotebookModel implements INotebookModel {
     } else {
       this.sharedModel = YNotebook.create({
         disableDocumentWideUndoRedo:
-          options.disableDocumentWideUndoRedo ?? false,
+          options.disableDocumentWideUndoRedo ?? true,
         data: {
           nbformat: nbformat.MAJOR_VERSION,
           nbformat_minor: nbformat.MINOR_VERSION,
@@ -527,6 +527,11 @@ export namespace NotebookModel {
 
     /**
      * Defines if the document can be undo/redo.
+     *
+     * Default: true
+     *
+     * @experimental
+     * @alpha
      */
     disableDocumentWideUndoRedo?: boolean;
   }

--- a/packages/notebook/src/modelfactory.ts
+++ b/packages/notebook/src/modelfactory.ts
@@ -15,15 +15,21 @@ export class NotebookModelFactory
   /**
    * Construct a new notebook model factory.
    */
-  constructor(options: NotebookModelFactory.IOptions) {
+  constructor(options: NotebookModelFactory.IOptions = {}) {
     this._disableDocumentWideUndoRedo =
-      options.disableDocumentWideUndoRedo || false;
+      options.disableDocumentWideUndoRedo ?? true;
     this._collaborative = options.collaborative ?? true;
   }
 
   /**
    * Define the disableDocumentWideUndoRedo property.
+   *
+   * @experimental
+   * @alpha
    */
+  get disableDocumentWideUndoRedo(): boolean {
+    return this._disableDocumentWideUndoRedo;
+  }
   set disableDocumentWideUndoRedo(disableDocumentWideUndoRedo: boolean) {
     this._disableDocumentWideUndoRedo = disableDocumentWideUndoRedo;
   }
@@ -118,6 +124,11 @@ export namespace NotebookModelFactory {
 
     /**
      * Defines if the document can be undo/redo.
+     *
+     * Default: true
+     *
+     * @experimental
+     * @alpha
      */
     disableDocumentWideUndoRedo?: boolean;
   }

--- a/packages/notebook/src/testutils.ts
+++ b/packages/notebook/src/testutils.ts
@@ -251,9 +251,7 @@ export namespace NBTestUtils {
 namespace Private {
   let manager: ServiceManager;
 
-  export const notebookFactory = new NotebookModelFactory({
-    disableDocumentWideUndoRedo: false
-  });
+  export const notebookFactory = new NotebookModelFactory();
 
   /**
    * Get or create the service manager singleton.

--- a/packages/notebook/src/testutils.ts
+++ b/packages/notebook/src/testutils.ts
@@ -101,7 +101,7 @@ export namespace NBTestUtils {
       name: 'binding',
       factory: ({ model }) =>
         EditorExtensionRegistry.createImmutableExtension(
-          ybinding((model.sharedModel as any).ysource)
+          ybinding({ ytext: (model.sharedModel as any).ysource })
         )
     });
     const factoryService = new CodeMirrorEditorFactory({

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1121,7 +1121,7 @@ export namespace StaticNotebook {
     recordTiming: false,
     maxNumberOutputs: 50,
     showEditorForReadOnlyMarkdown: true,
-    disableDocumentWideUndoRedo: false,
+    disableDocumentWideUndoRedo: true,
     renderingLayout: 'default',
     sideBySideLeftMarginOverride: '10px',
     sideBySideRightMarginOverride: '10px',

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -71,9 +71,7 @@ describe('@jupyterlab/notebook', () => {
           windowingMode: 'none'
         }
       });
-      const model = new NotebookModel({
-        disableDocumentWideUndoRedo: true
-      });
+      const model = new NotebookModel();
       model.fromJSON(utils.DEFAULT_CONTENT);
       widget.model = model;
       model.sharedModel.clearUndoHistory();

--- a/packages/notebook/test/model.spec.ts
+++ b/packages/notebook/test/model.spec.ts
@@ -59,9 +59,7 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should allow undoing a change', () => {
-        const model = new NotebookModel({
-          disableDocumentWideUndoRedo: true
-        });
+        const model = new NotebookModel();
         const cell = model.sharedModel.insertCell(0, {
           cell_type: 'code',
           source: 'foo'

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -46,7 +46,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^0.3.1",
+    "@jupyter/ydoc": "^0.3.4",
     "@jupyterlab/coreutils": "^6.0.0-alpha.20",
     "@jupyterlab/nbformat": "^4.0.0-alpha.20",
     "@jupyterlab/settingregistry": "^4.0.0-alpha.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1452,10 +1452,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@jupyter/ydoc@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@jupyter/ydoc/-/ydoc-0.3.1.tgz#d7859a9bb511f19571559ee8a4e12d2d2e50b64f"
-  integrity sha512-e7tzgNYJW3XhO0gf39cKQrXxw1/1Z7h950xsKauwUij06ngMluj464b+FK1/n3/p/jD1GMhx5RNkQYvX6V9tAg==
+"@jupyter/ydoc@^0.3.4":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@jupyter/ydoc/-/ydoc-0.3.4.tgz#e13d4ecb39f76ccca55ca8ae5fe9cdbc8518baa3"
+  integrity sha512-6B1Qe8c+u759pbi3dTCntNDhRxpeoQVQnFyQKejYOr5ILep8PZOvg78OI6whWhLV3HEgFAFTKdE1tmn6ktolvQ==
   dependencies:
     "@jupyterlab/nbformat" "^3.0.0 || ^4.0.0-alpha.15"
     "@lumino/coreutils" "^1.11.0 || ^2.0.0-alpha.6"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #10791
Fixes #11556
Fixes https://github.com/jupyterlab/jupyterlab/issues/14113
Closes https://github.com/jupyterlab/jupyterlab/pull/11640

Requires https://github.com/jupyter-server/jupyter_ydoc/pull/148

Question: should we rename the settings and activate it by default so the behavior of undo is restored to the old (<=3.0) behavior?

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Fix properly the action origin to be tracked in the history track

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Non-document wide history matches the old undo behavior
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None