### PR TITLE
Remove pre-commit job

### DIFF
--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -147,14 +147,3 @@ jobs:
         with:
           ignore_glob: "packages/ui-components/docs/source/ui_components.rst images"
           ignore_links: "../api/*.* .*/images/[\\w-]+.png https://docs.github.com/en/.* https://blog.jupyter.org/jupyterlab-is-ready-for-users-5a6f039b8906 https://jupyterlab.github.io https://registry.npmjs.org/.* https://mybinder.org/v2/gh/jupyterlab/.*"
-
-  pre-commit:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v2
-      - name: Base Setup
-        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - name: Install Jupyterlab
-        run: pip install -e .
-      - uses: pre-commit/action@v2.0.0


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Follow-up of https://github.com/jupyterlab/jupyterlab/pull/15122
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Remove pre-commit job as done in https://github.com/jupyterlab/jupyterlab/pull/13562 for 4.x

That step is not reliable and it is duplicating the job using the pre-commit app.