### PR TITLE
Added restart in place commands and UI

### DIFF
--- a/examples/notebook/src/commands.ts
+++ b/examples/notebook/src/commands.ts
@@ -314,7 +314,7 @@ export const setupCommands = (
     icon: args => (args.toolbar ? fastForwardIcon : undefined),
     execute: () => {
       void sessionContextDialogs
-        .restart(nbWidget.sessionContext)
+        .restart(nbWidget.sessionContext, false)
         .then(restarted => {
           if (restarted) {
             void NotebookActions.runAll(

--- a/examples/notebook/src/commands.ts
+++ b/examples/notebook/src/commands.ts
@@ -190,7 +190,7 @@ export const setupCommands = (
     caption: 'Restart the kernel',
     icon: args => (args.toolbar ? refreshIcon : undefined),
     execute: () =>
-      sessionContextDialogs.restart(nbWidget.context.sessionContext)
+      sessionContextDialogs.restart(nbWidget.context.sessionContext, false)
   });
   commands.addCommand(COMMAND_IDS.switchKernel, {
     label: 'Switch Kernel',

--- a/packages/apputils/src/toolbar/widget.tsx
+++ b/packages/apputils/src/toolbar/widget.tsx
@@ -74,7 +74,8 @@ export namespace Toolbar {
       icon: refreshIcon,
       onClick: () => {
         void (dialogs ?? new SessionContextDialogs({ translator })).restart(
-          sessionContext
+          sessionContext,
+          false
         );
       },
       tooltip: trans.__('Restart the kernel')

--- a/packages/apputils/test/sessioncontext.spec.ts
+++ b/packages/apputils/test/sessioncontext.spec.ts
@@ -627,7 +627,7 @@ describe('@jupyterlab/apputils', () => {
         });
         await sessionContext.initialize();
         await sessionContext!.session?.kernel?.info;
-        const restart = sessionContextDialogs.restart(sessionContext);
+        const restart = sessionContextDialogs.restart(sessionContext, false);
 
         await acceptDialog();
         expect(await restart).toBe(true);
@@ -644,7 +644,7 @@ describe('@jupyterlab/apputils', () => {
           }
         });
 
-        const restart = sessionContextDialogs.restart(sessionContext);
+        const restart = sessionContextDialogs.restart(sessionContext, false);
         await dismissDialog();
         expect(await restart).toBe(false);
         expect(called).toBe(false);
@@ -653,7 +653,7 @@ describe('@jupyterlab/apputils', () => {
       it('should start the same kernel as the previously started kernel', async () => {
         await sessionContext.initialize();
         await sessionContext.shutdown();
-        await sessionContextDialogs.restart(sessionContext);
+        await sessionContextDialogs.restart(sessionContext, false);
         expect(sessionContext?.session?.kernel).toBeTruthy();
       });
     });

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -633,7 +633,7 @@ async function activateConsole(
       if (!current) {
         return;
       }
-      return sessionDialogs.restart(current.console.sessionContext);
+      return sessionDialogs.restart(current.console.sessionContext, false);
     },
     isEnabled
   });

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -224,7 +224,7 @@ const notebooks: JupyterFrontEndPlugin<IDebugger.IHandler> = {
         }
 
         const { content, sessionContext } = widget;
-        const restarted = await sessionDialogs.restart(sessionContext);
+        const restarted = await sessionDialogs.restart(sessionContext, false);
         if (!restarted) {
           return;
         }

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -634,7 +634,7 @@ export namespace Commands {
           widget => widget.sessionContext.session?.path === current.context.path
         );
         if (widget) {
-          return sessionDialogs.restart(widget.sessionContext);
+          return sessionDialogs.restart(widget.sessionContext, false);
         }
       },
       label: trans.__('Restart Kernel'),

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -34,6 +34,7 @@ import { ServerConnection } from '@jupyterlab/services';
 import { ISettingRegistry, SettingRegistry } from '@jupyterlab/settingregistry';
 import { ITranslator, TranslationBundle } from '@jupyterlab/translation';
 import {
+  circleEmptyIcon,
   fastForwardIcon,
   RankedMenu,
   refreshIcon,
@@ -82,6 +83,8 @@ export namespace CommandIDs {
   export const reconnectToKernel = 'kernelmenu:reconnect-to-kernel';
 
   export const restartKernel = 'kernelmenu:restart';
+
+  export const restartKernelInPlace = 'kernelmenu:restart-in-place';
 
   export const restartKernelAndClear = 'kernelmenu:restart-and-clear';
 
@@ -496,6 +499,19 @@ function createKernelMenu(
       trans
     ),
     icon: args => (args.toolbar ? refreshIcon : undefined)
+  });
+
+  commands.addCommand(CommandIDs.restartKernelInPlace, {
+    ...createSemanticCommand(
+      app,
+      menu.kernelUsers.restartKernel,
+      {
+        label: trans.__('Restart Kernel In Place…'),
+        caption: trans.__('Restart the kernel in place')
+      },
+      trans
+    ),
+    icon: args => (args.toolbar ? circleEmptyIcon : undefined)
   });
 
   commands.addCommand(

--- a/packages/notebook-extension/schema/panel.json
+++ b/packages/notebook-extension/schema/panel.json
@@ -13,21 +13,18 @@
       { "name": "cut", "command": "notebook:cut-cell", "rank": 21 },
       { "name": "copy", "command": "notebook:copy-cell", "rank": 22 },
       { "name": "paste", "command": "notebook:paste-cell-below", "rank": 23 },
+      { "name": "run", "command": "runmenu:run", "rank": 30 },
+      { "name": "interrupt", "command": "kernelmenu:interrupt", "rank": 31 },
+      { "name": "restart", "command": "kernelmenu:restart", "rank": 32 },
       {
-        "name": "run",
-        "command": "notebook:run-cell-and-select-next",
-        "rank": 30
+        "name": "restart-in-place",
+        "command": "notebook:restart-kernel-in-place",
+        "rank": 33
       },
-      {
-        "name": "interrupt",
-        "command": "notebook:interrupt-kernel",
-        "rank": 31
-      },
-      { "name": "restart", "command": "notebook:restart-kernel", "rank": 32 },
       {
         "name": "restart-and-run",
-        "command": "notebook:restart-run-all",
-        "rank": 33
+        "command": "runmenu:restart-and-run-all",
+        "rank": 34
       },
       { "name": "cellType", "rank": 40 },
       { "name": "spacer", "type": "spacer", "rank": 100 },

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -94,6 +94,7 @@ import {
   addAboveIcon,
   addBelowIcon,
   buildIcon,
+  circleEmptyIcon,
   copyIcon,
   cutIcon,
   duplicateIcon,
@@ -138,6 +139,8 @@ namespace CommandIDs {
   export const restart = 'notebook:restart-kernel';
 
   export const restartClear = 'notebook:restart-clear-output';
+
+  export const restartInPlace = 'notebook:restart-kernel-in-place';
 
   export const restartAndRunToSelected = 'notebook:restart-and-run-to-selected';
 
@@ -2327,11 +2330,24 @@ function addCommands(
       const current = getCurrent(tracker, shell, args);
 
       if (current) {
-        return sessionDialogs.restart(current.sessionContext);
+        return sessionDialogs.restart(current.sessionContext, false);
       }
     },
     isEnabled: args => (args.toolbar ? true : isEnabled()),
     icon: args => (args.toolbar ? refreshIcon : undefined)
+  });
+  commands.addCommand(CommandIDs.restartInPlace, {
+    label: trans.__('Restart Kernel In Place…'),
+    caption: trans.__('Restart the kernel in place'),
+    execute: args => {
+      const current = getCurrent(tracker, shell, args);
+
+      if (current) {
+        return sessionDialogs.restart(current.sessionContext, true);
+      }
+    },
+    icon: args => (args.toolbar ? circleEmptyIcon : undefined),
+    isEnabled
   });
   commands.addCommand(CommandIDs.shutdown, {
     label: trans.__('Shut Down Kernel'),
@@ -3409,6 +3425,7 @@ function populatePalette(
     CommandIDs.restart,
     CommandIDs.restartClear,
     CommandIDs.restartRunAll,
+    CommandIDs.restartInPlace,
     CommandIDs.runAll,
     CommandIDs.renderAllMarkdown,
     CommandIDs.runAllAbove,

--- a/packages/notebook/src/default-toolbar.tsx
+++ b/packages/notebook/src/default-toolbar.tsx
@@ -223,7 +223,7 @@ export namespace ToolbarItems {
       icon: fastForwardIcon,
       onClick: () => {
         const dialogs_ = dialogs ?? new SessionContextDialogs({ translator });
-        void dialogs_.restart(panel.sessionContext).then(restarted => {
+        void dialogs_.restart(panel.sessionContext, false).then(restarted => {
           if (restarted) {
             void NotebookActions.runAll(
               panel.content,

--- a/packages/notebook/test/executionindicator.spec.tsx
+++ b/packages/notebook/test/executionindicator.spec.tsx
@@ -111,7 +111,7 @@ describe('@jupyterlab/notebook', () => {
         content: widget,
         context: ipySessionContext
       });
-      await ipySessionContext.restartKernel();
+      await ipySessionContext.restartKernel(false);
     });
 
     afterEach(() => {

--- a/packages/services/examples/browser/src/kernel.ts
+++ b/packages/services/examples/browser/src/kernel.ts
@@ -49,7 +49,7 @@ export async function main(): Promise<void> {
   }
 
   log('Restarting kernel');
-  await kernel.restart();
+  await kernel.restart(false);
 
   log('Shutting down kernel');
   await kernel.shutdown();

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -472,14 +472,14 @@ export class KernelConnection implements Kernel.IKernelConnection {
    * The promise will be rejected if the request fails or the response is
    * invalid.
    */
-  async restart(): Promise<void> {
+  async restart(inPlace: boolean): Promise<void> {
     if (this.status === 'dead') {
       throw new Error('Kernel is dead');
     }
     this._updateStatus('restarting');
     this._clearKernelState();
     this._kernelSession = RESTARTING_KERNEL_SESSION;
-    await restapi.restartKernel(this.id, this.serverSettings);
+    await restapi.restartKernel(this.id, this.serverSettings, inPlace);
     // Reconnect to the kernel to address cases where kernel ports
     // have changed during the restart.
     await this.reconnect();

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -201,7 +201,7 @@ export interface IKernelConnection extends IObservableDisposable {
    * The promise will be rejected if the kernel status is `'dead'` or if the
    * request fails or the response is invalid.
    */
-  restart(): Promise<void>;
+  restart(inPlace: boolean): Promise<void>;
 
   /**
    * Send a `kernel_info_request` message.

--- a/packages/services/src/kernel/restapi.ts
+++ b/packages/services/src/kernel/restapi.ts
@@ -126,13 +126,14 @@ export type IKernelOptions = Partial<Pick<IModel, 'name'>>;
  */
 export async function restartKernel(
   id: string,
-  settings: ServerConnection.ISettings = ServerConnection.makeSettings()
+  settings: ServerConnection.ISettings = ServerConnection.makeSettings(),
+  inPlace: boolean
 ): Promise<void> {
   const url = URLExt.join(
     settings.baseUrl,
     KERNEL_SERVICE_URL,
     encodeURIComponent(id),
-    'restart'
+    inPlace ? 'restart-in-place' : 'restart'
   );
   const init = { method: 'POST' };
 

--- a/packages/services/test/kernel/ikernel.spec.ts
+++ b/packages/services/test/kernel/ikernel.spec.ts
@@ -374,7 +374,7 @@ describe('Kernel.IKernel', () => {
         find: () => kernel.status === 'restarting'
       });
       await kernel.requestKernelInfo();
-      await kernel.restart();
+      await kernel.restart(false);
       await expect(emission).resolves.not.toThrow();
       await kernel.requestKernelInfo();
       await kernel.shutdown();
@@ -653,34 +653,34 @@ describe('Kernel.IKernel', () => {
       const kernel = await kernelManager.startNew();
       await kernel.info;
       await kernel.requestKernelInfo();
-      await kernel.restart();
+      await kernel.restart(false);
       await expect(kernel.requestKernelInfo()).resolves.not.toThrow();
       await kernel.shutdown();
     });
 
     it('should fail if the kernel does not restart', async () => {
       handleRequest(defaultKernel, 500, {});
-      const restart = defaultKernel.restart();
+      const restart = defaultKernel.restart(false);
       await expect(restart).rejects.toThrow();
     });
 
     it('should throw an error for an invalid response', async () => {
       const { id, name } = defaultKernel;
       handleRequest(defaultKernel, 205, { id, name });
-      await expect(defaultKernel.restart()).rejects.toThrow(
+      await expect(defaultKernel.restart(false)).rejects.toThrow(
         /Invalid response: 205 Reset Content/
       );
     });
 
     it('should throw an error for an error response', async () => {
       handleRequest(defaultKernel, 500, {});
-      const restart = defaultKernel.restart();
+      const restart = defaultKernel.restart(false);
       await expect(restart).rejects.toThrow();
     });
 
     it('should throw an error for an invalid id', async () => {
       handleRequest(defaultKernel, 200, {});
-      const restart = defaultKernel.restart();
+      const restart = defaultKernel.restart(false);
       await expect(restart).rejects.toThrow();
     });
 
@@ -690,7 +690,7 @@ describe('Kernel.IKernel', () => {
       await kernel.requestKernelInfo();
       const comm = kernel.createComm('test');
       const future = kernel.requestExecute({ code: 'foo' });
-      await kernel.restart();
+      await kernel.restart(false);
       await kernel.requestKernelInfo();
       expect(future.isDisposed).toBe(true);
       expect(comm.isDisposed).toBe(true);

--- a/packages/services/test/mock.spec.ts
+++ b/packages/services/test/mock.spec.ts
@@ -79,7 +79,7 @@ describe('mock', () => {
     describe('.restart()', () => {
       it('should be a no-op', async () => {
         const kernel = new Mock.KernelMock({});
-        await expect(kernel.restart()).resolves.not.toThrow();
+        await expect(kernel.restart(false)).resolves.not.toThrow();
       });
     });
 


### PR DESCRIPTION
## References

Jupyter Client implementation of https://github.com/jupyter/enhancement-proposals/issues/117

## Code changes

- Added new toolbar element for restart in place
- Changed restart function stack to pass in a boolean restart in place flag
- Edited the rest API caller to call a new restart-in-place endpoint on jupyter server

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

- Added a restart_in_place flag on restart functions in Session, Session Context, and KernelConnection that must be specified. Considering making this an optional parameter for backwards compatibility, but would hurt readability.