### PR TITLE
Fix CI: remove/update broken docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 **[Installation](#installation)** |
-**[Documentation](http://jupyterlab.readthedocs.io)** |
+**[Documentation](https://jupyterlab.readthedocs.io)** |
 **[Contributing](#contributing)** |
 **[License](#license)** |
 **[Team](#team)** |
 **[Getting help](#getting-help)** |
 
-# [JupyterLab](http://jupyterlab.github.io/jupyterlab/)
+# [JupyterLab](https://jupyterlab.readthedocs.io)
 
 [![PyPI version](https://badge.fury.io/py/jupyterlab.svg)](https://badge.fury.io/py/jupyterlab)
 [![Downloads](https://pepy.tech/badge/jupyterlab/month)](https://pepy.tech/project/jupyterlab/month)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -389,10 +389,6 @@ shasum -a 256 dist/*.tar.gz
 - Create a PR with the version bump
 - Update `recipe/meta.yaml` with the new version and sha256 and reset the build number to 0.
 
-## Updating API Docs
-
-Run `source scripts/docs_push.sh` to update the `gh-pages` branch that backs http://jupyterlab.github.io/jupyterlab/.
-
 ## Making a manual patch release
 
 - Backport the change to the previous release branch

--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -2,7 +2,7 @@
 
 Javascript client for the Jupyter services REST APIs
 
-[API Docs](http://jupyterlab.github.io/jupyterlab/)
+[API Docs](https://jupyterlab.readthedocs.io/en/stable/api/)
 
 [REST API Docs](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter-server/jupyter_server/main/jupyter_server/services/api/api.yaml)
 

--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -2,7 +2,7 @@
 
 Javascript client for the Jupyter services REST APIs
 
-[API Docs](https://jupyterlab.readthedocs.io/en/stable/api/)
+[API Docs](https://jupyterlab.readthedocs.io/en/latest/api/)
 
 [REST API Docs](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter-server/jupyter_server/main/jupyter_server/services/api/api.yaml)
 


### PR DESCRIPTION
Fixes failing `Linux Tests / check_links (pull_request)` job across recent pull requests.

It looks like `jupyterlab.github.io` stopped working. It is probably better to keep deploying docs on RDT only (and https://github.com/jupyterlab/jupyterlab/tree/gh-pages was not updated for three years now).