### PR TITLE
Log console can be linked to any document widget

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -467,16 +467,23 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
       // Stop watching the title of the previously current widget
       if (oldValue) {
         oldValue.title.changed.disconnect(this._updateTitlePanelTitle, this);
+
+        if (oldValue instanceof DocumentWidget) {
+          oldValue.context.pathChanged.disconnect(
+            this._updateCurrentPath,
+            this
+          );
+        }
       }
 
       // Start watching the title of the new current widget
       if (newValue) {
         newValue.title.changed.connect(this._updateTitlePanelTitle, this);
         this._updateTitlePanelTitle();
-      }
 
-      if (newValue && newValue instanceof DocumentWidget) {
-        newValue.context.pathChanged.connect(this._updateCurrentPath, this);
+        if (newValue instanceof DocumentWidget) {
+          newValue.context.pathChanged.connect(this._updateCurrentPath, this);
+        }
       }
       this._updateCurrentPath();
     });
@@ -518,6 +525,14 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
    */
   get currentChanged(): ISignal<this, ILabShell.IChangedArgs> {
     return this._currentChanged;
+  }
+
+  /**
+   * Current document path.
+   */
+  // FIXME deprecation `undefined` is to ensure backward compatibility in 4.x
+  get currentPath(): string | null | undefined {
+    return this._currentPath;
   }
 
   /**

--- a/packages/logconsole-extension/package.json
+++ b/packages/logconsole-extension/package.json
@@ -38,7 +38,6 @@
     "@jupyterlab/apputils": "^4.0.0-rc.1",
     "@jupyterlab/coreutils": "^6.0.0-rc.1",
     "@jupyterlab/logconsole": "^4.0.0-rc.1",
-    "@jupyterlab/notebook": "^4.0.0-rc.1",
     "@jupyterlab/rendermime": "^4.0.0-rc.1",
     "@jupyterlab/settingregistry": "^4.0.0-rc.1",
     "@jupyterlab/statusbar": "^4.0.0-rc.1",

--- a/packages/logconsole-extension/style/index.css
+++ b/packages/logconsole-extension/style/index.css
@@ -11,6 +11,5 @@
 @import url('~@jupyterlab/rendermime/style/index.css');
 @import url('~@jupyterlab/application/style/index.css');
 @import url('~@jupyterlab/logconsole/style/index.css');
-@import url('~@jupyterlab/notebook/style/index.css');
 
 @import url('./base.css');

--- a/packages/logconsole-extension/style/index.js
+++ b/packages/logconsole-extension/style/index.js
@@ -11,6 +11,5 @@ import '@jupyterlab/apputils/style/index.js';
 import '@jupyterlab/rendermime/style/index.js';
 import '@jupyterlab/application/style/index.js';
 import '@jupyterlab/logconsole/style/index.js';
-import '@jupyterlab/notebook/style/index.js';
 
 import './base.css';

--- a/packages/logconsole-extension/tsconfig.json
+++ b/packages/logconsole-extension/tsconfig.json
@@ -19,9 +19,6 @@
       "path": "../logconsole"
     },
     {
-      "path": "../notebook"
-    },
-    {
       "path": "../rendermime"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3656,7 +3656,6 @@ __metadata:
     "@jupyterlab/apputils": ^4.0.0-rc.1
     "@jupyterlab/coreutils": ^6.0.0-rc.1
     "@jupyterlab/logconsole": ^4.0.0-rc.1
-    "@jupyterlab/notebook": ^4.0.0-rc.1
     "@jupyterlab/rendermime": ^4.0.0-rc.1
     "@jupyterlab/settingregistry": ^4.0.0-rc.1
     "@jupyterlab/statusbar": ^4.0.0-rc.1


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Seen when working on https://github.com/jupyterlab/jupyter_collaboration/pull/145

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
`LogConsole` does not required the widget to be a notebook; only a `DocumentWidget` defining `context.path`.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Log console can be used for text file
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
> It introduces a new `LabShell.currentPath` to access the path linked to signal `LabShell.currentPathChanged`. This is additive.