### PR TITLE
Fix drive handling for sessions and terminals

### DIFF
--- a/packages/console/src/panel.ts
+++ b/packages/console/src/panel.ts
@@ -8,7 +8,7 @@ import {
   SessionContextDialogs
 } from '@jupyterlab/apputils';
 import { IEditorMimeTypeService } from '@jupyterlab/codeeditor';
-import { PathExt, Time, URLExt } from '@jupyterlab/coreutils';
+import { PathExt, Time } from '@jupyterlab/coreutils';
 import {
   IRenderMimeRegistry,
   RenderMimeRegistry
@@ -54,7 +54,7 @@ export class ConsolePanel extends MainAreaWidget<Panel> {
     const contentFactory = (this.contentFactory = options.contentFactory);
     const count = Private.count++;
     if (!path) {
-      path = URLExt.join(basePath || '', `console-${count}-${UUID.uuid4()}`);
+      path = PathExt.join(basePath || '', `console-${count}-${UUID.uuid4()}`);
     }
 
     sessionContext = this._sessionContext =
@@ -62,7 +62,7 @@ export class ConsolePanel extends MainAreaWidget<Panel> {
       new SessionContext({
         sessionManager: manager.sessions,
         specsManager: manager.kernelspecs,
-        path,
+        path: manager.contents.localPath(path),
         name: name || trans.__('Console %1', count),
         type: 'console',
         kernelPreference: options.kernelPreference,

--- a/packages/console/test/panel.spec.ts
+++ b/packages/console/test/panel.spec.ts
@@ -13,6 +13,8 @@ import {
   mimeTypeService,
   rendermime
 } from './utils';
+import { Drive } from '@jupyterlab/services';
+import { UUID } from '@lumino/coreutils';
 
 class TestPanel extends ConsolePanel {
   methods: string[] = [];
@@ -35,6 +37,7 @@ describe('console/panel', () => {
   const manager = new ServiceManagerMock();
 
   beforeAll(async () => {
+    manager.contents.addDrive(new Drive({ name: 'TestDrive' }));
     return await manager.ready;
   });
 
@@ -59,6 +62,19 @@ describe('console/panel', () => {
         expect(Array.from(panel.node.classList)).toEqual(
           expect.arrayContaining(['jp-ConsolePanel'])
         );
+      });
+
+      it('should set the session context path to local path', () => {
+        const localPath = `${UUID.uuid4()}.txt`;
+        const panel = new TestPanel({
+          manager,
+          contentFactory,
+          rendermime,
+          mimeTypeService,
+          path: `TestDrive:${localPath}`
+        });
+
+        expect(panel.sessionContext.path).toEqual(localPath);
       });
     });
 

--- a/packages/docregistry/test/context.spec.ts
+++ b/packages/docregistry/test/context.spec.ts
@@ -8,7 +8,7 @@ import {
   TextModelFactory
 } from '@jupyterlab/docregistry';
 import { RenderMimeRegistry } from '@jupyterlab/rendermime';
-import { Contents, ServiceManager } from '@jupyterlab/services';
+import { Contents, Drive, ServiceManager } from '@jupyterlab/services';
 import {
   acceptDialog,
   dismissDialog,
@@ -25,6 +25,7 @@ describe('docregistry/context', () => {
 
   beforeAll(() => {
     manager = new ServiceManagerMock();
+    manager.contents.addDrive(new Drive({ name: 'TestDrive' }));
     return manager.ready;
   });
 
@@ -52,6 +53,17 @@ describe('docregistry/context', () => {
           path: UUID.uuid4() + '.txt'
         });
         expect(context).toBeInstanceOf(Context);
+      });
+
+      it('should set the session path with local path', () => {
+        const localPath = `${UUID.uuid4()}.txt`;
+        context = new Context({
+          manager,
+          factory,
+          path: `TestDrive:${localPath}`
+        });
+
+        expect(context.sessionContext.path).toEqual(localPath);
       });
     });
 

--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -353,6 +353,7 @@ function addCommands(
     execute: async args => {
       const name = args['name'] as string;
       const cwd = args['cwd'] as string;
+      const localPath = serviceManager.contents.localPath(cwd);
 
       let session;
       if (name) {
@@ -364,12 +365,15 @@ function addCommands(
         } else {
           // we are restoring a terminal widget but the corresponding terminal was closed
           // let's start a new terminal with the original name
-          session = await serviceManager.terminals.startNew({ name, cwd });
+          session = await serviceManager.terminals.startNew({
+            name,
+            cwd: localPath
+          });
         }
       } else {
         // we are creating a new terminal widget with a new terminal
         // let the server choose the terminal name
-        session = await serviceManager.terminals.startNew({ cwd });
+        session = await serviceManager.terminals.startNew({ cwd: localPath });
       }
 
       const term = new XTerm(session, options, translator);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #14443
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Set `sessionContext` has `localPath` (dropping the drive name)
Pass `cwd` without the drive name when starting terminals

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
For browser with non-default drive (like for RTC), the kernels should start in the file folder and the terminals and consoles should open in the current directory.
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None