### PR TITLE
Fix docs for semantic commands registration

### DIFF
--- a/docs/source/extension/extension_points.rst
+++ b/docs/source/extension/extension_points.rst
@@ -621,23 +621,12 @@ Here is an example of using the ``closeAndCleaners`` semantic menu item:
 .. code:: typescript
 
     mainMenu.fileMenu.closeAndCleaners.add({
-      tracker,
-      action: 'Shutdown',
-      name: 'My Activity',
-      closeAndCleanup: current => {
-        current.close();
-        return current.shutdown();
-      }
+      id: 'notebook:close-and-shutdown',
+      isEnabled: (w: Widget) => tracker.currentWidget !== null && tracker.has(w)
     });
 
-In this example, ``tracker`` is a :ref:`widget-tracker`, which allows the menu
-item to determine whether to delegate the menu command to your activity,
-``name`` is a name given to your activity in the menu label,
-``action`` is a verb given to the cleanup operation in the menu label,
-and ``closeAndCleanup`` is the actual function that performs the cleanup operation.
-So if the current application activity is held in the ``tracker``,
-then the menu item will show ``Shutdown My Activity``, and delegate to the
-``closeAndCleanup`` function that was provided.
+In this example, ``tracker`` is a :ref:`notebook-tracker`, which allows the menu
+item to determine whether to delegate the menu command to your activity, and ``id`` is a the command identifier.
 
 More examples for how to register semantic menu items are found throughout the JupyterLab code base.
 The available semantic menu items are:

--- a/docs/source/extension/extension_points.rst
+++ b/docs/source/extension/extension_points.rst
@@ -625,7 +625,7 @@ Here is an example of using the ``closeAndCleaners`` semantic menu item:
       isEnabled: (w: Widget) => tracker.currentWidget !== null && tracker.has(w)
     });
 
-In this example, ``tracker`` is a :ref:`notebook-tracker`, which allows the menu
+In this example, ``tracker`` is a :ref:`widget-tracker`, which allows the menu
 item to determine whether to delegate the menu command to your activity, and ``id`` is a the command identifier.
 
 More examples for how to register semantic menu items are found throughout the JupyterLab code base.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

The example code in the document page was not correct anymore: https://jupyterlab.readthedocs.io/en/latest/extension/extension_points.html#registering-a-semantic-menu-item

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update the documentation for the "Registering a Semantic Menu Item" section.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Extension developer facing documentation.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
