### PR TITLE
Fix `filebrowser.open` and add ability to provide a factory

### DIFF
--- a/galata/src/helpers/activity.ts
+++ b/galata/src/helpers/activity.ts
@@ -67,8 +67,14 @@ export class ActivityHelper {
    * @param name Activity name
    * @returns Handle on the tab or null if the tab is not found
    */
-  getTab(name?: string): Promise<ElementHandle<Element> | null> {
-    return this.getTabLocator(name).elementHandle();
+  async getTab(name?: string): Promise<ElementHandle<Element> | null> {
+    let handle: ElementHandle<Element> | null = null;
+    try {
+      handle = await this.getTabLocator(name).elementHandle({ timeout: 500 });
+    } catch {
+      handle = null;
+    }
+    return handle;
   }
 
   /**
@@ -104,7 +110,14 @@ export class ActivityHelper {
       locator = page.getByRole('main').locator(`[role="tabpanel"][id="${id}"]`);
     }
 
-    return locator.elementHandle();
+    let handle: ElementHandle<Element> | null = null;
+    try {
+      handle = await locator.elementHandle({ timeout: 500 });
+    } catch {
+      handle = null;
+    }
+
+    return handle;
   }
 
   /**

--- a/galata/src/helpers/filebrowser.ts
+++ b/galata/src/helpers/filebrowser.ts
@@ -98,10 +98,11 @@ export class FileBrowserHelper {
    * Note: This will double click on the file;
    * an editor needs to be available for the given file type.
    *
-   * @param filePath Notebook path
+   * @param filePath File path
+   * @param factory Document factory to use
    * @returns Action success status
    */
-  async open(filePath: string): Promise<boolean> {
+  async open(filePath: string, factory?: string): Promise<boolean> {
     await this.revealFileInBrowser(filePath);
     const name = path.basename(filePath);
 
@@ -109,10 +110,28 @@ export class FileBrowserHelper {
       `xpath=${this.xpBuildFileSelector(name)}`
     );
     if (fileItem) {
-      await fileItem.click({ clickCount: 2 });
-      await this.page.getByRole('main').getByRole('tab', { name }).waitFor({
-        state: 'visible'
-      });
+      if (factory) {
+        await fileItem.click({ button: 'right' });
+        await this.page
+          .getByRole('listitem')
+          .filter({ hasText: 'Open With' })
+          .click();
+        await this.page
+          .getByRole('menuitem', { name: factory, exact: true })
+          .click();
+      } else {
+        await fileItem.dblclick();
+      }
+      // Use `last` as if a file is already open, it will simply be activated
+      // if not it will be opened with optionally another factory (but we don't have a way
+      // to know that from the DOM).
+      await this.page
+        .getByRole('main')
+        .getByRole('tab', { name })
+        .last()
+        .waitFor({
+          state: 'visible'
+        });
     } else {
       return false;
     }

--- a/galata/test/galata/filebrowser.spec.ts
+++ b/galata/test/galata/filebrowser.spec.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { expect, test } from '@jupyterlab/galata';
+
+const DEFAULT_NAME = 'Untitled.ipynb';
+
+test.describe('filebrowser helper', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.menu.clickMenuItem('File>New>Notebook');
+
+    await page
+      .locator('.jp-Dialog')
+      .getByRole('button', { name: 'Select Kernel', exact: true })
+      .click();
+
+    await page.activity.closeAll();
+  });
+
+  test('should open a file', async ({ page }) => {
+    await page.filebrowser.open(DEFAULT_NAME);
+
+    expect(await page.activity.isTabActive(DEFAULT_NAME)).toEqual(true);
+  });
+
+  test('should activate already opened file', async ({ page }) => {
+    await page.menu.clickMenuItem('File>New>Console');
+
+    await page
+      .locator('.jp-Dialog')
+      .getByRole('button', { name: 'Select Kernel', exact: true })
+      .click();
+
+    expect.soft(await page.activity.isTabActive(DEFAULT_NAME)).toEqual(false);
+    await page.filebrowser.open(DEFAULT_NAME);
+    expect(await page.activity.isTabActive(DEFAULT_NAME)).toEqual(true);
+  });
+
+  test('should open the file with another factory', async ({ page }) => {
+    await page.filebrowser.open(DEFAULT_NAME);
+
+    await page.filebrowser.open(DEFAULT_NAME, 'Editor');
+
+    await expect(
+      page.getByRole('main').getByRole('tab', { name: DEFAULT_NAME })
+    ).toHaveCount(2);
+  });
+});


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Follow up of #14945
Fixes #10969
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
- Add support to open a file with a specific factory
- More robust test of activity tab existence
- Add test for helper `filebrowser.open`

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None