### PR TITLE
Add signal when an item factory is added to the toolbar

### DIFF
--- a/packages/apputils/src/tokens.ts
+++ b/packages/apputils/src/tokens.ts
@@ -341,6 +341,11 @@ export interface IToolbarWidgetRegistry {
     toolbarItemName: string,
     factory: (main: T) => Widget
   ): ((main: T) => Widget) | undefined;
+
+  /**
+   * A signal emitted when a factory widget has been added.
+   */
+  readonly factoryAdded: ISignal<this, string>;
 }
 
 /**

--- a/packages/apputils/src/toolbar/factory.ts
+++ b/packages/apputils/src/toolbar/factory.ts
@@ -303,6 +303,25 @@ export function createToolbarFactory(
       }
     };
 
+    const updateWidget = (
+      registry: IToolbarWidgetRegistry,
+      itemName: string
+    ) => {
+      const itemIndex = Array.from(items).findIndex(
+        item => item.name === itemName
+      );
+      if (itemIndex >= -1) {
+        toolbar.set(itemIndex, {
+          name: itemName,
+          widget: toolbarRegistry.createWidget(
+            factoryName,
+            widget,
+            items.get(itemIndex)
+          )
+        });
+      }
+    };
+
     const toolbar = new ObservableList<ToolbarRegistry.IToolbarItem>({
       values: Array.from(items).map(item => {
         return {
@@ -313,24 +332,13 @@ export function createToolbarFactory(
     });
 
     // Re-render the widget if a new factory has been added.
-    toolbarRegistry.factoryAdded.connect((_, itemName) => {
-      for (let i = 0; i < items.length; i++) {
-        if (items.get(i).name === itemName) {
-          toolbar.set(i, {
-            name: itemName,
-            widget: toolbarRegistry.createWidget(
-              factoryName,
-              widget,
-              items.get(i)
-            )
-          });
-        }
-      }
-    });
+    toolbarRegistry.factoryAdded.connect(updateWidget);
 
     items.changed.connect(updateToolbar);
+
     widget.disposed.connect(() => {
       items.changed.disconnect(updateToolbar);
+      toolbarRegistry.factoryAdded.disconnect(updateWidget);
     });
 
     return toolbar;

--- a/packages/apputils/src/toolbar/factory.ts
+++ b/packages/apputils/src/toolbar/factory.ts
@@ -310,7 +310,7 @@ export function createToolbarFactory(
       const itemIndex = Array.from(items).findIndex(
         item => item.name === itemName
       );
-      if (itemIndex >= -1) {
+      if (itemIndex >= 0) {
         toolbar.set(itemIndex, {
           name: itemName,
           widget: toolbarRegistry.createWidget(

--- a/packages/apputils/src/toolbar/factory.ts
+++ b/packages/apputils/src/toolbar/factory.ts
@@ -312,6 +312,22 @@ export function createToolbarFactory(
       })
     });
 
+    // Re-render the widget if a new factory has been added.
+    toolbarRegistry.factoryAdded.connect((_, itemName) => {
+      for (let i = 0; i < items.length; i++) {
+        if (items.get(i).name === itemName) {
+          toolbar.set(i, {
+            name: itemName,
+            widget: toolbarRegistry.createWidget(
+              factoryName,
+              widget,
+              items.get(i)
+            )
+          });
+        }
+      }
+    });
+
     items.changed.connect(updateToolbar);
     widget.disposed.connect(() => {
       items.changed.disconnect(updateToolbar);

--- a/packages/apputils/src/toolbar/registry.ts
+++ b/packages/apputils/src/toolbar/registry.ts
@@ -11,6 +11,7 @@ import {
 import { CommandRegistry } from '@lumino/commands';
 import { Widget } from '@lumino/widgets';
 import { IToolbarWidgetRegistry, ToolbarRegistry } from '../tokens';
+import { ISignal, Signal } from '@lumino/signaling';
 
 /**
  * Concrete implementation of IToolbarWidgetRegistry interface
@@ -38,6 +39,13 @@ export class ToolbarWidgetRegistry implements IToolbarWidgetRegistry {
     ) => Widget
   ) {
     this._defaultFactory = factory;
+  }
+
+  /**
+   * A signal emitted when a factory widget has been added.
+   */
+  get factoryAdded(): ISignal<this, string> {
+    return this._factoryAdded;
   }
 
   /**
@@ -79,6 +87,7 @@ export class ToolbarWidgetRegistry implements IToolbarWidgetRegistry {
       this._widgets.set(widgetFactory, namespace);
     }
     namespace.set(toolbarItemName, factory);
+    this._factoryAdded.emit(toolbarItemName);
     return oldFactory;
   }
 
@@ -107,6 +116,7 @@ export class ToolbarWidgetRegistry implements IToolbarWidgetRegistry {
   ) => Widget;
   protected _widgets: Map<string, Map<string, (main: Widget) => Widget>> =
     new Map<string, Map<string, (main: Widget) => Widget>>();
+  protected _factoryAdded = new Signal<this, string>(this);
 }
 
 /**


### PR DESCRIPTION
See https://github.com/jupyterlab/jupyterlab/issues/14366 for context.

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/14366
The issue was first notified in https://github.com/jupyter/notebook/pull/6838

## Code changes

Adds a signal in `ToolbarWidgetRegistry`, which is emitted when an item factory is added to the registry.
This signal is caught by the `toolbarFactory` to render again the widget.

## User-facing changes

None

## Backwards-incompatible changes

None

EDIT:
Tested successfully on https://github.com/jupyter/notebook/pull/6838