### PR TITLE
Make `IStatusBar` optional for the notification plugin

### DIFF
--- a/packages/apputils-extension/src/notificationplugin.tsx
+++ b/packages/apputils-extension/src/notificationplugin.tsx
@@ -370,11 +370,10 @@ export const notificationPlugin: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/apputils-extension:notification',
   description: 'Add the notification center and its status indicator.',
   autoStart: true,
-  requires: [IStatusBar],
-  optional: [ISettingRegistry, ITranslator],
+  optional: [IStatusBar, ISettingRegistry, ITranslator],
   activate: (
     app: JupyterFrontEnd,
-    statusBar: IStatusBar,
+    statusBar: IStatusBar | null,
     settingRegistry: ISettingRegistry | null,
     translator: ITranslator | null
   ): void => {
@@ -624,11 +623,13 @@ export const notificationPlugin: JupyterFrontEndPlugin<void> = {
 
     notificationStatus.addClass('jp-Notification-Status');
 
-    statusBar.registerStatusItem(notificationPlugin.id, {
-      item: notificationStatus,
-      align: 'right',
-      rank: -1
-    });
+    if (statusBar) {
+      statusBar.registerStatusItem(notificationPlugin.id, {
+        item: notificationStatus,
+        align: 'right',
+        rank: -1
+      });
+    }
   }
 };
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

This should help for Notebook 7: https://github.com/jupyter/notebook/issues/6867

Or other lab-based applications that would like to reuse this plugin but don't provide the status bar.

## Code changes

Make `IStatusBar` optional in the notification plugin.

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
