### PR TITLE
Update yarn commands to fix binder

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,8 @@ enableImmutableInstalls: false
 
 enableInlineBuilds: false
 
+enableScripts: true
+
 enableTelemetry: false
 
 httpTimeout: 60000

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -28,7 +28,8 @@ mkdir -p ~/.jupyter
 cp binder/jupyter_config.py ~/.jupyter/
 
 # replace the default entry point until jupyter-server is the default on binder
-cp ${NB_PYTHON_PREFIX}/bin/jupyter-lab ${NB_PYTHON_PREFIX}/bin/jupyter-notebook
+#cp ${NB_PYTHON_PREFIX}/bin/jupyter-lab ${NB_PYTHON_PREFIX}/bin/jupyter-notebook
+ls ${NB_PYTHON_PREFIX}/bin/  2>&1 | tee _reports_/00_executables_list.txt
 
 # capture configuration and debug information
 (time pip list)                                        2>&1 | tee _reports_/03_pip_list.txt

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -13,8 +13,8 @@ set -euxo pipefail
 mkdir _reports_
 
 # pre-install nodejs deps and build outside of editable python install
-(time yarn --ignore-scripts --ignore-optional)         2>&1 | tee _reports_/00_yarn.txt
-(time yarn build:dev:prod:minimize:report)             2>&1 | tee _reports_/01_build.txt
+(time yarn install --ignore-scripts --ignore-optional)        2>&1 | tee _reports_/00_yarn.txt
+(time yarn run build:dev:prod:minimize:report)                2>&1 | tee _reports_/01_build.txt
 
 # hoist report to where a reviewer might see it
 mv dev_mode/static/webpack-bundle-analyzer.html _reports_/

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -13,7 +13,7 @@ set -euxo pipefail
 mkdir _reports_
 
 # pre-install nodejs deps and build outside of editable python install
-yarn config set enableScripts false               2>&1 | tee _reports_/00_config.txt
+#yarn config set enableScripts false               2>&1 | tee _reports_/00_config.txt
 (time yarn install)                               2>&1 | tee _reports_/00_yarn.txt
 (time yarn run build:dev:prod:minimize:report)    2>&1 | tee _reports_/01_build.txt
 

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -13,7 +13,7 @@ set -euxo pipefail
 mkdir _reports_
 
 # pre-install nodejs deps and build outside of editable python install
-#yarn config set enableScripts false               2>&1 | tee _reports_/00_config.txt
+yarn config set enableScripts false               2>&1 | tee _reports_/00_config.txt
 (time yarn install)                               2>&1 | tee _reports_/00_yarn.txt
 (time yarn run build:dev:prod:minimize:report)    2>&1 | tee _reports_/01_build.txt
 

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -13,8 +13,9 @@ set -euxo pipefail
 mkdir _reports_
 
 # pre-install nodejs deps and build outside of editable python install
-(time yarn install --ignore-scripts --ignore-optional)        2>&1 | tee _reports_/00_yarn.txt
-(time yarn run build:dev:prod:minimize:report)                2>&1 | tee _reports_/01_build.txt
+yarn config set enableScripts false               2>&1 | tee _reports_/00_config.txt
+(time yarn install)                               2>&1 | tee _reports_/00_yarn.txt
+(time yarn run build:dev:prod:minimize:report)    2>&1 | tee _reports_/01_build.txt
 
 # hoist report to where a reviewer might see it
 mv dev_mode/static/webpack-bundle-analyzer.html _reports_/

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -208,7 +208,7 @@ def ensure_node_modules(cwd, logger=None):
     """
     logger = _ensure_logger(logger)
     yarn_proc = ProgressProcess(
-        ["node", YARN_PATH, "check", "--verify-tree"], cwd=cwd, logger=logger
+        ["node", YARN_PATH, "install", "--immutable"], cwd=cwd, logger=logger
     )
     ret = yarn_proc.wait()
 


### PR DESCRIPTION
## References

Yarn 3 migration follow-up. Fixes #14264

## Code changes

- fully specifies yarn commands (e.g. `yarn install` instead of `yarn`).
- disables scripts using config (`enableScripts = false`, close enough to `--ignore-scripts` in old yarn but does not disable scripts for current project https://github.com/yarnpkg/yarn/issues/7338#issuecomment-1426863192, https://github.com/yarnpkg/berry/pull/4781),
- removes `ignore-optional` which is not implemented in yarn 3 (and not planned see https://github.com/yarnpkg/berry/discussions/2412)

## User-facing changes

N/A

## Backwards-incompatible changes

N/A
