### PR TITLE
Fix expanionStates error 

### DIFF
--- a/galata/test/jupyterlab/workspace.test.ts
+++ b/galata/test/jupyterlab/workspace.test.ts
@@ -266,18 +266,37 @@ test.describe('Workspace in doc mode', () => {
         left: {
           collapsed: false,
           visible: true,
-          current: 'filebrowser',
+          current: 'running-sessions',
           widgets: [
             'filebrowser',
             'running-sessions',
             '@jupyterlab/toc:plugin',
             'extensionmanager.main-view'
-          ]
+          ],
+          widgetStates: {
+            ['jp-running-sessions']: {
+              sizes: [0.25, 0.25, 0.25, 0.25],
+              expansionStates: [true, true, true, true]
+            },
+            ['extensionmanager.main-view']: {
+              sizes: [
+                0.3333333333333333, 0.3333333333333333, 0.3333333333333333
+              ],
+              expansionStates: [false, false, false]
+            }
+          }
         },
         right: {
           collapsed: true,
           visible: true,
-          widgets: []
+          current: 'debugger-sidebar',
+          widgets: ['jp-property-inspector', 'debugger-sidebar'],
+          widgetStates: {
+            ['jp-debugger-sidebar']: {
+              sizes: [1, 0, 0, 0, 0],
+              expansionStates: [false, false, false, false, false]
+            }
+          }
         },
         relativeSizes: [0.4, 0.6, 0],
         top: {

--- a/galata/test/jupyterlab/workspace.test.ts
+++ b/galata/test/jupyterlab/workspace.test.ts
@@ -266,7 +266,7 @@ test.describe('Workspace in doc mode', () => {
         left: {
           collapsed: false,
           visible: true,
-          current: 'running-sessions',
+          current: 'filebrowser',
           widgets: [
             'filebrowser',
             'running-sessions',
@@ -276,7 +276,7 @@ test.describe('Workspace in doc mode', () => {
           widgetStates: {
             ['jp-running-sessions']: {
               sizes: [0.25, 0.25, 0.25, 0.25],
-              expansionStates: [true, true, true, true]
+              expansionStates: [false, false, false, false]
             },
             ['extensionmanager.main-view']: {
               sizes: [
@@ -289,11 +289,10 @@ test.describe('Workspace in doc mode', () => {
         right: {
           collapsed: true,
           visible: true,
-          current: 'debugger-sidebar',
           widgets: ['jp-property-inspector', 'debugger-sidebar'],
           widgetStates: {
             ['jp-debugger-sidebar']: {
-              sizes: [1, 0, 0, 0, 0],
+              sizes: [0.2, 0.2, 0.2, 0.2, 0.2],
               expansionStates: [false, false, false, false, false]
             }
           }

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -2067,7 +2067,7 @@ namespace Private {
       if (data.widgetStates) {
         this._stackedPanel.widgets.forEach((w: SidePanel) => {
           if (w.id && w.content instanceof SplitPanel) {
-            const state = data.widgetStates[w.id];
+            const state = data.widgetStates[w.id] ?? {};
             w.content.widgets.forEach((wi, widx) => {
               const expansion = (state.expansionStates ?? [])[widx];
               if (


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->
This should fix the error coming from the `expansionStates` encountered when working in dev mode on jupyterlab.

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/15163

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

When rehydrating the sidebar and extracting the `widgetStates`, if the user didn't modify the expansion states or sizes of any subpannel, so they are still in their original state, the variable should be empty.

```
const state = data.widgetStates[w.id] ?? {};
```

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

This issue was encountered by those working in dev mode, so now that will be fixed and there should be no more errors, even when frequently refreshing the notebook.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes
None.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

cc: @fcollonval 
