### PR TITLE
Only apply margin on `<select>` instead of using universal CSS selector

### DIFF
--- a/packages/lsp-extension/style/base.css
+++ b/packages/lsp-extension/style/base.css
@@ -3,6 +3,6 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-.jp-LSPExtension-FormGroup-content > * {
-  margin-right: 25px;
+.jp-LSPExtension-FormGroup-content > select {
+  margin: 0 12px;
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #14236
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Apply margin only on the middle item

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Slight visual change

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/8435071/233396840-7f7f3ecc-5a03-4fe2-b9aa-38ac8e0076ae.png) | ![image](https://user-images.githubusercontent.com/8435071/233396698-6d978d43-af7f-466f-abaa-07d5e98fdc33.png) |

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None