### PR TITLE
Remove hard coded text-plain in multiple places

### DIFF
--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -9,6 +9,7 @@ import { ITranslator } from '@jupyterlab/translation';
 import { JSONObject } from '@lumino/coreutils';
 import { IDisposable } from '@lumino/disposable';
 import { ISignal, Signal } from '@lumino/signaling';
+import { IEditorMimeTypeService } from './mimetype';
 
 /**
  * A namespace for code editors.
@@ -163,7 +164,8 @@ export namespace CodeEditor {
       // Track if we need to dispose the model or not.
       this.standaloneModel = typeof options.sharedModel === 'undefined';
       this.sharedModel = options.sharedModel ?? new YFile();
-      this._mimeType = options.mimeType ?? 'text/plain';
+      this._mimeType =
+        options.mimeType ?? IEditorMimeTypeService.defaultMimeType;
     }
 
     /**
@@ -233,7 +235,7 @@ export namespace CodeEditor {
 
     private _isDisposed = false;
     private _selections = new ObservableMap<ITextSelection[]>();
-    private _mimeType = 'text/plain';
+    private _mimeType = IEditorMimeTypeService.defaultMimeType;
     private _mimeTypeChanged = new Signal<this, IChangedArgs<string>>(this);
   }
 

--- a/packages/codemirror/src/language.ts
+++ b/packages/codemirror/src/language.ts
@@ -27,7 +27,7 @@ export class EditorLanguageRegistry implements IEditorLanguageRegistry {
     // Add default language text/plain -> No expressions to parse
     this.addLanguage({
       name: 'none',
-      mime: 'text/plain',
+      mime: IEditorMimeTypeService.defaultMimeType,
       support: new LanguageSupport(
         // Create a dummy parser that as no expression to parse
         LRLanguage.define({ parser: buildParser('@top Program { }') })

--- a/packages/codemirror/src/language.ts
+++ b/packages/codemirror/src/language.ts
@@ -27,7 +27,7 @@ export class EditorLanguageRegistry implements IEditorLanguageRegistry {
     // Add default language text/plain -> No expressions to parse
     this.addLanguage({
       name: 'none',
-      mime: IEditorMimeTypeService.defaultMimeType,
+      mime: 'text/plain',
       support: new LanguageSupport(
         // Create a dummy parser that as no expression to parse
         LRLanguage.define({ parser: buildParser('@top Program { }') })

--- a/packages/docregistry/src/mimedocument.ts
+++ b/packages/docregistry/src/mimedocument.ts
@@ -2,6 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { Printing, showErrorMessage } from '@jupyterlab/apputils';
+import { IEditorMimeTypeService } from '@jupyterlab/codeeditor';
 import { ActivityMonitor } from '@jupyterlab/coreutils';
 import {
   IRenderMime,
@@ -283,7 +284,9 @@ export class MimeDocumentFactory extends ABCWidgetFactory<MimeDocument> {
    */
   protected createNewWidget(context: DocumentRegistry.Context): MimeDocument {
     const ft = this._fileType;
-    const mimeType = ft?.mimeTypes.length ? ft.mimeTypes[0] : 'text/plain';
+    const mimeType = ft?.mimeTypes.length
+      ? ft.mimeTypes[0]
+      : IEditorMimeTypeService.defaultMimeType;
 
     const rendermime = this._rendermime.clone({
       resolver: context.urlResolver

--- a/packages/fileeditor/src/fileeditorlspadapter.ts
+++ b/packages/fileeditor/src/fileeditorlspadapter.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import { IEditorMimeTypeService } from '@jupyterlab/codeeditor';
 import { CodeMirrorEditor } from '@jupyterlab/codemirror';
 import { DocumentRegistry, IDocumentWidget } from '@jupyterlab/docregistry';
 import {
@@ -73,13 +74,13 @@ export class FileEditorAdapter extends WidgetLSPAdapter<
   get mimeType(): string {
     const mimeTypeFromModel = this.editor.model.mimeType;
     const codeMirrorMimeType: string = Array.isArray(mimeTypeFromModel)
-      ? mimeTypeFromModel[0] ?? 'text/plain'
+      ? mimeTypeFromModel[0] ?? IEditorMimeTypeService.defaultMimeType
       : mimeTypeFromModel;
     const contentsModel = this.editor.context.contentsModel;
 
     // when MIME type is not known it defaults to 'text/plain',
     // so if it is different we can accept it as it is
-    if (codeMirrorMimeType != 'text/plain') {
+    if (codeMirrorMimeType != IEditorMimeTypeService.defaultMimeType) {
       return codeMirrorMimeType;
     } else if (contentsModel) {
       // a script that does not have a MIME type known by the editor

--- a/packages/notebook/src/notebooklspadapter.ts
+++ b/packages/notebook/src/notebooklspadapter.ts
@@ -3,6 +3,7 @@
 
 import { SessionContext } from '@jupyterlab/apputils';
 import { Cell, ICellModel } from '@jupyterlab/cells';
+import { IEditorMimeTypeService } from '@jupyterlab/codeeditor';
 import {
   Document,
   IAdapterOptions,
@@ -67,7 +68,9 @@ export class NotebookAdapter extends WidgetLSPAdapter<NotebookPanel> {
     } else {
       mimeType = languageMetadata.mimetype;
     }
-    return Array.isArray(mimeType) ? mimeType[0] ?? 'text/plain' : mimeType;
+    return Array.isArray(mimeType)
+      ? mimeType[0] ?? IEditorMimeTypeService.defaultMimeType
+      : mimeType;
   }
 
   /**

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -210,7 +210,7 @@ export class StaticNotebook extends WindowedList {
 
     this._editorConfig = StaticNotebook.defaultEditorConfig;
     this._notebookConfig = StaticNotebook.defaultNotebookConfig;
-    this._mimetype = 'text/plain';
+    this._mimetype = IEditorMimeTypeService.defaultMimeType;
     this._notebookModel = null;
     this._modelChanged = new Signal<this, void>(this);
     this._modelContentChanged = new Signal<this, void>(this);
@@ -540,7 +540,7 @@ export class StaticNotebook extends WindowedList {
       }
     }
     if (!newValue) {
-      this._mimetype = 'text/plain';
+      this._mimetype = IEditorMimeTypeService.defaultMimeType;
       return;
     }
     this._updateMimetype();


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Follow-up of https://github.com/jupyterlab/jupyterlab/pull/15175

I searched for hard-coded places of `text/plain` and remove those not making sense (reviewers please don't hesitate to challenge that statement)
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Remove hard-coded `text/plain` by the default mime type constant.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None