### PR TITLE
Check applicable provider in ProviderReconciliator

### DIFF
--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -283,7 +283,10 @@ export class CompletionHandler implements IDisposable {
   /**
    * Handle a text changed signal from an editor.
    */
-  protected onTextChanged(str: ISharedText, changed: SourceChange): void {
+  protected async onTextChanged(
+    str: ISharedText,
+    changed: SourceChange
+  ): Promise<void> {
     const model = this.completer.model;
     if (!model || !this._enabled) {
       return;
@@ -297,10 +300,10 @@ export class CompletionHandler implements IDisposable {
     if (
       this._autoCompletion &&
       this._reconciliator.shouldShowContinuousHint &&
-      this._reconciliator.shouldShowContinuousHint(
+      (await this._reconciliator.shouldShowContinuousHint(
         this.completer.isVisible,
         changed
-      )
+      ))
     ) {
       void this._makeRequest(
         editor.getCursorPosition(),

--- a/packages/completer/src/manager.ts
+++ b/packages/completer/src/manager.ts
@@ -207,11 +207,11 @@ export class CompletionProviderManager implements ICompletionProviderManager {
   private async generateReconciliator(
     completerContext: ICompletionContext
   ): Promise<ProviderReconciliator> {
-    let providers: Array<ICompletionProvider> = [];
+    const providers: Array<ICompletionProvider> = [];
     //TODO Update list with rank
     for (const id of this._activeProviders) {
       const provider = this._providers.get(id);
-      if (provider && (await provider.isApplicable(completerContext))) {
+      if (provider) {
         providers.push(provider);
       }
     }

--- a/packages/completer/src/reconciliator.ts
+++ b/packages/completer/src/reconciliator.ts
@@ -24,6 +24,11 @@ export class ProviderReconciliator implements IProviderReconciliator {
     this._timeout = options.timeout;
   }
 
+  /**
+   * Check for the providers which are applicable with the current context
+   *
+   * @return  List of applicable providers
+   */
   async applicableProviders(): Promise<Array<ICompletionProvider>> {
     const isApplicablePromises = this._providers.map(p =>
       p.isApplicable(this._context)
@@ -39,7 +44,7 @@ export class ProviderReconciliator implements IProviderReconciliator {
    *
    * @param {CompletionHandler.IRequest} request - The completion request.
    */
-  public async fetch(
+  async fetch(
     request: CompletionHandler.IRequest,
     trigger?: CompletionTriggerKind
   ): Promise<CompletionHandler.ICompletionItemsReply | null> {

--- a/packages/completer/src/reconciliator.ts
+++ b/packages/completer/src/reconciliator.ts
@@ -24,6 +24,14 @@ export class ProviderReconciliator implements IProviderReconciliator {
     this._timeout = options.timeout;
   }
 
+  async applicableProviders(): Promise<Array<ICompletionProvider>> {
+    const isApplicablePromises = this._providers.map(p =>
+      p.isApplicable(this._context)
+    );
+    const applicableProviders = await Promise.all(isApplicablePromises);
+    return this._providers.filter((_, idx) => applicableProviders[idx]);
+  }
+
   /**
    * Fetch response from multiple providers, If a provider can not return
    * the response for a completer request before timeout,
@@ -38,7 +46,8 @@ export class ProviderReconciliator implements IProviderReconciliator {
     const current = ++this._fetching;
     let promises: Promise<CompletionHandler.ICompletionItemsReply | null>[] =
       [];
-    for (const provider of this._providers) {
+    const applicableProviders = await this.applicableProviders();
+    for (const provider of applicableProviders) {
       let promise: Promise<CompletionHandler.ICompletionItemsReply | null>;
       promise = provider.fetch(request, this._context, trigger).then(reply => {
         if (current !== this._fetching) {
@@ -72,12 +81,16 @@ export class ProviderReconciliator implements IProviderReconciliator {
    * @param completerIsVisible - The visible status of completer widget.
    * @param changed - CodeMirror changed argument.
    */
-  public shouldShowContinuousHint(
+  async shouldShowContinuousHint(
     completerIsVisible: boolean,
     changed: SourceChange
-  ): boolean {
-    if (this._providers[0].shouldShowContinuousHint) {
-      return this._providers[0].shouldShowContinuousHint(
+  ): Promise<boolean> {
+    const applicableProviders = await this.applicableProviders();
+    if (applicableProviders.length === 0) {
+      return false;
+    }
+    if (applicableProviders[0].shouldShowContinuousHint) {
+      return applicableProviders[0].shouldShowContinuousHint(
         completerIsVisible,
         changed,
         this._context

--- a/packages/completer/src/reconciliator.ts
+++ b/packages/completer/src/reconciliator.ts
@@ -29,7 +29,7 @@ export class ProviderReconciliator implements IProviderReconciliator {
    *
    * @return  List of applicable providers
    */
-  async applicableProviders(): Promise<Array<ICompletionProvider>> {
+  protected async applicableProviders(): Promise<Array<ICompletionProvider>> {
     const isApplicablePromises = this._providers.map(p =>
       p.isApplicable(this._context)
     );

--- a/packages/completer/src/tokens.ts
+++ b/packages/completer/src/tokens.ts
@@ -206,5 +206,5 @@ export interface IProviderReconciliator {
   shouldShowContinuousHint(
     completerIsVisible: boolean,
     changed: SourceChange
-  ): boolean;
+  ): Promise<boolean>;
 }

--- a/packages/metapackage/test/completer/handler.spec.ts
+++ b/packages/metapackage/test/completer/handler.spec.ts
@@ -48,7 +48,7 @@ class TestCompletionHandler extends CompletionHandler {
   methods: string[] = [];
 
   async onTextChanged(str: ISharedText, changed: SourceChange): Promise<void> {
-    super.onTextChanged(str, changed);
+    void super.onTextChanged(str, changed);
     this.methods.push('onTextChanged');
   }
 
@@ -428,7 +428,7 @@ describe('@jupyterlab/completer', () => {
           } as SourceChange,
           context
         );
-        spy.mockClear();
+        spy.mockRestore();
       });
     });
 

--- a/packages/metapackage/test/completer/reconciliator.spec.ts
+++ b/packages/metapackage/test/completer/reconciliator.spec.ts
@@ -230,7 +230,7 @@ describe('completer/reconciliator', () => {
           ...defaultOptions,
           providers: [fooProvider1, fooProvider2]
         });
-        const applicableProvides = await reconciliator.applicableProviders();
+        const applicableProvides = await reconciliator['applicableProviders']();
         expect(spy1).toHaveBeenCalledTimes(1);
         expect(spy2).toHaveBeenCalledTimes(1);
         expect(applicableProvides).toEqual(

--- a/packages/metapackage/test/completer/reconciliator.spec.ts
+++ b/packages/metapackage/test/completer/reconciliator.spec.ts
@@ -220,5 +220,25 @@ describe('completer/reconciliator', () => {
         expect(fooProvider2.shouldShowContinuousHint).toHaveBeenCalledTimes(0);
       });
     });
+    describe('#applicableProviders()', () => {
+      it('should call `isApplicable` of all providers', async () => {
+        const fooProvider1 = new FooCompletionProvider();
+        const spy1 = jest.spyOn(fooProvider1, 'isApplicable');
+        const fooProvider2 = new FooCompletionProvider();
+        const spy2 = jest.spyOn(fooProvider2, 'isApplicable');
+        const reconciliator = new ProviderReconciliator({
+          ...defaultOptions,
+          providers: [fooProvider1, fooProvider2]
+        });
+        const applicableProvides = await reconciliator.applicableProviders();
+        expect(spy1).toHaveBeenCalledTimes(1);
+        expect(spy2).toHaveBeenCalledTimes(1);
+        expect(applicableProvides).toEqual(
+          expect.arrayContaining([fooProvider1, fooProvider2])
+        );
+        spy1.mockRestore();
+        spy2.mockRestore();
+      });
+    });
   });
 });

--- a/packages/metapackage/test/completer/reconciliator.spec.ts
+++ b/packages/metapackage/test/completer/reconciliator.spec.ts
@@ -103,7 +103,7 @@ describe('completer/reconciliator', () => {
           ...defaultOptions,
           providers: [fooProvider1, fooProvider2]
         });
-        void reconciliator.fetch({ offset: 0, text: '' });
+        await reconciliator.fetch({ offset: 0, text: '' });
         expect(fooProvider1.fetch).toHaveBeenCalled();
         expect(fooProvider2.fetch).toHaveBeenCalled();
       });
@@ -215,7 +215,7 @@ describe('completer/reconciliator', () => {
           ...defaultOptions,
           providers: [fooProvider1, fooProvider2]
         });
-        reconciliator.shouldShowContinuousHint(true, null as any);
+        await reconciliator.shouldShowContinuousHint(true, null as any);
         expect(fooProvider1.shouldShowContinuousHint).toHaveBeenCalledTimes(1);
         expect(fooProvider2.shouldShowContinuousHint).toHaveBeenCalledTimes(0);
       });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
Closes https://github.com/jupyterlab/jupyterlab/issues/15016
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- The list of applicable providers is checked on every `fetch` call instead of on the `ProviderReconciliator` creation time.

## User-facing changes

N/A

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

- `IProviderReconciliator` interface is changed, `shouldShowContinuousHint` returns `Promise<boolean>` instead of `boolean`