### PR TITLE
Remove deprecated code

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -327,6 +327,19 @@ Here are the changes in the Javascript package ``@jupyterlab/galata`` from 4.x t
      store in ``@jupyterlab/galata/lib/extension``. And the global object has been renamed ``window.galata`` instead
      of ``window.galataip`` (it still exists but it is deprecated).
 
+Deprecated code removed
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The following deprecated API's have been removed:
+
+- ``@jupyterlab/csvviewer``: ``CSVDelimiter.delimiterChanged`` has been removed - dead code. You can directly access the delimiter from the ``CSVViewer`` widget.
+- ``@jupyterlab/mainmenu``: ``IJupyterLabMenu`` and ``JupyterLabMenu`` have been removed. You can use directly ``IRankedMenu`` and ``RankedMenu`` from ``@jupyterlab/ui-components``
+- ``@jupyterlab/notebook``: ``NotebookWidgetFactory`` default toolbar is now empty as the button helpers are deprecated.
+- ``@jupyterlab/rendermime``: ``RenderMimeRegistry.IUrlResolverOptions`` does not accept ``session``; you must set the ``path`` (accessible through ``session.path``).
+- ``@jupyterlab/ui-components``:
+   * ``RankedMenu.menu : Menu`` has been removed as ``RankedMenu`` inherits from ``Menu``.
+   * ``LabIconStyle.IProps`` does not accept ``kind`` nor ``justify``. You should use ``stylesheet`` or ``elementPosition`` respectively.
+
 Extension Development Changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -476,7 +476,7 @@ export namespace CompletionHandler {
   /**
    * Connector for completion items.
    *
-   * @deprecated to add a new source of completions, register a completion provider;
+   * @deprecated since v4 to add a new source of completions, register a completion provider;
    *   to customise how completions get merged, provide a custom reconciliator.
    */
   export type ICompletionItemsConnector = IDataConnector<

--- a/packages/console/src/panel.ts
+++ b/packages/console/src/panel.ts
@@ -70,7 +70,7 @@ export class ConsolePanel extends MainAreaWidget<Panel> {
       });
 
     const resolver = new RenderMimeRegistry.UrlResolver({
-      session: sessionContext,
+      path,
       contents: manager.contents
     });
     rendermime = rendermime.clone({ resolver });

--- a/packages/csvviewer/src/toolbar.ts
+++ b/packages/csvviewer/src/toolbar.ts
@@ -4,7 +4,6 @@
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { Styling } from '@jupyterlab/ui-components';
 import { Message } from '@lumino/messaging';
-import { ISignal, Signal } from '@lumino/signaling';
 import { Widget } from '@lumino/widgets';
 import type { CSVViewer } from './widget';
 
