### PR TITLE
Fix icon and theme/styles for grid in CSV/TSV viewer

### DIFF
--- a/packages/csvviewer-extension/src/index.ts
+++ b/packages/csvviewer-extension/src/index.ts
@@ -161,12 +161,6 @@ function activateCsv(
   let searchProviderInitialized = false;
 
   factory.widgetCreated.connect(async (sender, widget) => {
-    if (searchRegistry && !searchProviderInitialized) {
-      const { CSVSearchProvider } = await import('./searchprovider');
-      searchRegistry.add('csv', CSVSearchProvider);
-      searchProviderInitialized = true;
-    }
-
     // Track the widget.
     void tracker.add(widget);
     // Notify the widget tracker if restore data needs to update.
@@ -179,7 +173,16 @@ function activateCsv(
       widget.title.iconClass = ft.iconClass!;
       widget.title.iconLabel = ft.iconLabel!;
     }
-    // Set the theme for the new widget.
+
+    // Delay await to execute `widget.title` setters (above) synchronously
+    if (searchRegistry && !searchProviderInitialized) {
+      const { CSVSearchProvider } = await import('./searchprovider');
+      searchRegistry.add('csv', CSVSearchProvider);
+      searchProviderInitialized = true;
+    }
+
+    // Set the theme for the new widget; requires `.content` to be loaded.
+    await widget.content.ready;
     widget.content.style = style;
     widget.content.rendererConfig = rendererConfig;
   });
@@ -194,7 +197,8 @@ function activateCsv(
     rendererConfig = isLight
       ? Private.LIGHT_TEXT_CONFIG
       : Private.DARK_TEXT_CONFIG;
-    tracker.forEach(grid => {
+    tracker.forEach(async grid => {
+      await grid.content.ready;
       grid.content.style = style;
       grid.content.rendererConfig = rendererConfig;
     });
@@ -311,12 +315,6 @@ function activateTsv(
   let searchProviderInitialized = false;
 
   factory.widgetCreated.connect(async (sender, widget) => {
-    if (searchRegistry && !searchProviderInitialized) {
-      const { CSVSearchProvider } = await import('./searchprovider');
-      searchRegistry.add('tsv', CSVSearchProvider);
-      searchProviderInitialized = true;
-    }
-
     // Track the widget.
     void tracker.add(widget);
     // Notify the widget tracker if restore data needs to update.
@@ -329,7 +327,16 @@ function activateTsv(
       widget.title.iconClass = ft.iconClass!;
       widget.title.iconLabel = ft.iconLabel!;
     }
-    // Set the theme for the new widget.
+
+    // Delay await to execute `widget.title` setters (above) synchronously
+    if (searchRegistry && !searchProviderInitialized) {
+      const { CSVSearchProvider } = await import('./searchprovider');
+      searchRegistry.add('tsv', CSVSearchProvider);
+      searchProviderInitialized = true;
+    }
+
+    // Set the theme for the new widget; requires `.content` to be loaded.
+    await widget.content.ready;
     widget.content.style = style;
     widget.content.rendererConfig = rendererConfig;
   });
@@ -344,7 +351,8 @@ function activateTsv(
     rendererConfig = isLight
       ? Private.LIGHT_TEXT_CONFIG
       : Private.DARK_TEXT_CONFIG;
-    tracker.forEach(grid => {
+    tracker.forEach(async grid => {
+      await grid.content.ready;
       grid.content.style = style;
       grid.content.rendererConfig = rendererConfig;
     });

--- a/packages/csvviewer/src/widget.ts
+++ b/packages/csvviewer/src/widget.ts
@@ -232,7 +232,14 @@ export class CSVViewer extends Widget {
 
     this.addClass(CSV_CLASS);
 
-    void this.initialize();
+    this._ready = this.initialize();
+  }
+
+  /**
+   * Promise which resolves when the content is ready.
+   */
+  get ready(): Promise<void> {
+    return this._ready;
   }
 
   protected async initialize(): Promise<void> {
@@ -407,6 +414,7 @@ export class CSVViewer extends Widget {
   private _delimiter = ',';
   private _revealed = new PromiseDelegate<void>();
   private _baseRenderer: TextRenderConfig | null = null;
+  private _ready: Promise<void>;
 }
 
 /**


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/14250

## Code changes

Move spreadsheet icon setter to before `await` to execute it synchronously - otherwise the icon is set too late (after adding widget to main area and hence too late to get proper class applied) due to async code execution.

Also fixes an issue with style being set on content which is not ready and throwing an error by awaiting on initialisation (adds new public `ready` member on `CSVViewer`).

## User-facing changes

| Before | After |
|--|--|
|![Screenshot from 2023-07-12 18-54-57](https://github.com/jupyterlab/jupyterlab/assets/5832902/7e6be775-b3aa-4bbf-9a2b-749be1399866) | ![Screenshot from 2023-07-12 18-55-23](https://github.com/jupyterlab/jupyterlab/assets/5832902/83a419a5-fbc6-42aa-b6ce-06e93cbe3339) |


## Backwards-incompatible changes

Adds a non-optional API member `ready` on `CSVViewer` class, we can make it optional on backport.