### PR TITLE
fixes codemirror settings

### DIFF
--- a/packages/codemirror-extension/src/services.tsx
+++ b/packages/codemirror-extension/src/services.tsx
@@ -146,14 +146,11 @@ export const extensionPlugin: JupyterFrontEndPlugin<IEditorExtensionRegistry> =
               () => registry.settingsSchema,
               []
             ) as any;
-            const editorConfiguration =
-              (props.formContext.settings as ISettingRegistry.ISettings).id ===
-              SETTINGS_ID
-                ? registry.baseConfiguration
-                : registry.defaultConfiguration;
             const defaultFormData: Record<string, any> = {};
             // Only provide customizable options
-            for (const [key, value] of Object.entries(editorConfiguration)) {
+            for (const [key, value] of Object.entries(
+              registry.defaultConfiguration
+            )) {
               if (typeof properties[key] !== 'undefined') {
                 defaultFormData[key] = value;
               }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

#14637 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

The defaultFormData is updated to truly represent the defaults, where before if would take the current baseConfiguration as the default if possible

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

The user can now change two or more codemirror settings consistently and reliable 

https://github.com/jupyterlab/jupyterlab/assets/13774419/a91da208-a8fb-4bf7-b8a0-10a505e77a93

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None that I am aware.
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
