### PR TITLE
Enable base numbering option

### DIFF
--- a/docs/source/user/toc.rst
+++ b/docs/source/user/toc.rst
@@ -80,6 +80,7 @@ The table of contents behavior can be modified via settings which can be set in 
 * **numberingH1** : Whether to number the first-level headings (``h1``) or not.
 * **numberHeaders** : Whether to number the headings or not.
 * **syncCollapseState** : Whether to synchronize the cell and the table of contents collapse state or not.
+* **baseNumbering** : Starting point for heading numbering (default: 1).
 
 .. note::
 

--- a/packages/toc-extension/schema/registry.json
+++ b/packages/toc-extension/schema/registry.json
@@ -59,6 +59,12 @@
       "title": "Synchronize collapse state",
       "description": "If set to true, when a heading is collapsed in the table of contents the corresponding section in the document is collapsed as well and vice versa. This inhibits the cell output headings.",
       "default": false
+    },
+    "baseNumbering": {
+      "title": "Base level for the highest headings",
+      "type": "integer",
+      "description": "The number headings start at.",
+      "default": 1
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
## References

Closes #14571.

## Code changes


## User-facing changes

The already-implemented `baseNumbering` option is now exposed as a configurable setting.

## Backwards-incompatible changes

None
