### PR TITLE
Fix connection loop issue with standalone foreign document in LSP

### DIFF
--- a/packages/lsp/src/virtual/document.ts
+++ b/packages/lsp/src/virtual/document.ts
@@ -461,9 +461,6 @@ export class VirtualDocument implements IDisposable {
    * Clear the virtual document and all related stuffs
    */
   clear(): void {
-    this.unusedStandaloneDocuments.forEach(item =>
-      item.forEach(doc => doc.dispose())
-    );
     this.unusedStandaloneDocuments.clear();
 
     for (let document of this.foreignDocuments.values()) {
@@ -745,7 +742,7 @@ export class VirtualDocument implements IDisposable {
             );
             continue;
           }
-          let foreignDocument = this.chooseForeignDocument(extractor);
+          let foreignDocument = this._chooseForeignDocument(extractor);
           foreignDocumentsMap.set(result.range, {
             virtualLine: foreignDocument.lastVirtualLine,
             virtualDocument: foreignDocument,
@@ -800,8 +797,6 @@ export class VirtualDocument implements IDisposable {
    * Close all foreign documents.
    */
   closeAllForeignDocuments(): void {
-    console.log('closing');
-
     for (let document of this.foreignDocuments.values()) {
       this.closeForeign(document);
     }
@@ -897,6 +892,19 @@ export class VirtualDocument implements IDisposable {
   }
 
   /**
+   * Compute the position in root document from the position of
+   * a virtual document.
+   */
+  transformVirtualToRoot(position: IVirtualPosition): IRootPosition | null {
+    const editor = this.virtualLines.get(position.line)?.editor;
+    const editorPosition = this.transformVirtualToEditor(position);
+    if (!editor || !editorPosition) {
+      return null;
+    }
+    return this.root.transformFromEditorToRoot(editor, editorPosition);
+  }
+
+  /**
    * Get the corresponding editor of the virtual line.
    */
   getEditorAtVirtualLine(pos: IVirtualPosition): Document.IEditor {
@@ -973,7 +981,7 @@ export class VirtualDocument implements IDisposable {
   /**
    * Get the foreign document that can be opened with the input extractor.
    */
-  private chooseForeignDocument(
+  private _chooseForeignDocument(
     extractor: IForeignCodeExtractor
   ): VirtualDocument {
     let foreignDocument: VirtualDocument;
@@ -1012,13 +1020,16 @@ export class VirtualDocument implements IDisposable {
     standalone: boolean,
     fileExtension: string
   ): VirtualDocument {
-    let document = new VirtualDocument({
+    let document = new (this.constructor as new (
+      ...args: ConstructorParameters<typeof VirtualDocument>
+    ) => VirtualDocument)({
       ...this.options,
       parent: this,
       standalone: standalone,
       fileExtension: fileExtension,
       language: language
     });
+
     const context: Document.IForeignContext = {
       foreignDocument: document,
       parentHost: this

--- a/packages/lsp/test/document.spec.ts
+++ b/packages/lsp/test/document.spec.ts
@@ -225,16 +225,16 @@ describe('@jupyterlab/lsp', () => {
         expect(foreignDocumentsMap.size).toEqual(1);
       });
     });
-    describe('#chooseForeignDocument', () => {
+    describe('#_chooseForeignDocument', () => {
       it('should select the foreign document for markdown cell', () => {
-        const md: VirtualDocument = document['chooseForeignDocument'](
+        const md: VirtualDocument = document['_chooseForeignDocument'](
           markdownCellExtractor
         );
         expect(md.uri).toBe('test.ipynb.python-markdown.md');
       });
       it('should select the foreign document for raw cell', () => {
         const md: VirtualDocument =
-          document['chooseForeignDocument'](rawCellExtractor);
+          document['_chooseForeignDocument'](rawCellExtractor);
         expect(md.uri).toBe('test.ipynb.python-text.txt');
       });
     });
@@ -282,14 +282,14 @@ describe('@jupyterlab/lsp', () => {
       it('should emit the `foreignDocumentClosed` signal', () => {
         const cb = jest.fn();
         document.foreignDocumentClosed.connect(cb);
-        const md: VirtualDocument = document['chooseForeignDocument'](
+        const md: VirtualDocument = document['_chooseForeignDocument'](
           markdownCellExtractor
         );
         document.closeForeign(md);
         expect(cb).toHaveBeenCalled();
       });
       it('should close correctly foreign documents', () => {
-        const md: VirtualDocument = document['chooseForeignDocument'](
+        const md: VirtualDocument = document['_chooseForeignDocument'](
           markdownCellExtractor
         );
         md.closeAllForeignDocuments = jest.fn();
@@ -312,7 +312,7 @@ describe('@jupyterlab/lsp', () => {
         );
       });
       it('should get the markdown content of the document', () => {
-        const md = document['chooseForeignDocument'](markdownCellExtractor);
+        const md = document['_chooseForeignDocument'](markdownCellExtractor);
 
         expect(md.value).toContain(
           'test line in markdown 1\ntest line in markdown 2'

--- a/packages/lsp/test/document.spec.ts
+++ b/packages/lsp/test/document.spec.ts
@@ -245,7 +245,7 @@ describe('@jupyterlab/lsp', () => {
           document['_chooseForeignDocument'](rawCellExtractor);
         expect(md.uri).toBe('test.ipynb.python-text.txt');
       });
-      it('should use unused virtual document if availble', () => {
+      it('should use unused virtual document if available', () => {
         document.appendCodeBlock({
           value: 'test line in raw 1\ntest line in raw 2',
           ceEditor: {} as Document.IEditor,


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Partially addresses #15126
Improvement in `VirtualDocument`: 
- `chooseForeignDocument` now reuses unused standalone virtual document
- `openForeign` creates foreign documents from the current class instead of `VirtualDocument`.
- New method `transformVirtualToRoot`
## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
