### PR TITLE
Fix typo in CoffeeScript label

### DIFF
--- a/packages/codemirror/src/language.ts
+++ b/packages/codemirror/src/language.ts
@@ -679,7 +679,7 @@ export namespace EditorLanguageRegistry {
       },
       {
         name: 'CoffeeScript',
-        displayName: trans.__('CoffeScript'),
+        displayName: trans.__('CoffeeScript'),
         alias: ['coffee', 'coffee-script'],
         mime: [
           'application/vnd.coffeescript',


### PR DESCRIPTION
## References

Addresses a typo reported in #14372

## Code changes

```diff
-CoffeScript
+CoffeeScript
```

## User-facing changes

As a bove

## Backwards-incompatible changes

N/A
