### PR TITLE
Create dev environment with docker

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,12 +1,8 @@
 name: Docker Tests
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-  release:
-    types: [published]
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   docker:

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,0 +1,32 @@
+name: Docker Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  release:
+    types: [published]
+
+jobs:
+  docker:
+    name: Docker Dev Container
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build the image
+        run: |
+          bash ./docker/start.sh build
+          docker image ls 2>&1 | grep -ie "jupyterlab_dev" -
+
+      - name: Start the dev container
+        run: |
+          bash ./docker/start.sh dev-detach
+
+      - name: Wait for JupyterLab
+        uses: ifaxity/wait-on-action@v1
+        with:
+          resource: http-get://localhost:8888/
+          timeout: 360000

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 FROM mambaorg/micromamba:latest
 
 # Create new user

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,43 @@
+FROM mambaorg/micromamba:latest
+
+# Create new user
+ARG NEW_MAMBA_USER_ID=57440
+ARG NEW_MAMBA_USER_GID=57440
+ARG NEW_MAMBA_USER=labdev
+
+USER root
+
+RUN if grep -q '^ID=alpine$' /etc/os-release; then \
+      # alpine does not have usermod/groupmod
+      apk add --no-cache --virtual temp-packages shadow=4.13-r0; \
+    fi && \
+    usermod "--login=${NEW_MAMBA_USER}" "--home=/home/${NEW_MAMBA_USER}" \
+        --move-home "-u ${NEW_MAMBA_USER_ID}" "${MAMBA_USER}" && \
+    groupmod "--new-name=${NEW_MAMBA_USER}" \
+        "-g ${NEW_MAMBA_USER_GID}" "${MAMBA_USER}" && \
+    if grep -q '^ID=alpine$' /etc/os-release; then \
+      # remove the packages that were only needed for usermod/groupmod
+      apk del temp-packages; \
+    fi && \
+    # Update the expected value of MAMBA_USER for the
+    # _entrypoint.sh consistency check.
+    echo "${NEW_MAMBA_USER}" > "/etc/arg_mamba_user" && \
+    :
+ENV MAMBA_USER=$NEW_MAMBA_USER
+USER $MAMBA_USER
+
+
+WORKDIR /home/$MAMBA_USER/jupyterlab_cache
+COPY --chown=$MAMBA_USER:$MAMBA_USER .. .
+
+RUN  micromamba install -n base -c conda-forge git rsync -y && micromamba install -y -n base -f /home/$MAMBA_USER/jupyterlab_cache/binder/environment.yml && micromamba clean --all --yes
+
+RUN micromamba run jlpm install
+
+WORKDIR /home/$MAMBA_USER/jupyterlab
+
+RUN micromamba run rsync -ar /home/$MAMBA_USER/jupyterlab_cache/. /home/$MAMBA_USER/jupyterlab && micromamba run python -m pip install -e  ".[dev,docs,test]"
+
+EXPOSE 8888
+
+WORKDIR  /home/$MAMBA_USER/jupyterlab

--- a/docker/Dockerfile.dockerignore
+++ b/docker/Dockerfile.dockerignore
@@ -1,0 +1,39 @@
+.dockerignore
+Dockerfile
+
+# project files
+coverage/
+
+dev_mode/listings
+dev_mode/schemas
+dev_mode/static
+dev_mode/themes
+dev_mode/workspaces
+dev_mode/stats.json
+
+# Skip docs
+**/docs/source/_build
+
+
+junit.xml
+
+jupyterlab/geckodriver
+jupyterlab/static
+jupyterlab/schemas
+jupyterlab/themes
+jupyterlab/style.js
+jupyterlab/tests/**/static
+jupyterlab/tests/**/labextension
+
+# Remove after next release
+jupyterlab/imports.css
+
+packages/nbconvert-css/style/
+packages/services/examples/node/config.json
+packages/services/examples/browser/tmp
+packages/theme-*/static
+
+tests/**/coverage
+tests/**/.cache-loader
+
+**/node_modules

--- a/docker/Dockerfile.dockerignore
+++ b/docker/Dockerfile.dockerignore
@@ -1,3 +1,6 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 .dockerignore
 Dockerfile
 

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -29,35 +29,39 @@ IMAGE_TAG="jupyterlab_dev:$ROOT_DIR_MD5"
 DEV_CONTAINER="jupyterlab_dev_container_$ROOT_DIR_MD5"
 
 build_image () {
-  docker build  --build-arg NEW_MAMBA_USER_ID=$UID --build-arg NEW_MAMBA_USER_GID=$GID $ROOT_DIR -f $SCRIPT_DIR/Dockerfile -t $IMAGE_TAG
+    docker build  --build-arg NEW_MAMBA_USER_ID=$UID --build-arg NEW_MAMBA_USER_GID=$GID $ROOT_DIR -f $SCRIPT_DIR/Dockerfile -t $IMAGE_TAG
 }
 
 stop_contaniner () {
-  docker stop $DEV_CONTAINER &>/dev/null || true
+    docker stop $DEV_CONTAINER &>/dev/null || true
 }
 
 if [[ $CMD == 'build' ]]; then