@@ -36,16 +35,6 @@ export class CSVDelimiter extends Widget {
   }
 
   /**
-   * A signal emitted when the delimiter selection has changed.
-   *
-   * @deprecated since v3.2
-   * This is dead code now.
-   */
-  get delimiterChanged(): ISignal<this, string> {
-    return this._delimiterChanged;
-  }
-
-  /**
    * The delimiter dropdown menu.
    */
   get selectNode(): HTMLSelectElement {
@@ -65,7 +54,6 @@ export class CSVDelimiter extends Widget {
   handleEvent(event: Event): void {
     switch (event.type) {
       case 'change':
-        this._delimiterChanged.emit(this.selectNode.value);
         this._widget.delimiter = this.selectNode.value;
         break;
       default:
@@ -87,7 +75,6 @@ export class CSVDelimiter extends Widget {
     this.selectNode.removeEventListener('change', this);
   }
 
-  private _delimiterChanged = new Signal<this, string>(this);
   protected _widget: CSVViewer;
 }
 

--- a/packages/csvviewer/test/toolbar.spec.ts
+++ b/packages/csvviewer/test/toolbar.spec.ts
@@ -40,17 +40,14 @@ describe('csvviewer/toolbar', () => {
 
     describe('#delimiterChanged', () => {
       it('should emit a value when the dropdown value changes', () => {
-        const widget = new CSVDelimiter({ widget: mockViewer() });
-        let delimiterTest = '';
+        const parent = mockViewer();
+        const widget = new CSVDelimiter({ widget: parent });
         const index = DELIMITERS.length - 1;
         const wanted = DELIMITERS[index];
-        widget.delimiterChanged.connect((s, value) => {
-          delimiterTest = value;
-        });
         Widget.attach(widget, document.body);
         widget.selectNode.selectedIndex = index;
         simulate(widget.selectNode, 'change');
-        expect(delimiterTest).toBe(wanted);
+        expect(parent.delimiter).toBe(wanted);
         widget.dispose();
       });
     });

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -28,7 +28,6 @@ import {
   IRunMenu,
   ITabsMenu,
   IViewMenu,
-  JupyterLabMenu,
   MainMenu
 } from '@jupyterlab/mainmenu';
 import { ServerConnection } from '@jupyterlab/services';
@@ -36,6 +35,7 @@ import { ISettingRegistry, SettingRegistry } from '@jupyterlab/settingregistry';
 import { ITranslator, TranslationBundle } from '@jupyterlab/translation';
 import {
   fastForwardIcon,
+  RankedMenu,
   refreshIcon,
   runIcon,
   stopIcon
@@ -154,7 +154,7 @@ const plugin: JupyterFrontEndPlugin<IMainMenu> = {
     if (registry) {
       await Private.loadSettingsMenu(
         registry,
-        (aMenu: JupyterLabMenu) => {
+        (aMenu: RankedMenu) => {
           menu.addMenu(aMenu, false, { rank: aMenu.rank });
         },
         options => MainMenu.generateMenu(commands, options, trans),
@@ -784,7 +784,7 @@ namespace Private {
   export async function loadSettingsMenu(
     registry: ISettingRegistry,
     addMenu: (menu: Menu) => void,
-    menuFactory: (options: IMainMenu.IMenuOptions) => JupyterLabMenu,
+    menuFactory: (options: IMainMenu.IMenuOptions) => RankedMenu,
     translator: ITranslator
   ): Promise<void> {
     const trans = translator.load('jupyterlab');

--- a/packages/mainmenu/src/index.ts
+++ b/packages/mainmenu/src/index.ts
@@ -15,11 +15,3 @@ export * from './settings';
 export * from './view';
 export * from './tabs';
 export * from './tokens';
-
-/**
- * @deprecated since version 3.1
- */
-export {
-  IRankedMenu as IJupyterLabMenu,
-  RankedMenu as JupyterLabMenu
-} from '@jupyterlab/ui-components';

--- a/packages/metapackage/test/rendermime/registry.spec.ts
+++ b/packages/metapackage/test/rendermime/registry.spec.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { SessionContext } from '@jupyterlab/apputils';
 import { PageConfig } from '@jupyterlab/coreutils';
 import { MathJaxTypesetter } from '@jupyterlab/mathjax2';
 import {
@@ -319,7 +318,6 @@ describe('rendermime/registry', () => {
 
     describe('.UrlResolver', () => {
       let manager: ServiceManager.IManager;
-      let resolverSession: RenderMimeRegistry.UrlResolver;
       let resolverPath: RenderMimeRegistry.UrlResolver;
       let contents: Contents.IManager;
       let session: Session.ISessionConnection;
@@ -338,10 +336,6 @@ describe('rendermime/registry', () => {
           path: path,
           type: 'test'
         });
-        resolverSession = new RenderMimeRegistry.UrlResolver({
-          session,
-          contents: manager.contents
-        });
         resolverPath = new RenderMimeRegistry.UrlResolver({
           path: path,
           contents: manager.contents
@@ -354,40 +348,14 @@ describe('rendermime/registry', () => {
 
       describe('#constructor', () => {
         it('should create a UrlResolver instance', () => {
-          expect(resolverSession).toBeInstanceOf(
-            RenderMimeRegistry.UrlResolver
-          );
           expect(resolverPath).toBeInstanceOf(RenderMimeRegistry.UrlResolver);
         });
       });
 
       describe('.path', () => {
-        it('should give precedence to the explicit path over the session', async () => {
-          const resolver = new RenderMimeRegistry.UrlResolver({
-            session: new SessionContext({
-              sessionManager: manager.sessions,
-              specsManager: manager.kernelspecs,
-              path: pathParent + '/pr%25 ' + UUID.uuid4(),
-              kernelPreference: { canStart: false, shouldStart: false }
-            }),
-            contents: manager.contents,
-            path: '/some/path/file.txt'
-          });
-          expect(await resolver.resolveUrl('./foo')).toContain('some/path/foo');
-        });
-
-        it('should fall back to the session path if only the session is given', () => {
-          expect(resolverSession.path).toBe(path);
-        });
-
         it('should allow the path to be changed', async () => {
           const resolver = new RenderMimeRegistry.UrlResolver({
-            session: new SessionContext({
-              sessionManager: manager.sessions,
-              specsManager: manager.kernelspecs,
-              path: pathParent + '/pr%25 ' + UUID.uuid4(),
-              kernelPreference: { canStart: false, shouldStart: false }
-            }),
+            path: pathParent + '/pr%25 ' + UUID.uuid4(),
             contents: manager.contents
           });
           resolver.path = '/some/path/file.txt';
@@ -405,9 +373,6 @@ describe('rendermime/registry', () => {
 
       describe('#resolveUrl()', () => {
         it('should resolve a relative url', async () => {
-          expect(await resolverSession.resolveUrl('./foo')).toContain(
-            urlParent + '/foo'
-          );
           expect(await resolverPath.resolveUrl('./foo')).toContain(
             urlParent + '/foo'
           );
@@ -415,12 +380,7 @@ describe('rendermime/registry', () => {
 
         it('should resolve a relative url with no active session', async () => {
           const resolver = new RenderMimeRegistry.UrlResolver({
-            session: new SessionContext({
-              sessionManager: manager.sessions,
-              specsManager: manager.kernelspecs,
-              path: pathParent + '/pr%25 ' + UUID.uuid4(),
-              kernelPreference: { canStart: false, shouldStart: false }
-            }),
+            path: pathParent + '/pr%25 ' + UUID.uuid4(),
             contents: manager.contents
           });
           const path = await resolver.resolveUrl('./foo');
@@ -428,18 +388,12 @@ describe('rendermime/registry', () => {
         });
 
         it('should ignore urls that have a protocol', async () => {
-          expect(await resolverSession.resolveUrl('http://foo')).toContain(
-            'http://foo'
-          );
           expect(await resolverPath.resolveUrl('http://foo')).toContain(
             'http://foo'
           );
         });
 
         it('should resolve URLs with escapes', async () => {
-          expect(
-            await resolverSession.resolveUrl('has%20space%23hash')
-          ).toContain(urlParent + '/has%20space%23hash');
           expect(await resolverPath.resolveUrl('has%20space%23hash')).toContain(
             urlParent + '/has%20space%23hash'
           );

--- a/packages/notebook/src/default-toolbar.tsx
+++ b/packages/notebook/src/default-toolbar.tsx
@@ -249,6 +249,8 @@ export namespace ToolbarItems {
 
   /**
    * Get the default toolbar items for panel
+   *
+   * @deprecated since v4
    */
   export function getDefaultItems(
     panel: NotebookPanel,

--- a/packages/notebook/src/widgetfactory.ts
+++ b/packages/notebook/src/widgetfactory.ts
@@ -1,15 +1,11 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import {
-  ISessionContextDialogs,
-  sessionContextDialogs
-} from '@jupyterlab/apputils';
+import { ISessionContextDialogs } from '@jupyterlab/apputils';
 import { IEditorMimeTypeService } from '@jupyterlab/codeeditor';
 import { ABCWidgetFactory, DocumentRegistry } from '@jupyterlab/docregistry';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { ITranslator } from '@jupyterlab/translation';
-import { ToolbarItems } from './default-toolbar';
 import { INotebookModel } from './model';
 import { NotebookPanel } from './panel';
 import { StaticNotebook } from './widget';
@@ -35,7 +31,6 @@ export class NotebookWidgetFactory extends ABCWidgetFactory<
       options.editorConfig || StaticNotebook.defaultEditorConfig;
     this._notebookConfig =
       options.notebookConfig || StaticNotebook.defaultNotebookConfig;
-    this._sessionDialogs = options.sessionDialogs || sessionContextDialogs;
   }
 
   /*
@@ -101,22 +96,8 @@ export class NotebookWidgetFactory extends ABCWidgetFactory<
     return new NotebookPanel({ context, content });
   }
 
-  /**
-   * Default factory for toolbar items to be added after the widget is created.
-   */
-  protected defaultToolbarFactory(
-    widget: NotebookPanel
-  ): DocumentRegistry.IToolbarItem[] {
-    return ToolbarItems.getDefaultItems(
-      widget,
-      this._sessionDialogs,
-      this.translator
-    );
-  }
-
   private _editorConfig: StaticNotebook.IEditorConfig;
   private _notebookConfig: StaticNotebook.INotebookConfig;
-  private _sessionDialogs: ISessionContextDialogs;
 }
 
 /**

--- a/packages/notebook/test/widgetfactory.spec.ts
+++ b/packages/notebook/test/widgetfactory.spec.ts
@@ -103,9 +103,8 @@ describe('@jupyterlab/notebook', () => {
       it('should populate the default toolbar items', () => {
         const factory = utils.createNotebookWidgetFactory();
         const panel = factory.createNew(context);
-        const items = Array.from(panel.toolbar.names());
-        expect(items).toEqual(expect.arrayContaining(['save']));
-        expect(items).toEqual(expect.arrayContaining(['restart']));
+        // It will only contain the popup opener
+        expect(Array.from(panel.toolbar.names())).toHaveLength(1);
       });
 
       it('should populate the customized toolbar items', () => {

--- a/packages/rendermime/src/registry.ts
+++ b/packages/rendermime/src/registry.ts
@@ -2,10 +2,10 @@
 | Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
-import { ISanitizer, ISessionContext, Sanitizer } from '@jupyterlab/apputils';
+import { ISanitizer, Sanitizer } from '@jupyterlab/apputils';
 import { PathExt, URLExt } from '@jupyterlab/coreutils';
 import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
-import { Contents, Session } from '@jupyterlab/services';
+import { Contents } from '@jupyterlab/services';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
 import { MimeModel } from './mimemodel';
@@ -330,15 +330,7 @@ export namespace RenderMimeRegistry {
      * Create a new url resolver.
      */
     constructor(options: IUrlResolverOptions) {
-      if (options.path) {
-        this._path = options.path;
-      } else if (options.session) {
-        this._session = options.session;
-      } else {
-        throw new Error(
-          "Either 'path' or 'session' must be given as a constructor option"
-        );
-      }
+      this._path = options.path;
       this._contents = options.contents;
     }
 
@@ -346,7 +338,7 @@ export namespace RenderMimeRegistry {
      * The path of the object, from which local urls can be derived.
      */
     get path(): string {
-      return this._path ?? this._session.path;
+      return this._path;
     }
     set path(value: string) {
       this._path = value;
@@ -410,7 +402,6 @@ export namespace RenderMimeRegistry {
     }
 
     private _path: string;
-    private _session: ISessionContext | Session.ISessionConnection;
     private _contents: Contents.IManager;
   }
 
@@ -424,20 +415,7 @@ export namespace RenderMimeRegistry {
      * #### Notes
      * Either session or path must be given, and path takes precedence.
      */
-    path?: string;
-
-    /**
-     * The session used by the resolver.
-     *
-     * @deprecated use the `path` option instead and update it as needed.
-     *
-     * #### Notes
-     * For convenience, this can be a session context as well. Either session
-     * or path must be given, and path takes precedence.
-     *
-     * TODO: remove this option and make `path` required.
-     */
-    session?: ISessionContext | Session.ISessionConnection;
+    path: string;
 
     /**
      * The contents manager used by the resolver.
@@ -477,13 +455,5 @@ namespace Private {
       }
       return p1.id - p2.id;
     });
-  }
-
-  export function sessionConnection(
-    s: Session.ISessionConnection | ISessionContext
-  ): Session.ISessionConnection | null {
-    return (s as any).sessionChanged
-      ? (s as ISessionContext).session
-      : (s as Session.ISessionConnection);
   }
 }

--- a/packages/ui-components/src/components/menu.ts
+++ b/packages/ui-components/src/components/menu.ts
@@ -111,16 +111,6 @@ export class RankedMenu extends Menu implements IRankedMenu {
   }
 
   /**
-   * The underlying Lumino menu.
-   *
-   * @deprecated since v3.1
-   * RankMenu inherits from Menu since v3.1
-   */
-  get menu(): Menu {
-    return this;
-  }
-
-  /**
    * Menu rank.
    */
   get rank(): number | undefined {

--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -720,7 +720,7 @@ export class WindowedList<
    *
    * @param scrollOffset Offset to scroll
    *
-   * @deprecated This is an internal helper. Prefer calling `scrollToItem`.
+   * @deprecated since v4 This is an internal helper. Prefer calling `scrollToItem`.
    */
   scrollTo(scrollOffset: number): void {
     if (!this.viewModel.windowingActive) {

--- a/packages/ui-components/src/style/icon.ts
+++ b/packages/ui-components/src/style/icon.ts
@@ -139,16 +139,6 @@ export namespace LabIconStyle {
      * the array, giving precedence to the rightmost values.
      */
     stylesheet?: ISheetResolvable | ISheetResolvable[];
-
-    /**
-     * @deprecated use stylesheet instead
-     */
-    kind?: IBuiltin;
-
-    /**
-     * @deprecated use elementPosition instead
-     */
-    justify?: 'center' | 'right' | 'left';
   }
 
   /**
@@ -529,24 +519,7 @@ export namespace LabIconStyle {
       return '';
     }
 
-    let {
-      elementPosition,
-      elementSize,
-      stylesheet,
-      kind,
-      justify,
-      ...elementCSS
-    } = props;
-
-    // DEPRECATED: alias kind => stylesheet
-    if (!stylesheet) {
-      stylesheet = kind;
-    }
-
-    // DEPRECATED: alias justify => elementPosition
-    if (!elementPosition) {
-      elementPosition = justify;
-    }
+    let { elementPosition, elementSize, stylesheet, ...elementCSS } = props;
 
     // add option args with defined values to overrides
     const options = {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes https://github.com/jupyterlab/jupyterlab/issues/13719
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
The following deprecated API's have been removed:

- ``@jupyterlab/csvviewer``: ``CSVDelimiter.delimiterChanged`` has been removed - dead code. You can directly access the delimiter from the ``CSVViewer`` widget.
- ``@jupyterlab/mainmenu``: ``IJupyterLabMenu`` and ``JupyterLabMenu`` have been removed. You can use directly ``IRankedMenu`` and ``RankedMenu`` from ``@jupyterlab/ui-components``
- ``@jupyterlab/notebook``: ``NotebookWidgetFactory`` default toolbar is now empty as the button helpers are deprecated.
- ``@jupyterlab/rendermime``: ``RenderMimeRegistry.IUrlResolverOptions`` does not accept ``session``; you must set the ``path`` (accessible through ``session.path``).
- ``@jupyterlab/ui-components``:
   * ``RankedMenu.menu : Menu`` has been removed as ``RankedMenu`` inherits from ``Menu``.
   * ``LabIconStyle.IProps`` does not accept ``kind`` nor ``justify``. You should use ``stylesheet`` or ``elementPosition`` respectively.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
Deprecated API (in 3.x or before) have been removed