### PR TITLE
Fix docs build on Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -20,6 +20,7 @@ tasks:
       export MAMBA_EXE=/workspace/bin/micromamba
       $(/workspace/bin/micromamba shell hook --shell=bash)
       export JUPYTER_PREFER_ENV_PATH=1
+      export TZ=UTC
       micromamba activate
       EOT
       source /workspace/bin/activate-env.sh


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

The docs build has been failing for a while on Gitpod with the following error:

```
ValueError: ZoneInfo keys may not be absolute paths, got: /UTC
```

![image](https://github.com/jupyterlab/jupyterlab/assets/591645/9c4113bd-8de3-4b65-a9c3-f805b74c40d6)


This seems to be related to https://github.com/nektos/act/issues/1853.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Apply the trick from https://github.com/nektos/act/issues/1853 to set `TZ=UTC`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
