### PR TITLE
Ensure that initial text is updated on subsequent searches

### DIFF
--- a/galata/test/jupyterlab/notebook-search.test.ts
+++ b/galata/test/jupyterlab/notebook-search.test.ts
@@ -7,6 +7,13 @@ import * as path from 'path';
 
 const fileName = 'search.ipynb';
 
+function getSelectionRange(textarea: HTMLTextAreaElement) {
+  return {
+    start: textarea.selectionStart,
+    end: textarea.selectionEnd
+  };
+}
+
 test.describe('Notebook Search', () => {
   test.beforeEach(async ({ page, tmpPath }) => {
     await page.contents.uploadFile(
@@ -87,20 +94,46 @@ test.describe('Notebook Search', () => {
 
     // Go to first line
     await page.keyboard.press('PageUp');
-
     // Select first line
     await page.keyboard.press('Shift+End');
-
     // Open search box
     await page.keyboard.press('Control+f');
 
-    // Expect it to be populated with first line
-    await page.waitForSelector(
+    // Expect it to be populated with the first line
+    const inputWithFirstLine = page.locator(
       '[placeholder="Find"] >> text="Test with one notebook withr"'
     );
+    expect(inputWithFirstLine).toBeVisible();
+    expect(inputWithFirstLine).toBeFocused();
+    // Expect the newly set text to be selected
+    expect(await inputWithFirstLine.evaluate(getSelectionRange)).toStrictEqual({
+      start: 0,
+      end: 28
+    });
 
     // Expect both matches to be found (xfail)
     // await page.waitForSelector('text=1/2');
+
+    // Enter first cell again
+    await page.notebook.enterCellEditingMode(0);
+    // Go to last line
+    await page.keyboard.press('PageDown');
+    // Select last line
+    await page.keyboard.press('Shift+Home');
+    // Update search box
+    await page.keyboard.press('Control+f');
+
+    // Expect it to be populated with the last line
+    const inputWithLastLine = page.locator(
+      '[placeholder="Find"] >> text="This is a multi line with hits with"'
+    );
+    expect(inputWithLastLine).toBeVisible();
+    expect(inputWithLastLine).toBeFocused();
+    // Expect the newly set text to be selected
+    expect(await inputWithLastLine.evaluate(getSelectionRange)).toStrictEqual({
+      start: 0,
+      end: 35
+    });
 
     await expect(page.locator('.jp-DocumentSearch-overlay')).toBeVisible();
   });
@@ -181,7 +214,7 @@ test.describe('Notebook Search', () => {
     await page.fill('[placeholder="Find"]', 'text/');
     await page.waitForSelector('text=1/3');
 
-    // Activete third cell
+    // Activate third cell
     const cell = await page.notebook.getCell(2);
     const editor = await cell.$('.jp-Editor');
     await editor.click();

--- a/galata/test/jupyterlab/notebook-search.test.ts
+++ b/galata/test/jupyterlab/notebook-search.test.ts
@@ -103,8 +103,8 @@ test.describe('Notebook Search', () => {
     const inputWithFirstLine = page.locator(
       '[placeholder="Find"] >> text="Test with one notebook withr"'
     );
-    expect(inputWithFirstLine).toBeVisible();
-    expect(inputWithFirstLine).toBeFocused();
+    await expect(inputWithFirstLine).toBeVisible();
+    await expect(inputWithFirstLine).toBeFocused();
     // Expect the newly set text to be selected
     expect(await inputWithFirstLine.evaluate(getSelectionRange)).toStrictEqual({
       start: 0,
@@ -127,8 +127,8 @@ test.describe('Notebook Search', () => {
     const inputWithLastLine = page.locator(
       '[placeholder="Find"] >> text="This is a multi line with hits with"'
     );
-    expect(inputWithLastLine).toBeVisible();
-    expect(inputWithLastLine).toBeFocused();
+    await expect(inputWithLastLine).toBeVisible();
+    await expect(inputWithLastLine).toBeFocused();
     // Expect the newly set text to be selected
     expect(await inputWithLastLine.evaluate(getSelectionRange)).toStrictEqual({
       start: 0,
@@ -136,6 +136,32 @@ test.describe('Notebook Search', () => {
     });
 
     await expect(page.locator('.jp-DocumentSearch-overlay')).toBeVisible();
+  });
+
+  test('Restore previous search query if there is no selection', async ({
+    page
+  }) => {
+    const inputWithTestLocator = page.locator(
+      '[placeholder="Find"] >> text="test"'
+    );
+    const overlayLocator = page.locator('.jp-DocumentSearch-overlay');
+
+    // Search for "test"
+    await page.keyboard.press('Control+f');
+    await page.fill('[placeholder="Find"]', 'test');
+    await page.waitForSelector('text=1/2');
+
+    // Close search box
+    await page.keyboard.press('Escape');
+    await expect(overlayLocator).toBeHidden();
+
+    // Open search box again
+    await page.keyboard.press('Control+f');
+    await expect(overlayLocator).toBeVisible();
+    // Expect the text to be set in the input field
+    await expect(inputWithTestLocator).toBeVisible();
+    // Expect the search to be active again
+    await page.waitForSelector('text=1/2');
   });
 
   test('Close with Escape', async ({ page }) => {

--- a/packages/documentsearch-extension/src/index.ts
+++ b/packages/documentsearch-extension/src/index.ts
@@ -233,7 +233,9 @@ const extension: JupyterFrontEndPlugin<ISearchProviderRegistry> = {
           if (searchText) {
             searchWidget.setSearchText(searchText);
           } else {
-            searchWidget.setSearchText(searchWidget.model.initialQuery);
+            searchWidget.setSearchText(
+              searchWidget.model.suggestedInitialQuery
+            );
           }
           searchWidget.focusSearchInput();
         }
@@ -250,7 +252,9 @@ const extension: JupyterFrontEndPlugin<ISearchProviderRegistry> = {
           if (searchText) {
             searchWidget.setSearchText(searchText);
           } else {
-            searchWidget.setSearchText(searchWidget.model.initialQuery);
+            searchWidget.setSearchText(
+              searchWidget.model.suggestedInitialQuery
+            );
           }
           const replaceText = args['replaceText'] as string;
           if (replaceText) {

--- a/packages/documentsearch/src/searchmodel.ts
+++ b/packages/documentsearch/src/searchmodel.ts
@@ -100,7 +100,25 @@ export class SearchDocumentModel
    * The initial query string.
    */
   get initialQuery(): string {
-    return this._searchExpression || this.searchProvider.getInitialQuery();
+    return this._initialQuery;
+  }
+  set initialQuery(v: string) {
+    if (v) {
+      // Usually the value comes from user selection (set by search provider).
+      this._initialQuery = v;
+    } else {
+      // If user selection is empty, we fall back to most recent value (if any).
+      this._initialQuery = this._searchExpression;
+    }
+  }
+
+  /**
+   * Initial query as suggested by provider.
+   *
+   * A common choice is the text currently selected by the user.
+   */
+  get suggestedInitialQuery(): string {
+    return this.searchProvider.getInitialQuery();
   }
 
   /**
@@ -338,6 +356,7 @@ export class SearchDocumentModel
   private _disposed = new Signal<this, void>(this);
   private _parsingError = '';
   private _preserveCase = false;
+  private _initialQuery = '';
   private _filters: IFilters = {};
   private _replaceText: string;
   private _searchDebouncer: Debouncer;

--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -67,11 +67,17 @@ interface ISearchInputProps {
 function SearchInput(props: ISearchInputProps): JSX.Element {
   const [rows, setRows] = useState<number>(1);
 
-  const updateRows = useCallback(() => {
-    if (props.inputRef?.current) {
-      setRows(props.inputRef.current.value.split(/\n/).length);
-    }
-  }, []);
+  const updateRows = useCallback(
+    (event?: React.SyntheticEvent<HTMLTextAreaElement>) => {
+      const element = event
+        ? (event.target as HTMLTextAreaElement)
+        : props.inputRef?.current;
+      if (element) {
+        setRows(element.value.split(/\n/).length);
+      }
+    },
+    []
+  );
 
   useEffect(() => {
     // For large part, `focusSearchInput()` is responsible for focusing and
@@ -92,11 +98,11 @@ function SearchInput(props: ISearchInputProps): JSX.Element {
       rows={rows}
       onChange={e => {
         props.onChange(e);
-        updateRows();
+        updateRows(e);
       }}
       onKeyDown={e => {
         props.onKeyDown(e);
-        updateRows();
+        updateRows(e);
       }}
       // Setting a key ensures that `defaultValue` will become updated
       // when the initial value changes.

--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -24,7 +24,7 @@ import { ISignal, Signal } from '@lumino/signaling';
 import { UseSignal } from '@jupyterlab/apputils';
 import { Message } from '@lumino/messaging';
 import * as React from 'react';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { SearchDocumentModel } from './searchmodel';
 import { IFilter, IFilters, IReplaceOptionsSupport } from './tokens';
 
@@ -67,6 +67,12 @@ interface ISearchInputProps {
 function SearchInput(props: ISearchInputProps): JSX.Element {
   const [rows, setRows] = useState<number>(1);
 
+  const updateRows = useCallback(() => {
+    if (props.inputRef?.current) {
+      setRows(props.inputRef.current.value.split(/\n/).length);
+    }
+  }, []);
+
   useEffect(() => {
     // For large part, `focusSearchInput()` is responsible for focusing and
     // selecting the search input, however when `initialValue` changes, this
@@ -74,6 +80,9 @@ function SearchInput(props: ISearchInputProps): JSX.Element {
     // which means that `focusSearchInput` is no longer effective as it has
     // already fired before the re-render, hence we use this conditional effect.
     props.inputRef?.current?.select();
+    // After any change to initial value we also want to update rows in case if
+    // multi-line text was selected.
+    updateRows();
   }, [props.initialValue]);
 
   return (
@@ -83,11 +92,11 @@ function SearchInput(props: ISearchInputProps): JSX.Element {
       rows={rows}
       onChange={e => {
         props.onChange(e);
-        setRows((e.target as HTMLTextAreaElement).value.split(/\n/).length);
+        updateRows();
       }}
       onKeyDown={e => {
         props.onKeyDown(e);
-        setRows((e.target as HTMLTextAreaElement).value.split(/\n/).length);
+        updateRows();
       }}
       // Setting a key ensures that `defaultValue` will become updated
       // when the initial value changes.

--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -55,13 +55,13 @@ const SPACER_CLASS = 'jp-DocumentSearch-spacer';
 
 interface ISearchInputProps {
   placeholder: string;
-  value: string;
   title: string;
-  initialValue?: string;
+  initialValue: string;
   inputRef?: React.RefObject<HTMLTextAreaElement>;
   onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
   onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   autoFocus: boolean;
+  autoUpdate: boolean;
 }
 
 function SearchInput(props: ISearchInputProps): JSX.Element {
@@ -106,7 +106,7 @@ function SearchInput(props: ISearchInputProps): JSX.Element {
       }}
       // Setting a key ensures that `defaultValue` will become updated
       // when the initial value changes.
-      key={props.initialValue}
+      key={props.autoUpdate ? props.initialValue : null}
       tabIndex={0}
       ref={props.inputRef}
       title={props.title}
@@ -152,13 +152,13 @@ function SearchEntry(props: ISearchEntryProps): JSX.Element {
     <div className={wrapperClass}>
       <SearchInput
         placeholder={trans.__('Find')}
-        value={props.initialSearchText}
         onChange={e => props.onChange(e)}
         onKeyDown={e => props.onKeydown(e)}
         inputRef={props.inputRef}
         initialValue={props.initialSearchText}
         title={trans.__('Find')}
         autoFocus={true}
+        autoUpdate={true}
       />
       <button
         className={BUTTON_WRAPPER_CLASS}
@@ -215,11 +215,12 @@ function ReplaceEntry(props: IReplaceEntryProps): JSX.Element {
       <div className={INPUT_WRAPPER_CLASS}>
         <SearchInput
           placeholder={trans.__('Replace')}
-          value={props.replaceText ?? ''}
+          initialValue={props.replaceText ?? ''}
           onKeyDown={e => props.onReplaceKeydown(e)}
           onChange={e => props.onChange(e)}
           title={trans.__('Replace')}
           autoFocus={false}
+          autoUpdate={false}
         />
         {props.replaceOptionsSupport?.preserveCase ? (
           <button

--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -754,7 +754,11 @@ export class SearchDocumentView extends VDomRenderer<SearchDocumentModel> {
    */
   setSearchText(search: string): void {
     this.model.initialQuery = search;
-    this.model.searchExpression = search;
+    // Only set the new search text to search expression if there is any
+    // to avoid nullifying the one that was remembered from last time.
+    if (search) {
+      this.model.searchExpression = search;
+    }
   }
 
   /**

--- a/packages/documentsearch/test/searchmodel.spec.ts
+++ b/packages/documentsearch/test/searchmodel.spec.ts
@@ -74,18 +74,26 @@ describe('documentsearch/searchmodel', () => {
       });
     });
 
-    describe('#initialQuery', () => {
-      it('should get query from search expression or provider', () => {
+    describe('#suggestedInitialQuery', () => {
+      it('should return inital query from provider', () => {
+        expect(model.suggestedInitialQuery).toEqual('unset');
         provider.initialQuery = 'provider-set-query';
-        expect(model.initialQuery).toEqual('provider-set-query');
-        model.searchExpression = 'query';
-        expect(model.initialQuery).toEqual('query');
-        model.searchExpression = '';
-        expect(model.initialQuery).toEqual('provider-set-query');
+        expect(model.suggestedInitialQuery).toEqual('provider-set-query');
+      });
+    });
+
+    describe('#initialQuery', () => {
+      it('should set/get inital non-empty query', () => {
+        model.initialQuery = 'externally-set-query';
+        expect(model.initialQuery).toEqual('externally-set-query');
+      });
+      it('should fallback to previous search expression on empty value in setter', () => {
+        model.searchExpression = 'search-expression';
+        model.initialQuery = '';
+        expect(model.initialQuery).toEqual('search-expression');
       });
       it('should remember last query', async () => {
-        provider.initialQuery = 'provider-set-query';
-        model.searchExpression = 'query';
+        model.initialQuery = 'query';
         expect(model.initialQuery).toEqual('query');
         await model.endQuery();
         expect(model.initialQuery).toEqual('query');


### PR DESCRIPTION
## References

Fixes #14306

## Code changes

- split up `initialQuery` in search model that had a circular logic preventing proper functioning into:
  - `initialQuery` getter/setter pair for read/manipulation from widget
  - `suggestedInitialQuery` to expose the initial query suggested by search provider (usually the selected text)
- use `key` trick to enforce update of textarea's `defaultValue` when `initialQuery` changes
  - use effect hook to ensure the text selection in textarea gets updated afterwards
- rename `searchText` widget props to `initialSearchText` to clarify the purpose

## User-facing changes

Invoking search (e.g. with <kbd>Ctrl</kbd> + <kbd>F</kbd>) will update the query to text selected in editor:

![Initial-search-input](https://user-images.githubusercontent.com/5832902/230906762-c68cff89-ce09-49e3-bc0d-decd93047811.gif)

**Note**: some editors do not update the text if current selection spans multiple lines. This PR does not introduce such a restriction (multi-line selections also update the search text). If any of reviewers believe we should adapt such a restrictions (I don't see a solid argument for it, but happy to be proven wrong) let's open a new issue to discuss.

As previously, previous search text is restored if there is no selection; this behaviour is now covered by integration tests:

![previous-search-text-is-restored](https://user-images.githubusercontent.com/5832902/230915332-9da679b3-bb49-4e2d-a9b1-343c68eaf9cb.gif)


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
