### PR TITLE
Removes named shells from docs

### DIFF
--- a/docs/source/user/directories.rst
+++ b/docs/source/user/directories.rst
@@ -90,9 +90,8 @@ application environment.
 
 The following configurations may be present in this file:
 
-1. ``terminalsAvailable`` identifies whether a terminal (i.e. ``bash/tsch``
-   on Mac/Linux OR ``PowerShell`` on Windows) is available to be launched
-   via the Launcher. (This configuration was predominantly required for
+1. ``terminalsAvailable`` identifies whether a terminal can be launched
+   via the Launcher. (This configuration was mostly required for
    Windows prior to PowerShell access being enabled in Jupyter Lab.) The
    value for this field is a Boolean: ``true`` or ``false``.
 2. ``disabledExtensions`` controls which extensions should not load at all.

--- a/docs/source/user/terminal.rst
+++ b/docs/source/user/terminal.rst
@@ -6,10 +6,9 @@
 Terminals
 ==========
 
-JupyterLab terminals provide full support for system shells (bash, tsch,
-etc.) on Mac/Linux and PowerShell on Windows. You can run anything in
-your system shell with a terminal, including programs such as vim or
-emacs. The terminals run on the system where the Jupyter server is
+JupyterLab terminals provide full support for system shells. You can
+run any binary or script on your system in a terminal. The terminals
+run on the system where the Jupyter server is
 running, with the privileges of your user. Thus, if JupyterLab is
 installed on your local machine, the JupyterLab terminals will run
 there.


### PR DESCRIPTION

## References

Alternative to #14147.

## Code changes

None.

## User-facing changes

Changes the documentation to remove specific mentions of shells, where possible, and makes additional copy edits for brevity.

## Backwards-incompatible changes

None.