### PR TITLE
Bump `@jupyterlab/rendermime-interfaces` to `3.9.0-alpha.1`

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -92,7 +92,7 @@
     "@jupyterlab/property-inspector": "~4.1.0-alpha.2",
     "@jupyterlab/rendermime": "~4.1.0-alpha.2",
     "@jupyterlab/rendermime-extension": "~4.1.0-alpha.2",
-    "@jupyterlab/rendermime-interfaces": "~3.8.3-alpha.1",
+    "@jupyterlab/rendermime-interfaces": "~3.9.0-alpha.1",
     "@jupyterlab/running": "~4.1.0-alpha.2",
     "@jupyterlab/running-extension": "~4.1.0-alpha.2",
     "@jupyterlab/services": "~7.1.0-alpha.2",

--- a/examples/federated/core_package/package.json
+++ b/examples/federated/core_package/package.json
@@ -61,7 +61,7 @@
     "@jupyterlab/pdf-extension": "~4.1.0-alpha.2",
     "@jupyterlab/rendermime": "~4.1.0-alpha.0",
     "@jupyterlab/rendermime-extension": "~4.1.0-alpha.2",
-    "@jupyterlab/rendermime-interfaces": "^3.8.0",
+    "@jupyterlab/rendermime-interfaces": "^3.9.0-alpha.1",
     "@jupyterlab/services": "~7.1.0-alpha.0",
     "@jupyterlab/settingeditor": "~4.1.0-alpha.0",
     "@jupyterlab/settingeditor-extension": "~4.1.0-alpha.2",

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -47,7 +47,7 @@
     "@jupyterlab/coreutils": "^6.1.0-alpha.2",
     "@jupyterlab/docregistry": "^4.1.0-alpha.2",
     "@jupyterlab/rendermime": "^4.1.0-alpha.2",
-    "@jupyterlab/rendermime-interfaces": "^3.8.3-alpha.1",
+    "@jupyterlab/rendermime-interfaces": "^3.9.0-alpha.1",
     "@jupyterlab/services": "^7.1.0-alpha.2",
     "@jupyterlab/statedb": "^4.1.0-alpha.2",
     "@jupyterlab/translation": "^4.1.0-alpha.2",

--- a/packages/apputils-extension/package.json
+++ b/packages/apputils-extension/package.json
@@ -44,7 +44,7 @@
     "@jupyterlab/docregistry": "^4.1.0-alpha.2",
     "@jupyterlab/filebrowser": "^4.1.0-alpha.2",
     "@jupyterlab/mainmenu": "^4.1.0-alpha.2",
-    "@jupyterlab/rendermime-interfaces": "^3.8.3-alpha.1",
+    "@jupyterlab/rendermime-interfaces": "^3.9.0-alpha.1",
     "@jupyterlab/services": "^7.1.0-alpha.2",
     "@jupyterlab/settingregistry": "^4.1.0-alpha.2",
     "@jupyterlab/statedb": "^4.1.0-alpha.2",

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@jupyterlab/coreutils": "^6.1.0-alpha.2",
     "@jupyterlab/observables": "^5.1.0-alpha.2",
-    "@jupyterlab/rendermime-interfaces": "^3.8.3-alpha.1",
+    "@jupyterlab/rendermime-interfaces": "^3.9.0-alpha.1",
     "@jupyterlab/services": "^7.1.0-alpha.2",
     "@jupyterlab/settingregistry": "^4.1.0-alpha.2",
     "@jupyterlab/statedb": "^4.1.0-alpha.2",

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -40,7 +40,7 @@
     "@jupyterlab/nbformat": "^4.1.0-alpha.2",
     "@jupyterlab/observables": "^5.1.0-alpha.2",
     "@jupyterlab/rendermime": "^4.1.0-alpha.2",
-    "@jupyterlab/rendermime-interfaces": "^3.8.3-alpha.1",
+    "@jupyterlab/rendermime-interfaces": "^3.9.0-alpha.1",
     "@lumino/disposable": "^2.1.2",
     "@lumino/signaling": "^2.1.2"
   },

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -48,7 +48,7 @@
     "@jupyterlab/coreutils": "^6.1.0-alpha.2",
     "@jupyterlab/observables": "^5.1.0-alpha.2",
     "@jupyterlab/rendermime": "^4.1.0-alpha.2",
