### PR TITLE
simplify binder python baseline

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
   # runtimes
   - nodejs >=18,<19
-  - python >=3.11,<3.12
+  - python =3.11
   # package managers
   - pip
   - yarn >=3,<4


### PR DESCRIPTION
## References

- backport of #14102

## Code changes

- change `python` pin to be compatible with https://github.com/jupyterhub/repo2docker/issues/1301

## User-facing changes

- binder should build

## Backwards-incompatible changes

- n/a