### PR TITLE
Updates announcements to better conform to RFC atom standard.

### DIFF
--- a/docs/source/user/announcements.rst
+++ b/docs/source/user/announcements.rst
@@ -37,7 +37,8 @@ using the command line option ``--LabApp.news_url="<URL_TO_FEED_XML_FILE>"``.
 
 .. note::
 
-    An entry in a custom feed is required to have the following tags: ``title``, ``id``, and ``updated``. The following tags are also used but not required: ``published``, ``summary``, and at least one ``link`` with attribute ``rel="alternate"``.
+    An entry in a custom feed is required to have the following tags: ``title``, ``id``, and ``updated``.
+    The following tags are also used but not required: ``published``, ``summary``, and at least one ``link``.
 
 Binder
 ------

--- a/docs/source/user/announcements.rst
+++ b/docs/source/user/announcements.rst
@@ -33,7 +33,7 @@ Jupyter news
 ^^^^^^^^^^^^
 
 The news are fetched from a news feed. The URL can be customized to point to any `Atom feed <https://www.rfc-editor.org/rfc/rfc5023>`_
-using the command line option ``--LabApp.news_url="<URL_TO_FEED_XML_FILE>"``.
+using the command line option ``--LabApp.news_url="<URL_TO_FEED_XML_FILE>"``. An entry in a custom feed is required to have the following tags: title, id, and updated. The following tags are also used but not required: published, summary, and at least one link.
 
 Binder
 ------

--- a/docs/source/user/announcements.rst
+++ b/docs/source/user/announcements.rst
@@ -33,7 +33,11 @@ Jupyter news
 ^^^^^^^^^^^^
 
 The news are fetched from a news feed. The URL can be customized to point to any `Atom feed <https://www.rfc-editor.org/rfc/rfc5023>`_
-using the command line option ``--LabApp.news_url="<URL_TO_FEED_XML_FILE>"``. An entry in a custom feed is required to have the following tags: title, id, and updated. The following tags are also used but not required: published, summary, and at least one link.
+using the command line option ``--LabApp.news_url="<URL_TO_FEED_XML_FILE>"``.
+
+.. note::
+
+    An entry in a custom feed is required to have the following tags: ``title``, ``id``, and ``updated``. The following tags are also used but not required: ``published``, ``summary``, and at least one ``link`` with attribute ``rel="alternate"``.
 
 Binder
 ------

--- a/jupyterlab/handlers/announcements.py
+++ b/jupyterlab/handlers/announcements.py
@@ -23,6 +23,10 @@ JUPYTERLAB_LAST_RELEASE_URL = "https://pypi.org/pypi/jupyterlab/json"
 JUPYTERLAB_RELEASE_URL = "https://github.com/jupyterlab/jupyterlab/releases/tag/v"
 
 
