### PR TITLE
Use @jupyterlab/shared-models

### DIFF
--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -42,7 +42,6 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.4",
     "@jupyterlab/apputils": "^3.6.3",
     "@jupyterlab/attachments": "^3.6.3",
     "@jupyterlab/codeeditor": "^3.6.3",

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -54,6 +54,7 @@
     "@jupyterlab/outputarea": "^3.6.3",
     "@jupyterlab/rendermime": "^3.6.3",
     "@jupyterlab/services": "^6.6.3",
+    "@jupyterlab/shared-models": "^3.6.3",
     "@jupyterlab/ui-components": "^3.6.3",
     "@lumino/algorithm": "^1.9.0",
     "@lumino/coreutils": "^1.11.0",

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -15,7 +15,7 @@ import { IChangedArgs } from '@jupyterlab/coreutils';
 
 import * as nbformat from '@jupyterlab/nbformat';
 
-import * as models from '@jupyter/ydoc';
+import * as models from '@jupyterlab/shared-models';
 
 import { UUID } from '@lumino/coreutils';
 

--- a/packages/cells/test/model.spec.ts
+++ b/packages/cells/test/model.spec.ts
@@ -18,7 +18,7 @@ import { OutputAreaModel } from '@jupyterlab/outputarea';
 
 import { NBTestUtils } from '@jupyterlab/testutils';
 import { JSONObject } from '@lumino/coreutils';
-import { YCodeCell } from '@jupyter/ydoc';
+import { YCodeCell } from '@jupyterlab/shared-models';
 
 class TestModel extends CellModel {
   get type(): 'raw' {

--- a/packages/cells/tsconfig.json
+++ b/packages/cells/tsconfig.json
@@ -40,6 +40,9 @@
       "path": "../services"
     },
     {
+      "path": "../shared-models"
+    },
+    {
       "path": "../ui-components"
     }
   ]

