### PR TITLE
Remove all registry handling in lock files

### DIFF
--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -664,37 +664,6 @@ function ensureBuildUtils() {
 }
 
 /**
- * Ensure lockfile structure
- */
-function ensureLockfile(): string[] {
-  const staging = './jupyterlab/staging';
-  const lockFile = path.join(staging, 'yarn.lock');
-  const content = fs.readFileSync(lockFile, { encoding: 'utf-8' });
-  let newContent = content;
-  const messages = [];
-
-  // Verify that all packages have resolved to the correct (default) registry
-  const resolvedPattern =
-    /^\s*resolved "((?!https:\/\/registry\.yarnpkg\.com\/).*)"\s*$/gm;
-  let badRegistry;
-  while ((badRegistry = resolvedPattern.exec(content)) !== null) {
-    messages.push(`Fixing bad npm/yarn registry: ${badRegistry[1]}`);
-    const parsed = new URL(badRegistry[1]);
-    const newUrl = badRegistry[1].replace(
-      parsed.origin,
-      'https://registry.yarnpkg.com'
-    );
-    newContent = newContent.replace(badRegistry[1], newUrl);
-  }
-
-  if (content !== newContent) {
-    // Write the updated lockfile data back
-    fs.writeFileSync(lockFile, newContent, 'utf-8');
-  }
-  return messages;
-}
-
-/**
  * Ensure the repo integrity.
  */
 export async function ensureIntegrity(): Promise<boolean> {
@@ -841,12 +810,6 @@ export async function ensureIntegrity(): Promise<boolean> {
       messages[pkgName] = [];
     }
     messages[pkgName] = messages[pkgName].concat(pkgMessages);
-  }
-
-  // Ensure the staging area lockfile
-  const lockFileMessages = ensureLockfile();
-  if (lockFileMessages.length > 0) {
-    messages['lockfile'] = lockFileMessages;
   }
 
   // Handle the top level package.

--- a/buildutils/src/local-repository.ts
+++ b/buildutils/src/local-repository.ts
@@ -6,7 +6,6 @@
 /* eslint-disable camelcase */
 import * as fs from 'fs-extra';
 import * as child_process from 'child_process';
-import * as crypto from 'crypto';
 import * as path from 'path';
 import * as os from 'os';
 import * as ps from 'process';
@@ -255,39 +254,6 @@ async function stopLocalRegistry(out_dir: string) {
 }
 
 /**
- * Fix the yarn lock links in the given directory.
- */
-function fixLinks(package_dir: string) {
-  let yarn_reg = '';
-  try {
-    yarn_reg = utils.run(
-      'yarn config get npmRegistryServer',
-      { stdio: 'pipe' },
-      true
-    );
-  } catch (e) {
-    // Do nothing
-  }
-  yarn_reg = yarn_reg || 'https://registry.yarnpkg.com';
-  const lock_file = path.join(package_dir, 'yarn.lock');
-  console.log(`Fixing links in ${lock_file}`);
-  const content = fs.readFileSync(lock_file, { encoding: 'utf-8' });
-
-  let shasum = crypto.createHash('sha256');
-  let hash = shasum.update(content);
-  console.log('Prior hash', hash.digest('hex'));
-
-  const regex = /http\:\/\/0\.0\.0\.0\:\d+/g;
-  const new_content = content.replace(regex, yarn_reg);
-
-  shasum = crypto.createHash('sha256');
-  hash = shasum.update(new_content);
-  console.log('After hash', hash.digest('hex'));
-
-  fs.writeFileSync(lock_file, new_content, 'utf8');
-}
-
-/**
  * Publish the npm tar files in a given directory
  */
 function publishPackages(dist_dir: string) {
@@ -325,14 +291,6 @@ program
     utils.exitOnUncaughtException();
     const out_dir = options.path || DEFAULT_OUT_DIR;
     await stopLocalRegistry(out_dir);
-  });
-
-program
-  .command('fix-links')
-  .option('--path <path>', 'Path to the directory with a yarn lock')
-  .action((options: any) => {
-    utils.exitOnUncaughtException();
-    fixLinks(options.path || process.cwd());
   });
 
 program

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -115,22 +115,6 @@ CSS Variables, and are not directly supported at this time.
 A tool like `postcss <https://postcss.org/>`__ can be used to convert the CSS files in the
 ``jupyterlab/build`` directory manually if desired.
 
-Usage with private NPM registry
--------------------------------
-
-To install some extensions, you will need access to an NPM packages registry. Some companies do not allow
-reaching directly public registry and have a private registry. To use it, you need to configure ``npm``
-**and** ``yarn`` to point to that registry (ask your corporate IT department for the correct URL):
-
-.. code::
-
-    npm config set registry https://registry.company.com/
-    yarn config set registry https://registry.company.com/
-
-JupyterLab will pick up that registry automatically. You can check which registry URL is used by JupyterLab by running::
-
-    python -c "from jupyterlab.commands import AppOptions; print(AppOptions().registry)"
-
 Installation problems
 ---------------------
 

--- a/docs/source/user/directories.rst
+++ b/docs/source/user/directories.rst
@@ -41,16 +41,7 @@ shipped with the Python package, you can launch as
 
 The build process uses a specific ``yarn`` version with a default working
 combination of npm packages stored in a ``yarn.lock`` file shipped with
-JupyterLab. Those package source urls point to the default yarn registry.
-However, if you defined your own yarn registry in the yarn configuration, the
-default yarn registry will be replaced by your custom registry. If you then
-switch back to the default yarn registry, you will need to clean your
-``staging`` folder before building:
-
-.. code:: bash
-
-    jupyter lab clean
-    jupyter lab build
+JupyterLab.
 
 
 Disabling Rebuild Checks

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1350,15 +1350,7 @@ class _AppHandler:
         # copy known-good yarn.lock if missing
         lock_path = pjoin(staging, "yarn.lock")
         lock_template = pjoin(HERE, "staging", "yarn.lock")
-        if (
-            self.registry != YARN_DEFAULT_REGISTRY
-        ):  # Replace on the fly the yarn repository see #3658
-            with open(lock_template, encoding="utf-8") as f:
-                template = f.read()
-            template = template.replace(YARN_DEFAULT_REGISTRY, self.registry.strip("/"))
-            with open(lock_path, "w", encoding="utf-8") as f:
-                f.write(template)
-        elif not osp.exists(lock_path):
+        if not osp.exists(lock_path):
             shutil.copy(lock_template, lock_path)
             os.chmod(lock_path, stat.S_IWRITE | stat.S_IREAD)
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Yarn 3 does not store the registry in the lock file any longer.
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Remove all custom check and handling of the lock file.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None