### PR TITLE
Improve position of output scroll toggle overlay

### DIFF
--- a/packages/cells/style/widget.css
+++ b/packages/cells/style/widget.css
@@ -104,6 +104,10 @@
   );
 }
 
+.jp-CodeCell.jp-mod-outputsScrolled .jp-OutputArea-promptOverlay {
+  left: calc(-1 * var(--jp-private-cell-scrolling-output-offset));
+}
+
 /*-----------------------------------------------------------------------------
 | CodeCell
 |----------------------------------------------------------------------------*/


### PR DESCRIPTION
## References

Follow-up to #14072

## Code changes

Add `left` offset when scrolling is enabled to account for `margin-left` from:

https://github.com/jupyterlab/jupyterlab/blob/830931dead61c78dbc5ab12cafd6a8d2e280a75d/packages/cells/style/widget.css#L72-L77

## User-facing changes

Before:

![before](https://user-images.githubusercontent.com/5832902/221416882-d990e840-fc79-4b26-afde-362f88c62f89.gif)

After:

![after](https://user-images.githubusercontent.com/5832902/221416892-e103e85f-4407-4822-8166-3908344d5e23.gif)

## Backwards-incompatible changes

None