### PR TITLE
License header job fix: ignore text files, update format

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -37,6 +37,7 @@ header:
     - 'jupyterlab/staging'
     - 'packages/codemirror/test/foo.grammar'
     - 'packages/extensionmanager-extension/examples/listings/settings/@jupyterlab/extensionmanager-extension/plugin.jupyterlab-settings'
+    - 'scripts/release_template.txt'
     - 'typedoc-theme'
     - 'LICENSE'
     - 'yarn.lock'

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -32,6 +32,7 @@ header:
     - 'dev_mode/style.js'
     - 'examples/federated/example.cert'
     - 'galata/test/jupyterlab/notebooks/'
+    - 'galata/test/*/*-snapshots/*.txt'
     - 'jupyterlab.desktop'
     - 'jupyterlab/staging'
     - 'packages/codemirror/test/foo.grammar'

--- a/examples/console/index.css
+++ b/examples/console/index.css
@@ -1,6 +1,5 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2016, Jupyter Development Team.
-|
+| Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 body {

--- a/galata/extension/src/global.ts
+++ b/galata/extension/src/global.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/ban-types */
 /*
  * Copyright (c) Jupyter Development Team.
- * Copyright (c) Bloomberg Finance LP.
  * Distributed under the terms of the Modified BSD License.
+ * Copyright (c) Bloomberg Finance LP.
  */
 
 import type { IRouter, JupyterFrontEnd } from '@jupyterlab/application';

--- a/galata/extension/src/global.ts
+++ b/galata/extension/src/global.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/ban-types */
-// Copyright (c) Jupyter Development Team.
-// Copyright (c) Bloomberg Finance LP.
-// Distributed under the terms of the Modified BSD License.
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Copyright (c) Bloomberg Finance LP.
+ * Distributed under the terms of the Modified BSD License.
+ */
 
 import type { IRouter, JupyterFrontEnd } from '@jupyterlab/application';
 import type {

--- a/galata/extension/src/tokens.ts
+++ b/galata/extension/src/tokens.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Jupyter Development Team.
- * Copyright (c) Bloomberg Finance LP.
  * Distributed under the terms of the Modified BSD License.
+ * Copyright (c) Bloomberg Finance LP.
  */
 
 import type { JupyterFrontEnd } from '@jupyterlab/application';

--- a/galata/extension/src/tokens.ts
+++ b/galata/extension/src/tokens.ts
@@ -1,6 +1,8 @@
-// Copyright (c) Jupyter Development Team.
-// Copyright (c) Bloomberg Finance LP.
-// Distributed under the terms of the Modified BSD License.
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Copyright (c) Bloomberg Finance LP.
+ * Distributed under the terms of the Modified BSD License.
+ */
 
 import type { JupyterFrontEnd } from '@jupyterlab/application';
 import type { IRouter } from '@jupyterlab/application';

--- a/galata/src/extension.ts
+++ b/galata/src/extension.ts
@@ -1,6 +1,8 @@
-// Copyright (c) Jupyter Development Team.
-// Copyright (c) Bloomberg Finance LP.
-// Distributed under the terms of the Modified BSD License.
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Copyright (c) Bloomberg Finance LP.
+ * Distributed under the terms of the Modified BSD License.
+ */
 
 // This export the types (and only the types) from extension/token.ts
 // Required for typedoc to be happy otherwise we could have used `from '@jupyterlab/extension/lib/token';`

--- a/galata/src/extension.ts
+++ b/galata/src/extension.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Jupyter Development Team.
- * Copyright (c) Bloomberg Finance LP.
  * Distributed under the terms of the Modified BSD License.
+ * Copyright (c) Bloomberg Finance LP.
  */
 
 // This export the types (and only the types) from extension/token.ts

--- a/galata/src/index.ts
+++ b/galata/src/index.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Jupyter Development Team.
- * Copyright (c) Bloomberg Finance LP.
  * Distributed under the terms of the Modified BSD License.
+ * Copyright (c) Bloomberg Finance LP.
  */
 /**
  * @packageDocumentation

--- a/galata/src/index.ts
+++ b/galata/src/index.ts
@@ -1,6 +1,8 @@
-// Copyright (c) Jupyter Development Team.
-// Copyright (c) Bloomberg Finance LP.
-// Distributed under the terms of the Modified BSD License.
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Copyright (c) Bloomberg Finance LP.
+ * Distributed under the terms of the Modified BSD License.
+ */
 /**
  * @packageDocumentation
  * @module galata

--- a/galata/test/galata/contents.spec.ts
+++ b/galata/test/galata/contents.spec.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Jupyter Development Team.
- * Copyright (c) Bloomberg Finance LP.
  * Distributed under the terms of the Modified BSD License.
+ * Copyright (c) Bloomberg Finance LP.
  */
 
 import * as path from 'path';

--- a/galata/test/galata/contents.spec.ts
+++ b/galata/test/galata/contents.spec.ts
@@ -1,6 +1,8 @@
-// Copyright (c) Jupyter Development Team.
-// Copyright (c) Bloomberg Finance LP.
-// Distributed under the terms of the Modified BSD License.
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Copyright (c) Bloomberg Finance LP.
+ * Distributed under the terms of the Modified BSD License.
+ */
 
 import * as path from 'path';
 

--- a/galata/test/galata/notebook.spec.ts
+++ b/galata/test/galata/notebook.spec.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Jupyter Development Team.
- * Copyright (c) Bloomberg Finance LP.
  * Distributed under the terms of the Modified BSD License.
+ * Copyright (c) Bloomberg Finance LP.
  */
 
 import * as path from 'path';

--- a/galata/test/galata/notebook.spec.ts
+++ b/galata/test/galata/notebook.spec.ts
@@ -1,6 +1,8 @@
-// Copyright (c) Jupyter Development Team.
-// Copyright (c) Bloomberg Finance LP.
-// Distributed under the terms of the Modified BSD License.
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Copyright (c) Bloomberg Finance LP.
+ * Distributed under the terms of the Modified BSD License.
+ */
 
 import * as path from 'path';
 

--- a/galata/test/galata/test.spec.ts
+++ b/galata/test/galata/test.spec.ts
@@ -1,6 +1,8 @@
-// Copyright (c) Jupyter Development Team.
-// Copyright (c) Bloomberg Finance LP.
-// Distributed under the terms of the Modified BSD License.
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Copyright (c) Bloomberg Finance LP.
+ * Distributed under the terms of the Modified BSD License.
+ */
 
 import { expect, test } from '@jupyterlab/galata';
 

--- a/galata/test/galata/test.spec.ts
+++ b/galata/test/galata/test.spec.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Jupyter Development Team.
- * Copyright (c) Bloomberg Finance LP.
  * Distributed under the terms of the Modified BSD License.
+ * Copyright (c) Bloomberg Finance LP.
  */
 
 import { expect, test } from '@jupyterlab/galata';

--- a/packages/apputils-extension/style/base.css
+++ b/packages/apputils-extension/style/base.css
@@ -1,6 +1,5 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2017, Jupyter Development Team.
-|
+| Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 

--- a/packages/apputils-extension/style/splash.css
+++ b/packages/apputils-extension/style/splash.css
@@ -1,6 +1,5 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2016, Jupyter Development Team.
-|
+| Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 

--- a/packages/apputils/style/base.css
+++ b/packages/apputils/style/base.css
@@ -1,6 +1,5 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2017, Jupyter Development Team.
-|
+| Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 

--- a/packages/apputils/style/dialog.css
+++ b/packages/apputils/style/dialog.css
@@ -1,6 +1,5 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2017, Jupyter Development Team.
-|
+| Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 

--- a/packages/apputils/style/mainareawidget.css
+++ b/packages/apputils/style/mainareawidget.css
@@ -1,6 +1,5 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2016, Jupyter Development Team.
-|
+| Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 

--- a/packages/codeeditor/style/base.css
+++ b/packages/codeeditor/style/base.css
@@ -1,6 +1,5 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2016, Jupyter Development Team.
-|
+| Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 @import url('./linecol.css');

--- a/packages/completer/style/base.css
+++ b/packages/completer/style/base.css
@@ -1,6 +1,5 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2016, Jupyter Development Team.
-|
+| Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 

--- a/packages/metadataform/style/base.css
+++ b/packages/metadataform/style/base.css
@@ -1,6 +1,5 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2019, Jupyter Development Team.
-|
+| Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 

--- a/packages/property-inspector/style/base.css
+++ b/packages/property-inspector/style/base.css
@@ -1,6 +1,5 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2019, Jupyter Development Team.
-|
+| Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 

--- a/packages/services/examples/node/index.js
+++ b/packages/services/examples/node/index.js
@@ -1,6 +1,5 @@
 /* -----------------------------------------------------------------------------
-| Copyright (c) 2014-2015, Jupyter Development Team.
-|
+| Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 'use strict';

--- a/packages/services/examples/typescript-browser-with-output/src/index.ts
+++ b/packages/services/examples/typescript-browser-with-output/src/index.ts
@@ -1,6 +1,5 @@
 /* -----------------------------------------------------------------------------
-| Copyright (c) 2014-2017, Jupyter Development Team.
-|
+| Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 /**

--- a/packages/ui-components/style/hoverbox.css
+++ b/packages/ui-components/style/hoverbox.css
@@ -1,6 +1,5 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2016, Jupyter Development Team.
-|
+| Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 

--- a/packages/ui-components/style/spinner.css
+++ b/packages/ui-components/style/spinner.css
@@ -1,6 +1,5 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2017, Jupyter Development Team.
-|
+| Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 

--- a/packages/ui-components/style/styling.css
+++ b/packages/ui-components/style/styling.css
@@ -1,6 +1,5 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2017, Jupyter Development Team.
-|
+| Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 

--- a/packages/ui-components/style/toolbar.css
+++ b/packages/ui-components/style/toolbar.css
@@ -1,6 +1,5 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2016, Jupyter Development Team.
-|
+| Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 

--- a/scripts/i18n_check.py
+++ b/scripts/i18n_check.py
@@ -1,5 +1,5 @@
 """Handle a hash digest of the translatable strings."""
-# Copyright (c) 2021 Jupyter Development Team.
+# Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
 from hashlib import sha256

--- a/scripts/milestone_check.py
+++ b/scripts/milestone_check.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Jupyter Development Team.
+# Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
 # Generate a GitHub token at https://github.com/settings/tokens


### PR DESCRIPTION
## References

Closes #15067

## Code changes

Ignores text files in galata snapshots (`txt` is no longer automatically ignored since https://github.com/apache/skywalking-eyes/pull/141).

## User-facing changes

None

## Backwards-incompatible changes

None