### PR TITLE
Fix cursor placement in stdin history search and navigation

### DIFF
--- a/galata/test/jupyterlab/outputarea-stdin.test.ts
+++ b/galata/test/jupyterlab/outputarea-stdin.test.ts
@@ -50,6 +50,6 @@ test.describe('Stdin for ipdb', () => {
 
     // Check that the input remains focused and cursor is at the end.
     await page.keyboard.insertText('x');
-    await expect(page.locator('body')).toContainText('foofoox');
+    await expect(page.locator('.jp-Stdin-input')).toHaveValue('foofoox');
   });
 });

--- a/galata/test/jupyterlab/outputarea-stdin.test.ts
+++ b/galata/test/jupyterlab/outputarea-stdin.test.ts
@@ -12,7 +12,7 @@ test.describe('Stdin for ipdb', () => {
     await page.notebook.setCell(0, 'code', 'raise');
     await page.notebook.addCell('code', '%debug');
 
-    // Run first cell on proceed to the second one.
+    // Run first cell and proceed to the second one.
     await page.notebook.runCell(0);
 
     // Run the selected (second) cell without proceeding and without waiting
@@ -47,5 +47,9 @@ test.describe('Stdin for ipdb', () => {
     const imageName = 'stdin-history-search.png';
     const cell = await page.notebook.getCell(1);
     expect(await cell.screenshot()).toMatchSnapshot(imageName);
+
+    // Check that the input remains focused and cursor is at the end.
+    await page.keyboard.insertText('x');
+    await expect(page.locator('body')).toContainText('foofoox');
   });
 });

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -1159,7 +1159,7 @@ export class Stdin extends Widget implements IStdin {
 
   private _setInputValue(value: string) {
     this._input.value = value;
-    // Set cursor at the end; this is usyally not necessary when input is
+    // Set cursor at the end; this is usually not necessary when input is
     // focused but having the explicit placement ensures consistency.
     this._input.setSelectionRange(value.length, value.length);
   }

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -1098,8 +1098,11 @@ export class Stdin extends Widget implements IStdin {
               this._valueCache = input.value;
             }
 
-            input.value = historyLine;
+            this._setInputValue(historyLine);
             this._historyIndex = searchHistoryIx;
+            // The default action for ArrowUp is moving to first character
+            // but we want to keep the cursor at the end.
+            event.preventDefault();
           }
         }
       } else if (event.key === 'ArrowUp') {
@@ -1110,8 +1113,11 @@ export class Stdin extends Widget implements IStdin {
           if (this._historyIndex === 0) {
             this._valueCache = input.value;
           }
-          input.value = historyLine;
+          this._setInputValue(historyLine);
           --this._historyIndex;
+          // The default action for ArrowUp is moving to first character
+          // but we want to keep the cursor at the end.
+          event.preventDefault();
         }
       } else if (event.key === 'ArrowDown') {
         this.resetSearch();
@@ -1119,12 +1125,12 @@ export class Stdin extends Widget implements IStdin {
         if (this._historyIndex === 0) {
           // do nothing
         } else if (this._historyIndex === -1) {
-          input.value = this._valueCache;
+          this._setInputValue(this._valueCache);
           ++this._historyIndex;
         } else {
           const historyLine = Stdin._historyAt(this._historyIndex + 1);
           if (historyLine) {
-            input.value = historyLine;
+            this._setInputValue(historyLine);
             ++this._historyIndex;
           }
         }
@@ -1149,6 +1155,13 @@ export class Stdin extends Widget implements IStdin {
    */
   protected onBeforeDetach(msg: Message): void {
     this._input.removeEventListener('keydown', this);
+  }
+
+  private _setInputValue(value: string) {
+    this._input.value = value;
+    // Set cursor at the end; this is usyally not necessary when input is
+    // focused but having the explicit placement ensures consistency.
+    this._input.setSelectionRange(value.length, value.length);
   }
 
   private _future: Kernel.IShellFuture;


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/14222

## Code changes

Ensure the cursor is placed at the end by:
- preventing default action of the keydown event
- setting the selection at the end

## User-facing changes

Cursor stays at the end when using <kbd>arrow up</kbd> key

## Backwards-incompatible changes

None, but will require a manual backport