### PR TITLE
Automated Changelog Entry for 3.6.5 on 3.6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 3.6.5
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.6.4...497dd4e71839cda0d5fb4e1961c2300a07fa9b4f))
+
+### Bugs fixed
+
+- Ensure the kernel selector show the default kernel if notebook does not have a valid assigned kernel [#14693](https://github.com/jupyterlab/jupyterlab/pull/14693) ([@echarles](https://github.com/echarles))
+- Avoid clearing the host node while rendering Markdown [#14579](https://github.com/jupyterlab/jupyterlab/pull/14579) ([@c3Vu](https://github.com/c3Vu))
+
+### Maintenance and upkeep improvements
+
+- Update requirements: conda != Python, jupyter-server over notebook [#14709](https://github.com/jupyterlab/jupyterlab/pull/14709) ([@krassowski](https://github.com/krassowski))
+- Fix integration test looking for jupyter heading [#14621](https://github.com/jupyterlab/jupyterlab/pull/14621) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2023-05-31&to=2023-06-26&type=c))
+
+[@andrii-i](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aandrii-i+updated%3A2023-05-31..2023-06-26&type=Issues) | [@brijsiyag](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abrijsiyag+updated%3A2023-05-31..2023-06-26&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aecharles+updated%3A2023-05-31..2023-06-26&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2023-05-31..2023-06-26&type=Issues) | [@GabrielaVives](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AGabrielaVives+updated%3A2023-05-31..2023-06-26&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2023-05-31..2023-06-26&type=Issues) | [@JasonWeill](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AJasonWeill+updated%3A2023-05-31..2023-06-26&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2023-05-31..2023-06-26&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2023-05-31..2023-06-26&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2023-05-31..2023-06-26&type=Issues) | [@lumberbot-app](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Alumberbot-app+updated%3A2023-05-31..2023-06-26&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2023-05-31..2023-06-26&type=Issues) | [@tonyfast](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atonyfast+updated%3A2023-05-31..2023-06-26&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2023-05-31..2023-06-26&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 3.6.4
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab/compare/v3.6.3...2031b9b07504b015605e049dc73dded15dd6d7f0))
@@ -44,8 +66,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab/graphs/contributors?from=2023-03-31&to=2023-05-31&type=c))
 
 [@andrii-i](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aandrii-i+updated%3A2023-03-31..2023-05-31&type=Issues) | [@brichet](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Abrichet+updated%3A2023-03-31..2023-05-31&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Aellisonbg+updated%3A2023-03-31..2023-05-31&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Afcollonval+updated%3A2023-03-31..2023-05-31&type=Issues) | [@gabalafou](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agabalafou+updated%3A2023-03-31..2023-05-31&type=Issues) | [@GabrielaVives](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AGabrielaVives+updated%3A2023-03-31..2023-05-31&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Agithub-actions+updated%3A2023-03-31..2023-05-31&type=Issues) | [@HaudinFlorence](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AHaudinFlorence+updated%3A2023-03-31..2023-05-31&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ahbcarlos+updated%3A2023-03-31..2023-05-31&type=Issues) | [@JasonWeill](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3AJasonWeill+updated%3A2023-03-31..2023-05-31&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajtpio+updated%3A2023-03-31..2023-05-31&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ajupyterlab-probot+updated%3A2023-03-31..2023-05-31&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Akrassowski+updated%3A2023-03-31..2023-05-31&type=Issues) | [@lumberbot-app](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Alumberbot-app+updated%3A2023-03-31..2023-05-31&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Ameeseeksmachine+updated%3A2023-03-31..2023-05-31&type=Issues) | [@mlucool](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Amlucool+updated%3A2023-03-31..2023-05-31&type=Issues) | [@tonyfast](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Atonyfast+updated%3A2023-03-31..2023-05-31&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+involves%3Awelcome+updated%3A2023-03-31..2023-05-31&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 3.6.3
 


### PR DESCRIPTION
Automated Changelog Entry for 3.6.5 on 3.6.x
```
Python version: 3.6.5
npm version: @jupyterlab/repo-top: 0.0.1
npm workspace versions:
@jupyterlab/builder: 3.6.5
@jupyterlab/buildutils: 3.6.5
@jupyterlab/template: 3.6.5
@jupyterlab/application-top: 3.6.5
@jupyterlab/example-app: 3.6.5
@jupyterlab/example-cell: 3.6.5
@jupyterlab/example-console: 3.6.5
@jupyterlab/example-federated: 2.7.5
@jupyterlab/example-federated-core: 2.7.5
@jupyterlab/example-federated-md: 2.7.5
@jupyterlab/example-federated-middle: 2.7.5
@jupyterlab/example-federated-phosphor: 2.7.5
@jupyterlab/example-filebrowser: 3.6.5
@jupyterlab/example-notebook: 3.6.5
@jupyterlab/example-terminal: 3.6.5
@jupyterlab/galata: 4.5.5
@jupyterlab/mock-extension: 3.6.5
@jupyterlab/mock-consumer: 3.6.5
@jupyterlab/mock-provider: 3.6.5
@jupyterlab/mock-token: 3.6.5
@jupyterlab/application: 3.6.5
@jupyterlab/application-extension: 3.6.5
@jupyterlab/apputils: 3.6.5
@jupyterlab/apputils-extension: 3.6.5
@jupyterlab/attachments: 3.6.5
@jupyterlab/cell-toolbar: 3.6.5
@jupyterlab/cell-toolbar-extension: 3.6.5
@jupyterlab/cells: 3.6.5
@jupyterlab/celltags: 3.6.5
@jupyterlab/celltags-extension: 3.6.5
@jupyterlab/codeeditor: 3.6.5
@jupyterlab/codemirror: 3.6.5
@jupyterlab/codemirror-extension: 3.6.5
@jupyterlab/collaboration: 3.6.5
@jupyterlab/collaboration-extension: 3.6.5
@jupyterlab/completer: 3.6.5
@jupyterlab/completer-extension: 3.6.5
@jupyterlab/console: 3.6.5
@jupyterlab/console-extension: 3.6.5
@jupyterlab/coreutils: 5.6.5
@jupyterlab/csvviewer: 3.6.5
@jupyterlab/csvviewer-extension: 3.6.5
@jupyterlab/debugger: 3.6.5
@jupyterlab/debugger-extension: 3.6.5
@jupyterlab/docmanager: 3.6.5
@jupyterlab/docmanager-extension: 3.6.5
@jupyterlab/docprovider: 3.6.5
@jupyterlab/docprovider-extension: 3.6.5
@jupyterlab/docregistry: 3.6.5
@jupyterlab/documentsearch: 3.6.5
@jupyterlab/documentsearch-extension: 3.6.5
@jupyterlab/extensionmanager: 3.6.5
@jupyterlab/extensionmanager-extension: 3.6.5
@jupyterlab/filebrowser: 3.6.5
@jupyterlab/filebrowser-extension: 3.6.5
@jupyterlab/fileeditor: 3.6.5
@jupyterlab/fileeditor-extension: 3.6.5
@jupyterlab/help-extension: 3.6.5
@jupyterlab/htmlviewer: 3.6.5
@jupyterlab/htmlviewer-extension: 3.6.5
@jupyterlab/hub-extension: 3.6.5
@jupyterlab/imageviewer: 3.6.5
@jupyterlab/imageviewer-extension: 3.6.5
@jupyterlab/inspector: 3.6.5
@jupyterlab/inspector-extension: 3.6.5
@jupyterlab/javascript-extension: 3.6.5
@jupyterlab/json-extension: 3.6.5
@jupyterlab/launcher: 3.6.5
@jupyterlab/launcher-extension: 3.6.5
@jupyterlab/logconsole: 3.6.5
@jupyterlab/logconsole-extension: 3.6.5
@jupyterlab/mainmenu: 3.6.5
@jupyterlab/mainmenu-extension: 3.6.5
@jupyterlab/markdownviewer: 3.6.5
@jupyterlab/markdownviewer-extension: 3.6.5
@jupyterlab/mathjax2: 3.6.5
@jupyterlab/mathjax2-extension: 3.6.5
@jupyterlab/metapackage: 3.6.5
@jupyterlab/nbconvert-css: 3.6.5
@jupyterlab/nbformat: 3.6.5
@jupyterlab/notebook: 3.6.5
@jupyterlab/notebook-extension: 3.6.5
@jupyterlab/observables: 4.6.5
@jupyterlab/outputarea: 3.6.5
@jupyterlab/pdf-extension: 3.6.5
@jupyterlab/property-inspector: 3.6.5
@jupyterlab/rendermime: 3.6.5
@jupyterlab/rendermime-extension: 3.6.5
@jupyterlab/rendermime-interfaces: 3.6.5
@jupyterlab/running: 3.6.5
@jupyterlab/running-extension: 3.6.5
@jupyterlab/services: 6.6.5
@jupyterlab/example-services-browser: 3.6.5
node-example: 3.6.5
@jupyterlab/example-services-outputarea: 3.6.5
@jupyterlab/settingeditor: 3.6.5
@jupyterlab/settingeditor-extension: 3.6.5
@jupyterlab/settingregistry: 3.6.5
@jupyterlab/shared-models: 3.6.5
@jupyterlab/shortcuts-extension: 3.6.5
@jupyterlab/statedb: 3.6.5
@jupyterlab/statusbar: 3.6.5
@jupyterlab/statusbar-extension: 3.6.5
@jupyterlab/terminal: 3.6.5
@jupyterlab/terminal-extension: 3.6.5
@jupyterlab/theme-dark-extension: 3.6.5
@jupyterlab/theme-light-extension: 3.6.5
@jupyterlab/toc: 5.6.5
@jupyterlab/toc-extension: 5.6.5
@jupyterlab/tooltip: 3.6.5
@jupyterlab/tooltip-extension: 3.6.5
@jupyterlab/translation: 3.6.5
@jupyterlab/translation-extension: 3.6.5
@jupyterlab/ui-components: 3.6.5
@jupyterlab/ui-components-extension: 3.6.5
@jupyterlab/vdom: 3.6.5
@jupyterlab/vdom-extension: 3.6.5
@jupyterlab/vega5-extension: 3.6.5
@jupyterlab/testutils: 3.6.5
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyterlab/jupyterlab/releases/tag/untagged-aa508f5be65c0f806a0f  |
| Since | v3.6.4 |