### PR TITLE
Fix examples further to CodeMirror API change

### DIFF
--- a/examples/cell/src/index.ts
+++ b/examples/cell/src/index.ts
@@ -54,11 +54,11 @@ import {
   SessionManager
 } from '@jupyterlab/services';
 
+import { IYText } from '@jupyter/ydoc';
+
 import { CommandRegistry } from '@lumino/commands';
 
 import { BoxPanel, Widget } from '@lumino/widgets';
-
-import { IYText } from '@jupyter/ydoc';
 
 function main(): void {
   const kernelManager = new KernelManager();
@@ -69,9 +69,7 @@ function main(): void {
     specsManager,
     name: 'Example'
   });
-  const languages = new EditorLanguageRegistry();
-
-  const extensions = () => {
+  const editorExtensions = () => {
     const registry = new EditorExtensionRegistry();
     for (const extensionFactory of EditorExtensionRegistry.getDefaultExtensions({})) {
       registry.addExtension(extensionFactory);
@@ -88,10 +86,9 @@ function main(): void {
         );
       }
     });
-
     return registry;
   }
-
+  const languages = new EditorLanguageRegistry();
   EditorLanguageRegistry.getDefaultLanguages()
     .filter(language =>
       ['ipython', 'julia', 'python'].includes(language.name.toLowerCase())
@@ -99,8 +96,9 @@ function main(): void {
     .forEach(language => {
       languages.addLanguage(language);
     });
+
   const factoryService = new CodeMirrorEditorFactory({
-    extensions: extensions(),
+    extensions: editorExtensions(),
     languages
   });
   const mimeService = new CodeMirrorMimeTypeService(languages);

--- a/examples/cell/src/index.ts
+++ b/examples/cell/src/index.ts
@@ -77,7 +77,7 @@ function main(): void {
       registry.addExtension(extensionFactory);
     }
     registry.addExtension({
-      name: 'yjs-binding',
+      name: 'shared-model-binding',
       factory: options => {
         const sharedModel = options.model.sharedModel as IYText;
         return EditorExtensionRegistry.createImmutableExtension(

--- a/examples/cell/src/index.ts
+++ b/examples/cell/src/index.ts
@@ -30,8 +30,8 @@ import { Cell, CodeCell, CodeCellModel } from '@jupyterlab/cells';
 import {
   CodeMirrorEditorFactory,
   CodeMirrorMimeTypeService,
-  EditorLanguageRegistry,
   EditorExtensionRegistry,
+  EditorLanguageRegistry,
   ybinding
 } from '@jupyterlab/codemirror';
 
@@ -71,7 +71,9 @@ function main(): void {
   });
   const editorExtensions = () => {
     const registry = new EditorExtensionRegistry();
-    for (const extensionFactory of EditorExtensionRegistry.getDefaultExtensions({})) {
+    for (const extensionFactory of EditorExtensionRegistry.getDefaultExtensions(
+      {}
+    )) {
       registry.addExtension(extensionFactory);
     }
     registry.addExtension({
@@ -87,7 +89,7 @@ function main(): void {
       }
     });
     return registry;
-  }
+  };
   const languages = new EditorLanguageRegistry();
   EditorLanguageRegistry.getDefaultLanguages()
     .filter(language =>

--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -7,6 +7,7 @@
     "clean": "rimraf build"
   },
   "dependencies": {
+    "@jupyter/ydoc": "^0.3.4",
     "@jupyterlab/application": "^4.0.0-beta.0",
     "@jupyterlab/codemirror": "^4.0.0-beta.0",
     "@jupyterlab/console": "^4.0.0-beta.0",

--- a/examples/console/src/index.ts
+++ b/examples/console/src/index.ts
@@ -21,7 +21,9 @@ import { ServiceManager } from '@jupyterlab/services';
 import {
   CodeMirrorEditorFactory,
   CodeMirrorMimeTypeService,
-  EditorLanguageRegistry
+  EditorLanguageRegistry,
+  EditorExtensionRegistry,
+  ybinding
 } from '@jupyterlab/codemirror';
 
 import { ConsolePanel } from '@jupyterlab/console';
@@ -36,6 +38,8 @@ import {
   nullTranslator,
   TranslationManager
 } from '@jupyterlab/translation';
+
+import { IYText } from '@jupyter/ydoc';
 
 async function main(): Promise<any> {
   const translator = new TranslationManager();
@@ -88,6 +92,26 @@ function startApp(
 
   const rendermime = new RenderMimeRegistry({ initialFactories });
 
+  const editorExtensions = () => {
+    const registry = new EditorExtensionRegistry();
+    for (const extensionFactory of EditorExtensionRegistry.getDefaultExtensions({})) {
+      registry.addExtension(extensionFactory);
+    }
+    registry.addExtension({
+      name: 'yjs-binding',
+      factory: options => {
+        const sharedModel = options.model.sharedModel as IYText;
+        return EditorExtensionRegistry.createImmutableExtension(
+          ybinding({
+            ytext: sharedModel.ysource,
+            undoManager: sharedModel.undoManager ?? undefined
+          })
+        );
+      }
+    });
+    return registry;
+  }
+
   const languages = new EditorLanguageRegistry();
   EditorLanguageRegistry.getDefaultLanguages()
     .filter(language =>
@@ -96,7 +120,10 @@ function startApp(
     .forEach(language => {
       languages.addLanguage(language);
     });
-  const factoryService = new CodeMirrorEditorFactory({ languages });
+  const factoryService = new CodeMirrorEditorFactory({
+    extensions: editorExtensions(),
+    languages
+  });
   const mimeTypeService = new CodeMirrorMimeTypeService(languages);
   const editorFactory = factoryService.newInlineEditor;
   const contentFactory = new ConsolePanel.ContentFactory({ editorFactory });

--- a/examples/console/src/index.ts
+++ b/examples/console/src/index.ts
@@ -21,8 +21,8 @@ import { ServiceManager } from '@jupyterlab/services';
 import {
   CodeMirrorEditorFactory,
   CodeMirrorMimeTypeService,
-  EditorLanguageRegistry,
   EditorExtensionRegistry,
+  EditorLanguageRegistry,
   ybinding
 } from '@jupyterlab/codemirror';
 
@@ -94,7 +94,9 @@ function startApp(
 
   const editorExtensions = () => {
     const registry = new EditorExtensionRegistry();
-    for (const extensionFactory of EditorExtensionRegistry.getDefaultExtensions({})) {
+    for (const extensionFactory of EditorExtensionRegistry.getDefaultExtensions(
+      {}
+    )) {
       registry.addExtension(extensionFactory);
     }
     registry.addExtension({
@@ -110,7 +112,7 @@ function startApp(
       }
     });
     return registry;
-  }
+  };
 
   const languages = new EditorLanguageRegistry();
   EditorLanguageRegistry.getDefaultLanguages()

--- a/examples/console/src/index.ts
+++ b/examples/console/src/index.ts
@@ -100,7 +100,7 @@ function startApp(
       registry.addExtension(extensionFactory);
     }
     registry.addExtension({
-      name: 'yjs-binding',
+      name: 'shared-model-binding',
       factory: options => {
         const sharedModel = options.model.sharedModel as IYText;
         return EditorExtensionRegistry.createImmutableExtension(

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -7,6 +7,7 @@
     "clean": "rimraf build"
   },
   "dependencies": {
+    "@jupyter/ydoc": "^0.3.4",
     "@jupyterlab/application": "^4.0.0-beta.0",
     "@jupyterlab/apputils": "^4.0.0-beta.0",
     "@jupyterlab/codemirror": "^4.0.0-beta.0",

--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -114,7 +114,7 @@ function createApp(manager: ServiceManager.IManager): void {
       registry.addExtension(extensionFactory);
     }
     registry.addExtension({
-      name: 'yjs-binding',
+      name: 'shared-model-binding',
       factory: options => {
         const sharedModel = options.model.sharedModel as IYText;
         return EditorExtensionRegistry.createImmutableExtension(

--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -35,8 +35,8 @@ import {
 import {
   CodeMirrorEditorFactory,
   CodeMirrorMimeTypeService,
-  EditorLanguageRegistry,
   EditorExtensionRegistry,
+  EditorLanguageRegistry,
   ybinding
 } from '@jupyterlab/codemirror';
 
@@ -108,7 +108,9 @@ function createApp(manager: ServiceManager.IManager): void {
   const mFactory = new NotebookModelFactory({});
   const editorExtensions = () => {
     const registry = new EditorExtensionRegistry();
-    for (const extensionFactory of EditorExtensionRegistry.getDefaultExtensions({})) {
+    for (const extensionFactory of EditorExtensionRegistry.getDefaultExtensions(
+      {}
+    )) {
       registry.addExtension(extensionFactory);
     }
     registry.addExtension({
@@ -124,7 +126,7 @@ function createApp(manager: ServiceManager.IManager): void {
       }
     });
     return registry;
-  }
+  };
   const languages = new EditorLanguageRegistry();
   EditorLanguageRegistry.getDefaultLanguages()
     .filter(language =>

--- a/packages/codemirror-extension/src/services.tsx
+++ b/packages/codemirror-extension/src/services.tsx
@@ -200,7 +200,7 @@ export const extensionPlugin: JupyterFrontEndPlugin<IEditorExtensionRegistry> =
   };
 
 /**
- * CodeMirror binding provider.
+ * CodeMirror shared model binding provider.
  */
 export const bindingPlugin: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/codemirror-extension:binding',

--- a/packages/codemirror-extension/src/services.tsx
+++ b/packages/codemirror-extension/src/services.tsx
@@ -200,7 +200,7 @@ export const extensionPlugin: JupyterFrontEndPlugin<IEditorExtensionRegistry> =
   };
 
 /**
- * CodeMirror real-time collaboration binding provider.
+ * CodeMirror binding provider.
  */
 export const bindingPlugin: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/codemirror-extension:binding',
@@ -208,7 +208,7 @@ export const bindingPlugin: JupyterFrontEndPlugin<void> = {
   requires: [IEditorExtensionRegistry],
   activate: (app: JupyterFrontEnd, extensions: IEditorExtensionRegistry) => {
     extensions.addExtension({
-      name: 'yjs-binding',
+      name: 'shared-model-binding',
       factory: options => {
         const sharedModel = options.model.sharedModel as IYText;
         return EditorExtensionRegistry.createImmutableExtension(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2953,6 +2953,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/example-console@workspace:examples/console"
   dependencies:
+    "@jupyter/ydoc": ^0.3.4
     "@jupyterlab/application": ^4.0.0-beta.0
     "@jupyterlab/codemirror": ^4.0.0-beta.0
     "@jupyterlab/console": ^4.0.0-beta.0
@@ -3099,6 +3100,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/example-notebook@workspace:examples/notebook"
   dependencies:
+    "@jupyter/ydoc": ^0.3.4
     "@jupyterlab/application": ^4.0.0-beta.0
     "@jupyterlab/apputils": ^4.0.0-beta.0
     "@jupyterlab/codemirror": ^4.0.0-beta.0


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/14221

## Code changes

Update the cell and notebook examples

## User-facing changes

The outputs are now displayed as before for the `cell`, `notebook` and `console` examples..

![Untitled6](https://user-images.githubusercontent.com/226720/228817317-73e2056b-e70c-4c19-a3dc-f00f46351213.gif)

## Backwards-incompatible changes

None
