### PR TITLE
Backport PR #14414 on branch 3.6.x (Fix CI: remove/update broken docs links)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 **[Installation](#installation)** |
-**[Documentation](http://jupyterlab.readthedocs.io)** |
+**[Documentation](https://jupyterlab.readthedocs.io)** |
 **[Contributing](#contributing)** |
 **[License](#license)** |
 **[Team](#team)** |
 **[Getting help](#getting-help)** |
 
-# [JupyterLab](http://jupyterlab.github.io/jupyterlab/)
+# [JupyterLab](https://jupyterlab.readthedocs.io)
 
 [![PyPI version](https://badge.fury.io/py/jupyterlab.svg)](https://badge.fury.io/py/jupyterlab)
 [![Downloads](https://pepy.tech/badge/jupyterlab/month)](https://pepy.tech/project/jupyterlab/month)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -260,10 +260,6 @@ shasum -a 256 dist/*.tar.gz
 - Create a PR with the version bump
 - Update `recipe/meta.yaml` with the new version and md5 and reset the build number to 0.
 
-## Updating API Docs
-
-Run `source scripts/docs_push.sh` to update the `gh-pages` branch that backs http://jupyterlab.github.io/jupyterlab/.
-
 ## Making a patch release
 
 - Backport the change to the previous release branch

--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -2,7 +2,7 @@
 
 Javascript client for the Jupyter services REST APIs
 
-[API Docs](https://jupyterlab.readthedocs.io/en/latest/api/)
+[API Docs](https://jupyterlab.readthedocs.io/en/3.6.x/api/)
 
 [REST API Docs](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/master/notebook/services/api/api.yaml)
 

--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -2,7 +2,7 @@
 
 Javascript client for the Jupyter services REST APIs
 
-[API Docs](http://jupyterlab.github.io/jupyterlab/)
+[API Docs](https://jupyterlab.readthedocs.io/en/latest/api/)
 
 [REST API Docs](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/master/notebook/services/api/api.yaml)
 


### PR DESCRIPTION
## References

Backport PR #14414: Fix CI: remove/update broken docs links