### PR TITLE
Add CellList as exported type

### DIFF
--- a/packages/notebook/src/index.ts
+++ b/packages/notebook/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 export * from './actions';
+export * from './celllist';
 export * from './default-toolbar';
 export * from './executionindicator';
 export * from './model';


### PR DESCRIPTION
## References

Closes #14184.

## Code changes

This PR adds `CellList` as an export from the `notebook` package.

## User-facing changes

None.

## Backwards-incompatible changes

None.
