### PR TITLE
initialize _replaceText to ''

### DIFF
--- a/packages/documentsearch/src/searchmodel.ts
+++ b/packages/documentsearch/src/searchmodel.ts
@@ -358,7 +358,7 @@ export class SearchDocumentModel
   private _preserveCase = false;
   private _initialQuery = '';
   private _filters: IFilters = {};
-  private _replaceText: string;
+  private _replaceText: string = '';
   private _searchDebouncer: Debouncer;
   private _searchExpression = '';
   private _useRegex = false;

--- a/packages/documentsearch/test/searchmodel.spec.ts
+++ b/packages/documentsearch/test/searchmodel.spec.ts
@@ -141,5 +141,35 @@ describe('documentsearch/searchmodel', () => {
         query.lastIndex = 0;
       });
     });
+
+    describe('#replaceText', () => {
+      it('defaults to empty string', () => {
+        expect(model.replaceText).toEqual('');
+      });
+
+      it('changes after assignment with setter', () => {
+        model.replaceText = 'test';
+        expect(model.replaceText).toEqual('test');
+      });
+
+      it('emits `stateChanged` signal on assignment', () => {
+        let emitted = false;
+        model.stateChanged.connect(() => {
+          emitted = true;
+        });
+        model.replaceText = 'test';
+        expect(emitted).toEqual(true);
+      });
+
+      it('does not emit `stateChanged` signal if value has not changed', () => {
+        let emitted = 0;
+        model.stateChanged.connect(() => {
+          emitted += 1;
+        });
+        model.replaceText = '1';
+        model.replaceText = '1';
+        expect(emitted).toEqual(1);
+      });
+    });
   });
 });


### PR DESCRIPTION
## References

- Fixes #14419

> In notebook and file editor when replacing search matches the replace text defaults to undefined which is then inserted (instead of empty string).

## Code changes

initialize `_replaceText` to `''` so that it would not be `undefined`.

## User-facing changes

Empty space `''` is now pasted on "Replace All" when "Replace" field is empty

Before:
![233845166-d1d25507-4684-4178-aa7e-8bdd1ed45f3c](https://user-images.githubusercontent.com/26686070/234438784-a7295b16-f116-4485-9dc0-1b83bd73d014.gif)

After:
![Paste empty sapce 2](https://user-images.githubusercontent.com/26686070/234438633-b7b765d6-c346-4cdc-8b78-1006709217a5.gif)

## Backwards-incompatible changes

None
