### PR TITLE
Initialize PluginList ._query to '' instead of undefined if query parameter is not passed

### DIFF
--- a/packages/settingeditor/src/jsonsettingeditor.tsx
+++ b/packages/settingeditor/src/jsonsettingeditor.tsx
@@ -66,8 +66,7 @@ export class JsonSettingEditor extends SplitPanel {
     const list = (this._list = new PluginList({
       confirm,
       registry,
-      translator: this.translator,
-      query: ''
+      translator: this.translator
     }));
     const when = options.when;
 

--- a/packages/settingeditor/src/jsonsettingeditor.tsx
+++ b/packages/settingeditor/src/jsonsettingeditor.tsx
@@ -66,7 +66,8 @@ export class JsonSettingEditor extends SplitPanel {
     const list = (this._list = new PluginList({
       confirm,
       registry,
-      translator: this.translator
+      translator: this.translator,
+      query: ''
     }));
     const when = options.when;
 

--- a/packages/settingeditor/src/pluginlist.tsx
+++ b/packages/settingeditor/src/pluginlist.tsx
@@ -64,7 +64,7 @@ export class PluginList extends ReactWidget {
     );
     this.setError = this.setError.bind(this);
     this._evtMousedown = this._evtMousedown.bind(this);
-    this._query = options.query;
+    this._query = options.query ?? '';
 
     this._allPlugins = PluginList.sortPlugins(this.registry).filter(plugin => {
       const { schema } = plugin;


### PR DESCRIPTION
## References

- Fixes #14440
- Fixes transitively jupyter/notebook#6854

## Code changes

Initialize `PluginList._query` to '' instead of `undefined` if `query` parameter is not passed.

## User-facing changes

All plugins in JSON Settings Editor are not filtered out by default

![JSON_settings_editor](https://user-images.githubusercontent.com/26686070/236061145-a88e4333-5e0f-4cba-b2a2-d02d0538f727.gif)

## Backwards-incompatible changes

None
