### PR TITLE
Remove `unusedDocuments`, fix culling of foreign documents

### DIFF
--- a/packages/lsp/src/virtual/document.ts
+++ b/packages/lsp/src/virtual/document.ts
@@ -806,14 +806,12 @@ export class VirtualDocument implements IDisposable {
     const usedDocuments = new Set<VirtualDocument>();
     for (const line of this.sourceLines.values()) {
       for (const block of line.foreignDocumentsMap.values()) {
-        usedDocuments.add(block.virtualDocument as VirtualDocument);
+        usedDocuments.add(block.virtualDocument);
       }
     }
 
     const documentIDs = new Map<VirtualDocument, string[]>();
-    for (const [id, document] of (
-      this.foreignDocuments as Map<string, VirtualDocument>
-    ).entries()) {
+    for (const [id, document] of this.foreignDocuments.entries()) {
       const ids = documentIDs.get(document);
       if (typeof ids !== 'undefined') {
         documentIDs.set(document, [...ids, id]);

--- a/packages/lsp/src/virtual/document.ts
+++ b/packages/lsp/src/virtual/document.ts
@@ -924,7 +924,7 @@ export class VirtualDocument implements IDisposable {
 
   /**
    * When this counter goes down to 0, the document will be destroyed and the associated connection will be closed;
-   * This is meant to reduce the number of open connections when a a foreign code snippet was removed from the document.
+   * This is meant to reduce the number of open connections when a foreign code snippet was removed from the document.
    *
    * Note: top level virtual documents are currently immortal (unless killed by other means); it might be worth
    * implementing culling of unused documents, but if and only if JupyterLab will also implement culling of

--- a/packages/lsp/src/virtual/document.ts
+++ b/packages/lsp/src/virtual/document.ts
@@ -241,7 +241,6 @@ export class VirtualDocument implements IDisposable {
     );
     this._remainingLifetime = 6;
 
-    this.unusedDocuments = new Set();
     this.documentInfo = new VirtualDocumentInfo(this);
     this.updateManager = new UpdateManager(this);
     this.updateManager.updateBegan.connect(this._updateBeganSlot, this);
@@ -446,7 +445,6 @@ export class VirtualDocument implements IDisposable {
 
     this.foreignDocuments.clear();
     this.sourceLines.clear();
-    this.unusedDocuments.clear();
     this.unusedStandaloneDocuments.clear();
     this.virtualLines.clear();
 
@@ -470,7 +468,6 @@ export class VirtualDocument implements IDisposable {
     // TODO - deep clear (assure that there is no memory leak)
     this.unusedStandaloneDocuments.clear();
 
-    this.unusedDocuments = new Set();
     this.virtualLines.clear();
     this.sourceLines.clear();
     this.lastVirtualLine = 0;
@@ -806,10 +803,36 @@ export class VirtualDocument implements IDisposable {
    * Close all expired documents.
    */
   closeExpiredDocuments(): void {
-    for (let document of this.unusedDocuments.values()) {
+    const usedDocuments = new Set<VirtualDocument>();
+    for (const line of this.sourceLines.values()) {
+      for (const block of line.foreignDocumentsMap.values()) {
+        usedDocuments.add(block.virtualDocument as VirtualDocument);
+      }
+    }
+
+    const documentIDs = new Map<VirtualDocument, string[]>();
+    for (const [id, document] of (
+      this.foreignDocuments as Map<string, VirtualDocument>
+    ).entries()) {
+      const ids = documentIDs.get(document);
+      if (typeof ids !== 'undefined') {
+        documentIDs.set(document, [...ids, id]);
+      }
+      documentIDs.set(document, [id]);
+    }
+    const allDocuments = new Set<VirtualDocument>(documentIDs.keys());
+    const unusedVirtualDocuments = new Set(
+      [...allDocuments].filter(x => !usedDocuments.has(x))
+    );
+
+    for (let document of unusedVirtualDocuments.values()) {
       document.remainingLifetime -= 1;
       if (document.remainingLifetime <= 0) {
         document.dispose();
+        const ids = documentIDs.get(document)!;
+        for (const id of ids) {
+          this.foreignDocuments.delete(id);
+        }
       }
     }
   }
@@ -927,7 +950,6 @@ export class VirtualDocument implements IDisposable {
   protected sourceLines: Map<number, ISourceLine>;
   protected lineBlocks: Array<string>;
 
-  protected unusedDocuments: Set<VirtualDocument>;
   protected unusedStandaloneDocuments: DefaultMap<
     language,
     Array<VirtualDocument>

--- a/packages/lsp/test/document.spec.ts
+++ b/packages/lsp/test/document.spec.ts
@@ -137,7 +137,6 @@ describe('@jupyterlab/lsp', () => {
         document.dispose();
         expect(document.foreignDocuments.size).toEqual(0);
         expect(document['sourceLines'].size).toEqual(0);
-        expect(document['unusedDocuments'].size).toEqual(0);
         expect(document['unusedStandaloneDocuments'].size).toEqual(0);
         expect(document['virtualLines'].size).toEqual(0);
       });

--- a/packages/lsp/test/document.spec.ts
+++ b/packages/lsp/test/document.spec.ts
@@ -238,6 +238,34 @@ describe('@jupyterlab/lsp', () => {
         expect(md.uri).toBe('test.ipynb.python-text.txt');
       });
     });
+    describe('#closeExpiredDocuments', () => {
+      it('should close expired foreign documents', async () => {
+        // We start with a notebook having a code cell, a raw cell and a markdown cell
+        // this means we have two foreign documents which can expire: one for markdown
+        // cell and one for raw cell.
+        expect(new Set(document.foreignDocuments.keys())).toEqual(
+          new Set(['text', 'markdown'])
+        );
+        const newNotebookState = [
+          {
+            value: 'test line in markdown 1\ntest line in markdown 2',
+            ceEditor: {} as Document.IEditor,
+            type: 'markdown'
+          }
+        ];
+        // If user just removed the last raw cell we do expire the virtual document
+        // associated immediately (because if they are just cutting and pasting
+        // cells we may be able to recycle connections). However if user keeps modifying
+        // the notebook, we ultimately discard the virtual document as expired.
+        for (let i = 0; i < 10; i++) {
+          await document.updateManager.updateDocuments(newNotebookState);
+          document.closeExpiredDocuments();
+        }
+        expect(new Set(document.foreignDocuments.keys())).toEqual(
+          new Set(['markdown'])
+        );
+      });
+    });
     describe('#openForeign', () => {
       it('should create a new foreign document', () => {
         const doc: VirtualDocument = document['openForeign'](


### PR DESCRIPTION
## References

Follow up to https://github.com/jupyterlab/jupyterlab/pull/12534
Developed in response to a failing test caught on https://github.com/jupyter-lsp/jupyterlab-lsp/pull/978

## Code changes

- The unused protected property `unusedDocuments` is removed (it was never written to since #12534, it was functioning properly with different logic in lsp extension)
- The logic to cull the unused foreign documents is re-implemented in `closeExpiredDocuments()` without need to keep state on the `VirtualDocument` instance

## User-facing changes

When user creates a markdown or raw cell and then deletes it (without other cells of this type present), the connection to LSP server is not held indefinitely but culled after six further document changes.

## Backwards-incompatible changes

Removal of the protected `unusedDocuments` method is notable but we are not advertising LSP as stable yet, and it would be useless in the current state anyways so it should be fine.