### PR TITLE
Fix documentation formatting

### DIFF
--- a/docs/source/getting_started/starting.rst
+++ b/docs/source/getting_started/starting.rst
@@ -14,7 +14,7 @@ Start JupyterLab using:
 
 JupyterLab will open automatically in your browser.
 
-If your notebook files are not in the current directory, you can pass your working directory path as argument when starting JupyterLab. Avoid running it from your root volume (e.g. `C:\` on Windows or `/` on Linux) to limit the risk of modifying system files.
+If your notebook files are not in the current directory, you can pass your working directory path as argument when starting JupyterLab. Avoid running it from your root volume (e.g. ``C:\`` on Windows or ``/`` on Linux) to limit the risk of modifying system files.
 
 Example:
 


### PR DESCRIPTION
Use correct RST formatting. Before:

![Screenshot from the "Getting Started" documentation page showing botched markup: the text reads "… e.g. C: on Windows or / on Linux" with a backtick after "C:" and before the slash and the initial part in italic.](https://user-images.githubusercontent.com/2131598/235351892-ee738e3e-f92f-4b6a-9dea-16e9c089845d.png)

