### PR TITLE
Copy absolute path with first slash in the file browser

### DIFF
--- a/packages/coreutils/src/path.ts
+++ b/packages/coreutils/src/path.ts
@@ -21,6 +21,16 @@ export namespace PathExt {
   }
 
   /**
+   * Join all arguments together and normalize the resulting path and reserve the leading slash.
+   *
+   * @param paths - The string paths to join.
+   */
+  export function joinWithLeadingSlash(...paths: string[]): string {
+    const path = posix.join(...paths);
+    return path === '.' ? '' : path;
+  }
+
+  /**
    * Return the last portion of a path. Similar to the Unix basename command.
    * Often used to extract the file name from a fully qualified path.
    *

--- a/packages/coreutils/src/path.ts
+++ b/packages/coreutils/src/path.ts
@@ -21,7 +21,7 @@ export namespace PathExt {
   }
 
   /**
-   * Join all arguments together and normalize the resulting path and reserve the leading slash.
+   * Join all arguments together and normalize the resulting path and preserve the leading slash.
    *
    * @param paths - The string paths to join.
    */

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -65,7 +65,6 @@ import {
 import { find, map } from '@lumino/algorithm';
 import { CommandRegistry } from '@lumino/commands';
 import { ContextMenu } from '@lumino/widgets';
-import { posix } from 'path';
 
 const FILE_BROWSER_FACTORY = 'FileBrowser';
 const FILE_BROWSER_PLUGIN_ID = '@jupyterlab/filebrowser-extension:browser';
@@ -1215,7 +1214,7 @@ function addCommands(
       }
 
       if (PageConfig.getOption('copyAbsolutePath') === 'true') {
-        const absolutePath = posix.join(
+        const absolutePath = PathExt.joinWithLeadingSlash(
           PageConfig.getOption('serverRoot') ?? '',
           item.value.path
         );

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -65,6 +65,7 @@ import {
 import { find, map } from '@lumino/algorithm';
 import { CommandRegistry } from '@lumino/commands';
 import { ContextMenu } from '@lumino/widgets';
+import { posix } from 'path';
 
 const FILE_BROWSER_FACTORY = 'FileBrowser';
 const FILE_BROWSER_PLUGIN_ID = '@jupyterlab/filebrowser-extension:browser';
@@ -1214,7 +1215,7 @@ function addCommands(
       }
 
       if (PageConfig.getOption('copyAbsolutePath') === 'true') {
-        const absolutePath = PathExt.join(
+        const absolutePath = posix.join(
           PageConfig.getOption('serverRoot') ?? '',
           item.value.path
         );


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->
Follow-up of https://github.com/jupyterlab/jupyterlab/pull/14842
There is no first slash when coping a absolute path.

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Change `PathExt.json` to `posix.json`.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->
None.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None.

---

Edit to specify how it relates to 14842