### PR TITLE
Keep extension manager panel sizes when pagination changes

### DIFF
--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -740,7 +740,6 @@ export class ExtensionsPanel extends SidePanel {
       (this.content as AccordionPanel).collapse(0);
       (this.content as AccordionPanel).expand(1);
       (this.content as AccordionPanel).expand(2);
-      (this.content.layout as AccordionLayout).setRelativeSizes([0, 1, 1]);
     }
   }
 

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -659,7 +659,7 @@ export class ExtensionsPanel extends SidePanel {
       (this.content as AccordionPanel).collapse(2);
     }
 
-    this.model.stateChanged.connect(this._onDisclaimedChanged, this);
+    this.model.stateChanged.connect(this._onStateChanged, this);
   }
 
   /**
@@ -669,7 +669,7 @@ export class ExtensionsPanel extends SidePanel {
     if (this.isDisposed) {
       return;
     }
-    this.model.stateChanged.disconnect(this._onDisclaimedChanged, this);
+    this.model.stateChanged.disconnect(this._onStateChanged, this);
     super.dispose();
   }
 
@@ -735,12 +735,13 @@ export class ExtensionsPanel extends SidePanel {
     super.onActivateRequest(msg);
   }
 
-  private _onDisclaimedChanged(): void {
+  private _onStateChanged(): void {
     if (!this._wasDisclaimed && this.model.isDisclaimed) {
       (this.content as AccordionPanel).collapse(0);
       (this.content as AccordionPanel).expand(1);
       (this.content as AccordionPanel).expand(2);
     }
+    this._wasDisclaimed = this.model.isDisclaimed;
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->
fix https://github.com/jupyterlab/jupyterlab/issues/14088

## Code changes

<!-- Describe the code changes and how they address the issue. -->
packages/extensionmanager/src/widget.tsx

at _onDisclaimedChanged function cancel  setRelativeSizes
![image](https://user-images.githubusercontent.com/49218295/224536117-0452c426-3ca6-487d-9eb6-7bcb28747323.png)

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->
Maintain the height set by the user when updating the data

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
no