### PR TITLE
Experimental inline completer

### DIFF
--- a/packages/completer-extension/package.json
+++ b/packages/completer-extension/package.json
@@ -43,6 +43,7 @@
     "@jupyterlab/settingregistry": "^4.1.0-alpha.1",
     "@jupyterlab/translation": "^4.1.0-alpha.1",
     "@jupyterlab/ui-components": "^4.1.0-alpha.1",
+    "@lumino/commands": "^2.1.3",
     "@lumino/coreutils": "^2.1.2",
     "@rjsf/utils": "^5.1.0",
     "react": "^18.2.0"

--- a/packages/completer-extension/package.json
+++ b/packages/completer-extension/package.json
@@ -41,6 +41,7 @@
     "@jupyterlab/application": "^4.1.0-alpha.1",
     "@jupyterlab/completer": "^4.1.0-alpha.1",
     "@jupyterlab/settingregistry": "^4.1.0-alpha.1",
+    "@jupyterlab/translation": "^4.1.0-alpha.1",
     "@jupyterlab/ui-components": "^4.1.0-alpha.1",
     "@lumino/coreutils": "^2.1.2",
     "@rjsf/utils": "^5.1.0",

--- a/packages/completer-extension/schema/inline-completer.json
+++ b/packages/completer-extension/schema/inline-completer.json
@@ -16,6 +16,11 @@
       "command": "inline-completer:accept",
       "keys": ["Alt", "End"],
       "selector": ".jp-mod-completer-enabled"
+    },
+    {
+      "command": "inline-completer:invoke",
+      "keys": ["Alt", "\\"],
+      "selector": ".jp-mod-completer-enabled"
     }
   ],
   "properties": {},

--- a/packages/completer-extension/schema/inline-completer.json
+++ b/packages/completer-extension/schema/inline-completer.json
@@ -1,0 +1,24 @@
+{
+  "title": "Inline Completer",
+  "description": "Inline completer settings.",
+  "jupyter.lab.shortcuts": [
+    {
+      "command": "inline-completer:next",
+      "keys": ["Alt", "]"],
+      "selector": ".jp-mod-completer-enabled"
+    },
+    {
+      "command": "inline-completer:previous",
+      "keys": ["Alt", "["],
+      "selector": ".jp-mod-completer-enabled"
+    },
+    {
+      "command": "inline-completer:accept",
+      "keys": ["Alt", "End"],
+      "selector": ".jp-mod-completer-enabled"
+    }
+  ],
+  "properties": {},
+  "additionalProperties": false,
+  "type": "object"
+}

--- a/packages/completer-extension/src/index.ts
+++ b/packages/completer-extension/src/index.ts
@@ -12,6 +12,7 @@ import {
 import {
   CompletionProviderManager,
   ContextCompleterProvider,
+  HistoryInlineCompletionProvider,
   ICompletionProviderManager,
   KernelCompleterProvider
 } from '@jupyterlab/completer';
@@ -21,12 +22,13 @@ import {
   IFormRendererRegistry
 } from '@jupyterlab/ui-components';
 import type { FieldProps } from '@rjsf/utils';
+import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 
 import { renderAvailableProviders } from './renderer';
 
 const COMPLETION_MANAGER_PLUGIN = '@jupyterlab/completer-extension:manager';
 
-const defaultProvider: JupyterFrontEndPlugin<void> = {
+const defaultProviders: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/completer-extension:base-service',
   description: 'Adds context and kernel completion providers.',
   requires: [ICompletionProviderManager],
@@ -37,6 +39,26 @@ const defaultProvider: JupyterFrontEndPlugin<void> = {
   ): void => {
     completionManager.registerProvider(new ContextCompleterProvider());
     completionManager.registerProvider(new KernelCompleterProvider());
+  }
+};
+
+const inlineHistoryProvider: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlab/completer-extension:inline-history',
+  description:
+    'Adds inline completion provider suggesting code from execution history.',
+  requires: [ICompletionProviderManager],
+  optional: [ITranslator],
+  autoStart: true,
+  activate: (
+    app: JupyterFrontEnd,
+    completionManager: ICompletionProviderManager,
+    translator: ITranslator | null
+  ): void => {
+    completionManager.registerInlineProvider(
+      new HistoryInlineCompletionProvider({
+        translator: translator ?? nullTranslator
+      })
+    );
   }
 };
 