+def format_datetime(dt_str: str):
+    return datetime.fromisoformat(dt_str).timestamp() * 1000
+
+
 @dataclass(frozen=True)
 class Notification:
     """Notification
@@ -226,32 +230,54 @@ class NewsHandler(APIHandler):
                 tree = ET.fromstring(response.body)  # noqa S314
 
                 def build_entry(node):
-                    return Notification(
-                        message=node.find("atom:title", xml_namespaces).text
-                        + "\n"
-                        + node.find("atom:summary", xml_namespaces).text,
-                        createdAt=datetime.fromisoformat(
-                            node.find("atom:published", xml_namespaces).text
-                        ).timestamp()
-                        * 1000,
-                        modifiedAt=datetime.fromisoformat(
-                            node.find("atom:updated", xml_namespaces).text
-                        ).timestamp()
-                        * 1000,
+                    def get_xml_text(attr: str, required: bool = False) -> str:
+                        node_item = node.find(f"atom:{attr}", xml_namespaces)
+                        if node_item is not None:
+                            return node_item.text
+                        elif required:
+                            error_m = (
+                                f'atom feed entry does not contain a required attribute: {attr}'
+                            )
+                            raise KeyError(error_m)
+                        else:
+                            return ''
+
+                    entry_title = get_xml_text("title", required=True)
+                    entry_id = get_xml_text("id", required=True)
+                    entry_updated = get_xml_text("updated", required=True)
+                    entry_published = get_xml_text("published")
+                    entry_summary = get_xml_text("summary")
+                    entry_link = node.find("atom:link[@rel='alternate']", xml_namespaces).get(
+                        "href"
+                    )
+
+                    message = (
+                        "\n".join([entry_title, entry_summary]) if entry_summary else entry_title
+                    )
+                    modified_at = format_datetime(entry_updated)
+                    created_at = (
+                        modified_at if not entry_published else format_datetime(entry_published)
+                    )
+                    notification = Notification(
+                        message=message,
+                        createdAt=created_at,
+                        modifiedAt=modified_at,
                         type="info",
                         link=(
                             trans.__("Open full post"),
-                            node.find("atom:link", xml_namespaces).get("href"),
+                            entry_link,
                         ),
                         options={
                             "data": {
-                                "id": node.find("atom:id", xml_namespaces).text,
+                                "id": entry_id,
                                 "tags": ["news"],
                             }
                         },
                     )
+                    return notification
 
-                news.extend(map(build_entry, tree.findall("atom:entry", xml_namespaces)))
+                entries = map(build_entry, tree.findall("atom:entry", xml_namespaces))
+                news.extend(entries)
             except Exception as e:
                 self.log.debug(
                     f"Failed to get announcements from Atom feed: {self.news_url}",

--- a/jupyterlab/handlers/announcements.py
+++ b/jupyterlab/handlers/announcements.py
@@ -252,7 +252,7 @@ class NewsHandler(APIHandler):
                         alternate = list(filter(lambda elem: elem.get('rel') == 'alternate', links))
                         link_node = alternate[0] if alternate else links[0]
                     else:
-                        link_node = links[0]
+                        link_node = links[0] if len(links) == 1 else None
                     entry_link = link_node.get("href") if link_node is not None else None
 
                     message = (
@@ -265,7 +265,9 @@ class NewsHandler(APIHandler):
                         createdAt=created_at,
                         modifiedAt=modified_at,
                         type="info",
-                        link=(
+                        link=None
+                        if entry_link is None
+                        else (
                             trans.__("Open full post"),
                             entry_link,
                         ),

--- a/jupyterlab/tests/test_announcements.py
+++ b/jupyterlab/tests/test_announcements.py
@@ -203,7 +203,7 @@ async def test_NewsHandler_link_no_rel(mock_client, labserverapp, jp_fetch):
     ]
 
 
-FAKE_NO_LINK_ATOM_FEED = b"""<?xml version='1.0' encoding='UTF-8'?><feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en"><id>https://jupyterlab.github.io/assets/feed.xml</id><title>JupyterLab News</title><updated>2023-05-03T17:06:43.950978+00:00</updated><author><name>John Doe</name><email>john@example.de</email></author><link href="https://jupyterlab.github.io/assets/feed.xml" rel="self" type="application/atom+xml"/><link href="https://jupyterlab.github.io/assets/" rel="alternate" type="text/html"/><generator uri="https://lkiesow.github.io/python-feedgen" version="0.9.0">python-feedgen</generator><logo>http://ex.com/logo.jpg</logo><subtitle>Subscribe to get news about JupyterLab.</subtitle><entry><id>https://jupyterlab.github.io/assets/posts/2022/11/02/demo</id><title>Thanks for using JupyterLab</title><updated>2022-11-02T14:00:00+00:00</updated><link href="https://jupyterlab.github.io/assets/posts/2022/11/02/demo.html" type="text/html" title="Thanks for using JupyterLab"/><summary>Big thanks to you, beloved JupyterLab user.</summary><published>2022-11-02T14:00:00+00:00</published></entry></feed>"""
+FAKE_NO_LINK_ATOM_FEED = b"""<?xml version='1.0' encoding='UTF-8'?><feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en"><id>https://jupyterlab.github.io/assets/feed.xml</id><title>JupyterLab News</title><updated>2023-05-03T17:06:43.950978+00:00</updated><author><name>John Doe</name><email>john@example.de</email></author><link href="https://jupyterlab.github.io/assets/feed.xml" rel="self" type="application/atom+xml"/><link href="https://jupyterlab.github.io/assets/" rel="alternate" type="text/html"/><generator uri="https://lkiesow.github.io/python-feedgen" version="0.9.0">python-feedgen</generator><logo>http://ex.com/logo.jpg</logo><subtitle>Subscribe to get news about JupyterLab.</subtitle><entry><id>https://jupyterlab.github.io/assets/posts/2022/11/02/demo</id><title>Thanks for using JupyterLab</title><updated>2022-11-02T14:00:00+00:00</updated><summary>Big thanks to you, beloved JupyterLab user.</summary><published>2022-11-02T14:00:00+00:00</published></entry></feed>"""
 
 
 @patch("tornado.httpclient.AsyncHTTPClient", new_callable=fake_client_factory)
