### PR TITLE
Fix typo in `Notification.dismiss`

### DIFF
--- a/docs/source/extension/ui_helpers.rst
+++ b/docs/source/extension/ui_helpers.rst
@@ -330,7 +330,7 @@ notifications using:
 
 .. code:: typescript
 
-  Notification.dimiss(id?: string): void;
+  Notification.dismiss(id?: string): void;
 
 .. note::
 


### PR DESCRIPTION
Fixes missing `s` in the docs.