### PR TITLE
Fix failure when setting debugger variables filter

### DIFF
--- a/packages/debugger/src/panels/variables/grid.ts
+++ b/packages/debugger/src/panels/variables/grid.ts
@@ -3,18 +3,19 @@
 
 import { IThemeManager } from '@jupyterlab/apputils';
 
+import { ITranslator } from '@jupyterlab/translation';
+
 import { CommandRegistry } from '@lumino/commands';
+
+import { PromiseDelegate } from '@lumino/coreutils';
+
+import { Message } from '@lumino/messaging';
 
 import { Panel } from '@lumino/widgets';
 
 import { IDebugger } from '../../tokens';
 
-import { VariablesModel } from './model';
-import { ITranslator } from '@jupyterlab/translation';
-
 import type * as GridPanelModule from './gridpanel';
-import { PromiseDelegate } from '@lumino/coreutils';
-import { Message } from '@lumino/messaging';
 
 /**
  * A data grid that displays variables in a debugger session.
@@ -27,67 +28,87 @@ export class VariablesBodyGrid extends Panel {
    */
   constructor(options: VariablesBodyGrid.IOptions) {
     super();
-
-    this._model = options.model;
-    this._options = options;
-
+    this.commands = options.commands;
+    this.model = options.model;
+    this.themeManager = options.themeManager;
+    this.translator = options.translator;
+    this.model.changed.connect(() => this.update(), this);
     this.addClass('jp-DebuggerVariables-body');
+  }
+
+  /**
+   * The variable filter list.
+   */
+  get filter(): Set<string> {
+    return this._filter;
+  }
+  set filter(filter: Set<string>) {
+    this._filter = filter;
+    this.update();
+  }
+
+  /**
+   * The current scope of the variables
+   */
+  get scope(): string {
+    return this._scope;
+  }
+  set scope(scope: string) {
+    this._scope = scope;
+    this.update();
+  }
+
+  protected commands: CommandRegistry;
+  protected model: IDebugger.Model.IVariables;
+  protected themeManager: IThemeManager | null | undefined;
+  protected translator: ITranslator | undefined;
+
+  /**
+   * Load the grid panel implementation.
+   */
+  protected async initialize(): Promise<unknown> {
+    if (this._grid || this._pending) {
+      return;
+    }
+
+    const pending = (this._pending = Private.ensureGridPanel());
+    const { Grid } = await pending;
+    const { commands, model, themeManager, translator } = this;
+
+    this._grid = new Grid({ commands, model, themeManager, translator });
+    this._grid.addClass('jp-DebuggerVariables-grid');
+    this._pending = null;
+    this.addWidget(this._grid);
+    this.update();
   }
 
   /**
    * Wait until actually displaying the grid to trigger initialization.
    */
   protected onBeforeShow(msg: Message): void {
-    if (!this._grid) {
+    if (!this._grid && !this._pending) {
       void this.initialize();
     }
+    super.onBeforeShow(msg);
   }
 
   /**
-   * Load the grid panel implementation.
+   * Handle `update-request` messages.
    */
-  protected async initialize(): Promise<void> {
-    const { model, commands, themeManager, scopes, translator } = this._options;
-    const { Grid } = await Private.ensureGridPanel();
-    this._grid = new Grid({ commands, model, themeManager, translator });
-    this._grid.addClass('jp-DebuggerVariables-grid');
-    this._model.changed.connect((model: VariablesModel): void => {
-      this._update();
-    }, this);
-    this._grid.dataModel.setData(scopes ?? []);
-    this.addWidget(this._grid);
+  protected onUpdateRequest(msg: Message): void {
+    if (this._grid) {
+      const { dataModel } = this._grid;
+      dataModel.filter = this._filter;
+      dataModel.scope = this._scope;
+      dataModel.setData(this.model.scopes ?? []);
+    }
+    super.onUpdateRequest(msg);
   }
 
-  /**
-   * Set the variable filter list.
-   *
-   * @param filter The variable filter to apply.
-   */
-  set filter(filter: Set<string>) {
-    (this._grid.dataModel as GridPanelModule.GridModel).filter = filter;
-    this._update();
-  }
-
-  /**
-   * Set the current scope.
-   *
-   * @param scope The current scope for the variables.
-   */
-  set scope(scope: string) {
-    (this._grid.dataModel as GridPanelModule.GridModel).scope = scope;
-    this._update();
-  }
-
-  /**
-   * Update the underlying data model
-   */
-  private _update(): void {
-    this._grid.dataModel.setData(this._model.scopes ?? []);
-  }
-
-  private _grid: GridPanelModule.Grid;
-  private _model: IDebugger.Model.IVariables;
-  private _options: VariablesBodyGrid.IOptions;
+  private _filter: Set<string> = new Set();
+  private _grid: GridPanelModule.Grid | null = null;
+  private _pending: Promise<unknown> | null = null;
+  private _scope: string;
 }
 
 /**

--- a/packages/debugger/src/panels/variables/grid.ts
+++ b/packages/debugger/src/panels/variables/grid.ts
@@ -64,7 +64,7 @@ export class VariablesBodyGrid extends Panel {
   /**
    * Load the grid panel implementation and instantiate a grid.
    */
-  protected async initialize(): Promise<unknown> {
+  protected async initialize(): Promise<void> {
     if (this._grid || this._pending) {
       return;
     }

--- a/packages/debugger/src/panels/variables/grid.ts
+++ b/packages/debugger/src/panels/variables/grid.ts
@@ -7,8 +7,6 @@ import { ITranslator } from '@jupyterlab/translation';
 
 import { CommandRegistry } from '@lumino/commands';
 
-import { PromiseDelegate } from '@lumino/coreutils';
-
 import { Message } from '@lumino/messaging';
 
 import { Panel } from '@lumino/widgets';
@@ -48,7 +46,7 @@ export class VariablesBodyGrid extends Panel {
   }
 
   /**
-   * The current scope of the variables
+   * The current scope of the variables.
    */
   get scope(): string {
     return this._scope;
@@ -64,15 +62,15 @@ export class VariablesBodyGrid extends Panel {
   protected translator: ITranslator | undefined;
 
   /**
-   * Load the grid panel implementation.
+   * Load the grid panel implementation and instantiate a grid.
    */
   protected async initialize(): Promise<unknown> {
     if (this._grid || this._pending) {
       return;
     }
 
-    const pending = (this._pending = Private.ensureGridPanel());
-    const { Grid } = await pending;
+    // Lazily load the datagrid module when the first grid is requested.
+    const { Grid } = await (this._pending = import('./gridpanel'));
     const { commands, model, themeManager, translator } = this;
 
     this._grid = new Grid({ commands, model, themeManager, translator });
@@ -143,23 +141,5 @@ export namespace VariablesBodyGrid {
      * The application language translator.
      */
     translator?: ITranslator;
-  }
-}
-
-/**
- * A private namespace for managing lazy loading of the underlying grid panel.
- */
-namespace Private {
-  let gridPanelLoaded: PromiseDelegate<typeof GridPanelModule> | null = null;
-
-  /**
-   * Lazily load the datagrid module when the first grid is requested.
-   */
-  export async function ensureGridPanel(): Promise<typeof GridPanelModule> {
-    if (gridPanelLoaded == null) {
-      gridPanelLoaded = new PromiseDelegate();
-      gridPanelLoaded.resolve(await import('./gridpanel'));
-    }
-    return gridPanelLoaded.promise;
   }
 }

--- a/packages/debugger/src/panels/variables/gridpanel.ts
+++ b/packages/debugger/src/panels/variables/gridpanel.ts
@@ -161,27 +161,25 @@ export class GridModel extends DataModel {
    */
   constructor(translator?: ITranslator) {
     super();
-    translator = translator || nullTranslator;
-    this._trans = translator.load('jupyterlab');
+    this._trans = (translator || nullTranslator).load('jupyterlab');
   }
 
   /**
-   * Set the variable filter list.
+   * The variable filter list.
    */
+  get filter(): Set<string> {
+    return this._filter;
+  }
   set filter(filter: Set<string>) {
     this._filter = filter;
   }
 
   /**
-   * Get the current scope for the variables.
+   * The current scope for the variables.
    */
   get scope(): string {
     return this._scope;
   }
-
-  /**
-   * Set the variable scope
-   */
   set scope(scope: string) {
     this._scope = scope;
   }


### PR DESCRIPTION
This is a follow-up PR after:
- https://github.com/jupyterlab/jupyterlab/pull/14037

This PR fixes a run-time failure when trying to set variable filters for `xeus-python`:

https://user-images.githubusercontent.com/159529/229621418-8824ea52-0892-41b7-844a-6527c1b8cb0b.mov

---
Additionally, this PR **possibly** fixes https://github.com/jupyterlab/jupyterlab/issues/11012

---
cc: @bollwyvl @krassowski 

## References
- https://github.com/jupyterlab/jupyterlab/issues/11012
- https://github.com/jupyterlab/jupyterlab/pull/14037

## Code changes
Refactors the `VariablesBodyGrid` class to accept `filter`, `scope`, and `model` changes whether or not the grid is visible.

## User-facing changes
Setting a filter no longer generates a console error.

## Backwards-incompatible changes
N/A