### PR TITLE
Fix Show Keyboard Shortcuts command

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -650,8 +650,7 @@ const utilityCommands: JupyterFrontEndPlugin<void> = {
         const included = currentWidget?.node.contains(document.activeElement);
 
         if (!included && currentWidget instanceof MainAreaWidget) {
-          const currentNode =
-            currentWidget.content.node ?? currentWidget?.node;
+          const currentNode = currentWidget.content.node ?? currentWidget?.node;
           currentNode?.focus();
         }
         const options = { commands, trans };

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -646,14 +646,12 @@ const utilityCommands: JupyterFrontEndPlugin<void> = {
         'Show relevant keyboard shortcuts for the current active widget'
       ),
       execute: args => {
-        const included = app.shell.currentWidget?.node.contains(
-          document.activeElement
-        );
+        const currentWidget = app.shell.currentWidget;
+        const included = currentWidget?.node.contains(document.activeElement);
 
-        if (!included) {
+        if (!included && currentWidget instanceof MainAreaWidget) {
           const currentNode =
-            (app.shell.currentWidget as MainAreaWidget)?.content.node ??
-            app.shell.currentWidget?.node;
+            currentWidget.content.node ?? app.shell.currentWidget?.node;
           currentNode?.focus();
         }
         const options = { commands, trans };

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -651,7 +651,7 @@ const utilityCommands: JupyterFrontEndPlugin<void> = {
 
         if (!included && currentWidget instanceof MainAreaWidget) {
           const currentNode =
-            currentWidget.content.node ?? app.shell.currentWidget?.node;
+            currentWidget.content.node ?? currentWidget?.node;
           currentNode?.focus();
         }
         const options = { commands, trans };


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/15169

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Handle the case where `app.shell.currentWidget` is not a `MainAreaWidget`. Like the file browser widget in Notebook 7 for example.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

This should allow Notebook 7 users to open the dialog on the file browser page.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
