### PR TITLE
Add context for translatable strings to avoid clash with 3.x

### DIFF
--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -378,7 +378,8 @@ export namespace Commands {
     commands.addCommand(CommandIDs.changeTabs, {
       label: args => {
         if (args.size) {
-          return trans.__('Spaces: %1', args.size ?? '');
+          // Use a context to differentiate with string set as plural in 3.x
+          return trans._p('v4', 'Spaces: %1', args.size ?? '');
         } else {
           return trans.__('Indent with Tab');
         }

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -139,7 +139,8 @@ export const tabSpaceStatus: JupyterFrontEndPlugin<void> = {
     for (const size of ['1', '2', '4', '8']) {
       const args: JSONObject = {
         size,
-        name: trans.__('Spaces: %1', size)
+        // Use a context to differentiate with string set as plural in 3.x
+        name: trans._p('v4', 'Spaces: %1', size)
       };
       menu.addItem({ command, args });
     }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
When trying to merge the translatable string of 4.0.0b0 with 3.6.x branch, I got bitten by a string that was wrongly using plural form in 3.x and no more in 4.0.0.

Seen when working on https://github.com/jupyterlab/language-packs/pull/451
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Add context to differentiate the translatable string with 3.x

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None