### PR TITLE
Harmonizes form renderer ids

### DIFF
--- a/packages/celltags-extension/schema/plugin.json
+++ b/packages/celltags-extension/schema/plugin.json
@@ -24,7 +24,7 @@
       },
       "metadataOptions": {
         "/tags": {
-          "customRenderer": "celltags-extension:plugin.renderer"
+          "customRenderer": "@jupyterlab/celltags-extension:plugin.renderer"
         }
       }
     }

--- a/packages/celltags-extension/src/index.ts
+++ b/packages/celltags-extension/src/index.ts
@@ -40,7 +40,10 @@ const customCellTag: JupyterFrontEndPlugin<void> = {
           return new CellTagField(tracker).render(props);
         }
       };
-      formRegistry.addRenderer('celltags-extension:plugin.renderer', component);
+      formRegistry.addRenderer(
+        '@jupyterlab/celltags-extension:plugin.renderer',
+        component
+      );
     }
   }
 };

--- a/packages/notebook-extension/schema/tools.json
+++ b/packages/notebook-extension/schema/tools.json
@@ -103,7 +103,7 @@
       },
       "metadataOptions": {
         "_CELL-TOOL": {
-          "customRenderer": "notebook-extension:active-cell-tool.renderer"
+          "customRenderer": "@jupyterlab/notebook-extension:active-cell-tool.renderer"
         },
         "/raw_mimetype": {
           "cellTypes": ["raw"]
@@ -131,10 +131,10 @@
       },
       "metadataOptions": {
         "_CELL-METADATA": {
-          "customRenderer": "notebook-extension:metadata-editor.cell-metadata"
+          "customRenderer": "@jupyterlab/notebook-extension:metadata-editor.cell-metadata"
         },
         "_NOTEBOOK-METADATA": {
-          "customRenderer": "notebook-extension:metadata-editor.notebook-metadata"
+          "customRenderer": "@jupyterlab/notebook-extension:metadata-editor.notebook-metadata"
         }
       }
     }

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -999,7 +999,7 @@ const customMetadataEditorFields: JupyterFrontEndPlugin<void> = {
       }
     };
     formRegistry.addRenderer(
-      'notebook-extension:metadata-editor.cell-metadata',
+      '@jupyterlab/notebook-extension:metadata-editor.cell-metadata',
       cellComponent
     );
 
@@ -1014,7 +1014,7 @@ const customMetadataEditorFields: JupyterFrontEndPlugin<void> = {
       }
     };
     formRegistry.addRenderer(
-      'notebook-extension:metadata-editor.notebook-metadata',
+      '@jupyterlab/notebook-extension:metadata-editor.notebook-metadata',
       notebookComponent
     );
   }
@@ -1044,7 +1044,7 @@ const activeCellTool: JupyterFrontEndPlugin<void> = {
       }
     };
     formRegistry.addRenderer(
-      'notebook-extension:active-cell-tool.renderer',
+      '@jupyterlab/notebook-extension:active-cell-tool.renderer',
       component
     );
   }

--- a/packages/ui-components-extension/src/index.ts
+++ b/packages/ui-components-extension/src/index.ts
@@ -32,15 +32,16 @@ const labiconManager: JupyterFrontEndPlugin<ILabIconManager> = {
 /**
  * Sets up the renderer registry to be used by the FormEditor component.
  */
-const rendererRegistryPlugin: JupyterFrontEndPlugin<IFormRendererRegistry> = {
-  id: '@jupyterlab/ui-components-extension:form-renderer-registry',
-  description: 'Provides the settings form renderer registry.',
-  provides: IFormRendererRegistry,
-  autoStart: true,
-  activate: (app: JupyterFrontEnd): IFormRendererRegistry => {
-    const editorRegistry = new FormRendererRegistry();
-    return editorRegistry;
-  }
-};
+const formRendererRegistryPlugin: JupyterFrontEndPlugin<IFormRendererRegistry> =
+  {
+    id: '@jupyterlab/ui-components-extension:form-renderer-registry',
+    description: 'Provides the settings form renderer registry.',
+    provides: IFormRendererRegistry,
+    autoStart: true,
+    activate: (app: JupyterFrontEnd): IFormRendererRegistry => {
+      const formRendererRegistry = new FormRendererRegistry();
+      return formRendererRegistry;
+    }
+  };
 
-export default [labiconManager, rendererRegistryPlugin];
+export default [labiconManager, formRendererRegistryPlugin];


### PR DESCRIPTION
This PR is simply to harmonize some ids of `IFormRenderer`, by starting them with the full plugin id.

## References

None

## Code changes

Some form renderers IDs.

## User-facing changes

None

## Backwards-incompatible changes

None
