### PR TITLE
Enable `--extensions-in-dev-mode` on Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -33,7 +33,7 @@ tasks:
       source /workspace/bin/activate-env.sh
       # Set no token and allow any origin, so that you can open it in a new tab
       # Disable iframe security so can load in the editor as well
-      jupyter lab --dev-mode --watch --ServerApp.IdentityProvider.token='' --ServerApp.allow_origin=* --ServerApp.tornado_settings='{"headers": {"Content-Security-Policy": "frame-ancestors *"}}'
+      jupyter lab --dev-mode --watch --extensions-in-dev-mode --ServerApp.IdentityProvider.token='' --ServerApp.allow_origin=* --ServerApp.tornado_settings='{"headers": {"Content-Security-Policy": "frame-ancestors *"}}'
 
   - name: auto-activate
     command: |


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This will make it more convenient to test third-party extensions with the latest state of the JupyterLab dev branch while working on Gitpod.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Gitpod config update to enable `--extensions-in-dev-mode`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
