### PR TITLE
Update the compat message when running `jupyter labextension list` 

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -2328,7 +2328,7 @@ def _log_multiple_compat_errors(logger, errors_map):
                 [
                     "\n   The following extensions are outdated:",
                     *outdated,
-                    '\n   Consider running "jupyter labextension update --all" to check for updates.\n',
+                    '\n   Consider checking if an update is available for these packages.\n',
                 ]
             )
         )


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Currently running `jupyter labextension list` will suggest using the `jupyter labextension update --all` command to update extensions when it finds compatibility issues:

```
   The following extensions are outdated:
        jupyterlab_pygments
        @jupyter-widgets/jupyterlab-manager
        @voila-dashboards/jupyterlab-preview

   Consider running "jupyter labextension update --all" to check for updates.

```

However the `jupyter labextension update` command is now deprecated and will be removed in the future:

- https://github.com/jupyterlab/jupyterlab/issues/12386
- https://github.com/jupyterlab/jupyterlab/issues/11336

## Code changes

Update the message printed in the terminal to not suggest using this command.

## User-facing changes

Users listing extensions should not see `jupyter labextension update --all` anymore.

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
