### PR TITLE
SeparateLSP settings handling out to another plugin

### DIFF
--- a/packages/lsp-extension/src/index.ts
+++ b/packages/lsp-extension/src/index.ts
@@ -38,12 +38,13 @@ import { Signal } from '@lumino/signaling';
 import { renderServerSetting } from './renderer';
 
 import type { FieldProps } from '@rjsf/utils';
+
 const plugin: JupyterFrontEndPlugin<ILSPDocumentConnectionManager> = {
   activate,
   id: '@jupyterlab/lsp-extension:plugin',
   description: 'Provides the language server connection manager.',
-  requires: [ISettingRegistry, ITranslator],
-  optional: [IRunningSessionManagers, IFormRendererRegistry],
+  requires: [ITranslator],
+  optional: [IRunningSessionManagers],
   provides: ILSPDocumentConnectionManager,
   autoStart: true
 };
@@ -53,6 +54,15 @@ const featurePlugin: JupyterFrontEndPlugin<ILSPFeatureManager> = {
   description: 'Provides the language server feature manager.',
   activate: () => new FeatureManager(),
   provides: ILSPFeatureManager,
+  autoStart: true
+};
+
+const settingsPlugin: JupyterFrontEndPlugin<void> = {
+  activate: activateSettings,
+  id: '@jupyterlab/lsp-extension:settings',
+  description: 'Provides the language server settings.',
+  requires: [ILSPDocumentConnectionManager, ISettingRegistry, ITranslator],
+  optional: [IFormRendererRegistry],
   autoStart: true
 };
 
@@ -88,18 +98,40 @@ const codeExtractorManagerPlugin: JupyterFrontEndPlugin<ILSPCodeExtractorsManage
  */
 function activate(
   app: JupyterFrontEnd,
-  settingRegistry: ISettingRegistry,
   translator: ITranslator,
-  runningSessionManagers: IRunningSessionManagers | null,
-  settingRendererRegistry: IFormRendererRegistry | null
+  runningSessionManagers: IRunningSessionManagers | null
 ): ILSPDocumentConnectionManager {
-  const LANGUAGE_SERVERS = 'languageServers';
   const languageServerManager = new LanguageServerManager({
     settings: app.serviceManager.serverSettings
   });
   const connectionManager = new DocumentConnectionManager({
     languageServerManager
   });
+
+  // Add a sessions manager if the running extension is available
+  if (runningSessionManagers) {
+    addRunningSessionManager(
+      runningSessionManagers,
+      connectionManager,
+      translator
+    );
+  }
+
+  return connectionManager;
+}
+
+/**
+ * Activate the lsp settings plugin.
+ */
+function activateSettings(
+  app: JupyterFrontEnd,
+  connectionManager: ILSPDocumentConnectionManager,
+  settingRegistry: ISettingRegistry,
+  translator: ITranslator,
+  settingRendererRegistry: IFormRendererRegistry | null
+): void {
+  const LANGUAGE_SERVERS = 'languageServers';
+  const languageServerManager = connectionManager.languageServerManager;
 
   const updateOptions = (settings: ISettingRegistry.ISettings) => {
     const options = settings.composite as Required<LanguageServersExperimental>;
@@ -179,15 +211,6 @@ function activate(
       console.error(reason.message);
     });
 
-  // Add a sessions manager if the running extension is available
-  if (runningSessionManagers) {
-    addRunningSessionManager(
-      runningSessionManagers,
-      connectionManager,
-      translator
-    );
-  }
-
   if (settingRendererRegistry) {
     const renderer: IFormRenderer = {
       fieldRenderer: (props: FieldProps) => {
@@ -199,8 +222,6 @@ function activate(
       renderer
     );
   }
-
-  return connectionManager;
 }
 
 export class RunningLanguageServer implements IRunningSessions.IRunningItem {
@@ -284,4 +305,9 @@ function addRunningSessionManager(
 /**
  * Export the plugin as default.
  */
-export default [plugin, featurePlugin, codeExtractorManagerPlugin];
+export default [
+  plugin,
+  featurePlugin,
+  settingsPlugin,
+  codeExtractorManagerPlugin
+];

--- a/packages/lsp/src/tokens.ts
+++ b/packages/lsp/src/tokens.ts
@@ -131,7 +131,7 @@ export interface ILanguageServerManager extends IDisposable {
    *
    * Enable the language server services
    */
-  enable(): void;
+  enable(): Promise<void>;
 
   /**
    * @alpha
@@ -408,6 +408,11 @@ export interface ILSPDocumentConnectionManager {
    * A promise that is fulfilled when the connection manager is ready.
    */
   readonly ready: Promise<void>;
+
+  /**
+   * Initial configuration for the language servers.
+   */
+  initialConfigurations: TLanguageServerConfigurations;
 
   /**
    * Handles the settings that do not require an existing connection


### PR DESCRIPTION
## References

https://github.com/jupyterlab/jupyterlab/issues/14711

## Code changes

Adds a new plugin where LSP settings are handled. This enables downstream overriding it.

In particular, it is currently impossible to sanely override `ILSPDocumentConnectionManager` provider (which is the same plugin as the one handling settings) due to deduplication issues. This decouples the two functionalities.

## User-facing changes

None

## Backwards-incompatible changes

None