### PR TITLE
feat(filebrowser): copy absolute path instead of relative path

### DIFF
--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -247,6 +247,13 @@ export namespace PageConfig {
   }
 
   /**
+   * Getter for JupyterLab server root folder
+   */
+  export function getServerRoot(): string {
+    return getOption('serverRoot') || '';
+  }
+
+  /**
    * Private page config data for the Jupyter application.
    */
   let configData: { [key: string]: string } | null = null;

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -1209,7 +1209,7 @@ function addCommands(
         return;
       }
 
-      Clipboard.copyToSystem(item.value.path);
+      Clipboard.copyToSystem(item.value.osPath);
     },
     isVisible: () =>
       // So long as this command only handles one file at time, don't show it

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -50,6 +50,11 @@ export namespace Contents {
     readonly path: string;
 
     /**
+     * The full absolute file path.
+     */
+    osPath: string;
+
+    /**
      * The path as returned by the server contents API.
      *
      * #### Notes
@@ -1133,6 +1138,8 @@ export class Drive implements Contents.IDrive {
       throw err;
     }
     const data = await response.json();
+    // convert to absolute path
+    data.osPath = PathExt.join(settings.serverRoot, data.path);
     validate.validateContentsModel(data);
     return data;
   }

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -52,7 +52,7 @@ export namespace Contents {
     /**
      * The full absolute file path.
      */
-    osPath: string;
+    osPath: string | null;
 
     /**
      * The path as returned by the server contents API.

--- a/packages/services/src/contents/validate.ts
+++ b/packages/services/src/contents/validate.ts
@@ -12,6 +12,7 @@ export function validateContentsModel(
 ): asserts model is Contents.IModel {
   validateProperty(model, 'name', 'string');
   validateProperty(model, 'path', 'string');
+  validateProperty(model, 'osPath', 'string');
   validateProperty(model, 'type', 'string');
   validateProperty(model, 'created', 'string');
   validateProperty(model, 'last_modified', 'string');

--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -66,6 +66,11 @@ export namespace ServerConnection {
     readonly appendToken: boolean;
 
     /**
+     * The root folder of the server.
+     */
+    readonly serverRoot: string;
+
+    /**
      * The `fetch` method to use.
      */
     readonly fetch: (
@@ -239,6 +244,7 @@ namespace Private {
           process?.env?.JEST_WORKER_ID !== undefined) ||
         URLExt.getHostName(pageBaseUrl) !== URLExt.getHostName(wsUrl),
       ...options,
+      serverRoot: PageConfig.getServerRoot(),
       baseUrl,
       wsUrl
     };


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->
Fixes #9485 
## Code changes

<!-- Describe the code changes and how they address the issue. -->
* add serverRoot to serverconnection in services
* add osPath to contents in services
* replace path to osPath in copy command of filebrowser-extension

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->
None
## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
* Obtain absolute paths instead of relative paths when copying paths in filebrowser.