### PR TITLE
Disable language server auto-detection to speed up tests on CI

### DIFF
--- a/packages/testing/src/start_jupyter_server.ts
+++ b/packages/testing/src/start_jupyter_server.ts
@@ -273,6 +273,9 @@ namespace Private {
         },
         KernelManager: {
           shutdown_wait_time: 1.0
+        },
+        LanguageServerManager: {
+          autodetect: false
         }
       },
       options.configData || {}


### PR DESCRIPTION
## References

This was noted in https://github.com/jupyter/nbdime/pull/664#issuecomment-1702970927, let's see how much of a boost we can get on JupyterLab CI

## Code changes

Disables LSP server auto-detection for unrelated unit tests

## User-facing changes

None

## Backwards-incompatible changes

Downstream reusing server start script in tests and relying on LSP will need to adjust their config, but this is very hypothetical (even LSP extension does not do that).