### PR TITLE
Deprecate LSP adapter `getIndexAt()` method

### DIFF
--- a/packages/fileeditor/src/fileeditorlspadapter.ts
+++ b/packages/fileeditor/src/fileeditorlspadapter.ts
@@ -174,6 +174,7 @@ export class FileEditorAdapter extends WidgetLSPAdapter<
    * Get the index of editor from the cursor position in the virtual
    * document. Since there is only one editor, this method always return
    * 0
+   * @deprecated This is error-prone and will be removed in JupyterLab 5.0, use `getEditorIndex()` with `virtualDocument.getEditorAtVirtualLine(position)` instead.
    *
    * @param position - the position of cursor in the virtual document.
    * @return  {number} - index of the virtual editor

--- a/packages/lsp/src/adapters/adapter.ts
+++ b/packages/lsp/src/adapters/adapter.ts
@@ -339,8 +339,8 @@ export abstract class WidgetLSPAdapter<T extends IDocumentWidget>
 
   /**
    * Get the index of editor from the cursor position in the virtual
-   * document. Since there is only one editor, this method always return
-   * 0
+   * document.
+   * @deprecated This is error-prone and will be removed in JupyterLab 5.0, use `getEditorIndex()` with `virtualDocument.getEditorAtVirtualLine(position)` instead.
    *
    * @param position - the position of cursor in the virtual document.
    * @return - index of the virtual editor

--- a/packages/notebook/src/notebooklspadapter.ts
+++ b/packages/notebook/src/notebooklspadapter.ts
@@ -132,6 +132,7 @@ export class NotebookAdapter extends WidgetLSPAdapter<NotebookPanel> {
   /**
    * Get the index of editor from the cursor position in the virtual
    * document.
+   * @deprecated This is error-prone and will be removed in JupyterLab 5.0, use `getEditorIndex()` with `virtualDocument.getEditorAtVirtualLine(position)` instead.
    *
    * @param position - the position of cursor in the virtual document.
    */


### PR DESCRIPTION
## References

Relates to #15027

## Code changes

- Deprecates `getIndexAt()` method in the LSP adapter, with intent to remove in 5.0.
- Fixes wrongly copy-pasted doc fragment in the itnerface

## User-facing changes

None

## Backwards-incompatible changes

None