### PR TITLE
Move opening help resources to a separate plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 # JupyterLab Changelog
 
+## v4.1
+
+### 4.1.0 - Highlights
+
+#### Moved plugins
+
+Some internal JupyterLab plugins have been re-organized to allow for better flexibility for deployments and downstream applications like Notebook 7. This might affect users that disable specific plugins with the `jupyter labextension disable` command or the `disabledExtensions` config option.
+
+- The `help:open` command is not defined in the `@jupyterlab/help-extension:resources` plugin anymore, but has been moved to a new `@jupyterlab/help-extension:open` plugin instead.
+
 ## v4.0
 
 ### 4.0.0 - Highlights

--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -196,50 +196,24 @@ const jupyterForum: JupyterFrontEndPlugin<void> = {
 };
 
 /**
- * A plugin to add a list of resources to the help menu.
+ * A plugin to add to open resources in IFrames or new browser tabs.
  */
-const resources: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlab/help-extension:resources',
-  description: 'Adds commands to Jupyter reference documentation websites.',
+const open: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlab/help-extension:open',
   autoStart: true,
-  requires: [IMainMenu, ITranslator],
-  optional: [ILabShell, ICommandPalette, ILayoutRestorer],
+  requires: [ITranslator],
+  optional: [ILayoutRestorer],
   activate: (
     app: JupyterFrontEnd,
-    mainMenu: IMainMenu,
     translator: ITranslator,
-    labShell: ILabShell | null,
-    palette: ICommandPalette | null,
     restorer: ILayoutRestorer | null
   ): void => {
+    const { commands, shell } = app;
     const trans = translator.load('jupyterlab');
-    let counter = 0;
-    const category = trans.__('Help');
     const namespace = 'help-doc';
-    const { commands, shell, serviceManager } = app;
-    const tracker = new WidgetTracker<MainAreaWidget<IFrame>>({ namespace });
-    const resources = [
-      {
-        text: trans.__('JupyterLab Reference'),
-        url: 'https://jupyterlab.readthedocs.io/en/latest/'
-      },
-      {
-        text: trans.__('JupyterLab FAQ'),
-        url: 'https://jupyterlab.readthedocs.io/en/latest/getting_started/faq.html'
-      },
-      {
-        text: trans.__('Jupyter Reference'),
-        url: 'https://jupyter.org/documentation'
-      },
-      {
-        text: trans.__('Markdown Reference'),
-        url: 'https://commonmark.org/help/'
-      }
-    ];
 
-    resources.sort((a: any, b: any) => {
-      return a.text.localeCompare(b.text);
-    });
+    const tracker = new WidgetTracker<MainAreaWidget<IFrame>>({ namespace });
+    let counter = 0;
 
     /**
      * Create a new HelpWidget widget.
@@ -298,6 +272,51 @@ const resources: JupyterFrontEndPlugin<void> = {
         name: widget => widget.content.url
       });
     }
+  }
+};
+
+/**
+ * A plugin to add a list of resources to the help menu.
+ */
+const resources: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlab/help-extension:resources',
+  description: 'Adds commands to Jupyter reference documentation websites.',
+  autoStart: true,
+  requires: [IMainMenu, ITranslator],
+  optional: [ILabShell, ICommandPalette],
+  activate: (
+    app: JupyterFrontEnd,
+    mainMenu: IMainMenu,
+    translator: ITranslator,
+    labShell: ILabShell | null,
+    palette: ICommandPalette | null,
+    restorer: ILayoutRestorer | null
+  ): void => {
+    const trans = translator.load('jupyterlab');
+    const category = trans.__('Help');
+    const { commands, serviceManager } = app;
+    const resources = [
+      {
+        text: trans.__('JupyterLab Reference'),
+        url: 'https://jupyterlab.readthedocs.io/en/latest/'
+      },
+      {
+        text: trans.__('JupyterLab FAQ'),
+        url: 'https://jupyterlab.readthedocs.io/en/latest/getting_started/faq.html'
+      },
+      {
+        text: trans.__('Jupyter Reference'),
+        url: 'https://jupyter.org/documentation'
+      },
+      {
+        text: trans.__('Markdown Reference'),
+        url: 'https://commonmark.org/help/'
+      }
+    ];
+
+    resources.sort((a: any, b: any) => {
+      return a.text.localeCompare(b.text);
+    });
 
     // Populate the Help menu.
     const helpMenu = mainMenu.helpMenu;
@@ -629,6 +648,7 @@ const licenses: JupyterFrontEndPlugin<void> = {
 const plugins: JupyterFrontEndPlugin<any>[] = [
   about,
   jupyterForum,
+  open,
   resources,
   licenses
 ];

--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -290,7 +290,6 @@ const resources: JupyterFrontEndPlugin<void> = {
     translator: ITranslator,
     labShell: ILabShell | null,
     palette: ICommandPalette | null,
-    restorer: ILayoutRestorer | null
   ): void => {
     const trans = translator.load('jupyterlab');
     const category = trans.__('Help');

--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -289,7 +289,7 @@ const resources: JupyterFrontEndPlugin<void> = {
     mainMenu: IMainMenu,
     translator: ITranslator,
     labShell: ILabShell | null,
-    palette: ICommandPalette | null,
+    palette: ICommandPalette | null
   ): void => {
     const trans = translator.load('jupyterlab');
     const category = trans.__('Help');


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

This should help with https://github.com/jupyter/notebook/issues/6963 and https://github.com/jupyter/notebook/pull/6968

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Move the command that opens help resources in the `main` area in IFrames or new browser tabs to a new plugin.

That way, downstream applications like Notebook 7 can choose to not include this plugin and provide their own instead.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