@@ -124,5 +146,9 @@ const manager: JupyterFrontEndPlugin<ICompletionProviderManager> = {
 /**
  * Export the plugins as default.
  */
-const plugins: JupyterFrontEndPlugin<any>[] = [manager, defaultProvider];
+const plugins: JupyterFrontEndPlugin<any>[] = [
+  manager,
+  defaultProviders,
+  inlineHistoryProvider
+];
 export default plugins;

--- a/packages/completer-extension/src/index.ts
+++ b/packages/completer-extension/src/index.ts
@@ -39,6 +39,7 @@ namespace CommandIDs {
   export const nextInline = 'inline-completer:next';
   export const previousInline = 'inline-completer:previous';
   export const acceptInline = 'inline-completer:accept';
+  export const invokeInline = 'inline-completer:invoke';
 }
 
 const defaultProviders: JupyterFrontEndPlugin<void> = {
@@ -145,27 +146,34 @@ const inlineCompleterCommands: JupyterFrontEndPlugin<void> = {
     translator: ITranslator | null
   ): void => {
     const trans = (translator || nullTranslator).load('jupyterlab');
+    const isEnabled = () => !!app.shell.currentWidget;
     app.commands.addCommand(CommandIDs.nextInline, {
       execute: () => {
         completionManager.cycleInline(app.shell.currentWidget!.id!, 'next');
       },
       label: trans.__('Next Inline Completion'),
-      isEnabled: () => !!app.shell.currentWidget
+      isEnabled
     });
     app.commands.addCommand(CommandIDs.previousInline, {
       execute: () => {
         completionManager.cycleInline(app.shell.currentWidget!.id!, 'previous');
       },
       label: trans.__('Previous Inline Completion'),
-      isEnabled: () => !!app.shell.currentWidget
+      isEnabled
     });
     app.commands.addCommand(CommandIDs.acceptInline, {
       execute: () => {
-        // TODO
-        completionManager.cycleInline(app.shell.currentWidget!.id!, 'previous');
+        completionManager.acceptInline(app.shell.currentWidget!.id!);
       },
       label: trans.__('Accept Inline Completion'),
-      isEnabled: () => !!app.shell.currentWidget
+      isEnabled
+    });
+    app.commands.addCommand(CommandIDs.invokeInline, {
+      execute: () => {
+        completionManager.invokeInline(app.shell.currentWidget!.id!);
+      },
+      label: trans.__('Invoke Inline Completer'),
+      isEnabled
     });
   }
 };

--- a/packages/completer-extension/tsconfig.json
+++ b/packages/completer-extension/tsconfig.json
@@ -17,6 +17,9 @@
     },
     {
       "path": "../ui-components"
+    },
+    {
+      "path": "../translation"
     }
   ]
 }

--- a/packages/completer-extension/tsconfig.json
+++ b/packages/completer-extension/tsconfig.json
@@ -16,10 +16,10 @@
       "path": "../settingregistry"
     },
     {
-      "path": "../ui-components"
+      "path": "../translation"
     },
     {
-      "path": "../translation"
+      "path": "../ui-components"
     }
   ]
 }

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -45,13 +45,17 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
+    "@codemirror/state": "^6.2.0",
+    "@codemirror/view": "^6.9.6",
     "@jupyter/ydoc": "^1.0.2",
     "@jupyterlab/apputils": "^4.2.0-alpha.1",
     "@jupyterlab/codeeditor": "^4.1.0-alpha.1",
+    "@jupyterlab/codemirror": "^4.1.0-alpha.1",
     "@jupyterlab/coreutils": "^6.1.0-alpha.1",
     "@jupyterlab/rendermime": "^4.1.0-alpha.1",
     "@jupyterlab/services": "^7.1.0-alpha.1",
     "@jupyterlab/statedb": "^4.1.0-alpha.1",
+    "@jupyterlab/translation": "^4.1.0-alpha.1",
     "@jupyterlab/ui-components": "^4.1.0-alpha.1",
     "@lumino/algorithm": "^2.0.1",
     "@lumino/coreutils": "^2.1.2",

