### PR TITLE
Prevent memory leak when clearing outputs via context menu

### DIFF
--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -54,6 +54,12 @@ export abstract class JupyterFrontEnd<
       sortBySelector: false
     });
 
+    this.contextMenu.menu.aboutToClose.connect(() => {
+      // Make sure we do not keep a reference to DOM node that was hovered over
+      // when the context menu was last opened in event's `target` property.
+      this._contextMenuEvent = null;
+    });
+
     // The default restored promise if one does not exist in the options.
     const restored = new Promise<void>(resolve => {
       requestAnimationFrame(() => {
@@ -203,7 +209,7 @@ export abstract class JupyterFrontEnd<
     }
   }
 
-  private _contextMenuEvent: MouseEvent;
+  private _contextMenuEvent: MouseEvent | null = null;
   private _format: U;
   private _formatChanged = new Signal<this, U>(this);
 }


### PR DESCRIPTION
## References

https://github.com/deshaw/jupyterlab-limit-output/issues/3#issuecomment-1465280675

## Code changes

Remove the reference to pointer event when then context menu closes.

## User-facing changes

Lower memory usage when clearing outputs after opening context menu (or closing file after opening a context menu on it, etc).

## Backwards-incompatible changes

None.