### PR TITLE
fix: update blocked extensions uris

### DIFF
--- a/packages/extensionmanager-extension/examples/listings/Makefile
+++ b/packages/extensionmanager-extension/examples/listings/Makefile
@@ -1,9 +1,9 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-export BLOCKED_EXTENSIONS_URIS="https://raw.githubusercontent.com/datalayer-jupyterlab/jupyterlab-listings-example/master/blockedExtensions_simple.json"
+export BLOCKED_EXTENSIONS_URIS="https://raw.githubusercontent.com/datalayer-jupyterlab/jupyterlab-listings-example/main/blocked_extensions_simple.json"
 # export BLOCKED_EXTENSIONS_URIS=""
-# export ALLOWED_EXTENSIONS_URIS="https://raw.githubusercontent.com/datalayer-jupyterlab/jupyterlab-listings-example/master/allowedExtensions_only_jlab.json"
+# export ALLOWED_EXTENSIONS_URIS="https://raw.githubusercontent.com/datalayer-jupyterlab/jupyterlab-listings-example/main/allowed_extensions_only_jlab.json"
 export ALLOWED_EXTENSIONS_URIS=""
 export LISTINGS_REFRESH_SECONDS=120
 export LISTINGS_REQUEST_OPTS="{'timeout': 10}"

--- a/packages/extensionmanager-extension/examples/listings/Makefile
+++ b/packages/extensionmanager-extension/examples/listings/Makefile
@@ -1,9 +1,9 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-export BLOCKED_EXTENSIONS_URIS="https://raw.githubusercontent.com/datalayer-jupyterlab/jupyterlab-listings-example/main/blocked_extensions_simple.json"
+export BLOCKED_EXTENSIONS_URIS="https://raw.githubusercontent.com/jupyterlab/jupyterlab/main/packages/extensionmanager-extension/examples/listings/list/blocked_extensions.json"
 # export BLOCKED_EXTENSIONS_URIS=""
-# export ALLOWED_EXTENSIONS_URIS="https://raw.githubusercontent.com/datalayer-jupyterlab/jupyterlab-listings-example/main/allowed_extensions_only_jlab.json"
+# export ALLOWED_EXTENSIONS_URIS="https://raw.githubusercontent.com/jupyterlab/jupyterlab/main/packages/extensionmanager-extension/examples/listings/list/allowed_extensions.json"
 export ALLOWED_EXTENSIONS_URIS=""
 export LISTINGS_REFRESH_SECONDS=120
 export LISTINGS_REQUEST_OPTS="{'timeout': 10}"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

PR updates the `$BLOCKED_EXTENSIONS_URIS` env to the correct `extensions_simple.json` file. It moves to `main` branch instead of `master` (since it's default). It also updates the `$ALLOWED_EXTENSIONS_URIS` env which is less important because it's commented. 

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
