### PR TITLE
Suppresses header check inside frontmatter

### DIFF
--- a/packages/toc/src/utils/markdown.ts
+++ b/packages/toc/src/utils/markdown.ts
@@ -82,10 +82,13 @@ export function getHeadings(text: string): IMarkdownHeading[] {
       continue;
     }
 
-    // Don't check for Markdown headings if in a YAML frontmatter block
-    if (line === '---') {
+    // Don't check for Markdown headings if in a YAML frontmatter block.
+    // We can only start a frontmatter block on the first line of the file.
+    // At other positions in a markdown file, '---' represents a horizontal rule.
+    if (line === '---' && (isFrontmatterBlock || lineIdx === 0)) {
       isFrontmatterBlock = !isFrontmatterBlock;
     }
+
     if (isFrontmatterBlock) {
       continue;
     }

--- a/packages/toc/src/utils/markdown.ts
+++ b/packages/toc/src/utils/markdown.ts
@@ -65,6 +65,7 @@ export function getHeadings(text: string): IMarkdownHeading[] {
   // Iterate over the lines to get the header level and text for each line:
   const headings = new Array<IMarkdownHeading>();
   let isCodeBlock;
+  let isFrontmatterBlock;
   for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
     const line = lines[lineIdx];
 
@@ -73,11 +74,19 @@ export function getHeadings(text: string): IMarkdownHeading[] {
       continue;
     }
 
-    // Don't check for Markdown headings if in a code block:
+    // Don't check for Markdown headings if in a code block
     if (line.startsWith('```')) {
       isCodeBlock = !isCodeBlock;
     }
     if (isCodeBlock) {
+      continue;
+    }
+
+    // Don't check for Markdown headings if in a YAML frontmatter block
+    if (line === '---') {
+      isFrontmatterBlock = !isFrontmatterBlock;
+    }
+    if (isFrontmatterBlock) {
       continue;
     }
 

--- a/packages/toc/src/utils/markdown.ts
+++ b/packages/toc/src/utils/markdown.ts
@@ -65,8 +65,27 @@ export function getHeadings(text: string): IMarkdownHeading[] {
   // Iterate over the lines to get the header level and text for each line:
   const headings = new Array<IMarkdownHeading>();
   let isCodeBlock;
-  let isFrontmatterBlock;
-  for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
+  let lineIdx = 0;
+
+  // Don't check for Markdown headings if in a YAML frontmatter block.
+  // We can only start a frontmatter block on the first line of the file.
+  // At other positions in a markdown file, '---' represents a horizontal rule.
+  if (lines[lineIdx] === '---' ) {
+    // Search for another '---' and treat that as the end of the frontmatter.
+    // If we don't find one, treat the file as containing no frontmatter.
+    for (
+      let frontmatterEndLineIdx = lineIdx + 1;
+      frontmatterEndLineIdx < lines.length;
+      frontmatterEndLineIdx++
+    ) {
+      if (lines[frontmatterEndLineIdx] === '---') {
+        lineIdx = frontmatterEndLineIdx + 1;
+        break;
+      }
+    }
+  }
+
+  for (; lineIdx < lines.length; lineIdx++) {
     const line = lines[lineIdx];
 
     if (line === '') {
@@ -79,17 +98,6 @@ export function getHeadings(text: string): IMarkdownHeading[] {
       isCodeBlock = !isCodeBlock;
     }
     if (isCodeBlock) {
-      continue;
-    }
-
-    // Don't check for Markdown headings if in a YAML frontmatter block.
-    // We can only start a frontmatter block on the first line of the file.
-    // At other positions in a markdown file, '---' represents a horizontal rule.
-    if (line === '---' && (isFrontmatterBlock || lineIdx === 0)) {
-      isFrontmatterBlock = !isFrontmatterBlock;
-    }
-
-    if (isFrontmatterBlock) {
       continue;
     }
 

--- a/packages/toc/src/utils/markdown.ts
+++ b/packages/toc/src/utils/markdown.ts
@@ -70,7 +70,7 @@ export function getHeadings(text: string): IMarkdownHeading[] {
   // Don't check for Markdown headings if in a YAML frontmatter block.
   // We can only start a frontmatter block on the first line of the file.
   // At other positions in a markdown file, '---' represents a horizontal rule.
-  if (lines[lineIdx] === '---' ) {
+  if (lines[lineIdx] === '---') {
     // Search for another '---' and treat that as the end of the frontmatter.
     // If we don't find one, treat the file as containing no frontmatter.
     for (

--- a/packages/toc/test/markdown.spec.ts
+++ b/packages/toc/test/markdown.spec.ts
@@ -230,7 +230,8 @@ front: matter
               skip: false
             }
           ]
-        ][
+        ],
+        [
           `---
 front: matter
 ---
@@ -240,8 +241,7 @@ front: matter
 # Header between horizontal rules
 ---
 
-# Header after horizontal rules`
-        ],
+# Header after horizontal rules`,
         [
           {
             text: 'Header',
@@ -268,7 +268,21 @@ front: matter
             skip: false
           }
         ]
-      ])('should extract headings from %s', (src, headers) => {
+      ],
+      [
+        `---
+# Header`,
+        [
+          {
+            text: 'Header',
+            level: 1,
+            line: 1,
+            raw: '# Header',
+            prefix: '1. ',
+            skip: false
+          }
+        ]
+      ]])('should extract headings from %s', (src, headers) => {
         const headings = TableOfContentsUtils.filterHeadings(
           TableOfContentsUtils.Markdown.getHeadings(src),
           {

--- a/packages/toc/test/markdown.spec.ts
+++ b/packages/toc/test/markdown.spec.ts
@@ -197,7 +197,10 @@ describe('TableOfContentsUtils', () => {
         ['---\n<h1>Title</h1>\n---', []],
         ['---\n# Title\n---', []],
         [
-          '---\n<h1>Ignored</h1>\n---\n# Title',
+          `---
+<h1>Ignored</h1>
+---
+# Title`,
           [
             {
               text: 'Title',
@@ -208,6 +211,62 @@ describe('TableOfContentsUtils', () => {
               skip: false
             }
           ]
+        ],
+        [
+          `---
+front: matter
+---
+
+# Header
+
+> this has whitespace _after_`,
+          [
+            {
+              text: 'Header',
+              level: 1,
+              line: 4,
+              raw: '# Header',
+              prefix: '1. ',
+              skip: false
+            }
+          ]
+        ][
+          `---
+front: matter
+---
+# Header
+          
+---
+# Header between horizontal rules
+---
+
+# Header after horizontal rules`
+        ],
+        [
+          {
+            text: 'Header',
+            level: 1,
+            line: 3,
+            raw: '# Header',
+            prefix: '1. ',
+            skip: false
+          },
+          {
+            text: 'Header between horizontal rules',
+            level: 1,
+            line: 6,
+            raw: '# Header between horizontal rules',
+            prefix: '2. ',
+            skip: false
+          },
+          {
+            text: 'Header after horizontal rules',
+            level: 1,
+            line: 9,
+            raw: '# Header after horizontal rules',
+            prefix: '3. ',
+            skip: false
+          }
         ]
       ])('should extract headings from %s', (src, headers) => {
         const headings = TableOfContentsUtils.filterHeadings(

--- a/packages/toc/test/markdown.spec.ts
+++ b/packages/toc/test/markdown.spec.ts
@@ -242,47 +242,48 @@ front: matter
 ---
 
 # Header after horizontal rules`,
+          [
+            {
+              text: 'Header',
+              level: 1,
+              line: 3,
+              raw: '# Header',
+              prefix: '1. ',
+              skip: false
+            },
+            {
+              text: 'Header between horizontal rules',
+              level: 1,
+              line: 6,
+              raw: '# Header between horizontal rules',
+              prefix: '2. ',
+              skip: false
+            },
+            {
+              text: 'Header after horizontal rules',
+              level: 1,
+              line: 9,
+              raw: '# Header after horizontal rules',
+              prefix: '3. ',
+              skip: false
+            }
+          ]
+        ],
         [
-          {
-            text: 'Header',
-            level: 1,
-            line: 3,
-            raw: '# Header',
-            prefix: '1. ',
-            skip: false
-          },
-          {
-            text: 'Header between horizontal rules',
-            level: 1,
-            line: 6,
-            raw: '# Header between horizontal rules',
-            prefix: '2. ',
-            skip: false
-          },
-          {
-            text: 'Header after horizontal rules',
-            level: 1,
-            line: 9,
-            raw: '# Header after horizontal rules',
-            prefix: '3. ',
-            skip: false
-          }
-        ]
-      ],
-      [
-        `---
+          `---
 # Header`,
-        [
-          {
-            text: 'Header',
-            level: 1,
-            line: 1,
-            raw: '# Header',
-            prefix: '1. ',
-            skip: false
-          }
+          [
+            {
+              text: 'Header',
+              level: 1,
+              line: 1,
+              raw: '# Header',
+              prefix: '1. ',
+              skip: false
+            }
+          ]
         ]
-      ]])('should extract headings from %s', (src, headers) => {
+      ])('should extract headings from %s', (src, headers) => {
         const headings = TableOfContentsUtils.filterHeadings(
           TableOfContentsUtils.Markdown.getHeadings(src),
           {

--- a/packages/toc/test/markdown.spec.ts
+++ b/packages/toc/test/markdown.spec.ts
@@ -235,7 +235,7 @@ front: matter
 front: matter
 ---
 # Header
-          
+
 ---
 # Header between horizontal rules
 ---

--- a/packages/toc/test/markdown.spec.ts
+++ b/packages/toc/test/markdown.spec.ts
@@ -193,7 +193,22 @@ describe('TableOfContentsUtils', () => {
         ['\nTitle\n\n--', []],
         ['```\n# Title\n```', []],
         ['```\nTitle\n--\n```', []],
-        ['```\n<h1>Title</h1>\n```', []]
+        ['```\n<h1>Title</h1>\n```', []],
+        ['---\n<h1>Title</h1>\n---', []],
+        ['---\n# Title\n---', []],
+        [
+          '---\n<h1>Ignored</h1>\n---\n# Title',
+          [
+            {
+              text: 'Title',
+              level: 1,
+              line: 3,
+              raw: '# Title',
+              prefix: '1. ',
+              skip: false
+            }
+          ]
+        ]
       ])('should extract headings from %s', (src, headers) => {
         const headings = TableOfContentsUtils.filterHeadings(
           TableOfContentsUtils.Markdown.getHeadings(src),


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #14200.

## Code changes

Suppresses Markdown header check inside YAML frontmatter, defined as lines surrounded by `---` on a line by itself.

## User-facing changes

In the Markdown block below, `Summary` and `Motivation` are recognized as headings, and nothing in the frontmatter is.

```
---
title: Adopting a text-based diagram syntax in Jupyter Markdown
authors: (alphabetically) Nick Bollweg (@bollwyvl)
issue-number: 100
pr-number: 101
date-started: 2021-03-14
---

# Summary

Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

# Motivation

Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
```

## Backwards-incompatible changes

None.
