### PR TITLE
Keep active cell rendered in the `full` windowed mode

### DIFF
--- a/galata/test/jupyterlab/notebook-scroll.test.ts
+++ b/galata/test/jupyterlab/notebook-scroll.test.ts
@@ -42,16 +42,13 @@ test.describe('Notebook Scroll', () => {
     test(`Scroll to ${link}`, async ({ page }) => {
       const firstCell = await page.notebook.getCell(0);
       await firstCell.scrollIntoViewIfNeeded();
-      expect(await firstCell.boundingBox()).toBeTruthy();
 
       await page.click(`a:has-text("${link}")`);
 
       await firstCell.waitForElementState('hidden');
-      expect(await firstCell.boundingBox()).toBeFalsy();
 
       const lastCell = await page.notebook.getCell(cellIdx);
       await lastCell.waitForElementState('visible');
-      expect(await lastCell.boundingBox()).toBeTruthy();
     });
   }
 });

--- a/galata/test/jupyterlab/windowed-notebook.test.ts
+++ b/galata/test/jupyterlab/windowed-notebook.test.ts
@@ -131,34 +131,37 @@ test('should not detach active code cell input when scrolling down', async ({
   expect(await firstCell.waitForSelector('.jp-InputArea')).toBeDefined();
 });
 
-test('should scroll back to the active cell on typing', async ({
-  page,
-  tmpPath
-}) => {
-  await page.notebook.openByPath(`${tmpPath}/${fileName}`);
+for (const cellType of ['code', 'markdown']) {
+  test(`should scroll back to the active ${cellType} cell on typing`, async ({
+    page,
+    tmpPath
+  }) => {
+    await page.notebook.openByPath(`${tmpPath}/${fileName}`);
 
-  await page.notebook.enterCellEditingMode(0);
-  const h = await page.notebook.getNotebookInPanel();
-  const firstCellSelector = '.jp-Cell[data-windowed-list-index="0"]';
-  const firstCell = await h!.waitForSelector(firstCellSelector);
+    await page.notebook.setCellType(0, cellType);
+    await page.notebook.enterCellEditingMode(0);
+    const h = await page.notebook.getNotebookInPanel();
+    const firstCellSelector = '.jp-Cell[data-windowed-list-index="0"]';
+    const firstCell = await h!.waitForSelector(firstCellSelector);
 
-  const bbox = await h!.boundingBox();
-  await page.mouse.move(bbox!.x, bbox!.y);
-  await Promise.all([
-    firstCell.waitForElementState('hidden'),
-    page.mouse.wheel(0, 1200)
-  ]);
+    const bbox = await h!.boundingBox();
+    await page.mouse.move(bbox!.x, bbox!.y);
+    await Promise.all([
+      firstCell.waitForElementState('hidden'),
+      page.mouse.wheel(0, 1200)
+    ]);
 
-  // Type in the cell
-  await page.keyboard.type('new text', { delay: 100 });
+    // Type in the cell
+    await page.keyboard.type('TEST', { delay: 150 });
 
-  // Expect the cell to become visible again
-  await firstCell.waitForElementState('visible');
+    // Expect the cell to become visible again
+    await firstCell.waitForElementState('visible');
 
-  // Expect the text to populate the cell editor
-  const firstCellInput = await page.notebook.getCellInput(0);
-  expect(await firstCellInput.textContent()).toContain('new text');
-});
+    // Expect the text to populate the cell editor
+    const firstCellInput = await page.notebook.getCellInput(0);
+    expect(await firstCellInput.textContent()).toContain('TEST');
+  });
+}
 
 test('should scroll back to the cell below the active cell on arrow down key', async ({
   page,

--- a/galata/test/jupyterlab/windowed-notebook.test.ts
+++ b/galata/test/jupyterlab/windowed-notebook.test.ts
@@ -55,12 +55,15 @@ test('should not update height when hiding', async ({ page, tmpPath }) => {
   expect(parseInt(innerHeight, 10)).toEqual(initialHeight);
 });
 
-test('should hide first code cell when scrolling down', async ({
+test('should hide first inactive code cell when scrolling down', async ({
   page,
   tmpPath
 }) => {
   await page.notebook.openByPath(`${tmpPath}/${fileName}`);
 
+  // Activate >second< cell
+  await page.notebook.selectCells(1);
+  // Test if the >first< (now inactive) cell gets detached
   const h = await page.notebook.getNotebookInPanel();
   const firstCellSelector = '.jp-Cell[data-windowed-list-index="0"]';
   const firstCell = await h!.waitForSelector(firstCellSelector);
@@ -76,12 +79,15 @@ test('should hide first code cell when scrolling down', async ({
   expect(await firstCell.textContent()).toEqual('[16]:local link\n');
 });
 
-test('should reattached a code code cell when scrolling back into the viewport', async ({
+test('should reattached inactive code cell when scrolling back into the viewport', async ({
   page,
   tmpPath
 }) => {
   await page.notebook.openByPath(`${tmpPath}/${fileName}`);
 
+  // Activate >second< cell
+  await page.notebook.selectCells(1);
+  // Test if the >first< (now inactive) cell gets re-attached
   const h = await page.notebook.getNotebookInPanel();
   const firstCellSelector = '.jp-Cell[data-windowed-list-index="0"]';
   const firstCell = await h!.waitForSelector(firstCellSelector);
@@ -101,6 +107,88 @@ test('should reattached a code code cell when scrolling back into the viewport',
 
   // Check that the input area is back
   expect(await firstCell.waitForSelector('.jp-InputArea')).toBeDefined();
+});
+
+test('should not detach active code cell input when scrolling down', async ({
+  page,
+  tmpPath
+}) => {
+  await page.notebook.openByPath(`${tmpPath}/${fileName}`);
+
+  await page.notebook.selectCells(0);
+  const h = await page.notebook.getNotebookInPanel();
+  const firstCellSelector = '.jp-Cell[data-windowed-list-index="0"]';
+  const firstCell = await h!.waitForSelector(firstCellSelector);
+
+  const bbox = await h!.boundingBox();
+  await page.mouse.move(bbox!.x, bbox!.y);
+  await Promise.all([
+    firstCell.waitForElementState('hidden'),
+    page.mouse.wheel(0, 1200)
+  ]);
+
+  // Check the input is still defined
+  expect(await firstCell.waitForSelector('.jp-InputArea')).toBeDefined();
+});
+
+test('should scroll back to the active cell on typing', async ({
+  page,
+  tmpPath
+}) => {
+  await page.notebook.openByPath(`${tmpPath}/${fileName}`);
+
+  await page.notebook.enterCellEditingMode(0);
+  const h = await page.notebook.getNotebookInPanel();
+  const firstCellSelector = '.jp-Cell[data-windowed-list-index="0"]';
+  const firstCell = await h!.waitForSelector(firstCellSelector);
+
+  const bbox = await h!.boundingBox();
+  await page.mouse.move(bbox!.x, bbox!.y);
+  await Promise.all([
+    firstCell.waitForElementState('hidden'),
+    page.mouse.wheel(0, 1200)
+  ]);
+
+  // Type in the cell
+  await page.keyboard.type('new text', { delay: 100 });
+
+  // Expect the cell to become visible again
+  await firstCell.waitForElementState('visible');
+
+  // Expect the text to populate the cell editor
+  const firstCellInput = await page.notebook.getCellInput(0);
+  expect(await firstCellInput.textContent()).toContain('new text');
+});
+
+test('should scroll back to the cell below the active cell on arrow down key', async ({
+  page,
+  tmpPath
+}) => {
+  await page.notebook.openByPath(`${tmpPath}/${fileName}`);
+
+  // Activate the first cell.
+  await page.notebook.selectCells(0);
+  const h = await page.notebook.getNotebookInPanel();
+  const firstCell = await h!.waitForSelector(
+    '.jp-Cell[data-windowed-list-index="0"]'
+  );
+  const secondCell = await h!.waitForSelector(
+    '.jp-Cell[data-windowed-list-index="1"]'
+  );
+
+  const bbox = await h!.boundingBox();
+  await page.mouse.move(bbox!.x, bbox!.y);
+  await Promise.all([
+    firstCell.waitForElementState('hidden'),
+    secondCell.waitForElementState('hidden'),
+    page.mouse.wheel(0, 1200)
+  ]);
+
+  // Select cell below the active cell
+  await page.keyboard.press('ArrowDown');
+
+  // Expect the second cell to become visible again.
+  await secondCell.waitForElementState('visible');
 });
 
 test('should detach a markdown code cell when scrolling out of the viewport', async ({

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -2095,7 +2095,7 @@ export class Notebook extends StaticNotebook {
     const activeCell = this.activeCell;
     if (this.mode === 'edit' && activeCell) {
       // Test for !== true to cover hasFocus is false and editor is not yet rendered.
-      if (activeCell.editor?.hasFocus() !== true) {
+      if (activeCell.editor?.hasFocus() !== true || !activeCell.inViewport) {
         if (activeCell.inViewport) {
           activeCell.editor?.focus();
         } else {

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1400,6 +1400,7 @@ export class Notebook extends StaticNotebook {
 
     this._activeCellIndex = newValue;
     const cell = this.widgets[newValue] ?? null;
+    (this.layout as NotebookWindowedLayout).activeCell = cell;
     const cellChanged = cell !== this._activeCell;
     if (cellChanged) {
       // Post an update request.

--- a/packages/notebook/src/windowing.ts
+++ b/packages/notebook/src/windowing.ts
@@ -179,10 +179,11 @@ export class NotebookWindowedLayout extends WindowedLayout {
     // Status may change in onBeforeAttach
     const wasPlaceholder = (widget as Cell).isPlaceholder();
     // Initialized sub-widgets or attached them for CodeCell
-    if (this.parent!.isAttached) {
+    // Because this reattaches all sub-widget to the DOM which leads
+    // to a loss of focus, we do not call it for soft-hidden cells.
+    if (this.parent!.isAttached && !this._isSoftHidden(widget)) {
       MessageLoop.sendMessage(widget, Widget.Msg.BeforeAttach);
     }
-
     if (!wasPlaceholder && widget.node.parentElement) {
       if (this._isSoftHidden(widget)) {
         // Restore visibility for active, or previously active cell

--- a/packages/notebook/src/windowing.ts
+++ b/packages/notebook/src/windowing.ts
@@ -110,6 +110,17 @@ export class NotebookWindowedLayout extends WindowedLayout {
   }
 
   /**
+   * Notebook's active cell
+   */
+  get activeCell(): Widget | null {
+    return this._activeCell;
+  }
+  set activeCell(widget: Widget | null) {
+    this._activeCell = widget;
+  }
+  private _activeCell: Widget | null;
+
+  /**
    * Dispose the layout
    * */
   dispose(): void {
@@ -177,6 +188,12 @@ export class NotebookWindowedLayout extends WindowedLayout {
       widget instanceof CodeCell &&
       widget.node.parentElement
     ) {
+      if (widget.node.style.opacity === '0') {
+        // Restore visibility for active, or previously active cell
+        widget.node.style.opacity = '1';
+        widget.node.style.height = '';
+      }
+
       // We don't remove code cells to preserve outputs internal state
       widget.node.style.display = '';
 
@@ -235,6 +252,16 @@ export class NotebookWindowedLayout extends WindowedLayout {
       !widget.node.classList.contains(DROP_SOURCE_CLASS) &&
       widget !== this._willBeRemoved
     ) {
+      // Note: `index` is relative to the displayed cells, not all cells,
+      // hence we compare with the widget itself.
+      if (widget === this.activeCell) {
+        // Do not change display of the active cell to allow user to continue providing input
+        // into the code mirror editor when out of view. We still hide the cell so to prevent
+        // minor visual glitches when scrolling.
+        widget.node.style.opacity = '0';
+        widget.node.style.height = '0';
+        return;
+      }
       // We don't remove code cells to preserve outputs internal state
       // Transform does not work because the widget height is kept (at lease in FF)
       widget.node.style.display = 'none';

--- a/packages/notebook/src/windowing.ts
+++ b/packages/notebook/src/windowing.ts
@@ -181,10 +181,11 @@ export class NotebookWindowedLayout extends WindowedLayout {
     // Initialized sub-widgets or attached them for CodeCell
     // Because this reattaches all sub-widget to the DOM which leads
     // to a loss of focus, we do not call it for soft-hidden cells.
-    if (this.parent!.isAttached && !this._isSoftHidden(widget)) {
+    const isSoftHidden = this._isSoftHidden(widget);
+    if (this.parent!.isAttached && !isSoftHidden) {
       MessageLoop.sendMessage(widget, Widget.Msg.BeforeAttach);
     }
-    if (this._isSoftHidden(widget)) {
+    if (isSoftHidden) {
       // Restore visibility for active, or previously active cell
       this._toggleSoftVisibility(widget, true);
     }
@@ -198,7 +199,7 @@ export class NotebookWindowedLayout extends WindowedLayout {
 
       // Reset cache
       this._topHiddenCodeCells = -1;
-    } else {
+    } else if (!isSoftHidden) {
       // Look up the next sibling reference node.
       const siblingIndex = this._findNearestChildBinarySearch(
         this.parent!.viewportNode.childElementCount - 1,


### PR DESCRIPTION
## References

Fixes #15073

## Code changes

- Adds `activeCell` to `NotebookWindowedLayout`.
- Instead of using `display: none` uses `opacity` + `height` to "hide" the cell without detaching its event handlers
- Ensure that typing in the cell scrolls to the active cell (by updating `ensureFocus` which is invoked on `keydown` so that it checks if the cell is in the viewport, not only if it was previously rendered)

## User-facing changes

### Before

![before](https://github.com/jupyterlab/jupyterlab/assets/5832902/6625efaf-b02b-45a9-bf11-aa52f5221f9f)

### After

![after](https://github.com/jupyterlab/jupyterlab/assets/5832902/d5aa9639-29c5-4b14-b777-f0f6240b6e1f)

## Backwards-incompatible changes

I presume none because `Notebook.layout` is typed as `WindowedLayout` rather than `NotebookWindowedLayout` which is an implementation detail, but let me know if you consider it to be public.