### PR TITLE
Store information about execution failure timing

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1632,6 +1632,15 @@ export namespace CodeCell {
       // execution, clear the prompt.
       if (future && !cell.isDisposed && cell.outputArea.future === future) {
         cell.setPrompt('');
+        if (recordTiming && future.isDisposed) {
+          // Record the time when the cell execution was aborted
+          const timingInfo: any = Object.assign(
+            {},
+            model.getMetadata('execution')
+          );
+          timingInfo['execution_failed'] = new Date().toISOString();
+          model.setMetadata('execution', timingInfo);
+        }
       }
       throw e;
     }


### PR DESCRIPTION
## References

https://github.com/deshaw/jupyterlab-execute-time/issues/84

## Code changes

Adds `execution_failed` to `execution` metadata when execution is aborted due to kernel restart/when kernel dies.

Questions:
- is `execution_failed` the best name? the other existing keys are derived from message channel/name/status:
    https://github.com/jupyterlab/jupyterlab/blob/897418f0f25ffbbee3aa06a62770a53246823f85/packages/cells/test/widget.spec.ts#L905-L911

## User-facing changes

Users of `jupyterlab-execute-time` will be able to see when the execution failed/after how much time rather than incorrectly seeing the execution timer continue.

| Before | After |
|--------|--------|
| ![execute-before](https://github.com/jupyterlab/jupyterlab/assets/5832902/b1eb1628-0d0f-4cf5-9cdb-902b981ba0c6) | ![execute-after](https://github.com/jupyterlab/jupyterlab/assets/5832902/1214f257-8af5-415e-b26d-3f638d2d1cfd) | 

## Backwards-incompatible changes

None