### PR TITLE
Update the Classic Notebook FAQ section in the documentation

### DIFF
--- a/docs/source/getting_started/faq.rst
+++ b/docs/source/getting_started/faq.rst
@@ -11,8 +11,7 @@ General
 -------
 
 -  :ref:`What is JupyterLab? <overview>`
--  :ref:`Is JupyterLab ready to use? <releases>`
--  :ref:`What will happen to the classic Jupyter Notebook? <releases>`
+-  :ref:`What will happen to the classic Jupyter Notebook? <classic>`
 -  `Where is the official online documentation for
    JupyterLab? <https://jupyterlab.readthedocs.io>`__
 -  :ref:`How can you report a bug or issue? <issue>`

--- a/docs/source/getting_started/overview.rst
+++ b/docs/source/getting_started/overview.rst
@@ -54,35 +54,13 @@ from vim, emacs, and Sublime Text in the text editor.
 JupyterLab :ref:`extensions <user_extensions>` can customize or enhance any part
 of JupyterLab, including new themes, file editors, and custom components.
 
-JupyterLab is served from the same `server
-<https://jupyter-notebook.readthedocs.io/en/stable/>`__ and uses the same
-`notebook document format <https://nbformat.readthedocs.io/en/latest/>`__ as the
-classic Jupyter Notebook.
+JupyterLab uses the same `notebook document format <https://nbformat.readthedocs.io/en/latest/>`__
+as the classic Jupyter Notebook.
 
-.. toctree::
-   :maxdepth: 2
+.. _classic:
 
-   installation
-   starting
-   issue
-   faq
-   changelog
-
-.. _releases:
-
-JupyterLab Releases
--------------------
-
-Since JupyterLab 0.32 (February 2018), the releases of JupyterLab are suitable
-for general daily use by both Jupyter novices and users experienced with the
-Classic Notebook interface. As of the 1.0 release (June 2019), it is
-additionally ready for extension writers who wish to further customize the
-JupyterLab experience for others. Please review the :ref:`changelog` for
-detailed descriptions of each release.
-
-The extension developer API is evolving, and we also are currently iterating on UI/UX improvements.
-We appreciate feedback on our `GitHub issues page <https://github.com/jupyterlab/jupyterlab/issues>`__
-as we evolve towards a stable extension development API.
+What will happen to the Classic Notebook?
+-----------------------------------------
 
 As JupyterLab 4 development continues, and Notebook 7 development follows,
 Notebook 7 will eventually replace the classic Jupyter Notebook.
@@ -92,4 +70,14 @@ As of JupyterLab 4, the Notebook web application, will no longer
 be installed alongside JupyterLab as it is no longer a JupyterLab
 dependency. To find out more about the future of the classic
 Jupyter Notebook in the ecosystem, visit the
-`NbClassic documentation <https://nbclassic.readthedocs.io/en/latest/nbclassic.html#nbclassic-in-the-jupyter-ecosystem>`__.
+`Jupyter Notebook 7 documentation <https://jupyter-notebook.readthedocs.io/en/latest/migrate_to_notebook7.html>`__.
+
+
+.. toctree::
+   :maxdepth: 2
+
+   installation
+   starting
+   issue
+   faq
+   changelog


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/12115

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Make the "What will happen to the Classic Notebook?" section more visible in the docs
- [x] Remove the "JupyterLab Releases" section since it was mentioning the early beta releases and 1.0 and might still confuse users that JupyterLab is not yet ready for use and extensions

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Documentation update:

https://jupyterlab--14070.org.readthedocs.build/en/14070/getting_started/overview.html

![image](https://user-images.githubusercontent.com/591645/220884686-ec8cd85d-acbe-4e34-b9aa-9d7610a796e8.png)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
