### PR TITLE
Inherit font family from `.cm-editor`

### DIFF
--- a/packages/codemirror/src/theme.ts
+++ b/packages/codemirror/src/theme.ts
@@ -32,6 +32,11 @@ export const jupyterEditorTheme = EditorView.theme({
     caretColor: 'var(--jp-editor-cursor-color)'
   },
 
+  /* Inherit font family from .cm-editor */
+  '.cm-scroller': {
+    fontFamily: 'inherit'
+  },
+
   '.cm-cursor, .cm-dropCursor': {
     borderLeft:
       'var(--jp-code-cursor-width0) solid var(--jp-editor-cursor-color)'


### PR DESCRIPTION
## References

Should fix #14592

## Code changes

| Before | After | 3.x (reference)
|--|--|--|
|![Screenshot from 2023-05-27 11-07-46](https://github.com/jupyterlab/jupyterlab/assets/5832902/158820fc-1661-4b63-8013-abdef0eb5522) | ![Screenshot from 2023-05-27 10-56-07](https://github.com/jupyterlab/jupyterlab/assets/5832902/8c7e1a93-d3f7-41fd-ba72-ae18b30fa291) | ![image](https://github.com/jupyterlab/jupyterlab/assets/5832902/52b597c5-47fa-45ae-8d52-efccba8374b0) |



Note: this PR uses `inherit`(as in 3.x) rather than just hard-coding font family in `.cm-scroller` to `var(--jp-code-font-family)` as `inherit` this is needed for changing fonts from settings to work.

## User-facing changes

Changing font family from settings works again

| Before | After | 
|--|--|
| ![Screenshot from 2023-05-27 11-05-18](https://github.com/jupyterlab/jupyterlab/assets/5832902/045b6c5e-05d9-4f68-9ffb-d2ac36a7e030) | ![Screenshot from 2023-05-27 11-00-48](https://github.com/jupyterlab/jupyterlab/assets/5832902/9819bdf9-eeec-402c-9ef3-463aaeccba59) |


## Backwards-incompatible changes

None