@@ -220,10 +220,7 @@ async def test_NewsHandler_no_links(mock_client, labserverapp, jp_fetch):
             "message": "Thanks for using JupyterLab\nBig thanks to you, beloved JupyterLab user.",
             "modifiedAt": 1667397600000.0,
             "type": "info",
-            "link": [
-                "Open full post",
-                "https://jupyterlab.github.io/assets/posts/2022/11/02/demo.html",
-            ],
+            "link": None,
             "options": {
                 "data": {
                     "id": "https://jupyterlab.github.io/assets/posts/2022/11/02/demo",

--- a/jupyterlab/tests/test_announcements.py
+++ b/jupyterlab/tests/test_announcements.py
@@ -170,3 +170,65 @@ async def test_NewsHandler_no_published(mock_client, labserverapp, jp_fetch):
             },
         }
     ]
+
+
+FAKE_LINK_NO_REL_ATOM_FEED = b"""<?xml version='1.0' encoding='UTF-8'?><feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en"><id>https://jupyterlab.github.io/assets/feed.xml</id><title>JupyterLab News</title><updated>2023-05-03T17:06:43.950978+00:00</updated><author><name>John Doe</name><email>john@example.de</email></author><link href="https://jupyterlab.github.io/assets/feed.xml" rel="self" type="application/atom+xml"/><link href="https://jupyterlab.github.io/assets/" rel="alternate" type="text/html"/><generator uri="https://lkiesow.github.io/python-feedgen" version="0.9.0">python-feedgen</generator><logo>http://ex.com/logo.jpg</logo><subtitle>Subscribe to get news about JupyterLab.</subtitle><entry><id>https://jupyterlab.github.io/assets/posts/2022/11/02/demo</id><title>Thanks for using JupyterLab</title><updated>2022-11-02T14:00:00+00:00</updated><link href="https://jupyterlab.github.io/assets/posts/2022/11/02/demo.html" type="text/html" title="Thanks for using JupyterLab"/><summary>Big thanks to you, beloved JupyterLab user.</summary><published>2022-11-02T14:00:00+00:00</published></entry></feed>"""
+
+
+@patch("tornado.httpclient.AsyncHTTPClient", new_callable=fake_client_factory)
+async def test_NewsHandler_link_no_rel(mock_client, labserverapp, jp_fetch):
+    mock_client.body = FAKE_LINK_NO_REL_ATOM_FEED
+
+    response = await jp_fetch("lab", "api", "news", method="GET")
+
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload["news"] == [
+        {
+            "createdAt": 1667397600000.0,
+            "message": "Thanks for using JupyterLab\nBig thanks to you, beloved JupyterLab user.",
+            "modifiedAt": 1667397600000.0,
+            "type": "info",
+            "link": [
+                "Open full post",
+                "https://jupyterlab.github.io/assets/posts/2022/11/02/demo.html",
+            ],
+            "options": {
+                "data": {
+                    "id": "https://jupyterlab.github.io/assets/posts/2022/11/02/demo",
+                    "tags": ["news"],
+                }
+            },
+        }
+    ]
+
+
+FAKE_NO_LINK_ATOM_FEED = b"""<?xml version='1.0' encoding='UTF-8'?><feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en"><id>https://jupyterlab.github.io/assets/feed.xml</id><title>JupyterLab News</title><updated>2023-05-03T17:06:43.950978+00:00</updated><author><name>John Doe</name><email>john@example.de</email></author><link href="https://jupyterlab.github.io/assets/feed.xml" rel="self" type="application/atom+xml"/><link href="https://jupyterlab.github.io/assets/" rel="alternate" type="text/html"/><generator uri="https://lkiesow.github.io/python-feedgen" version="0.9.0">python-feedgen</generator><logo>http://ex.com/logo.jpg</logo><subtitle>Subscribe to get news about JupyterLab.</subtitle><entry><id>https://jupyterlab.github.io/assets/posts/2022/11/02/demo</id><title>Thanks for using JupyterLab</title><updated>2022-11-02T14:00:00+00:00</updated><link href="https://jupyterlab.github.io/assets/posts/2022/11/02/demo.html" type="text/html" title="Thanks for using JupyterLab"/><summary>Big thanks to you, beloved JupyterLab user.</summary><published>2022-11-02T14:00:00+00:00</published></entry></feed>"""
+
+
+@patch("tornado.httpclient.AsyncHTTPClient", new_callable=fake_client_factory)
+async def test_NewsHandler_no_links(mock_client, labserverapp, jp_fetch):
+    mock_client.body = FAKE_NO_LINK_ATOM_FEED
+
+    response = await jp_fetch("lab", "api", "news", method="GET")
+
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload["news"] == [
+        {
+            "createdAt": 1667397600000.0,
+            "message": "Thanks for using JupyterLab\nBig thanks to you, beloved JupyterLab user.",
+            "modifiedAt": 1667397600000.0,
+            "type": "info",
+            "link": [
+                "Open full post",
+                "https://jupyterlab.github.io/assets/posts/2022/11/02/demo.html",
+            ],
+            "options": {
+                "data": {
+                    "id": "https://jupyterlab.github.io/assets/posts/2022/11/02/demo",
+                    "tags": ["news"],
+                }
+            },
+        }
+    ]

