### PR TITLE
Fix incorrect CSS value for statusbar popover shadow

### DIFF
--- a/packages/statusbar/style/base.css
+++ b/packages/statusbar/style/base.css
@@ -60,7 +60,7 @@
 }
 
 .jp-StatusBar-HoverItem {
-  box-shadow: '0px 4px 4px rgba(0, 0, 0, 0.25)';
+  box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
 }
 
 .jp-StatusBar-TextItem {


### PR DESCRIPTION
## References

Follow up after #13584

## Code changes

Remove quotes around box-shadow value copied over from typestyle and then please stylelint.

## User-facing changes

| Current 4.0.2 | This PR (as was in 3.x) |
|--|--|
| ![Screenshot from 2023-07-03 21-10-06](https://github.com/jupyterlab/jupyterlab/assets/5832902/e5944e34-2c11-4b78-8eef-7d8b0618a05a) | ![Screenshot from 2023-07-03 21-10-22](https://github.com/jupyterlab/jupyterlab/assets/5832902/46352544-e12c-4fc9-b893-5a8959d661d7) |


## Backwards-incompatible changes

None
