### PR TITLE
Save and restore sidebar subpanels sizes and expansion states

### DIFF
--- a/packages/application/src/layoutrestorer.ts
+++ b/packages/application/src/layoutrestorer.ts
@@ -448,8 +448,7 @@ export class LayoutRestorer implements ILayoutRestorer {
     }
     const dehydrated: Private.ISideArea = {
       collapsed: area.collapsed,
-      visible: area.visible,
-      expansionStates: area.expansionStates
+      visible: area.visible
     };
     if (area.currentWidget) {
       const current = Private.nameProperty.get(area.currentWidget);
@@ -462,8 +461,13 @@ export class LayoutRestorer implements ILayoutRestorer {
         .map(widget => Private.nameProperty.get(widget))
         .filter(name => !!name);
     }
-    if (area.sizes) {
-      dehydrated.sizes = area.sizes;
+    if (area.widgetStates) {
+      dehydrated.widgetStates = area.widgetStates as {
+        [id: string]: {
+          sizes: number[] | null;
+          expansionStates: boolean[] | null;
+        };
+      };
     }
     return dehydrated;
   }
@@ -484,8 +488,12 @@ export class LayoutRestorer implements ILayoutRestorer {
         currentWidget: null,
         visible: true,
         widgets: null,
-        sizes: null,
-        expansionStates: [true]
+        widgetStates: {
+          ['null']: {
+            sizes: null,
+            expansionStates: null
+          }
+        }
       };
     }
     const internal = this._widgets;
@@ -501,15 +509,18 @@ export class LayoutRestorer implements ILayoutRestorer {
             internal.has(`${name}`) ? internal.get(`${name}`) : null
           )
           .filter(widget => !!widget);
-    const sizes = area.sizes as number[];
-    const expansionStates = area.expansionStates as boolean[];
+    const widgetStates = area.widgetStates as {
+      [id: string]: {
+        sizes: number[] | null;
+        expansionStates: boolean[] | null;
+      };
+    };
     return {
       collapsed,
       currentWidget: currentWidget!,
       widgets: widgets as Widget[] | null,
       visible: area.visible ?? true,
-      sizes,
-      expansionStates
+      widgetStates: widgetStates
     };
   }
 

--- a/packages/application/src/layoutrestorer.ts
+++ b/packages/application/src/layoutrestorer.ts
@@ -448,7 +448,8 @@ export class LayoutRestorer implements ILayoutRestorer {
     }
     const dehydrated: Private.ISideArea = {
       collapsed: area.collapsed,
-      visible: area.visible
+      visible: area.visible,
+      expansionStates: area.expansionStates
     };
     if (area.currentWidget) {
       const current = Private.nameProperty.get(area.currentWidget);
@@ -460,6 +461,9 @@ export class LayoutRestorer implements ILayoutRestorer {
       dehydrated.widgets = area.widgets
         .map(widget => Private.nameProperty.get(widget))
         .filter(name => !!name);
+    }
+    if (area.sizes) {
+      dehydrated.sizes = area.sizes;
     }
     return dehydrated;
   }
@@ -479,7 +483,9 @@ export class LayoutRestorer implements ILayoutRestorer {
         collapsed: true,
         currentWidget: null,
         visible: true,
-        widgets: null
+        widgets: null,
+        sizes: null,
+        expansionStates: [true]
       };
     }
     const internal = this._widgets;
@@ -495,11 +501,15 @@ export class LayoutRestorer implements ILayoutRestorer {
             internal.has(`${name}`) ? internal.get(`${name}`) : null
           )
           .filter(widget => !!widget);
+    const sizes = area.sizes as number[];
+    const expansionStates = area.expansionStates as boolean[];
     return {
       collapsed,
       currentWidget: currentWidget!,
       widgets: widgets as Widget[] | null,
-      visible: area.visible ?? true
+      visible: area.visible ?? true,
+      sizes,
+      expansionStates
     };
   }
 