--- a/packages/completer/src/default/inlinehistoryprovider.ts
+++ b/packages/completer/src/default/inlinehistoryprovider.ts
@@ -1,0 +1,87 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+import type {
+  IInlineCompletionContext,
+  IInlineCompletionProvider,
+  InlineCompletionTriggerKind
+} from '../tokens';
+import type { CompletionHandler } from '../handler';
+import { KernelMessage } from '@jupyterlab/services';
+import {
+  ITranslator,
+  nullTranslator,
+  TranslationBundle
+} from '@jupyterlab/translation';
+
+/**
+ * An example inline completion provider using history to populate suggestions.
+ */
+export class HistoryInlineCompletionProvider
+  implements IInlineCompletionProvider
+{
+  identifier = 'history';
+
+  constructor(protected options: HistoryInlineCompletionProvider.IOptions) {
+    const translator = options.translator || nullTranslator;
+    this._trans = translator.load('jupyterlab');
+  }
+
+  get name(): string {
+    return this._trans.__('History');
+  }
+  async fetch(
+    request: CompletionHandler.IRequest,
+    context: IInlineCompletionContext,
+    trigger?: InlineCompletionTriggerKind
+  ) {
+    const kernel = context.session?.kernel;
+
+    if (!kernel) {
+      throw new Error('No kernel for completion request.');
+    }
+
+    const historyRequest: KernelMessage.IHistoryRequestMsg['content'] = {
+      output: false,
+      raw: true,
+      hist_access_type: 'tail',
+      n: 500
+    };
+
+    // TODO: cache results
+    const reply = await kernel.requestHistory(historyRequest);
+
+    const items = [];
+    const multiLinePrefix = request.text.slice(0, request.offset);
+    const linePrefix = multiLinePrefix.split('\n').slice(-1)[0];
+    if (linePrefix === '') {
+      return { items: [] };
+    }
+    if (reply.content.status === 'ok') {
+      for (const entry of reply.content.history) {
+        const sourceLines = (entry[2] as string).split('\n');
+        for (let i = 0; i < sourceLines.length; i++) {
+          const line = sourceLines[i];
+          if (line.startsWith(linePrefix)) {
+            const followingLines =
+              line.slice(linePrefix.length, line.length) +
+              '\n' +
+              sourceLines.slice(i + 1).join('\n');
+            items.push({
+              insertText: followingLines
+            });
+          }
+        }
+      }
+    }
+
+    return { items };
+  }
+
+  private _trans: TranslationBundle;
+}
+
+export namespace HistoryInlineCompletionProvider {
+  export interface IOptions {
+    translator?: ITranslator;
+  }
+}

--- a/packages/completer/src/index.ts
+++ b/packages/completer/src/index.ts
@@ -11,5 +11,7 @@ export * from './widget';
 export * from './tokens';
 export * from './manager';
 export * from './reconciliator';
+//export * from './inline';
 export * from './default/contextprovider';
 export * from './default/kernelprovider';
+export * from './default/inlinehistoryprovider';

--- a/packages/completer/src/index.ts
+++ b/packages/completer/src/index.ts
@@ -11,7 +11,7 @@ export * from './widget';
 export * from './tokens';
 export * from './manager';
 export * from './reconciliator';
-//export * from './inline';
+export * from './inline';
 export * from './default/contextprovider';
 export * from './default/kernelprovider';
 export * from './default/inlinehistoryprovider';

