### PR TITLE
Fix completer documentation panel hiding and animation

### DIFF
--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -349,6 +349,7 @@ export class Completer extends Widget {
       this._docPanel.innerText = '';
       node.appendChild(this._docPanel);
       this._docPanelExpanded = false;
+      this._docPanel.style.display = 'none';
       this._updateDocPanel(resolvedItem, active);
     }
 

--- a/packages/completer/style/base.css
+++ b/packages/completer/style/base.css
@@ -181,8 +181,8 @@
 
 .jp-Completer-loading-bar-container {
   height: 2px;
-  width: 100%;
-  background-color: var(--jp-layout-color2);
+  width: calc(100% - var(--jp-private-completer-item-height));
+  left: var(--jp-private-completer-item-height);
   position: absolute;
   overflow: hidden;
   top: 0;
@@ -191,7 +191,7 @@
 .jp-Completer-loading-bar {
   height: 100%;
   width: 50%;
-  background-color: var(--jp-layout-color4);
+  background-color: var(--jp-accent-color2);
   position: absolute;
   left: -50%;
   animation: jp-Completer-loading 2s ease-in 0.5s infinite;

--- a/packages/metapackage/test/completer/widget.spec.ts
+++ b/packages/metapackage/test/completer/widget.spec.ts
@@ -9,10 +9,9 @@ import {
   CompletionHandler
 } from '@jupyterlab/completer';
 import { YFile } from '@jupyter/ydoc';
-import { framePromise, sleep } from '@jupyterlab/testing';
+import { framePromise, simulate, sleep } from '@jupyterlab/testing';
 import { Message, MessageLoop } from '@lumino/messaging';
 import { Panel, Widget } from '@lumino/widgets';
-import { simulate } from 'simulate-event';
 
 const TEST_ITEM_CLASS = 'jp-TestItem';
 
@@ -435,12 +434,12 @@ describe('completer/widget', () => {
     });
 
     describe('#handleEvent()', () => {
-      it('should handle document keydown, mousedown, and scroll events', () => {
+      it('should handle document keydown, pointerdown, and scroll events', () => {
         const anchor = createEditorWidget();
         const widget = new LogWidget({ editor: anchor.editor });
         Widget.attach(anchor, document.body);
         Widget.attach(widget, document.body);
-        ['keydown', 'mousedown', 'scroll'].forEach(type => {
+        ['keydown', 'pointerdown', 'scroll'].forEach(type => {
           simulate(document.body, type);
           expect(widget.events).toEqual(expect.arrayContaining([type]));
         });
@@ -864,8 +863,8 @@ describe('completer/widget', () => {
         anchor.dispose();
       });
 
-      describe('mousedown', () => {
-        it('should trigger a selected signal on mouse down', () => {
+      describe('pointerdown', () => {
+        it('should trigger a selected signal on pointer down', () => {
           let anchor = createEditorWidget();
           let model = new CompleterModel();
           let options: Completer.IOptions = {
@@ -894,13 +893,13 @@ describe('completer/widget', () => {
 
           simulate(anchor.node, 'keydown', { keyCode: 9 }); // Tab key
           expect(model.query).toBe('ba');
-          simulate(item, 'mousedown');
+          simulate(item, 'pointerdown');
           expect(value).toBe('baz');
           widget.dispose();
           anchor.dispose();
         });
 
-        it('should ignore nonstandard mouse clicks (e.g., right click)', () => {
+        it('should ignore nonstandard pointer clicks (e.g., right click)', () => {
           let anchor = createEditorWidget();
           let model = new CompleterModel();
           let options: Completer.IOptions = {
@@ -920,13 +919,13 @@ describe('completer/widget', () => {
           Widget.attach(widget, document.body);
           MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
           expect(value).toBe('');
-          simulate(widget.node, 'mousedown', { button: 1 });
+          simulate(widget.node, 'pointerdown', { button: 1 });
           expect(value).toBe('');
           widget.dispose();
           anchor.dispose();
         });
 
-        it('should ignore a mouse down that misses an item', () => {
+        it('should ignore a pointer down that misses an item', () => {
           let anchor = createEditorWidget();
           let model = new CompleterModel();
           let options: Completer.IOptions = {
@@ -946,13 +945,13 @@ describe('completer/widget', () => {
           Widget.attach(widget, document.body);
           MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
           expect(value).toBe('');
-          simulate(widget.node, 'mousedown');
+          simulate(widget.node, 'pointerdown');
           expect(value).toBe('');
           widget.dispose();
           anchor.dispose();
         });
 
-        it('should hide widget if mouse down misses it', () => {
+        it('should hide widget if pointer down misses it', () => {
           let anchor = createEditorWidget();
           let model = new CompleterModel();
           let options: Completer.IOptions = {
@@ -971,7 +970,7 @@ describe('completer/widget', () => {
           Widget.attach(widget, document.body);
           MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
           expect(widget.isHidden).toBe(false);
-          simulate(anchor.node, 'mousedown');
+          simulate(anchor.node, 'pointerdown');
           MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
           expect(widget.isHidden).toBe(true);
           widget.dispose();

--- a/packages/testing/src/common.ts
+++ b/packages/testing/src/common.ts
@@ -3,7 +3,7 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-import { simulate } from 'simulate-event';
+import { simulate as simulateEvent } from 'simulate-event';
 
 import { PromiseDelegate } from '@lumino/coreutils';
 
@@ -12,6 +12,37 @@ import { ISignal, Signal } from '@lumino/signaling';
 import { sleep } from '@jupyterlab/coreutils/lib/testutils';
 
 export { sleep } from '@jupyterlab/coreutils/lib/testutils';
+
+// Add a simple polyfill for `PointerEvent` which is not yet supported by jsdom
+// see https://github.com/jsdom/jsdom/pull/2666
+if (!global.PointerEvent) {
+  class PointerEvent extends MouseEvent {
+    // no-op
+  }
+  global.PointerEvent = PointerEvent as any;
+}
+
+const POINTER_EVENTS = [
+  'pointerdown',
+  'pointerenter',
+  'pointerleave',
+  'pointermove',
+  'pointerout',
+  'pointerover',
+  'pointerup'
+];
+
+/**
+ * Extends `simulate` from no longer actively developed `simulate-event`
+ * with a subset of `pointer` events.
+ */
+export function simulate(element: EventTarget, type: string, options?: any) {
+  if (POINTER_EVENTS.includes(type)) {
+    element.dispatchEvent(new PointerEvent(type, options));
+  } else {
+    simulateEvent(element, type, options);
+  }
+}
 
 /**
  * Test a single emission from a signal.

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -18,7 +18,8 @@ export {
   waitForDialog,
   acceptDialog,
   dangerDialog,
-  dismissDialog
+  dismissDialog,
+  simulate
 } from './common';
 
 export { JupyterServer } from './start_jupyter_server';


### PR DESCRIPTION
## References

- follow up to #15132
- fixes #15203
- temporarily includes #15237 (to ease testing)

## Code changes

- adds a test case
- fixes the docpanel persisting and occluding completions in certain updates
- (style) improves loading animation to avoid overlap with completion type indicator/icon

## User-facing changes

### Bug fix

| Before | After |
|---|---|
| ![did-not-work-before](https://github.com/jupyterlab/jupyterlab/assets/5832902/144d398c-e753-48bb-a752-8ddd29006c58) |  ![works-after](https://github.com/jupyterlab/jupyterlab/assets/5832902/cfc5a695-88fe-4958-b34b-e3bf24940cf4)  |


### Style fix

| Before | After |
|---|---|
|![animation-before](https://github.com/jupyterlab/jupyterlab/assets/5832902/88c3c881-a11f-4d34-944e-a29b430468e9)| ![animation-after](https://github.com/jupyterlab/jupyterlab/assets/5832902/0bc86576-a740-479d-9fd8-23aeb1167b85) |

## Backwards-incompatible changes

None
