### PR TITLE
updated link color

### DIFF
--- a/packages/ui-components/style/base.css
+++ b/packages/ui-components/style/base.css
@@ -28,13 +28,11 @@ body {
 
 /* Disable native link decoration styles everywhere outside of dialog boxes */
 a {
-  text-decoration: unset;
-  color: unset;
+  text-decoration: underline;
 }
 
 a:hover {
-  text-decoration: unset;
-  color: unset;
+  color: var(--jp-ui-font-color0);
 }
 
 /* Accessibility for links inside dialog box text */


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
 Issue : #14166
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Changed colour and text decoration of links - Base level

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
**Problem was with Link colour which was mentioned in #14166**

**Note: The Screenshot below is maybe from a older version. When i checked for the "Trust Notebook" widget, there was no link colour or styling on the link.**

**I'm not sure it may even break other parts of the code. If that happens, i'll sure look into it.**
Screenshot from issue : 

![](https://user-images.githubusercontent.com/26686070/224459732-6cfaa664-f188-432f-ba65-5eb4175bd62b.png)


Screenshot from current version:
![Screenshot 2023-08-20 at 9 15 25 PM](https://github.com/jupyterlab/jupyterlab/assets/78207450/646f15eb-329f-4087-85e4-21984c5484ef)


Screenshot after fixing styling : 

![Screenshot 2023-08-20 at 9 00 34 PM](https://github.com/jupyterlab/jupyterlab/assets/78207450/42b9ba1a-84d2-4c6f-8e4d-bc4333fb76d1)


<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

No Changes
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