-  echo "Building docker image"
-  build_image
-
-elif [[ $CMD == 'clean' ]]; then
-  # Stop the dev container if it's running
-  stop_contaniner
-  docker rmi $IMAGE_TAG --force
-
-elif [[ $CMD == 'stop' ]]; then
-  stop_contaniner
-
-elif [[ $CMD == 'dev' || $CMD == 'shell' || $CMD == '' ]]; then
-  if test -z "$(docker images -q $IMAGE_TAG)"; then
-    echo "Image does not exist, start building!"
+    echo "Building docker image"
     build_image
-  fi
+
+    elif [[ $CMD == 'clean' ]]; then
+    # Stop the dev container if it's running
     stop_contaniner
-    if [[ $CMD == 'dev' || $CMD == '' ]]; then
-      DOCKER_CMD="$RSYNC_CMD && jupyter lab --dev-mode --watch --ip 0.0.0.0"
-    else
-      DOCKER_CMD="$RSYNC_CMD && bash"
+    docker rmi $IMAGE_TAG --force
+
+    elif [[ $CMD == 'stop' ]]; then
+    stop_contaniner
+
+    elif [[ $CMD == 'dev' || $CMD == 'dev-detach' || $CMD == 'shell' || $CMD == '' ]]; then
+    if test -z "$(docker images -q $IMAGE_TAG)"; then
+        echo "Image does not exist, start building!"
+        build_image
     fi
-    docker run -it --name $DEV_CONTAINER --rm -p 8888:8888 -v $ROOT_DIR:/home/$DEV_USER/jupyterlab --entrypoint "/bin/bash" $IMAGE_TAG -i -c "$DOCKER_CMD"
+    stop_contaniner
+    if [[ $CMD == 'dev' || $CMD == '' || $CMD == 'dev-detach' ]]; then
+        DOCKER_CMD="$RSYNC_CMD && jupyter lab --dev-mode --watch --ip 0.0.0.0"
+    else
+        DOCKER_CMD="$RSYNC_CMD && bash"
+    fi
+    RUN_MODE="-it"
+    if [[ $CMD == 'dev-detach' ]]; then
+        RUN_MODE="-d"
+    fi
+    docker run $RUN_MODE --name $DEV_CONTAINER --rm -p 8888:8888 -v $ROOT_DIR:/home/$DEV_USER/jupyterlab --entrypoint "/bin/bash" $IMAGE_TAG -i -c "$DOCKER_CMD"
 fi

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+set -ex
+set -o pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT_DIR=$(dirname $SCRIPT_DIR)
+
+DEV_USER="labdev"
+GID=$(id -g)
+RSYNC_CMD="rsync -ar /home/$DEV_USER/jupyterlab_cache/node_modules/. /home/$DEV_USER/jupyterlab/node_modules"
+CMD=$1 # possible command: build, clean, dev, shell
+
+
+stringmd5() {
+    echo "md5sum,md5" | tr ',' '\n' | while read -r cmd; do
+        if [[ -x "$(command -v "${cmd}")" ]]; then
+            num=$(( 0x$(echo "$1" | command "${cmd}" | cut -d ' ' -f 1 | head -c 15) ))
+            [[ $num -lt 0 ]] && num=$((num * -1))
+            echo $num
+        fi
+    done
+}
+
+ROOT_DIR_MD5=$(stringmd5 $ROOT_DIR)
+IMAGE_TAG="jupyterlab_dev:$ROOT_DIR_MD5"
+DEV_CONTAINER="jupyterlab_dev_container_$ROOT_DIR_MD5"
+
+build_image () {
+  docker build  --build-arg NEW_MAMBA_USER_ID=$UID --build-arg NEW_MAMBA_USER_GID=$GID $ROOT_DIR -f $SCRIPT_DIR/Dockerfile -t $IMAGE_TAG
+}
+
+stop_contaniner () {
+  docker stop $DEV_CONTAINER &>/dev/null || true
+}
+
+if [[ $CMD == 'build' ]]; then
+  echo "Building docker image"
+  build_image
+
+elif [[ $CMD == 'clean' ]]; then
+  # Stop the dev container if it's running
+  stop_contaniner
+  docker rmi $IMAGE_TAG --force
+
+elif [[ $CMD == 'stop' ]]; then
+  stop_contaniner
+
+elif [[ $CMD == 'dev' || $CMD == 'shell' || $CMD == '' ]]; then
+  if test -z "$(docker images -q $IMAGE_TAG)"; then
+    echo "Image does not exist, start building!"
+    build_image
+  fi
+    stop_contaniner
+    if [[ $CMD == 'dev' || $CMD == '' ]]; then
+      DOCKER_CMD="$RSYNC_CMD && jupyter lab --dev-mode --watch --ip 0.0.0.0"
+    else
+      DOCKER_CMD="$RSYNC_CMD && bash"
+    fi
+    docker run -it --name $DEV_CONTAINER --rm -p 8888:8888 -v $ROOT_DIR:/home/$DEV_USER/jupyterlab --entrypoint "/bin/bash" $IMAGE_TAG -i -c "$DOCKER_CMD"
+fi

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -353,11 +353,53 @@ With Homebrew:
 Using automation to set up a local development environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-While there is a lot to learn by following the steps above, they can be automated to save time. This section shows how
