### PR TITLE
Fix Font size of accordion headers in Settings Editor

### DIFF
--- a/packages/settingeditor/style/base.css
+++ b/packages/settingeditor/style/base.css
@@ -243,14 +243,13 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
 }
 
 .jp-SettingsPanel .jp-SettingsHeader h2 {
-  font-size: var(--jp-content-font-size3);
-  color: var(--jp-ui-font-color0);
+  font-size: var(--jp-content-font-size1);
+  color: var(--jp-ui-font-color1);
   font-weight: 300;
-  margin: 1em;
 }
 
 .jp-SettingsPanel .jp-SettingsHeader-description {
-  font-size: var(--jp-content-font-size2);
+  font-size: var(--jp-content-font-size1);
   color: var(--jp-ui-font-color1);
   font-weight: 200;
   margin: 1em;
@@ -260,7 +259,6 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
 .jp-SettingsPanel .jp-SettingsTitle {
   display: flex;
   align-items: center;
-  padding-left: 1em;
 }
 
 .jp-SettingsPanel .jp-SettingsTitle-caret {
@@ -352,7 +350,7 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
   border: none;
   outline: none;
   box-shadow: none;
-  font-size: var(--jp-content-font-size2);
+  font-size: var(--jp-content-font-size1);
   color: var(--jp-brand-color1);
   cursor: pointer;
   margin-right: 5px;

--- a/packages/settingeditor/style/base.css
+++ b/packages/settingeditor/style/base.css
@@ -262,7 +262,6 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
 }
 
 .jp-SettingsPanel .jp-SettingsTitle-caret {
-  width: 2em;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
## References

- Fixes #14007 

## Code changes

Makes styling of accordion headers in Settings Editor match other jupyterlab components by reducing font size, removing padding, making caret smaller (by removing `2em` width on its parent component)

## User-facing changes

Accordion headers in Settings Editor now look in line with other jupyterlab components

Current head-of-master:
![Screenshot 2023-02-23 at 4 56 04 PM](https://user-images.githubusercontent.com/26686070/221065749-af663f13-5ad8-4c49-8cfd-b39f5e14b325.png)

With this change:
![Screenshot 2023-02-23 at 4 55 54 PM](https://user-images.githubusercontent.com/26686070/221065756-0e7896ad-0baa-4194-b3b1-808a94d46373.png)

## Backwards-incompatible changes

None
