### PR TITLE
Update virtual documents conditionally

### DIFF
--- a/packages/lsp/src/adapters/adapter.ts
+++ b/packages/lsp/src/adapters/adapter.ts
@@ -97,6 +97,14 @@ export abstract class WidgetLSPAdapter<
     this._editorToAdapter = new WeakMap();
     this.editorAdded.connect(this._onEditorAdded, this);
     this.editorRemoved.connect(this._onEditorRemoved, this);
+    this._connectionManager.languageServerManager.sessionsChanged.connect(
+      this._onLspSessionOrFeatureChanged,
+      this
+    );
+    this.options.featureManager.featureRegistered.connect(
+      this._onLspSessionOrFeatureChanged,
+      this
+    );
   }
 
   /**
@@ -271,6 +279,14 @@ export abstract class WidgetLSPAdapter<
     }
     this.editorAdded.disconnect(this._onEditorAdded, this);
     this.editorRemoved.disconnect(this._onEditorRemoved, this);
+    this._connectionManager.languageServerManager.sessionsChanged.disconnect(
+      this._onLspSessionOrFeatureChanged,
+      this
+    );
+    this.options.featureManager.featureRegistered.disconnect(
+      this._onLspSessionOrFeatureChanged,
+      this
+    );
     this._isDisposed = true;
     this.disconnect();
     this._virtualDocument = null;
@@ -531,10 +547,9 @@ export abstract class WidgetLSPAdapter<
    * Create the virtual document using current path and language.
    */
   protected initVirtual(): void {
-    const { model } = this.widget.context;
     this._virtualDocument?.dispose();
     this._virtualDocument = this.createVirtualDocument();
-    model.contentChanged.connect(this._onContentChanged, this);
+    this._onLspSessionOrFeatureChanged();
   }
 
   /**
@@ -652,6 +667,7 @@ export abstract class WidgetLSPAdapter<
    */
   private async _connect(virtualDocument: VirtualDocument) {
     let language = virtualDocument.language;
+    console.log('connection', language);
 
     let capabilities: ClientCapabilities = {
       textDocument: {
@@ -681,6 +697,7 @@ export abstract class WidgetLSPAdapter<
     };
 
     let connection = await this.connectionManager.connect(options);
+    console.log('connection', connection);
 
     if (connection) {
       await this.onConnected({ virtualDocument, connection });
@@ -717,5 +734,24 @@ export abstract class WidgetLSPAdapter<
     }
     this._updateFinished = promise.catch(console.warn);
     await this.updateFinished;
+  }
+
+  private _shouldUpdateVirtualDocument(): boolean {
+    const { languageServerManager } = this.connectionManager;
+
+    return (
+      languageServerManager.isEnabled &&
+      languageServerManager.getMatchingServers({ language: this.language }) &&
+      this.options.featureManager.features.length > 0
+    );
+  }
+
+  private _onLspSessionOrFeatureChanged(): void {
+    const { model } = this.widget.context;
+    if (this._shouldUpdateVirtualDocument()) {
+      model.contentChanged.connect(this._onContentChanged, this);
+    } else {
+      model.contentChanged.disconnect(this._onContentChanged, this);
+    }
   }
 }

--- a/packages/lsp/src/adapters/adapter.ts
+++ b/packages/lsp/src/adapters/adapter.ts
@@ -734,37 +734,34 @@ export abstract class WidgetLSPAdapter<
     await this.updateFinished;
   }
 
