### PR TITLE
Commit JS and Python packages in one commit on release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,7 +11,6 @@ on:
       steps_to_skip:
         description: "Comma separated list of steps to skip"
         required: false
-        default: "ensure-sha"
 
 jobs:
   publish_release:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -117,7 +117,7 @@ Fill in the information as mentioned in the body of the changelog PR, for exampl
 | ------------------------------------- | ---------- |
 | The target branch                     | main       |
 | The URL of the draft GitHub release   |            |
-| Comma separated list of steps to skip | ensure-sha |
+| Comma separated list of steps to skip |            |
 
 The "Publish Release" workflow:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -113,11 +113,11 @@ On the [Actions](https://github.com/jupyterlab/jupyterlab/actions) page, select 
 
 Fill in the information as mentioned in the body of the changelog PR, for example:
 
-| Input                                 | Value      |
-| ------------------------------------- | ---------- |
-| The target branch                     | main       |
-| The URL of the draft GitHub release   |            |
-| Comma separated list of steps to skip |            |
+| Input                                 | Value |
+| ------------------------------------- | ----- |
+| The target branch                     | main  |
+| The URL of the draft GitHub release   |       |
+| Comma separated list of steps to skip |       |
 
 The "Publish Release" workflow:
 

--- a/buildutils/src/bumpversion.ts
+++ b/buildutils/src/bumpversion.ts
@@ -80,7 +80,7 @@ commander
       lernaVersion += ' --preid=alpha';
     }
 
-    let cmd = `lerna version -m \"[ci skip] New version\" --force-publish=* --no-push ${lernaVersion}`;
+    let cmd = `lerna version --no-git-tag-version --force-publish=* --no-push ${lernaVersion}`;
     if (opts.force) {
       cmd += ' --yes';
     }

--- a/buildutils/src/bumpversion.ts
+++ b/buildutils/src/bumpversion.ts
@@ -6,8 +6,6 @@
 import { program as commander } from 'commander';
 import * as utils from './utils';
 
-const METAPACKAGE = '@jupyterlab/metapackage';
-
 // Specify the program signature.
 commander
   .description('Update the version and publish')
@@ -87,7 +85,7 @@ commander
       cmd += ' --yes';
     }
 
-    const oldVersion = utils.getJSVersion(METAPACKAGE);
+    const oldVersion = utils.getJSVersion('metapackage');
 
     // For a major release, we bump 10 minor versions so that we do
     // not conflict with versions during minor releases of the top
@@ -100,7 +98,7 @@ commander
       utils.run(cmd);
     }
 
-    const newVersion = utils.getJSVersion(METAPACKAGE);
+    const newVersion = utils.getJSVersion('metapackage');
     if (spec !== 'major' && oldVersion === newVersion) {
       // lerna didn't version anything, so we assume the user aborted
       throw new Error('Lerna aborted');

--- a/buildutils/src/bumpversion.ts
+++ b/buildutils/src/bumpversion.ts
@@ -84,14 +84,7 @@ commander
     if (opts.force) {
       cmd += ' --yes';
     }
-    const oldVersion = utils.run(
-      'git rev-parse HEAD',
-      {
-        stdio: 'pipe',
-        encoding: 'utf8'
-      },
-      true
-    );
+
     // For a major release, we bump 10 minor versions so that we do
     // not conflict with versions during minor releases of the top
     // level package.
@@ -101,19 +94,6 @@ commander
       }
     } else {
       utils.run(cmd);
-    }
-
-    const newVersion = utils.run(
-      'git rev-parse HEAD',
-      {
-        stdio: 'pipe',
-        encoding: 'utf8'
-      },
-      true
-    );
-    if (oldVersion === newVersion) {
-      // lerna didn't version anything, so we assume the user aborted
-      throw new Error('Lerna aborted');
     }
 
     // Bump the version.

--- a/buildutils/src/bumpversion.ts
+++ b/buildutils/src/bumpversion.ts
@@ -6,6 +6,8 @@
 import { program as commander } from 'commander';
 import * as utils from './utils';
 
+const METAPACKAGE = '@jupyterlab/metapackage';
+
 // Specify the program signature.
 commander
   .description('Update the version and publish')
@@ -85,6 +87,8 @@ commander
       cmd += ' --yes';
     }
 
+    const oldVersion = utils.getJSVersion(METAPACKAGE);
+
     // For a major release, we bump 10 minor versions so that we do
     // not conflict with versions during minor releases of the top
     // level package.
