### PR TITLE
Fix CodeMirror tooltip positioning and tooltip background

### DIFF
--- a/packages/codemirror/src/extension.ts
+++ b/packages/codemirror/src/extension.ts
@@ -26,7 +26,8 @@ import {
   keymap,
   lineNumbers,
   rectangularSelection,
-  scrollPastEnd
+  scrollPastEnd,
+  tooltips
 } from '@codemirror/view';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { JSONExt, ReadonlyJSONObject } from '@lumino/coreutils';
@@ -789,6 +790,12 @@ export namespace EditorExtensionRegistry {
           type: 'number',
           title: trans.__('Tab size')
         }
+      }),
+      Object.freeze({
+        name: 'tooltips',
+        factory: () =>
+          // we need absolute due to use of `contain: layout` in lumino
+          createImmutableExtension(tooltips({ position: 'absolute' }))
       }),
       Object.freeze({
         name: 'allowMultipleSelections',

--- a/packages/codemirror/src/extension.ts
+++ b/packages/codemirror/src/extension.ts
@@ -794,8 +794,15 @@ export namespace EditorExtensionRegistry {
       Object.freeze({
         name: 'tooltips',
         factory: () =>
-          // we need absolute due to use of `contain: layout` in lumino
-          createImmutableExtension(tooltips({ position: 'absolute' }))
+          // we need `absolute` due to use of `contain: layout` in lumino;
+          // we attach to body to ensure cursor collaboration tooltip is
+          // visible in first line of the editor.
+          createImmutableExtension(
+            tooltips({
+              position: 'absolute',
+              parent: document.body
+            })
+          )
       }),
       Object.freeze({
         name: 'allowMultipleSelections',

--- a/packages/codemirror/src/theme.ts
+++ b/packages/codemirror/src/theme.ts
@@ -72,6 +72,10 @@ export const jupyterEditorTheme = EditorView.theme({
     backgroundColor:
       'var(--jp-search-selected-match-background-color) !important',
     color: 'var(--jp-search-selected-match-color) !important'
+  },
+
+  '.cm-tooltip': {
+    backgroundColor: 'var(--jp-layout-color1)'
   }
 });
 


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/14857 and background (see below).

This mostly concerns extensions, core lab does not make use of the built-in CodeMirror tooltips. Since extensions may want to let's fix it. Also, it is a trivial change.

## Code changes

- Add background color override for tooltips as currently we override font color (indirectly) but not background
- Configure tooltip positioning to fix it when used in JupyterLab which uses `contain: strict` for performance reasons

## User-facing changes

| Before | After |
|--|--|
|  ![Screenshot from 2023-07-19 19-54-26](https://github.com/jupyterlab/jupyterlab/assets/5832902/26002d9b-3c02-4517-9ad4-70624a963260) | ![Screenshot from 2023-07-19 19-53-59](https://github.com/jupyterlab/jupyterlab/assets/5832902/b0bbc008-5048-4524-b6e0-877f13947856) |


## Backwards-incompatible changes

None