### PR TITLE
Backport of MathJax double init/font URL fix and binder/log updates

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -11,3 +11,18 @@ nodeLinker: node-modules
 npmRegistryServer: "https://registry.yarnpkg.com"
 
 yarnPath: ./jupyterlab/staging/yarn.js
+
+# these messages provide no actionable information, and make non-TTY output
+# almost unreadable, masking real dependency-related information
+# see: https://yarnpkg.com/advanced/error-codes
+logFilters:
+  - code: YN0006 # SOFT_LINK_BUILD
+    level: discard
+  - code: YN0007 # MUST_BUILD
+    level: discard
+  - code: YN0008 # MUST_REBUILD
+    level: discard
+  - code: YN0013 # FETCH_NOT_CACHED
+    level: discard
+  - code: YN0019 # UNUSED_CACHE_ENTRY
+    level: discard

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -19,13 +19,13 @@ dependencies:
   - ipykernel
   - jinja2 >=3.0.3
   - jupyter_core
-  - jupyter_server >=2.0.1,<3
+  - jupyter_server >=2.4.0,<3
   - jupyter-lsp >=2.0.0
   - jupyterlab_server >=2.19.0,<3
   - notebook-shim >=0.2
   - packaging
   - tornado >=6.2.0
-  - traitlets
+  - traitlets >=5.10.1
   # test
   - coverage
   - pytest >=7.0
@@ -48,12 +48,18 @@ dependencies:
   - ruff
   # demo
   - jupyter-server-proxy
-  - jupyterlab-link-share >=0.2
   - matplotlib-base
+  - notebook >=7.0.4
   - numpy
   - vega_datasets
   - xeus-python
   # extra conda stuff
   - jsonschema-with-format-nongpl
+  # jupyter-collaboration 1.2.0
+  - jupyter_ydoc >=1.0.1,<2.0.0
+  - ypy-websocket >=0.12.1,<0.13.0
+  - jupyter_events >=0.7.0
+  - jupyter_server_fileid >=0.7.0,<1
   - pip:
-    - jupyter-collaboration >=1.0.0a5
+    # can't be installed with `conda` in binder, due to `jupyterlab-link-share``
+    - jupyter-collaboration ==1.2.0

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -19,8 +19,8 @@ mkdir _reports_
 # hoist report to where a reviewer might see it
 mv dev_mode/static/webpack-bundle-analyzer.html _reports_/
 
-# assume best-effort versions from conda-forge for all deps
-(time pip install -vv -e .[dev] --no-build-isolation)  2>&1 | tee _reports_/02_pip_install.txt
+# overload best-effort versions from conda-forge for all deps
+(time pip install -v -e .[dev] --no-build-isolation)  2>&1 | tee _reports_/02_pip_install.txt
 
 # copy configuration to well-known location
 mkdir -p ~/.jupyter

--- a/examples/example.spec.ts
+++ b/examples/example.spec.ts
@@ -5,7 +5,7 @@
 
 import { ConsoleMessage, expect, test } from '@playwright/test';
 
-const URL = process.env['BASE_URL'];
+const URL = `${process.env['BASE_URL']}`;
 
 test.setTimeout(120000);
 
