### PR TITLE
Fix side-by-side cell input/output rendering in Firefox

### DIFF
--- a/packages/ui-components/style/windowedlist.css
+++ b/packages/ui-components/style/windowedlist.css
@@ -14,5 +14,7 @@
 
 .jp-WindowedPanel-window {
   position: absolute;
+  left: 0;
+  right: 0;
   overflow: visible;
 }


### PR DESCRIPTION
This PR throttles side-by-side rendering so that the rendering thread is not flooded with every cursor move event and it fixes the broken rendering of side-by-side input/output for cells in Firefox.

## References
Fixes https://github.com/jupyterlab/jupyterlab/issues/13848

## Code changes
- Uses a `Throttler` to handle quickly occurring cursor move events.
- Sets the `jp-WindowedPanel-window` class to use the full available width.

## User-facing changes
**Before**
<img width="1087" alt="Screenshot 2023-05-02 at 22 51 37" src="https://user-images.githubusercontent.com/159529/235794014-f2f0938b-9681-4d70-bc15-0a6601d9af01.png">


**After**
<img width="1047" alt="Screenshot 2023-05-02 at 22 50 43" src="https://user-images.githubusercontent.com/159529/235793855-04e1123e-8a33-4007-a4e9-3cbaf0225dcf.png">


## Backwards-incompatible changes
N/A