### PR TITLE
Add user facing changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,11 +64,11 @@ _Notebook windowing_ might add side effects with notebooks containing cells inje
 
 ### Real Time Collaboration
 
-In JupyterLab 3.6, we made a huge step forward for real time collaboration (RTC).
-We decided to extract the feature to an external extension: [jupyter_collaboration](https://github.com/jupyterlab/jupyter_collaboration).
-The rationale is to limit the dependencies for users who don't need RTC. We also separated RTC to benefit organizations that do not meet the specific requirements regarding file content management.
+JupyterLab 3.6 already made significant improvements to the Real Time Collaboration (RTC) feature.
+The feature has now been to a separate repository: [jupyter_collaboration](https://github.com/jupyterlab/jupyter_collaboration).
+The rationale is to limit the dependencies for users who don't need RTC. Separating RTC also helps organizations using JupyterLab that do not meet the specific requirements regarding file content management.
 
-If you want to try RTC, you can install it:
+To enable RTC, install the `jupyter-collaboration` package with:
 
 - with pip: `pip install "jupyter-collaboration>=1.0.0a0"`
 - with conda: _not yet available_
@@ -80,7 +80,7 @@ Some highlights:
 
 ###️ For developers
 
-For contributors and extension authors, here are the main tools that you need to upgrade to work with JupyterLab 4:
+Here are the main tool updates that may affect extension authors and developers:
 
 - TypeScript v5
 - Yarn v3
@@ -89,7 +89,7 @@ For contributors and extension authors, here are the main tools that you need to
 
 We also recommend NodeJS v18, the only version to remain supported in 2024 (see [Node release schedule](https://github.com/nodejs/release#release-schedule)).
 
-To ease your code migration to JupyterLab 4, have a look at the [migration guide](https://jupyterlab.readthedocs.io/en/latest/extension/extension_migration.html). You can also look at the following PRs that migrated some extensions:
+To ease code migration to JupyterLab 4, have a look at the [migration guide](https://jupyterlab.readthedocs.io/en/latest/extension/extension_migration.html). A few existing extensions have already been migrated and can be used as examples:
 - the [extensions examples](https://github.com/jupyterlab/extension-examples/pull/225)
 - the [Jupyter MIME type renderers](https://github.com/jupyterlab/jupyter-renderers/pull/296)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ JupyterLab is now faster, thanks to the following improvements:
 
 - CSS rules optimization: CSS selectors have been optimized to improve web browser performance when many elements are present on a page.
 - Upgrade to CodeMirror 6: Especially for notebooks with many cells, the new CodeMirror version is far more efficient than the previous version. Large notebooks should load more quickly.
+- Upgrade to MathJax 3: The mathematical equations renderer library has been been upgrade from v2 to v3 allowing faster rendering.
 - Notebook windowing: By rendering only the parts of a notebook that fit in the web browser viewport, JupyterLab is much more efficient. See an important note below.
 
 Notebook windowing _might_ add side effects with notebooks containing cells injecting new CSS styles or JavaScript. It may also be less convenient if some cell outputs are displaying [iframes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe). If you have issues with notebook rendering, try changing the user setting _Notebook_ > _Windowing mode_ to `defer` or `none`. (`none` should be used as a last resort, because it disables all optimizations.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,93 @@
 
 ## 4.0
 
+Below are the major highlights in JupyterLab 4.
+
+### New text editor
+
+CodeMirror, the text editor used for cells and file editors, has been updated to [CodeMirror 6](https://codemirror.net/). This brings important
+performance improvements as well as better customization capabilities.
+The editor settings have also been improved. Previously settings had to be individually set for each type of cell, the file editor, and the console editor. Now they are all set in one place, and you can choose to use the default settings for all editors and change some settings for specific cases. For example, it is possible to hide the line numbers for markdown cells.
+
+Developers can now provide editor extensions, like themes and programming language parsers, through new application registries.
+
+### New extension manager
+
+Starting with JupyterLab 3, extensions can be installed via Python packages.
+
+In JupyterLab 4, building on this feature, the Extension Manager can now list and install extensions from [pypi.org](https://pypi.org/search/?c=Framework+%3A%3A+Jupyter+%3A%3A+JupyterLab).
+
+Developers can provide an alternative package repository to display your own set of extensions.
+
+### Improved document search
+
+The Search and Replace functionality has been improved with new features when searching in a notebook:
+
+- Highlight matches in rendered markdown cells
+- Search in selection
+- Multi-line search
+- Replace using regex capture-group references
+- Replace while preserving case
+
+### UI improvements
+
+Some new elements have been added or changed in the UI:
+
+- Rework the running kernels section
+- "Add cell" button at the notebook bottom
+- Dialog to display keyboard shortcuts as in the Classic Notebook (use <kbd>CTRL+SHIFT+H</kbd>)
+- Display first line of cell input and outputs when they are collapsed
+
+### Accessibility improvements
+
+JupyterLab is not yet fully accessible. Currently the focus is on making Notebook 7 accessible.
+A big part of the code is shared, though, and the following accessibility improvements are in JupyterLab 4:
+
+- Improved focus and keyboard navigation in the file browser
+- Add more roles and labels to UI elements
+- Main menu collapses to a hamburger menu if the web page is not wide enough to display all items.
+
+### Performance enhancements
+
+JupyterLab is now faster, thanks to the following improvements:
+
+- CSS rules optimization: CSS selectors have been optimized to improve web browser performance when many elements are present on a page.
+- Upgrade to CodeMirror 6: Especially for notebooks with many cells, the new CodeMirror version is far more efficient than the previous version. Large notebook should now load faster.
+- Notebook windowing: By rendering only the parts of a notebook that fit in the web browser viewport, JupyterLab is much more efficient. See an important note below.
+
+_Notebook windowing_ might add side effects with notebooks containing cells injecting new CSS styles or JavaScript. It may also be less convenient if some cell outputs are displaying [iframes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe). If you have issues with notebook rendering, try changing the user setting _Notebook_ > _Windowing mode_ to `defer` or `none`. (`none` should be used as a last resort, because it disables all optimizations.)
+
+### Real Time Collaboration
+
+In JupyterLab 3.6, we made a huge step forward for real time collaboration (RTC).
+We decided to extract the feature to an external extension: [jupyter_collaboration](https://github.com/jupyterlab/jupyter_collaboration).
+The rationale is to limit the dependencies for users who don't need RTC. We also separated RTC to benefit organizations that do not meet the specific requirements regarding file content management.
+
+If you want to try RTC, you can install it:
+
+- with pip: `pip install "jupyter-collaboration>=1.0.0a0"`
+- with conda: _not yet available_
+
+Some highlights:
+
+- Support displaying multiple cursors and selections
+- Support registration of new shared model types
+
+###️ For developers
+
+For contributors and extension authors, here are the main tools that you need to upgrade to work with JupyterLab 4:
+
+- TypeScript v5
+- Yarn v3
+- React v18
+- Lumino v2
+
+We also recommend NodeJS v18, the only version to remain supported in 2024 (see [Node release schedule](https://github.com/nodejs/release#release-schedule)).
+
+To ease your code migration to JupyterLab 4, have a look at the [migration guide](https://jupyterlab.readthedocs.io/en/latest/extension/extension_migration.html). You can also look at the following PRs that migrated some extensions:
+- the [extensions examples](https://github.com/jupyterlab/extension-examples/pull/225)
+- the [Jupyter MIME type renderers](https://github.com/jupyterlab/jupyter-renderers/pull/296)
+
 <!-- <START NEW CHANGELOG ENTRY> -->
 
 ## 4.0.0b2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Developers can now provide editor extensions, like themes and programming langua
 Starting with JupyterLab 3, extensions can be installed via Python packages
 (or other providers of [prebuilt extensions](https://jupyterlab.readthedocs.io/en/latest/extension/extension_dev.html#prebuilt-extensions)).
 
-In JupyterLab 4, building on this feature, the Extension Manager can now list and install extensions from [pypi.org](https://pypi.org/search/?c=Framework+%3A%3A+Jupyter+%3A%3A+JupyterLab).
+In JupyterLab 4, building on this feature, the Extension Manager now includes extensions from [pypi.org](https://pypi.org/search/?c=Framework+%3A%3A+Jupyter+%3A%3A+JupyterLab).
 This removes the build step from installation of extension when using Extension Manager.
 
 Developers can provide an alternative package repository to display their own set of extensions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Below are the major highlights in JupyterLab 4.
 
 CodeMirror, the text editor used for cells and file editors, has been updated to [CodeMirror 6](https://codemirror.net/). This brings important
 performance improvements as well as better customization capabilities.
-The editor settings have also been improved. Previously settings had to be individually set for each type of cell, the file editor, and the console editor. Now they are all set in one place, and you can choose to use the default settings for all editors and change some settings for specific cases. For example, it is possible to hide the line numbers for markdown cells.
+The editor settings have also been improved. Previously settings had to be individually set for each type of cell, the file editor, and the console editor. Now they are all set in one place, which makes it easier to use the default settings for all editors or change some settings for specific cases. For example, it is possible to hide the line numbers for markdown cells.
 
 Developers can now provide editor extensions, like themes and programming language parsers, through new application registries.
 
@@ -22,7 +22,7 @@ Starting with JupyterLab 3, extensions can be installed via Python packages.
 
 In JupyterLab 4, building on this feature, the Extension Manager can now list and install extensions from [pypi.org](https://pypi.org/search/?c=Framework+%3A%3A+Jupyter+%3A%3A+JupyterLab).
 
-Developers can provide an alternative package repository to display your own set of extensions.
+Developers can provide an alternative package repository to display their own set of extensions.
 
 ### Improved document search
 
@@ -89,8 +89,8 @@ Here are the main tool updates that may affect extension authors and developers:
 
 We also recommend NodeJS v18, the only version to remain supported in 2024 (see [Node release schedule](https://github.com/nodejs/release#release-schedule)).
 
-To ease code migration to JupyterLab 4, have a look at the [migration guide](https://jupyterlab.readthedocs.io/en/latest/extension/extension_migration.html). A few existing extensions have already been migrated and can be used as examples:
-- the [extensions examples](https://github.com/jupyterlab/extension-examples/pull/225)
+To ease code migration to JupyterLab 4, developers can have a look at the [migration guide](https://jupyterlab.readthedocs.io/en/latest/extension/extension_migration.html). A few existing extensions have already been migrated and can be used as examples:
+- the [Extensions Examples](https://github.com/jupyterlab/extension-examples/pull/225)
 - the [Jupyter MIME type renderers](https://github.com/jupyterlab/jupyter-renderers/pull/296)
 
 <!-- <START NEW CHANGELOG ENTRY> -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ Some highlights:
 - Support displaying multiple cursors and selections
 - Support registration of new shared model types
 
-###️ For developers
+### For developers
 
 Here are the main tool updates that may affect extension authors and developers:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Below are the major highlights in JupyterLab 4.
 ### New text editor
 
 CodeMirror, the text editor used for cells and file editors, has been updated to [CodeMirror 6](https://codemirror.net/). This brings important
-performance improvements as well as better customization capabilities.
+accessibility and performance improvements as well as better customization capabilities.
 The editor settings have also been improved. Previously settings had to be individually set for each type of cell, the file editor, and the console editor. Now they are all set in one place, which makes it easier to use the default settings for all editors or change some settings for specific cases. For example, it is possible to hide the line numbers for markdown cells.
 
 Developers can now provide editor extensions, like themes and programming language parsers, through new application registries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,17 @@ Below are the major highlights in JupyterLab 4.
 
 CodeMirror, the text editor used for cells and file editors, has been updated to [CodeMirror 6](https://codemirror.net/). This brings important
 accessibility and performance improvements as well as better customization capabilities.
-The editor settings have also been improved. Previously settings had to be individually set for each type of cell, the file editor, and the console editor. Now they are all set in one place, which makes it easier to use the default settings for all editors or change some settings for specific cases. For example, it is possible to hide the line numbers for markdown cells.
+We have also improved the editor settings. Previously, users had to customize settings separately for each type of cell, the file editor, and the console editor. Now, you can change your settings in one place. It is now easier to use the default settings for all editors and to change some settings for specific cases. For example, you can now hide line numbers only for markdown cells.
 
 Developers can now provide editor extensions, like themes and programming language parsers, through new application registries.
 
 ### New extension manager
 
-Starting with JupyterLab 3, extensions can be installed via Python packages.
+Starting with JupyterLab 3, extensions can be installed via Python packages
+(or other providers of [prebuilt extensions](https://jupyterlab.readthedocs.io/en/latest/extension/extension_dev.html#prebuilt-extensions)).
 
 In JupyterLab 4, building on this feature, the Extension Manager can now list and install extensions from [pypi.org](https://pypi.org/search/?c=Framework+%3A%3A+Jupyter+%3A%3A+JupyterLab).
+This removes the build step from installation of extension when using Extension Manager.
 
 Developers can provide an alternative package repository to display their own set of extensions.
 
@@ -39,58 +41,58 @@ The Search and Replace functionality has been improved with new features when se
 Some new elements have been added or changed in the UI:
 
 - Rework the running kernels section
-- "Add cell" button at the notebook bottom
-- Dialog to display keyboard shortcuts as in the Classic Notebook (use <kbd>CTRL+SHIFT+H</kbd>)
-- Display first line of cell input and outputs when they are collapsed
+- "Add a new cell" button at the bottom of a notebook
+- Dialog to display keyboard shortcuts as in the Classic Notebook (use <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>H</kbd>)
+- Display the first line of cell input and outputs when they are collapsed
 
 ### Accessibility improvements
 
-JupyterLab is not yet fully accessible. Currently the focus is on making Notebook 7 accessible.
+JupyterLab is not yet fully accessible. Currently, we are focused on making Notebook 7 accessible.
 A big part of the code is shared, though, and the following accessibility improvements are in JupyterLab 4:
 
 - Improved focus and keyboard navigation in the file browser
-- Add more roles and labels to UI elements
-- Main menu collapses to a hamburger menu if the web page is not wide enough to display all items.
+- More ARIA roles and labels were added to UI elements
+- Main menu collapses to a hamburger menu if there is not enough space to display all items.
 
 ### Performance enhancements
 
 JupyterLab is now faster, thanks to the following improvements:
 
 - CSS rules optimization: CSS selectors have been optimized to improve web browser performance when many elements are present on a page.
-- Upgrade to CodeMirror 6: Especially for notebooks with many cells, the new CodeMirror version is far more efficient than the previous version. Large notebook should now load faster.
+- Upgrade to CodeMirror 6: Especially for notebooks with many cells, the new CodeMirror version is far more efficient than the previous version. Large notebooks should load more quickly.
 - Notebook windowing: By rendering only the parts of a notebook that fit in the web browser viewport, JupyterLab is much more efficient. See an important note below.
 
-_Notebook windowing_ might add side effects with notebooks containing cells injecting new CSS styles or JavaScript. It may also be less convenient if some cell outputs are displaying [iframes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe). If you have issues with notebook rendering, try changing the user setting _Notebook_ > _Windowing mode_ to `defer` or `none`. (`none` should be used as a last resort, because it disables all optimizations.)
+Notebook windowing _might_ add side effects with notebooks containing cells injecting new CSS styles or JavaScript. It may also be less convenient if some cell outputs are displaying [iframes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe). If you have issues with notebook rendering, try changing the user setting _Notebook_ > _Windowing mode_ to `defer` or `none`. (`none` should be used as a last resort, because it disables all optimizations.)
 
 ### Real Time Collaboration
 
 JupyterLab 3.6 already made significant improvements to the Real Time Collaboration (RTC) feature.
-The feature has now been to a separate repository: [jupyter_collaboration](https://github.com/jupyterlab/jupyter_collaboration).
+The feature is now in a separate repository: [jupyter_collaboration](https://github.com/jupyterlab/jupyter_collaboration).
 The rationale is to limit the dependencies for users who don't need RTC. Separating RTC also helps organizations using JupyterLab that do not meet the specific requirements regarding file content management.
 
-To enable RTC, install the `jupyter-collaboration` package with:
+To enable RTC, install the `jupyter-collaboration` package with either `pip` or `conda`.
 
 - with pip: `pip install "jupyter-collaboration>=1.0.0a0"`
 - with conda: _not yet available_
 
-Some highlights:
+RTC highlights in the standalone `jupyter-collboration` package, version 1.0.0, include:
 
-- Support displaying multiple cursors and selections
-- Support registration of new shared model types
+- Support for displaying multiple cursors and selections
+- Support for registration of new shared model types
 
 ### For developers
 
-Here are the main tool updates that may affect extension authors and developers:
+Here are the main tool updates that will benefit extension authors and developers:
 
 - TypeScript v5
 - Yarn v3
 - React v18
 - Lumino v2
 
-We also recommend NodeJS v18, the only version to remain supported in 2024 (see [Node release schedule](https://github.com/nodejs/release#release-schedule)).
+We recommend using Node.js v18 or newer, because older versions will reach end of life in 2023 or earlier (see [Node release schedule](https://github.com/nodejs/release#release-schedule)).
 
-To ease code migration to JupyterLab 4, developers can have a look at the [migration guide](https://jupyterlab.readthedocs.io/en/latest/extension/extension_migration.html). A few existing extensions have already been migrated and can be used as examples:
-- the [Extensions Examples](https://github.com/jupyterlab/extension-examples/pull/225)
+To ease code migration to JupyterLab 4, developers should review the [migration guide](https://jupyterlab.readthedocs.io/en/latest/extension/extension_migration.html). A few existing extensions have already been migrated and can be used as examples:
+- the [JupyterLab Extensions by Examples](https://github.com/jupyterlab/extension-examples/pull/225)
 - the [Jupyter MIME type renderers](https://github.com/jupyterlab/jupyter-renderers/pull/296)
 
 <!-- <START NEW CHANGELOG ENTRY> -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ JupyterLab is now faster, thanks to the following improvements:
 
 - CSS rules optimization: CSS selectors have been optimized to improve web browser performance when many elements are present on a page.
 - Upgrade to CodeMirror 6: Especially for notebooks with many cells, the new CodeMirror version is far more efficient than the previous version. Large notebooks should load more quickly.
-- Upgrade to MathJax 3: The mathematical equations renderer library has been been upgrade from v2 to v3 allowing faster rendering.
+- Upgrade to MathJax 3: The mathematical equations renderer library has been been upgraded from v2 to v3 allowing faster rendering.
 - Notebook windowing: By rendering only the parts of a notebook that fit in the web browser viewport, JupyterLab is much more efficient. See an important note below.
 
 Notebook windowing _might_ add side effects with notebooks containing cells injecting new CSS styles or JavaScript. It may also be less convenient if some cell outputs are displaying [iframes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe). If you have issues with notebook rendering, try changing the user setting _Notebook_ > _Windowing mode_ to `defer` or `none`. (`none` should be used as a last resort, because it disables all optimizations.)


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #14060 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update the changelog to add user friendly notes to the top of the document under the `v4` header.

This is heavily inspired by https://hackmd.io/MRJvGbyRTyKvqNAdoLCA-w.

The PR changes a bit the tone of the notes in the Hackmd by avoiding the use of `we` / `you` to make it more neutral and similar to the rest of the changelog.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Users can have a better idea of the new changes in JupyterLab 4.

![image](https://user-images.githubusercontent.com/591645/234518482-86db58ca-03b9-4cfc-bc89-db3958232c2a.png)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
