### PR TITLE
Remove `@jupyterlab/celltags` from the `resolutions`

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -29,7 +29,6 @@
     "@jupyterlab/cell-toolbar": "~4.0.0",
     "@jupyterlab/cell-toolbar-extension": "~4.0.0",
     "@jupyterlab/cells": "~4.0.0",
-    "@jupyterlab/celltags": "~4.0.0-alpha.20",
     "@jupyterlab/celltags-extension": "~4.0.0",
     "@jupyterlab/codeeditor": "~4.0.0",
     "@jupyterlab/codemirror": "~4.0.0",


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Remove the old `@jupyterlab/celltags` package from the `resolutions`.

This was noticed in https://github.com/jupyterlab/jupyterlab/issues/14549#issuecomment-1549185813.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Removed `@jupyterlab/celltags` as the package was removed in JupyterLab 4.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
