### PR TITLE
Search boxes: switch to `defaultValue`, add a test for typing

### DIFF
--- a/galata/test/jupyterlab/notebook-search.test.ts
+++ b/galata/test/jupyterlab/notebook-search.test.ts
@@ -35,6 +35,18 @@ test.describe('Notebook Search', () => {
     expect(await nbPanel.screenshot()).toMatchSnapshot('search.png');
   });
 
+  test('Typing in search box', async ({ page }) => {
+    // Check against React being too eager with controling state of input box
+    await page.keyboard.press('Control+f');
+
+    await page.fill('[placeholder="Find"]', '14');
+    await page.press('[placeholder="Find"]', 'ArrowLeft');
+    await page.type('[placeholder="Find"]', '2');
+    await page.type('[placeholder="Find"]', '3');
+
+    await expect(page.locator('[placeholder="Find"]')).toHaveValue('1234');
+  });
+
   test('RegExp parsing failure', async ({ page }) => {
     await page.keyboard.press('Control+f');
 

--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -80,9 +80,8 @@ function SearchInput(props: ISearchInputProps): JSX.Element {
       tabIndex={0}
       ref={props.inputRef}
       title={props.title}
-    >
-      {props.value}
-    </textarea>
+      defaultValue={props.value}
+    ></textarea>
   );
 }
 


### PR DESCRIPTION
## References

Closes #13881

While the issue was already fixed by #13810, the solution included in there was generating a warning in development mode of React highlighting that textarea in React should not have children elements and value needs to be implemented using `value` or `defaultValue`.

## Code changes

- switch to `defaultValue` in search input (note that `value` makes React fully manage the input causing #13881 bug)
- added a minimal integration test case (without a screenshot)

## User-facing changes

Typing works well.

## Backwards-incompatible changes

None