### PR TITLE
Expose `processedItemsCache` as a protected member

### DIFF
--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -114,7 +114,7 @@ export class CompleterModel implements Completer.IModel {
     const ending = original.text.substring(end);
     query = query.substring(0, query.lastIndexOf(ending));
     this._query = query;
-    this._processedItemsCache = null;
+    this.processedItemsCache = null;
     this._queryChanged.emit({ newValue: this._query, origin: 'editorUpdate' });
     this._stateChanged.emit(undefined);
   }
@@ -142,7 +142,7 @@ export class CompleterModel implements Completer.IModel {
   }
   set query(newValue: string) {
     this._query = newValue;
-    this._processedItemsCache = null;
+    this.processedItemsCache = null;
     this._queryChanged.emit({ newValue: this._query, origin: 'setter' });
   }
 
@@ -180,19 +180,21 @@ export class CompleterModel implements Completer.IModel {
    *
    * #### Notes
    * This is a read-only property.
+   * When overriding it is recommended to cache results in `processedItemsCache`
+   * property which will be automatically nullified when needed.
    */
   completionItems(): CompletionHandler.ICompletionItems {
-    if (!this._processedItemsCache) {
+    if (!this.processedItemsCache) {
       let query = this._query;
       if (query) {
-        this._processedItemsCache = this._markup(query);
+        this.processedItemsCache = this._markup(query);
       } else {
-        this._processedItemsCache = this._completionItems.map(item => {
+        this.processedItemsCache = this._completionItems.map(item => {
           return this._escapeItemLabel(item);
         });
       }
     }
-    return this._processedItemsCache;
+    return this.processedItemsCache;
   }
 
   /**
@@ -212,7 +214,7 @@ export class CompleterModel implements Completer.IModel {
     this._orderedTypes = Private.findOrderedCompletionItemTypes(
       this._completionItems
     );
-    this._processedItemsCache = null;
+    this.processedItemsCache = null;
     this._stateChanged.emit(undefined);
   }
 
@@ -486,7 +488,7 @@ export class CompleterModel implements Completer.IModel {
     this._completionItems = [];
     this._original = null;
     this._query = '';
-    this._processedItemsCache = null;
+    this.processedItemsCache = null;
     this._subsetMatch = false;
     this._typeMap = {};
     this._orderedTypes = [];
@@ -495,12 +497,12 @@ export class CompleterModel implements Completer.IModel {
     }
   }
 
+  protected processedItemsCache: CompletionHandler.ICompletionItems | null =
+    null;
   private _current: Completer.ITextState | null = null;
   private _cursor: Completer.ICursorSpan | null = null;
   private _isDisposed = false;
   private _completionItems: CompletionHandler.ICompletionItems = [];
-  private _processedItemsCache: CompletionHandler.ICompletionItems | null =
-    null;
   private _original: Completer.ITextState | null = null;
   private _query = '';
   private _subsetMatch = false;


### PR DESCRIPTION
## References

Follow-up to #13663

## Code changes

Exposes `processedItemsCache` as a protected member of the default `CompleterModel` to allow sub-classes to re-use it. This will allow the completer model in the LSP extension to benefit from caching.

Because `processedItemsCache` needs to be nullfied among others in private `_reset()` method (and cache invalidation is hard, especially in sub-classes because the parent class may change without it being visible in subclass code) it is preferable to expose this property rather than re-implement it downstream. An alternative solution would be exposing protected signals for cache invalidation but I don't think this is worth the overhead.

## User-facing changes

None

## Backwards-incompatible changes

None