### PR TITLE
Fix TableOfContentsFactory typing

### DIFF
--- a/packages/fileeditor/src/toc/factory.ts
+++ b/packages/fileeditor/src/toc/factory.ts
@@ -23,7 +23,8 @@ export interface IEditorHeading extends TableOfContents.IHeading {
  * Base table of contents model factory for file editor
  */
 export abstract class EditorTableOfContentsFactory extends TableOfContentsFactory<
-  IDocumentWidget<FileEditor>
+  IDocumentWidget<FileEditor>,
+  IEditorHeading
 > {
   /**
    * Create a new table of contents model for the widget
@@ -39,13 +40,7 @@ export abstract class EditorTableOfContentsFactory extends TableOfContentsFactor
     IEditorHeading,
     IDocumentWidget<FileEditor, DocumentRegistry.IModel>
   > {
-    const model = super.createNew(
-      widget,
-      configuration
-    ) as TableOfContentsModel<
-      IEditorHeading,
-      IDocumentWidget<FileEditor, DocumentRegistry.IModel>
-    >;
+    const model = super.createNew(widget, configuration);
 
     const onActiveHeadingChanged = (
       model: TableOfContentsModel<

--- a/packages/toc/src/factory.ts
+++ b/packages/toc/src/factory.ts
@@ -18,8 +18,10 @@ const RENDER_TIMEOUT = 1000;
 /**
  * Abstract table of contents model factory for IDocumentWidget.
  */
-export abstract class TableOfContentsFactory<W extends IDocumentWidget>
-  implements TableOfContents.IFactory<W>
+export abstract class TableOfContentsFactory<
+  W extends IDocumentWidget,
+  H extends TableOfContents.IHeading = TableOfContents.IHeading
+> implements TableOfContents.IFactory<W, H>
 {
   /**
    * Constructor
@@ -52,7 +54,7 @@ export abstract class TableOfContentsFactory<W extends IDocumentWidget>
   createNew(
     widget: W,
     configuration?: TableOfContents.IConfig
-  ): TableOfContentsModel<TableOfContents.IHeading, W> {
+  ): TableOfContentsModel<H, W> {
     const model = this._createNew(widget, configuration);
 
     const context = widget.context;
@@ -102,5 +104,5 @@ export abstract class TableOfContentsFactory<W extends IDocumentWidget>
   protected abstract _createNew(
     widget: W,
     configuration?: TableOfContents.IConfig
-  ): TableOfContentsModel<TableOfContents.IHeading, W>;
+  ): TableOfContentsModel<H, W>;
 }

--- a/packages/toc/src/tokens.ts
+++ b/packages/toc/src/tokens.ts
@@ -73,7 +73,10 @@ export namespace TableOfContents {
   /**
    * Table of content model factory interface
    */
-  export interface IFactory<W extends Widget = Widget> {
+  export interface IFactory<
+    W extends Widget = Widget,
+    H extends IHeading = IHeading
+  > {
     /**
      * Whether the factory can handle the widget or not.
      *
@@ -92,7 +95,7 @@ export namespace TableOfContents {
     createNew: (
       widget: W,
       configuration?: TableOfContents.IConfig
-    ) => IModel<IHeading>;
+    ) => IModel<H>;
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #14474
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Add heading type as template to `TableOfContentsFactory`

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None