### PR TITLE
Fix save as in collaborative mode

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -56,4 +56,4 @@ dependencies:
   # extra conda stuff
   - jsonschema-with-format-nongpl
   - pip:
-    - jupyter-collaboration >=1.0.0a3
+    - jupyter-collaboration >=1.0.0a4

--- a/galata/test/galata/jupyterlabpage.spec.ts
+++ b/galata/test/galata/jupyterlabpage.spec.ts
@@ -79,7 +79,7 @@ test.describe('listeners', () => {
       const callback = d => {
         // We need to slightly wait before rejecting otherwise
         // the `locator('.jp-Dialog').waitFor()` is not resolved.
-        setTimeout(() => d?.reject(), 100);
+        setTimeout(() => d?.reject(), 200);
         window.galata.off('dialog', callback);
       };
       window.galata.on('dialog', callback);
@@ -108,7 +108,7 @@ test.describe('listeners', () => {
       const callback = d => {
         // We need to slightly wait before rejecting otherwise
         // the `locator('.jp-Dialog').waitFor()` is not resolved.
-        setTimeout(() => d?.reject(), 100);
+        setTimeout(() => d?.reject(), 200);
       };
       window.galata.once('dialog', callback);
     });

--- a/galata/test/galata/jupyterlabpage.spec.ts
+++ b/galata/test/galata/jupyterlabpage.spec.ts
@@ -79,7 +79,7 @@ test.describe('listeners', () => {
       const callback = d => {
         // We need to slightly wait before rejecting otherwise
         // the `locator('.jp-Dialog').waitFor()` is not resolved.
-        setTimeout(() => d?.reject(), 200);
+        setTimeout(() => d?.reject(), 100);
         window.galata.off('dialog', callback);
       };
       window.galata.on('dialog', callback);
@@ -108,7 +108,7 @@ test.describe('listeners', () => {
       const callback = d => {
         // We need to slightly wait before rejecting otherwise
         // the `locator('.jp-Dialog').waitFor()` is not resolved.
-        setTimeout(() => d?.reject(), 200);
+        setTimeout(() => d?.reject(), 100);
       };
       window.galata.once('dialog', callback);
     });

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -955,7 +955,24 @@ function addCommands(
             buttons: [Dialog.okButton()]
           });
         }
-        return context.saveAs();
+
+        const onChange = (
+          sender: Contents.IManager,
+          args: Contents.IChangedArgs
+        ) => {
+          console.debug('[CommandIDs.saveAs] fileChanged:', args);
+          if (args.type === 'save' && args.newValue?.path !== context.path) {
+            commands.execute(CommandIDs.open, {
+              path: args.newValue?.path
+            });
+          }
+        };
+        docManager.services.contents.fileChanged.connect(onChange);
+        context.saveAs().finally(() => {
+          console.debug('[CommandIDs.saveAs] finally');
+          docManager.services.contents.fileChanged.disconnect(onChange);
+          docManager.closeFile(context.path);
+        });
       }
     }
   });

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -960,17 +960,23 @@ function addCommands(
           sender: Contents.IManager,
           args: Contents.IChangedArgs
         ) => {
-          if (args.type === 'save' && args.newValue?.path !== context.path) {
+          if (
+            args.type === 'save' &&
+            args.newValue &&
+            args.newValue.path !== context.path
+          ) {
             void commands.execute(CommandIDs.open, {
-              path: args.newValue?.path
+              path: args.newValue.path
             });
           }
         };
         docManager.services.contents.fileChanged.connect(onChange);
-        context.saveAs().finally(() => {
-          docManager.services.contents.fileChanged.disconnect(onChange);
-          void docManager.closeFile(context.path);
-        });
+        context
+          .saveAs()
+          .then(() => void docManager.closeFile(context.path))
+          .finally(() =>
+            docManager.services.contents.fileChanged.disconnect(onChange)
+          );
       }
     }
   });

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -960,18 +960,16 @@ function addCommands(
           sender: Contents.IManager,
           args: Contents.IChangedArgs
         ) => {
-          console.debug('[CommandIDs.saveAs] fileChanged:', args);
           if (args.type === 'save' && args.newValue?.path !== context.path) {
-            commands.execute(CommandIDs.open, {
+            void commands.execute(CommandIDs.open, {
               path: args.newValue?.path
             });
           }
         };
         docManager.services.contents.fileChanged.connect(onChange);
         context.saveAs().finally(() => {
-          console.debug('[CommandIDs.saveAs] finally');
           docManager.services.contents.fileChanged.disconnect(onChange);
-          docManager.closeFile(context.path);
+          void docManager.closeFile(context.path);
         });
       }
     }

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -275,16 +275,19 @@ export class Context<
    */
   async saveAs(): Promise<void> {
     await this.ready;
+    const localPath = this._manager.contents.localPath(this.path);
+    const newLocalPath = await Private.getSavePath(localPath);
 
-    const newPath = await Private.getSavePath(this._path);
-
-    if (!newPath) {
+    if (!newLocalPath) {
       return Promise.reject('Save as cancelled by user.');
     }
-
     if (this.isDisposed) {
       return;
     }
+
+    const drive = this._manager.contents.driveName(this.path);
+    const newPath = drive == '' ? newLocalPath : `${drive}:${newLocalPath}`;
+
     if (newPath === this._path) {
       return this.save();
     }

--- a/packages/docregistry/test/context.spec.ts
+++ b/packages/docregistry/test/context.spec.ts
@@ -456,6 +456,15 @@ describe('docregistry/context', () => {
         await promise;
         expect(context.path).toBe(path);
       });
+
+      it('should be rejected if the user cancel the dialog', async () => {
+        await context.initialize(true);
+
+        const promise = context.saveAs();
+        await dismissDialog();
+
+        await expect(promise).rejects.toEqual('Save as cancelled by user.');
+      });
     });
 
     describe('#revert()', () => {

--- a/packages/docregistry/test/context.spec.ts
+++ b/packages/docregistry/test/context.spec.ts
@@ -376,11 +376,17 @@ describe('docregistry/context', () => {
         const oldPath = context.path;
         await context.saveAs();
         await promise;
-        expect(context.path).toBe(newPath);
+        // We no longer rename the current document
+        //expect(context.path).toBe(newPath);
         // Make sure the both files are there now.
         const model = await manager.contents.get('', { content: true });
         expect(model.content.find((x: any) => x.name === oldPath)).toBeTruthy();
         expect(model.content.find((x: any) => x.name === newPath)).toBeTruthy();
+
+        // Make sure both files are equal
+        const model1 = await manager.contents.get(oldPath, { content: true });
+        const model2 = await manager.contents.get(newPath, { content: true });
+        expect(model1.content).toEqual(model2.content);
       });
 
       it('should bring up a conflict dialog', async () => {
@@ -401,9 +407,22 @@ describe('docregistry/context', () => {
         });
         await context.initialize(true);
         const promise = func();
+
+        const oldPath = context.path;
         await context.saveAs();
         await promise;
-        expect(context.path).toBe(newPath);
+
+        // We no longer rename the current document
+        //expect(context.path).toBe(newPath);
+        // Make sure the both files are there now.
+        const model = await manager.contents.get('', { content: true });
+        expect(model.content.find((x: any) => x.name === oldPath)).toBeTruthy();
+        expect(model.content.find((x: any) => x.name === newPath)).toBeTruthy();
+
+        // Make sure both files are equal
+        const model1 = await manager.contents.get(oldPath, { content: true });
+        const model2 = await manager.contents.get(newPath, { content: true });
+        expect(model1.content).toEqual(model2.content);
       });
 
       it('should keep the file if overwrite is aborted', async () => {


### PR DESCRIPTION
Fixes #14107

## References
This PR was started in #14130 as a fix for lab v3.6. I am opening a new PR because we must also fix it in lab v4.

## Code changes
After saving the document with a different name, we do not rename the document in memory. Instead, we close it and open the new one.

## User-facing changes
In collaborative mode, we can not rename the document in memory. After a "Save As" action, we need to open the new document and close the old one. By closing the document and opening the new one, we are losing the state of the old document. Most editors do this, and, in my opinion, it is the most predictable behavior.

See https://github.com/jupyterlab/jupyterlab/pull/14130 for more context.

## Backwards-incompatible changes


## Screencast

https://user-images.githubusercontent.com/26092748/224733083-bc40840e-cd91-4bf3-8527-cb144b263e0c.mov

