### PR TITLE
Adds ids_only argument to the fetch settings request

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -112,6 +112,7 @@ module.exports = {
           'file_extension',
           'help_links',
           'hist_access_type',
+          'ids_only',
           'implementation_version',
           'installed_version',
           'is_allowed',

--- a/packages/apputils-extension/src/settingconnector.ts
+++ b/packages/apputils-extension/src/settingconnector.ts
@@ -39,12 +39,14 @@ export class SettingConnector extends DataConnector<
   }
 
   async list(
-    query: 'active' | 'all' = 'all'
+    query: 'active' | 'all' | 'ids' = 'all'
   ): Promise<{ ids: string[]; values: ISettingRegistry.IPlugin[] }> {
     const { isDeferred, isDisabled } = PageConfig.Extension;
-    const { ids, values } = await this._connector.list();
+    const { ids, values } = await this._connector.list(
+      query === 'ids' ? 'ids' : undefined
+    );
 
-    if (query === 'all') {
+    if (['all', 'ids'].includes(query)) {
       return { ids, values };
     }
 

--- a/packages/apputils-extension/src/settingconnector.ts
+++ b/packages/apputils-extension/src/settingconnector.ts
@@ -38,16 +38,24 @@ export class SettingConnector extends DataConnector<
     return throttlers[id].invoke();
   }
 
+  async list(query: 'ids'): Promise<{ ids: string[] }>;
+  async list(
+    query: 'active' | 'all'
+  ): Promise<{ ids: string[]; values: ISettingRegistry.IPlugin[] }>;
   async list(
     query: 'active' | 'all' | 'ids' = 'all'
-  ): Promise<{ ids: string[]; values: ISettingRegistry.IPlugin[] }> {
+  ): Promise<{ ids: string[]; values?: ISettingRegistry.IPlugin[] }> {
     const { isDeferred, isDisabled } = PageConfig.Extension;
     const { ids, values } = await this._connector.list(
       query === 'ids' ? 'ids' : undefined
     );
 
-    if (['all', 'ids'].includes(query)) {
+    if (query === 'all') {
       return { ids, values };
+    }
+
+    if (query === 'ids') {
+      return { ids };
     }
 
     return {

--- a/packages/apputils-extension/src/settingsplugin.ts
+++ b/packages/apputils-extension/src/settingsplugin.ts
@@ -39,7 +39,7 @@ export const settingsPlugin: JupyterFrontEndPlugin<ISettingRegistry> = {
     // setting registry.
     void app.restored.then(async () => {
       const plugins = await connector.list('ids');
-      plugins.ids.forEach(async (id, index) => {
+      plugins.ids.forEach(async id => {
         if (!app.hasPlugin(id) || isDisabled(id) || id in registry.plugins) {
           return;
         }
@@ -48,10 +48,11 @@ export const settingsPlugin: JupyterFrontEndPlugin<ISettingRegistry> = {
           await registry.load(id);
         } catch (error) {
           console.warn(`Settings failed to load for (${id})`, error);
-          if (plugins.values[index].schema['jupyter.lab.transform']) {
+          if (!app.isPluginActivated(id)) {
             console.warn(
-              `This may happen if {autoStart: false} in (${id}) ` +
-                `or if it is one of the deferredExtensions in page config.`
+              `If 'jupyter.lab.transform=true' in the plugin schema, this ` +
+                `may happen if {autoStart: false} in (${id}) or if it is ` +
+                `one of the deferredExtensions in page config.`
             );
           }
         }

--- a/packages/apputils-extension/src/settingsplugin.ts
+++ b/packages/apputils-extension/src/settingsplugin.ts
@@ -38,7 +38,7 @@ export const settingsPlugin: JupyterFrontEndPlugin<ISettingRegistry> = {
     // because otherwise, its settings will never become available in the
     // setting registry.
     void app.restored.then(async () => {
-      const plugins = await connector.list('all');
+      const plugins = await connector.list('ids');
       plugins.ids.forEach(async (id, index) => {
         if (!app.hasPlugin(id) || isDisabled(id) || id in registry.plugins) {
           return;


### PR DESCRIPTION
When the app is restored, the settings are requested again to use only the schema ids [here](https://github.com/jupyterlab/jupyterlab/blob/a396badbb6a3c840bdc088b22463fbcb42376bbe/packages/apputils-extension/src/settingsplugin.ts#L41).

This PR adds an optional argument to the `api/settings` request to retrieve only the IDs, and do not look into the schema and settings files.

The server side part of this feature is https://github.com/jupyterlab/jupyterlab_server/pull/385.

NOTE:
- this is backward compatible. If the server doesn't know this new argument, it will be ignored and the list of the settings and schema content will be returned as currently.

## References

Related to https://github.com/jupyterlab/jupyterlab_server/issues/380

## Code changes

Adds a new query option to the parameter of the `SettingsConnector.list()` and to the `service.settings.SettingManager.list()` methods.

## User-facing changes

None

## Backwards-incompatible changes

None