### PR TITLE
Skip checking for updates in UI tests

### DIFF
--- a/galata/src/galata.ts
+++ b/galata/src/galata.ts
@@ -32,6 +32,7 @@ export namespace galata {
    */
   export const DEFAULT_SETTINGS: Record<string, any> = {
     '@jupyterlab/apputils-extension:notification': {
+      checkForUpdates: false,
       fetchNews: 'false'
     },
     '@jupyterlab/fileeditor-extension:plugin': {},

--- a/galata/test/jupyterlab/announcements.test.ts
+++ b/galata/test/jupyterlab/announcements.test.ts
@@ -65,6 +65,7 @@ test.describe('Update available', () => {
     await galata.Mock.mockSettings(page, settings, {
       ...galata.DEFAULT_SETTINGS,
       '@jupyterlab/apputils-extension:notification': {
+        checkForUpdates: true,
         fetchNews: 'true'
       }
     });
@@ -115,6 +116,7 @@ test.describe('Update available', () => {
     await galata.Mock.mockSettings(page, settings, {
       ...galata.DEFAULT_SETTINGS,
       '@jupyterlab/apputils-extension:notification': {
+        checkForUpdates: true,
         fetchNews: 'true'
       }
     });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Integration tests on old version branches are failing like: https://github.com/jupyterlab/jupyterlab/actions/runs/5057283387/jobs/9075847529?pr=14583

It actually makes sense to disable it by default as extension authors using galata may not always update JupyterLab to the latest version.

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
For integration tests, deactivate check for JupyterLab update.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None