### PR TITLE
Remove a noisy console warn in the metadata form

### DIFF
--- a/packages/metadataform/src/metadataform.ts
+++ b/packages/metadataform/src/metadataform.ts
@@ -335,19 +335,16 @@ export class MetadataFormWidget
   /**
    * Handle a change to the active cell metadata.
    */
-  protected onActiveCellMetadataChanged(msg: Message): void {
+  protected onActiveCellMetadataChanged(_: Message): void {
     if (!this._updatingMetadata && this.isVisible) this._update();
   }
 
-  protected onActiveNotebookPanelChanged(msg: Message): void {
-    // Do not use notebook metadata if model is null.
-    let notebook = this.notebookTools.activeNotebookPanel;
-    if (notebook === null || notebook.model === null) {
-      console.warn('Notebook model is null, its metadata cannot be updated.');
-      this._notebookModelNull = true;
-    } else {
-      this._notebookModelNull = false;
-    }
+  /**
+   * Handle when the active notebook panel changes.
+   */
+  protected onActiveNotebookPanelChanged(_: Message): void {
+    const notebook = this.notebookTools.activeNotebookPanel;
+    this._notebookModelNull = notebook === null || notebook.model === null;
     if (!this._updatingMetadata && this.isVisible) this._update();
   }
 


### PR DESCRIPTION
This PR removes a `console.warn` that occurs too frequently / in benign circumstances.

cc: @brichet 

## References
N/A

## Code changes
N/A

## User-facing changes
N/A

## Backwards-incompatible changes
N/A