-to do that using Vagrant as an example.
-
-The main advantages of using automation are: reduced time to get the environment up-and-running, reduced time to
+While there is a lot to learn by following the steps above, they can be automated to save time. The main advantages of using automation are: reduced time to get the environment up-and-running, reduced time to
 re-build the environment, better standardisation ("baseline", reproducible environments).
+This section shows how to do that using Docker and Vagrant.
+
+**Setup using Docker**
+""""""""""""""""""""""""
+
+To start a JupyterLab development container in a UNIX system with docker installed:
+
+1. Fork the JupyterLab `repository <https://github.com/jupyterlab/jupyterlab>`__.
+
+2. Start the container:
+
+.. code:: bash
+
+   git clone https://github.com/<your-github-username>/jupyterlab.git
+   cd jupyterlab
+   bash docker/start.sh
+
+The above command will build the docker image if it does not exist, then start the container with JupyterLab running in watch mode. The port 8888 is exposed and the current JupyterLab repo is mounted into the container. Then you can start developing JupyterLab with your favorite IDE, JupyterLab will be rebuilt on the fly.
+
+Other available commands:
+
+.. code:: bash
+
+   bash docker/start.sh dev  # Same as calling bash docker/start.sh
+   bash docker/start.sh stop  # Stop the running container
+   bash docker/start.sh clean  # Remove the docker image
+   bash docker/start.sh build  # Rebuild the docker image
+
+   # Log into the container's shell with the JupyterLab environment activated.
+   # It's useful to run the tests or install dependencies.
+   bash docker/start.sh shell
+
+To add TypeScript dependencies to the project, you need to log into the container's shell, install the dependencies to update the package.json and yarn.lock files, and then rebuild the docker image.
+
+.. code:: bash
+
+   bash docker/start.sh shell
+   # In the container shell
+   jlpm add ...
+   exit
+   # Back to host shell
+   bash docker/start.sh build
+
+**Setup using Vagrant**
+""""""""""""""""""""""""""""
 
 A practical example can be found `there <https://github.com/markgreene74/jupyterlab-local-dev-with-vagrant>`_ and
 includes a ``Vagrantfile``, the bootstrap files and additional documentation.


### PR DESCRIPTION
## References

Similar to the `gitpod` setup, but for people who prefer to work offline.
To start a JupyterLab dev container on a UNIX system with docker installed:
```bash
bash docker/start.sh
````
This command will build the docker image if it does not exist, then start the container with JupyterLab running in watch mode. The port `8888` is exposed and the current JupyterLab repo is mounted into the container.

Other available commands:

- `bash docker/start.sh dev`: same as calling `bash docker/start.sh`
- `bash docker/start.sh stop`: stop the running container
- `bash docker/start.sh clean`: remove the docker image
- `bash docker/start.sh build`: rebuild the docker image
- `bash docker/start.sh shell`: log into the container's shell with the JupyterLab environment activated. It's useful to run the tests or install dependencies. 

##  How it works

To avoid polluting the `node_module` directory with packages coming from the host machine while still preserving the hot-reload capability, the js dependencies in the container are actually stored in the `/home/$DEV_USER/jupyterlab_cache/node_modules/` while the working directory is mounted to `/home/$DEV_USER/jupyterlab`. On container startup,  the `node_modules` at `jupyterlab_cache` is `rsync-ed` back to the host.

Since the image and container name contain the hash of the current JupyterLab directory, two clones of JupyterLab will generate different images.

## How to add dependencies 

Due to the above setup, the easiest way to add new dependencies is to log into the container's shell, install the dependencies to update the `package.json` and `yarn.lock` files, and then rebuild the docker image.

```bash
bash docker/start.sh shell
# In the container shell
jlpm add ...
exit
# back to host shell
bash docker/start.sh build
```