### PR TITLE
Pass traceback to ServerConnection.ResponseError

### DIFF
--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -143,13 +143,14 @@ export namespace ServerConnection {
     static async create(response: Response): Promise<ResponseError> {
       try {
         const data = await response.json();
-        if (data['traceback']) {
-          console.error(data['traceback']);
+        const { message, traceback } = data;
+        if (traceback) {
+          console.error(traceback);
         }
         return new ResponseError(
           response,
-          data['message'] ? data['message'] : undefined,
-          data['traceback'] ? data['traceback'] : undefined
+          message ?? ResponseError._defaultMessage(response),
+          traceback ?? ''
         );
       } catch (e) {
         console.debug(e);
@@ -162,7 +163,7 @@ export namespace ServerConnection {
      */
     constructor(
       response: Response,
-      message = `Invalid response: ${response.status} ${response.statusText}`,
+      message = ResponseError._defaultMessage(response),
       traceback = ''
     ) {
       super(message);
@@ -179,6 +180,10 @@ export namespace ServerConnection {
      * The traceback associated with the error.
      */
     traceback: string;
+
+    private static _defaultMessage(response: Response): string {
+      return `Invalid response: ${response.status} ${response.statusText}`;
+    }
   }
 
   /**

--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -146,10 +146,11 @@ export namespace ServerConnection {
         if (data['traceback']) {
           console.error(data['traceback']);
         }
-        if (data['message']) {
-          return new ResponseError(response, data['message']);
-        }
-        return new ResponseError(response);
+        return new ResponseError(
+          response,
+          data['message'] ? data['message'] : undefined,
+          data['traceback'] ? data['traceback'] : undefined
+        );
       } catch (e) {
         console.debug(e);
         return new ResponseError(response);

--- a/packages/services/test/serverconnection.spec.ts
+++ b/packages/services/test/serverconnection.spec.ts
@@ -78,4 +78,44 @@ describe('ServerConnection', () => {
       expect(err.message).toBe('Invalid response: 200 OK');
     });
   });
+
+  describe('ResponseError', () => {
+    describe('#create', () => {
+      it.each([
+        {
+          status: 456,
+          statusText: 'Dummy error'
+        },
+        {
+          status: 456,
+          statusText: 'Dummy error',
+          message: 'Nice error message'
+        },
+        {
+          status: 456,
+          statusText: 'Dummy error',
+          traceback: 'Nice traceback'
+        },
+        {
+          status: 456,
+          statusText: 'Dummy error',
+          message: 'Nice error message',
+          traceback: 'Nice traceback'
+        },
+      ])('should create a error response from %j', async (data) => {
+        const error = await ResponseError.create(
+          {
+            json: jest.fn().mockImplementation(
+              async () => {
+                Promise.resolve(data)
+              }
+            )
+          } as any
+        );
+
+        expect(error.message).toEqual(data.message ?? 'Invalid response: 456 Dummy error')
+        expect(error.traceback).toEqual(data.traceback ?? '')
+      });
+    });
+  });
 });

--- a/packages/services/test/serverconnection.spec.ts
+++ b/packages/services/test/serverconnection.spec.ts
@@ -89,32 +89,31 @@ describe('ServerConnection', () => {
         {
           status: 456,
           statusText: 'Dummy error',
-          message: 'Nice error message'
+          body: { message: 'Nice error message' }
         },
         {
           status: 456,
           statusText: 'Dummy error',
-          traceback: 'Nice traceback'
+          body: { traceback: 'Nice traceback' }
         },
         {
           status: 456,
           statusText: 'Dummy error',
-          message: 'Nice error message',
-          traceback: 'Nice traceback'
-        },
-      ])('should create a error response from %j', async (data) => {
-        const error = await ResponseError.create(
-          {
-            json: jest.fn().mockImplementation(
-              async () => {
-                Promise.resolve(data)
-              }
-            )
-          } as any
-        );
+          body: {
+            message: 'Nice error message',
+            traceback: 'Nice traceback'
+          }
+        }
+      ])('should create a error response from %j', async response => {
+        const error = await ServerConnection.ResponseError.create({
+          ...response,
+          json: () => Promise.resolve(response.body ?? {})
+        } as any);
 
-        expect(error.message).toEqual(data.message ?? 'Invalid response: 456 Dummy error')
-        expect(error.traceback).toEqual(data.traceback ?? '')
+        expect(error.message).toEqual(
+          response.body?.message ?? 'Invalid response: 456 Dummy error'
+        );
+        expect(error.traceback).toEqual(response.body?.traceback ?? '');
       });
     });
   });


### PR DESCRIPTION
In my Jupyter Lab environment, `Error: Unhandled Error` is reported by monitoring tool. I'm investigating each errors and making some handling for them. However `Error: Unhandled Error` does not have enough infomation to be handled properly. On jupyter lab side, I found that `ServerConnection.ResponseError` has a room for server side `traceback`, but it is not well managed. If `trackback` works properly, it can give us enough infomation for errors to be handled.

(It is reported as `Error`, but actually `ServerConnection.ResponseError`)

## References
- https://github.com/jupyter-server/jupyter_server/issues/1247

## Code changes
Pass `trackback` to ServerConnection.ResponseError. I think it is intended behavior of ResponseError at first, but looks like missing somehow.

I wrote the code in a conservative manner to preserve previous behavior as much I can. That is why `data['message'] ? data['message'] : undefined` comes.

## User-facing changes
No

## Backwards-incompatible changes
Actually, I found no code that uses `traceback` of the ResponseError constructor. It is backword compatible.
