### PR TITLE
Fix cursor when hovering a kernel in the Running tab

### DIFF
--- a/packages/running/style/base.css
+++ b/packages/running/style/base.css
@@ -61,10 +61,15 @@
 
 .jp-RunningSessions-item:hover {
   background-color: var(--jp-layout-color2);
+  cursor: pointer;
 }
 
 .jp-RunningSessions-item.jp-mod-running-child {
   padding-left: 40px;
+}
+
+.jp-RunningSessions-item.jp-mod-kernel:not(.jp-mod-running-child) {
+  user-select: none;
 }
 
 .jp-RunningSessions-item img {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/14326
  * The mouse cursor should not be a text insertion-point cursor.
  * The collapser and kernel name should be non-selectable.
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Changed running packages css styles.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

https://user-images.githubusercontent.com/21135321/231499258-97266106-6b11-46fe-8fa3-cc5125253eb5.mp4



## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