--- a/packages/application/test/layoutrestorer.spec.ts
+++ b/packages/application/test/layoutrestorer.spec.ts
@@ -61,16 +61,24 @@ describe('apputils', () => {
             currentWidget: null,
             widgets: null,
             visible: false,
-            sizes: null,
-            expansionStates: [true, true, true, true]
+            widgetStates: {
+              ['null']: {
+                sizes: null,
+                expansionStates: null
+              }
+            }
           },
           rightArea: {
             collapsed: true,
             currentWidget: null,
             widgets: null,
             visible: false,
-            sizes: null,
-            expansionStates: [true, true, true, true]
+            widgetStates: {
+              ['null']: {
+                sizes: null,
+                expansionStates: null
+              }
+            }
           },
           relativeSizes: null,
           topArea: { simpleVisibility: true }
@@ -99,16 +107,24 @@ describe('apputils', () => {
             currentWidget: null,
             widgets: null,
             visible: false,
-            sizes: null,
-            expansionStates: [true, true, true, true]
+            widgetStates: {
+              ['null']: {
+                sizes: null,
+                expansionStates: null
+              }
+            }
           },
           rightArea: {
             collapsed: true,
             currentWidget: null,
             widgets: null,
             visible: false,
-            sizes: null,
-            expansionStates: [true, true, true, true]
+            widgetStates: {
+              ['null']: {
+                sizes: null,
+                expansionStates: null
+              }
+            }
           },
           relativeSizes: null,
           topArea: { simpleVisibility: true }
@@ -151,16 +167,24 @@ describe('apputils', () => {
             collapsed: true,
             widgets: [currentWidget],
             visible: true,
-            sizes: null,
-            expansionStates: [true, true, true, true]
+            widgetStates: {
+              [currentWidget.id]: {
+                sizes: null,
+                expansionStates: [true]
+              }
+            }
           },
           rightArea: {
             collapsed: true,
             currentWidget: null,
             widgets: null,
             visible: false,
-            sizes: null,
-            expansionStates: [true, true, true, true]
+            widgetStates: {
+              ['null']: {
+                sizes: null,
+                expansionStates: null
+              }
+            }
           },
           relativeSizes: null,
           topArea: { simpleVisibility: true }
@@ -221,16 +245,24 @@ describe('apputils', () => {
             collapsed: true,
             widgets: null,
             visible: false,
-            sizes: null,
-            expansionStates: [true, true, true, true]
+            widgetStates: {
+              ['null']: {
+                sizes: null,
+                expansionStates: null
+              }
+            }
           },
           rightArea: {
             collapsed: true,
             currentWidget: null,
             widgets: null,
             visible: false,
-            sizes: null,
-            expansionStates: [true, true, true, true]
+            widgetStates: {
+              ['null']: {
+                sizes: null,
+                expansionStates: null
+              }
+            }
           },
           relativeSizes: null,
           topArea: { simpleVisibility: true }
@@ -259,16 +291,24 @@ describe('apputils', () => {
             collapsed: true,
             widgets: [currentWidget],
             visible: true,
-            sizes: null,
-            expansionStates: [true, true, true, true]
+            widgetStates: {
+              [currentWidget.id]: {
+                sizes: null,
+                expansionStates: [true]
+              }
+            }
           },
           rightArea: {
             collapsed: true,
             currentWidget: null,
             widgets: null,
             visible: false,
-            sizes: null,
-            expansionStates: [true, true, true, true]
+            widgetStates: {
+              ['null']: {
+                sizes: null,
+                expansionStates: null
+              }
+            }
           },
           relativeSizes: null,
           topArea: { simpleVisibility: true }

--- a/packages/application/test/layoutrestorer.spec.ts
+++ b/packages/application/test/layoutrestorer.spec.ts
@@ -60,13 +60,17 @@ describe('apputils', () => {
             collapsed: true,
             currentWidget: null,
             widgets: null,
-            visible: false
+            visible: false,
+            sizes: null,
+            expansionStates: [true, true, true, true]
           },
           rightArea: {
             collapsed: true,
             currentWidget: null,
             widgets: null,
-            visible: false
+            visible: false,
+            sizes: null,
+            expansionStates: [true, true, true, true]
           },
           relativeSizes: null,
           topArea: { simpleVisibility: true }
@@ -94,13 +98,17 @@ describe('apputils', () => {
             collapsed: true,
             currentWidget: null,
             widgets: null,
-            visible: false
+            visible: false,
+            sizes: null,
+            expansionStates: [true, true, true, true]
           },
           rightArea: {
             collapsed: true,
             currentWidget: null,
             widgets: null,
-            visible: false
+            visible: false,
+            sizes: null,
+            expansionStates: [true, true, true, true]
           },
           relativeSizes: null,
           topArea: { simpleVisibility: true }
@@ -142,13 +150,17 @@ describe('apputils', () => {
             currentWidget,
             collapsed: true,
             widgets: [currentWidget],
-            visible: true
+            visible: true,
+            sizes: null,
+            expansionStates: [true, true, true, true]
           },
           rightArea: {
             collapsed: true,
             currentWidget: null,
             widgets: null,
-            visible: false
+            visible: false,
+            sizes: null,
+            expansionStates: [true, true, true, true]
           },
           relativeSizes: null,
           topArea: { simpleVisibility: true }
@@ -208,13 +220,17 @@ describe('apputils', () => {
             currentWidget: null,
             collapsed: true,
             widgets: null,
-            visible: false
+            visible: false,
+            sizes: null,
+            expansionStates: [true, true, true, true]
           },
           rightArea: {
             collapsed: true,
             currentWidget: null,
             widgets: null,
-            visible: false
+            visible: false,
+            sizes: null,
+            expansionStates: [true, true, true, true]
           },
           relativeSizes: null,
           topArea: { simpleVisibility: true }
@@ -242,13 +258,17 @@ describe('apputils', () => {
             currentWidget,
             collapsed: true,
             widgets: [currentWidget],
-            visible: true
+            visible: true,
+            sizes: null,
+            expansionStates: [true, true, true, true]
           },
           rightArea: {
             collapsed: true,
             currentWidget: null,
             widgets: null,
-            visible: false
+            visible: false,
+            sizes: null,
+            expansionStates: [true, true, true, true]
           },
           relativeSizes: null,
           topArea: { simpleVisibility: true }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->
This PR makes possible the full saving and restoration of the sidebars, including the subpanels sizes and expansion states.

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

It listens to the new signal introduced  in this PR https://github.com/jupyterlab/lumino/pull/614 in `lumino`, namely [`expansionToggled`](https://github.com/jupyterlab/lumino/blob/95f69a3a0caba53bce4a642b1f1e47b7fd7e4006/packages/widgets/src/accordionpanel.ts#L60), such that the saving of the sidebar's layout is triggered when one of the subpanels is collapsed or expanded.

It also listens to the signal [`handleMoved`](https://github.com/jupyterlab/lumino/blob/95f69a3a0caba53bce4a642b1f1e47b7fd7e4006/packages/widgets/src/splitpanel.ts#L115), which makes it possible for the layout of the sidebar to also be saved when the vertical size of any of the subpanels is changed. The horizontal size of the entire sidebar is already being saved, as a consequence of the layout saving of the main dock panel.

## Code changes

<!-- Describe the code changes and how they address the issue. -->

To allow for the full saving and restoration of the sidebar layout, the `ISideArea` interface has been extended, such that it includes two new properties `sizes` and `expansionStates` which will store the vertical sizes, and respectively the expansion state of each subpanel.

The listeners for the signals mentioned above are also initialized when a widget is added to the sidebar, in the case of an `AccordionPanel` or `SidePanel`.

When a saving of the sidebar's layout is triggered, the `dehydrate` method now extracts the vertical sizes, as well as the expansion states, while the `rehydrate` method will restore them.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

The users will now be able to see the sidebars' layout being automatically saved with any changes that might have been made, regarding sizes of subpanels or their expansion states, and respectively restored in the case of refreshing or reopening JupyterLab.

![image](https://github.com/jupyterlab/jupyterlab/assets/91504950/d3611ef1-4ccf-42ee-b80e-beb7ec474007)

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
