### PR TITLE
Add the releaser workflows to the repo

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -1,0 +1,42 @@
+name: "Step 1: Prep Release"
+on:
+  workflow_dispatch:
+    inputs:
+      version_spec:
+        description: "New Version Specifier"
+        default: "next"
+        required: false
+      branch:
+        description: "The branch to target"
+        required: false
+      post_version_spec:
+        description: "Post Version Specifier"
+        required: false
+      since:
+        description: "Use PRs with activity since this date or git reference"
+        required: false
+      since_last_stable:
+        description: "Use PRs with activity since the last stable git tag"
+        required: false
+        type: boolean
+jobs:
+  prep_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+      - name: Prep Release
+        id: prep-release
+        uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@v2
+        with:
+          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          version_spec: ${{ github.event.inputs.version_spec }}
+          post_version_spec: ${{ github.event.inputs.post_version_spec }}
+          target: ${{ github.event.inputs.target }}
+          branch: ${{ github.event.inputs.branch }}
+          since: ${{ github.event.inputs.since }}
+          since_last_stable: ${{ github.event.inputs.since_last_stable }}
+
+      - name: "** Next Step **"
+        run: |
+          echo "Optional): Review Draft Release: ${{ steps.prep-release.outputs.release_url }}"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,55 @@
+name: "Step 2: Publish Release"
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "The target branch"
+        required: false
+      release_url:
+        description: "The URL of the draft GitHub release"
+        required: false
+      steps_to_skip:
+        description: "Comma separated list of steps to skip"
+        required: false
+        default: "ensure-sha"
+
+jobs:
+  publish_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+      - name: Populate Release
+        id: populate-release
+        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@v2
+        with:
+          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          target: ${{ github.event.inputs.target }}
+          branch: ${{ github.event.inputs.branch }}
+          release_url: ${{ github.event.inputs.release_url }}
+          steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
+
+      - name: Finalize Release
+        id: finalize-release
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+          PYPI_TOKEN_MAP: ${{ secrets.PYPI_TOKEN_MAP }}
+          TWINE_USERNAME: __token__
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        uses: jupyter-server/jupyter-releaser/.github/actions/finalize-release@v2
+        with:
+          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          target: ${{ github.event.inputs.target }}
+          release_url: ${{ steps.populate-release.outputs.release_url }}
+
+      - name: "** Next Step **"
+        if: ${{ success() }}
+        run: |
+          echo "Verify the final release"
+          echo ${{ steps.finalize-release.outputs.release_url }}
+
+      - name: "** Failure Message **"
+        if: ${{ failure() }}
+        run: |
+          echo "Failed to Publish the Draft Release Url:"
+          echo ${{ steps.populate-release.outputs.release_url }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,11 +54,11 @@ The recommended time period for the Release Candidate phase is a minimum of 1 we
 
 ## Automated Releases with the Jupyter Releaser
 
-The recommended way to make a release is to use [`jupyter_releaser`](https://github.com/jupyter-server/jupyter_releaser#checklist-for-adoption).
+The recommended way to make a release is to use [`jupyter_releaser`](https://jupyter-releaser.readthedocs.io/en/latest/how_to_guides/convert_repo_from_repo.html).
 
 ### Workflow
 
-The full process is documented in https://jupyter-releaser.readthedocs.io/en/latest/get_started/making_release_from_releaser.html#making-your-first-release-from-jupyter-releaser. There is a recording of the full workflow on [YouTube](https://youtu.be/cdRvvyZvYKM).
+The full process is documented in https://jupyter-releaser.readthedocs.io/en/latest/get_started/making_release_from_repo.html. There is a recording of the full workflow on [YouTube](https://youtu.be/cdRvvyZvYKM).
 
 Here is a quick summary of the different steps.
 
@@ -69,11 +69,13 @@ It is good practice to let other maintainers and users know when starting a new 
 For this we usually leave a small message in the `jupyterlab` room on Gitter: https://gitter.im/jupyterlab/jupyterlab.
 Once the release is done, we also post a message with a link to the release notes, which include the changelog.
 
-#### Prep Release
+#### 1. Prep Release
 
 The first step is to generate a new changelog entry for the upcoming release.
 
-We use the "Prep Release" workflow as documented here: https://jupyter-releaser.readthedocs.io/en/latest/get_started/making_release_from_releaser.html#prep-release
+We use the "Prep Release" workflow as documented here: https://jupyter-releaser.readthedocs.io/en/latest/get_started/making_release_from_repo.html#prep-release
+
+Go the Actions tab of the JupyterLab Repo and click on the `1. Prep Release` workflow: https://github.com/jupyterlab/jupyterlab/actions
 
 The workflow takes a couple of input parameters. Here is an overview with example values:
 
@@ -94,11 +96,11 @@ Click on "Run workflow", then wait for:
 1. Tests to pass
 1. Merge the changelog PR
 
-### Full Release
+### 2. Publish Release
 
 #### PyPI and npm tokens
 
-Before running the "Full Release" workflow, make sure you have been added to:
+Before running the "Publish Release" workflow, make sure you have been added to:
 
 - the `jupyterlab` project on PyPI: https://pypi.org/project/jupyterlab/
 - the `@jupyterlab` organization on npm: https://www.npmjs.com/settings/jupyterlab/packages
@@ -107,18 +109,17 @@ Then create the PyPI and npm tokens. Check out the links in the [Jupyter Release
 
 #### Running the workflow
 
-On the `jupyter_releaser` fork, select the "Full Release" workflow.
+On the [Actions](https://github.com/jupyterlab/jupyterlab/actions) page, select the "2. Publish Release" workflow.
 
 Fill in the information as mentioned in the body of the changelog PR, for example:
 
-| Input        | Value                 |
-| ------------ | --------------------- |
-| Target       | jupyterlab/jupyterlab |
-| Branch       | master                |
-| Version Spec | next                  |
-| Since        | v4.0.0a15             |
+| Input                                 | Value                 |
+| ------------------------------------- | --------------------- |
+| The target branch                     | master                |
+| The URL of the draft GitHub release   |                       |
+| Comma separated list of steps to skip | ensure-sha            |
 
-The "Full Release" workflow:
+The "Publish Release" workflow:
 
 - builds and uploads the `jupyterlab` Python package to PyPI
 - builds the `@jupyterlab/*` packages and uploads them to `npm`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -113,11 +113,11 @@ On the [Actions](https://github.com/jupyterlab/jupyterlab/actions) page, select 
 
 Fill in the information as mentioned in the body of the changelog PR, for example:
 
-| Input                                 | Value                 |
-| ------------------------------------- | --------------------- |
-| The target branch                     | master                |
-| The URL of the draft GitHub release   |                       |
-| Comma separated list of steps to skip | ensure-sha            |
+| Input                                 | Value      |
+| ------------------------------------- | ---------- |
+| The target branch                     | master     |
+| The URL of the draft GitHub release   |            |
+| Comma separated list of steps to skip | ensure-sha |
 
 The "Publish Release" workflow:
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/team-compass/issues/165

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Add the Jupyter Releaser workflows to the repo so releases can more easily be made from https://github.com/jupyterlab/jupyterlab/actions
- [x] Skip `ensure-sha` for now https://github.com/jupyterlab/jupyterlab/issues/13442
- [x] Add `jupyterlab-bot` to the repo: https://github.com/jupyterlab-bot
- [x] Add `jupyterlab-releaser` to PyPI: https://pypi.org/user/jupyterlab-releaser
- [x] Add `jupyterlab-releaser-bot` to `npm`: https://www.npmjs.com/~jupyterlab-release-bot
- [x] Update `RELEASE.md` (update instructions and workflow names to releaser v2)
- [x] Add `ADMIN_TOKEN`
- [x] Add `PYPI_TOKEN`
- [x] Add `NPM_TOKEN`

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
