### PR TITLE
Backport PR #14063 on branch 3.6.x (Fix non-document wide undo stack)

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -16,7 +16,7 @@
     "watch": "webpack --watch"
   },
   "resolutions": {
-    "@jupyter/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.3",
     "@jupyterlab/application": "~3.6.1",
     "@jupyterlab/application-extension": "~3.6.1",
     "@jupyterlab/apputils": "~3.6.1",

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -42,7 +42,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.3",
     "@jupyterlab/apputils": "^3.6.1",
     "@jupyterlab/attachments": "^3.6.1",
     "@jupyterlab/codeeditor": "^3.6.1",

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -510,7 +510,9 @@ export class AttachmentsCellModel extends CellModel {
     reinitialize?: boolean
   ): void {
     if (reinitialize) {
-      const attachments = ((sharedModel as unknown) as models.YRawCell).getAttachments();
+      const attachments = (
+        sharedModel as unknown as models.YRawCell
+      ).getAttachments();
       this._attachments.fromJSON(attachments ?? {});
     }
     super.switchSharedModel(sharedModel, reinitialize);
@@ -936,9 +938,11 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
   ): void {
     const codeCell = this.sharedModel as models.YCodeCell;
     globalModelDBMutex(() => {
-      codeCell.execution_count = args.newValue
-        ? (args.newValue as number)
-        : null;
+      codeCell.transact(() => {
+        codeCell.execution_count = args.newValue
+          ? (args.newValue as number)
+          : null;
+      }, false);
     });
     this.contentChanged.emit(void 0);
     this.stateChanged.emit({

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -510,9 +510,7 @@ export class AttachmentsCellModel extends CellModel {
     reinitialize?: boolean
   ): void {
     if (reinitialize) {
-      const attachments = (
-        sharedModel as unknown as models.YRawCell
-      ).getAttachments();
+      const attachments = ((sharedModel as unknown) as models.YRawCell).getAttachments();
       this._attachments.fromJSON(attachments ?? {});
     }
     super.switchSharedModel(sharedModel, reinitialize);

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -41,7 +41,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.3",
     "@jupyterlab/coreutils": "^5.6.1",
     "@jupyterlab/nbformat": "^3.6.1",
     "@jupyterlab/observables": "^4.6.1",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -39,7 +39,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.3",
     "@jupyterlab/apputils": "^3.6.1",
     "@jupyterlab/codeeditor": "^3.6.1",
     "@jupyterlab/coreutils": "^5.6.1",

--- a/packages/docprovider-extension/package.json
+++ b/packages/docprovider-extension/package.json
@@ -34,7 +34,7 @@
     "watch": "tsc -w --listEmittedFiles"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.3",
     "@jupyterlab/application": "^3.6.1",
     "@jupyterlab/coreutils": "^5.6.1",
     "@jupyterlab/docprovider": "^3.6.1",

--- a/packages/docprovider/package.json
+++ b/packages/docprovider/package.json
@@ -39,7 +39,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.3",
     "@jupyterlab/apputils": "^3.6.1",
     "@jupyterlab/coreutils": "^5.6.1",
     "@jupyterlab/services": "^6.6.1",

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -41,7 +41,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.3",
     "@jupyterlab/apputils": "^3.6.1",
     "@jupyterlab/codeeditor": "^3.6.1",
     "@jupyterlab/codemirror": "^3.6.1",

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -877,7 +877,7 @@
       "title": "Experimental settings to enable the undo/redo on the notebook document level.",
       "description": "Disable the undo/redo on the notebook document level, so actions independent cells can have their own history. The undo/redo never applies on the outputs, in other words, outputs don't have history. A moved cell completely looses history capability for now.",
       "type": "boolean",
-      "default": false
+      "default": true
     },
     "renderingLayout": {
       "title": "Rendering Layout",

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -628,21 +628,22 @@ export const notebookTrustItem: JupyterFrontEndPlugin<void> = {
 /**
  * The notebook widget factory provider.
  */
-const widgetFactoryPlugin: JupyterFrontEndPlugin<NotebookWidgetFactory.IFactory> = {
-  id: '@jupyterlab/notebook-extension:widget-factory',
-  provides: INotebookWidgetFactory,
-  requires: [
-    NotebookPanel.IContentFactory,
-    IEditorServices,
-    IRenderMimeRegistry,
-    ISessionContextDialogs,
-    IToolbarWidgetRegistry,
-    ITranslator
-  ],
-  optional: [ISettingRegistry],
-  activate: activateWidgetFactory,
-  autoStart: true
-};
+const widgetFactoryPlugin: JupyterFrontEndPlugin<NotebookWidgetFactory.IFactory> =
+  {
+    id: '@jupyterlab/notebook-extension:widget-factory',
+    provides: INotebookWidgetFactory,
+    requires: [
+      NotebookPanel.IContentFactory,
+      IEditorServices,
+      IRenderMimeRegistry,
+      ISessionContextDialogs,
+      IToolbarWidgetRegistry,
+      ITranslator
+    ],
+    optional: [ISettingRegistry],
+    activate: activateWidgetFactory,
+    autoStart: true
+  };
 
 /**
  * The cloned output provider.
@@ -1076,12 +1077,13 @@ function activateCodeConsole(
         // eslint-disable-next-line
         while (true) {
           code = srcLines.slice(firstLine, lastLine).join('\n');
-          const reply = await current.context.sessionContext.session?.kernel?.requestIsComplete(
-            {
-              // ipython needs an empty line at the end to correctly identify completeness of indented code
-              code: code + '\n\n'
-            }
-          );
+          const reply =
+            await current.context.sessionContext.session?.kernel?.requestIsComplete(
+              {
+                // ipython needs an empty line at the end to correctly identify completeness of indented code
+                code: code + '\n\n'
+              }
+            );
           if (reply?.content.status === 'complete') {
             if (curLine < lastLine) {
               // we find a block of complete statement containing the current line, great!
@@ -1433,8 +1435,8 @@ function activateNotebookHandler(
     factory.shutdownOnClose = settings.get('kernelShutdown')
       .composite as boolean;
 
-    modelFactory.disableDocumentWideUndoRedo = settings.get(
-      'experimentalDisableDocumentWideUndoRedo'
+    modelFactory.disableDocumentWideUndoRedo = !settings.get(
+      'documentWideUndoRedo'
     ).composite as boolean;
 
     updateTracker({
@@ -1456,11 +1458,11 @@ function activateNotebookHandler(
       type: 'notebook'
     });
     if (model != undefined) {
-      const widget = ((await commands.execute('docmanager:open', {
+      const widget = (await commands.execute('docmanager:open', {
         path: model.path,
         factory: FACTORY,
         kernel: { name: kernelName }
-      })) as unknown) as IDocumentWidget;
+      })) as unknown as IDocumentWidget;
       widget.isUntitled = true;
       return widget;
     }
@@ -2856,9 +2858,7 @@ namespace Private {
   /**
    * The default Export To ... formats and their human readable labels.
    */
-  export function getFormatLabels(
-    translator: ITranslator
-  ): {
+  export function getFormatLabels(translator: ITranslator): {
     [k: string]: string;
   } {
     translator = translator || nullTranslator;

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -628,22 +628,21 @@ export const notebookTrustItem: JupyterFrontEndPlugin<void> = {
 /**
  * The notebook widget factory provider.
  */
-const widgetFactoryPlugin: JupyterFrontEndPlugin<NotebookWidgetFactory.IFactory> =
-  {
-    id: '@jupyterlab/notebook-extension:widget-factory',
-    provides: INotebookWidgetFactory,
-    requires: [
-      NotebookPanel.IContentFactory,
-      IEditorServices,
-      IRenderMimeRegistry,
-      ISessionContextDialogs,
-      IToolbarWidgetRegistry,
-      ITranslator
-    ],
-    optional: [ISettingRegistry],
-    activate: activateWidgetFactory,
-    autoStart: true
-  };
+const widgetFactoryPlugin: JupyterFrontEndPlugin<NotebookWidgetFactory.IFactory> = {
+  id: '@jupyterlab/notebook-extension:widget-factory',
+  provides: INotebookWidgetFactory,
+  requires: [
+    NotebookPanel.IContentFactory,
+    IEditorServices,
+    IRenderMimeRegistry,
+    ISessionContextDialogs,
+    IToolbarWidgetRegistry,
+    ITranslator
+  ],
+  optional: [ISettingRegistry],
+  activate: activateWidgetFactory,
+  autoStart: true
+};
 
 /**
  * The cloned output provider.
@@ -1077,13 +1076,12 @@ function activateCodeConsole(
         // eslint-disable-next-line
         while (true) {
           code = srcLines.slice(firstLine, lastLine).join('\n');
-          const reply =
-            await current.context.sessionContext.session?.kernel?.requestIsComplete(
-              {
-                // ipython needs an empty line at the end to correctly identify completeness of indented code
-                code: code + '\n\n'
-              }
-            );
+          const reply = await current.context.sessionContext.session?.kernel?.requestIsComplete(
+            {
+              // ipython needs an empty line at the end to correctly identify completeness of indented code
+              code: code + '\n\n'
+            }
+          );
           if (reply?.content.status === 'complete') {
             if (curLine < lastLine) {
               // we find a block of complete statement containing the current line, great!
@@ -1458,11 +1456,11 @@ function activateNotebookHandler(
       type: 'notebook'
     });
     if (model != undefined) {
-      const widget = (await commands.execute('docmanager:open', {
+      const widget = ((await commands.execute('docmanager:open', {
         path: model.path,
         factory: FACTORY,
         kernel: { name: kernelName }
-      })) as unknown as IDocumentWidget;
+      })) as unknown) as IDocumentWidget;
       widget.isUntitled = true;
       return widget;
     }
@@ -2858,7 +2856,9 @@ namespace Private {
   /**
    * The default Export To ... formats and their human readable labels.
    */
-  export function getFormatLabels(translator: ITranslator): {
+  export function getFormatLabels(
+    translator: ITranslator
+  ): {
     [k: string]: string;
   } {
     translator = translator || nullTranslator;

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -41,7 +41,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.0",
+    "@jupyter/ydoc": "~0.2.3",
     "@jupyterlab/apputils": "^3.6.1",
     "@jupyterlab/cells": "^3.6.1",
     "@jupyterlab/codeeditor": "^3.6.1",

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1179,7 +1179,7 @@ export namespace NotebookActions {
    * @param notebook - The target notebook widget.
    *
    * #### Notes
-   * This is a no-op if if there are no cell actions to undo.
+   * This is a no-op if there are no cell actions to undo.
    */
   export function undo(notebook: Notebook): void {
     if (!notebook.model || !notebook.activeCell) {
@@ -1836,9 +1836,7 @@ export namespace NotebookActions {
    *
    * @param cell - The target cell widget.
    */
-  export function getHeadingInfo(
-    cell: Cell
-  ): {
+  export function getHeadingInfo(cell: Cell): {
     isHeading: boolean;
     headingLevel: number;
     collapsed?: boolean;

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1836,7 +1836,9 @@ export namespace NotebookActions {
    *
    * @param cell - The target cell widget.
    */
-  export function getHeadingInfo(cell: Cell): {
+  export function getHeadingInfo(
+    cell: Cell
+  ): {
     isHeading: boolean;
     headingLevel: number;
     collapsed?: boolean;

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -88,7 +88,7 @@ export class NotebookModel implements INotebookModel {
       this.modelDB = new ModelDB();
     }
     this.sharedModel = new models.YNotebook({
-      disableDocumentWideUndoRedo: options.disableDocumentWideUndoRedo ?? false
+      disableDocumentWideUndoRedo: options.disableDocumentWideUndoRedo ?? true
     }) as models.ISharedNotebook;
     this._isInitialized = options.isInitialized === false ? false : true;
     const factory =
@@ -592,6 +592,11 @@ export namespace NotebookModel {
 
     /**
      * Defines if the document can be undo/redo.
+     *
+     * Default: true
+     *
+     * @experimental
+     * @alpha
      */
     disableDocumentWideUndoRedo?: boolean;
 

--- a/packages/notebook/src/modelfactory.ts
+++ b/packages/notebook/src/modelfactory.ts
@@ -11,8 +11,7 @@ import { INotebookModel, NotebookModel } from './model';
  * A model factory for notebooks.
  */
 export class NotebookModelFactory
-  implements DocumentRegistry.IModelFactory<INotebookModel>
-{
+  implements DocumentRegistry.IModelFactory<INotebookModel> {
   /**
    * Construct a new notebook model factory.
    */

--- a/packages/notebook/src/modelfactory.ts
+++ b/packages/notebook/src/modelfactory.ts
@@ -11,14 +11,15 @@ import { INotebookModel, NotebookModel } from './model';
  * A model factory for notebooks.
  */
 export class NotebookModelFactory
-  implements DocumentRegistry.IModelFactory<INotebookModel> {
+  implements DocumentRegistry.IModelFactory<INotebookModel>
+{
   /**
    * Construct a new notebook model factory.
    */
   constructor(options: NotebookModelFactory.IOptions) {
     this._collaborative = options.collaborative ?? true;
     this._disableDocumentWideUndoRedo =
-      options.disableDocumentWideUndoRedo || false;
+      options.disableDocumentWideUndoRedo ?? true;
     const codeCellContentFactory = options.codeCellContentFactory;
     this.contentFactory =
       options.contentFactory ||
@@ -32,7 +33,13 @@ export class NotebookModelFactory
 
   /**
    * Define the disableDocumentWideUndoRedo property.
+   *
+   * @experimental
+   * @alpha
    */
+  get disableDocumentWideUndoRedo(): boolean {
+    return this._disableDocumentWideUndoRedo;
+  }
   set disableDocumentWideUndoRedo(disableDocumentWideUndoRedo: boolean) {
     this._disableDocumentWideUndoRedo = disableDocumentWideUndoRedo;
   }
@@ -137,6 +144,11 @@ export namespace NotebookModelFactory {
 
     /**
      * Defines if the document can be undo/redo.
+     *
+     * Default: true
+     *
+     * @experimental
+     * @alpha
      */
     disableDocumentWideUndoRedo?: boolean;
 

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -686,8 +686,8 @@ export class StaticNotebook extends Widget {
       contentFactory,
       updateEditorOnShow: false,
       placeholder: false,
-      showEditorForReadOnlyMarkdown: this._notebookConfig
-        .showEditorForReadOnlyMarkdown
+      showEditorForReadOnlyMarkdown:
+        this._notebookConfig.showEditorForReadOnlyMarkdown
     };
     const cell = this.contentFactory.createMarkdownCell(options, this);
     cell.syncCollapse = true;
@@ -833,12 +833,13 @@ export class StaticNotebook extends Widget {
     );
 
     // Control editor visibility for read-only Markdown cells
-    const showEditorForReadOnlyMarkdown = this._notebookConfig
-      .showEditorForReadOnlyMarkdown;
+    const showEditorForReadOnlyMarkdown =
+      this._notebookConfig.showEditorForReadOnlyMarkdown;
     if (showEditorForReadOnlyMarkdown !== undefined) {
       for (const cell of this.widgets) {
         if (cell.model.type === 'markdown') {
-          (cell as MarkdownCell).showEditorForReadOnly = showEditorForReadOnlyMarkdown;
+          (cell as MarkdownCell).showEditorForReadOnly =
+            showEditorForReadOnlyMarkdown;
         }
       }
     }
@@ -1090,7 +1091,7 @@ export namespace StaticNotebook {
     observedBottomMargin: '1000px',
     maxNumberOutputs: 50,
     showEditorForReadOnlyMarkdown: true,
-    disableDocumentWideUndoRedo: false,
+    disableDocumentWideUndoRedo: true,
     renderingLayout: 'default',
     sideBySideLeftMarginOverride: '10px',
     sideBySideRightMarginOverride: '10px',
@@ -1102,7 +1103,8 @@ export namespace StaticNotebook {
    */
   export class ContentFactory
     extends Cell.ContentFactory
-    implements IContentFactory {
+    implements IContentFactory
+  {
     /**
      * Create a new code cell widget.
      *

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -686,8 +686,8 @@ export class StaticNotebook extends Widget {
       contentFactory,
       updateEditorOnShow: false,
       placeholder: false,
-      showEditorForReadOnlyMarkdown:
-        this._notebookConfig.showEditorForReadOnlyMarkdown
+      showEditorForReadOnlyMarkdown: this._notebookConfig
+        .showEditorForReadOnlyMarkdown
     };
     const cell = this.contentFactory.createMarkdownCell(options, this);
     cell.syncCollapse = true;
@@ -833,13 +833,12 @@ export class StaticNotebook extends Widget {
     );
 
     // Control editor visibility for read-only Markdown cells
-    const showEditorForReadOnlyMarkdown =
-      this._notebookConfig.showEditorForReadOnlyMarkdown;
+    const showEditorForReadOnlyMarkdown = this._notebookConfig
+      .showEditorForReadOnlyMarkdown;
     if (showEditorForReadOnlyMarkdown !== undefined) {
       for (const cell of this.widgets) {
         if (cell.model.type === 'markdown') {
-          (cell as MarkdownCell).showEditorForReadOnly =
-            showEditorForReadOnlyMarkdown;
+          (cell as MarkdownCell).showEditorForReadOnly = showEditorForReadOnlyMarkdown;
         }
       }
     }
@@ -1103,8 +1102,7 @@ export namespace StaticNotebook {
    */
   export class ContentFactory
     extends Cell.ContentFactory
-    implements IContentFactory
-  {
+    implements IContentFactory {
     /**
      * Create a new code cell widget.
      *

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -62,9 +62,7 @@ describe('@jupyterlab/notebook', () => {
         contentFactory: utils.createNotebookFactory(),
         mimeTypeService: utils.mimeTypeService
       });
-      const model = new NotebookModel({
-        disableDocumentWideUndoRedo: true
-      });
+      const model = new NotebookModel();
       model.fromJSON(utils.DEFAULT_CONTENT);
       widget.model = model;
       model.sharedModel.clearUndoHistory();

--- a/packages/notebook/test/model.spec.ts
+++ b/packages/notebook/test/model.spec.ts
@@ -72,9 +72,7 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should allow undoing a change', () => {
-        const model = new NotebookModel({
-          disableDocumentWideUndoRedo: true
-        });
+        const model = new NotebookModel();
         const cell = model.contentFactory.createCodeCell({});
         cell.value.text = 'foo';
         const cellJSON = cell.toJSON();

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     jupyter_core
     jupyterlab_server~=2.19
     jupyter_server>=1.16.0,<3
-    jupyter_ydoc~=0.2.2
+    jupyter_ydoc~=0.2.3
     jupyter_server_ydoc~=0.8.0
     nbclassic
     notebook<7

--- a/yarn.lock
+++ b/yarn.lock
@@ -1431,10 +1431,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@jupyter/ydoc@~0.2.0":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@jupyter/ydoc/-/ydoc-0.2.2.tgz#a2be83d2a0e076cef7ed77302e69153a0a4d6c16"
-  integrity sha512-UtU7ZxpL0k+QF9So4wtGxaS2C+nno58dig7sQUaBn48wlQDiuypzKgUmF7I37srpu6f/ywon3JBuEjxuL1CIBQ==
+"@jupyter/ydoc@~0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@jupyter/ydoc/-/ydoc-0.2.3.tgz#468a88d0250c5d59800a5cc15a33df211b4b2141"
+  integrity sha512-mwmlzOYXr4StXL1ijrSkt6+Bu4cF5nZQAep2zULa5IDe/PVDBqDtMrLqZyKQOgB3IT/sLJidU1P3wTdb8bwmww==
   dependencies:
     "@jupyterlab/nbformat" "^3.0.0 || ^4.0.0-alpha.15"
     "@lumino/coreutils" "^1.11.0 || ^2.0.0-alpha.6"


### PR DESCRIPTION
Backport PR #14063

:warning: This changes the default value of `experimentalDisableDocumentWideUndoRedo` to `true` to recover the historical undo behavior