-    "@jupyterlab/rendermime-interfaces": "^3.8.3-alpha.1",
+    "@jupyterlab/rendermime-interfaces": "^3.9.0-alpha.1",
     "@jupyterlab/services": "^7.1.0-alpha.2",
     "@jupyterlab/translation": "^4.1.0-alpha.2",
     "@jupyterlab/ui-components": "^4.1.0-alpha.2",

--- a/packages/fileeditor-extension/package.json
+++ b/packages/fileeditor-extension/package.json
@@ -55,7 +55,7 @@
     "@jupyterlab/lsp": "^4.1.0-alpha.2",
     "@jupyterlab/mainmenu": "^4.1.0-alpha.2",
     "@jupyterlab/observables": "^5.1.0-alpha.2",
-    "@jupyterlab/rendermime-interfaces": "^3.8.3-alpha.1",
+    "@jupyterlab/rendermime-interfaces": "^3.9.0-alpha.1",
     "@jupyterlab/services": "^7.1.0-alpha.2",
     "@jupyterlab/settingregistry": "^4.1.0-alpha.2",
     "@jupyterlab/statusbar": "^4.1.0-alpha.2",

--- a/packages/javascript-extension/package.json
+++ b/packages/javascript-extension/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@jupyterlab/rendermime": "^4.1.0-alpha.2",
-    "@jupyterlab/rendermime-interfaces": "^3.8.3-alpha.1"
+    "@jupyterlab/rendermime-interfaces": "^3.9.0-alpha.1"
   },
   "devDependencies": {
     "rimraf": "~3.0.0",

--- a/packages/json-extension/package.json
+++ b/packages/json-extension/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@jupyterlab/apputils": "^4.2.0-alpha.2",
     "@jupyterlab/codemirror": "^4.1.0-alpha.2",
-    "@jupyterlab/rendermime-interfaces": "^3.8.3-alpha.1",
+    "@jupyterlab/rendermime-interfaces": "^3.9.0-alpha.1",
     "@jupyterlab/translation": "^4.1.0-alpha.2",
     "@jupyterlab/ui-components": "^4.1.0-alpha.2",
     "@lezer/highlight": "^1.1.4",

--- a/packages/mermaid-extension/package.json
+++ b/packages/mermaid-extension/package.json
@@ -40,7 +40,7 @@
     "@jupyterlab/application": "^4.1.0-alpha.2",
     "@jupyterlab/apputils": "^4.2.0-alpha.2",
     "@jupyterlab/mermaid": "^4.1.0-alpha.2",
-    "@jupyterlab/rendermime-interfaces": "^3.8.3-alpha.1",
+    "@jupyterlab/rendermime-interfaces": "^3.9.0-alpha.1",
     "@jupyterlab/translation": "^4.1.0-alpha.2"
   },
   "devDependencies": {

--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@jupyterlab/apputils": "^4.2.0-alpha.2",
     "@jupyterlab/coreutils": "^6.1.0-alpha.2",
-    "@jupyterlab/rendermime-interfaces": "^3.8.3-alpha.1",
+    "@jupyterlab/rendermime-interfaces": "^3.9.0-alpha.1",
     "@lumino/coreutils": "^2.1.2",
     "@lumino/widgets": "^2.3.1-alpha.0",
     "mermaid": "^10.5.0"

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -107,7 +107,7 @@
     "@jupyterlab/property-inspector": "^4.1.0-alpha.2",
     "@jupyterlab/rendermime": "^4.1.0-alpha.2",
     "@jupyterlab/rendermime-extension": "^4.1.0-alpha.2",
-    "@jupyterlab/rendermime-interfaces": "^3.8.3-alpha.1",
+    "@jupyterlab/rendermime-interfaces": "^3.9.0-alpha.1",
     "@jupyterlab/running": "^4.1.0-alpha.2",
     "@jupyterlab/running-extension": "^4.1.0-alpha.2",
     "@jupyterlab/services": "^7.1.0-alpha.2",

--- a/packages/outputarea/package.json
+++ b/packages/outputarea/package.json
@@ -46,7 +46,7 @@
     "@jupyterlab/nbformat": "^4.1.0-alpha.2",
     "@jupyterlab/observables": "^5.1.0-alpha.2",
     "@jupyterlab/rendermime": "^4.1.0-alpha.2",
-    "@jupyterlab/rendermime-interfaces": "^3.8.3-alpha.1",
+    "@jupyterlab/rendermime-interfaces": "^3.9.0-alpha.1",
     "@jupyterlab/services": "^7.1.0-alpha.2",
     "@jupyterlab/translation": "^4.1.0-alpha.2",
     "@lumino/algorithm": "^2.0.1",

--- a/packages/pdf-extension/package.json
+++ b/packages/pdf-extension/package.json
@@ -37,7 +37,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/rendermime-interfaces": "^3.8.3-alpha.1",
+    "@jupyterlab/rendermime-interfaces": "^3.9.0-alpha.1",
     "@lumino/coreutils": "^2.1.2",
     "@lumino/disposable": "^2.1.2",
     "@lumino/widgets": "^2.3.1-alpha.0"

--- a/packages/rendermime-interfaces/package.json
+++ b/packages/rendermime-interfaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/rendermime-interfaces",
-  "version": "3.8.3-alpha.1",
+  "version": "3.9.0-alpha.1",
   "description": "JupyterLab - Interfaces for Mime Renderers",
   "homepage": "https://github.com/jupyterlab/jupyterlab",
   "bugs": {

--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -46,7 +46,7 @@
     "@jupyterlab/coreutils": "^6.1.0-alpha.2",
     "@jupyterlab/nbformat": "^4.1.0-alpha.2",
     "@jupyterlab/observables": "^5.1.0-alpha.2",
-    "@jupyterlab/rendermime-interfaces": "^3.8.3-alpha.1",
+    "@jupyterlab/rendermime-interfaces": "^3.9.0-alpha.1",
     "@jupyterlab/services": "^7.1.0-alpha.2",
     "@jupyterlab/translation": "^4.1.0-alpha.2",
     "@lumino/coreutils": "^2.1.2",

--- a/packages/running-extension/package.json
+++ b/packages/running-extension/package.json
@@ -41,7 +41,7 @@
     "@jupyterlab/application": "^4.1.0-alpha.2",
     "@jupyterlab/coreutils": "^6.1.0-alpha.2",
     "@jupyterlab/docregistry": "^4.1.0-alpha.2",
-    "@jupyterlab/rendermime-interfaces": "^3.8.3-alpha.1",
+    "@jupyterlab/rendermime-interfaces": "^3.9.0-alpha.1",
     "@jupyterlab/running": "^4.1.0-alpha.2",
     "@jupyterlab/services": "^7.1.0-alpha.2",
     "@jupyterlab/translation": "^4.1.0-alpha.2",

--- a/packages/translation/package.json
+++ b/packages/translation/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@jupyterlab/coreutils": "^6.1.0-alpha.2",
-    "@jupyterlab/rendermime-interfaces": "^3.8.3-alpha.1",
+    "@jupyterlab/rendermime-interfaces": "^3.9.0-alpha.1",
     "@jupyterlab/services": "^7.1.0-alpha.2",
     "@jupyterlab/statedb": "^4.1.0-alpha.2",
     "@lumino/coreutils": "^2.1.2"

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@jupyterlab/coreutils": "^6.1.0-alpha.2",
     "@jupyterlab/observables": "^5.1.0-alpha.2",
-    "@jupyterlab/rendermime-interfaces": "^3.8.3-alpha.1",
+    "@jupyterlab/rendermime-interfaces": "^3.9.0-alpha.1",
     "@jupyterlab/translation": "^4.1.0-alpha.2",
     "@lumino/algorithm": "^2.0.1",
     "@lumino/commands": "^2.1.3",

--- a/packages/vega5-extension/package.json
+++ b/packages/vega5-extension/package.json
@@ -38,7 +38,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/rendermime-interfaces": "^3.8.3-alpha.1",
+    "@jupyterlab/rendermime-interfaces": "^3.9.0-alpha.1",
     "@lumino/coreutils": "^2.1.2",
     "@lumino/widgets": "^2.3.1-alpha.0",
     "vega": "^5.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2178,7 +2178,7 @@ __metadata:
     "@jupyterlab/coreutils": ^6.1.0-alpha.2
     "@jupyterlab/docregistry": ^4.1.0-alpha.2
     "@jupyterlab/rendermime": ^4.1.0-alpha.2
-    "@jupyterlab/rendermime-interfaces": ^3.8.3-alpha.1
+    "@jupyterlab/rendermime-interfaces": ^3.9.0-alpha.1
     "@jupyterlab/services": ^7.1.0-alpha.2
     "@jupyterlab/statedb": ^4.1.0-alpha.2
     "@jupyterlab/testing": ^4.1.0-alpha.2
@@ -2212,7 +2212,7 @@ __metadata:
     "@jupyterlab/docregistry": ^4.1.0-alpha.2
     "@jupyterlab/filebrowser": ^4.1.0-alpha.2
     "@jupyterlab/mainmenu": ^4.1.0-alpha.2
-    "@jupyterlab/rendermime-interfaces": ^3.8.3-alpha.1
+    "@jupyterlab/rendermime-interfaces": ^3.9.0-alpha.1
     "@jupyterlab/services": ^7.1.0-alpha.2
     "@jupyterlab/settingregistry": ^4.1.0-alpha.2
     "@jupyterlab/statedb": ^4.1.0-alpha.2
@@ -2241,7 +2241,7 @@ __metadata:
   dependencies:
     "@jupyterlab/coreutils": ^6.1.0-alpha.2
     "@jupyterlab/observables": ^5.1.0-alpha.2
-    "@jupyterlab/rendermime-interfaces": ^3.8.3-alpha.1
+    "@jupyterlab/rendermime-interfaces": ^3.9.0-alpha.1
     "@jupyterlab/services": ^7.1.0-alpha.2
     "@jupyterlab/settingregistry": ^4.1.0-alpha.2
     "@jupyterlab/statedb": ^4.1.0-alpha.2
@@ -2277,7 +2277,7 @@ __metadata:
     "@jupyterlab/nbformat": ^4.1.0-alpha.2
     "@jupyterlab/observables": ^5.1.0-alpha.2
     "@jupyterlab/rendermime": ^4.1.0-alpha.2
-    "@jupyterlab/rendermime-interfaces": ^3.8.3-alpha.1
+    "@jupyterlab/rendermime-interfaces": ^3.9.0-alpha.1
     "@lumino/disposable": ^2.1.2
     "@lumino/signaling": ^2.1.2
     rimraf: ~3.0.0
@@ -2883,7 +2883,7 @@ __metadata:
     "@jupyterlab/coreutils": ^6.1.0-alpha.2
     "@jupyterlab/observables": ^5.1.0-alpha.2
     "@jupyterlab/rendermime": ^4.1.0-alpha.2
-    "@jupyterlab/rendermime-interfaces": ^3.8.3-alpha.1
+    "@jupyterlab/rendermime-interfaces": ^3.9.0-alpha.1
     "@jupyterlab/services": ^7.1.0-alpha.2
     "@jupyterlab/testing": ^4.1.0-alpha.2
     "@jupyterlab/translation": ^4.1.0-alpha.2
@@ -3401,7 +3401,7 @@ __metadata:
     "@jupyterlab/lsp": ^4.1.0-alpha.2
     "@jupyterlab/mainmenu": ^4.1.0-alpha.2
     "@jupyterlab/observables": ^5.1.0-alpha.2
-    "@jupyterlab/rendermime-interfaces": ^3.8.3-alpha.1
+    "@jupyterlab/rendermime-interfaces": ^3.9.0-alpha.1
     "@jupyterlab/services": ^7.1.0-alpha.2
     "@jupyterlab/settingregistry": ^4.1.0-alpha.2
     "@jupyterlab/statusbar": ^4.1.0-alpha.2
@@ -3651,7 +3651,7 @@ __metadata:
   resolution: "@jupyterlab/javascript-extension@workspace:packages/javascript-extension"
   dependencies:
     "@jupyterlab/rendermime": ^4.1.0-alpha.2
-    "@jupyterlab/rendermime-interfaces": ^3.8.3-alpha.1
+    "@jupyterlab/rendermime-interfaces": ^3.9.0-alpha.1
     rimraf: ~3.0.0
     typedoc: ~0.24.7
     typescript: ~5.0.4
@@ -3664,7 +3664,7 @@ __metadata:
   dependencies:
     "@jupyterlab/apputils": ^4.2.0-alpha.2
     "@jupyterlab/codemirror": ^4.1.0-alpha.2
-    "@jupyterlab/rendermime-interfaces": ^3.8.3-alpha.1
+    "@jupyterlab/rendermime-interfaces": ^3.9.0-alpha.1
     "@jupyterlab/translation": ^4.1.0-alpha.2
     "@jupyterlab/ui-components": ^4.1.0-alpha.2
     "@lezer/highlight": ^1.1.4
@@ -3941,7 +3941,7 @@ __metadata:
     "@jupyterlab/application": ^4.1.0-alpha.2
     "@jupyterlab/apputils": ^4.2.0-alpha.2
     "@jupyterlab/mermaid": ^4.1.0-alpha.2
-    "@jupyterlab/rendermime-interfaces": ^3.8.3-alpha.1
+    "@jupyterlab/rendermime-interfaces": ^3.9.0-alpha.1
     "@jupyterlab/translation": ^4.1.0-alpha.2
     rimraf: ~3.0.0
     typedoc: ~0.24.7
@@ -3955,7 +3955,7 @@ __metadata:
   dependencies:
     "@jupyterlab/apputils": ^4.2.0-alpha.2
     "@jupyterlab/coreutils": ^6.1.0-alpha.2
-    "@jupyterlab/rendermime-interfaces": ^3.8.3-alpha.1
+    "@jupyterlab/rendermime-interfaces": ^3.9.0-alpha.1
     "@lumino/coreutils": ^2.1.2
     "@lumino/widgets": ^2.3.1-alpha.0
     "@types/jest": ^29.2.0
@@ -4084,7 +4084,7 @@ __metadata:
     "@jupyterlab/property-inspector": ^4.1.0-alpha.2
     "@jupyterlab/rendermime": ^4.1.0-alpha.2
     "@jupyterlab/rendermime-extension": ^4.1.0-alpha.2
-    "@jupyterlab/rendermime-interfaces": ^3.8.3-alpha.1
+    "@jupyterlab/rendermime-interfaces": ^3.9.0-alpha.1
     "@jupyterlab/running": ^4.1.0-alpha.2
     "@jupyterlab/running-extension": ^4.1.0-alpha.2
     "@jupyterlab/services": ^7.1.0-alpha.2
@@ -4312,7 +4312,7 @@ __metadata:
     "@jupyterlab/nbformat": ^4.1.0-alpha.2
     "@jupyterlab/observables": ^5.1.0-alpha.2
     "@jupyterlab/rendermime": ^4.1.0-alpha.2
-    "@jupyterlab/rendermime-interfaces": ^3.8.3-alpha.1
+    "@jupyterlab/rendermime-interfaces": ^3.9.0-alpha.1
     "@jupyterlab/services": ^7.1.0-alpha.2
     "@jupyterlab/testing": ^4.1.0-alpha.2
     "@jupyterlab/translation": ^4.1.0-alpha.2
@@ -4335,7 +4335,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/pdf-extension@workspace:packages/pdf-extension"
   dependencies:
-    "@jupyterlab/rendermime-interfaces": ^3.8.3-alpha.1
+    "@jupyterlab/rendermime-interfaces": ^3.9.0-alpha.1
     "@lumino/coreutils": ^2.1.2
     "@lumino/disposable": ^2.1.2
     "@lumino/widgets": ^2.3.1-alpha.0
@@ -4415,7 +4415,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jupyterlab/rendermime-interfaces@^3.8.3-alpha.1, @jupyterlab/rendermime-interfaces@workspace:packages/rendermime-interfaces":
+"@jupyterlab/rendermime-interfaces@^3.9.0-alpha.1, @jupyterlab/rendermime-interfaces@workspace:packages/rendermime-interfaces":
   version: 0.0.0-use.local
   resolution: "@jupyterlab/rendermime-interfaces@workspace:packages/rendermime-interfaces"
   dependencies:
@@ -4435,7 +4435,7 @@ __metadata:
     "@jupyterlab/coreutils": ^6.1.0-alpha.2
     "@jupyterlab/nbformat": ^4.1.0-alpha.2
     "@jupyterlab/observables": ^5.1.0-alpha.2
-    "@jupyterlab/rendermime-interfaces": ^3.8.3-alpha.1
+    "@jupyterlab/rendermime-interfaces": ^3.9.0-alpha.1
     "@jupyterlab/services": ^7.1.0-alpha.2
     "@jupyterlab/testing": ^4.1.0-alpha.2
     "@jupyterlab/translation": ^4.1.0-alpha.2
@@ -4485,7 +4485,7 @@ __metadata:
     "@jupyterlab/application": ^4.1.0-alpha.2
     "@jupyterlab/coreutils": ^6.1.0-alpha.2
     "@jupyterlab/docregistry": ^4.1.0-alpha.2
-    "@jupyterlab/rendermime-interfaces": ^3.8.3-alpha.1
+    "@jupyterlab/rendermime-interfaces": ^3.9.0-alpha.1
     "@jupyterlab/running": ^4.1.0-alpha.2
     "@jupyterlab/services": ^7.1.0-alpha.2
     "@jupyterlab/translation": ^4.1.0-alpha.2
@@ -4937,7 +4937,7 @@ __metadata:
   resolution: "@jupyterlab/translation@workspace:packages/translation"
   dependencies:
     "@jupyterlab/coreutils": ^6.1.0-alpha.2
-    "@jupyterlab/rendermime-interfaces": ^3.8.3-alpha.1
+    "@jupyterlab/rendermime-interfaces": ^3.9.0-alpha.1
     "@jupyterlab/services": ^7.1.0-alpha.2
     "@jupyterlab/statedb": ^4.1.0-alpha.2
     "@jupyterlab/testing": ^4.1.0-alpha.2
@@ -4967,7 +4967,7 @@ __metadata:
   dependencies:
     "@jupyterlab/coreutils": ^6.1.0-alpha.2
     "@jupyterlab/observables": ^5.1.0-alpha.2
-    "@jupyterlab/rendermime-interfaces": ^3.8.3-alpha.1
+    "@jupyterlab/rendermime-interfaces": ^3.9.0-alpha.1
     "@jupyterlab/testing": ^4.1.0-alpha.2
     "@jupyterlab/translation": ^4.1.0-alpha.2
     "@lumino/algorithm": ^2.0.1
@@ -5001,7 +5001,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/vega5-extension@workspace:packages/vega5-extension"
   dependencies:
-    "@jupyterlab/rendermime-interfaces": ^3.8.3-alpha.1
+    "@jupyterlab/rendermime-interfaces": ^3.9.0-alpha.1
     "@jupyterlab/testutils": ^4.1.0-alpha.2
     "@lumino/coreutils": ^2.1.2
     "@lumino/widgets": ^2.3.1-alpha.0


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

As noticed in https://github.com/jupyterlab/jupyterlab/issues/14335#issuecomment-1752619782.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

The current `main` (targeting JupyterLab 4.1) defines the following version:

https://github.com/jupyterlab/jupyterlab/blob/0b33a5ca9318d909233914adb0cbd90d3bc7a472/packages/rendermime-interfaces/package.json#L3

While the `4.0.x` defines this version:

https://github.com/jupyterlab/jupyterlab/blob/14705251b7bd90f715a454c568e54655a63a19b4/packages/rendermime-interfaces/package.json#L3

This aligns the version to the one on `main` is "ahead".

## Code changes

Bump `@jupyterlab/rendermime-interfaces` to `3.9.0-alpha.1`

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
