### PR TITLE
Port LSP connection manager fixes/enhancements

### DIFF
--- a/packages/lsp-extension/src/index.ts
+++ b/packages/lsp-extension/src/index.ts
@@ -94,7 +94,9 @@ function activate(
   settingRendererRegistry: IFormRendererRegistry | null
 ): ILSPDocumentConnectionManager {
   const LANGUAGE_SERVERS = 'languageServers';
-  const languageServerManager = new LanguageServerManager({});
+  const languageServerManager = new LanguageServerManager({
+    settings: app.serviceManager.serverSettings
+  });
   const connectionManager = new DocumentConnectionManager({
     languageServerManager
   });

--- a/packages/lsp/src/connection_manager.ts
+++ b/packages/lsp/src/connection_manager.ts
@@ -2,6 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
+import { ServerConnection } from '@jupyterlab/services';
 import { IDocumentWidget } from '@jupyterlab/docregistry';
 import { ISignal, Signal } from '@lumino/signaling';
 
@@ -547,7 +548,8 @@ export namespace DocumentConnectionManager {
     virtualDocument: VirtualDocument,
     language: string
   ): IURIs | undefined {
-    const wsBase = PageConfig.getBaseUrl().replace(/^http/, 'ws');
+    const settings = ServerConnection.makeSettings();
+    const wsBase = settings.wsUrl;
     const rootUri = PageConfig.getOption('rootUri');
     const virtualDocumentsUri = PageConfig.getOption('virtualDocumentsUri');
 

--- a/packages/lsp/src/connection_manager.ts
+++ b/packages/lsp/src/connection_manager.ts
@@ -2,7 +2,6 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
-import { ServerConnection } from '@jupyterlab/services';
 import { IDocumentWidget } from '@jupyterlab/docregistry';
 import { ISignal, Signal } from '@lumino/signaling';
 
@@ -548,7 +547,7 @@ export namespace DocumentConnectionManager {
     virtualDocument: VirtualDocument,
     language: string
   ): IURIs | undefined {
-    const settings = ServerConnection.makeSettings();
+    const { settings } = Private.getLanguageServerManager();
     const wsBase = settings.wsUrl;
     const rootUri = PageConfig.getOption('rootUri');
     const virtualDocumentsUri = PageConfig.getOption('virtualDocumentsUri');
@@ -655,7 +654,8 @@ namespace Private {
   ): Promise<LSPConnection> {
     let connection = _connections.get(languageServerId);
     if (!connection) {
-      const socket = new WebSocket(uris.socket);
+      const { settings } = Private.getLanguageServerManager();
+      const socket = new settings.WebSocket(uris.socket);
       const connection = new LSPConnection({
         languageId: language,
         serverUri: uris.server,

--- a/packages/lsp/src/manager.ts
+++ b/packages/lsp/src/manager.ts
@@ -33,11 +33,19 @@ export class LanguageServerManager implements ILanguageServerManager {
   get isEnabled(): boolean {
     return this._enabled;
   }
+
   /**
    * Check if the manager is disposed.
    */
   get isDisposed(): boolean {
     return this._isDisposed;
+  }
+
+  /**
+   * Get server connection settings.
+   */
+  get settings() {
+    return this._settings;
   }
 
   /**
@@ -204,7 +212,7 @@ export class LanguageServerManager implements ILanguageServerManager {
     for (let key of Object.keys(sessions)) {
       let id: TLanguageServerId = key as TLanguageServerId;
       if (this._sessions.has(id)) {
-        Object.assign(this._sessions.get(id)!, sessions[key]);
+        Object.assign(this._sessions.get(id) || {}, sessions[key]);
       } else {
         this._sessions.set(id, sessions[key]);
       }

--- a/packages/lsp/src/tokens.ts
+++ b/packages/lsp/src/tokens.ts
@@ -94,6 +94,13 @@ export interface ILanguageServerManager extends IDisposable {
   /**
    * @alpha
    *
+   * Get server connection settings.
+   */
+  readonly settings: ServerConnection.ISettings;
+
+  /**
+   * @alpha
+   *
    * A promise that is fulfilled when the connection manager is ready.
    */
   readonly ready: Promise<void>;


### PR DESCRIPTION
## References

Closes https://github.com/jupyterlab/jupyterlab/issues/12944

## Code changes

Ports changes from:
- https://github.com/jupyter-lsp/jupyterlab-lsp/pull/820
- https://github.com/jupyter-lsp/jupyterlab-lsp/pull/882 (cherry-picked, only porting the first part)
- https://github.com/jupyter-lsp/jupyterlab-lsp/pull/930

## User-facing changes

None/LSP will work better in custom deployments and will work with new versions of Pyright specs.

## Backwards-incompatible changes

None
