### PR TITLE
Clean up events service types in preparation for release

### DIFF
--- a/packages/services/src/event/index.ts
+++ b/packages/services/src/event/index.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { URLExt } from '@jupyterlab/coreutils';
-
+import { JSONObject, ReadonlyJSONObject } from '@lumino/coreutils';
 import { IDisposable } from '@lumino/disposable';
 import { Poll } from '@lumino/polling';
 import { IStream, Signal, Stream } from '@lumino/signaling';
@@ -144,8 +144,7 @@ export namespace Event {
   /**
    * The event emission type.
    */
-  export type Emission = {
-    [key: string]: any;
+  export type Emission = ReadonlyJSONObject & {
     schema_id: string;
   };
 
@@ -153,7 +152,7 @@ export namespace Event {
    * The event request type.
    */
   export type Request = {
-    data: { [key: string]: any };
+    data: JSONObject;
     schema_id: string;
     version: string;
   };


### PR DESCRIPTION
This is a follow-on PR to the events service functionality to use the JSON object types that are used by other `@jupyterlab/services`.

## Code changes
- Makes explicit use of `JSONObject` and `ReadonlyJSONObject` to define `Event.Emission` and `Event.Request` types.

## User-facing changes
N/A

## Backwards-incompatible changes
Updates the API from other pre-releases, but no release.