### PR TITLE
Improve docker script

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,11 +29,13 @@ RUN if grep -q '^ID=alpine$' /etc/os-release; then \
 ENV MAMBA_USER=$NEW_MAMBA_USER
 USER $MAMBA_USER
 
-
 WORKDIR /home/$MAMBA_USER/jupyterlab_cache
-COPY --chown=$MAMBA_USER:$MAMBA_USER .. .
 
-RUN  micromamba install -n base -c conda-forge git rsync -y && micromamba install -y -n base -f /home/$MAMBA_USER/jupyterlab_cache/binder/environment.yml && micromamba clean --all --yes
+COPY --chown=$MAMBA_USER:$MAMBA_USER ../binder/environment.yml ./binder/environment.yml
+
+RUN  micromamba install -n base -c conda-forge git rsync -y && micromamba install -y -n base -f ./binder/environment.yml && micromamba clean --all --yes
+
+COPY --chown=$MAMBA_USER:$MAMBA_USER .. .
 
 RUN micromamba run jlpm install
 

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -13,6 +13,11 @@ GID=$(id -g)
 RSYNC_CMD="rsync -ar /home/$DEV_USER/jupyterlab_cache/node_modules/. /home/$DEV_USER/jupyterlab/node_modules"
 CMD=$1 # possible command: build, clean, dev, shell
 
+PORT=8888 # Optional, only used for the `dev` command
+re='^[0-9]+$'
+if [[ $2 =~ $re ]] ; then
+    PORT=$2
+fi
 
 stringmd5() {
     echo "md5sum,md5" | tr ',' '\n' | while read -r cmd; do
@@ -55,7 +60,7 @@ if [[ $CMD == 'build' ]]; then
     fi
     stop_contaniner
     if [[ $CMD == 'dev' || $CMD == '' || $CMD == 'dev-detach' ]]; then
-        DOCKER_CMD="$RSYNC_CMD && jupyter lab --dev-mode --watch --ip 0.0.0.0"
+        DOCKER_CMD="$RSYNC_CMD && jupyter lab --dev-mode --extensions-in-dev-mode --watch --ip 0.0.0.0 --port $PORT"
     else
         DOCKER_CMD="$RSYNC_CMD && bash"
     fi
@@ -63,5 +68,5 @@ if [[ $CMD == 'build' ]]; then
     if [[ $CMD == 'dev-detach' ]]; then
         RUN_MODE="-d"
     fi
-    docker run $RUN_MODE --name $DEV_CONTAINER --rm -p 8888:8888 -v $ROOT_DIR:/home/$DEV_USER/jupyterlab --entrypoint "/bin/bash" $IMAGE_TAG -i -c "$DOCKER_CMD"
+    docker run $RUN_MODE --name $DEV_CONTAINER --rm -p $PORT:$PORT -v $ROOT_DIR:/home/$DEV_USER/jupyterlab --entrypoint "/bin/bash" $IMAGE_TAG -i -c "$DOCKER_CMD"
 fi

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -378,7 +378,7 @@ Other available commands:
 
 .. code:: bash
 
-   bash docker/start.sh dev  # Same as calling bash docker/start.sh
+   bash docker/start.sh dev 4567 # Start JupyterLab dev container at port 4567
    bash docker/start.sh stop  # Stop the running container
    bash docker/start.sh clean  # Remove the docker image
    bash docker/start.sh build  # Rebuild the docker image


### PR DESCRIPTION

## References


- Improve Dockerfile to accelerate the build process
- Allow starting the dev container at different ports, the following command will start JupyterLab at port `4567` instead of the default one.
```bash
bash ./docker/start.sh dev 4567 
```

## Code changes


## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
