### PR TITLE
Fix broken links in galata/README.md

### DIFF
--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -148,4 +148,4 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
         with:
           ignore_glob: "packages/ui-components/docs/source/ui_components.rst images"
-          ignore_links: "../api/*.* .*/images/[\\w-]+.png https://docs.github.com/en/.* https://jupyterlab.github.io"
+          ignore_links: "../api/*.* .*/images/[\\w-]+.png https://docs.github.com/en/.* https://jupyterlab.github.io https://mybinder.org/v2/gh/jupyterlab/.*"

--- a/galata/README.md
+++ b/galata/README.md
@@ -133,7 +133,7 @@ PWDEBUG=1 jlpm playwright test
 
 If you have set up a custom login handler for your Jupyter application and don't want to remove it
 for your integration tests, you can try the following configuration (inspired by the
-[Playwright documentation](https://playwright.dev/docs/test-advanced#global-setup-and-teardown)):
+[Playwright documentation](https://playwright.dev/docs/test-global-setup-teardown)):
 
 1. Create a file named `global-setup.ts` at the root of the test folder containing the login steps:
 
@@ -615,7 +615,7 @@ By default, both projects will be executed when running `jlpm run test`. But you
 
 ## Configuration
 
-Galata can be configured by using [command line arguments](https://playwright.dev/docs/cli) or using [`playwright.config.js` file](https://playwright.dev/docs/test-configuration). Full list of config options can be accessed using `jlpm playwright test --help`.
+Galata can be configured by using [command line arguments](https://playwright.dev/docs/test-cli#reference) or using [`playwright.config.js` file](https://playwright.dev/docs/test-configuration). Full list of config options can be accessed using `jlpm playwright test --help`.
 
 ### Custom benchmark report
 


### PR DESCRIPTION
These broken links in the galata/README.md are causing the check_links job [to fail](https://github.com/jupyterlab/jupyterlab/actions/runs/4815902049/jobs/8575019636?pr=14115).

I checked that these news links make sense within the context of the readme.

---

Closes https://github.com/jupyterlab/jupyterlab/pull/14448 (superseeds it)