### PR TITLE
Add the standard SQL mimetype

### DIFF
--- a/packages/codemirror/src/language.ts
+++ b/packages/codemirror/src/language.ts
@@ -501,7 +501,7 @@ export namespace EditorLanguageRegistry {
       {
         name: 'SQL',
         displayName: trans.__('SQL'),
-        mime: 'text/x-sql',
+        mime: ['application/sql', 'text/x-sql'],
         extensions: ['sql'],
         load() {
           return sql('StandardSQL');


### PR DESCRIPTION
This PR add the standard mimetype for SQL (`application/sql`) in codemirror languages, according to https://www.rfc-editor.org/rfc/rfc6922.html

## User-facing changes

None

## Backwards-incompatible changes

None