### PR TITLE
Fix Binder link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [![Gitter](https://img.shields.io/badge/social_chat-gitter-blue.svg)](https://gitter.im/jupyterlab/jupyterlab)
 [![Gitpod](https://img.shields.io/badge/gitpod_editor-open-blue.svg)](https://gitpod.io/#https://github.com/jupyterlab/jupyterlab)
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab/jupyterlab-demo/75ab1750f37b27db8e135c2c4f2139da6b641609?urlpath=lab/tree/demo)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab/jupyterlab-demo/HEAD?urlpath=lab/tree/demo)
 
 An extensible environment for interactive and reproducible computing, based on the
 Jupyter Notebook and Architecture.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

The previous link was pointing to an outdated version of JupyterLab (`3.2.9`):

![image](https://github.com/jupyterlab/jupyterlab/assets/591645/b9e3b751-598c-449d-bff4-452185ccd3fd)

## Code changes

`README.md` edit.

## User-facing changes

Point to the latest commit of https://github.com/jupyterlab/jupyterlab-demo:


![image](https://github.com/jupyterlab/jupyterlab/assets/591645/a77e0c55-dbcb-41dd-80a8-ca8d2474084a)

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
