### PR TITLE
Fix documentation panel display logic of the completer

### DIFF
--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -403,11 +403,14 @@ export class CompleterModel implements Completer.IModel {
   }
 
   /**
-   * Lazy load missing data of item at `activeIndex`.
-   * @param {number} activeIndex - the item or its index
+   * Lazy load missing data of an item.
+   * @param indexOrValue - the item or its index
+   * @remarks
+   * Resolving item by index will be deprecated in
+   * the next major release.
+   *
    * @return Return `undefined` if the completion item with `activeIndex` index can not be found.
-   * Return a promise of `null` if another `resolveItem` is called (but still updates the
-   * underlying completion item with resolved data). Otherwise return the
+   *  Return a promise of `null` if another `resolveItem` is called. Otherwise return the
    * promise of resolved completion item.
    */
   resolveItem(
@@ -423,6 +426,12 @@ export class CompleterModel implements Completer.IModel {
     }
   }
 
+  /**
+   * Lazy load missing data of a completion item.
+   *
+   * @param  completionItem - the item to be resolved
+   * @return See `resolveItem` method
+   */
   private _resolveItemByValue(
     completionItem: CompletionHandler.ICompletionItem
   ): Promise<CompletionHandler.ICompletionItem | null> {
@@ -462,6 +471,14 @@ export class CompleterModel implements Completer.IModel {
         return Promise.resolve(completionItem);
       });
   }
