### PR TITLE
Treat experimental completer type information as optional

### DIFF
--- a/packages/completer/src/default/kernelprovider.ts
+++ b/packages/completer/src/default/kernelprovider.ts
@@ -52,8 +52,8 @@ export class KernelCompleterProvider implements ICompletionProvider {
     }
 
     const items = new Array<CompletionHandler.ICompletionItem>();
-    const metadata = response.metadata
-      ._jupyter_types_experimental as Array<JSONObject>;
+    const metadata = (response.metadata._jupyter_types_experimental ??
+      []) as Array<JSONObject>;
     response.matches.forEach((label, index) => {
       if (metadata[index]) {
         items.push({


### PR DESCRIPTION


## References
Fixes https://github.com/jupyterlab/jupyterlab/issues/14500

## Code changes
Treat experimental completer type information in `complete_reply` messages as optional.

## User-facing changes
Completer works for kernels that do not support experimental type information.

## Backwards-incompatible changes
N/A