--- a/packages/completer/src/inline.ts
+++ b/packages/completer/src/inline.ts
@@ -1,0 +1,348 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { CodeEditor } from '@jupyterlab/codeeditor';
+import { Widget } from '@lumino/widgets';
+import { CompletionHandler } from './handler';
+import { HoverBox } from '@jupyterlab/ui-components';
+import { IDisposable } from '@lumino/disposable';
+import { ISignal, Signal } from '@lumino/signaling';
+import { Message } from '@lumino/messaging';
+import { CodeMirrorEditor } from '@jupyterlab/codemirror';
+
+import {
+  Decoration,
+  DecorationSet,
+  EditorView,
+  WidgetType
+} from '@codemirror/view';
+import { StateEffect, StateField } from '@codemirror/state';
+/**
+ * Widget allowing user to choose among inline completions,
+ * typically by pressing next/previous buttons, and showing
+ * additional metadata about active completion, such as
+ * inline completion provider name.
+ */
+export class InlineCompleter extends Widget {
+  // TODO populate this with next/previous buttons, maybe create extension point to add custom buttons (per provider?)
+  // TODO: filtering or rejecting on text change, accepting via key press
+  constructor(options: InlineCompleter.IOptions) {
+    super({ node: document.createElement('div') });
+    this.model = options.model ?? null;
+    this.editor = options.editor ?? null;
+    this.addClass('jp-InlineCompleter');
+    this._ghostManager = createGhostManager();
+  }
+  private _ghostManager: IGhostTextManager;
+
+  /**
+   * The editor used by the completion widget.
+   */
+  get editor(): CodeEditor.IEditor | null | undefined {
+    return this._editor;
+  }
+  set editor(newValue: CodeEditor.IEditor | null | undefined) {
+    this._editor = newValue;
+  }
+
+  /**
+   * The model used by the completer widget.
+   */
+  get model(): InlineCompleter.IModel | null {
+    return this._model;
+  }
+  set model(model: InlineCompleter.IModel | null) {
+    if ((!model && !this._model) || model === this._model) {
+      return;
+    }
+    if (this._model) {
+      this._model.stateChanged.disconnect(this.onModelStateChanged, this);
+      //this._model.queryChanged.disconnect(this.onModelQueryChanged, this);
+    }
+    this._model = model;
+    if (this._model) {
+      this._model.stateChanged.connect(this.onModelStateChanged, this);
+      //this._model.queryChanged.connect(this.onModelQueryChanged, this);
+    }
+  }
+
+  protected onModelStateChanged(): void {
+    if (this.isAttached) {
+      this.update();
+    }
+  }
+
+  private _setText(text: string) {
+    const editor = this._editor;
+    const model = this._model;
+    if (!model || !editor) {
+      console.log('bail on set text');
+      return;
+    }
+
+    const view = (editor as CodeMirrorEditor).editor;
+    this._ghostManager.clearGhosts(view);
+    this._ghostManager.placeGhost(view, {
+      from: editor.getOffsetAt(model.cursor),
+      content: text
+    });
+  }
+
+  /**
+   * Handle `update-request` messages.
+   */
+  protected onUpdateRequest(msg: Message): void {
+    const model = this._model;
+    if (!model) {
+      return;
+    }
+    let reply = model.completionReply();
+
+    // If there are no items, reset and bail.
+    if (!reply || !reply.length) {
+      if (!this.isHidden) {
+        //this.reset();
+        this.hide();
+        //this._visibilityChanged.emit(undefined);
+      }
+      return;
+    }
+
+    if (this.isHidden) {
+      this.show();
+      this._setGeometry();
+      //this._visibilityChanged.emit(undefined);
+    } else {
+      this._setGeometry();
+    }
+    const first = reply[0].completions.items;
+    if (first.length) {
+      this._setText(first[0].insertText);
+    }
+  }
+
+  private _setGeometry() {
+    const { node } = this;
+    const model = this._model;
+    const editor = this._editor;
+
+    if (!editor || !model || !model.cursor) {
+      return;
+    }
+
+    const host =
+      (editor.host.closest('.jp-MainAreaWidget > .lm-Widget') as HTMLElement) ||
+      editor.host;
+
+    const anchor = editor.getCoordinateForPosition(model.cursor) as DOMRect;
+    HoverBox.setGeometry({
+      anchor,
+      host: host,
+      maxHeight: 20,
+      minHeight: 20,
+      node: node,
+      privilege: 'above',
+      outOfViewDisplay: {
+        top: 'stick-inside',
+        bottom: 'stick-inside',
+        left: 'stick-inside',
+        right: 'stick-outside'
+      }
+    });
+  }
+  private _editor: CodeEditor.IEditor | null | undefined = null;
+  private _model: InlineCompleter.IModel | null = null;
+}
+
+class GhostTextWidget extends WidgetType {
+  constructor(readonly content: string) {
+    super();
+  }
+
+  eq(other: GhostTextWidget) {
+    return other.content == this.content;
+  }
+
+  get lineBreaks() {
+    return (this.content.match(/\n/g) || '').length;
+  }
+
+  toDOM() {
+    let wrap = document.createElement('span');
+    // TODO proper class styling
+    wrap.style.whiteSpace = 'pre';
+    wrap.style.color = 'grey';
+    wrap.innerText = this.content;
+    return wrap;
+  }
+}
+
+/**
+ *
+ */
+export interface IGhostTextManager {
+  placeGhost(view: EditorView, text: IGhostText): void;
+  clearGhosts(view: EditorView): void;
+}
+
+export interface IGhostText {
+  from: number;
+  content: string;
+}
+
+export function createGhostManager(): IGhostTextManager {
+  const addMark = StateEffect.define<IGhostText>({
+    map: ({ from, content }, change) => ({
+      from: change.mapPos(from),
+      to: change.mapPos(from + content.length),
+      content,
+      _isGhostText: true
+    })
+  });
+
+  const removeMark = StateEffect.define<null>();
+
+  const markField = StateField.define<DecorationSet>({
+    create() {
+      return Decoration.none;
+    },
+    update(marks, tr) {
+      marks = marks.map(tr.changes);
+      for (let e of tr.effects) {
+        if (e.is(addMark)) {
+          const ghost = Decoration.widget({
+            widget: new GhostTextWidget(e.value.content),
+            side: 1
+          });
+          marks = marks.update({
+            add: [
+              ghost.range(
+                Math.min(e.value.from, tr.newDoc.length),
+                Math.min(
+                  e.value.from + e.value.content.length,
+                  tr.newDoc.length
+                )
+              )
+            ]
+          });
+        } else if (e.is(removeMark)) {
+          marks = marks.update({
+            filter: (_from, _to, value) => {
+              return value.spec._isGhostText;
+            }
+          });
+        }
+      }
+      return marks;
+    },
+    provide: f => EditorView.decorations.from(f)
+  });
+
+  //const views = new Set<EditorView>();
+
+  return {
+    placeGhost(view: EditorView, text: IGhostText) {
+      const effects: StateEffect<unknown>[] = [addMark.of(text)];
+
+      if (!view.state.field(markField, false)) {
+        effects.push(StateEffect.appendConfig.of([markField]));
+        effects.push(
+          StateEffect.appendConfig.of([
+            EditorView.domEventHandlers({
+              blur: () => {
+                const effects: StateEffect<unknown>[] = [removeMark.of(null)];
+                view.dispatch({ effects });
+              }
+            })
+          ])
+        );
+      }
+      view.dispatch({ effects });
+      //views.add(view);
+    },
+    clearGhosts(view: EditorView) {
+      const effects: StateEffect<unknown>[] = [removeMark.of(null)];
+      view.dispatch({ effects });
+    }
+  };
+}
+
+export namespace InlineCompleter {
+  export interface IOptions {
+    /**
+     * The semantic parent of the completer widget, its referent editor.
+     */
+    editor?: CodeEditor.IEditor | null;
+
+    /**
+     * The model for the completer widget.
+     */
+    model?: IModel;
+  }
+
+  /**
+   * Model for inline completions.
+   */
+  export interface IModel extends IDisposable {
+    /**
+     * A signal emitted when state of the completer model changes.
+     */
+    readonly stateChanged: ISignal<IModel, void>;
+
+    /**
+     * Original placement of cursor
+     */
+    cursor: CodeEditor.IPosition;
+
+    // TODO: not happy with this being named reply
+    setCompletionReply(reply: CompletionHandler.IInlineCompletionReply[]): void;
+
+    completionReply(): CompletionHandler.IInlineCompletionReply[];
+  }
+
+  /**
+   * Model for inline completions.
+   */
+  export class Model implements InlineCompleter.IModel {
+    setCompletionReply(reply: CompletionHandler.IInlineCompletionReply[]) {
+      this._reply = reply;
+      this.stateChanged.emit();
+    }
+
+    get cursor(): CodeEditor.IPosition {
+      return this._cursor;
+    }
+
+    set cursor(value: CodeEditor.IPosition) {
+      this._cursor = value;
+    }
+
+    completionReply() {
+      return this._reply;
+    }
+
+    /**
+     * Get whether the model is disposed.
+     */
+    get isDisposed(): boolean {
+      return this._isDisposed;
+    }
+
+    /**
+     * Dispose of the resources held by the model.
+     */
+    dispose(): void {
+      // Do nothing if already disposed.
+      if (this._isDisposed) {
+        return;
+      }
+      this._isDisposed = true;
+      Signal.clearData(this);
+    }
+
+    stateChanged = new Signal<this, void>(this);
+    private _isDisposed = false;
+    private _reply: CompletionHandler.IInlineCompletionReply[] = [];
+    private _cursor: CodeEditor.IPosition;
+  }
+}

