### PR TITLE
Relax `Event.IManager` interface

### DIFF
--- a/packages/services/src/event/index.ts
+++ b/packages/services/src/event/index.ts
@@ -173,7 +173,7 @@ export namespace Event {
     /**
      * An event stream that emits and yields each new event.
      */
-    stream: Event.Stream;
+    readonly stream: Event.Stream;
     /**
      * Post an event request to be emitted by the event bus.
      */

--- a/packages/services/src/event/index.ts
+++ b/packages/services/src/event/index.ts
@@ -16,7 +16,7 @@ const SERVICE_EVENTS_URL = 'api/events';
 /**
  * The events API service manager.
  */
-export class EventManager implements IDisposable {
+export class EventManager implements Event.IManager {
   /**
    * Create a new event manager.
    */
@@ -165,5 +165,18 @@ export namespace Event {
   /**
    * The interface for the event bus front-end.
    */
-  export interface IManager extends EventManager {}
+  export interface IManager extends IDisposable {
+    /**
+     * The server settings used to make API requests.
+     */
+    readonly serverSettings: ServerConnection.ISettings;
+    /**
+     * An event stream that emits and yields each new event.
+     */
+    stream: Event.Stream;
+    /**
+     * Post an event request to be emitted by the event bus.
+     */
+    emit(event: Event.Request): Promise<void>;
+  }
 }


### PR DESCRIPTION

## References

The current `Event.IManager` interface is deducted from the `EventManager ` class. This enforces that any implementation of `Event.IManager` needs to extend `EventManager`. This PR relaxes this constraint.

cc @afshin if this constraint is intended. 

## Code changes

`EventManager` is now implementing `Event.IManager`

## User-facing changes

N/A

## Backwards-incompatible changes

N/A since this is an interface relaxation.
