### PR TITLE
Make the browser check `default_url` configurable

### DIFF
--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -21,7 +21,7 @@ from jupyter_server.utils import pathname2url, urljoin
 from tornado.ioloop import IOLoop
 from tornado.iostream import StreamClosedError
 from tornado.websocket import WebSocketClosedError
-from traitlets import Bool
+from traitlets import Bool, Unicode
 
 from .labapp import LabApp, get_app_dir
 from .tests.test_app import TestEnv
@@ -170,7 +170,7 @@ class BrowserApp(LabApp):
     open_browser = False
 
     serverapp_config = {"base_url": "/foo/"}
-    default_url = "/lab?reset"
+    default_url = Unicode("/lab?reset", config=True, help="The default URL to redirect to from `/`")
     ip = "127.0.0.1"
     flags = test_flags
     aliases = test_aliases


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

This will allow using `python -m jupyterlab.browser_check` for other JupyterLab apps like Notebook 7.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Make `BrowserApp.default_url` configurable.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Usage: `python -m jupyterlab.browser_check --BrowserApp.default_url='/tree'`

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
