### PR TITLE
added dynamic functionality to the text spacing

### DIFF
--- a/packages/launcher/style/base.css
+++ b/packages/launcher/style/base.css
@@ -100,7 +100,7 @@
   flex-direction: column;
   cursor: pointer;
   width: var(--jp-private-launcher-card-size);
-  height: var(--jp-private-launcher-card-size);
+  min-height: var(--jp-private-launcher-card-size);
   margin: 8px;
   padding: 0;
   border: 1px solid var(--jp-border-color2);
@@ -154,14 +154,14 @@
 
 .jp-LauncherCard-label {
   width: 100%;
-  height: var(--jp-private-launcher-card-label-height);
+  min-height: var(--jp-private-launcher-card-label-height);
   padding: 0 4px 4px;
   box-sizing: border-box;
   overflow: hidden;
 }
 
 .jp-LauncherCard-label p {
-  height: 2.154em;
+  min-height: 2.154em;
   word-break: break-word;
   text-align: center;
   color: var(--jp-ui-font-color1);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
#9684 Adjustable Text Spacing (Low priority)

Fixes #12999
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Changed height in CSS of Launcher file on the: LauncherCard, LauncherCard-label and LauncherCard-label p to "min-height" to allow for text spacing to be dynamic. 
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

When the issue on #9684 is reproduced, the code changes allow for the full text within the Launcher cards to fully be shown no matter the text spacing or font, as the launcher card will automatically adjust to the text format.

To test changes, inspect page and go to where the launcher card titles are written and add extra text with spacing within the `class="jp-LauncherCard-label"` `<p>...</p>` tag.


## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
