### PR TITLE
Align copier version with the extension template

### DIFF
--- a/docs/source/extension/extension_tutorial.rst
+++ b/docs/source/extension/extension_tutorial.rst
@@ -66,7 +66,7 @@ new environment named ``jupyterlab-ext``.
 
 .. code:: bash
 
-    conda create -n jupyterlab-ext --override-channels --strict-channel-priority -c conda-forge -c nodefaults jupyterlab=4 nodejs=18 git copier=8 jinja2-time
+    conda create -n jupyterlab-ext --override-channels --strict-channel-priority -c conda-forge -c nodefaults jupyterlab=4 nodejs=18 git copier=7 jinja2-time
 
 Now activate the new environment so that all further commands you run
 work out of that environment.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

The extension teamplate currently recommends using `copier=7` while the tutorial mentions `copier=8`: https://github.com/jupyterlab/extension-template

![image](https://github.com/jupyterlab/jupyterlab/assets/591645/0d994103-58aa-42d8-8041-ce99740df9a8)

![image](https://github.com/jupyterlab/jupyterlab/assets/591645/5e47883c-788d-445b-86c0-a47fad73aa35)


This was noticed in https://github.com/jupyterlab/jupyterlab/issues/14898.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update extension tutorial.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Documentation change for extension authors.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
