### PR TITLE
Fix HTML lang being set to 'default' resulting in blind users with screenreader reading everything in German

### DIFF
--- a/packages/translation-extension/src/index.ts
+++ b/packages/translation-extension/src/index.ts
@@ -106,8 +106,7 @@ const langMenu: JupyterFrontEndPlugin<void> = {
             '_',
             '-'
           );
-        }
-        else {
+        } else {
           document.documentElement.lang = 'en-US';
         }
 

--- a/packages/translation-extension/src/index.ts
+++ b/packages/translation-extension/src/index.ts
@@ -99,7 +99,14 @@ const langMenu: JupyterFrontEndPlugin<void> = {
       .then(setting => {
         // Read the settings
         loadSetting(setting);
-        document.documentElement.lang = (currentLocale ?? '').replace('_', '-');
+
+        // Ensure currentLocale is not 'default' which is not a valid language code
+        if (currentLocale !== 'default') {
+          document.documentElement.lang = (currentLocale ?? '').replace(
+            '_',
+            '-'
+          );
+        }
 
         // Listen for your plugin setting changes using Signal
         setting.changed.connect(loadSetting);

--- a/packages/translation-extension/src/index.ts
+++ b/packages/translation-extension/src/index.ts
@@ -107,6 +107,9 @@ const langMenu: JupyterFrontEndPlugin<void> = {
             '-'
           );
         }
+        else {
+          document.documentElement.lang = 'en-US';
+        }
 
         // Listen for your plugin setting changes using Signal
         setting.changed.connect(loadSetting);


### PR DESCRIPTION
## References

- Fixes #14704
- Fixes (transitively) https://github.com/jupyter/notebook/issues/6924

## Code changes
Ensure `currentLocale` is not `default` which is not a valid language code before assigning it to `document.documentElement.lang`

## User-facing changes
Language is not getting set to `default` (invalid language code) resulting in all screen readers detecting it as German, screen readers can detect language

Without this PR:
![Screenshot 2023-06-16 at 7 50 00 PM](https://github.com/jupyterlab/jupyterlab/assets/26686070/91251f8f-2e35-4fd8-b603-050159503cb0)

With this PR:
![Screenshot 2023-06-16 at 7 50 32 PM](https://github.com/jupyterlab/jupyterlab/assets/26686070/9ad61e83-7265-4463-b6a4-7b7aa849e1c6)

## Backwards-incompatible changes

None
