### PR TITLE
blur footer for any key that triggers a 'select above', not just ArrowUp

### DIFF
--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -513,8 +513,18 @@
     },
     {
       "command": "notebook:move-cursor-up",
+      "keys": ["ArrowUp"],
+      "selector": ".jp-Notebook-footer"
+    },
+    {
+      "command": "notebook:move-cursor-up",
       "keys": ["K"],
       "selector": ".jp-Notebook:focus"
+    },
+    {
+      "command": "notebook:move-cursor-up",
+      "keys": ["K"],
+      "selector": ".jp-Notebook-footer"
     },
     {
       "command": "notebook:move-cursor-heading-above-or-collapse",

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -499,32 +499,22 @@
     {
       "command": "notebook:move-cursor-down",
       "keys": ["ArrowDown"],
-      "selector": ".jp-Notebook:focus"
+      "selector": "[data-jp-traversable]:focus"
     },
     {
       "command": "notebook:move-cursor-down",
       "keys": ["J"],
-      "selector": ".jp-Notebook:focus"
+      "selector": "[data-jp-traversable]:focus"
     },
     {
       "command": "notebook:move-cursor-up",
       "keys": ["ArrowUp"],
-      "selector": ".jp-Notebook:focus"
-    },
-    {
-      "command": "notebook:move-cursor-up",
-      "keys": ["ArrowUp"],
-      "selector": ".jp-Notebook-footer"
+      "selector": "[data-jp-traversable]:focus"
     },
     {
       "command": "notebook:move-cursor-up",
       "keys": ["K"],
-      "selector": ".jp-Notebook:focus"
-    },
-    {
-      "command": "notebook:move-cursor-up",
-      "keys": ["K"],
-      "selector": ".jp-Notebook-footer"
+      "selector": "[data-jp-traversable]:focus"
     },
     {
       "command": "notebook:move-cursor-heading-above-or-collapse",

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -847,6 +847,7 @@ export namespace NotebookActions {
     if (!notebook.model || !notebook.activeCell) {
       return;
     }
+    notebook.footer?.onSelectAbove();
     if (notebook.activeCellIndex === 0) {
       return;
     }

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -847,7 +847,9 @@ export namespace NotebookActions {
     if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    notebook.footer?.onSelectAbove();
+    if (notebook.footer?.onSelectAbove()) {
+      return;
+    }
     if (notebook.activeCellIndex === 0) {
       return;
     }

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -847,9 +847,13 @@ export namespace NotebookActions {
     if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    if (notebook.footer?.onSelectAbove()) {
+    const footer = (notebook.layout as NotebookWindowedLayout).footer;
+    if (footer && document.activeElement === footer.node) {
+      footer.node.blur();
+      notebook.mode = 'command';
       return;
     }
+
     if (notebook.activeCellIndex === 0) {
       return;
     }

--- a/packages/notebook/src/notebookfooter.ts
+++ b/packages/notebook/src/notebookfooter.ts
@@ -32,13 +32,6 @@ export class NotebookFooter extends Widget {
       case 'click':
         this.onClick();
         break;
-      case 'keydown': {
-        const key = (event as KeyboardEvent).key;
-        if (key === 'ArrowUp' || key === 'k') {
-          this.onArrowUp();
-          break;
-        }
-      }
     }
   }
 

--- a/packages/notebook/src/notebookfooter.ts
+++ b/packages/notebook/src/notebookfooter.ts
@@ -50,6 +50,10 @@ export class NotebookFooter extends Widget {
    * blur the footer and switch to command mode.
    */
   public onSelectAbove(): void {
+    if (document.activeElement !== this.node) {
+      // short-circuit if the footer is not currently focused
+      return;
+    }
     this.node.blur();
     this.notebook.mode = 'command';
   }

--- a/packages/notebook/src/notebookfooter.ts
+++ b/packages/notebook/src/notebookfooter.ts
@@ -33,8 +33,8 @@ export class NotebookFooter extends Widget {
         this.onClick();
         break;
       case 'keydown': {
-        const keyEvent = event as KeyboardEvent;
-        if (keyEvent.key === 'ArrowUp' || keyEvent.key === 'k') {
+        const key = (event as KeyboardEvent).key;
+        if (key === 'ArrowUp' || key === 'k') {
           this.onArrowUp();
           break;
         }

--- a/packages/notebook/src/notebookfooter.ts
+++ b/packages/notebook/src/notebookfooter.ts
@@ -11,6 +11,11 @@ import { NotebookActions } from './actions';
 const NOTEBOOK_FOOTER_CLASS = 'jp-Notebook-footer';
 
 /**
+ * The data attribute added to a widget that can be traversed with up/down arrow and j/k shortcuts.
+ */
+const TRAVERSABLE = 'jpTraversable';
+
+/**
  * A footer widget added after the last cell of the notebook.
  */
 export class NotebookFooter extends Widget {
@@ -19,6 +24,7 @@ export class NotebookFooter extends Widget {
    */
   constructor(protected notebook: Notebook) {
     super({ node: document.createElement('button') });
+    this.node.dataset[TRAVERSABLE] = 'true';
     const trans = notebook.translator.load('jupyterlab');
     this.addClass(NOTEBOOK_FOOTER_CLASS);
     this.node.innerText = trans.__('Click to add a cell.');

--- a/packages/notebook/src/notebookfooter.ts
+++ b/packages/notebook/src/notebookfooter.ts
@@ -45,28 +45,12 @@ export class NotebookFooter extends Widget {
     NotebookActions.insertBelow(this.notebook);
   }
 
-  /**
-   * When an event (such as a keydown keyboard event) occurs that triggers selection of the widget above the footer,
-   * blur the footer and switch to command mode.
-   * Returns whether the footer was blurred.
-   */
-  public onSelectAbove(): boolean {
-    if (document.activeElement !== this.node) {
-      // short-circuit if the footer is not currently focused
-      return false;
-    }
-    this.node.blur();
-    this.notebook.mode = 'command';
-    return true;
-  }
-
   /*
    * Handle `after-detach` messages for the widget.
    */
   protected onAfterAttach(msg: Message): void {
     super.onAfterAttach(msg);
     this.node.addEventListener('click', this);
-    this.node.addEventListener('keydown', this);
   }
 
   /**
@@ -74,7 +58,6 @@ export class NotebookFooter extends Widget {
    */
   protected onBeforeDetach(msg: Message): void {
     this.node.removeEventListener('click', this);
-    this.node.removeEventListener('keydown', this);
     super.onBeforeDetach(msg);
   }
 }

--- a/packages/notebook/src/notebookfooter.ts
+++ b/packages/notebook/src/notebookfooter.ts
@@ -32,11 +32,13 @@ export class NotebookFooter extends Widget {
       case 'click':
         this.onClick();
         break;
-      case 'keydown':
-        if ((event as KeyboardEvent).key === 'ArrowUp') {
+      case 'keydown': {
+        const keyEvent = event as KeyboardEvent;
+        if (keyEvent.key === 'ArrowUp' || keyEvent.key === 'k') {
           this.onArrowUp();
           break;
         }
+      }
     }
   }
 

--- a/packages/notebook/src/notebookfooter.ts
+++ b/packages/notebook/src/notebookfooter.ts
@@ -48,14 +48,17 @@ export class NotebookFooter extends Widget {
   /**
    * When an event (such as a keydown keyboard event) occurs that triggers selection of the widget above the footer,
    * blur the footer and switch to command mode.
+   * Returns whether the footer was blurred
+   * Returns whether the footer was blurred.
    */
-  public onSelectAbove(): void {
+  public onSelectAbove(): boolean {
     if (document.activeElement !== this.node) {
       // short-circuit if the footer is not currently focused
-      return;
+      return false;
     }
     this.node.blur();
     this.notebook.mode = 'command';
+    return true;
   }
 
   /*

--- a/packages/notebook/src/notebookfooter.ts
+++ b/packages/notebook/src/notebookfooter.ts
@@ -48,7 +48,6 @@ export class NotebookFooter extends Widget {
   /**
    * When an event (such as a keydown keyboard event) occurs that triggers selection of the widget above the footer,
    * blur the footer and switch to command mode.
-   * Returns whether the footer was blurred
    * Returns whether the footer was blurred.
    */
   public onSelectAbove(): boolean {

--- a/packages/notebook/src/notebookfooter.ts
+++ b/packages/notebook/src/notebookfooter.ts
@@ -53,9 +53,10 @@ export class NotebookFooter extends Widget {
   }
 
   /**
-   * On arrow up key pressed (keydown keyboard event), blur the footer and switch to command mode.
+   * When an event (such as a keydown keyboard event) occurs that triggers selection of the widget above the footer,
+   * blur the footer and switch to command mode.
    */
-  protected onArrowUp(): void {
+  public onSelectAbove(): void {
     this.node.blur();
     this.notebook.mode = 'command';
   }

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -52,6 +52,11 @@ const CODE_RUNNER = 'jpCodeRunner';
 const UNDOER = 'jpUndoer';
 
 /**
+ * The data attribute added to a widget that can be traversed with up/down arrow and j/k shortcuts.
+ */
+const TRAVERSABLE = 'jpTraversable';
+
+/**
  * The class name added to notebook widgets.
  */
 const NB_CLASS = 'jp-Notebook';
@@ -218,6 +223,7 @@ export class StaticNotebook extends WindowedList {
     this.node.dataset[KERNEL_USER] = 'true';
     this.node.dataset[UNDOER] = 'true';
     this.node.dataset[CODE_RUNNER] = 'true';
+    this.node.dataset[TRAVERSABLE] = 'true';
     this.rendermime = options.rendermime;
     this.translator = options.translator || nullTranslator;
     this.contentFactory = options.contentFactory;

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1261,6 +1261,9 @@ export namespace StaticNotebook {
  * A notebook widget that supports interactivity.
  */
 export class Notebook extends StaticNotebook {
+
+  footer: NotebookFooter;
+
   /**
    * Construct a notebook widget.
    */
@@ -1271,7 +1274,7 @@ export class Notebook extends StaticNotebook {
     this.node.setAttribute('data-lm-dragscroll', 'true');
     this.activeCellChanged.connect(this._updateSelectedCells, this);
     this.selectionChanged.connect(this._updateSelectedCells, this);
-    this.addFooter();
+    this.footer = this.addFooter();
   }
 
   /**
@@ -1284,9 +1287,10 @@ export class Notebook extends StaticNotebook {
   /**
    * Adds a footer to the notebook.
    */
-  protected addFooter(): void {
+  protected addFooter(): NotebookFooter {
     const info = new NotebookFooter(this);
     (this.layout as NotebookWindowedLayout).footer = info;
+    return info;
   }
 
   /**

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1262,7 +1262,7 @@ export namespace StaticNotebook {
  */
 export class Notebook extends StaticNotebook {
 
-  footer: NotebookFooter;
+  protected footer: NotebookFooter;
 
   /**
    * Construct a notebook widget.

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1261,9 +1261,6 @@ export namespace StaticNotebook {
  * A notebook widget that supports interactivity.
  */
 export class Notebook extends StaticNotebook {
-
-  public footer: NotebookFooter;
-
   /**
    * Construct a notebook widget.
    */
@@ -1274,7 +1271,7 @@ export class Notebook extends StaticNotebook {
     this.node.setAttribute('data-lm-dragscroll', 'true');
     this.activeCellChanged.connect(this._updateSelectedCells, this);
     this.selectionChanged.connect(this._updateSelectedCells, this);
-    this.footer = this.addFooter();
+    this.addFooter();
   }
 
   /**
@@ -1287,10 +1284,9 @@ export class Notebook extends StaticNotebook {
   /**
    * Adds a footer to the notebook.
    */
-  protected addFooter(): NotebookFooter {
+  protected addFooter(): void {
     const info = new NotebookFooter(this);
     (this.layout as NotebookWindowedLayout).footer = info;
-    return info;
   }
 
   /**

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1262,7 +1262,7 @@ export namespace StaticNotebook {
  */
 export class Notebook extends StaticNotebook {
 
-  protected footer: NotebookFooter;
+  public footer: NotebookFooter;
 
   /**
    * Construct a notebook widget.


### PR DESCRIPTION
This just makes sure that 'k' can still work for navigating after the 'Click to add a cell' footer has been focused.

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