@@ -94,6 +98,12 @@ commander
       }
     } else {
       utils.run(cmd);
+    }
+
+    const newVersion = utils.getJSVersion(METAPACKAGE);
+    if (spec !== 'major' && oldVersion === newVersion) {
+      // lerna didn't version anything, so we assume the user aborted
+      throw new Error('Lerna aborted');
     }
 
     // Bump the version.

--- a/buildutils/src/bumpversion.ts
+++ b/buildutils/src/bumpversion.ts
@@ -58,7 +58,7 @@ commander
 
     // Handle dry runs.
     if (opts.dryRun) {
-      utils.run(`bumpversion --dry-run --verbose ${spec}`);
+      utils.run(`bumpversion --allow-dirty --dry-run --verbose ${spec}`);
       return;
     }
 
@@ -97,7 +97,7 @@ commander
     }
 
     // Bump the version.
-    utils.run(`bumpversion ${spec}`);
+    utils.run(`bumpversion --allow-dirty ${spec}`);
 
     // Run the post-bump script.
     utils.postbump(commit);

--- a/buildutils/src/patch-release.ts
+++ b/buildutils/src/patch-release.ts
@@ -36,28 +36,8 @@ commander
     if (options.force) {
       cmd += ' --yes';
     }
-    const oldVersion = utils.run(
-      'git rev-parse HEAD',
-      {
-        stdio: 'pipe',
-        encoding: 'utf8'
-      },
-      true
-    );
+
     utils.run(cmd);
-    const newVersion = utils.run(
-      'git rev-parse HEAD',
-      {
-        stdio: 'pipe',
-        encoding: 'utf8'
-      },
-      true
-    );
-    if (oldVersion === newVersion) {
-      console.debug('aborting');
-      // lerna didn't version anything, so we assume the user aborted
-      throw new Error('Lerna aborted');
-    }
 
     // Patch the python version
     utils.run('bumpversion patch'); // switches to alpha

--- a/buildutils/src/patch-release.ts
+++ b/buildutils/src/patch-release.ts
@@ -29,7 +29,7 @@ commander
     utils.prebump();
 
     // Version the changed
-    let cmd = `lerna version patch -m \"[ci skip] New version\" --no-push`;
+    let cmd = `lerna version patch --no-git-tag-version --no-push`;
     if (options.all) {
       cmd += ' --force-publish=*';
     }

--- a/buildutils/src/patch-release.ts
+++ b/buildutils/src/patch-release.ts
@@ -6,8 +6,6 @@
 import { program as commander } from 'commander';
 import * as utils from './utils';
 
-const METAPACKAGE = '@jupyterlab/metapackage';
-
 // Specify the program signature.
 commander
   .description('Create a patch release')
@@ -39,9 +37,9 @@ commander
       cmd += ' --yes';
     }
 
-    const oldVersion = utils.getJSVersion(METAPACKAGE);
+    const oldVersion = utils.getJSVersion('metapackage');
     utils.run(cmd);
-    const newVersion = utils.getJSVersion(METAPACKAGE);
+    const newVersion = utils.getJSVersion('metapackage');
 
     if (oldVersion === newVersion) {
       // lerna didn't version anything, so we assume the user aborted

--- a/buildutils/src/patch-release.ts
+++ b/buildutils/src/patch-release.ts
@@ -6,6 +6,8 @@
 import { program as commander } from 'commander';
 import * as utils from './utils';
 
+const METAPACKAGE = '@jupyterlab/metapackage';
+
 // Specify the program signature.
 commander
   .description('Create a patch release')
@@ -37,7 +39,14 @@ commander
       cmd += ' --yes';
     }
 
+    const oldVersion = utils.getJSVersion(METAPACKAGE);
     utils.run(cmd);
+    const newVersion = utils.getJSVersion(METAPACKAGE);
+
+    if (oldVersion === newVersion) {
+      // lerna didn't version anything, so we assume the user aborted
+      throw new Error('Lerna aborted');
+    }
 
     // Patch the python version
     utils.run('bumpversion patch --allow-dirty'); // switches to alpha

--- a/buildutils/src/patch-release.ts
+++ b/buildutils/src/patch-release.ts
@@ -40,7 +40,7 @@ commander
     utils.run(cmd);
 
     // Patch the python version
-    utils.run('bumpversion patch'); // switches to alpha
+    utils.run('bumpversion patch --allow-dirty'); // switches to alpha
     utils.run('bumpversion release --allow-dirty'); // switches to beta
     utils.run('bumpversion release --allow-dirty'); // switches to rc.
     utils.run('bumpversion release --allow-dirty'); // switches to final.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/13442

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Instead of creating 2 commits on release, 1 for bumping the JS packages, 1 for the Python package, commit everything in a single commit.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