--- a/packages/cells/tsconfig.test.json
+++ b/packages/cells/tsconfig.test.json
@@ -36,6 +36,9 @@
       "path": "../services"
     },
     {
+      "path": "../shared-models"
+    },
+    {
       "path": "../ui-components"
     },
     {
@@ -76,6 +79,9 @@
     },
     {
       "path": "../services"
+    },
+    {
+      "path": "../shared-models"
     },
     {
       "path": "../ui-components"

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -41,7 +41,6 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.4",
     "@jupyterlab/coreutils": "^5.6.3",
     "@jupyterlab/nbformat": "^3.6.3",
     "@jupyterlab/observables": "^4.6.3",

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -45,6 +45,7 @@
     "@jupyterlab/coreutils": "^5.6.3",
     "@jupyterlab/nbformat": "^3.6.3",
     "@jupyterlab/observables": "^4.6.3",
+    "@jupyterlab/shared-models": "^3.6.3",
     "@jupyterlab/translation": "^3.6.3",
     "@jupyterlab/ui-components": "^3.6.3",
     "@lumino/coreutils": "^1.11.0",

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -11,7 +11,7 @@ import {
   ModelDB,
   ObservableValue
 } from '@jupyterlab/observables';
-import * as models from '@jupyter/ydoc';
+import * as models from '@jupyterlab/shared-models';
 import { ITranslator } from '@jupyterlab/translation';
 import { JSONObject } from '@lumino/coreutils';
 import { IDisposable } from '@lumino/disposable';

--- a/packages/codeeditor/tsconfig.json
+++ b/packages/codeeditor/tsconfig.json
@@ -16,6 +16,9 @@
       "path": "../observables"
     },
     {
+      "path": "../shared-models"
+    },
+    {
       "path": "../translation"
     },
     {

--- a/packages/codeeditor/tsconfig.test.json
+++ b/packages/codeeditor/tsconfig.test.json
@@ -12,6 +12,9 @@
       "path": "../observables"
     },
     {
+      "path": "../shared-models"
+    },
+    {
       "path": "../translation"
     },
     {
@@ -31,6 +34,9 @@
     },
     {
       "path": "../observables"
+    },
+    {
+      "path": "../shared-models"
     },
     {
       "path": "../translation"

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -39,7 +39,6 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.4",
     "@jupyterlab/apputils": "^3.6.3",
     "@jupyterlab/codeeditor": "^3.6.3",
     "@jupyterlab/coreutils": "^5.6.3",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -45,6 +45,7 @@
     "@jupyterlab/coreutils": "^5.6.3",
     "@jupyterlab/nbformat": "^3.6.3",
     "@jupyterlab/observables": "^4.6.3",
+    "@jupyterlab/shared-models": "^3.6.3",
     "@jupyterlab/statusbar": "^3.6.3",
     "@jupyterlab/translation": "^3.6.3",
     "@lumino/algorithm": "^1.9.0",

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -10,7 +10,7 @@ import {
   IObservableMap,
   IObservableString
 } from '@jupyterlab/observables';
-import * as models from '@jupyter/ydoc';
+import * as models from '@jupyterlab/shared-models';
 import {
   ITranslator,
   nullTranslator,

--- a/packages/codemirror/tsconfig.json
+++ b/packages/codemirror/tsconfig.json
@@ -22,6 +22,9 @@
       "path": "../observables"
     },
     {
+      "path": "../shared-models"
+    },
+    {
       "path": "../statusbar"
     },
     {

--- a/packages/codemirror/tsconfig.test.json
+++ b/packages/codemirror/tsconfig.test.json
@@ -18,6 +18,9 @@
       "path": "../observables"
     },
     {
+      "path": "../shared-models"
+    },
+    {
       "path": "../statusbar"
     },
     {
@@ -43,6 +46,9 @@
     },
     {
       "path": "../observables"
+    },
+    {
+      "path": "../shared-models"
     },
     {
       "path": "../statusbar"

--- a/packages/docprovider-extension/package.json
+++ b/packages/docprovider-extension/package.json
@@ -39,6 +39,7 @@
     "@jupyterlab/coreutils": "^5.6.3",
     "@jupyterlab/docprovider": "^3.6.3",
     "@jupyterlab/services": "^6.6.3",
+    "@jupyterlab/shared-models": "^3.6.3",
     "@jupyterlab/translation": "^3.6.3"
   },
   "devDependencies": {

--- a/packages/docprovider-extension/package.json
+++ b/packages/docprovider-extension/package.json
@@ -34,7 +34,6 @@
     "watch": "tsc -w --listEmittedFiles"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.4",
     "@jupyterlab/application": "^3.6.3",
     "@jupyterlab/coreutils": "^5.6.3",
     "@jupyterlab/docprovider": "^3.6.3",

--- a/packages/docprovider-extension/src/index.ts
+++ b/packages/docprovider-extension/src/index.ts
@@ -18,7 +18,7 @@ import {
 } from '@jupyterlab/docprovider';
 import { ServerConnection } from '@jupyterlab/services';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
-import { DocumentChange, YDocument } from '@jupyter/ydoc';
+import { DocumentChange, YDocument } from '@jupyterlab/shared-models';
 
 /**
  * The default document provider plugin

--- a/packages/docprovider-extension/tsconfig.json
+++ b/packages/docprovider-extension/tsconfig.json
@@ -19,6 +19,9 @@
       "path": "../services"
     },
     {
+      "path": "../shared-models"
+    },
+    {
       "path": "../translation"
     }
   ]

--- a/packages/docprovider/package.json
+++ b/packages/docprovider/package.json
@@ -43,6 +43,7 @@
     "@jupyterlab/apputils": "^3.6.3",
     "@jupyterlab/coreutils": "^5.6.3",
     "@jupyterlab/services": "^6.6.3",
+    "@jupyterlab/shared-models": "^3.6.3",
     "@jupyterlab/translation": "^3.6.3",
     "@lumino/coreutils": "^1.11.0",
     "@lumino/disposable": "^1.10.0",

--- a/packages/docprovider/package.json
+++ b/packages/docprovider/package.json
@@ -39,7 +39,6 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.4",
     "@jupyterlab/apputils": "^3.6.3",
     "@jupyterlab/coreutils": "^5.6.3",
     "@jupyterlab/services": "^6.6.3",

--- a/packages/docprovider/src/tokens.ts
+++ b/packages/docprovider/src/tokens.ts
@@ -3,7 +3,7 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-import { ISharedDocument } from '@jupyter/ydoc';
+import { ISharedDocument } from '@jupyterlab/shared-models';
 import { Token } from '@lumino/coreutils';
 import { IDisposable } from '@lumino/disposable';
 

--- a/packages/docprovider/src/yprovider.ts
+++ b/packages/docprovider/src/yprovider.ts
@@ -8,7 +8,7 @@ import { Dialog, showErrorMessage } from '@jupyterlab/apputils';
 import { ServerConnection, User } from '@jupyterlab/services';
 import { nullTranslator, TranslationBundle } from '@jupyterlab/translation';
 
-import { DocumentChange, YDocument } from '@jupyter/ydoc';
+import { DocumentChange, YDocument } from '@jupyterlab/shared-models';
 
 import { PromiseDelegate } from '@lumino/coreutils';
 import { Signal } from '@lumino/signaling';

--- a/packages/docprovider/tsconfig.json
+++ b/packages/docprovider/tsconfig.json
@@ -16,6 +16,9 @@
       "path": "../services"
     },
     {
+      "path": "../shared-models"
+    },
+    {
       "path": "../translation"
     }
   ]

--- a/packages/docprovider/tsconfig.test.json
+++ b/packages/docprovider/tsconfig.test.json
@@ -12,6 +12,9 @@
       "path": "../services"
     },
     {
+      "path": "../shared-models"
+    },
+    {
       "path": "../translation"
     },
     {
@@ -28,6 +31,9 @@
     },
     {
       "path": "../services"
+    },
+    {
+      "path": "../shared-models"
     },
     {
       "path": "../translation"

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -41,7 +41,6 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.4",
     "@jupyterlab/apputils": "^3.6.3",
     "@jupyterlab/codeeditor": "^3.6.3",
     "@jupyterlab/codemirror": "^3.6.3",

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -51,6 +51,7 @@
     "@jupyterlab/rendermime": "^3.6.3",
     "@jupyterlab/rendermime-interfaces": "^3.6.3",
     "@jupyterlab/services": "^6.6.3",
+    "@jupyterlab/shared-models": "^3.6.3",
     "@jupyterlab/translation": "^3.6.3",
     "@jupyterlab/ui-components": "^3.6.3",
     "@lumino/algorithm": "^1.9.0",

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { DocumentChange, ISharedDocument } from '@jupyter/ydoc';
+import { DocumentChange, ISharedDocument } from '@jupyterlab/shared-models';
 import {
   Dialog,
   ISessionContext,

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -7,7 +7,7 @@ import { Mode } from '@jupyterlab/codemirror';
 import { IChangedArgs, PathExt } from '@jupyterlab/coreutils';
 import { IModelDB, IObservableList } from '@jupyterlab/observables';
 import { Contents } from '@jupyterlab/services';
-import * as models from '@jupyter/ydoc';
+import * as models from '@jupyterlab/shared-models';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { PartialJSONValue } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -14,7 +14,7 @@ import {
 import { IModelDB, IObservableList } from '@jupyterlab/observables';
 import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 import { Contents, Kernel } from '@jupyterlab/services';
-import { ISharedDocument, ISharedFile } from '@jupyter/ydoc';
+import { ISharedDocument, ISharedFile } from '@jupyterlab/shared-models';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import {
   fileIcon,

--- a/packages/docregistry/tsconfig.json
+++ b/packages/docregistry/tsconfig.json
@@ -34,6 +34,9 @@
       "path": "../services"
     },
     {
+      "path": "../shared-models"
+    },
+    {
       "path": "../translation"
     },
     {

--- a/packages/docregistry/tsconfig.test.json
+++ b/packages/docregistry/tsconfig.test.json
@@ -30,6 +30,9 @@
       "path": "../services"
     },
     {
+      "path": "../shared-models"
+    },
+    {
       "path": "../translation"
     },
     {
@@ -67,6 +70,9 @@
     },
     {
       "path": "../services"
+    },
+    {
+      "path": "../shared-models"
     },
     {
       "path": "../translation"

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -52,6 +52,7 @@
     "@jupyterlab/rendermime": "^3.6.3",
     "@jupyterlab/services": "^6.6.3",
     "@jupyterlab/settingregistry": "^3.6.3",
+    "@jupyterlab/shared-models": "^3.6.3",
     "@jupyterlab/statusbar": "^3.6.3",
     "@jupyterlab/translation": "^3.6.3",
     "@jupyterlab/ui-components": "^3.6.3",

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -41,7 +41,6 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "~0.2.4",
     "@jupyterlab/apputils": "^3.6.3",
     "@jupyterlab/cells": "^3.6.3",
     "@jupyterlab/codeeditor": "^3.6.3",

--- a/packages/notebook/src/celllist.ts
+++ b/packages/notebook/src/celllist.ts
@@ -9,7 +9,7 @@ import {
   IObservableUndoableList,
   ObservableMap
 } from '@jupyterlab/observables';
-import * as models from '@jupyter/ydoc';
+import * as models from '@jupyterlab/shared-models';
 import {
   ArrayExt,
   ArrayIterator,

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -23,7 +23,7 @@ import {
   IObservableUndoableList,
   ModelDB
 } from '@jupyterlab/observables';
-import * as models from '@jupyter/ydoc';
+import * as models from '@jupyterlab/shared-models';
 import {
   ITranslator,
   nullTranslator,

--- a/packages/notebook/tsconfig.json
+++ b/packages/notebook/tsconfig.json
@@ -37,6 +37,9 @@
       "path": "../settingregistry"
     },
     {
+      "path": "../shared-models"
+    },
+    {
       "path": "../statusbar"
     },
     {

--- a/packages/notebook/tsconfig.test.json
+++ b/packages/notebook/tsconfig.test.json
@@ -33,6 +33,9 @@
       "path": "../settingregistry"
     },
     {
+      "path": "../shared-models"
+    },
+    {
       "path": "../statusbar"
     },
     {
@@ -76,6 +79,9 @@
     },
     {
       "path": "../settingregistry"
+    },
+    {
+      "path": "../shared-models"
     },
     {
       "path": "../statusbar"


### PR DESCRIPTION
This fixes `@jupyterlab/shared-models` not being provided in the shared scope.