### PR TITLE
Wait for `.lm-hidden` class to disappear before taking snapshot

### DIFF
--- a/galata/test/documentation/general.test.ts
+++ b/galata/test/documentation/general.test.ts
@@ -132,6 +132,9 @@ test.describe('General', () => {
     await expect(
       page.locator('.jp-ActiveCellTool .jp-InputPrompt')
     ).not.toBeEmpty();
+    await expect(
+      page.locator('.jp-ActiveCellTool .jp-InputPrompt')
+    ).not.toHaveClass(/lm-mod-hidden/);
 
     expect(
       await page.screenshot({


### PR DESCRIPTION
## References

Closes #14150, supersedes #14151

## Code changes

Wait for `.lm-hidden` to disappear before taking the snapshot

## User-facing changes

None

## Backwards-incompatible changes

None
