### PR TITLE
Restore rectangular selection (CodeMirror 6 migration follow-up)

### DIFF
--- a/packages/codemirror/src/extension.ts
+++ b/packages/codemirror/src/extension.ts
@@ -16,6 +16,7 @@ import {
   StateEffect
 } from '@codemirror/state';
 import {
+  crosshairCursor,
   drawSelection,
   EditorView,
   highlightActiveLine,
@@ -24,6 +25,7 @@ import {
   KeyBinding,
   keymap,
   lineNumbers,
+  rectangularSelection,
   scrollPastEnd
 } from '@codemirror/view';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
@@ -716,6 +718,22 @@ export namespace EditorExtensionRegistry {
         schema: {
           type: 'boolean',
           title: trans.__('Match Brackets')
+        }
+      }),
+      Object.freeze({
+        name: 'rectangularSelection',
+        default: true,
+        factory: () =>
+          createConditionalExtension([
+            rectangularSelection(),
+            crosshairCursor()
+          ]),
+        schema: {
+          type: 'boolean',
+          title: trans.__('Rectangular selection'),
+          description: trans.__(
+            'Rectangular (block) selection can be created by dragging the mouse pointer while holding the left mouse button and the Alt key. When the Alt key is pressed, a crosshair cursor will appear, indicating that the rectangular selection mode is active.'
+          )
         }
       }),
       Object.freeze({


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/14359 - rectangular selection was missed during CodeMirror 5 → CodeMirror 6 transition.

## Code changes

Adds new conditional extension/setting.

## User-facing changes

Restored  rectangular selection extension that was enabled by default in all versions JupyterLab and Jupyter Notebook using CodeMirror 5, using equivalent CodeMirror 6 extension:

![rectangular-selection](https://user-images.githubusercontent.com/5832902/232227042-a3430ff9-1b76-447e-b892-8bf939f00ae5.gif)

Differently to JupyterLab 3.x, users can new disable this feature via settings:

![Screenshot from 2023-04-15 14-28-10](https://user-images.githubusercontent.com/5832902/232226845-7ffa3840-d17e-4f36-948b-055d22285c8f.png)


## Backwards-incompatible changes

Only relevant to 4.x version.