### PR TITLE
Use config compatible with notebook 7

### DIFF
--- a/jupyterlab/galata/__init__.py
+++ b/jupyterlab/galata/__init__.py
@@ -28,8 +28,8 @@ def configure_jupyter_server(c):
     # Add test helpers extension shipped with JupyterLab.
     # You can replace the following line by the two following one
     #   import jupyterlab
-    #   c.LabApp.extra_labextensions_path = str(Path(jupyterlab.__file__).parent / "galata")
-    c.LabApp.extra_labextensions_path = str(Path(__file__).parent)
+    #   c.LabServerApp.extra_labextensions_path = str(Path(jupyterlab.__file__).parent / "galata")
+    c.LabServerApp.extra_labextensions_path = str(Path(__file__).parent)
 
     c.ServerApp.root_dir = os.environ.get(
         "JUPYTERLAB_GALATA_ROOT_DIR", mkdtemp(prefix="galata-test-")


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Follow-up of https://github.com/jupyterlab-contrib/jupyter-archive/pull/118
Apply https://github.com/jupyter/notebook/blob/b5133c67f1a5c9c87d99abc44b7b04e6214aca45/ui-tests/test/jupyter_server_config.py#L18
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Use `LabServerApp.extra_labextensions_path` instead of `LabApp.extra_labextensions_path` in galata configuration to reduce customization needed for notebook 7

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None