### PR TITLE
In defer mode render enough cells to fill the viewport

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -887,8 +887,19 @@ export class StaticNotebook extends WindowedList {
       cellIdx++;
     }
 
+    // If the notebook is not fully rendered
     if (cellIdx < this.cellsArray.length) {
-      this._scheduleCellRenderOnIdle();
+      // If we are defering the cell rendering and the rendered cells do
+      // not fill the viewport yet
+      if (
+        this.notebookConfig.windowingMode === 'defer' &&
+        this.viewportNode.clientHeight < this.node.clientHeight
+      ) {
+        // Spend more time rendering cells to fill the viewport
+        await this._runOnIdleTime();
+      } else {
+        this._scheduleCellRenderOnIdle();
+      }
     } else {
       if (this._idleCallBack) {
         window.cancelIdleCallback(this._idleCallBack);


### PR DESCRIPTION
even if it takes more than a macro cycle

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #14608
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
In notebook defer rendering mode, cells are rendered to at least fill the viewport before starting rendering on idle time.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Cells should not pop-up when opening a notebook
Notebook opening time may increase
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None