### PR TITLE
Add bottom area to add cells

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -2740,7 +2740,6 @@ function addCommands(
     label: trans.__('Select Cell Below'),
     execute: args => {
       const current = getCurrent(tracker, shell, args);
-
       if (current) {
         return NotebookActions.selectBelow(current.content);
       }

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -850,7 +850,7 @@ export namespace NotebookActions {
 
     if (notebook.activeCellIndex === maxCellIndex) {
       const footer = (notebook.layout as NotebookWindowedLayout).footer;
-      footer?.focus();
+      footer?.node.focus();
     }
 
     // Find last non-hidden cell

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -17,6 +17,7 @@ import {
   isRawCellModel,
   MarkdownCell
 } from '@jupyterlab/cells';
+/*import { NotebookWindowedLayout } from './windowing';*/
 import { signalToPromise } from '@jupyterlab/coreutils';
 import * as nbformat from '@jupyterlab/nbformat';
 import { KernelMessage } from '@jupyterlab/services';
@@ -27,6 +28,7 @@ import { JSONExt, JSONObject } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 import * as React from 'react';
 import { Notebook, StaticNotebook } from './widget';
+import { NotebookWindowedLayout } from './windowing';
 
 /**
  * The mimetype used for Jupyter cell data.
@@ -846,15 +848,18 @@ export namespace NotebookActions {
       return;
     }
     let maxCellIndex = notebook.widgets.length - 1;
+
+    if (notebook.activeCellIndex === maxCellIndex) {
+      const footer = (notebook.layout as NotebookWindowedLayout).footer;
+      footer?.focus();
+    }
+
     // Find last non-hidden cell
     while (
       notebook.widgets[maxCellIndex].isHidden ||
       notebook.widgets[maxCellIndex].inputHidden
     ) {
       maxCellIndex -= 1;
-    }
-    if (notebook.activeCellIndex === maxCellIndex) {
-      return;
     }
 
     let possibleNextCellIndex = notebook.activeCellIndex + 1;
@@ -869,7 +874,6 @@ export namespace NotebookActions {
     }
 
     const state = Private.getState(notebook);
-
     notebook.activeCellIndex = possibleNextCellIndex;
     notebook.deselectAll();
     Private.handleState(notebook, state, true);

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -17,7 +17,6 @@ import {
   isRawCellModel,
   MarkdownCell
 } from '@jupyterlab/cells';
-/*import { NotebookWindowedLayout } from './windowing';*/
 import { signalToPromise } from '@jupyterlab/coreutils';
 import * as nbformat from '@jupyterlab/nbformat';
 import { KernelMessage } from '@jupyterlab/services';

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -848,17 +848,17 @@ export namespace NotebookActions {
     }
     let maxCellIndex = notebook.widgets.length - 1;
 
-    if (notebook.activeCellIndex === maxCellIndex) {
-      const footer = (notebook.layout as NotebookWindowedLayout).footer;
-      footer?.node.focus();
-    }
-
     // Find last non-hidden cell
     while (
       notebook.widgets[maxCellIndex].isHidden ||
       notebook.widgets[maxCellIndex].inputHidden
     ) {
       maxCellIndex -= 1;
+    }
+    if (notebook.activeCellIndex === maxCellIndex) {
+      const footer = (notebook.layout as NotebookWindowedLayout).footer;
+      footer?.node.focus();
+      return;
     }
 
     let possibleNextCellIndex = notebook.activeCellIndex + 1;
@@ -873,6 +873,7 @@ export namespace NotebookActions {
     }
 
     const state = Private.getState(notebook);
+
     notebook.activeCellIndex = possibleNextCellIndex;
     notebook.deselectAll();
     Private.handleState(notebook, state, true);

--- a/packages/notebook/src/notebookfooter.ts
+++ b/packages/notebook/src/notebookfooter.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
 import { Widget } from '@lumino/widgets';
 import { Message } from '@lumino/messaging';
 import { Notebook } from './widget';

--- a/packages/notebook/src/notebookfooter.ts
+++ b/packages/notebook/src/notebookfooter.ts
@@ -54,21 +54,8 @@ export class NotebookFooter extends Widget {
    * On arrow up key pressed (keydown keyboard event), blur the footer and switch to command mode.
    */
   protected onArrowUp(): void {
-    this.blur();
-    this.notebook.mode = 'command';
-  }
-  /**
-   * Focus the footer and the hidden button
-   */
-  focus(): void {
-    this.node.focus();
-  }
-
-  /**
-   * Blur the footer and the hidden button
-   */
-  blur(): void {
     this.node.blur();
+    this.notebook.mode = 'command';
   }
 
   /*

--- a/packages/notebook/src/notebookfooter.ts
+++ b/packages/notebook/src/notebookfooter.ts
@@ -8,6 +8,8 @@ import { Message } from '@lumino/messaging';
 import { Notebook } from './widget';
 import { NotebookActions } from './actions';
 
+const NOTEBOOK_FOOTER_CLASS = 'jp-Notebook-footer';
+
 /**
  * A footer widget added after the last cell of the notebook.
  */
@@ -17,7 +19,11 @@ export class NotebookFooter extends Widget {
    */
   constructor(protected notebook: Notebook) {
     super();
-    this.node.className = 'jp-Notebook-footer';
+    this.addClass(NOTEBOOK_FOOTER_CLASS);
+    this._createHiddenButton();
+    const text = document.createElement('p');
+    text.innerText = 'Click to add a cell.';
+    this.node.appendChild(text);
   }
 
   /**
@@ -26,24 +32,53 @@ export class NotebookFooter extends Widget {
   handleEvent(event: Event): void {
     switch (event.type) {
       case 'click':
-        this.onClick(event);
+        this.onClick(event as MouseEvent);
         break;
+      case 'keydown':
+        if ((event as KeyboardEvent).key === 'ArrowUp') {
+          this.onArrowUp();
+          break;
+        }
     }
   }
 
   /**
-   * On single click, insert a cell below (at the end of the notebook as default behavior).
+   * On single click (mouse event), insert a cell below (at the end of the notebook as default behavior).
    */
   onClick(event: any): void {
     NotebookActions.insertBelow(this.notebook);
   }
 
+  /**
+   * On arrow up key pressed (keydown keyboard event), blur the footer and switch to command mode.
+   */
+  onArrowUp(): void {
+    this.blur();
+    this.notebook.mode = 'command';
+  }
+  /**
+   * Focus the footer and the hidden button
+   */
+  focus(): void {
+    this.addClass('focused');
+    this._hiddenButton.focus();
+  }
+
+  /**
+   * Blur the footer and the hidden button
+   */
+  blur(): void {
+    this.removeClass('focused');
+    this._hiddenButton.blur();
+  }
+
   /*
-   * Handle `before-detach` messages for the widget.
+   * Handle `after-detach` messages for the widget.
    */
   protected onAfterAttach(msg: Message): void {
     super.onAfterAttach(msg);
     this.node.addEventListener('click', this);
+    this.node.addEventListener('keydown', this);
   }
 
   /**
@@ -51,6 +86,16 @@ export class NotebookFooter extends Widget {
    */
   protected onBeforeDetach(msg: Message): void {
     this.node.removeEventListener('click', this);
+    this.node.removeEventListener('keydown', this);
     super.onBeforeDetach(msg);
   }
+  /**
+   * Create an hidden button in the notebookfooter widget that enables to add a new cell when it is cliked.
+   */
+  private _createHiddenButton(): void {
+    this._hiddenButton = document.createElement('button');
+    this._hiddenButton.classList.add('hidden');
+    this.node.appendChild(this._hiddenButton);
+  }
+  private _hiddenButton: HTMLButtonElement;
 }

--- a/packages/notebook/src/notebookfooter.ts
+++ b/packages/notebook/src/notebookfooter.ts
@@ -1,0 +1,32 @@
+import { Widget } from '@lumino/widgets';
+import { Message } from '@lumino/messaging';
+import { Notebook } from './widget';
+import { NotebookActions } from './actions';
+
+export class NotebookFooter extends Widget {
+  constructor(protected notebook: Notebook) {
+    super();
+    this.node.className = 'jp-Notebook-footer';
+  }
+
+  handleEvent(event: Event): void {
+    switch (event.type) {
+      case 'dblclick':
+        this.onDblClick(event);
+        break;
+    }
+  }
+
+  onDblClick(event: any): void {
+    NotebookActions.insertBelow(this.notebook);
+  }
+
+  protected onAfterAttach(msg: Message): void {
+    super.onAfterAttach(msg);
+    this.node.addEventListener('dblclick', this);
+  }
+  protected onBeforeDetach(msg: Message): void {
+    this.node.removeEventListener('dblclick', this);
+    super.onBeforeDetach(msg);
+  }
+}

--- a/packages/notebook/src/notebookfooter.ts
+++ b/packages/notebook/src/notebookfooter.ts
@@ -44,7 +44,6 @@ export class NotebookFooter extends Widget {
    * On single click (mouse event), insert a cell below (at the end of the notebook as default behavior).
    */
   protected onClick(): void {
-    console.log('notebook:', this.notebook);
     if (this.notebook.widgets.length > 0) {
       this.notebook.activeCellIndex = this.notebook.widgets.length - 1;
     }

--- a/packages/notebook/src/notebookfooter.ts
+++ b/packages/notebook/src/notebookfooter.ts
@@ -18,12 +18,10 @@ export class NotebookFooter extends Widget {
    * Construct a footer widget.
    */
   constructor(protected notebook: Notebook) {
-    super();
+    super({ node: document.createElement('button') });
+    const trans = notebook.translator.load('jupyterlab');
     this.addClass(NOTEBOOK_FOOTER_CLASS);
-    this._createHiddenButton();
-    const text = document.createElement('p');
-    text.innerText = 'Click to add a cell.';
-    this.node.appendChild(text);
+    this.node.innerText = trans.__('Click to add a cell.');
   }
 
   /**
@@ -32,7 +30,7 @@ export class NotebookFooter extends Widget {
   handleEvent(event: Event): void {
     switch (event.type) {
       case 'click':
-        this.onClick(event as MouseEvent);
+        this.onClick();
         break;
       case 'keydown':
         if ((event as KeyboardEvent).key === 'ArrowUp') {
@@ -45,14 +43,18 @@ export class NotebookFooter extends Widget {
   /**
    * On single click (mouse event), insert a cell below (at the end of the notebook as default behavior).
    */
-  onClick(event: any): void {
+  protected onClick(): void {
+    console.log('notebook:', this.notebook);
+    if (this.notebook.widgets.length > 0) {
+      this.notebook.activeCellIndex = this.notebook.widgets.length - 1;
+    }
     NotebookActions.insertBelow(this.notebook);
   }
 
   /**
    * On arrow up key pressed (keydown keyboard event), blur the footer and switch to command mode.
    */
-  onArrowUp(): void {
+  protected onArrowUp(): void {
     this.blur();
     this.notebook.mode = 'command';
   }
@@ -60,16 +62,14 @@ export class NotebookFooter extends Widget {
    * Focus the footer and the hidden button
    */
   focus(): void {
-    this.addClass('focused');
-    this._hiddenButton.focus();
+    this.node.focus();
   }
 
   /**
    * Blur the footer and the hidden button
    */
   blur(): void {
-    this.removeClass('focused');
-    this._hiddenButton.blur();
+    this.node.blur();
   }
 
   /*
@@ -89,13 +89,4 @@ export class NotebookFooter extends Widget {
     this.node.removeEventListener('keydown', this);
     super.onBeforeDetach(msg);
   }
-  /**
-   * Create an hidden button in the notebookfooter widget that enables to add a new cell when it is cliked.
-   */
-  private _createHiddenButton(): void {
-    this._hiddenButton = document.createElement('button');
-    this._hiddenButton.classList.add('hidden');
-    this.node.appendChild(this._hiddenButton);
-  }
-  private _hiddenButton: HTMLButtonElement;
 }

--- a/packages/notebook/src/notebookfooter.ts
+++ b/packages/notebook/src/notebookfooter.ts
@@ -11,22 +11,22 @@ export class NotebookFooter extends Widget {
 
   handleEvent(event: Event): void {
     switch (event.type) {
-      case 'dblclick':
-        this.onDblClick(event);
+      case 'click':
+        this.onClick(event);
         break;
     }
   }
 
-  onDblClick(event: any): void {
+  onClick(event: any): void {
     NotebookActions.insertBelow(this.notebook);
   }
 
   protected onAfterAttach(msg: Message): void {
     super.onAfterAttach(msg);
-    this.node.addEventListener('dblclick', this);
+    this.node.addEventListener('click', this);
   }
   protected onBeforeDetach(msg: Message): void {
-    this.node.removeEventListener('dblclick', this);
+    this.node.removeEventListener('click', this);
     super.onBeforeDetach(msg);
   }
 }

--- a/packages/notebook/src/notebookfooter.ts
+++ b/packages/notebook/src/notebookfooter.ts
@@ -3,12 +3,21 @@ import { Message } from '@lumino/messaging';
 import { Notebook } from './widget';
 import { NotebookActions } from './actions';
 
+/**
+ * A footer widget added after the last cell of the notebook.
+ */
 export class NotebookFooter extends Widget {
+  /**
+   * Construct a footer widget.
+   */
   constructor(protected notebook: Notebook) {
     super();
     this.node.className = 'jp-Notebook-footer';
   }
 
+  /**
+   * Handle incoming events.
+   */
   handleEvent(event: Event): void {
     switch (event.type) {
       case 'click':
@@ -17,14 +26,24 @@ export class NotebookFooter extends Widget {
     }
   }
 
+  /**
+   * On single click, insert a cell below (at the end of the notebook as default behavior).
+   */
   onClick(event: any): void {
     NotebookActions.insertBelow(this.notebook);
   }
 
+  /*
+   * Handle `before-detach` messages for the widget.
+   */
   protected onAfterAttach(msg: Message): void {
     super.onAfterAttach(msg);
     this.node.addEventListener('click', this);
   }
+
+  /**
+   * Handle `before-detach` messages for the widget.
+   */
   protected onBeforeDetach(msg: Message): void {
     this.node.removeEventListener('click', this);
     super.onBeforeDetach(msg);

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1204,6 +1204,7 @@ export class Notebook extends StaticNotebook {
     this.node.setAttribute('data-lm-dragscroll', 'true');
     this.activeCellChanged.connect(this._updateSelectedCells, this);
     this.selectionChanged.connect(this._updateSelectedCells, this);
+    this.addFooter();
   }
 
   /**
@@ -1240,7 +1241,6 @@ export class Notebook extends StaticNotebook {
         this.activeCellIndex = newActiveCellIndex;
       }
     }
-    this.addFooter();
   }
 
   /**

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1218,9 +1218,7 @@ export class Notebook extends StaticNotebook {
    * Adds a footer to the notebook.
    */
   protected addFooter(): void {
-    const trans = this.translator.load('jupyterlab');
     const info = new NotebookFooter(this);
-    info.node.textContent = trans.__('Click to add a cell.');
     (this.layout as NotebookWindowedLayout).footer = info;
   }
 

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1219,7 +1219,7 @@ export class Notebook extends StaticNotebook {
   protected addFooter(): void {
     const trans = this.translator.load('jupyterlab');
     const info = new NotebookFooter(this);
-    info.node.textContent = trans.__('Double-click here to add a new cell.');
+    info.node.textContent = trans.__('Click to add a cell.');
     (this.layout as NotebookWindowedLayout).footer = info;
   }
 

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -34,6 +34,7 @@ import { CellList } from './celllist';
 import { DROP_SOURCE_CLASS, DROP_TARGET_CLASS } from './constants';
 import { INotebookModel } from './model';
 import { NotebookViewModel, NotebookWindowedLayout } from './windowing';
+import { NotebookFooter } from './notebookfooter';
 
 /**
  * The data attribute added to a widget that has an active kernel.
@@ -1213,6 +1214,16 @@ export class Notebook extends StaticNotebook {
   }
 
   /**
+   * Adds a footer to the notebook.
+   */
+  protected addFooter(): void {
+    const trans = this.translator.load('jupyterlab');
+    const info = new NotebookFooter(this);
+    info.node.textContent = trans.__('Double-click here to add a new cell.');
+    (this.layout as NotebookWindowedLayout).footer = info;
+  }
+
+  /**
    * Handle a change cells event.
    */
   protected _onCellsChanged(
@@ -1229,6 +1240,7 @@ export class Notebook extends StaticNotebook {
         this.activeCellIndex = newActiveCellIndex;
       }
     }
+    this.addFooter();
   }
 
   /**

--- a/packages/notebook/src/windowing.ts
+++ b/packages/notebook/src/windowing.ts
@@ -112,13 +112,13 @@ export class NotebookWindowedLayout extends WindowedLayout {
   /**
    * Set Notebook's footer
    *
-   * @param v: Widget | null
+   * @param footer: Widget | null
    */
-  set footer(v: NotebookFooter | null) {
+  set footer(footer: NotebookFooter | null) {
     if (this._footer && this._footer.isAttached) {
       NotebookFooter.detach(this._footer);
     }
-    this._footer = v;
+    this._footer = footer;
     if (this._footer && this.parent?.isAttached) {
       NotebookFooter.attach(this._footer, this.parent!.node);
     }

--- a/packages/notebook/src/windowing.ts
+++ b/packages/notebook/src/windowing.ts
@@ -9,7 +9,7 @@ import {
   WindowedList,
   WindowedListModel
 } from '@jupyterlab/ui-components';
-import { MessageLoop } from '@lumino/messaging';
+import { Message, MessageLoop } from '@lumino/messaging';
 import { Widget } from '@lumino/widgets';
 import { DROP_SOURCE_CLASS, DROP_TARGET_CLASS } from './constants';
 import { NotebookFooter } from './notebookfooter';
@@ -76,7 +76,7 @@ export class NotebookWindowedLayout extends WindowedLayout {
   private _footer: NotebookFooter | null = null;
 
   /**
-   * Returns Notebook's header
+   * Notebook's header
    *
    * @return Widget | null
    */
@@ -87,7 +87,7 @@ export class NotebookWindowedLayout extends WindowedLayout {
   /**
    * Set Notebook's header
    *
-   * @param v: Widget | null
+   * @param header: Widget | null
    */
   set header(header: Widget | null) {
     if (this._header && this._header.isAttached) {
@@ -100,19 +100,14 @@ export class NotebookWindowedLayout extends WindowedLayout {
   }
 
   /**
-   * Returns Notebook's footer
+   ** Notebook widget's footer
    *
-   * @return NotebookFooter | null
-   */
+   **/
 
   get footer(): NotebookFooter | null {
     return this._footer;
   }
-  /**
-   * Set Notebook's footer
-   *
-   * @param footer: NotebookFooter | null
-   */
+
   set footer(footer: NotebookFooter | null) {
     if (this._footer && this._footer.isAttached) {
       NotebookFooter.detach(this._footer);
@@ -122,9 +117,35 @@ export class NotebookWindowedLayout extends WindowedLayout {
       NotebookFooter.attach(this._footer, this.parent!.node);
     }
   }
+
   /**
-   * Remove a widget from the layout.
-   *
+   * Dispose the layout
+   * */
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this._header?.dispose();
+    this._footer?.dispose();
+    super.dispose();
+  }
+
+  protected onAfterAttach(msg: Message): void {
+    if (this._header && !this._header.isAttached) {
+      Widget.attach(
+        this._header,
+        this.parent!.node,
+        this.parent!.node.firstElementChild as HTMLElement | null
+      );
+    }
+    if (this._footer && !this._footer.isAttached) {
+      Widget.attach(this._footer, this.parent!.node);
+    }
+  }
+
+  /**
+   * * A message handler invoked on a `'child-removed'` message.
+   * *
    * @param widget - The widget to remove from the layout.
    *
    * #### Notes

--- a/packages/notebook/src/windowing.ts
+++ b/packages/notebook/src/windowing.ts
@@ -100,20 +100,12 @@ export class NotebookWindowedLayout extends WindowedLayout {
   }
 
   /**
-   * Returns Notebook's footer
-   *
-   * @return NotebookFooter | null
+   * Notebook widget's footer
    */
 
   get footer(): NotebookFooter | null {
     return this._footer;
   }
-
-  /**
-   * Set Notebook's footer
-   *
-   * @param footer: Widget | null
-   */
   set footer(footer: NotebookFooter | null) {
     if (this._footer && this._footer.isAttached) {
       NotebookFooter.detach(this._footer);

--- a/packages/notebook/src/windowing.ts
+++ b/packages/notebook/src/windowing.ts
@@ -12,6 +12,7 @@ import {
 import { MessageLoop } from '@lumino/messaging';
 import { Widget } from '@lumino/widgets';
 import { DROP_SOURCE_CLASS, DROP_TARGET_CLASS } from './constants';
+import { NotebookFooter } from './notebookfooter';
 
 /**
  * Notebook view model for the windowed list.
@@ -72,6 +73,7 @@ export class NotebookViewModel extends WindowedListModel {
  */
 export class NotebookWindowedLayout extends WindowedLayout {
   private _header: Widget | null = null;
+  private _footer: NotebookFooter | null = null;
 
   /**
    * Returns Notebook's header
@@ -97,6 +99,30 @@ export class NotebookWindowedLayout extends WindowedLayout {
     }
   }
 
+  /**
+   * Returns Notebook's footer
+   *
+   * @return NotebookFooter | null
+   */
+
+  get footer(): NotebookFooter | null {
+    return this._footer;
+  }
+
+  /**
+   * Set Notebook's footer
+   *
+   * @param v: Widget | null
+   */
+  set footer(v: NotebookFooter | null) {
+    if (this._footer && this._footer.isAttached) {
+      NotebookFooter.detach(this._footer);
+    }
+    this._footer = v;
+    if (this._footer && this.parent?.isAttached) {
+      NotebookFooter.attach(this._footer, this.parent!.node);
+    }
+  }
   /**
    * Remove a widget from the layout.
    *

--- a/packages/notebook/src/windowing.ts
+++ b/packages/notebook/src/windowing.ts
@@ -12,7 +12,6 @@ import {
 import { Message, MessageLoop } from '@lumino/messaging';
 import { Widget } from '@lumino/widgets';
 import { DROP_SOURCE_CLASS, DROP_TARGET_CLASS } from './constants';
-import { NotebookFooter } from './notebookfooter';
 
 /**
  * Notebook view model for the windowed list.
@@ -73,22 +72,14 @@ export class NotebookViewModel extends WindowedListModel {
  */
 export class NotebookWindowedLayout extends WindowedLayout {
   private _header: Widget | null = null;
-  private _footer: NotebookFooter | null = null;
+  private _footer: Widget | null = null;
 
   /**
    * Notebook's header
-   *
-   * @return Widget | null
    */
   get header(): Widget | null {
     return this._header;
   }
-
-  /**
-   * Set Notebook's header
-   *
-   * @param header: Widget | null
-   */
   set header(header: Widget | null) {
     if (this._header && this._header.isAttached) {
       Widget.detach(this._header);
@@ -100,21 +91,18 @@ export class NotebookWindowedLayout extends WindowedLayout {
   }
 
   /**
-   ** Notebook widget's footer
-   *
-   **/
-
-  get footer(): NotebookFooter | null {
+   * Notebook widget's footer
+   */
+  get footer(): Widget | null {
     return this._footer;
   }
-
-  set footer(footer: NotebookFooter | null) {
+  set footer(footer: Widget | null) {
     if (this._footer && this._footer.isAttached) {
-      NotebookFooter.detach(this._footer);
+      Widget.detach(this._footer);
     }
     this._footer = footer;
     if (this._footer && this.parent?.isAttached) {
-      NotebookFooter.attach(this._footer, this.parent!.node);
+      Widget.attach(this._footer, this.parent!.node);
     }
   }
 
@@ -128,20 +116,6 @@ export class NotebookWindowedLayout extends WindowedLayout {
     this._header?.dispose();
     this._footer?.dispose();
     super.dispose();
-  }
-
-  protected onAfterAttach(msg: Message): void {
-    super.onAfterAttach(msg);
-    if (this._header && !this._header.isAttached) {
-      Widget.attach(
-        this._header,
-        this.parent!.node,
-        this.parent!.node.firstElementChild as HTMLElement | null
-      );
-    }
-    if (this._footer && !this._footer.isAttached) {
-      Widget.attach(this._footer, this.parent!.node);
-    }
   }
 
   /**
@@ -336,6 +310,30 @@ export class NotebookWindowedLayout extends WindowedLayout {
     } else {
       ref.insertAdjacentElement('beforebegin', widget.node);
     }
+  }
+
+  protected onAfterAttach(msg: Message): void {
+    super.onAfterAttach(msg);
+    if (this._header && !this._header.isAttached) {
+      Widget.attach(
+        this._header,
+        this.parent!.node,
+        this.parent!.node.firstElementChild as HTMLElement | null
+      );
+    }
+    if (this._footer && !this._footer.isAttached) {
+      Widget.attach(this._footer, this.parent!.node);
+    }
+  }
+
+  protected onBeforeDetach(msg: Message): void {
+    if (this._header?.isAttached) {
+      Widget.detach(this._header);
+    }
+    if (this._footer?.isAttached) {
+      Widget.detach(this._footer);
+    }
+    this.onBeforeDetach(msg);
   }
 
   /**

--- a/packages/notebook/src/windowing.ts
+++ b/packages/notebook/src/windowing.ts
@@ -333,7 +333,7 @@ export class NotebookWindowedLayout extends WindowedLayout {
     if (this._footer?.isAttached) {
       Widget.detach(this._footer);
     }
-    this.onBeforeDetach(msg);
+    super.onBeforeDetach(msg);
   }
 
   /**

--- a/packages/notebook/src/windowing.ts
+++ b/packages/notebook/src/windowing.ts
@@ -131,6 +131,7 @@ export class NotebookWindowedLayout extends WindowedLayout {
   }
 
   protected onAfterAttach(msg: Message): void {
+    super.onAfterAttach(msg);
     if (this._header && !this._header.isAttached) {
       Widget.attach(
         this._header,

--- a/packages/notebook/src/windowing.ts
+++ b/packages/notebook/src/windowing.ts
@@ -89,23 +89,30 @@ export class NotebookWindowedLayout extends WindowedLayout {
    *
    * @param v: Widget | null
    */
-  set header(v: Widget | null) {
+  set header(header: Widget | null) {
     if (this._header && this._header.isAttached) {
       Widget.detach(this._header);
     }
-    this._header = v;
+    this._header = header;
     if (this._header && this.parent?.isAttached) {
       Widget.attach(this._header, this.parent!.node);
     }
   }
 
   /**
-   * Notebook widget's footer
+   * Returns Notebook's footer
+   *
+   * @return NotebookFooter | null
    */
 
   get footer(): NotebookFooter | null {
     return this._footer;
   }
+  /**
+   * Set Notebook's footer
+   *
+   * @param footer: NotebookFooter | null
+   */
   set footer(footer: NotebookFooter | null) {
     if (this._footer && this._footer.isAttached) {
       NotebookFooter.detach(this._footer);

--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -10,6 +10,7 @@
 @import './toolbar.css';
 @import './executionindicator.css';
 @import './toc.css';
+@import './notebookfooter.css';
 
 /*-----------------------------------------------------------------------------
 | CSS variables

--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -27,6 +27,21 @@
 /*-----------------------------------------------------------------------------
 | Notebook
 |----------------------------------------------------------------------------*/
+.jp-Notebook-footer {
+  height: 10%;
+  width: calc(100%);
+  padding: 0;
+  color: transparent;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.jp-Notebook-footer:hover {
+  border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
+  border-radius: 0;
+  color: var(--jp-layout-color3);
+}
 
 /* stylelint-disable selector-max-class */
 

--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -28,21 +28,6 @@
 /*-----------------------------------------------------------------------------
 | Notebook
 |----------------------------------------------------------------------------*/
-.jp-Notebook-footer {
-  height: 10%;
-  width: calc(100%);
-  padding: 0;
-  color: transparent;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-.jp-Notebook-footer:hover {
-  border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
-  border-radius: 0;
-  color: var(--jp-layout-color3);
-}
 
 /* stylelint-disable selector-max-class */
 

--- a/packages/notebook/style/notebookfooter.css
+++ b/packages/notebook/style/notebookfooter.css
@@ -5,8 +5,6 @@
 
 .jp-Notebook-footer {
   height: 10%;
-
-  /*color: transparent;*/
   display: flex;
   justify-content: center;
   align-items: center;
@@ -15,8 +13,6 @@
     var(--jp-cell-prompt-width) + var(--jp-cell-collapser-width) +
       var(--jp-cell-padding)
   );
-
-  /*border: var(--jp-border-width);*/
   border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
   border-radius: 0;
   color: var(--jp-layout-color3);
@@ -37,3 +33,16 @@
   border-radius: 0;
   color: var(--jp-layout-color3);
 } */
+
+.jp-Notebook-footer.focused {
+  border: var(--jp-border-width) solid var(--jp-cell-editor-active-border-color);
+  box-shadow: var(--jp-input-box-shadow);
+  background-color: var(--jp-cell-editor-active-background);
+}
+
+.jp-Notebook-footer .hidden {
+  opacity: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}

--- a/packages/notebook/style/notebookfooter.css
+++ b/packages/notebook/style/notebookfooter.css
@@ -19,10 +19,10 @@
   border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
   color: var(--jp-layout-color3);
   margin-top: 6px;
+  background-color: transparent;
+  cursor: pointer;
 }
 
 .jp-Notebook-footer:focus {
   border: var(--jp-border-width) solid var(--jp-cell-editor-active-border-color);
-  box-shadow: var(--jp-input-box-shadow);
-  background-color: var(--jp-cell-editor-active-background);
 }

--- a/packages/notebook/style/notebookfooter.css
+++ b/packages/notebook/style/notebookfooter.css
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
 .jp-Notebook-footer {
   height: 10%;
   color: transparent;

--- a/packages/notebook/style/notebookfooter.css
+++ b/packages/notebook/style/notebookfooter.css
@@ -17,7 +17,7 @@
       )
   );
   border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
-  color: var(--jp-layout-color3);
+  color: var(--jp-ui-font-color3);
   margin-top: 6px;
   background: none;
   cursor: pointer;
@@ -27,7 +27,7 @@
   border-color: var(--jp-cell-editor-active-border-color);
 }
 
-/* For devices that support hovering, footer until hover */
+/* For devices that support hovering, hide footer until hover */
 @media (hover: hover) {
   .jp-Notebook-footer {
     opacity: 0;

--- a/packages/notebook/style/notebookfooter.css
+++ b/packages/notebook/style/notebookfooter.css
@@ -1,0 +1,19 @@
+.jp-Notebook-footer {
+  height: 10%;
+  color: transparent;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: var(--jp-cell-padding);
+  margin-left: calc(
+    var(--jp-cell-prompt-width) + var(--jp-cell-collapser-width) +
+      var(--jp-cell-padding)
+  );
+  border: var(--jp-border-width);
+}
+
+.jp-Notebook-footer:hover {
+  border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
+  border-radius: 0;
+  color: var(--jp-layout-color3);
+}

--- a/packages/notebook/style/notebookfooter.css
+++ b/packages/notebook/style/notebookfooter.css
@@ -4,45 +4,25 @@
  */
 
 .jp-Notebook-footer {
-  height: 10%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin: var(--jp-cell-padding);
+  height: 27px;
   margin-left: calc(
     var(--jp-cell-prompt-width) + var(--jp-cell-collapser-width) +
       var(--jp-cell-padding)
   );
+  width: calc(
+    100% -
+      (
+        var(--jp-cell-prompt-width) + var(--jp-cell-collapser-width) +
+          var(--jp-cell-padding) + var(--jp-cell-padding)
+      )
+  );
   border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
-  border-radius: 0;
   color: var(--jp-layout-color3);
+  margin-top: 6px;
 }
 
-/* For devices that support hovering, hide checkboxes until hovered, selected...*/
-
-/* @media (hover: hover) {
-  .jp-Notebook-footer:hover {
-    border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
-    border-radius: 0;
-    color: var(--jp-layout-color3);
-  }
-}*/
-
-/* .jp-Notebook-footer:hover {
-  border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
-  border-radius: 0;
-  color: var(--jp-layout-color3);
-} */
-
-.jp-Notebook-footer.focused {
+.jp-Notebook-footer:focus {
   border: var(--jp-border-width) solid var(--jp-cell-editor-active-border-color);
   box-shadow: var(--jp-input-box-shadow);
   background-color: var(--jp-cell-editor-active-background);
-}
-
-.jp-Notebook-footer .hidden {
-  opacity: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
 }

--- a/packages/notebook/style/notebookfooter.css
+++ b/packages/notebook/style/notebookfooter.css
@@ -12,8 +12,12 @@
   border: var(--jp-border-width);
 }
 
-.jp-Notebook-footer:hover {
-  border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
-  border-radius: 0;
-  color: var(--jp-layout-color3);
+/* For devices that support hovering, hide checkboxes until hovered, selected...*/
+
+@media (hover: hover) {
+  .jp-Notebook-footer:hover {
+    border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
+    border-radius: 0;
+    color: var(--jp-layout-color3);
+  }
 }

--- a/packages/notebook/style/notebookfooter.css
+++ b/packages/notebook/style/notebookfooter.css
@@ -5,7 +5,8 @@
 
 .jp-Notebook-footer {
   height: 10%;
-  color: transparent;
+
+  /*color: transparent;*/
   display: flex;
   justify-content: center;
   align-items: center;
@@ -14,15 +15,25 @@
     var(--jp-cell-prompt-width) + var(--jp-cell-collapser-width) +
       var(--jp-cell-padding)
   );
-  border: var(--jp-border-width);
+
+  /*border: var(--jp-border-width);*/
+  border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
+  border-radius: 0;
+  color: var(--jp-layout-color3);
 }
 
 /* For devices that support hovering, hide checkboxes until hovered, selected...*/
 
-@media (hover: hover) {
+/* @media (hover: hover) {
   .jp-Notebook-footer:hover {
     border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
     border-radius: 0;
     color: var(--jp-layout-color3);
   }
-}
+}*/
+
+/* .jp-Notebook-footer:hover {
+  border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
+  border-radius: 0;
+  color: var(--jp-layout-color3);
+} */

--- a/packages/notebook/style/notebookfooter.css
+++ b/packages/notebook/style/notebookfooter.css
@@ -19,10 +19,22 @@
   border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
   color: var(--jp-layout-color3);
   margin-top: 6px;
-  background-color: transparent;
+  background: none;
   cursor: pointer;
 }
 
 .jp-Notebook-footer:focus {
-  border: var(--jp-border-width) solid var(--jp-cell-editor-active-border-color);
+  border-color: var(--jp-cell-editor-active-border-color);
+}
+
+/* For devices that support hovering, footer until hover */
+@media (hover: hover) {
+  .jp-Notebook-footer {
+    opacity: 0;
+  }
+
+  .jp-Notebook-footer:focus,
+  .jp-Notebook-footer:hover {
+    opacity: 1;
+  }
 }

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -1414,18 +1414,14 @@ describe('@jupyter/notebook', () => {
         const child = widget.widgets[0];
         await framePromise();
         Widget.detach(widget);
-        expect(widget.methods).toEqual(
-          expect.arrayContaining(['onBeforeDetach'])
-        );
+        expect(widget.methods).toContain('onBeforeDetach');
         widget.events = [];
         simulate(widget.node, 'mousedown');
-        expect(widget.events).toEqual(
-          expect.not.arrayContaining(['mousedown'])
-        );
+        expect(widget.events).not.toContain('mousedown');
         simulate(widget.node, 'dblclick');
-        expect(widget.events).toEqual(expect.not.arrayContaining(['dblclick']));
+        expect(widget.events).not.toContain('dblclick');
         simulate(child.node, 'focusin');
-        expect(widget.events).toEqual(expect.not.arrayContaining(['focusin']));
+        expect(widget.events).not.toContain('focusin');
         widget.dispose();
       });
     });


### PR DESCRIPTION
Add a footer widget at the end of the notebook that is clickable, in a similar way to what exists in the classic notebook.

![add-cells-double-clicking1](https://user-images.githubusercontent.com/99649086/222706383-7ff460be-0262-4259-9f7b-955c0672c073.gif)


## References
Fixes #7535
## Code changes
- a new file `packages/notebooks/src/notebookfooter.ts` introducing the Notebook footer class has been added
- changes have been introduced in `packages/notebooks/src/widget.ts` and in `packages/notebooks/src/windowing.ts`
- css changes have been introduced in `packages/notebooks/style/base.css` to customize the footer widget

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
