### PR TITLE
Activate the deferred plugins after shell restore

### DIFF
--- a/packages/application/src/lab.ts
+++ b/packages/application/src/lab.ts
@@ -44,15 +44,9 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell> {
 
     this.restored = this.shell.restored
       .then(() => {
-        // Backward compatibility
-        try {
-          // @ts-ignore
-          this.activateDeferredPlugins().catch(error => {
-            console.error('Error when activating deferred plugins\n:', error);
-          });
-        } catch (error) {
-          // no-op
-        }
+        this.activateDeferredPlugins().catch(error => {
+          console.error('Error when activating deferred plugins\n:', error);
+        });
 
         if (this._info.deferred) {
           Promise.all(

--- a/packages/application/src/lab.ts
+++ b/packages/application/src/lab.ts
@@ -47,7 +47,7 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell> {
         // Backward compatibility
         try {
           // @ts-ignore
-          this.activateDeferredPlugins();
+          this.activateDeferredPlugins().catch(error => { console.error('Error when activating deferred plugins\n:', error); };
         } catch (error) {
           // no-op
         }

--- a/packages/application/src/lab.ts
+++ b/packages/application/src/lab.ts
@@ -53,9 +53,9 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell> {
         }
 
         if (this._info.deferred) {
-          this._info.deferred.matches.forEach(pluginID =>
+          Promise.all(this._info.deferred.matches.map(pluginID =>
             this.activatePlugin(pluginID)
-          );
+          )).catch(error => { console.error('Error when activating customize list of deferred plugins:\n', error); });
         }
       })
       .catch(() => undefined);

--- a/packages/application/src/lab.ts
+++ b/packages/application/src/lab.ts
@@ -47,15 +47,24 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell> {
         // Backward compatibility
         try {
           // @ts-ignore
-          this.activateDeferredPlugins().catch(error => { console.error('Error when activating deferred plugins\n:', error); };
+          this.activateDeferredPlugins().catch(error => {
+            console.error('Error when activating deferred plugins\n:', error);
+          });
         } catch (error) {
           // no-op
         }
 
         if (this._info.deferred) {
-          Promise.all(this._info.deferred.matches.map(pluginID =>
-            this.activatePlugin(pluginID)
-          )).catch(error => { console.error('Error when activating customize list of deferred plugins:\n', error); });
+          Promise.all(
+            this._info.deferred.matches.map(pluginID =>
+              this.activatePlugin(pluginID)
+            )
+          ).catch(error => {
+            console.error(
+              'Error when activating customize list of deferred plugins:\n',
+              error
+            );
+          });
         }
       })
       .catch(() => undefined);

--- a/packages/application/src/lab.ts
+++ b/packages/application/src/lab.ts
@@ -30,9 +30,6 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell> {
           }
         })
     });
-    this.restored = this.shell.restored
-      .then(() => undefined)
-      .catch(() => undefined);
 
     // Create an IInfo dictionary from the options to override the defaults.
     const info = Object.keys(JupyterLab.defaultInfo).reduce((acc, val) => {
@@ -44,6 +41,24 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell> {
 
     // Populate application info.
     this._info = { ...JupyterLab.defaultInfo, ...info };
+
+    this.restored = this.shell.restored
+      .then(() => {
+        // Backward compatibility
+        try {
+          // @ts-ignore
+          this.activateDeferredPlugins();
+        } catch (error) {
+          // no-op
+        }
+
+        if (this._info.deferred) {
+          this._info.deferred.matches.forEach(pluginID =>
+            this.activatePlugin(pluginID)
+          );
+        }
+      })
+      .catch(() => undefined);
 
     // Populate application paths override the defaults if necessary.
     const defaultURLs = JupyterLab.defaultPaths.urls;

--- a/packages/application/test/lab.spec.ts
+++ b/packages/application/test/lab.spec.ts
@@ -1,0 +1,84 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  JupyterFrontEndPlugin,
+  JupyterLab,
+  LayoutRestorer
+} from '@jupyterlab/application';
+import { StateDB } from '@jupyterlab/statedb';
+import { CommandRegistry } from '@lumino/commands';
+import { DockPanel } from '@lumino/widgets';
+
+describe('plugins', () => {
+  let lab: JupyterLab;
+  let plugin: JupyterFrontEndPlugin<void> = {
+    id: '@jupyterlab/test-extension:plugin',
+    autoStart: true,
+    activate: async () => {
+      await new Promise(f => setTimeout(f, 5000));
+    }
+  };
+
+  beforeEach(() => {
+    lab = new JupyterLab({});
+  });
+
+  it('autoStart plugin should be activated when application restore', async () => {
+    lab.registerPlugin(plugin);
+    await lab.start();
+    const restorer = new LayoutRestorer({
+      connector: new StateDB(),
+      first: Promise.resolve<void>(void 0),
+      registry: new CommandRegistry()
+    });
+    const mode: DockPanel.Mode = 'multiple-document';
+    lab.shell.restoreLayout(mode, restorer);
+    await lab.restored;
+    expect(
+      lab.isPluginActivated('@jupyterlab/test-extension:plugin')
+    ).toBeTruthy();
+  });
+
+  it('autoStart=false plugin should never be activated', async () => {
+    plugin.autoStart = false;
+    lab.registerPlugin(plugin);
+    await lab.start();
+    const restorer = new LayoutRestorer({
+      connector: new StateDB(),
+      first: Promise.resolve<void>(void 0),
+      registry: new CommandRegistry()
+    });
+    const mode: DockPanel.Mode = 'multiple-document';
+    lab.shell.restoreLayout(mode, restorer);
+    await lab.restored;
+    expect(
+      lab.isPluginActivated('@jupyterlab/test-extension:plugin')
+    ).toBeFalsy();
+    await lab.allPluginsActivated;
+    expect(
+      lab.isPluginActivated('@jupyterlab/test-extension:plugin')
+    ).toBeFalsy();
+  });
+
+  it('deferred plugin should not be activated right after application restore', async () => {
+    plugin.autoStart = 'defer';
+    lab.registerPlugin(plugin);
+    await lab.start();
+    const restorer = new LayoutRestorer({
+      connector: new StateDB(),
+      first: Promise.resolve<void>(void 0),
+      registry: new CommandRegistry()
+    });
+    const mode: DockPanel.Mode = 'multiple-document';
+    lab.shell.restoreLayout(mode, restorer);
+    await lab.restored;
+    expect(
+      lab.isPluginActivated('@jupyterlab/test-extension:plugin')
+    ).toBeFalsy();
+    await lab.allPluginsActivated;
+    expect(
+      lab.isPluginActivated('@jupyterlab/test-extension:plugin')
+    ).toBeTruthy();
+  });
+});

--- a/packages/application/test/lab.spec.ts
+++ b/packages/application/test/lab.spec.ts
@@ -33,7 +33,7 @@ describe('plugins', () => {
       registry: new CommandRegistry()
     });
     const mode: DockPanel.Mode = 'multiple-document';
-    lab.shell.restoreLayout(mode, restorer);
+    void lab.shell.restoreLayout(mode, restorer);
     await lab.restored;
     expect(
       lab.isPluginActivated('@jupyterlab/test-extension:plugin')
@@ -50,7 +50,7 @@ describe('plugins', () => {
       registry: new CommandRegistry()
     });
     const mode: DockPanel.Mode = 'multiple-document';
-    lab.shell.restoreLayout(mode, restorer);
+    void lab.shell.restoreLayout(mode, restorer);
     await lab.restored;
     expect(
       lab.isPluginActivated('@jupyterlab/test-extension:plugin')
@@ -71,7 +71,7 @@ describe('plugins', () => {
       registry: new CommandRegistry()
     });
     const mode: DockPanel.Mode = 'multiple-document';
-    lab.shell.restoreLayout(mode, restorer);
+    void lab.shell.restoreLayout(mode, restorer);
     await lab.restored;
     expect(
       lab.isPluginActivated('@jupyterlab/test-extension:plugin')

--- a/packages/apputils-extension/src/settingconnector.ts
+++ b/packages/apputils-extension/src/settingconnector.ts
@@ -45,7 +45,7 @@ export class SettingConnector extends DataConnector<
   async list(
     query: 'active' | 'all' | 'ids' = 'all'
   ): Promise<{ ids: string[]; values?: ISettingRegistry.IPlugin[] }> {
-    const { isDeferred, isDisabled } = PageConfig.Extension;
+    const { isDisabled } = PageConfig.Extension;
     const { ids, values } = await this._connector.list(
       query === 'ids' ? 'ids' : undefined
     );
@@ -59,8 +59,8 @@ export class SettingConnector extends DataConnector<
     }
 
     return {
-      ids: ids.filter(id => !isDeferred(id) && !isDisabled(id)),
-      values: values.filter(({ id }) => !isDeferred(id) && !isDisabled(id))
+      ids: ids.filter(id => !isDisabled(id)),
+      values: values.filter(({ id }) => !isDisabled(id))
     };
   }
 


### PR DESCRIPTION
This PR improves pageload time by deferring the activation of huge extensions.

After the shell restore, activates the plugins that have been deferred from:
- `page_config.json`, currently they are not activated at all if not required by another plugin
- the new plugin option `deferred` coming from https://github.com/jupyterlab/lumino/pull/588

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/14576

Related to https://github.com/jupyterlab/lumino/pull/588

## Code changes

The changes are in `JupyterLab` class.

## User-facing changes

Activation of a plugin containing a 5s sleep:

<table>
  <tr>
    <th>CURRENT LOADING</th>
    <th>DEFERRING ACTIVATION</th>
  </tr>
  <tr>
    <td><img src="https://github.com/jupyterlab/jupyterlab/assets/32258950/67a4fba5-54ab-4d7b-9f57-f4460fa05e03"></td>
     <td><img src="https://github.com/jupyterlab/jupyterlab/assets/32258950/55b91f34-b569-4fa3-83bc-cf96e6aebd63"></td>
  </tr>
</table>

## Backwards-incompatible changes

This is currently backward compatible but I used `// @ts-ignore` to avoid error at compilation.
There may be better implementation for it.