### PR TITLE
bug: Add fallback value for undefined className prop in GroupItem component

### DIFF
--- a/packages/statusbar/src/components/group.tsx
+++ b/packages/statusbar/src/components/group.tsx
@@ -13,7 +13,7 @@ export function GroupItem(
   const numChildren = React.Children.count(children);
 
   return (
-    <div className={`jp-StatusBar-GroupItem ${className}`} {...rest}>
+    <div className={`jp-StatusBar-GroupItem ${className || ''}`} {...rest}>
       {React.Children.map(children, (child, i) => {
         if (i === 0) {
           return <div style={{ marginRight: `${spacing}px` }}>{child}</div>;


### PR DESCRIPTION
## References
- Fixes [The class name of status bar items includes undefined #14083](https://github.com/jupyterlab/jupyterlab/issues/14083)

## Code changes
This pull request adds a fallback value to the className prop in the GroupItem component in order to resolve 'undefined' being added as a class. The fallback value, `className || ''`, provides an empty string as a default value for the className prop in case it's undefined or falsy. This ensures that the resulting className string will always be defined, even if the className prop is not provided.

```diff
export function GroupItem(
  props: GroupItem.IProps & React.HTMLAttributes<HTMLDivElement>
): React.ReactElement<GroupItem.IProps> {
  const { spacing, children, className, ...rest } = props;
  const numChildren = React.Children.count(children);

  return (
-    <div className={`jp-StatusBar-GroupItem ${className}`} {...rest}>
+    <div className={`jp-StatusBar-GroupItem ${className || ''}`} {...rest}>
     {React.Children.map(children, (child, i) => {
        if (i === 0) {
          return <div style={{ marginRight: `${spacing}px` }}>{child}</div>;
        } else if (i === numChildren - 1) {
          return <div style={{ marginLeft: `${spacing}px` }}>{child}</div>;
        } else {
          return <div style={{ margin: `0px ${spacing}px` }}>{child}</div>;
        }
      })}
    </div>
  );
}
```

## User-facing changes
None I'm aware of

## Backwards-incompatible changes
None I'm aware of


*Note: I am brand new to open source and this is my first commit to a code base. I am trying my best to make this PR correctly, but please forgive me if I've made a mistake. I would be extremely grateful for any feedback, in general or specific to my proposed solution.*