--- a/packages/completer/src/manager.ts
+++ b/packages/completer/src/manager.ts
@@ -28,10 +28,6 @@ export namespace CompletionProviderManager {
  * A manager for completion providers.
  */
 export class CompletionProviderManager implements ICompletionProviderManager {
-  // it might be good to hook inline completer here for two reasons:
-  // - we will be able to suppress invoke easily
-  // - we will not duplicate the widget (_panelHandlers) logic
-
   /**
    * Construct a new completer manager.
    */
@@ -215,17 +211,6 @@ export class CompletionProviderManager implements ICompletionProviderManager {
     }
   }
 
-  invokeInline(id: string): void {
-    // TODO (with appropriate trigger)
-  }
-
-  cycleInline(id: string, direction: 'next' | 'previous'): void {
-    const handler = this._panelHandlers.get(id);
-    if (handler && handler.inlineCompleter) {
-      handler.inlineCompleter.cycle(direction);
-    }
-  }
-
   /**
    * Activate `select` command in the widget with provided id.
    *
@@ -235,6 +220,46 @@ export class CompletionProviderManager implements ICompletionProviderManager {
     const handler = this._panelHandlers.get(id);
     if (handler) {
       handler.completer.selectActive();
+    }
+  }
+
+  /**
+   * Invoke inline completer.
+   * @experimental
+   *
+   * @param id - the id of notebook panel, console panel or code editor.
+   */
+  invokeInline(id: string): void {
+    const handler = this._panelHandlers.get(id);
+    if (handler && handler.inlineCompleter) {
+      handler.invokeInline();
+    }
+  }
+
+  /**
+   * Switch to next or previous completion of inline completer.
+   * @experimental
+   *
+   * @param id - the id of notebook panel, console panel or code editor.
+   * @param direction - the cycling direction.
+   */
+  cycleInline(id: string, direction: 'next' | 'previous'): void {
+    const handler = this._panelHandlers.get(id);
+    if (handler && handler.inlineCompleter) {
+      handler.inlineCompleter.cycle(direction);
+    }
+  }
+
+  /**
+   * Accept active inline completion.
+   * @experimental
+   *
+   * @param id - the id of notebook panel, console panel or code editor.
+   */
+  acceptInline(id: string): void {
+    const handler = this._panelHandlers.get(id);
+    if (handler && handler.inlineCompleter) {
+      handler.inlineCompleter.accept();
     }
   }
 

--- a/packages/completer/src/tokens.ts
+++ b/packages/completer/src/tokens.ts
@@ -299,12 +299,29 @@ export interface ICompletionProviderManager {
   select(id: string): void;
 
   /**
-   * Switch to next or previous completion of inline completer
+   * Invoke inline completer.
+   * @experimental
    *
-   * @param {string} id - the id of notebook panel, console panel or code editor.
+   * @param id - the id of notebook panel, console panel or code editor.
+   */
+  invokeInline(id: string): void;
+
+  /**
+   * Switch to next or previous completion of inline completer.
+   * @experimental
+   *
+   * @param id - the id of notebook panel, console panel or code editor.
    * @param direction - the cycling direction
    */
   cycleInline(id: string, direction: 'next' | 'previous'): void;
+
+  /**
+   * Accept active inline completion.
+   * @experimental
+   *
+   * @param id - the id of notebook panel, console panel or code editor.
+   */
+  acceptInline(id: string): void;
 
   /**
    * Update completer handler of a widget with new context.

--- a/packages/completer/src/tokens.ts
+++ b/packages/completer/src/tokens.ts
@@ -10,6 +10,7 @@ import { ISignal } from '@lumino/signaling';
 import { Widget } from '@lumino/widgets';
 import { CompletionHandler } from './handler';
 import { Completer } from './widget';
+import { InlineCompleter } from './inline';
 
 /**
  * The type of completion request.
@@ -248,6 +249,21 @@ export interface IInlineCompletionProvider<
 }
 
 /**
+ * Inline completer factory
+ */
+export interface IInlineCompleterFactory {
+  factory(options: InlineCompleter.IOptions): InlineCompleter;
+}
+
+/**
+ * Token allowing to override (or disable) inline completer widget factory.
+ */
+export const IInlineCompleterFactory = new Token<IInlineCompleterFactory>(
+  '@jupyterlab/completer:IInlineCompleterFactory',
+  'A factory of inline completer widgets.'
+);
+
+/**
  * The exported token used to register new provider.
  */
 export const ICompletionProviderManager = new Token<ICompletionProviderManager>(
@@ -283,6 +299,14 @@ export interface ICompletionProviderManager {
   select(id: string): void;
 
   /**
+   * Switch to next or previous completion of inline completer
+   *
+   * @param {string} id - the id of notebook panel, console panel or code editor.
+   * @param direction - the cycling direction
+   */
+  cycleInline(id: string, direction: 'next' | 'previous'): void;
+
+  /**
    * Update completer handler of a widget with new context.
    *
    * @param newCompleterContext - The completion context.
@@ -310,12 +334,14 @@ export interface IProviderReconciliator {
   ): Promise<CompletionHandler.ICompletionItemsReply | null>;
 
   /**
-   * TODO - document me
+   * Returns a list of promises to enable showing results from
+   * the provider which resolved fastest, even if other providers
+   * are still generating.
    */
   fetchInline(
     request: CompletionHandler.IRequest,
     trigger?: InlineCompletionTriggerKind
-  ): Promise<CompletionHandler.IInlineCompletionReply[] | null>;
+  ): Promise<IInlineCompletionList<CompletionHandler.IInlineItem> | null>[];
 
   /**
    * Check if completer should make request to fetch completion responses

--- a/packages/completer/style/base.css
+++ b/packages/completer/style/base.css
@@ -237,5 +237,11 @@
   border: var(--jp-border-width) solid var(--jp-border-color1);
   display: flex;
   flex-direction: row;
-  padding: 8px 4px;
+  align-items: center;
+  padding: 4px 8px;
+}
+
+.jp-InlineCompleter > .jp-Toolbar {
+  box-shadow: none;
+  border-bottom: none;
 }

--- a/packages/completer/style/base.css
+++ b/packages/completer/style/base.css
@@ -206,3 +206,36 @@
     transform: translateX(400%);
   }
 }
+
+.jp-GhostText {
+  opacity: 0.5; /* or color? */
+  white-space: pre;
+}
+
+.jp-GhostText-hiding {
+  opacity: 0;
+  background-color: grey;
+  display: inline-block;
+  vertical-align: top;
+  animation: jp-GhostText-hide 300ms 700ms ease-out forwards;
+}
+
+@keyframes jp-GhostText-hide {
+  0% {
+    font-size: unset;
+  }
+
+  100% {
+    font-size: 0;
+  }
+}
+
+.jp-InlineCompleter {
+  box-shadow: var(--jp-elevation-z6);
+  background: var(--jp-layout-color1);
+  color: var(--jp-content-font-color1);
+  border: var(--jp-border-width) solid var(--jp-border-color1);
+  display: flex;
+  flex-direction: row;
+  padding: 8px 4px;
+}

--- a/packages/completer/style/index.css
+++ b/packages/completer/style/index.css
@@ -7,5 +7,6 @@
 @import url('~@lumino/widgets/style/index.css');
 @import url('~@jupyterlab/ui-components/style/index.css');
 @import url('~@jupyterlab/apputils/style/index.css');
+@import url('~@jupyterlab/codemirror/style/index.css');
 @import url('~@jupyterlab/rendermime/style/index.css');
 @import url('./base.css');

--- a/packages/completer/style/index.js
+++ b/packages/completer/style/index.js
@@ -7,6 +7,7 @@
 import '@lumino/widgets/style/index.js';
 import '@jupyterlab/ui-components/style/index.js';
 import '@jupyterlab/apputils/style/index.js';
+import '@jupyterlab/codemirror/style/index.js';
 import '@jupyterlab/rendermime/style/index.js';
 
 import './base.css';

--- a/packages/completer/tsconfig.json
+++ b/packages/completer/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../codeeditor"
     },
     {
+      "path": "../codemirror"
+    },
+    {
       "path": "../coreutils"
     },
     {
@@ -25,13 +28,10 @@
       "path": "../statedb"
     },
     {
-      "path": "../ui-components"
-    },
-    {
-      "path": "../codemirror"
-    },
-    {
       "path": "../translation"
+    },
+    {
+      "path": "../ui-components"
     }
   ]
 }

