### PR TITLE
Implement dialog element for dialogs with accessibility

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -23,7 +23,7 @@
     "@jupyter/ydoc": "~1.0.2",
     "@jupyterlab/application": "~4.0.0",
     "@jupyterlab/application-extension": "~4.0.0",
-    "@jupyterlab/apputils": "~4.0.0",
+    "@jupyterlab/apputils": "~4.1.0",
     "@jupyterlab/apputils-extension": "~4.0.0",
     "@jupyterlab/attachments": "~4.0.0",
     "@jupyterlab/cell-toolbar": "~4.0.0",

--- a/examples/cell/package.json
+++ b/examples/cell/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@jupyter/ydoc": "^1.0.2",
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/cells": "^4.0.0",
     "@jupyterlab/codemirror": "^4.0.0",
     "@jupyterlab/completer": "^4.0.0",

--- a/examples/filebrowser/package.json
+++ b/examples/filebrowser/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/codemirror": "^4.0.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/docmanager": "^4.0.0",

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@jupyter/ydoc": "^1.0.2",
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/codemirror": "^4.0.0",
     "@jupyterlab/completer": "^4.0.0",
     "@jupyterlab/coreutils": "^6.0.0",

--- a/galata/extension/package.json
+++ b/galata/extension/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/cells": "^4.0.0",
     "@jupyterlab/debugger": "^4.0.0",
     "@jupyterlab/docmanager": "^4.0.0",

--- a/galata/package.json
+++ b/galata/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/debugger": "^4.0.0",
     "@jupyterlab/docmanager": "^4.0.0",

