### PR TITLE
Micro update terminal.rst: added xonsh

### DIFF
--- a/docs/source/user/directories.rst
+++ b/docs/source/user/directories.rst
@@ -87,7 +87,7 @@ application environment.
 
 The following configurations may be present in this file:
 
-1. ``terminalsAvailable`` identifies whether a terminal (i.e. ``bash/tsch``
+1. ``terminalsAvailable`` identifies whether a terminal (i.e. ``bash/tsch/xonsh``
    on Mac/Linux OR ``PowerShell`` on Windows) is available to be launched
    via the Launcher. (This configuration was predominantly required for
    Windows prior to PowerShell access being enabled in Jupyter Lab.) The

--- a/docs/source/user/terminal.rst
+++ b/docs/source/user/terminal.rst
@@ -3,7 +3,7 @@
 Terminals
 ==========
 
-JupyterLab terminals provide full support for system shells (bash, tsch,
+JupyterLab terminals provide full support for system shells (bash, tsch, xonsh,
 etc.) on Mac/Linux and PowerShell on Windows. You can run anything in
 your system shell with a terminal, including programs such as vim or
 emacs. The terminals run on the system where the Jupyter server is


### PR DESCRIPTION
Hello! JupyterLab is awesome! 

I added small mention of the python-powered [xonsh shell](https://xon.sh) because with xonsh the shell in JupyterLab becomes supercharged. You can use python in the notebook as well as in the shell with xonsh. It's handy and easy. This is why xonsh mention is very appreciated here.

Thanks!