### PR TITLE
Fix for "Dialogs have unreadable colour of links in dark mode #14084"

### DIFF
--- a/packages/application/style/buttons.css
+++ b/packages/application/style/buttons.css
@@ -94,7 +94,7 @@ button.jp-mod-styled.jp-mod-warn:focus-visible {
 
 .jp-Button-flat:hover {
   background-color: var(--jp-warn-color-hover, rgba(153, 153, 153, 0.1));
-  color: rgb(255,255,255) !important;
+  color: rgb(255, 255, 255) !important;
 }
 
 .jp-Button-flat:focus {

--- a/packages/application/style/buttons.css
+++ b/packages/application/style/buttons.css
@@ -94,6 +94,7 @@ button.jp-mod-styled.jp-mod-warn:focus-visible {
 
 .jp-Button-flat:hover {
   background-color: var(--jp-warn-color-hover, rgba(153, 153, 153, 0.1));
+  color: rgb(255,255,255) !important;
 }
 
 .jp-Button-flat:focus {

--- a/packages/ui-components/style/base.css
+++ b/packages/ui-components/style/base.css
@@ -40,7 +40,7 @@ a:hover {
 /* Accessibility for links inside dialog box text */
 .jp-Dialog-content a {
   text-decoration: revert;
-  color: revert;
+  color: var(--jp-content-link-color);
 }
 
 .jp-Dialog-content a:hover {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Addresses issue #14084
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Changes the color property on .jp-Dialog-content a (dialogue box text) to make them more visible in Dark Mode
Changes the hovered color property on .jp-Button-flat (button text) to make them more visible in Light and Dark Mode.
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
### Change 1
Under command palette in notebook > trust this notebook:

The color of the link/text "the Jupyter security documentation" went from a non legible dark blue to an easy to read light blue.

This changes the color of the element inside of Light and Dark Mode. Now, the link is easy to read on both.

DARKMODE - BEFORE

![linkBeforeDark](https://user-images.githubusercontent.com/8412613/222983200-4c3ea30e-e3b6-44ad-9658-46c1525beebb.png)

DARKMODE - AFTER

![linkAfterDark](https://user-images.githubusercontent.com/8412613/222983285-17f5a1b2-7c7b-4f45-af87-fb232c6d72c7.png)

LIGHTMODE - BEFORE

![linkBeforeLight](https://user-images.githubusercontent.com/8412613/222983468-521c0acf-7093-43d5-9d58-727005df2495.png)

LIGHTMODE - AFTER

![linkAfterLight](https://user-images.githubusercontent.com/8412613/222983480-87fef13d-c72b-4195-814e-2d0d36588d97.png)

### Sidenote on change 1

Although this was is not a change, this may want to be addressed later. The color on element referenced above still has the default non-legible dark blue color when the user hovers over it. This was not part of the original issue so i left it as is, I just wanted to point it out. I'll put screenshots below.

LIGHTMODE - SIDENOTE

![linkHoverAfterLight](https://user-images.githubusercontent.com/8412613/222983866-ba97693d-9e3c-47c5-b616-abb22e809108.png)

DARKMODE - SIDENOTE

![linkHoverAfterDark](https://user-images.githubusercontent.com/8412613/222983890-2c4f93c9-7a49-4ab4-b9fe-bf8ae49df501.png)




### Change 2
Under Help > About JupyterLab:

The color of the links inside of the buttons (while hovered) went from a non legible dark blue to an easy to read white.

This changes the color of the elements inside of Light and Dark Mode. Now the links are easy to read on both.

DARKMODE - BEFORE

![buttonBeforeDark](https://user-images.githubusercontent.com/8412613/222984027-1bedb40e-5bb8-475d-8731-ec0594e7f056.png)

DARKMODE - AFTER

![buttonAfterDark](https://user-images.githubusercontent.com/8412613/222984045-8d55bee2-2822-4030-86d8-e0a29e7a87d9.png)

LIGHTMODE - BEFORE

![buttonBeforeLight](https://user-images.githubusercontent.com/8412613/222984071-de6b6f4c-29a2-4c23-8605-11fc333767ef.png)

LIGHTMODE - AFTER

![buttonAfterLight](https://user-images.githubusercontent.com/8412613/222984082-ef2913b9-8a02-4e72-92dc-99bcbfe029ba.png)

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes
None.
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