@@ -22,15 +22,7 @@ test('should load the example', async ({ page }) => {
     const text = msg.text();
     console.log(msg.type(), '>>', text);
 
-    if (
-      msg.type() === 'error' &&
-      // Ignore 404 for MathJax fonts
-      msg
-        .location()
-        .url.match(
-          /js\/output\/chtml\/fonts\/tex-woff-v2\/MathJax_(Zero|Math-Italic|Main-Regular)\.woff$/
-        ) === null
-    ) {
+    if (msg.type() === 'error') {
       errorLogs += 1;
     }
 

--- a/packages/mathjax-extension/package.json
+++ b/packages/mathjax-extension/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@jupyterlab/application": "^4.0.6",
     "@jupyterlab/rendermime": "^4.0.6",
+    "@lumino/coreutils": "^2.1.2",
     "mathjax-full": "^3.2.2"
   },
   "devDependencies": {

--- a/packages/mathjax-extension/src/index.ts
+++ b/packages/mathjax-extension/src/index.ts
@@ -5,6 +5,8 @@
  * @module mathjax-extension
  */
 
+import { PromiseDelegate } from '@lumino/coreutils';
+
 import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
@@ -36,61 +38,10 @@ namespace CommandArgs {
  */
 export class MathJaxTypesetter implements ILatexTypesetter {
   protected async _ensureInitialized() {
-    if (this._initialized) {
-      return;
+    if (!this._initialized) {
+      this._mathDocument = await Private.ensureMathDocument();
+      this._initialized = true;
     }
-
-    await import('mathjax-full/js/input/tex/require/RequireConfiguration');
-    const { mathjax } = await import('mathjax-full/js/mathjax');
-    const { CHTML } = await import('mathjax-full/js/output/chtml');
-    const { TeX } = await import('mathjax-full/js/input/tex');
-    const { TeXFont } = await import('mathjax-full/js/output/chtml/fonts/tex');
-    const { AllPackages } = await import(
-      'mathjax-full/js/input/tex/AllPackages'
-    );
-    const { SafeHandler } = await import('mathjax-full/js/ui/safe/SafeHandler');
-    const { HTMLHandler } = await import(
-      'mathjax-full/js/handlers/html/HTMLHandler'
-    );
-    const { browserAdaptor } = await import(
-      'mathjax-full/js/adaptors/browserAdaptor'
-    );
-    const { AssistiveMmlHandler } = await import(
-      'mathjax-full/js/a11y/assistive-mml'
-    );
-
-    mathjax.handlers.register(
-      AssistiveMmlHandler(SafeHandler(new HTMLHandler(browserAdaptor())))
-    );
-
-    class EmptyFont extends TeXFont {
-      defaultFonts = {};
-    }
-
-    const chtml = new CHTML({
-      // Override dynamically generated fonts in favor of our font css
-      font: new EmptyFont()
-    });
-
-    const tex = new TeX({
-      packages: AllPackages.concat('require'),
-      inlineMath: [
-        ['$', '$'],
-        ['\\(', '\\)']
-      ],
-      displayMath: [
-        ['$$', '$$'],
-        ['\\[', '\\]']
-      ],
-      processEscapes: true,
-      processEnvironments: true
-    });
-
-    this._mathDocument = mathjax.document(window.document, {
-      InputJax: tex,
-      OutputJax: chtml
-    });
-    this._initialized = true;
   }
 
   /**
@@ -157,3 +108,78 @@ const mathJaxPlugin: JupyterFrontEndPlugin<ILatexTypesetter> = {
 };
 
 export default mathJaxPlugin;
+
+/**
+ * A namespace for module-private functionality.
+ */
+namespace Private {
+  let _loading: PromiseDelegate<MathDocument<any, any, any>> | null = null;
+
+  export async function ensureMathDocument(): Promise<
+    MathDocument<any, any, any>
+  > {
+    if (!_loading) {
+      _loading = new PromiseDelegate();
+
+      void import('mathjax-full/js/input/tex/require/RequireConfiguration');
+
+      const [
+        { mathjax },
+        { CHTML },
+        { TeX },
+        { TeXFont },
+        { AllPackages },
+        { SafeHandler },
+        { HTMLHandler },
+        { browserAdaptor },
+        { AssistiveMmlHandler }
+      ] = await Promise.all([
+        import('mathjax-full/js/mathjax'),
+        import('mathjax-full/js/output/chtml'),
+        import('mathjax-full/js/input/tex'),
+        import('mathjax-full/js/output/chtml/fonts/tex'),
+        import('mathjax-full/js/input/tex/AllPackages'),
+        import('mathjax-full/js/ui/safe/SafeHandler'),
+        import('mathjax-full/js/handlers/html/HTMLHandler'),
+        import('mathjax-full/js/adaptors/browserAdaptor'),
+        import('mathjax-full/js/a11y/assistive-mml')
+      ]);
+
+      mathjax.handlers.register(
+        AssistiveMmlHandler(SafeHandler(new HTMLHandler(browserAdaptor())))
+      );
+
+      class EmptyFont extends TeXFont {
+        protected static defaultFonts = {} as any;
+      }
+
+      const chtml = new CHTML({
+        // Override dynamically generated fonts in favor of our font css
+        font: new EmptyFont()
+      });
+
+      const tex = new TeX({
+        packages: AllPackages.concat('require'),
+        inlineMath: [
+          ['$', '$'],
+          ['\\(', '\\)']
+        ],
+        displayMath: [
+          ['$$', '$$'],
+          ['\\[', '\\]']
+        ],
+        processEscapes: true,
+        processEnvironments: true
+      });
+
+      const mathDocument = mathjax.document(window.document, {
+        InputJax: tex,
+        OutputJax: chtml
+      });
+
+      _loading.resolve(mathDocument);
+    }
+
+    return _loading.promise;
+  }
+}

--- a/packages/mathjax-extension/style/fonts.css
+++ b/packages/mathjax-extension/style/fonts.css
@@ -4,102 +4,119 @@
  */
 
 @font-face /* 0 */ {
+  font-display: swap;
   font-family: MJXZERO;
   src: url('~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Zero.woff')
     format('woff');
 }
 
 @font-face /* 1 */ {
+  font-display: swap;
   font-family: MJXTEX;
   src: url('~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Main-Regular.woff')
     format('woff');
 }
 
 @font-face /* 2 */ {
+  font-display: swap;
   font-family: MJXTEX-B;
   src: url('~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Main-Bold.woff')
     format('woff');
 }
 
 @font-face /* 3 */ {
+  font-display: swap;
   font-family: MJXTEX-I;
   src: url('~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Math-Italic.woff')
     format('woff');
 }
 
 @font-face /* 4 */ {
+  font-display: swap;
   font-family: MJXTEX-MI;
   src: url('~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Main-Italic.woff')
     format('woff');
 }
 
 @font-face /* 5 */ {
+  font-display: swap;
   font-family: MJXTEX-BI;
   src: url('~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Math-BoldItalic.woff')
     format('woff');
 }
 
 @font-face /* 6 */ {
+  font-display: swap;
   font-family: 'MJXTEX-S1';
   src: url('~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Size1-Regular.woff')
     format('woff');
 }
 
 @font-face /* 7 */ {
+  font-display: swap;
   font-family: 'MJXTEX-S2';
   src: url('~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Size2-Regular.woff')
     format('woff');
 }
 
 @font-face /* 8 */ {
+  font-display: swap;
   font-family: 'MJXTEX-S3';
   src: url('~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Size3-Regular.woff')
     format('woff');
 }
 
 @font-face /* 9 */ {
+  font-display: swap;
   font-family: 'MJXTEX-S4';
   src: url('~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Size4-Regular.woff')
     format('woff');
 }
 
 @font-face /* 10 */ {
+  font-display: swap;
   font-family: MJXTEX-A;
   src: url('~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_AMS-Regular.woff')
     format('woff');
 }
 
 @font-face /* 11 */ {
+  font-display: swap;
   font-family: MJXTEX-C;
   src: url('~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Calligraphic-Regular.woff')
     format('woff');
 }
 
 @font-face /* 12 */ {
+  font-display: swap;
   font-family: MJXTEX-CB;
   src: url('~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Calligraphic-Bold.woff')
     format('woff');
 }
 
 @font-face /* 13 */ {
+  font-display: swap;
   font-family: MJXTEX-FR;
   src: url('~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Fraktur-Regular.woff')
     format('woff');
 }
 
 @font-face /* 14 */ {
+  font-display: swap;
   font-family: MJXTEX-FRB;
   src: url('~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Fraktur-Bold.woff')
     format('woff');
 }
 
 @font-face /* 15 */ {
+  font-display: swap;
   font-family: MJXTEX-SS;
   src: url('~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_SansSerif-Regular.woff')
     format('woff');
 }
 
 @font-face /* 16 */ {
+  font-display: swap;
   font-family: MJXTEX-SSB;
   src: url('~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_SansSerif-Bold.woff')
     format('woff');
@@ -112,24 +129,28 @@
 }
 
 @font-face /* 18 */ {
+  font-display: swap;
   font-family: MJXTEX-SC;
   src: url('~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Script-Regular.woff')
     format('woff');
 }
 
 @font-face /* 19 */ {
+  font-display: swap;
   font-family: MJXTEX-T;
   src: url('~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Typewriter-Regular.woff')
     format('woff');
 }
 
 @font-face /* 20 */ {
+  font-display: swap;
   font-family: MJXTEX-V;
   src: url('~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Vector-Regular.woff')
     format('woff');
 }
 
 @font-face /* 21 */ {
+  font-display: swap;
   font-family: MJXTEX-VB;
   src: url('~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Vector-Bold.woff')
     format('woff');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3906,6 +3906,7 @@ __metadata:
   dependencies:
     "@jupyterlab/application": ^4.0.6
     "@jupyterlab/rendermime": ^4.0.6
+    "@lumino/coreutils": ^2.1.2
     mathjax-full: ^3.2.2
     rimraf: ~3.0.0
     typedoc: ~0.24.7


### PR DESCRIPTION
## References

- backport
  - #15230
  - #15214 (just the binder- and log-related parts)

## Code changes

- [x] avoid double request for mathjax fonts
- [x] remove `404` log ignores in examples test 
- [x] initialize `MathDocument` exactly once with a `PromiseDelegate`
- [x] add `font-display: swap;` for FLOUC 
- [x] hide all cache-related `jlpm` log noise
- [x] update binder config (worked a few days ago, hard to test these days, but still)

## User-facing changes

- MathJax fonts should load slightly faster
- downstreams  (e.g. `examples/`, jupyterlite) should get fewer 404

| note | screen |
|-|-|
| on binder, fonts are only loaded once | ![a screenshot of binder running this PR](https://github.com/jupyterlab/jupyterlab/assets/45380/f3ef6390-c197-4b9f-91a5-3dec5b957c17 "woff are only requested once") |


## Backwards-incompatible changes

- n/a