### PR TITLE
Avoid clearing the host node while rendering Markdown

### DIFF
--- a/packages/rendermime/src/widgets.ts
+++ b/packages/rendermime/src/widgets.ts
@@ -76,12 +76,12 @@ export abstract class RenderedCommon
    *
    * @param model - The mime model to render.
    *
-   * @param clearExisting - whether to clear existing nodes before render
+   * @param clearExisting - Whether to clear existing nodes before render.
    *
    * @returns A promise which resolves when rendering is complete.
    *
    * #### Notes
-   * If the DOM node for this widget already has content, it is emptied
+   * By default, if the DOM node for this widget already has content, it is emptied
    * before rendering. Subclasses that do not want this behavior
    * (if, for instance, they are using DOM diffing), should override
    * this method and not call `super.renderModel()`.

--- a/packages/rendermime/src/widgets.ts
+++ b/packages/rendermime/src/widgets.ts
@@ -79,15 +79,21 @@ export abstract class RenderedCommon
    * @param clearExisting - whether to clear existing nodes before render
    *
    * @returns A promise which resolves when rendering is complete.
+   *
+   * #### Notes
+   * If the DOM node for this widget already has content, it is emptied
+   * before rendering. Subclasses that do not want this behavior
+   * (if, for instance, they are using DOM diffing), should override
+   * this method and not call `super.renderModel()`.
    */
