### PR TITLE
Fixed home page link to sibling project.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,7 +25,7 @@ ideas with others.
 
 JupyterLab is a sibling to other notebook authoring applications under
 the `Project Jupyter <https://docs.jupyter.org/en/latest/>`_ umbrella, like
-`Jupyter Notebook <https://jupyterlab.readthedocs.io/en/latest/>`_ and
+`Jupyter Notebook <https://jupyter-notebook.readthedocs.io/en/latest/>`_ and
 `Jupyter Desktop <https://github.com/jupyterlab/jupyterlab-desktop>`_. JupyterLab
 offers a more advanced, feature rich, customizable experience compared to
 Jupyter Notebook.


### PR DESCRIPTION
This PR fixes the link on the docs index page to JupyterLab's sibling project, Jupyter notebook.