### PR TITLE
Expose `serverCapabilities`, `provides`, and  `updateLogging`

### DIFF
--- a/packages/lsp/src/connection.ts
+++ b/packages/lsp/src/connection.ts
@@ -245,7 +245,7 @@ export class LSPConnection extends LspWsConnection implements ILSPConnection {
 
   /**
    * Signal emitted when the connection receives an error
-   * message..
+   * message.
    */
   get errorSignal(): ISignal<ILSPConnection, any> {
     return this._errorSignal;
@@ -315,10 +315,10 @@ export class LSPConnection extends LspWsConnection implements ILSPConnection {
   }
 
   /**
-   * Check if a provider is available in the registered capabilities.
+   * Check if a capability is available in the server capabilities.
    */
-  provides(provider: keyof lsp.ServerCapabilities): boolean {
-    return !!(this.serverCapabilities && this.serverCapabilities[provider]);
+  provides(capability: keyof lsp.ServerCapabilities): boolean {
+    return !!(this.serverCapabilities && this.serverCapabilities[capability]);
   }
 
   /**
@@ -334,7 +334,7 @@ export class LSPConnection extends LspWsConnection implements ILSPConnection {
   }
 
   /**
-   * initialize a connection over a web socket that speaks the LSP
+   * Initialize a connection over a web socket that speaks the LSP.
    */
   connect(socket: WebSocket): void {
     super.connect(socket);

--- a/packages/lsp/src/connection_manager.ts
+++ b/packages/lsp/src/connection_manager.ts
@@ -404,7 +404,7 @@ export class DocumentConnectionManager
   }
 
   /**
-   * Disconnect the signals of requested virtual document uri.
+   * Disconnect the signals of requested virtual document URI.
    */
   unregisterDocument(uri: string, emit: boolean = true): void {
     const connection = this.connections.get(uri);
@@ -423,7 +423,7 @@ export class DocumentConnectionManager
   }
 
   /**
-   * Enable or disable the logging feature of the language servers
+   * Enable or disable the logging of language server communication.
    */
   updateLogging(
     logAllCommunication: boolean,

--- a/packages/lsp/src/tokens.ts
+++ b/packages/lsp/src/tokens.ts
@@ -412,6 +412,11 @@ export interface ILSPDocumentConnectionManager {
   updateConfiguration(allServerSettings: TLanguageServerConfigurations): void;
 
   /**
+   * Enable or disable the logging of language server communication.
+   */
+  updateLogging(logAllCommunication: boolean, setTrace: lsp.TraceValues): void;
+
+  /**
    * Handles the settings that the language servers accept using
    * `onDidChangeConfiguration` messages, which should be passed under
    * the "serverSettings" keyword in the setting registry.
@@ -850,6 +855,20 @@ export interface ILSPConnection extends ILspConnection, IObservableDisposable {
    * message..
    */
   errorSignal: ISignal<ILSPConnection, any>;
+
+  /**
+   * @alpha
+   *
+   * Check if a capability is available in the server capabilities.
+   */
+  provides(capability: keyof lsp.ServerCapabilities): boolean;
+
+  /**
+   * @alpha
+   *
+   * Lists server capabilities.
+   */
+  serverCapabilities: lsp.ServerCapabilities;
 
   /**
    * @alpha

--- a/packages/lsp/src/ws-connection/ws-connection.ts
+++ b/packages/lsp/src/ws-connection/ws-connection.ts
@@ -261,9 +261,9 @@ export class LspWsConnection implements ILspConnection {
   protected openedUris = new Map<string, boolean>();
 
   /**
-   * Server capabilities provider.
+   * Lists server capabilities.
    */
-  protected serverCapabilities: protocol.ServerCapabilities;
+  serverCapabilities: protocol.ServerCapabilities;
 
   /**
    * The connection is connected?


### PR DESCRIPTION
## References

Part one for #14711

## Code changes

- `ILSPDocumentConnectionManager` now exposes `updateLogging` along other `update*` methods
  - I do not expose `initialConfigurations` in this PR yet, I want to think about API more
  - this is needed to allow custom connection managers and/or settings forms
- `ILSPConnection` now exposes `serverCapabilities` and `provides`
   - `provides` is just a utility function but, pretty handy; we do not have to make a final call on it (it, as all other APIs is tagged as `@alpha`)
   - this is pretty fundamental—absolutely required to implement most LSP features

## User-facing changes

None

## Backwards-incompatible changes

None
