### PR TITLE
Exclude .yarn cache from the dist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,7 +180,6 @@ exclude = [
     "*.js.map",
     "/jupyterlab/staging/build",
     "/jupyterlab/staging/.yarn",
-    "/jupyterlab/tests",
     "node_modules"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,7 @@ exclude = [
     "/examples",
     "/galata/lib",
     "/jupyterlab/staging/build",
+    "/jupyterlab/staging/.yarn",
     "/packages",
     "/release",
     "/testutils",
@@ -178,6 +179,8 @@ include = [
 exclude = [
     "*.js.map",
     "/jupyterlab/staging/build",
+    "/jupyterlab/staging/.yarn",
+    "/jupyterlab/tests",
     "node_modules"
 ]
 


### PR DESCRIPTION
## References

Fixes #14241

The last release of JupyterLab is 90Mb! https://pypi.org/project/jupyterlab/4.0.0a37/#files

This PR fixes it by removing the `.yarn` cache from the sdist and the wheel

Kudos to @trungleduc for spotting it