### PR TITLE
Pass completion context to `shouldShowContinuousHint()`

### DIFF
--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -296,9 +296,8 @@ export class CompletionHandler implements IDisposable {
     }
     if (
       this._autoCompletion &&
-      (this._reconciliator as IProviderReconciliator)
-        .shouldShowContinuousHint &&
-      (this._reconciliator as IProviderReconciliator).shouldShowContinuousHint(
+      this._reconciliator.shouldShowContinuousHint &&
+      this._reconciliator.shouldShowContinuousHint(
         this.completer.isVisible,
         changed
       )

--- a/packages/completer/src/reconciliator.ts
+++ b/packages/completer/src/reconciliator.ts
@@ -79,7 +79,8 @@ export class ProviderReconciliator implements IProviderReconciliator {
     if (this._providers[0].shouldShowContinuousHint) {
       return this._providers[0].shouldShowContinuousHint(
         completerIsVisible,
-        changed
+        changed,
+        this._context
       );
     }
     return this._defaultShouldShowContinuousHint(completerIsVisible, changed);

--- a/packages/metapackage/test/completer/reconciliator.spec.ts
+++ b/packages/metapackage/test/completer/reconciliator.spec.ts
@@ -213,7 +213,7 @@ describe('completer/reconciliator', () => {
         fooProvider2.shouldShowContinuousHint = jest.fn();
         const reconciliator = new ProviderReconciliator({
           ...defaultOptions,
-          providers: [fooProvider1, fooProvider1]
+          providers: [fooProvider1, fooProvider2]
         });
         reconciliator.shouldShowContinuousHint(true, null as any);
         expect(fooProvider1.shouldShowContinuousHint).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## References

Fixes #15014

## Code changes

- Passes `ICompletionContext` on the level of reconciliator to properly implement the public API:
  https://github.com/jupyterlab/jupyterlab/blob/ac8f9e2f47b271785127757541a6fd8aa10c4d31/packages/completer/src/tokens.ts#L129-L138
    Note: it is only optional above to avoid breaking changes in API, but really it should always be available.
- Fixes a typo in related test
- Removes spurious type cast in handler's  `onTextChanged()`

## User-facing changes

Extensions (LSP) will be able to access context of when determining whether to automatically show completer after user typing text, which is critical for LSP.

## Backwards-incompatible changes

None
