### PR TITLE
Specify peerDependencies to remove yarn warning

### DIFF
--- a/packages/settingregistry/package.json
+++ b/packages/settingregistry/package.json
@@ -54,6 +54,9 @@
     "rimraf": "~3.0.0",
     "typescript": "~5.0.2"
   },
+  "peerDependencies": {
+    "react": ">=16"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -56,6 +56,9 @@
     "rimraf": "~3.0.0",
     "typescript": "~5.0.2"
   },
+  "peerDependencies": {
+    "typescript": ">=4.3"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4442,6 +4442,8 @@ __metadata:
     json5: ^2.2.3
     rimraf: ~3.0.0
     typescript: ~5.0.2
+  peerDependencies:
+    react: ">=16"
   languageName: unknown
   linkType: soft
 
@@ -4607,6 +4609,8 @@ __metadata:
     simulate-event: ~1.4.0
     ts-jest: ^29.0.0
     typescript: ~5.0.2
+  peerDependencies:
+    typescript: ">=4.3"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Seen in https://github.com/jupyterlab/jupyter_collaboration/pull/123

```

> @jupyter/collaboration-extension:"build:prod"

Building extension in .
➤ YN0000: ┌ Resolution step
Resolution step
  ➤ YN0002: │ @jupyterlab/settingregistry@npm:4.0.0-alpha.22 doesn't provide react (pf1e37), requested by @rjsf/utils
  ➤ YN0002: │ @jupyterlab/testing@npm:4.0.0-alpha.22 doesn't provide typescript (p7b61a), requested by ts-jest
  ➤ YN0002: │ @nrwl/devkit@npm:15.7.2 [efc3e] doesn't provide typescript (p8a4c8), requested by @phenomnomnominal/tsquery
  ➤ YN0000: │ Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code
➤ YN0000: └ Completed in 0s 493ms
```
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Add peer dependencies to remove warnings; the dependencies constraints are the one of the third party libraries to avoid increasing constraints uselessly downstream.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None