### PR TITLE
Allow opening links in new tabs when HTML is trusted

### DIFF
--- a/galata/test/jupyterlab/html-viewer.test.ts
+++ b/galata/test/jupyterlab/html-viewer.test.ts
@@ -35,7 +35,7 @@ test.describe('HTML Viewer', () => {
       for (const link of document.querySelectorAll('a')) {
         count +=
           window.getComputedStyle(link, '::after').content ==
-          '"Action disabled as the file is untrusted."'
+          '"Action disabled as the file is not trusted."'
             ? 1
             : 0;
       }
@@ -55,7 +55,7 @@ test.describe('HTML Viewer', () => {
       for (const link of document.querySelectorAll('a')) {
         count +=
           window.getComputedStyle(link, '::after').content ==
-          '"Action disabled as the file is untrusted."'
+          '"Action disabled as the file is not trusted."'
             ? 1
             : 0;
       }

--- a/galata/test/jupyterlab/html-viewer.test.ts
+++ b/galata/test/jupyterlab/html-viewer.test.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
 import { expect, test } from '@jupyterlab/galata';
 
 test.describe('HTML Viewer', () => {

--- a/galata/test/jupyterlab/html-viewer.test.ts
+++ b/galata/test/jupyterlab/html-viewer.test.ts
@@ -35,7 +35,7 @@ test.describe('HTML Viewer', () => {
       for (const link of document.querySelectorAll('a')) {
         count +=
           window.getComputedStyle(link, '::after').content ==
-          '"Link blocked as the file is untrusted."'
+          '"Action disabled as the file is untrusted."'
             ? 1
             : 0;
       }
@@ -55,7 +55,7 @@ test.describe('HTML Viewer', () => {
       for (const link of document.querySelectorAll('a')) {
         count +=
           window.getComputedStyle(link, '::after').content ==
-          '"Link blocked as the file is untrusted."'
+          '"Action disabled as the file is untrusted."'
             ? 1
             : 0;
       }

--- a/galata/test/jupyterlab/html-viewer.test.ts
+++ b/galata/test/jupyterlab/html-viewer.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@jupyterlab/galata';
+
+test.describe('HTML Viewer', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.menu.clickMenuItem('File>New>Text File');
+
+    await page.getByRole('main').getByRole('textbox').fill(`<html>
+<body>
+    <div style="height: 300px;"></div>
+    <a href="https://github.com" target="_blank">GitHub</a>
+</body>
+</html>`);
+
+    await page.menu.clickMenuItem('File>Save Text');
+
+    await page.getByPlaceholder('File name').fill('test.html');
+    await page.getByRole('button', { name: 'Rename' }).click();
+
+    await page.getByRole('listitem', { name: 'test.html' }).dblclick();
+  });
+
+  test('should notify links are blocked for untrusted file', async ({
+    page
+  }) => {
+    const frame = page.frame({ url: url => url.protocol == 'blob:' });
+    await frame!.getByRole('link', { name: 'GitHub' }).hover();
+
+    const warningCount = await frame!.evaluate(() => {
+      let count = 0;
+      for (const link of document.querySelectorAll('a')) {
+        count +=
+          window.getComputedStyle(link, '::after').content ==
+          '"Link blocked as the file is untrusted."'
+            ? 1
+            : 0;
+      }
+      return count;
+    });
+
+    expect(warningCount).toEqual(1);
+  });
+
+  test('should allow links for trusted file', async ({ page }) => {
+    await page.getByRole('button', { name: 'Trust HTML' }).click();
+    const frame = page.frame({ url: url => url.protocol == 'blob:' });
+    await frame!.getByRole('link', { name: 'GitHub' }).hover();
+
+    const warningCount = await frame!.evaluate(() => {
+      let count = 0;
+      for (const link of document.querySelectorAll('a')) {
+        count +=
+          window.getComputedStyle(link, '::after').content ==
+          '"Link blocked as the file is untrusted."'
+            ? 1
+            : 0;
+      }
+      return count;
+    });
+
+    expect(warningCount).toEqual(0);
+  });
+});

--- a/packages/htmlviewer/src/widget.tsx
+++ b/packages/htmlviewer/src/widget.tsx
@@ -272,7 +272,7 @@ namespace Private {
   /**
    * Sandbox exceptions for trusted HTML.
    */
-  export const trusted: IFrame.SandboxExceptions[] = ['allow-scripts'];
+  export const trusted: IFrame.SandboxExceptions[] = ['allow-scripts', 'allow-popups'];
 
   /**
    * Namespace for TrustedButton.

--- a/packages/htmlviewer/src/widget.tsx
+++ b/packages/htmlviewer/src/widget.tsx
@@ -36,12 +36,18 @@ const CSS_CLASS = 'jp-HTMLViewer';
 const UNTRUSTED_LINK_STYLE = (options: { warning: string }) => `<style>
 a[target="_blank"],
 area[target="_blank"],
-form[target="_blank"] {
+form[target="_blank"],
+button[formtarget="_blank"],
+input[formtarget="_blank"][type="image"],
+input[formtarget="_blank"][type="submit"] {
   cursor: not-allowed !important;
 }
 a[target="_blank"]:hover::after,
 area[target="_blank"]:hover::after,
-form[target="_blank"]:hover::after {
+form[target="_blank"]:hover::after,
+button[formtarget="_blank"]:hover::after,
+input[formtarget="_blank"][type="image"]:hover::after,
+input[formtarget="_blank"][type="submit"]:hover::after {
   content: "${options.warning}";
   box-sizing: border-box;
   position: fixed;
@@ -196,7 +202,7 @@ export class HTMLViewer
     if (!this.trusted) {
       const warning = this.translator
         .load('jupyterlab')
-        .__('Link blocked as the file is untrusted.');
+        .__('Action disabled as the file is untrusted.');
       doc.body.insertAdjacentHTML(
         'beforeend',
         UNTRUSTED_LINK_STYLE({ warning })

--- a/packages/htmlviewer/src/widget.tsx
+++ b/packages/htmlviewer/src/widget.tsx
@@ -34,18 +34,25 @@ const RENDER_TIMEOUT = 1000;
 const CSS_CLASS = 'jp-HTMLViewer';
 
 const UNTRUSTED_LINK_STYLE = (options: { warning: string }) => `<style>
-a {
+a[target="_blank"],
+area[target="_blank"],
+form[target="_blank"] {
   cursor: not-allowed !important;
 }
-a:hover::after {
+a[target="_blank"]:hover::after,
+area[target="_blank"]:hover::after,
+form[target="_blank"]:hover::after {
   content: "${options.warning}";
+  box-sizing: border-box;
   position: fixed;
   top: 0;
   left: 0;
+  width: 100%;
   z-index: 1000;
   border: 2px solid #e65100;
   background-color: #ffb74d;
   color: black;
+  text-align: center;
 }
 </style>`;
 

--- a/packages/htmlviewer/src/widget.tsx
+++ b/packages/htmlviewer/src/widget.tsx
@@ -355,7 +355,7 @@ namespace Private {
               (props.htmlDocument.trusted = !props.htmlDocument.trusted)
             }
             tooltip={trans.__(`Whether the HTML file is trusted.
-Trusting the file allows links and scripts to run in it,
+Trusting the file allows opening pop-ups and running scripts
 which may result in security risks.
 Only enable for files you trust.`)}
             label={

--- a/packages/htmlviewer/src/widget.tsx
+++ b/packages/htmlviewer/src/widget.tsx
@@ -58,6 +58,7 @@ input[formtarget="_blank"][type="submit"]:hover::after {
   border: 2px solid #e65100;
   background-color: #ffb74d;
   color: black;
+  font-family: system-ui, -apple-system, blinkmacsystemfont, 'Segoe UI', helvetica, arial, sans-serif;
   text-align: center;
 }
 </style>`;
@@ -202,7 +203,7 @@ export class HTMLViewer
     if (!this.trusted) {
       const warning = this.translator
         .load('jupyterlab')
-        .__('Action disabled as the file is untrusted.');
+        .__('Action disabled as the file is not trusted.');
       doc.body.insertAdjacentHTML(
         'beforeend',
         UNTRUSTED_LINK_STYLE({ warning })


### PR DESCRIPTION

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/14919

## Code changes

When user opts to trust a HTML file in the HTML viewer, allow code there to open
pages in a new tab by adding `allow-popups` to the IFrame's sandbox attribute.

## User-facing changes

Once a user trusts a HTML file, the file can open new windows either via JS or
via `target="_blank"` links.
