### PR TITLE
fix: heading doesn't scroll into view

### DIFF
--- a/packages/notebook/src/toc.ts
+++ b/packages/notebook/src/toc.ts
@@ -516,19 +516,23 @@ export class NotebookToCFactory extends TableOfContentsFactory<NotebookPanel> {
             return;
           }
 
-          findHeadingElement(heading).then(el => {
-            if (el) {
-              const widgetBox = widget.content.node.getBoundingClientRect();
-              const elementBox = el.getBoundingClientRect();
+          findHeadingElement(heading)
+            .then(el => {
+              if (el) {
+                const widgetBox = widget.content.node.getBoundingClientRect();
+                const elementBox = el.getBoundingClientRect();
 
-              if (
-                elementBox.top > widgetBox.bottom ||
-                elementBox.bottom < widgetBox.top
-              ) {
-                el.scrollIntoView({ block: 'center' });
+                if (
+                  elementBox.top > widgetBox.bottom ||
+                  elementBox.bottom < widgetBox.top
+                ) {
+                  el.scrollIntoView({ block: 'center' });
+                }
               }
-            }
-          });
+            })
+            .catch(reason => {
+              console.error('Fail to find the element of the heading.');
+            });
         };
 
         const cell = heading.cellRef;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
Fix #14591 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Previously, the element of each cell is stored in a map which relies on an async function `getIdForHeading`. The bug occurs when the element isn't computed yet. The code changes remove this map and find the element on the fly. 

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

Bug is fixed and heading will scroll into view as intended. 

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

None