### PR TITLE
Ensure the kernel selector show the default kernel if notebook does not have a valid assigned kernel

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -1565,6 +1565,7 @@ namespace Private {
     translator?: ITranslator,
     currentKernelDisplayName: string | null = null
   ): void {
+
     while (node.firstChild) {
       node.removeChild(node.firstChild);
     }
@@ -1599,8 +1600,8 @@ namespace Private {
       names.push(name);
     }
 
-    // Then look by language.
-    if (language) {
+    // Then look by language if we have a selected and existing kernel.
+    if (name && names.length > 0 && language) {
       for (const specName in specs.kernelspecs) {
         if (name !== specName && languages[specName] === language) {
           names.push(specName);


### PR DESCRIPTION
fixes case 2 of kernel selector incoherence as described in https://github.com/jupyterlab/jupyterlab/issues/14692