--- a/packages/completer/tsconfig.json
+++ b/packages/completer/tsconfig.json
@@ -26,6 +26,12 @@
     },
     {
       "path": "../ui-components"
+    },
+    {
+      "path": "../codemirror"
+    },
+    {
+      "path": "../translation"
     }
   ]
 }

--- a/packages/completer/tsconfig.test.json
+++ b/packages/completer/tsconfig.test.json
@@ -9,6 +9,9 @@
       "path": "../codeeditor"
     },
     {
+      "path": "../codemirror"
+    },
+    {
       "path": "../coreutils"
     },
     {
@@ -21,13 +24,10 @@
       "path": "../statedb"
     },
     {
-      "path": "../ui-components"
-    },
-    {
-      "path": "../codemirror"
-    },
-    {
       "path": "../translation"
+    },
+    {
+      "path": "../ui-components"
     },
     {
       "path": "."

--- a/packages/completer/tsconfig.test.json
+++ b/packages/completer/tsconfig.test.json
@@ -24,6 +24,12 @@
       "path": "../ui-components"
     },
     {
+      "path": "../codemirror"
+    },
+    {
+      "path": "../translation"
+    },
+    {
       "path": "."
     },
     {

--- a/packages/lsp/src/connection.ts
+++ b/packages/lsp/src/connection.ts
@@ -120,6 +120,7 @@ class ServerRequestHandler<
 export const Provider: { [key: string]: keyof lsp.ServerCapabilities } = {
   TEXT_DOCUMENT_SYNC: 'textDocumentSync',
   COMPLETION: 'completionProvider',
+  //INLINE_COMPLETION: 'inlineCompletionProvider',
   HOVER: 'hoverProvider',
   SIGNATURE_HELP: 'signatureHelpProvider',
   DECLARATION: 'declarationProvider',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2577,6 +2577,7 @@ __metadata:
     "@jupyterlab/application": ^4.1.0-alpha.1
     "@jupyterlab/completer": ^4.1.0-alpha.1
     "@jupyterlab/settingregistry": ^4.1.0-alpha.1
+    "@jupyterlab/translation": ^4.1.0-alpha.1
     "@jupyterlab/ui-components": ^4.1.0-alpha.1
     "@lumino/coreutils": ^2.1.2
     "@rjsf/utils": ^5.1.0
@@ -2591,14 +2592,18 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/completer@workspace:packages/completer"
   dependencies:
+    "@codemirror/state": ^6.2.0
+    "@codemirror/view": ^6.9.6
     "@jupyter/ydoc": ^1.0.2
     "@jupyterlab/apputils": ^4.2.0-alpha.1
     "@jupyterlab/codeeditor": ^4.1.0-alpha.1
+    "@jupyterlab/codemirror": ^4.1.0-alpha.1
     "@jupyterlab/coreutils": ^6.1.0-alpha.1
     "@jupyterlab/rendermime": ^4.1.0-alpha.1
     "@jupyterlab/services": ^7.1.0-alpha.1
     "@jupyterlab/statedb": ^4.1.0-alpha.1
     "@jupyterlab/testing": ^4.1.0-alpha.1
+    "@jupyterlab/translation": ^4.1.0-alpha.1
     "@jupyterlab/ui-components": ^4.1.0-alpha.1
     "@lumino/algorithm": ^2.0.1
     "@lumino/coreutils": ^2.1.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -2579,6 +2579,7 @@ __metadata:
     "@jupyterlab/settingregistry": ^4.1.0-alpha.1
     "@jupyterlab/translation": ^4.1.0-alpha.1
     "@jupyterlab/ui-components": ^4.1.0-alpha.1
+    "@lumino/commands": ^2.1.3
     "@lumino/coreutils": ^2.1.2
     "@rjsf/utils": ^5.1.0
     react: ^18.2.0


### PR DESCRIPTION
## References

Relates to #14267

## Code changes

- Adds a new `IInlineCompletionProvider` for extensions to provide inline completions (for example from various LLMs)
- Extends public `ICompletionManager` API with new methods:
  - `.registerInlineProvider(provider: IInlineCompletionProvider)`
  - `.invokeInline(id: string)`
  - `.cycleInline(id: string, direction: 'next' | 'previous')`
  - `.acceptInline(id: string)`
- Implements an example provider of inline completions using kernel history request

## User-facing changes

![image](https://github.com/jupyterlab/jupyterlab/assets/5832902/dac28e6d-d797-49ad-a41f-1d9774c2ab3e)

## Backwards-incompatible changes

To check.

## To be done

- inline completion widget (hover box)
  - [ ] reduce space taken by the widget (UI/UX input welcome)
  - [ ] ensure it is placed above the line so that it never obstructs neither the 
  - [ ] add a setting to enable/disable it
  - [ ] decide if it should be opt-in or opt-out
- settings
  - [ ] setting to enable/disable inline completions globally (default on)
  - [ ] setting to enable/disable specific providers
    - [ ] make the history provider off by default (so no providers are there and effectively the feature is off)
- tests:
  - [ ] unit
  - [ ] integration
- [ ] document the new API
- [ ] rethink what shortcuts to use to allow implementing accepting partial suggestions in the future
- [ ] loading indicator when more than one provider
- [ ] implement streaming support
- [ ] improve history provider