### PR TITLE
Add `--skip-dev-build`, use with `yarn` invocation to fix binder

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - python >=3.11,<3.12
   # package managers
   - pip
-  - yarn <2
+  - yarn >=3,<4
   # build
   - hatch-jupyter-builder >=0.3.2
   - hatchling >=1.5.0
@@ -20,7 +20,7 @@ dependencies:
   - jinja2 >=3.0.3
   - jupyter_core
   - jupyter_server >=2.0.1,<3
-  - jupyter-lsp >=1.5.1
+  - jupyter-lsp >=2.0.0
   - jupyterlab_server >=2.19.0,<3
   - notebook-shim >=0.2
   - packaging
@@ -56,4 +56,4 @@ dependencies:
   # extra conda stuff
   - jsonschema-with-format-nongpl
   - pip:
-    - jupyter-collaboration >=1.0.0a4
+    - jupyter-collaboration >=1.0.0a5

--- a/binder/jupyter_config.py
+++ b/binder/jupyter_config.py
@@ -47,5 +47,6 @@ c.ServerApp.log_level = logging.DEBUG
 
 c.LabApp.dev_mode = True
 c.LabApp.extensions_in_dev_mode = True
+c.LabApp.skip_dev_build = True
 
 c.ContentsManager.allow_hidden = True

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -13,7 +13,7 @@ set -euxo pipefail
 mkdir _reports_
 
 # pre-install nodejs deps and build outside of editable python install
-(time yarn --ignore-scripts --ignore-optional)         2>&1 | tee _reports_/00_yarn.txt
+(time yarn)                                            2>&1 | tee _reports_/00_yarn.txt
 (time yarn build:dev:prod:minimize:report)             2>&1 | tee _reports_/01_build.txt
 
 # hoist report to where a reviewer might see it
@@ -25,9 +25,6 @@ mv dev_mode/static/webpack-bundle-analyzer.html _reports_/
 # copy configuration to well-known location
 mkdir -p ~/.jupyter
 cp binder/jupyter_config.py ~/.jupyter/
-
-# replace the default entry point until jupyter-server is the default on binder
-cp ${NB_PYTHON_PREFIX}/bin/jupyter-lab ${NB_PYTHON_PREFIX}/bin/jupyter-notebook
 
 # capture configuration and debug information
 (time pip list)                                        2>&1 | tee _reports_/03_pip_list.txt

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -467,6 +467,10 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
         {"LabApp": {"dev_mode": True}},
         "Start the app in dev mode for running from source.",
     )
+    flags["skip-dev-build"] = (
+        {"LabApp": {"skip_dev_build": True}},
+        "Skip the initial install and JS build of the app in dev mode.",
+    )
     flags["watch"] = ({"LabApp": {"watch": True}}, "Start the app in watch mode.")
     flags["splice-source"] = (
         {"LabApp": {"splice_source": True}},
@@ -554,6 +558,12 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
     )
 
     watch = Bool(False, config=True, help="Whether to serve the app in watch mode")
+
+    skip_dev_build = Bool(
+        False,
+        config=True,
+        help="Whether to skip the initial install and JS build of the app in dev mode",
+    )
 
     splice_source = Bool(False, config=True, help="Splice source packages into app directory.")
 
@@ -713,7 +723,7 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
             self.log.info(CORE_NOTE.strip())
             ensure_core(self.log)
         elif self.dev_mode:
-            if not self.watch:
+            if not (self.watch or self.skip_dev_build):
                 ensure_dev(self.log)
                 self.log.info(DEV_NOTE)
         else:


### PR DESCRIPTION
## References

- extracted from #14272
- fixes #14264
- alternative to #14265

## Code changes

- [x] `jupyterlab/labapp.py`
  - [x] adds `--skip-dev-build` and `LabApp.skip_dev_build`
    - > there's probably a better way to tell it, _I've already built all this_
- [x] `binder`
  - [x] `environment.yml`
    - [x] sync with `pyproject.toml`
  - [x] `postBuild` 
    - [x] updates `jlpm` invocation for `>3`
  - [x] `jupyter_config.py` 
    - [x] configures `skip_dev_build`

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