--- a/galata/test/jupyterlab/kernel.test.ts
+++ b/galata/test/jupyterlab/kernel.test.ts
@@ -95,7 +95,7 @@ test.describe('Kernel', () => {
 
       await page
         .locator('.jp-Dialog')
-        .getByRole('button', { name: 'Select' })
+        .getByRole('button', { name: 'Select', exact: true })
         .click();
 
       await expect(page.getByTitle('Switch kernel')).toHaveText(
@@ -129,7 +129,7 @@ test.describe('Kernel', () => {
 
       await page
         .locator('.jp-Dialog')
-        .getByRole('button', { name: 'Select' })
+        .getByRole('button', { name: 'Select Kernel', exact: true })
         .click();
 
       await expect(page.getByTitle('Change kernel for Console 1')).toHaveText(

--- a/galata/test/jupyterlab/kernel.test.ts
+++ b/galata/test/jupyterlab/kernel.test.ts
@@ -95,7 +95,7 @@ test.describe('Kernel', () => {
 
       await page
         .locator('.jp-Dialog')
-        .getByRole('button', { name: 'Select', exact: true })
+        .getByRole('button', { name: 'Select Kernel', exact: true })
         .click();
 
       await expect(page.getByTitle('Switch kernel')).toHaveText(

--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/property-inspector": "^4.0.0",
     "@jupyterlab/settingregistry": "^4.0.0",

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.12.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/docregistry": "^4.0.0",
     "@jupyterlab/rendermime": "^4.0.0",

--- a/packages/apputils-extension/package.json
+++ b/packages/apputils-extension/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/docregistry": "^4.0.0",
     "@jupyterlab/filebrowser": "^4.0.0",

--- a/packages/apputils-extension/src/workspacesplugin.ts
+++ b/packages/apputils-extension/src/workspacesplugin.ts
@@ -263,7 +263,10 @@ namespace Private {
   ): Promise<string | null> {
     translator = translator || nullTranslator;
     const trans = translator.load('jupyterlab');
-    const saveBtn = Dialog.okButton({ label: trans.__('Save') });
+    const saveBtn = Dialog.okButton({
+      label: trans.__('Save'),
+      ariaLabel: trans.__('Save Current Workspace')
+    });
     const result = await showDialog({
       title: trans.__('Save Current Workspace As…'),
       body: new SaveWidget(defaultPath),

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/apputils",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "JupyterLab - Application Utilities",
   "keywords": [
     "jupyter",

--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -535,6 +535,10 @@ export namespace Dialog {
    */
   export interface IButton {
     /**
+     * The aria label for the button.
+     */
+    ariaLabel: string;
+    /**
      * The label for the button.
      */
     label: string;
@@ -762,6 +766,7 @@ export namespace Dialog {
     const trans = translator.load('jupyterlab');
     const defaultLabel = value.accept ? trans.__('Ok') : trans.__('Cancel');
     return {
+      ariaLabel: value.ariaLabel || value.label || defaultLabel,
       label: value.label || defaultLabel,
       iconClass: value.iconClass || '',
       iconLabel: value.iconLabel || '',
@@ -1060,6 +1065,7 @@ export namespace Dialog {
       const e = document.createElement('div');
       e.className = 'jp-Dialog-buttonLabel';
       e.title = data.caption;
+      e.ariaLabel = data.ariaLabel;
       e.appendChild(document.createTextNode(data.label));
       return e;
     }

--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -84,7 +84,9 @@ export class Dialog<T> extends Widget {
    * @param options - The dialog setup options.
    */
   constructor(options: Partial<Dialog.IOptions<T>> = {}) {
-    super();
+    const dialogNode = document.createElement('dialog');
+    dialogNode.ariaModal = 'true';
+    super({ node: dialogNode });
     this.addClass('jp-Dialog');
     const normalized = Private.handleOptions(options);
     const renderer = normalized.renderer;
@@ -117,6 +119,7 @@ export class Dialog<T> extends Widget {
     content.addClass('jp-Dialog-content');
     if (typeof options.body === 'string') {
       content.addClass('jp-Dialog-content-small');
+      dialogNode.ariaLabel = [normalized.title, options.body].join(' ');
     }
     layout.addWidget(content);
 

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -1338,8 +1338,7 @@ export class SessionContextDialogs implements ISessionContext.IDialogs {
     }
     const buttons = [
       Dialog.cancelButton({
-        label,
-        ariaLabel: trans.__('Cancel Kernel Select')
+        label
       }),
       Dialog.okButton({
         label: trans.__('Select'),

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -1337,8 +1337,14 @@ export class SessionContextDialogs implements ISessionContext.IDialogs {
       label = sessionContext.kernelDisplayName;
     }
     const buttons = [
-      Dialog.cancelButton({ label }),
-      Dialog.okButton({ label: trans.__('Select') })
+      Dialog.cancelButton({
+        label,
+        ariaLabel: trans.__('Cancel Kernel Select')
+      }),
+      Dialog.okButton({
+        label: trans.__('Select'),
+        ariaLabel: trans.__('Select Kernel')
+      })
     ];
 
     const autoStartDefault = sessionContext.kernelPreference.autoStartDefault;
@@ -1410,14 +1416,20 @@ export class SessionContextDialogs implements ISessionContext.IDialogs {
       throw new Error('No kernel to restart');
     }
 
-    const restartBtn = Dialog.warnButton({ label: 'Restart' });
+    const restartBtn = Dialog.warnButton({
+      label: 'Restart',
+      ariaLabel: trans.__('Confirm Kernel Restart')
+    });
     const result = await showDialog({
       title: trans.__('Restart Kernel?'),
       body: trans.__(
         'Do you want to restart the kernel of %1? All variables will be lost.',
         sessionContext.name
       ),
-      buttons: [Dialog.cancelButton(), restartBtn]
+      buttons: [
+        Dialog.cancelButton({ ariaLabel: trans.__('Cancel Kernel Restart') }),
+        restartBtn
+      ]
     });
 
     if (kernel.isDisposed) {

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -1417,7 +1417,7 @@ export class SessionContextDialogs implements ISessionContext.IDialogs {
     }
 
     const restartBtn = Dialog.warnButton({
-      label: 'Restart',
+      label: trans.__('Restart'),
       ariaLabel: trans.__('Confirm Kernel Restart')
     });
     const result = await showDialog({

--- a/packages/apputils/test/dialog.spec.tsx
+++ b/packages/apputils/test/dialog.spec.tsx
@@ -356,6 +356,7 @@ describe('@jupyterlab/apputils', () => {
       };
 
       const data: Dialog.IButton = {
+        ariaLabel: 'ariafoo',
         label: 'foo',
         iconClass: 'bar',
         iconLabel: 'foo',

--- a/packages/cell-toolbar-extension/package.json
+++ b/packages/cell-toolbar-extension/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/cell-toolbar": "^4.0.0",
     "@jupyterlab/settingregistry": "^4.0.0",
     "@jupyterlab/translation": "^4.0.0"

--- a/packages/cell-toolbar/package.json
+++ b/packages/cell-toolbar/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@jupyter/ydoc": "^1.0.2",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/cells": "^4.0.0",
     "@jupyterlab/docregistry": "^4.0.0",
     "@jupyterlab/notebook": "^4.0.0",

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -46,7 +46,7 @@
     "@codemirror/state": "^6.2.0",
     "@codemirror/view": "^6.9.6",
     "@jupyter/ydoc": "^1.0.2",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/attachments": "^4.0.0",
     "@jupyterlab/codeeditor": "^4.0.0",
     "@jupyterlab/codemirror": "^4.0.0",

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@jupyter/ydoc": "^1.0.2",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/codeeditor": "^4.0.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/rendermime": "^4.0.0",

--- a/packages/console-extension/package.json
+++ b/packages/console-extension/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/codeeditor": "^4.0.0",
     "@jupyterlab/completer": "^4.0.0",
     "@jupyterlab/console": "^4.0.0",

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -663,7 +663,14 @@ async function activateConsole(
           'Are you sure you want to close "%1"?',
           current.title.label
         ),
-        buttons: [Dialog.cancelButton(), Dialog.warnButton()]
+        buttons: [
+          Dialog.cancelButton({
+            ariaLabel: trans.__('Cancel console Shut Down')
+          }),
+          Dialog.warnButton({
+            ariaLabel: trans.__('Confirm console Shut Down')
+          })
+        ]
       }).then(result => {
         if (result.button.accept) {
           return commands

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -46,7 +46,7 @@
     "@codemirror/state": "^6.2.0",
     "@codemirror/view": "^6.9.6",
     "@jupyter/ydoc": "^1.0.2",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/cells": "^4.0.0",
     "@jupyterlab/codeeditor": "^4.0.0",
     "@jupyterlab/coreutils": "^6.0.0",

--- a/packages/csvviewer-extension/package.json
+++ b/packages/csvviewer-extension/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/csvviewer": "^4.0.0",
     "@jupyterlab/docregistry": "^4.0.0",
     "@jupyterlab/documentsearch": "^4.0.0",

--- a/packages/debugger-extension/package.json
+++ b/packages/debugger-extension/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/cells": "^4.0.0",
     "@jupyterlab/codeeditor": "^4.0.0",
     "@jupyterlab/console": "^4.0.0",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -53,7 +53,7 @@
     "@codemirror/view": "^6.9.6",
     "@jupyter/ydoc": "^1.0.2",
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/cells": "^4.0.0",
     "@jupyterlab/codeeditor": "^4.0.0",
     "@jupyterlab/codemirror": "^4.0.0",

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/docmanager": "^4.0.0",
     "@jupyterlab/docregistry": "^4.0.0",

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -794,7 +794,10 @@ function addCommands(
           body: new RevertConfirmWidget(targetCheckpoint, trans, type),
           buttons: [
             Dialog.cancelButton(),
-            Dialog.warnButton({ label: trans.__('Revert') })
+            Dialog.warnButton({
+              label: trans.__('Revert'),
+              ariaLabel: trans.__('Revert to Checkpoint')
+            })
           ]
         }).then(result => {
           if (context.isDisposed) {

--- a/packages/docmanager/package.json
+++ b/packages/docmanager/package.json
@@ -42,7 +42,7 @@
     "watch": "npm run test -- --watch"
   },
   "dependencies": {
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/docregistry": "^4.0.0",
     "@jupyterlab/services": "^7.0.0",

--- a/packages/docmanager/src/dialogs.ts
+++ b/packages/docmanager/src/dialogs.ts
@@ -54,7 +54,10 @@ export function renameDialog(
     focusNodeSelector: 'input',
     buttons: [
       Dialog.cancelButton(),
-      Dialog.okButton({ label: trans.__('Rename') })
+      Dialog.okButton({
+        label: trans.__('Rename'),
+        ariaLabel: trans.__('Rename File')
+      })
     ]
   }).then(result => {
     if (!result.value) {
@@ -115,7 +118,10 @@ export function shouldOverwrite(
     body: trans.__('"%1" already exists, overwrite?', path),
     buttons: [
       Dialog.cancelButton(),
-      Dialog.warnButton({ label: trans.__('Overwrite') })
+      Dialog.warnButton({
+        label: trans.__('Overwrite'),
+        ariaLabel: trans.__('Overwrite Existing File')
+      })
     ]
   };
   return showDialog(options).then(result => {

--- a/packages/docmanager/src/widgetmanager.ts
+++ b/packages/docmanager/src/widgetmanager.ts
@@ -394,14 +394,20 @@ export class DocumentWidgetManager implements IDisposable {
       const buttons = [
         Dialog.cancelButton(),
         Dialog.okButton({
-          label: isDirty ? trans.__('Close and save') : trans.__('Close')
+          label: isDirty ? trans.__('Close and save') : trans.__('Close'),
+          ariaLabel: isDirty
+            ? trans.__('Close and save Document')
+            : trans.__('Close Document')
         })
       ];
       if (isDirty) {
         buttons.splice(
           1,
           0,
-          Dialog.warnButton({ label: trans.__('Close without saving') })
+          Dialog.warnButton({
+            label: trans.__('Close without saving'),
+            ariaLabel: trans.__('Close Document without saving')
+          })
         );
       }
 
@@ -440,7 +446,10 @@ export class DocumentWidgetManager implements IDisposable {
         body: trans.__('Save changes in "%1" before closing?', fileName),
         buttons: [
           Dialog.cancelButton(),
-          Dialog.warnButton({ label: trans.__('Discard') }),
+          Dialog.warnButton({
+            label: trans.__('Discard'),
+            ariaLabel: trans.__('Discard changes to file')
+          }),
           Dialog.okButton({ label: saveLabel })
         ]
       });

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@jupyter/ydoc": "^1.0.2",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/codeeditor": "^4.0.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/observables": "^5.0.0",

--- a/packages/documentsearch-extension/package.json
+++ b/packages/documentsearch-extension/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/documentsearch": "^4.0.0",
     "@jupyterlab/settingregistry": "^4.0.0",
     "@jupyterlab/translation": "^4.0.0",

--- a/packages/documentsearch/package.json
+++ b/packages/documentsearch/package.json
@@ -38,7 +38,7 @@
     "watch": "tsc -w --listEmittedFiles"
   },
   "dependencies": {
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/translation": "^4.0.0",
     "@jupyterlab/ui-components": "^4.0.0",
     "@lumino/coreutils": "^2.1.1",

--- a/packages/extensionmanager-extension/package.json
+++ b/packages/extensionmanager-extension/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/extensionmanager": "^4.0.0",
     "@jupyterlab/settingregistry": "^4.0.0",
     "@jupyterlab/translation": "^4.0.0",

--- a/packages/extensionmanager/package.json
+++ b/packages/extensionmanager/package.json
@@ -37,7 +37,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/services": "^7.0.0",
     "@jupyterlab/translation": "^4.0.0",

--- a/packages/filebrowser-extension/package.json
+++ b/packages/filebrowser-extension/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/docmanager": "^4.0.0",
     "@jupyterlab/docregistry": "^4.0.0",

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -42,7 +42,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/docmanager": "^4.0.0",
     "@jupyterlab/docregistry": "^4.0.0",

--- a/packages/fileeditor-extension/package.json
+++ b/packages/fileeditor-extension/package.json
@@ -41,7 +41,7 @@
     "@codemirror/commands": "^6.2.3",
     "@codemirror/search": "^6.3.0",
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/codeeditor": "^4.0.0",
     "@jupyterlab/codemirror": "^4.0.0",
     "@jupyterlab/completer": "^4.0.0",

--- a/packages/fileeditor/package.json
+++ b/packages/fileeditor/package.json
@@ -40,7 +40,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/codeeditor": "^4.0.0",
     "@jupyterlab/codemirror": "^4.0.0",
     "@jupyterlab/coreutils": "^6.0.0",

--- a/packages/help-extension/package.json
+++ b/packages/help-extension/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/mainmenu": "^4.0.0",
     "@jupyterlab/services": "^7.0.0",

--- a/packages/htmlviewer-extension/package.json
+++ b/packages/htmlviewer-extension/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/docregistry": "^4.0.0",
     "@jupyterlab/htmlviewer": "^4.0.0",
     "@jupyterlab/observables": "^5.0.0",

--- a/packages/htmlviewer/package.json
+++ b/packages/htmlviewer/package.json
@@ -33,7 +33,7 @@
     "watch": "tsc -w --listEmittedFiles"
   },
   "dependencies": {
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/docregistry": "^4.0.0",
     "@jupyterlab/translation": "^4.0.0",

--- a/packages/hub-extension/package.json
+++ b/packages/hub-extension/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/services": "^7.0.0",
     "@jupyterlab/translation": "^4.0.0"

--- a/packages/imageviewer-extension/package.json
+++ b/packages/imageviewer-extension/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/docregistry": "^4.0.0",
     "@jupyterlab/imageviewer": "^4.0.0",
     "@jupyterlab/translation": "^4.0.0"

--- a/packages/imageviewer/package.json
+++ b/packages/imageviewer/package.json
@@ -42,7 +42,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/docregistry": "^4.0.0",
     "@lumino/coreutils": "^2.1.1",

--- a/packages/inspector-extension/package.json
+++ b/packages/inspector-extension/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/console": "^4.0.0",
     "@jupyterlab/inspector": "^4.0.0",
     "@jupyterlab/launcher": "^4.0.0",

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -42,7 +42,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/codeeditor": "^4.0.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/rendermime": "^4.0.0",

--- a/packages/json-extension/package.json
+++ b/packages/json-extension/package.json
@@ -33,7 +33,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/codemirror": "^4.0.0",
     "@jupyterlab/rendermime-interfaces": "^3.8.0",
     "@jupyterlab/translation": "^4.0.0",

--- a/packages/launcher-extension/package.json
+++ b/packages/launcher-extension/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/filebrowser": "^4.0.0",
     "@jupyterlab/launcher": "^4.0.0",
     "@jupyterlab/translation": "^4.0.0",

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -37,7 +37,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/translation": "^4.0.0",
     "@jupyterlab/ui-components": "^4.0.0",
     "@lumino/algorithm": "^2.0.0",

--- a/packages/logconsole-extension/package.json
+++ b/packages/logconsole-extension/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/logconsole": "^4.0.0",
     "@jupyterlab/rendermime": "^4.0.0",

--- a/packages/lsp/package.json
+++ b/packages/lsp/package.json
@@ -44,7 +44,7 @@
     "vscode-languageserver-protocol": "^3.17.0"
   },
   "dependencies": {
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/codeeditor": "^4.0.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/docregistry": "^4.0.0",

--- a/packages/mainmenu-extension/package.json
+++ b/packages/mainmenu-extension/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/mainmenu": "^4.0.0",
     "@jupyterlab/services": "^7.0.0",

--- a/packages/mainmenu/package.json
+++ b/packages/mainmenu/package.json
@@ -42,7 +42,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/translation": "^4.0.0",
     "@jupyterlab/ui-components": "^4.0.0",
     "@lumino/algorithm": "^2.0.0",

--- a/packages/markdownviewer-extension/package.json
+++ b/packages/markdownviewer-extension/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/markdownviewer": "^4.0.0",
     "@jupyterlab/rendermime": "^4.0.0",

--- a/packages/markdownviewer/package.json
+++ b/packages/markdownviewer/package.json
@@ -37,7 +37,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/docregistry": "^4.0.0",
     "@jupyterlab/rendermime": "^4.0.0",

--- a/packages/metadataform/package.json
+++ b/packages/metadataform/package.json
@@ -45,7 +45,7 @@
     "watch": "tsc -w --listEmittedFiles"
   },
   "dependencies": {
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/nbformat": "^4.0.0",
     "@jupyterlab/notebook": "^4.0.0",
     "@jupyterlab/settingregistry": "^4.0.0",

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
     "@jupyterlab/application-extension": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/apputils-extension": "^4.0.0",
     "@jupyterlab/attachments": "^4.0.0",
     "@jupyterlab/cell-toolbar": "^4.0.0",

--- a/packages/nbconvert-css/package.json
+++ b/packages/nbconvert-css/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/cells": "^4.0.0",
     "@jupyterlab/codemirror": "^4.0.0",
     "@jupyterlab/notebook": "^4.0.0",

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@jupyter/ydoc": "^1.0.2",
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/cells": "^4.0.0",
     "@jupyterlab/codeeditor": "^4.0.0",
     "@jupyterlab/codemirror": "^4.0.0",

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@jupyter/ydoc": "^1.0.2",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/cells": "^4.0.0",
     "@jupyterlab/codeeditor": "^4.0.0",
     "@jupyterlab/codemirror": "^4.0.0",

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2061,7 +2061,10 @@ export namespace NotebookActions {
       title: trans.__('Trust this notebook?'),
       buttons: [
         Dialog.cancelButton(),
-        Dialog.warnButton({ label: trans.__('Trust') })
+        Dialog.warnButton({
+          label: trans.__('Trust'),
+          ariaLabel: trans.__('Confirm Trusting this notebook')
+        })
       ] // FIXME?
     }).then(result => {
       if (result.button.accept) {

--- a/packages/outputarea/package.json
+++ b/packages/outputarea/package.json
@@ -42,7 +42,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/nbformat": "^4.0.0",
     "@jupyterlab/observables": "^5.0.0",
     "@jupyterlab/rendermime": "^4.0.0",

--- a/packages/rendermime-extension/package.json
+++ b/packages/rendermime-extension/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/docmanager": "^4.0.0",
     "@jupyterlab/rendermime": "^4.0.0",
     "@jupyterlab/translation": "^4.0.0"

--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -42,7 +42,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/nbformat": "^4.0.0",
     "@jupyterlab/observables": "^5.0.0",

--- a/packages/running/package.json
+++ b/packages/running/package.json
@@ -37,7 +37,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/translation": "^4.0.0",
     "@jupyterlab/ui-components": "^4.0.0",
     "@lumino/coreutils": "^2.1.1",

--- a/packages/settingeditor-extension/package.json
+++ b/packages/settingeditor-extension/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/codeeditor": "^4.0.0",
     "@jupyterlab/rendermime": "^4.0.0",
     "@jupyterlab/settingeditor": "^4.0.0",

--- a/packages/settingeditor/package.json
+++ b/packages/settingeditor/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/codeeditor": "^4.0.0",
     "@jupyterlab/inspector": "^4.0.0",
     "@jupyterlab/rendermime": "^4.0.0",

--- a/packages/statusbar-extension/package.json
+++ b/packages/statusbar-extension/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/settingregistry": "^4.0.0",
     "@jupyterlab/statusbar": "^4.0.0",
     "@jupyterlab/translation": "^4.0.0"

--- a/packages/terminal-extension/package.json
+++ b/packages/terminal-extension/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/launcher": "^4.0.0",
     "@jupyterlab/mainmenu": "^4.0.0",
     "@jupyterlab/running": "^4.0.0",

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -42,7 +42,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/services": "^7.0.0",
     "@jupyterlab/translation": "^4.0.0",
     "@lumino/coreutils": "^2.1.1",

--- a/packages/theme-dark-extension/package.json
+++ b/packages/theme-dark-extension/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/translation": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/theme-light-extension/package.json
+++ b/packages/theme-light-extension/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/translation": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/toc/package.json
+++ b/packages/toc/package.json
@@ -41,7 +41,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/docregistry": "^4.0.0",
     "@jupyterlab/observables": "^5.0.0",

--- a/packages/translation-extension/package.json
+++ b/packages/translation-extension/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/mainmenu": "^4.0.0",
     "@jupyterlab/settingregistry": "^4.0.0",
     "@jupyterlab/translation": "^4.0.0"

--- a/testutils/package.json
+++ b/testutils/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/apputils": "^4.0.0",
+    "@jupyterlab/apputils": "^4.1.0",
     "@jupyterlab/notebook": "^4.0.0",
     "@jupyterlab/rendermime": "^4.0.0",
     "@jupyterlab/testing": "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2008,7 +2008,7 @@ __metadata:
   resolution: "@jupyterlab/application-extension@workspace:packages/application-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/property-inspector": ^4.0.0
     "@jupyterlab/settingregistry": ^4.0.0
@@ -2110,7 +2110,7 @@ __metadata:
   resolution: "@jupyterlab/application@workspace:packages/application"
   dependencies:
     "@fortawesome/fontawesome-free": ^5.12.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/docregistry": ^4.0.0
     "@jupyterlab/rendermime": ^4.0.0
@@ -2143,7 +2143,7 @@ __metadata:
   resolution: "@jupyterlab/apputils-extension@workspace:packages/apputils-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/docregistry": ^4.0.0
     "@jupyterlab/filebrowser": ^4.0.0
@@ -2171,7 +2171,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jupyterlab/apputils@^4.0.0, @jupyterlab/apputils@workspace:packages/apputils":
+"@jupyterlab/apputils@^4.1.0, @jupyterlab/apputils@workspace:packages/apputils":
   version: 0.0.0-use.local
   resolution: "@jupyterlab/apputils@workspace:packages/apputils"
   dependencies:
@@ -2309,7 +2309,7 @@ __metadata:
   resolution: "@jupyterlab/cell-toolbar-extension@workspace:packages/cell-toolbar-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/cell-toolbar": ^4.0.0
     "@jupyterlab/settingregistry": ^4.0.0
     "@jupyterlab/translation": ^4.0.0
@@ -2323,7 +2323,7 @@ __metadata:
   resolution: "@jupyterlab/cell-toolbar@workspace:packages/cell-toolbar"
   dependencies:
     "@jupyter/ydoc": ^1.0.2
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/cells": ^4.0.0
     "@jupyterlab/docregistry": ^4.0.0
     "@jupyterlab/notebook": ^4.0.0
@@ -2349,7 +2349,7 @@ __metadata:
     "@codemirror/state": ^6.2.0
     "@codemirror/view": ^6.9.6
     "@jupyter/ydoc": ^1.0.2
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/attachments": ^4.0.0
     "@jupyterlab/codeeditor": ^4.0.0
     "@jupyterlab/codemirror": ^4.0.0
@@ -2525,7 +2525,7 @@ __metadata:
   resolution: "@jupyterlab/completer@workspace:packages/completer"
   dependencies:
     "@jupyter/ydoc": ^1.0.2
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/codeeditor": ^4.0.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/rendermime": ^4.0.0
@@ -2553,7 +2553,7 @@ __metadata:
   resolution: "@jupyterlab/console-extension@workspace:packages/console-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/codeeditor": ^4.0.0
     "@jupyterlab/completer": ^4.0.0
     "@jupyterlab/console": ^4.0.0
@@ -2582,7 +2582,7 @@ __metadata:
     "@codemirror/state": ^6.2.0
     "@codemirror/view": ^6.9.6
     "@jupyter/ydoc": ^1.0.2
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/cells": ^4.0.0
     "@jupyterlab/codeeditor": ^4.0.0
     "@jupyterlab/codemirror": ^4.0.0
@@ -2638,7 +2638,7 @@ __metadata:
   resolution: "@jupyterlab/csvviewer-extension@workspace:packages/csvviewer-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/csvviewer": ^4.0.0
     "@jupyterlab/docregistry": ^4.0.0
     "@jupyterlab/documentsearch": ^4.0.0
@@ -2684,7 +2684,7 @@ __metadata:
   resolution: "@jupyterlab/debugger-extension@workspace:packages/debugger-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/cells": ^4.0.0
     "@jupyterlab/codeeditor": ^4.0.0
     "@jupyterlab/console": ^4.0.0
@@ -2715,7 +2715,7 @@ __metadata:
     "@codemirror/view": ^6.9.6
     "@jupyter/ydoc": ^1.0.2
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/cells": ^4.0.0
     "@jupyterlab/codeeditor": ^4.0.0
     "@jupyterlab/codemirror": ^4.0.0
@@ -2755,7 +2755,7 @@ __metadata:
   resolution: "@jupyterlab/docmanager-extension@workspace:packages/docmanager-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/docmanager": ^4.0.0
     "@jupyterlab/docregistry": ^4.0.0
@@ -2781,7 +2781,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/docmanager@workspace:packages/docmanager"
   dependencies:
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/docregistry": ^4.0.0
     "@jupyterlab/services": ^7.0.0
@@ -2810,7 +2810,7 @@ __metadata:
   resolution: "@jupyterlab/docregistry@workspace:packages/docregistry"
   dependencies:
     "@jupyter/ydoc": ^1.0.2
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/codeeditor": ^4.0.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/observables": ^5.0.0
@@ -2840,7 +2840,7 @@ __metadata:
   resolution: "@jupyterlab/documentsearch-extension@workspace:packages/documentsearch-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/documentsearch": ^4.0.0
     "@jupyterlab/settingregistry": ^4.0.0
     "@jupyterlab/translation": ^4.0.0
@@ -2854,7 +2854,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/documentsearch@workspace:packages/documentsearch"
   dependencies:
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/testing": ^4.0.0
     "@jupyterlab/translation": ^4.0.0
     "@jupyterlab/ui-components": ^4.0.0
@@ -2930,7 +2930,7 @@ __metadata:
   dependencies:
     "@jupyter/ydoc": ^1.0.2
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/cells": ^4.0.0
     "@jupyterlab/codemirror": ^4.0.0
     "@jupyterlab/completer": ^4.0.0
@@ -3075,7 +3075,7 @@ __metadata:
   resolution: "@jupyterlab/example-filebrowser@workspace:examples/filebrowser"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/codemirror": ^4.0.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/docmanager": ^4.0.0
@@ -3106,7 +3106,7 @@ __metadata:
   dependencies:
     "@jupyter/ydoc": ^1.0.2
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/codemirror": ^4.0.0
     "@jupyterlab/completer": ^4.0.0
     "@jupyterlab/coreutils": ^6.0.0
@@ -3213,7 +3213,7 @@ __metadata:
   resolution: "@jupyterlab/extensionmanager-extension@workspace:packages/extensionmanager-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/extensionmanager": ^4.0.0
     "@jupyterlab/settingregistry": ^4.0.0
     "@jupyterlab/translation": ^4.0.0
@@ -3228,7 +3228,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/extensionmanager@workspace:packages/extensionmanager"
   dependencies:
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/services": ^7.0.0
     "@jupyterlab/translation": ^4.0.0
@@ -3254,7 +3254,7 @@ __metadata:
   resolution: "@jupyterlab/filebrowser-extension@workspace:packages/filebrowser-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/docmanager": ^4.0.0
     "@jupyterlab/docregistry": ^4.0.0
@@ -3278,7 +3278,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/filebrowser@workspace:packages/filebrowser"
   dependencies:
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/docmanager": ^4.0.0
     "@jupyterlab/docregistry": ^4.0.0
@@ -3314,7 +3314,7 @@ __metadata:
     "@codemirror/commands": ^6.2.3
     "@codemirror/search": ^6.3.0
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/codeeditor": ^4.0.0
     "@jupyterlab/codemirror": ^4.0.0
     "@jupyterlab/completer": ^4.0.0
@@ -3349,7 +3349,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/fileeditor@workspace:packages/fileeditor"
   dependencies:
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/codeeditor": ^4.0.0
     "@jupyterlab/codemirror": ^4.0.0
     "@jupyterlab/coreutils": ^6.0.0
@@ -3380,7 +3380,7 @@ __metadata:
   resolution: "@jupyterlab/galata-extension@workspace:galata/extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/builder": ^4.0.0
     "@jupyterlab/cells": ^4.0.0
     "@jupyterlab/debugger": ^4.0.0
@@ -3401,7 +3401,7 @@ __metadata:
   resolution: "@jupyterlab/galata@workspace:galata"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/debugger": ^4.0.0
     "@jupyterlab/docmanager": ^4.0.0
@@ -3429,7 +3429,7 @@ __metadata:
   resolution: "@jupyterlab/help-extension@workspace:packages/help-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/mainmenu": ^4.0.0
     "@jupyterlab/services": ^7.0.0
@@ -3451,7 +3451,7 @@ __metadata:
   resolution: "@jupyterlab/htmlviewer-extension@workspace:packages/htmlviewer-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/docregistry": ^4.0.0
     "@jupyterlab/htmlviewer": ^4.0.0
     "@jupyterlab/observables": ^5.0.0
@@ -3467,7 +3467,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/htmlviewer@workspace:packages/htmlviewer"
   dependencies:
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/docregistry": ^4.0.0
     "@jupyterlab/translation": ^4.0.0
@@ -3486,7 +3486,7 @@ __metadata:
   resolution: "@jupyterlab/hub-extension@workspace:packages/hub-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/services": ^7.0.0
     "@jupyterlab/translation": ^4.0.0
@@ -3500,7 +3500,7 @@ __metadata:
   resolution: "@jupyterlab/imageviewer-extension@workspace:packages/imageviewer-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/docregistry": ^4.0.0
     "@jupyterlab/imageviewer": ^4.0.0
     "@jupyterlab/translation": ^4.0.0
@@ -3514,7 +3514,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/imageviewer@workspace:packages/imageviewer"
   dependencies:
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/docregistry": ^4.0.0
     "@jupyterlab/testing": ^4.0.0
@@ -3534,7 +3534,7 @@ __metadata:
   resolution: "@jupyterlab/inspector-extension@workspace:packages/inspector-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/console": ^4.0.0
     "@jupyterlab/inspector": ^4.0.0
     "@jupyterlab/launcher": ^4.0.0
@@ -3552,7 +3552,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/inspector@workspace:packages/inspector"
   dependencies:
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/codeeditor": ^4.0.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/rendermime": ^4.0.0
@@ -3589,7 +3589,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/json-extension@workspace:packages/json-extension"
   dependencies:
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/codemirror": ^4.0.0
     "@jupyterlab/rendermime-interfaces": ^3.8.0
     "@jupyterlab/translation": ^4.0.0
@@ -3617,7 +3617,7 @@ __metadata:
   resolution: "@jupyterlab/launcher-extension@workspace:packages/launcher-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/filebrowser": ^4.0.0
     "@jupyterlab/launcher": ^4.0.0
     "@jupyterlab/translation": ^4.0.0
@@ -3635,7 +3635,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/launcher@workspace:packages/launcher"
   dependencies:
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/translation": ^4.0.0
     "@jupyterlab/ui-components": ^4.0.0
     "@lumino/algorithm": ^2.0.0
@@ -3657,7 +3657,7 @@ __metadata:
   resolution: "@jupyterlab/logconsole-extension@workspace:packages/logconsole-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/logconsole": ^4.0.0
     "@jupyterlab/rendermime": ^4.0.0
@@ -3721,7 +3721,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/lsp@workspace:packages/lsp"
   dependencies:
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/codeeditor": ^4.0.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/docregistry": ^4.0.0
@@ -3749,7 +3749,7 @@ __metadata:
   resolution: "@jupyterlab/mainmenu-extension@workspace:packages/mainmenu-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/mainmenu": ^4.0.0
     "@jupyterlab/services": ^7.0.0
@@ -3770,7 +3770,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/mainmenu@workspace:packages/mainmenu"
   dependencies:
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/testing": ^4.0.0
     "@jupyterlab/translation": ^4.0.0
     "@jupyterlab/ui-components": ^4.0.0
@@ -3791,7 +3791,7 @@ __metadata:
   resolution: "@jupyterlab/markdownviewer-extension@workspace:packages/markdownviewer-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/markdownviewer": ^4.0.0
     "@jupyterlab/rendermime": ^4.0.0
@@ -3808,7 +3808,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/markdownviewer@workspace:packages/markdownviewer"
   dependencies:
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/docregistry": ^4.0.0
     "@jupyterlab/rendermime": ^4.0.0
@@ -3872,7 +3872,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/metadataform@workspace:packages/metadataform"
   dependencies:
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/nbformat": ^4.0.0
     "@jupyterlab/notebook": ^4.0.0
     "@jupyterlab/settingregistry": ^4.0.0
@@ -3901,7 +3901,7 @@ __metadata:
   dependencies:
     "@jupyterlab/application": ^4.0.0
     "@jupyterlab/application-extension": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/apputils-extension": ^4.0.0
     "@jupyterlab/attachments": ^4.0.0
     "@jupyterlab/cell-toolbar": ^4.0.0
@@ -4040,7 +4040,7 @@ __metadata:
   resolution: "@jupyterlab/nbconvert-css@workspace:packages/nbconvert-css"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/cells": ^4.0.0
     "@jupyterlab/codemirror": ^4.0.0
     "@jupyterlab/notebook": ^4.0.0
@@ -4074,7 +4074,7 @@ __metadata:
   dependencies:
     "@jupyter/ydoc": ^1.0.2
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/cells": ^4.0.0
     "@jupyterlab/codeeditor": ^4.0.0
     "@jupyterlab/codemirror": ^4.0.0
@@ -4122,7 +4122,7 @@ __metadata:
   resolution: "@jupyterlab/notebook@workspace:packages/notebook"
   dependencies:
     "@jupyter/ydoc": ^1.0.2
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/cells": ^4.0.0
     "@jupyterlab/codeeditor": ^4.0.0
     "@jupyterlab/codemirror": ^4.0.0
@@ -4180,7 +4180,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/outputarea@workspace:packages/outputarea"
   dependencies:
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/nbformat": ^4.0.0
     "@jupyterlab/observables": ^5.0.0
     "@jupyterlab/rendermime": ^4.0.0
@@ -4240,7 +4240,7 @@ __metadata:
   resolution: "@jupyterlab/rendermime-extension@workspace:packages/rendermime-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/docmanager": ^4.0.0
     "@jupyterlab/rendermime": ^4.0.0
     "@jupyterlab/translation": ^4.0.0
@@ -4266,7 +4266,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/rendermime@workspace:packages/rendermime"
   dependencies:
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/nbformat": ^4.0.0
     "@jupyterlab/observables": ^5.0.0
@@ -4338,7 +4338,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/running@workspace:packages/running"
   dependencies:
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/translation": ^4.0.0
     "@jupyterlab/ui-components": ^4.0.0
     "@lumino/coreutils": ^2.1.1
@@ -4385,7 +4385,7 @@ __metadata:
   resolution: "@jupyterlab/settingeditor-extension@workspace:packages/settingeditor-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/codeeditor": ^4.0.0
     "@jupyterlab/rendermime": ^4.0.0
     "@jupyterlab/settingeditor": ^4.0.0
@@ -4405,7 +4405,7 @@ __metadata:
   resolution: "@jupyterlab/settingeditor@workspace:packages/settingeditor"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/codeeditor": ^4.0.0
     "@jupyterlab/inspector": ^4.0.0
     "@jupyterlab/rendermime": ^4.0.0
@@ -4509,7 +4509,7 @@ __metadata:
   resolution: "@jupyterlab/statusbar-extension@workspace:packages/statusbar-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/settingregistry": ^4.0.0
     "@jupyterlab/statusbar": ^4.0.0
     "@jupyterlab/translation": ^4.0.0
@@ -4557,7 +4557,7 @@ __metadata:
   resolution: "@jupyterlab/terminal-extension@workspace:packages/terminal-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/launcher": ^4.0.0
     "@jupyterlab/mainmenu": ^4.0.0
     "@jupyterlab/running": ^4.0.0
@@ -4578,7 +4578,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/terminal@workspace:packages/terminal"
   dependencies:
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/services": ^7.0.0
     "@jupyterlab/testing": ^4.0.0
     "@jupyterlab/translation": ^4.0.0
@@ -4634,7 +4634,7 @@ __metadata:
   resolution: "@jupyterlab/testutils@workspace:testutils"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/notebook": ^4.0.0
     "@jupyterlab/rendermime": ^4.0.0
     "@jupyterlab/testing": ^4.0.0
@@ -4648,7 +4648,7 @@ __metadata:
   resolution: "@jupyterlab/theme-dark-extension@workspace:packages/theme-dark-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/translation": ^4.0.0
     rimraf: ~3.0.0
     typedoc: ~0.24.7
@@ -4661,7 +4661,7 @@ __metadata:
   resolution: "@jupyterlab/theme-light-extension@workspace:packages/theme-light-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/translation": ^4.0.0
     rimraf: ~3.0.0
     typedoc: ~0.24.7
@@ -4688,7 +4688,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/toc@workspace:packages/toc"
   dependencies:
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/docregistry": ^4.0.0
     "@jupyterlab/observables": ^5.0.0
@@ -4756,7 +4756,7 @@ __metadata:
   resolution: "@jupyterlab/translation-extension@workspace:packages/translation-extension"
   dependencies:
     "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/apputils": ^4.1.0
     "@jupyterlab/mainmenu": ^4.0.0
     "@jupyterlab/settingregistry": ^4.0.0
     "@jupyterlab/translation": ^4.0.0


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
#6579 Modal dialogs are not accessible
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Change the dialog to use the dialog html element rather than the div element
Add aria title to the dialog
Add aria modal to the dialog to control focus for accessibility tools using aria
Add aria title to buttons and implement where required (this may be expanded upon in the future)

## User-facing changes

Users using accessibility tools will now have dialog labels announced and more meaningful titles for some dialog buttons 
Other users will not see any changes

## Backwards-incompatible changes

Dialog buttons now have an optional ariaLabel that can be used as well as label if the label is not suitable for users with accessibility needs

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
