### PR TITLE
Make codemirror state and view packages singleton

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -17,6 +17,8 @@
     "watch": "webpack --watch"
   },
   "resolutions": {
+    "@codemirror/state": "^6.2.0",
+    "@codemirror/view": "^6.7.0",
     "@jupyter/ydoc": "~0.3.4",
     "@jupyterlab/application": "~4.0.0-alpha.20",
     "@jupyterlab/application-extension": "~4.0.0-alpha.20",
@@ -259,6 +261,8 @@
     "buildDir": "./static",
     "outputDir": ".",
     "singletonPackages": [
+      "@codemirror/state",
+      "@codemirror/view",
       "@jupyter/ydoc",
       "@jupyterlab/application",
       "@jupyterlab/apputils",


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Adding a new extension in `jupyter-collaboration` to display the remote users selections/cursors I got hit by:

![image](https://user-images.githubusercontent.com/8435071/224784481-40b11392-bfaa-4729-a935-4401a771ac40.png)

If I tell the builder that the codemirror package are singleton, it fails to find them.

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Make codemirror state and view packages part of the shared singletons.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A