### PR TITLE
Automatic download links per OS

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -15,6 +15,33 @@ JupyterLab can be installed using ``conda``, ``mamba``, ``pip``, ``pipenv`` or `
     upgrade procedures to account for possible breaking changes that may disrupt your usage
     of JupyterLab and any related tools that are critical to your workflows.
 
+
+JupyterLab Desktop
+------------------
+JupyterLab Desktop is the easiest way to get started with Jupyter. Use the proper download link below to install for your platform
+    .. raw:: html
+
+	 <div id="downloads" class="unknown">
+	 <h2> Download JupyterLab </h2>
+	 <a class="osLink MacIntel" href="/osx.dmg">Download for OS X</a>
+	 <a class="osLink Linux" href="linux.snap">Download for linux</a>
+	 <a class="osLink Win32" href="windows.exe">Download for Windows</a>
+	 </div>
+
+	 <script>
+	 const el = document.getElementById('downloads').className = navigator.platform
+	 </script>
+	 <style>
+	 .MacIntel a {display:none}
+	 .MacIntel .MacIntel {display:inherit;}
+	 .Linux a {display:hidden;}
+	 .Linux .Linux {display:inherit;}
+	 .Win32 a {display:none;}
+	 .Win32 .Win32 {display:inherit;}
+	 </style>
+
+
+
 conda
 -----
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
https://github.com/jupyterlab/jupyterlab-desktop/pull/654

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes


## User-facing changes

This adds an automatically configured download link for jupyterlab desktop to the installation page.

It requires testing in different OSes.