-  private _shouldUpdateVirtualDocument(languages: string[]): boolean {
+  /**
+   * Check if the virtual document should be updated on content
+   * changed signal. Returns `true` if two following conditions are
+   * are satisfied:
+   *  - The LSP feature is enabled.
+   *  - The LSP features list is not empty.
+   */
+  private _shouldUpdateVirtualDocument(): boolean {
     const { languageServerManager } = this.connectionManager;
-    let matchedServer = false;
-    for (const language of languages) {
-      if (languageServerManager.getMatchingServers({ language })) {
-        matchedServer = true;
-        break;
-      }
-    }
     return (
       languageServerManager.isEnabled &&
-      matchedServer &&
       this.options.featureManager.features.length > 0
     );
   }
 
+  /**
+   * Connect the virtual document update handler with the content
+   * updated signal.This method is invoked at startup and when
+   * the LSP server status changed or when a LSP feature is registered.
+   */
   private _onLspSessionOrFeatureChanged(): void {
     if (!this._virtualDocument) {
       return;
     }
 
-    const languages = [
-      this._virtualDocument.language,
-      ...[...this._virtualDocument.foreignDocuments.values()].map(
-        it => it.language
-      )
-    ];
-
     const { model } = this.widget.context;
 
-    if (this._shouldUpdateVirtualDocument(languages)) {
+    if (this._shouldUpdateVirtualDocument()) {
       model.contentChanged.connect(this._onContentChanged, this);
     } else {
       model.contentChanged.disconnect(this._onContentChanged, this);

--- a/packages/lsp/test/adapters.spec.ts
+++ b/packages/lsp/test/adapters.spec.ts
@@ -215,7 +215,7 @@ describe('@jupyterlab/lsp', () => {
     });
   });
 
-  describe('WidgetLSPAdapter1', () => {
+  describe('WidgetLSPAdapter', () => {
     let shell: LabShell;
     let adapterTracker: WidgetLSPAdapterTracker;
 

--- a/packages/lsp/test/adapters.spec.ts
+++ b/packages/lsp/test/adapters.spec.ts
@@ -2,26 +2,28 @@
  * Copyright (c) Jupyter Development Team.
  * Distributed under the terms of the Modified BSD License.
  */
-
+import { LabShell } from '@jupyterlab/application';
+import { CodeEditor } from '@jupyterlab/codeeditor';
+import { CodeMirrorEditor } from '@jupyterlab/codemirror';
 import {
   CodeExtractorsManager,
+  Document,
   DocumentConnectionManager,
   EditorAdapter,
   FeatureManager,
+  IAdapterOptions,
+  IVirtualPosition,
   LanguageServerManager,
+  VirtualDocument,
+  WidgetLSPAdapter,
   WidgetLSPAdapterTracker
 } from '@jupyterlab/lsp';
-import { ServerConnection } from '@jupyterlab/services';
-import { CodeEditor } from '@jupyterlab/codeeditor';
-import { CodeMirrorEditor } from '@jupyterlab/codemirror';
 import { NotebookAdapter } from '@jupyterlab/notebook';
-import { LabShell } from '@jupyterlab/application';
-
-import { signalToPromise } from '@jupyterlab/testing';
 import { NBTestUtils } from '@jupyterlab/notebook/lib/testutils';
-
-import { Widget } from '@lumino/widgets';
+import { ServerConnection } from '@jupyterlab/services';
+import { signalToPromise } from '@jupyterlab/testing';
 import { PromiseDelegate } from '@lumino/coreutils';
+import { Widget } from '@lumino/widgets';
 
 const spy = jest.spyOn(ServerConnection, 'makeRequest');
 const specs = {
@@ -212,6 +214,130 @@ describe('@jupyterlab/lsp', () => {
       tracker.dispose();
     });
   });
+
+  describe('WidgetLSPAdapter1', () => {
+    let shell: LabShell;
+    let adapterTracker: WidgetLSPAdapterTracker;
+
+    beforeEach(async () => {
+      shell = new LabShell({ waitForRestore: false });
+      adapterTracker = new WidgetLSPAdapterTracker({ shell });
+      Widget.attach(shell, document.body);
+    });
+
+    afterEach(() => {
+      shell.dispose();
+      adapterTracker.dispose();
+    });
+    it('should create an adapter', async () => {
+      const { widgetAdapter } = await createMockAdapter(adapterTracker);
+      expect(widgetAdapter).toBeInstanceOf(WidgetLSPAdapter);
+      expect(widgetAdapter.language).toBe('python');
+      expect(widgetAdapter.mimeType).toBe('text/python');
+      await widgetAdapter.ready;
+      expect(widgetAdapter.virtualDocument).toBeInstanceOf(VirtualDocument);
+    });
+
+    it('should disconnect signals on disposing', async () => {
+      const { widgetAdapter, connectionManager, featureManager } =
+        await await createMockAdapter(adapterTracker);
+      const editorAddedSpy = jest.spyOn(
+        widgetAdapter.editorAdded,
+        'disconnect'
+      );
+      const editorRemovedSpy = jest.spyOn(
+        widgetAdapter.editorRemoved,
+        'disconnect'
+      );
+      const sessionsChangedSpy = jest.spyOn(
+        connectionManager.languageServerManager.sessionsChanged,
+        'disconnect'
+      );
+      const featureRegisteredSpy = jest.spyOn(
+        featureManager.featureRegistered,
+        'disconnect'
+      );
+      const disconnectSpy = jest.spyOn(widgetAdapter, 'disconnect');
+      widgetAdapter.dispose();
+      expect(editorAddedSpy).toHaveBeenCalled();
+      expect(editorRemovedSpy).toHaveBeenCalled();
+      expect(sessionsChangedSpy).toHaveBeenCalled();
+      expect(featureRegisteredSpy).toHaveBeenCalled();
+      expect(disconnectSpy).toHaveBeenCalled();
+    });
+
+    it('should not update virtual document if LSP is not avaiable', async () => {
+      const { widgetAdapter } = await createMockAdapter(adapterTracker);
+
+      const { model } = widgetAdapter.widget.context;
+      const contentChangedConnectSpy = jest.spyOn(
+        model.contentChanged,
+        'connect'
+      );
+      const contentChangedDisconnectSpy = jest.spyOn(
+        model.contentChanged,
+        'disconnect'
+      );
+      widgetAdapter['initVirtual']();
+      expect(contentChangedConnectSpy).toHaveBeenCalledTimes(0);
+      expect(contentChangedDisconnectSpy).toHaveBeenCalledTimes(1);
+    });
+    it('should update the virtual document if LSP server is activated and available', async () => {
+      const { widgetAdapter, connectionManager, featureManager } =
+        await createMockAdapter(adapterTracker);
+
+      const { model } = widgetAdapter.widget.context;
+      const contentChangedConnectSpy = jest.spyOn(
+        model.contentChanged,
+        'connect'
+      );
+      const contentChangedDisconnectSpy = jest.spyOn(
+        model.contentChanged,
+        'disconnect'
+      );
+      jest
+        .spyOn(connectionManager.languageServerManager, 'isEnabled', 'get')
+        .mockReturnValue(true);
+      jest
+        .spyOn(connectionManager.languageServerManager, 'getMatchingServers')
+        .mockReturnValue(['pylsp']);
+      featureManager.register({ id: 'foo-feature' });
+
+      widgetAdapter['initVirtual']();
+      expect(widgetAdapter.virtualDocument).toBeInstanceOf(VirtualDocument);
+      expect(contentChangedConnectSpy).toHaveBeenCalled();
+      expect(contentChangedDisconnectSpy).toHaveBeenCalledTimes(0);
+    });
+    it('should toggle the virtual document update if LSP server changed', async () => {
+      const { widgetAdapter, connectionManager, featureManager } =
+        await createMockAdapter(adapterTracker);
+
+      const { model } = widgetAdapter.widget.context;
+      const contentChangedConnectSpy = jest.spyOn(
+        model.contentChanged,
+        'connect'
+      );
+      const contentChangedDisconnectSpy = jest.spyOn(
+        model.contentChanged,
+        'disconnect'
+      );
+      widgetAdapter['initVirtual']();
+
+      expect(contentChangedConnectSpy).toHaveBeenCalledTimes(0);
+      expect(contentChangedDisconnectSpy).toHaveBeenCalled();
+
+      // Toggle LSP on
+      jest
+        .spyOn(connectionManager.languageServerManager, 'isEnabled', 'get')
+        .mockReturnValue(true);
+      jest
+        .spyOn(connectionManager.languageServerManager, 'getMatchingServers')
+        .mockReturnValue(['pylsp']);
+      featureManager.register({ id: 'foo-feature' });
+
+      expect(contentChangedConnectSpy).toHaveBeenCalled();
+    });
+  });
 });
 
 async function createAdapter(
@@ -241,4 +367,79 @@ async function createAdapter(
     languageServerManager.dispose();
   });
   return adapter;
+}
+
+class MockWidgetLSPAdapter extends WidgetLSPAdapter {
+  constructor(
+    public widget: any,
+    protected options: IAdapterOptions
+  ) {
+    super(widget, options);
+    this.initVirtual();
+  }
+  get wrapperElement(): HTMLElement {
+    return document.createElement('div');
+  }
+
+  get documentPath(): string {
+    return '';
+  }
+
+  get mimeType(): string {
+    return 'text/python';
+  }
+
+  get languageFileExtension(): string | undefined {
+    return undefined;
+  }
+
+  get activeEditor(): Document.IEditor | undefined {
+    return undefined;
+  }
+
+  get editors(): Document.ICodeBlockOptions[] {
+    return [];
+  }
+
+  get ready(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  createVirtualDocument(): VirtualDocument {
+    return new VirtualDocument({} as any);
+  }
+
+  getEditorIndexAt(position: IVirtualPosition): number {
+    return 0;
+  }
+
+  getEditorIndex(ceEditor: Document.IEditor): number {
+    return 0;
+  }
+
+  getEditorWrapper(ceEditor: Document.IEditor): HTMLElement {
+    return document.createElement('div');
+  }
+}
+
+async function createMockAdapter(adapterTracker: WidgetLSPAdapterTracker) {
+  const context = await NBTestUtils.createMockContext(false);
+  const widget = NBTestUtils.createNotebookPanel(context);
+
+  const languageServerManager = new LanguageServerManager({
+    retries: 0,
+    retriesInterval: 0
+  });
+  const connectionManager = new DocumentConnectionManager({
+    adapterTracker,
+    languageServerManager
+  });
+  const featureManager = new FeatureManager();
+  const foreignCodeExtractorsManager = new CodeExtractorsManager();
+  const widgetAdapter = new MockWidgetLSPAdapter(widget, {
+    featureManager,
+    connectionManager,
+    foreignCodeExtractorsManager
+  });
+  return { widgetAdapter, connectionManager, featureManager };
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Partially addresses https://github.com/jupyterlab/jupyterlab/issues/15144

> The LSP virtual document is not listening to updates if there is no LSP feature registered or no server connected

## Code changes

- The virtual document is connected to the `contentChanged` signal if three conditions are satisfied: 
  -  The LSP feature is enabled.
  -  There is a connected server for the language of the document.
  - The LSP features list is not empty.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