+
+  /**
+   * Lazy load missing data of a completion item by its index.
+   *
+   * @param  activeIndex - the index of item in the completion items list.
+   * @deprecated
+   * @return See `resolveItem` method
+   */
   private _resolveItemByIndex(
     activeIndex: number
   ): Promise<CompletionHandler.ICompletionItem | null> | undefined {

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -115,6 +115,7 @@ export class CompleterModel implements Completer.IModel {
     query = query.substring(0, query.lastIndexOf(ending));
     this._query = query;
     this.processedItemsCache = null;
+    this._processedToOriginalItem = null;
     this._queryChanged.emit({ newValue: this._query, origin: 'editorUpdate' });
     this._stateChanged.emit(undefined);
   }
@@ -143,6 +144,7 @@ export class CompleterModel implements Completer.IModel {
   set query(newValue: string) {
     this._query = newValue;
     this.processedItemsCache = null;
+    this._processedToOriginalItem = null;
     this._queryChanged.emit({ newValue: this._query, origin: 'setter' });
   }
 
@@ -187,11 +189,16 @@ export class CompleterModel implements Completer.IModel {
     if (!this.processedItemsCache) {
       let query = this._query;
       if (query) {
-        this.processedItemsCache = this._markup(query);
+        const markedItems = this._markup(query);
+        this.processedItemsCache = markedItems.map(it => it.processedItem);
+        this._processedToOriginalItem = new WeakMap(
+          markedItems.map(it => [it.processedItem, it.originalItem])
+        );
       } else {
         this.processedItemsCache = this._completionItems.map(item => {
           return this._escapeItemLabel(item);
         });
+        this._processedToOriginalItem = null;
       }
     }
     return this.processedItemsCache;
@@ -215,6 +222,7 @@ export class CompleterModel implements Completer.IModel {
       this._completionItems
     );
     this.processedItemsCache = null;
+    this._processedToOriginalItem = null;
     this._stateChanged.emit(undefined);
   }
 
@@ -365,33 +373,41 @@ export class CompleterModel implements Completer.IModel {
    * Check if CompletionItem matches against query.
    * Highlight matching prefix by adding <mark> tags.
    */
-  private _markup(query: string): CompletionHandler.ICompletionItems {
+  private _markup(query: string): {
+    processedItem: CompletionHandler.ICompletionItem;
+    originalItem: CompletionHandler.ICompletionItem;
+  }[] {
     const items = this._completionItems;
     let results: Private.ICompletionMatch[] = [];
-    for (let item of items) {
+    for (const originalItem of items) {
       // See if label matches query string
       // With ICompletionItems, the label may include parameters,
       // so we exclude them from the matcher.
       // e.g. Given label `foo(b, a, r)` and query `bar`,
       // don't count parameters, `b`, `a`, and `r` as matches.
-      const index = item.label.indexOf('(');
-      const text = index > -1 ? item.label.substring(0, index) : item.label;
+      const index = originalItem.label.indexOf('(');
+      const text =
+        index > -1
+          ? originalItem.label.substring(0, index)
+          : originalItem.label;
       const match = StringExt.matchSumOfSquares(escapeHTML(text), query);
       // Filter non-matching items.
       if (match) {
         // Highlight label text if there's a match
         let marked = StringExt.highlight(
-          escapeHTML(item.label),
+          escapeHTML(originalItem.label),
           match.indices,
           Private.mark
         );
         // Use `Object.assign` to evaluate getters.
-        const highlightedItem = Object.assign({}, item);
+        const highlightedItem = Object.assign({}, originalItem);
         highlightedItem.label = marked.join('');
-        highlightedItem.insertText = item.insertText ?? item.label;
+        highlightedItem.insertText =
+          originalItem.insertText ?? originalItem.label;
         results.push({
           item: highlightedItem,
-          score: match.score
+          score: match.score,
+          originalItem
         });
       }
     }
@@ -399,7 +415,10 @@ export class CompleterModel implements Completer.IModel {
 
     // Extract only the item (dropping the extra score attribute to not leak
     // implementation details to JavaScript callers.
-    return results.map(match => match.item);
+    return results.map(match => ({
+      processedItem: match.item,
+      originalItem: match.originalItem
+    }));
   }
 
   /**
@@ -414,16 +433,33 @@ export class CompleterModel implements Completer.IModel {
    * promise of resolved completion item.
    */
   resolveItem(
-    indexOrValue: number | CompletionHandler.ICompletionItem | undefined
+    indexOrValue: number | CompletionHandler.ICompletionItem
   ): Promise<CompletionHandler.ICompletionItem | null> | undefined {
-    if (indexOrValue === undefined) {
-      return;
-    }
+    let processedItem: CompletionHandler.ICompletionItem | undefined;
+
     if (typeof indexOrValue === 'number') {
-      return this._resolveItemByIndex(indexOrValue);
+      const completionItems = this.completionItems();
+      if (!completionItems || !completionItems[indexOrValue]) {
+        return undefined;
+      }
+      processedItem = completionItems[indexOrValue];
     } else {
-      return this._resolveItemByValue(indexOrValue);
+      processedItem = indexOrValue;
     }
+    if (!processedItem) {
+      return undefined;
+    }
+
+    let originalItem: CompletionHandler.ICompletionItem | undefined;
+    if (this._processedToOriginalItem) {
+      originalItem = this._processedToOriginalItem.get(processedItem);
+    } else {
+      originalItem = processedItem;
+    }
+    if (!originalItem) {
+      return undefined;
+    }
+    return this._resolveItemByValue(originalItem);
   }
 
   /**
@@ -473,28 +509,6 @@ export class CompleterModel implements Completer.IModel {
   }
 
   /**
-   * Lazy load missing data of a completion item by its index.
-   *
-   * @param  activeIndex - the index of item in the completion items list.
-   * @deprecated
-   * @return See `resolveItem` method
-   */
-  private _resolveItemByIndex(
-    activeIndex: number
-  ): Promise<CompletionHandler.ICompletionItem | null> | undefined {
-    if (!this.completionItems) {
-      return undefined;
-    }
-
-    let completionItems = this.completionItems();
-    if (!completionItems || !completionItems[activeIndex]) {
-      return undefined;
-    }
-    let completionItem = completionItems[activeIndex];
-    return this._resolveItemByValue(completionItem);
-  }
-
-  /**
    * Escape item label, storing the original label and adding `insertText` if needed.
    * If escaping changes label creates a new item unless `inplace` is true.
    */
@@ -524,6 +538,7 @@ export class CompleterModel implements Completer.IModel {
     this._original = null;
     this._query = '';
     this.processedItemsCache = null;
+    this._processedToOriginalItem = null;
     this._subsetMatch = false;
     this._typeMap = {};
     this._orderedTypes = [];
@@ -545,6 +560,16 @@ export class CompleterModel implements Completer.IModel {
   private _orderedTypes: string[] = [];
   private _stateChanged = new Signal<this, void>(this);
   private _queryChanged = new Signal<this, Completer.IQueryChange>(this);
+
+  /**
+   * The weak map between a processed completion item with the original item.
+   * It's used to keep track of original completion item in case of displaying
+   * the completer with query.
+   */
+  private _processedToOriginalItem: WeakMap<
+    CompletionHandler.ICompletionItem,
+    CompletionHandler.ICompletionItem
+  > | null = null;
 
   /**
    * A counter to cancel ongoing `resolveItem` call.
@@ -612,6 +637,11 @@ namespace Private {
      * A lower score is better. Zero is the best possible score.
      */
     score: number;
+
+    /**
+     * The original completion item data.
+     */
+    originalItem: CompletionHandler.ICompletionItem;
   }
 
   /**

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -416,8 +416,8 @@ export class CompleterModel implements Completer.IModel {
   resolveItem(
     indexOrValue: number | CompletionHandler.ICompletionItem | undefined
   ): Promise<CompletionHandler.ICompletionItem | null> | undefined {
-    if (!indexOrValue) {
-      return undefined;
+    if (indexOrValue === undefined) {
+      return;
     }
     if (typeof indexOrValue === 'number') {
       return this._resolveItemByIndex(indexOrValue);

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -426,7 +426,7 @@ export class CompleterModel implements Completer.IModel {
    * @param indexOrValue - the item or its index
    * @remarks
    * Resolving item by index will be deprecated in
-   * the next major release.
+   * the JupyterLab 5.0 and removed in JupyterLab 6.0.
    *
    * @return Return `undefined` if the completion item with `activeIndex` index can not be found.
    *  Return a promise of `null` if another `resolveItem` is called. Otherwise return the

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -561,8 +561,10 @@ export class Completer extends Widget {
     this._indexChanged.emit(this._activeIndex);
     const visibleCompletionItems = this.model?.completionItems();
     const activeCompletionItem = visibleCompletionItems?.[this._activeIndex];
-    const resolvedItem = this.model?.resolveItem(activeCompletionItem);
-    this._updateDocPanel(resolvedItem);
+    if (activeCompletionItem) {
+      const resolvedItem = this.model?.resolveItem(activeCompletionItem);
+      this._updateDocPanel(resolvedItem);
+    }
   }
 
   /**
@@ -1042,7 +1044,7 @@ export namespace Completer {
      * promise of resolved completion item.
      */
     resolveItem(
-      activeIndex: number | CompletionHandler.ICompletionItem | undefined
+      activeIndex: number | CompletionHandler.ICompletionItem
     ): Promise<CompletionHandler.ICompletionItem | null> | undefined;
 
     /**
@@ -1224,9 +1226,7 @@ export namespace Completer {
      */
     itemWidthHeuristic(item: CompletionHandler.ICompletionItem): number {
       // Get the label text for both escaped and unescaped text.
-      const labelText = item.label
-        .replace(/<(\/)?mark>/g, '')
-        .replace(/&lt;(\/)?mark&gt;/g, '');
+      const labelText = item.label.replace(/<(\/)?mark>/g, '');
       return labelText.length + (item.type?.length || 0);
     }
 

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -560,12 +560,9 @@ export class Completer extends Widget {
     ElementExt.scrollIntoViewIfNeeded(completionList, active);
     this._indexChanged.emit(this._activeIndex);
     const visibleCompletionItems = this.model?.completionItems();
-
     const activeCompletionItem = visibleCompletionItems?.[this._activeIndex];
-    if (activeCompletionItem) {
-      const resolvedItem = this.model?.resolveItem(activeCompletionItem);
-      this._updateDocPanel(resolvedItem);
-    }
+    const resolvedItem = this.model?.resolveItem(activeCompletionItem);
+    this._updateDocPanel(resolvedItem);
   }
 
   /**
@@ -1045,7 +1042,7 @@ export namespace Completer {
      * promise of resolved completion item.
      */
     resolveItem(
-      activeIndex: number | CompletionHandler.ICompletionItem
+      activeIndex: number | CompletionHandler.ICompletionItem | undefined
     ): Promise<CompletionHandler.ICompletionItem | null> | undefined;
 
     /**
@@ -1226,9 +1223,11 @@ export namespace Completer {
      * Get a heuristic for the width of an item.
      */
     itemWidthHeuristic(item: CompletionHandler.ICompletionItem): number {
-      return (
-        item.label.replace(/<\?mark>/g, '').length + (item.type?.length || 0)
-      );
+      // Get the label text for both escaped and unescaped text.
+      const labelText = item.label
+        .replace(/<(\/)?mark>/g, '')
+        .replace(/&lt;(\/)?mark&gt;/g, '');
+      return labelText.length + (item.type?.length || 0);
     }
 
     /**

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -338,7 +338,6 @@ export class Completer extends Widget {
 
     let active = node.querySelectorAll(`.${ITEM_CLASS}`)[this._activeIndex];
     active.classList.add(ACTIVE_CLASS);
-
     // Add the documentation panel
     if (this._showDoc) {
       let docPanel = document.createElement('div');
@@ -347,7 +346,7 @@ export class Completer extends Widget {
       node.appendChild(docPanel);
       this._docPanelExpanded = false;
     }
-    const resolvedItem = this.model?.resolveItem(this._activeIndex);
+    const resolvedItem = this.model?.resolveItem(items[this._activeIndex]);
     this._updateDocPanel(resolvedItem);
 
     if (this.isHidden) {
@@ -560,9 +559,13 @@ export class Completer extends Widget {
     let completionList = this.node.querySelector(`.${LIST_CLASS}`) as Element;
     ElementExt.scrollIntoViewIfNeeded(completionList, active);
     this._indexChanged.emit(this._activeIndex);
+    const visibleCompletionItems = this.model?.completionItems();
 
-    const resolvedItem = this.model?.resolveItem(this._activeIndex);
-    this._updateDocPanel(resolvedItem);
+    const activeCompletionItem = visibleCompletionItems?.[this._activeIndex];
+    if (activeCompletionItem) {
+      const resolvedItem = this.model?.resolveItem(activeCompletionItem);
+      this._updateDocPanel(resolvedItem);
+    }
   }
 
   /**
@@ -1038,7 +1041,7 @@ export namespace Completer {
      * promise of resolved completion item.
      */
     resolveItem(
-      activeIndex: number
+      activeIndex: number | CompletionHandler.ICompletionItem
     ): Promise<CompletionHandler.ICompletionItem | null> | undefined;
 
     /**

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -1225,7 +1225,8 @@ export namespace Completer {
      * Get a heuristic for the width of an item.
      */
     itemWidthHeuristic(item: CompletionHandler.ICompletionItem): number {
-      // Get the label text for both escaped and unescaped text.
+      // Get the label text without HTML markup (`<mark>` is the only markup
+      // that is allowed in processed items, everything else gets escaped).
       const labelText = item.label.replace(/<(\/)?mark>/g, '');
       return labelText.length + (item.type?.length || 0);
     }

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -1034,8 +1034,12 @@ export namespace Completer {
     setCompletionItems(items: CompletionHandler.ICompletionItems): void;
 
     /**
-     * Lazy load missing data of item at `activeIndex`.
-     * @param {number} activeIndex - index of item
+     * Lazy load missing data of an item.
+     * @param indexOrValue - the item or its index
+     * @remarks
+     * Resolving item by index will be deprecated in
+     * the next major release.
+     *
      * @return Return `undefined` if the completion item with `activeIndex` index can not be found.
      *  Return a promise of `null` if another `resolveItem` is called. Otherwise return the
      * promise of resolved completion item.

--- a/packages/metapackage/test/completer/widget.spec.ts
+++ b/packages/metapackage/test/completer/widget.spec.ts
@@ -1278,6 +1278,33 @@ describe('completer/widget', () => {
         model.handleTextChange(current);
         expect(widget.sizeCache).toEqual(undefined);
       });
+
+      it('should update the documentation panel of selected item', async () => {
+        let args = '';
+        const spy = jest
+          .spyOn(widget as any, '_updateDocPanel')
+          .mockImplementation(async (item: any) => {
+            if (item) {
+              args = (await item).insertText;
+            }
+          });
+        const current: Completer.ITextState = {
+          ...position,
+          text: 'c13'
+        };
+        model.handleTextChange(current);
+
+        await new Promise(process.nextTick);
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(args).toEqual('candx 13');
+
+        // Cycle to the second item
+        widget['_cycle']('down');
+        await new Promise(process.nextTick);
+        expect(spy).toHaveBeenCalledTimes(2);
+        expect(args).toEqual('candidate 13');
+        spy.mockRestore();
+      });
     });
   });
 });

--- a/packages/metapackage/test/completer/widget.spec.ts
+++ b/packages/metapackage/test/completer/widget.spec.ts
@@ -1307,4 +1307,23 @@ describe('completer/widget', () => {
       });
     });
   });
+  describe('Completer.Renderer', () => {
+    describe('#itemWidthHeuristic()', () => {
+      let renderer: Completer.Renderer;
+      beforeEach(() => {
+        renderer = new Completer.Renderer();
+      });
+      it('returns a sum of characters in label and type info', () => {
+        let width = renderer.itemWidthHeuristic({
+          label: 'test',
+          type: 'variable'
+        });
+        expect(width).toBe(12);
+      });
+      it('disregards <mark> markup', () => {
+        let width = renderer.itemWidthHeuristic({ label: '<mark>test</mark>' });
+        expect(width).toBe(4);
+      });
+    });
+  });
 });

--- a/packages/metapackage/test/completer/widget.spec.ts
+++ b/packages/metapackage/test/completer/widget.spec.ts
@@ -1285,7 +1285,7 @@ describe('completer/widget', () => {
           .spyOn(widget as any, '_updateDocPanel')
           .mockImplementation(async (item: any) => {
             if (item) {
-              args = (await item).insertText;
+              args = (await item).label;
             }
           });
         const current: Completer.ITextState = {


### PR DESCRIPTION
## References
Closes https://github.com/jupyterlab/jupyterlab/issues/15018
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- `CompleterModel.resolveItem` now accepts both the completion item and its index but resolving by index will be deprecated in the future.
- Fix the Regex issue in the default `itemWidthHeuristic`

## User-facing changes

N/A

## Backwards-incompatible changes

The interface `Completer.IModel` has been changed but still is compatible with previous versions.
