### PR TITLE
Fix completer tests after transition to pointer events

### DIFF
--- a/packages/metapackage/test/completer/widget.spec.ts
+++ b/packages/metapackage/test/completer/widget.spec.ts
@@ -9,10 +9,9 @@ import {
   CompletionHandler
 } from '@jupyterlab/completer';
 import { YFile } from '@jupyter/ydoc';
-import { framePromise, sleep } from '@jupyterlab/testing';
+import { framePromise, simulate, sleep } from '@jupyterlab/testing';
 import { Message, MessageLoop } from '@lumino/messaging';
 import { Panel, Widget } from '@lumino/widgets';
-import { simulate } from 'simulate-event';
 
 const TEST_ITEM_CLASS = 'jp-TestItem';
 
@@ -435,12 +434,12 @@ describe('completer/widget', () => {
     });
 
     describe('#handleEvent()', () => {
-      it('should handle document keydown, mousedown, and scroll events', () => {
+      it('should handle document keydown, pointerdown, and scroll events', () => {
         const anchor = createEditorWidget();
         const widget = new LogWidget({ editor: anchor.editor });
         Widget.attach(anchor, document.body);
         Widget.attach(widget, document.body);
-        ['keydown', 'mousedown', 'scroll'].forEach(type => {
+        ['keydown', 'pointerdown', 'scroll'].forEach(type => {
           simulate(document.body, type);
           expect(widget.events).toEqual(expect.arrayContaining([type]));
         });
@@ -864,8 +863,8 @@ describe('completer/widget', () => {
         anchor.dispose();
       });
 
-      describe('mousedown', () => {
-        it('should trigger a selected signal on mouse down', () => {
+      describe('pointerdown', () => {
+        it('should trigger a selected signal on pointer down', () => {
           let anchor = createEditorWidget();
           let model = new CompleterModel();
           let options: Completer.IOptions = {
@@ -894,13 +893,13 @@ describe('completer/widget', () => {
 
           simulate(anchor.node, 'keydown', { keyCode: 9 }); // Tab key
           expect(model.query).toBe('ba');
-          simulate(item, 'mousedown');
+          simulate(item, 'pointerdown');
           expect(value).toBe('baz');
           widget.dispose();
           anchor.dispose();
         });
 
-        it('should ignore nonstandard mouse clicks (e.g., right click)', () => {
+        it('should ignore nonstandard pointer clicks (e.g., right click)', () => {
           let anchor = createEditorWidget();
           let model = new CompleterModel();
           let options: Completer.IOptions = {
@@ -920,13 +919,13 @@ describe('completer/widget', () => {
           Widget.attach(widget, document.body);
           MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
           expect(value).toBe('');
-          simulate(widget.node, 'mousedown', { button: 1 });
+          simulate(widget.node, 'pointerdown', { button: 1 });
           expect(value).toBe('');
           widget.dispose();
           anchor.dispose();
         });
 
-        it('should ignore a mouse down that misses an item', () => {
+        it('should ignore a pointer down that misses an item', () => {
           let anchor = createEditorWidget();
           let model = new CompleterModel();
           let options: Completer.IOptions = {
@@ -946,13 +945,13 @@ describe('completer/widget', () => {
           Widget.attach(widget, document.body);
           MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
           expect(value).toBe('');
-          simulate(widget.node, 'mousedown');
+          simulate(widget.node, 'pointerdown');
           expect(value).toBe('');
           widget.dispose();
           anchor.dispose();
         });
 
-        it('should hide widget if mouse down misses it', () => {
+        it('should hide widget if pointer down misses it', () => {
           let anchor = createEditorWidget();
           let model = new CompleterModel();
           let options: Completer.IOptions = {
@@ -971,7 +970,7 @@ describe('completer/widget', () => {
           Widget.attach(widget, document.body);
           MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
           expect(widget.isHidden).toBe(false);
-          simulate(anchor.node, 'mousedown');
+          simulate(anchor.node, 'pointerdown');
           MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
           expect(widget.isHidden).toBe(true);
           widget.dispose();

--- a/packages/testing/src/common.ts
+++ b/packages/testing/src/common.ts
@@ -3,7 +3,7 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-import { simulate } from 'simulate-event';
+import { simulate as simulateEvent } from 'simulate-event';
 
 import { PromiseDelegate } from '@lumino/coreutils';
 
@@ -12,6 +12,37 @@ import { ISignal, Signal } from '@lumino/signaling';
 import { sleep } from '@jupyterlab/coreutils/lib/testutils';
 
 export { sleep } from '@jupyterlab/coreutils/lib/testutils';
+
+// Add a simple polyfill for `PointerEvent` which is not yet supported by jsdom
+// see https://github.com/jsdom/jsdom/pull/2666
+if (!global.PointerEvent) {
+  class PointerEvent extends MouseEvent {
+    // no-op
+  }
+  global.PointerEvent = PointerEvent as any;
+}
+
+const POINTER_EVENTS = [
+  'pointerdown',
+  'pointerenter',
+  'pointerleave',
+  'pointermove',
+  'pointerout',
+  'pointerover',
+  'pointerup'
+];
+
+/**
+ * Extends `simulate` from no longer actively developed `simulate-event`
+ * with a subset of `pointer` events.
+ */
+export function simulate(element: EventTarget, type: string, options?: any) {
+  if (POINTER_EVENTS.includes(type)) {
+    element.dispatchEvent(new PointerEvent(type, options));
+  } else {
+    simulateEvent(element, type, options);
+  }
+}
 
 /**
  * Test a single emission from a signal.

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -18,7 +18,8 @@ export {
   waitForDialog,
   acceptDialog,
   dangerDialog,
-  dismissDialog
+  dismissDialog,
+  simulate
 } from './common';
 
 export { JupyterServer } from './start_jupyter_server';


### PR DESCRIPTION
## References

Follow-up after #14534

## Code changes

- switches simulated events in tests from `mousedown` to `pointerdown`
- adds a polyfill for `pointerdown` to `@jupyterlab/testing`

## User-facing changes

None

## Backwards-incompatible changes

None