### PR TITLE
Add `| null` to the mermaid plugin activate parameter

### DIFF
--- a/packages/mermaid-extension/src/index.ts
+++ b/packages/mermaid-extension/src/index.ts
@@ -37,7 +37,7 @@ const core: JupyterFrontEndPlugin<IMermaidManager> = {
   autoStart: true,
   optional: [IThemeManager],
   provides: IMermaidManager,
-  activate: (app: JupyterFrontEnd, themes: IThemeManager) => {
+  activate: (app: JupyterFrontEnd, themes: IThemeManager | null) => {
     const manager = new MermaidManager({ themes });
     RenderedMermaid.manager = manager;
     return manager;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/14102#pullrequestreview-1591317605

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Define the `themes` parameter as `IThemeManager | null` since `IThemeManager` is optional.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