-  async renderCommonModel(
+  async renderModel(
     model: IRenderMime.IMimeModel,
-    clearExisting = true
+    clearExisting?: boolean
   ): Promise<void> {
     // TODO compare model against old model for early bail?
 
     // Empty any existing content in the node from previous renders
-    if (clearExisting) {
+    if (clearExisting !== false) {
       while (this.node.firstChild) {
         this.node.removeChild(this.node.firstChild);
       }
@@ -104,23 +110,6 @@ export abstract class RenderedCommon
     if (fragment) {
       this.setFragment(fragment as string);
     }
-  }
-
-  /**
-   * Render a mime model.
-   *
-   * @param model - The mime model to render.
-   *
-   * @returns A promise which resolves when rendering is complete.
-   *
-   * #### Notes
-   * If the DOM node for this widget already has content, it is emptied
-   * before rendering. Subclasses that do not want this behavior
-   * (if, for instance, they are using DOM diffing), should override
-   * this method and not call `super.renderModel()`.
-   */
-  async renderModel(model: IRenderMime.IMimeModel): Promise<void> {
-    await this.renderCommonModel(model);
   }
 
   /**
@@ -339,7 +328,7 @@ export class RenderedMarkdown extends RenderedHTMLCommon {
    * @returns A promise which resolves when rendering is complete.
    */
   async renderModel(model: IRenderMime.IMimeModel): Promise<void> {
-    await this.renderCommonModel(model, false);
+    await super.renderModel(model, false);
   }
 
   /**

--- a/packages/rendermime/src/widgets.ts
+++ b/packages/rendermime/src/widgets.ts
@@ -81,10 +81,10 @@ export abstract class RenderedCommon
    * @returns A promise which resolves when rendering is complete.
    *
    * #### Notes
-   * By default, if the DOM node for this widget already has content, it is emptied
-   * before rendering. Subclasses that do not want this behavior
-   * (if, for instance, they are using DOM diffing), should override
-   * this method and not call `super.renderModel()`.
+   * By default, if the DOM node for this widget already has content, it
+   * is emptied before rendering. Subclasses that do not want this behavior
+   * (if, for instance, they are using DOM diffing), should override this
+   * method or call `super.renderModel(model, false)`.
    */
   async renderModel(
     model: IRenderMime.IMimeModel,

--- a/packages/rendermime/src/widgets.ts
+++ b/packages/rendermime/src/widgets.ts
@@ -76,7 +76,7 @@ export abstract class RenderedCommon
    *
    * @param model - The mime model to render.
    *
-   * @param clearExisting - Whether to clear existing nodes before render.
+   * @param keepExisting - Whether to keep the existing rendering.
    *
    * @returns A promise which resolves when rendering is complete.
    *
@@ -84,16 +84,16 @@ export abstract class RenderedCommon
    * By default, if the DOM node for this widget already has content, it
    * is emptied before rendering. Subclasses that do not want this behavior
    * (if, for instance, they are using DOM diffing), should override this
-   * method or call `super.renderModel(model, false)`.
+   * method or call `super.renderModel(model, true)`.
    */
   async renderModel(
     model: IRenderMime.IMimeModel,
-    clearExisting?: boolean
+    keepExisting?: boolean
   ): Promise<void> {
     // TODO compare model against old model for early bail?
 
     // Empty any existing content in the node from previous renders
-    if (clearExisting !== false) {
+    if (!keepExisting) {
       while (this.node.firstChild) {
         this.node.removeChild(this.node.firstChild);
       }
@@ -328,7 +328,7 @@ export class RenderedMarkdown extends RenderedHTMLCommon {
    * @returns A promise which resolves when rendering is complete.
    */
   async renderModel(model: IRenderMime.IMimeModel): Promise<void> {
-    await super.renderModel(model, false);
+    await super.renderModel(model, true);
   }
 
   /**

--- a/packages/rendermime/src/widgets.ts
+++ b/packages/rendermime/src/widgets.ts
@@ -313,6 +313,20 @@ export class RenderedMarkdown extends RenderedHTMLCommon {
     });
   }
 
+  async renderModel(model: IRenderMime.IMimeModel): Promise<void> {
+    // Toggle the trusted class on the widget.
+    this.toggleClass('jp-mod-trusted', model.trusted);
+
+    // Render the actual content.
+    await this.render(model);
+
+    // Handle the fragment identifier if given.
+    const { fragment } = model.metadata;
+    if (fragment) {
+      this.setFragment(fragment as string);
+    }
+  }
+
   /**
    * A message handler invoked on an `'after-attach'` message.
    */

--- a/packages/rendermime/src/widgets.ts
+++ b/packages/rendermime/src/widgets.ts
@@ -76,20 +76,21 @@ export abstract class RenderedCommon
    *
    * @param model - The mime model to render.
    *
-   * @returns A promise which resolves when rendering is complete.
+   * @param clearExisting - whether to clear existing nodes before render
    *
-   * #### Notes
-   * If the DOM node for this widget already has content, it is emptied
-   * before rendering. Subclasses that do not want this behavior
-   * (if, for instance, they are using DOM diffing), should override
-   * this method and not call `super.renderModel()`.
+   * @returns A promise which resolves when rendering is complete.
    */
-  async renderModel(model: IRenderMime.IMimeModel): Promise<void> {
+  async renderCommonModel(
+    model: IRenderMime.IMimeModel,
+    clearExisting = true
+  ): Promise<void> {
     // TODO compare model against old model for early bail?
 
     // Empty any existing content in the node from previous renders
-    while (this.node.firstChild) {
-      this.node.removeChild(this.node.firstChild);
+    if (clearExisting) {
+      while (this.node.firstChild) {
+        this.node.removeChild(this.node.firstChild);
+      }
     }
 
     // Toggle the trusted class on the widget.
@@ -103,6 +104,23 @@ export abstract class RenderedCommon
     if (fragment) {
       this.setFragment(fragment as string);
     }
+  }
+
+  /**
+   * Render a mime model.
+   *
+   * @param model - The mime model to render.
+   *
+   * @returns A promise which resolves when rendering is complete.
+   *
+   * #### Notes
+   * If the DOM node for this widget already has content, it is emptied
+   * before rendering. Subclasses that do not want this behavior
+   * (if, for instance, they are using DOM diffing), should override
+   * this method and not call `super.renderModel()`.
+   */
+  async renderModel(model: IRenderMime.IMimeModel): Promise<void> {
+    await this.renderCommonModel(model);
   }
 
   /**
@@ -313,18 +331,15 @@ export class RenderedMarkdown extends RenderedHTMLCommon {
     });
   }
 
+  /**
+   * Render a mime model.
+   *
+   * @param model - The mime model to render.
+   *
+   * @returns A promise which resolves when rendering is complete.
+   */
   async renderModel(model: IRenderMime.IMimeModel): Promise<void> {
-    // Toggle the trusted class on the widget.
-    this.toggleClass('jp-mod-trusted', model.trusted);
-
-    // Render the actual content.
-    await this.render(model);
-
-    // Handle the fragment identifier if given.
-    const { fragment } = model.metadata;
-    if (fragment) {
-      this.setFragment(fragment as string);
-    }
+    await this.renderCommonModel(model, false);
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

Fixes #13734, alleviates #13678 (scroll is not lost when editing with preview side-by-side but is still lost when switching tabs)

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Before rendering the markdown, avoid clearing the host node so that the scroll position would not be lost. Markdown rendering took two steps before (1. empty the DOM; 2. render the DOM). And now the step 1 is skipped in markdown rendering. 

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

1. When editing markdown file keeps the content and the scroll position in the last render.
2. Rendering markdown would take a while and the content would be outdated before the render is complete.
3. This change would affect users who use markdownRendererFactory or RenderedMarkdown

https://github.com/jupyterlab/jupyterlab/assets/71494005/8efed9e4-c457-4d01-9aab-5fe954f93f31




<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
