### PR TITLE
Pin skywalking-eyes to patched version detecting license headers after `|`

### DIFF
--- a/.github/workflows/license-header.yml
+++ b/.github/workflows/license-header.yml
@@ -26,7 +26,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fix License Header
-        uses: apache/skywalking-eyes/header@v0.5.0
+        # pin to include https://github.com/apache/skywalking-eyes/pull/168
+        uses: apache/skywalking-eyes/header@e19b828cea6a6027cceae78f05d81317347d21be
         with:
           mode: fix
 


### PR DESCRIPTION
## References

This should help with  https://github.com/jupyterlab/jupyterlab/issues/15067 and #15068

Note: the check is expected to keep failing; it will be fixed in #15068.

## Code changes

Pin to include fix from https://github.com/apache/skywalking-eyes/pull/168 as recommended in https://github.com/apache/skywalking/issues/11302#issuecomment-1705088577

## User-facing changes

None

## Backwards-incompatible changes

None