### PR TITLE
Improve typing to avoid bad usage of `context.contentsModel.content`

### DIFF
--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -569,7 +569,7 @@ export namespace ToolbarItems {
    */
   export function createSaveButton(
     commands: CommandRegistry,
-    fileChanged: ISignal<any, Contents.IModel>
+    fileChanged: ISignal<any, Omit<Contents.IModel, 'content'>>
   ): Widget {
     return addCommandToolbarButtonClass(
       ReactWidget.create(

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -876,7 +876,7 @@ export namespace DocumentRegistry {
     /**
      * A signal emitted when the contentsModel changes.
      */
-    fileChanged: ISignal<this, Contents.IModel>;
+    fileChanged: ISignal<this, Omit<Contents.IModel, 'content'>>;
 
     /**
      * A signal emitted on the start and end of a saving operation.
@@ -920,9 +920,9 @@ export namespace DocumentRegistry {
      *
      * #### Notes
      * This will be null until the context is 'ready'. Since we only store
-     * metadata here, the `.contents` attribute will always be empty.
+     * metadata here, the `content` attribute is removed.
      */
-    readonly contentsModel: Contents.IModel | null;
+    readonly contentsModel: Omit<Contents.IModel, 'content'> | null;
 
     /**
      * The url resolver for the context.

--- a/packages/docregistry/test/context.spec.ts
+++ b/packages/docregistry/test/context.spec.ts
@@ -94,6 +94,17 @@ describe('docregistry/context', () => {
         await context.initialize(true);
         expect(called).toBe(true);
       });
+
+      it('should not contain the file content attribute', async () => {
+        let called = false;
+        context.fileChanged.connect((sender, args) => {
+          // @ts-expect-error content is omitted
+          expect(args['content']).toBeUndefined();
+          called = true;
+        });
+        await context.initialize(true);
+        expect(called).toBe(true);
+      });
     });
 
     describe('#saving', () => {
@@ -250,6 +261,8 @@ describe('docregistry/context', () => {
         void context.initialize(true);
         await context.ready;
         expect(context.contentsModel!.path).toBe(path);
+        // @ts-expect-error content is omitted
+        expect(context.contentsModel!['content']).toBeUndefined();
       });
     });
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #14659
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Remove explicitly `content` from `IContext.contentsModel` to ensure developers don't try to access the file content from that API - it was only written in the documentation that the content will be empty.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
Change `IContext.contentsModel` from `Contents.IModel` to `Omit<Contents.IModel, 'content'>`
Change `IContext.fileChanged` to pass `Omit<Contents.IModel, 'content'>` as argument instead of `Contents.IModel`.

Although this is a breaking change, it clarifies the API and prevents developper of consuming an always `undefined` content.