### PR TITLE
Fix `_updateConstraints` missing `protected`/`private` classifier.

### DIFF
--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -72,7 +72,7 @@ export class Completer extends Widget {
   /**
    * Cache style constraints from CSS.
    */
-  _updateConstraints() {
+  protected _updateConstraints() {
     const tempNode = document.createElement('div');
     tempNode.classList.add(LIST_CLASS);
     tempNode.style.visibility = 'hidden';


### PR DESCRIPTION
## References

Follow up to #13663 

## Code changes

It was meant to be private - simple typo in a previous PR. To avoid breakages in case if anyone has adopted it in a subclass I am marking it as `protected`. If anyone was using it as a public method this was an error - it should not be used like that.

## User-facing changes

None

## Backwards-incompatible changes

See code changes.