### PR TITLE
Add a valid email in update extension

### DIFF
--- a/jupyterlab/upgrade_extension.py
+++ b/jupyterlab/upgrade_extension.py
@@ -116,7 +116,7 @@ def update_extension(  # noqa
 
     # Build up the template answers and run the template engine
     author = data.get("author", "<author_name>")
-    author_email = "author_email@jupyter.com"
+    author_email = ""
     if isinstance(author, dict):
         author_name = author.get("name", "<author_name>")
         author_email = author.get("email", author_email)


### PR DESCRIPTION
This PR fixes the *usage* test, which currently fails while upgrading the mock extension.

## References

Probably since https://github.com/jupyterlab/extension-template/pull/43, which requires a valid email pattern.

Error: https://github.com/jupyterlab/jupyterlab/actions/runs/6221683949/job/16884129806

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None