### PR TITLE
Fixes documentation build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -253,7 +253,7 @@ html_theme_options = {
     "use_edit_page_button": True,
     "navbar_align": "left",
     "navbar_end": ["navbar-icon-links.html", "search-field.html"],
-    "footer_items": ["copyright.html"],
+    "footer_start": ["copyright.html"],
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ Pypi = "https://pypi.org/project/jupyterlab"
 docs = [
     "sphinx>=1.8",
     "sphinx-copybutton",
-    "pydata-sphinx-theme",
+    "pydata-sphinx-theme>=0.13.0",
     "pytest",
     "pytest-tornasync",
     "pytest-check-links",


### PR DESCRIPTION
This PR fixes the building of documentation, by replacing the deprecated `footer_items` option by `footer_start`.

The deprecated warning introduced in [pydata-sphinx-theme==0.13.0](https://github.com/pydata/pydata-sphinx-theme/pull/1184) makes the test fail.

## References

Failing linux-docs in https://github.com/jupyterlab/jupyterlab/pull/14026
