### PR TITLE
Fix failing `check_links` job

### DIFF
--- a/docs/source/extension/documents.rst
+++ b/docs/source/extension/documents.rst
@@ -38,7 +38,7 @@ communicate with each other.
 
 Models contain an instance of `ISharedDocument <https://jupyter-ydoc.readthedocs.io/en/latest/api/interfaces/ISharedDocument.html>`_
 that acts as data storage for the model's content. As of JupyterLab 4, the default data
-storage implementation is a `YDocument <https://jupyter-ydoc.readthedocs.io/en/latest/api/classes/YDocument.html>`_
+storage implementation is a `YDocument <https://jupyter-ydoc.readthedocs.io/en/latest/api/classes/YDocument-1.html>`_
 based on `Yjs <https://docs.yjs.dev>`_, a high-performance CRDT for building collaborative
 applications. Both the interface and the implementation are provided by the package
 `@jupyter/ydoc <https://github.com/jupyter-server/jupyter_ydoc>`_.


### PR DESCRIPTION
## References

Fixes #14248

As seen in #14238 and other PRs `check_links` job fails with:

```
docs/source/extension/documents.rst (second attempt)...

F                                                                        [100%]
=================================== FAILURES ===================================
_ /home/runner/work/jupyterlab/jupyterlab/docs/source/extension/documents.rst: https://jupyter-ydoc.readthedocs.io/en/latest/api/classes/YDocument.html _
https://jupyter-ydoc.readthedocs.io/en/latest/api/classes/YDocument.html: 404: Not Found
=============================== warnings summary ===============================
../../../../../opt/hostedtoolcache/Python/3.10.10/x64/lib/python3.10/site-packages/requests_cache/backends/base.py:324
  /opt/hostedtoolcache/Python/3.10.10/x64/lib/python3.10/site-packages/requests_cache/backends/base.py:324: DeprecationWarning: BaseCache.remove_expired_responses() is deprecated; please use .delete(expired=True) instead
    warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED docs/source/extension/documents.rst::/home/runner/work/jupyterlab/jupyterlab/docs/source/extension/documents.rst <a href=https://jupyter-ydoc.readthedocs.io/en/latest/api/classes/YDocument.html>
1 failed, 10 deselected, 1 warning in 0.32s
```

## Code changes

Replace https://jupyter-ydoc.readthedocs.io/en/latest/api/classes/YDocument.html with https://jupyter-ydoc.readthedocs.io/en/latest/api/classes/YDocument-1.html

## User-facing changes

None

## Backwards-incompatible changes

None
