### PR TITLE
Fix save as without changing the file name

### DIFF
--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -965,6 +965,7 @@ function addCommands(
             args.newValue &&
             args.newValue.path !== context.path
           ) {
+            void docManager.closeFile(context.path);
             void commands.execute(CommandIDs.open, {
               path: args.newValue.path
             });
@@ -973,7 +974,6 @@ function addCommands(
         docManager.services.contents.fileChanged.connect(onChange);
         context
           .saveAs()
-          .then(() => void docManager.closeFile(context.path))
           .finally(() =>
             docManager.services.contents.fileChanged.disconnect(onChange)
           );

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -278,10 +278,7 @@ export class Context<
     const localPath = this._manager.contents.localPath(this.path);
     const newLocalPath = await Private.getSavePath(localPath);
 
-    if (!newLocalPath) {
-      return Promise.reject('Save as cancelled by user.');
-    }
-    if (this.isDisposed) {
+    if (this.isDisposed || !newLocalPath) {
       return;
     }
 

--- a/packages/docregistry/test/context.spec.ts
+++ b/packages/docregistry/test/context.spec.ts
@@ -470,6 +470,20 @@ describe('docregistry/context', () => {
         const res = await changed;
         expect(res[1].newValue?.path).toEqual(path);
       });
+
+      it('should no trigger save signal if the user cancel the dialog', async () => {
+        let saveEmitted = false;
+        await context.initialize(true);
+        manager.contents.fileChanged.connect((sender, args) => {
+          if (args.type === 'save') {
+            saveEmitted = true;
+          }
+        });
+        const promise = context.saveAs();
+        await dismissDialog();
+        await promise;
+        expect(saveEmitted).toEqual(false);
+      });
     });
 
     describe('#revert()', () => {

--- a/packages/docregistry/test/context.spec.ts
+++ b/packages/docregistry/test/context.spec.ts
@@ -12,6 +12,7 @@ import { Contents, ServiceManager } from '@jupyterlab/services';
 import {
   acceptDialog,
   dismissDialog,
+  signalToPromise,
   waitForDialog
 } from '@jupyterlab/testing';
 import { ServiceManagerMock } from '@jupyterlab/services/lib/testutils';
@@ -366,18 +367,26 @@ describe('docregistry/context', () => {
           await waitForDialog();
           const dialog = document.body.getElementsByClassName('jp-Dialog')[0];
           const input = dialog.getElementsByTagName('input')[0];
-
           input.value = newPath;
           await acceptDialog();
         };
         const promise = func();
         await initialize;
 
+        const changed = signalToPromise(manager.contents.fileChanged);
         const oldPath = context.path;
         await context.saveAs();
         await promise;
+
         // We no longer rename the current document
         //expect(context.path).toBe(newPath);
+
+        // Make sure the signal emitted has a different path
+        const res = await changed;
+        expect(res[1].type).toBe('save');
+        expect(res[1].newValue?.path).toEqual(newPath);
+        expect(res[1].newValue?.path !== oldPath).toBe(true);
+
         // Make sure the both files are there now.
         const model = await manager.contents.get('', { content: true });
         expect(model.content.find((x: any) => x.name === oldPath)).toBeTruthy();
@@ -449,21 +458,17 @@ describe('docregistry/context', () => {
       });
 
       it('should just save if the file name does not change', async () => {
+        const changed = signalToPromise(manager.contents.fileChanged);
+
         const path = context.path;
         await context.initialize(true);
         const promise = context.saveAs();
         await acceptDialog();
         await promise;
         expect(context.path).toBe(path);
-      });
 
-      it('should be rejected if the user cancel the dialog', async () => {
-        await context.initialize(true);
-
-        const promise = context.saveAs();
-        await dismissDialog();
-
-        await expect(promise).rejects.toEqual('Save as cancelled by user.');
+        const res = await changed;
+        expect(res[1].newValue?.path).toEqual(path);
       });
     });
 


### PR DESCRIPTION
Follow-up #14182

I just realized there is an issue. When saving the document with the same name, the Drive emits a `save` event with the same name, so we close the document but do not open the new one.

This fix will prevent closing the document if we are not opening a new one.


https://user-images.githubusercontent.com/26092748/225632450-ec712710-3882-4c3f-b974-f637b02f1705.mov


cc @fcollonval 

## References

## Code changes

## User-facing changes

## Backwards-incompatible changes
