### PR TITLE
Fixes contextual help attachment logic

### DIFF
--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -270,7 +270,9 @@ const notebooks: JupyterFrontEndPlugin<void> = {
 
       // Listen for active cell changes.
       parent.content.activeCellChanged.connect((sender, cell) => {
-        handler.editor = cell && cell.editor;
+        cell?.ready.then(() => {
+          handler.editor = cell && cell.editor;
+        });
       });
 
       // Listen for parent disposal.

--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -270,7 +270,7 @@ const notebooks: JupyterFrontEndPlugin<void> = {
 
       // Listen for active cell changes.
       parent.content.activeCellChanged.connect((sender, cell) => {
-        cell?.ready.then(() => {
+        void cell?.ready.then(() => {
           if (cell === parent.content.activeCell) {
             handler.editor = cell!.editor;
           }

--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -271,7 +271,9 @@ const notebooks: JupyterFrontEndPlugin<void> = {
       // Listen for active cell changes.
       parent.content.activeCellChanged.connect((sender, cell) => {
         cell?.ready.then(() => {
-          handler.editor = cell && cell.editor;
+          if (cell === parent.content.activeCell) {
+            handler.editor = cell!.editor;
+          }
         });
       });
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #13822.

## Code changes

Waits for the cell to be ready before attaching the contextual help handler.

## User-facing changes

Before the change, contextual help does not appear

![image](https://user-images.githubusercontent.com/8435071/213467593-16c761f5-6ca1-45ed-baec-7cdbdd1c6175.png)

After the change, contextual help appears

<img width="1289" alt="image" src="https://user-images.githubusercontent.com/93281816/222595188-23a982a9-ee85-4425-a4ff-1d329d8bb213.png">

NOTE: Using the exact code as in the "before" screen shot, I still don't see the contextual help appear after this patch.

## Backwards-incompatible changes

None
