### PR TITLE
Don't listen for cell resizing when notebooks is hiding

### DIFF
--- a/galata/test/jupyterlab/windowed-notebook.test.ts
+++ b/galata/test/jupyterlab/windowed-notebook.test.ts
@@ -13,6 +13,32 @@ test.beforeEach(async ({ page, tmpPath }) => {
   await page.notebook.openByPath(`${tmpPath}/${fileName}`);
 });
 
+test('should not update height when hiding', async ({ page }) => {
+  // Wait to ensure the rendering logic is stable.
+  await page.waitForTimeout(200);
+
+  const h = await page.notebook.getNotebookInPanel();
+  const initialHeight = parseInt(
+    (await h?.$$eval(
+      '.jp-WindowedPanel-inner',
+      nodes => nodes[0].style.height
+    )) ?? '0',
+    10
+  );
+
+  expect(initialHeight).toBeGreaterThan(0);
+
+  await page.menu.clickMenuItem('File>New Launcher');
+
+  const innerHeight =
+    (await h?.$$eval(
+      '.jp-WindowedPanel-inner',
+      nodes => nodes[0].style.height
+    )) ?? '-1';
+
+  expect(parseInt(innerHeight, 10)).toEqual(initialHeight);
+});
+
 test('should hide first code cell when scrolling down', async ({ page }) => {
   const h = await page.notebook.getNotebookInPanel();
   const firstCellSelector = '.jp-Cell[data-windowed-list-index="0"]';

--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -19,6 +19,7 @@ import {
 import { Token } from '@lumino/coreutils';
 import { INotebookModel } from './model';
 import { Notebook, StaticNotebook } from './widget';
+import { Message } from '@lumino/messaging';
 
 /**
  * The class name added to notebook panels.
@@ -171,6 +172,26 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
         })
       );
     };
+  }
+
+  /**
+   * A message handler invoked on a 'before-hide' message.
+   */
+  protected onBeforeHide(msg: Message): void {
+    super.onBeforeHide(msg);
+    // Inform the windowed list that the notebook is gonna be hidden
+    this.content.isParentHidden = true;
+  }
+
+  /**
+   * A message handler invoked on a 'before-show' message.
+   */
+  protected onBeforeShow(msg: Message): void {
+    // Inform the windowed list that the notebook is gonna be shown
+    // Use onBeforeShow instead of onAfterShow to take into account
+    // resizing (like sidebars got expanded before switching to the notebook tab)
+    this.content.isParentHidden = false;
+    super.onBeforeShow(msg);
   }
 
   /**

--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -259,7 +259,15 @@ export abstract class WindowedListModel implements WindowedList.IModel {
     const totalSizeOfUnmeasuredItems =
       numUnmeasuredItems * this._estimatedWidgetSize;
 
-    return totalSizeOfMeasuredItems + totalSizeOfUnmeasuredItems;
+    const h = totalSizeOfMeasuredItems + totalSizeOfUnmeasuredItems;
+    console.log(
+      h,
+      this._lastMeasuredIndex,
+      this.widgetCount,
+      totalSizeOfMeasuredItems,
+      totalSizeOfUnmeasuredItems
+    );
+    return h;
   }
 
   /**
@@ -694,6 +702,19 @@ export class WindowedList<
   }
 
   /**
+   * Whether the parent is hidden or not.
+   *
+   * This should be set externally if a container is hidden to
+   * stop updating the widget size when hidden.
+   */
+  get isParentHidden(): boolean {
+    return this._isParentHidden;
+  }
+  set isParentHidden(v: boolean) {
+    this._isParentHidden = v;
+  }
+
+  /**
    * Widget layout
    */
   get layout(): WindowedLayout {
@@ -1029,6 +1050,10 @@ export class WindowedList<
   private _onWidgetResize(entries: ResizeObserverEntry[]): void {
     this._resetScrollToItem();
 
+    if (this.isHidden || this.isParentHidden) {
+      return;
+    }
+
     const newSizes: { index: number; size: number }[] = [];
     for (let entry of entries) {
       // Update size only if item is attached to the DOM
@@ -1044,6 +1069,7 @@ export class WindowedList<
         });
       }
     }
+    console.log(newSizes);
 
     // If some sizes changed
     if (this.viewModel.setWidgetSize(newSizes)) {
@@ -1076,6 +1102,7 @@ export class WindowedList<
 
   protected _viewModel: T;
   private _innerElement: HTMLDivElement;
+  private _isParentHidden: boolean;
   private _isScrolling: PromiseDelegate<void> | null;
   private _windowElement: HTMLDivElement;
   private _resetScrollToItemTimeout: number | null;

--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -259,8 +259,7 @@ export abstract class WindowedListModel implements WindowedList.IModel {
     const totalSizeOfUnmeasuredItems =
       numUnmeasuredItems * this._estimatedWidgetSize;
 
-    const h = totalSizeOfMeasuredItems + totalSizeOfUnmeasuredItems;
-    return h;
+    return totalSizeOfMeasuredItems + totalSizeOfUnmeasuredItems;
   }
 
   /**

--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -260,13 +260,6 @@ export abstract class WindowedListModel implements WindowedList.IModel {
       numUnmeasuredItems * this._estimatedWidgetSize;
 
     const h = totalSizeOfMeasuredItems + totalSizeOfUnmeasuredItems;
-    console.log(
-      h,
-      this._lastMeasuredIndex,
-      this.widgetCount,
-      totalSizeOfMeasuredItems,
-      totalSizeOfUnmeasuredItems
-    );
     return h;
   }
 
@@ -1069,7 +1062,6 @@ export class WindowedList<
         });
       }
     }
-    console.log(newSizes);
 
     // If some sizes changed
     if (this.viewModel.setWidgetSize(newSizes)) {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #14461 and fixes #14489
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Stop listening for cell resizing if a notebook is hidden.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
The viewport is not updated when the widget is hidden.

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None