### PR TITLE
add native viewing support for jsonl/ndjson

### DIFF
--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1409,6 +1409,17 @@ export namespace DocumentRegistry {
         icon: jsonIcon
       },
       {
+        name: 'jsonl',
+        displayName: trans.__('JSONLines File'),
+        extensions: ['.jsonl', '.ndjson'],
+        mimeTypes: [
+          'text/jsonl',
+          'application/jsonl',
+          'application/json-lines'
+        ],
+        icon: jsonIcon
+      },
+      {
         name: 'julia',
         displayName: trans.__('Julia File'),
         extensions: ['.jl'],

--- a/packages/json-extension/src/index.tsx
+++ b/packages/json-extension/src/index.tsx
@@ -23,6 +23,12 @@ const CSS_CLASS = 'jp-RenderedJSON';
  * The MIME type for JSON.
  */
 export const MIME_TYPE = 'application/json';
+// NOTE: not standardized yet
+export const MIME_TYPES_JSONL = [
+  'text/jsonl',
+  'application/jsonl',
+  'application/json-lines'
+];
 
 /**
  * A renderer for JSON data.
@@ -51,7 +57,20 @@ export class RenderedJSON
    */
   async renderModel(model: IRenderMime.IMimeModel): Promise<void> {
     const { Component } = await import('./component');
-    const data = (model.data[this._mimeType] || {}) as NonNullable<JSONValue>;
+
+    let data: NonNullable<JSONValue>;
+
+    // handle if json-lines format
+    if (MIME_TYPES_JSONL.indexOf(this._mimeType) >= 0) {
+      // convert into proper json
+      const lines = ((model.data[this._mimeType] || '') as string)
+        .trim()
+        .split(/\n/);
+      data = JSON.parse(`[${lines.join(',')}]`);
+    } else {
+      data = (model.data[this._mimeType] || {}) as NonNullable<JSONValue>;
+    }
+
     const metadata = (model.metadata[this._mimeType] || {}) as JSONObject;
     if (this._rootDOM === null) {
       this._rootDOM = createRoot(this.node);
@@ -89,7 +108,7 @@ export class RenderedJSON
  */
 export const rendererFactory: IRenderMime.IRendererFactory = {
   safe: true,
-  mimeTypes: [MIME_TYPE],
+  mimeTypes: [MIME_TYPE, ...MIME_TYPES_JSONL],
   createRenderer: options => new RenderedJSON(options)
 };
 
@@ -106,6 +125,19 @@ const extensions: IRenderMime.IExtension | IRenderMime.IExtension[] = [
       primaryFileType: 'json',
       fileTypes: ['json', 'notebook', 'geojson'],
       defaultFor: ['json']
+    }
+  },
+  {
+    id: '@jupyterlab/json-lines-extension:factory',
+    description: 'Adds renderer for JSONLines content.',
+    rendererFactory,
+    rank: 0,
+    dataType: 'string',
+    documentWidgetFactoryOptions: {
+      name: 'JSONLines',
+      primaryFileType: 'jsonl',
+      fileTypes: ['jsonl', 'ndjson'],
+      defaultFor: ['jsonl', 'ndjson']
     }
   }
 ];


### PR DESCRIPTION
## References

`jsonlines` / `ndjson` have traction (some examples lazily collected from the web, [shopify](https://shopify.dev/docs/api/usage/bulk-operations/imports#create-a-jsonl-file-and-include-graphql-variables), [duckdb](https://duckdb.org/docs/extensions/json.html)).

Since the differences are very trivial wrt existing `json` support, it isn't really worth it to defer this functionality to e.g. a community extension. 

## Code changes

Register `jsonl` and `ndjson` file types, and corresponding mime types. NOTE: standardization is trailing utilization, so it is messier than one would prefer.
https://github.com/ndjson/ndjson-spec/issues/35
https://github.com/wardi/jsonlines/issues/22

Then tweak the JSON extension to convert `jsonl` to `json` when the mime type is that of `jsonl`. 


## User-facing changes

`.jsonl` and `.ndjson` files will now appear as `json` files and open in the default json opener. 

![tmp](https://user-images.githubusercontent.com/3105306/235178400-9a53dc1b-85a2-48b0-9967-af0b365d7861.gif)

## Backwards-incompatible changes

None. May effect existing mime render extensions for `jsonl` and `ndjson`, if these exist. 

