### PR TITLE
Fixed styling of standard input box

### DIFF
--- a/packages/outputarea/style/base.css
+++ b/packages/outputarea/style/base.css
@@ -130,6 +130,14 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated::before {
   word-break: break-all;
   word-wrap: break-word;
   white-space: pre-wrap;
+
+  /* Styling fixes */
+  width: var(--jp-widgets-inline-width);
+  display: flex;
+  align-items: center;
+  opacity: .8;
+  margin-left: 3.7em;
+  padding: 1em;
 }
 
 /* tables */
@@ -234,6 +242,16 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated::before {
   padding: 0 0.25em;
   margin: 0 0.25em;
   flex: 0 0 70%;
+
+  /* input box Styling fixes */
+  padding: var(--jp-widgets-input-padding);
+  color: var(--jp-widgets-input-color);
+  font-size: var(--jp-widgets-font-size);
+  width: var(--jp-widgets-inline-width);
+  margin: var(--jp-widgets-margin);
+  margin-left: 1em;
+  border: var(--jp-widgets-input-border-width) solid var(--jp-widgets-input-border-color);
+  height: 20px;
 }
 
 .jp-Stdin-input::placeholder {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Issue No: #14458
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
The problem was with css classes `[.jp-OutputArea-output pre, .jp-Stdin-input]` where the input box was not styled properly. 

Changes made to these classes are : 

**For the input box container**  
**Xpath :** `//*[@id="id-5b5645db-679b-45fb-8f0a-d868567b0f93"]/div[5]/div[5]/div[2]/div/div[2]/pre/input`

> ```
>.jp-OutputArea-output pre { 
>
>    /* Rest of the css... */
>
>    width: var(--jp-widgets-inline-width);
>    display: flex;
>    align-items: center;
>    opacity: .8;
>    margin-left: 3.7em;
>    padding: 1em;
>
>}
> ```

**For the input box**
**Xpath :** `//*[@id="id-5b5645db-679b-45fb-8f0a-d868567b0f93"]/div[5]/div[5]/div[2]/div/div[2]/pre/input`
>``` 
>.jp-Stdin-input {
>
>    /* Rest of the css... */
>
>    padding: var(--jp-widgets-input-padding);
>    color: var(--jp-widgets-input-color);
>    font-size: var(--jp-widgets-font-size);
>    width: var(--jp-widgets-inline-width);
>    margin: var(--jp-widgets-margin);
>    margin-left: 1em;
>    border: var(--jp-widgets-input-border-width) solid var(--jp-widgets-input-border-color);
>    height: 20px;
>
>}
>```

Hope It fixes the problem !

## User-facing changes

Initially the problem was with the UI. 
As of issue: #14458
**Problem was:**

![image](https://github.com/jupyterlab/jupyterlab/assets/78207450/a824e700-5487-4a84-ae53-4993efda44bf)

Where input box was not styled properly!

**After refactoring code :**
![Screenshot 2023-08-11 at 6 32 03 PM](https://github.com/jupyterlab/jupyterlab/assets/78207450/f704142a-b649-4406-943e-770e8333c09b)

All though  it is  not responsive, but it works on desktops at least.

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
**No Changes**