--- a/jupyterlab/tests/test_announcements.py
+++ b/jupyterlab/tests/test_announcements.py
@@ -77,3 +77,96 @@ async def test_CheckForUpdateHandler_get_failure(mock_client, labserverapp, jp_f
     assert response.code == 200
     payload = json.loads(response.body)
     assert payload["notification"] is None
+
+
+FAKE_NO_SUMMARY_ATOM_FEED = b"""<?xml version='1.0' encoding='UTF-8'?><feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en"><id>https://jupyterlab.github.io/assets/feed.xml</id><title>JupyterLab News</title><updated>2023-05-02T19:01:33.669598+00:00</updated><author><name>John Doe</name><email>john@example.de</email></author><link href="https://jupyterlab.github.io/assets/feed.xml" rel="self" type="application/atom+xml"/><link href="https://jupyterlab.github.io/assets/" rel="alternate" type="text/html"/><generator uri="https://lkiesow.github.io/python-feedgen" version="0.9.0">python-feedgen</generator><logo>http://ex.com/logo.jpg</logo><subtitle>Subscribe to get news about JupyterLab.</subtitle><entry><id>https://jupyterlab.github.io/assets/posts/2022/11/02/demo</id><title>Thanks for using JupyterLab</title><updated>2022-11-02T14:00:00+00:00</updated><link href="https://jupyterlab.github.io/assets/posts/2022/11/02/demo.html" rel="alternate" type="text/html" title="Thanks for using JupyterLab"/><published>2022-11-02T14:00:00+00:00</published></entry></feed>"""
+
+
+@patch("tornado.httpclient.AsyncHTTPClient", new_callable=fake_client_factory)
+async def test_NewsHandler_get_missing_summary(mock_client, labserverapp, jp_fetch):
+    mock_client.body = FAKE_NO_SUMMARY_ATOM_FEED
+
+    response = await jp_fetch("lab", "api", "news", method="GET")
+
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload["news"] == [
+        {
+            "createdAt": 1667397600000.0,
+            "message": "Thanks for using JupyterLab",
+            "modifiedAt": 1667397600000.0,
+            "type": "info",
+            "link": [
+                "Open full post",
+                "https://jupyterlab.github.io/assets/posts/2022/11/02/demo.html",
+            ],
+            "options": {
+                "data": {
+                    "id": "https://jupyterlab.github.io/assets/posts/2022/11/02/demo",
+                    "tags": ["news"],
+                }
+            },
+        }
+    ]
+
+
+FAKE_MULTI_ENTRY_LINKS_ATOM_FEED = b"""<?xml version='1.0' encoding='UTF-8'?><feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en"><id>https://jupyterlab.github.io/assets/feed.xml</id><title>JupyterLab News</title><updated>2023-05-02T19:59:44.332080+00:00</updated><author><name>John Doe</name><email>john@example.de</email></author><link href="https://jupyterlab.github.io/assets/feed.xml" rel="self" type="application/atom+xml"/><link href="https://jupyterlab.github.io/assets/" rel="alternate" type="text/html"/><generator uri="https://lkiesow.github.io/python-feedgen" version="0.9.0">python-feedgen</generator><logo>http://ex.com/logo.jpg</logo><subtitle>Subscribe to get news about JupyterLab.</subtitle><entry><id>https://jupyterlab.github.io/assets/posts/2022/11/02/demo</id><title>Thanks for using JupyterLab</title><updated>2022-11-02T14:00:00+00:00</updated><link href="https://jupyterlab.github.io/assets/posts/2022/11/02/demo_self.html" rel="self" type="text/html" title="Thanks for using JupyterLab"/><link href="https://jupyterlab.github.io/assets/posts/2022/11/02/demo.html" rel="alternate" type="text/html" title="Thanks for using JupyterLab"/><summary>Big thanks to you, beloved JupyterLab user.</summary><published>2022-11-02T14:00:00+00:00</published></entry></feed>"""
+
+
+@patch("tornado.httpclient.AsyncHTTPClient", new_callable=fake_client_factory)
+async def test_NewsHandler_multi_entry_links(mock_client, labserverapp, jp_fetch):
+    mock_client.body = FAKE_MULTI_ENTRY_LINKS_ATOM_FEED
+
+    response = await jp_fetch("lab", "api", "news", method="GET")
+
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload["news"] == [
+        {
+            "createdAt": 1667397600000.0,
+            "message": "Thanks for using JupyterLab\nBig thanks to you, beloved JupyterLab user.",
+            "modifiedAt": 1667397600000.0,
+            "type": "info",
+            "link": [
+                "Open full post",
+                "https://jupyterlab.github.io/assets/posts/2022/11/02/demo.html",
+            ],
+            "options": {
+                "data": {
+                    "id": "https://jupyterlab.github.io/assets/posts/2022/11/02/demo",
+                    "tags": ["news"],
+                }
+            },
+        }
+    ]
+
+
+FAKE_NO_PUBLISHED_ATOM_FEED = b"""<?xml version='1.0' encoding='UTF-8'?><feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en"><id>https://jupyterlab.github.io/assets/feed.xml</id><title>JupyterLab News</title><updated>2023-05-02T19:32:08.566055+00:00</updated><author><name>John Doe</name><email>john@example.de</email></author><link href="https://jupyterlab.github.io/assets/feed.xml" rel="self" type="application/atom+xml"/><link href="https://jupyterlab.github.io/assets/" rel="alternate" type="text/html"/><generator uri="https://lkiesow.github.io/python-feedgen" version="0.9.0">python-feedgen</generator><logo>http://ex.com/logo.jpg</logo><subtitle>Subscribe to get news about JupyterLab.</subtitle><entry><id>https://jupyterlab.github.io/assets/posts/2022/11/02/demo</id><title>Thanks for using JupyterLab</title><updated>2022-11-02T14:00:00+00:00</updated><link href="https://jupyterlab.github.io/assets/posts/2022/11/02/demo.html" rel="alternate" type="text/html" title="Thanks for using JupyterLab"/><summary>Big thanks to you, beloved JupyterLab user.</summary></entry></feed>"""
+
+
+@patch("tornado.httpclient.AsyncHTTPClient", new_callable=fake_client_factory)
+async def test_NewsHandler_no_published(mock_client, labserverapp, jp_fetch):
+    mock_client.body = FAKE_NO_PUBLISHED_ATOM_FEED
+
+    response = await jp_fetch("lab", "api", "news", method="GET")
+
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload["news"] == [
+        {
+            "createdAt": 1667397600000.0,
+            "message": "Thanks for using JupyterLab\nBig thanks to you, beloved JupyterLab user.",
+            "modifiedAt": 1667397600000.0,
+            "type": "info",
+            "link": [
+                "Open full post",
+                "https://jupyterlab.github.io/assets/posts/2022/11/02/demo.html",
+            ],
+            "options": {
+                "data": {
+                    "id": "https://jupyterlab.github.io/assets/posts/2022/11/02/demo",
+                    "tags": ["news"],
+                }
+            },
+        }
+    ]

--- a/packages/apputils-extension/src/announcements.ts
+++ b/packages/apputils-extension/src/announcements.ts
@@ -162,7 +162,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
           try {
             const response = await requestAPI<{
               news: (Notification.INotification & {
-                link: [string, string | null];
+                link: [string, string | undefined];
               })[];
             }>(NEWS_API_URL);
 
@@ -222,7 +222,9 @@ export const announcements: JupyterFrontEndPlugin<void> = {
         if ((settings?.get('checkForUpdates').composite as boolean) ?? true) {
           const response = await requestAPI<{
             notification:
-              | (Notification.INotification & { link: [string, string | null] })
+              | (Notification.INotification & {
+                  link: [string, string | undefined];
+                })
               | null;
           }>(UPDATE_API_URL);
 

--- a/packages/apputils-extension/src/announcements.ts
+++ b/packages/apputils-extension/src/announcements.ts
@@ -161,7 +161,9 @@ export const announcements: JupyterFrontEndPlugin<void> = {
         if ((settings?.get('fetchNews').composite ?? 'false') === 'true') {
           try {
             const response = await requestAPI<{
-              news: (Notification.INotification & { link: [string, string] })[];
+              news: (Notification.INotification & {
+                link: [string, string | null];
+              })[];
             }>(NEWS_API_URL);
 
             for (const { link, message, type, options } of response.news) {
@@ -220,7 +222,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
         if ((settings?.get('checkForUpdates').composite as boolean) ?? true) {
           const response = await requestAPI<{
             notification:
-              | (Notification.INotification & { link: [string, string] })
+              | (Notification.INotification & { link: [string, string | null] })
               | null;
           }>(UPDATE_API_URL);
 

--- a/packages/apputils-extension/src/announcements.ts
+++ b/packages/apputils-extension/src/announcements.ts
@@ -162,7 +162,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
           try {
             const response = await requestAPI<{
               news: (Notification.INotification & {
-                link: [string, string | undefined];
+                link?: [string, string];
               })[];
             }>(NEWS_API_URL);
 
@@ -223,7 +223,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
           const response = await requestAPI<{
             notification:
               | (Notification.INotification & {
-                  link: [string, string | undefined];
+                  link?: [string, string];
                 })
               | null;
           }>(UPDATE_API_URL);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

Fixes #14358 

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Updates `NewsHandler.get` to better reflect the standards for an atom feed entry defined in [RFC 4287](https://datatracker.ietf.org/doc/html/rfc4287#section-4.1.2). It distinguishes between required and optional entry tags, and adds logic to handle missing optional tags. It also allows for an entry to have multiple link tags, selecting the link with attribute `rel="alternate"`.

I also added tests to account for different valid atom entry schemes.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

It will be easier for users to link custom atom feeds as it is closer to conforming to the atom standard. Users will be less likely to have notifications be silently dropped due to misaligned entry's

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None that I am aware of. 

---
[fcollonval] Auto link issue with action keyword