### PR TITLE
Issue #13965 resolved. <code> block in the UI must not show now when there is an error installing any extension.

### DIFF
--- a/packages/extensionmanager/src/dialog.tsx
+++ b/packages/extensionmanager/src/dialog.tsx
@@ -20,7 +20,7 @@ export function reportInstallError(
   const trans = translator.load('jupyterlab');
   const entries = [];
   entries.push(
-    <p>{trans.__('An error occurred installing <code>%1</code>.', name)}</p>
+    <p>{trans.__(`An error occured installing "${name}."`)}</p>
   );
   if (errorMessage) {
     entries.push(


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
