### PR TITLE
Add a title to the Markdown Preview widget

### DIFF
--- a/packages/markdownviewer/src/widget.ts
+++ b/packages/markdownviewer/src/widget.ts
@@ -332,7 +332,7 @@ export class MarkdownViewerFactory extends ABCWidgetFactory<MarkdownDocument> {
     content.title.icon = this._fileType?.icon;
     content.title.iconClass = this._fileType?.iconClass ?? '';
     content.title.iconLabel = this._fileType?.iconLabel ?? '';
-    content.title.caption = 'Markdown Preview';
+    content.title.caption = this.label;
     const widget = new MarkdownDocument({ content, context });
 
     return widget;

--- a/packages/markdownviewer/src/widget.ts
+++ b/packages/markdownviewer/src/widget.ts
@@ -332,6 +332,7 @@ export class MarkdownViewerFactory extends ABCWidgetFactory<MarkdownDocument> {
     content.title.icon = this._fileType?.icon;
     content.title.iconClass = this._fileType?.iconClass ?? '';
     content.title.iconLabel = this._fileType?.iconLabel ?? '';
+    content.title.caption = 'Markdown Preview';
     const widget = new MarkdownDocument({ content, context });
 
     return widget;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Similar to https://github.com/jupyterlab/jupyterlab/pull/13196.

## Code changes

Add `widget.title.caption` to the Markdown preview widget.

## User-facing changes

This will mostly be useful for Notebook 7 as noticed in https://github.com/jupyter/notebook/pull/6921:

![image](https://github.com/jupyterlab/jupyterlab/assets/591645/665c49a8-3a5d-496c-920e-3037c7320a79)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
