### PR TITLE
Fix CodeMirror theme selection background color

### DIFF
--- a/packages/codemirror/src/theme.ts
+++ b/packages/codemirror/src/theme.ts
@@ -46,7 +46,7 @@ export const jupyterEditorTheme = EditorView.theme({
     backgroundColor: 'var(--jp-editor-selected-background)'
   },
 
-  '&.cm-focused .cm-selectionBackground': {
+  '&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground': {
     backgroundColor: 'var(--jp-editor-selected-focused-background)'
   },
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes #14737

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update the CSS selector for the selection background color.

Previously, the rule from the base CodeMirror6 theme `.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground` takes precedence over our `.cm-focused .cm-selectionBackground` rule, so the theme selection color is not taking effect. Changing the selector to be the same as the base theme fixes the issue.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

|Before|After|
|:-----|:----|
|![Before](https://github.com/jupyterlab/jupyterlab/assets/36528777/c15b1995-cb8b-40be-837b-812eb34280fe)|![After](https://github.com/jupyterlab/jupyterlab/assets/36528777/1e0ed044-b9e4-43a4-98e2-7fbb13ac67b0)|


<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None.


<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
