### PR TITLE
Emit changed signal from outut area when an output is updated

### DIFF
--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -418,13 +418,23 @@ export class OutputAreaModel implements IOutputAreaModel {
    */
   private _onGenericChange(itemModel: IOutputModel): void {
     let idx: number;
+    let item: IOutputModel | null = null;
     for (idx = 0; idx < this.list.length; idx++) {
-      const item = this.list.get(idx);
+      item = this.list.get(idx);
       if (item === itemModel) {
         break;
       }
     }
-    this._stateChanged.emit(idx);
+    if (item != null) {
+      this._stateChanged.emit(idx);
+      this._changed.emit({
+        type: 'set',
+        newIndex: idx,
+        oldIndex: idx,
+        oldValues: [item],
+        newValues: [item]
+      });
+    }
   }
 
   private _lastStream = '';


### PR DESCRIPTION
## References

- fixes #14781

## Code changes

- [x] emit `changed` from `OutputAreaModel` when an output is updated with `setData` (or changes in any other way, presumably)
- [ ] add browser-based acceptance test that verifies changes are updated by e.g. vega

## User-facing changes

- users should see fallback/metadata from mime renderers which use `setData`

## Backwards-incompatible changes

- ???
