### PR TITLE
Update jupyter-lsp schema

### DIFF
--- a/packages/lsp/src/schema.ts
+++ b/packages/lsp/src/schema.ts
@@ -149,6 +149,10 @@ export interface ServerSpecProperties {
   display_name?: DisplayName;
   env?: EnvironmentVariables;
   extend?: Extensions;
+  /**
+   * Whether to write un-saved documents to disk in a transient `.virtual_documents` directory. Well-behaved language servers that work against in-memory files should set this to `false`, which will become the default in the future.
+   */
+  requires_documents_on_disk?: boolean;
   install?: Installation1;
   languages?: LanguageList;
   mime_types?: MIMETypes;


### PR DESCRIPTION
## References

Fixes a CI failure that arouse after release of jupyter-lsp 2.1:

```js
 FAIL  test/schema.spec.ts (5.383 s)
  ● @jupyterlab/lsp › schema.ts › verify the interfaces defined in `schema.ts` with the schema in jupyter_lsp

    'schema.ts' in '@jupyterlab/lsp' is not matching the 'jupyter_lsp' backend schema.
      Please update 'schema.ts' by running `npm run build:schema` in '@jupyterlab/lsp' and commit the changes.

      13 |         expect(value.toString().includes('true')).toBe(true);
      14 |       } catch (reason) {
    > 15 |         throw new Error(
         |               ^
      16 |           `'schema.ts' in '@jupyterlab/lsp' is not matching the 'jupyter_lsp' backend schema.
      17 |   Please update 'schema.ts' by running \`npm run build:schema\` in '@jupyterlab/lsp' and commit the changes.`
      18 |         );
```

## Code changes

Updates schema to match usptream by adding `requires_documents_on_disk?: boolean`.

## User-facing changes

None

## Backwards-incompatible changes

N/A