### PR TITLE
Fix incorrect indentation browser_check.py

### DIFF
--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -206,4 +206,4 @@ if __name__ == "__main__":
             BrowserApp.test_browser = False
             sys.argv.remove(option)
 
-        BrowserApp.launch_instance()
+    BrowserApp.launch_instance()


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

`BrowserApp.launch_instance()` is indented at the wrong level. These meant if you tried to call `python -m jupyterlab.browser_check --no-chrome-test ` you would get 
```
usage: browser_check.py [-h] [--debug] [--show-config] [--show-config-json] [--generate-config] [-y] [--allow-root] [--no-browser] [--autoreload] [--script]
                        [--no-script] [--core-mode] [--dev-mode] [--skip-dev-build] [--watch] [--splice-source] [--expose-app-in-browser]
                        [--extensions-in-dev-mode] [--collaborative] [--log-level ServerApp.log_level] [--config ServerApp.config_file] [--ip ServerApp.ip]       
                        [--port ServerApp.port] [--port-retries ServerApp.port_retries] [--sock ServerApp.sock] [--sock-mode ServerApp.sock_mode]
                        [--transport KernelManager.transport] [--keyfile ServerApp.keyfile] [--certfile ServerApp.certfile] [--client-ca ServerApp.client_ca]     
                        [--notebook-dir ServerApp.root_dir] [--preferred-dir ServerApp.preferred_dir] [--browser ServerApp.browser] [--pylab ServerApp.pylab]     
                        [--gateway-url GatewayClient.url] [--app-dir BrowserApp.app_dir]
                        [extra_args ...]
```

Because it would try to launch an instance before the `--no-chrome-test` flag is removed.

## User-facing changes

None.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
