### PR TITLE
Set out expectations for `good first issue` label

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -251,15 +251,15 @@ pass without a reply that unblocks it.
 Our expectation is that every new issue should be examined within a week of
 its creation.
 
-Triagers should label easier issues as ``good first issue`` to
+Triagers should label easier/lower complexity issues as ``good first issue`` to
 facilitate beginner contributions. A good first issue should have:
 
 * A clear, easily understood description, with screen shots and expectations that do not require much familiarity with the product
 * Links, either in the description or in comments, to documentation and source code files that are relevant to the issue
-* Recommended points of contact, either by GitHub username or on other forums (Discourse, etc) where a developer can get help
+* Recommended points of contact, either by GitHub username or on other forums (Discourse, etc) where a contributor can get help
 
 Unless an issue is time-sensitive, such as if it is a release blocker
-for an imminent release, experienced Jupyter developers should avoid
+for an imminent release, experienced Jupyter contributors should avoid
 picking up recent issues with the ``good first issue`` label.
 
 Tagging Issues with Labels

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -251,6 +251,11 @@ pass without a reply that unblocks it.
 Our expectation is that every new issue should be examined within a week of
 its creation.
 
+Triagers are encouraged to label easier issues as ``good first issue`` to
+facilitate beginner contributions; the triage team should ensure that
+sufficient context and links to relevant parts of the codebase are included
+before applying this label.
+
 Tagging Issues with Labels
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -260,7 +260,7 @@ facilitate beginner contributions. A good first issue should have:
 
 Unless an issue is time-sensitive, such as if it is a release blocker
 for an imminent release, experienced Jupyter developers should avoid
-picking up issues with the ``good first issue`` label.
+picking up recent issues with the ``good first issue`` label.
 
 Tagging Issues with Labels
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -254,7 +254,7 @@ its creation.
 Triagers should label easier/lower complexity issues as ``good first issue`` to
 facilitate beginner contributions. A good first issue should have:
 
-* A clear, easily understood description, with screen shots and expectations that do not require much familiarity with the product
+* A clear, easily understood description with screen shots and expectations that do not require much familiarity with the project
 * Links, either in the description or in comments, to documentation and source code files that are relevant to the issue
 * Recommended points of contact, either by GitHub username or on other forums (Discourse, etc) where a contributor can get help
 

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -251,10 +251,16 @@ pass without a reply that unblocks it.
 Our expectation is that every new issue should be examined within a week of
 its creation.
 
-Triagers are encouraged to label easier issues as ``good first issue`` to
-facilitate beginner contributions; the triage team should ensure that
-sufficient context and links to relevant parts of the codebase are included
-before applying this label.
+Triagers should label easier issues as ``good first issue`` to
+facilitate beginner contributions. A good first issue should have:
+
+* A clear, easily understood description, with screen shots and expectations that do not require much familiarity with the product
+* Links, either in the description or in comments, to documentation and source code files that are relevant to the issue
+* Recommended points of contact, either by GitHub username or on other forums (Discourse, etc) where a developer can get help
+
+Unless an issue is time-sensitive, such as if it is a release blocker
+for an imminent release, experienced Jupyter developers should avoid
+picking up issues with the ``good first issue`` label.
 
 Tagging Issues with Labels
 ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## References

This came out of todays Jupyter Accessibility call discussion where we brainstormed how to improve the experience of beginner contributors: a point was raised that not all `good first issue`s in JupyterLab are actually good issues for beginners, specifically sufficient context and links to the codebase are missing at times (thank you @trallard!). Since this label is occasionally applied by the triage team during [weekly triage call](https://github.com/jupyterlab/team-compass#weekly-jupyter-triage-meeting), this PR is to build consensus on (minimum) expectations for good first issues, and encourage the triage team to add (or ask for) any necessary context/links to codebase to facilitate beginner contributions.

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None