### PR TITLE
Fix creating files in custom drives, fix `ContentsManagerMock`

### DIFF
--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -255,7 +255,8 @@ export class FileBrowser extends SidePanel {
   ): Promise<Contents.IModel> {
     // normalize the path if the file is created from a custom drive
     if (options.path) {
-      options.path = this._toDrivePath(this.model.driveName, options.path);
+      const localPath = this._manager.services.contents.localPath(options.path);
+      options.path = this._toDrivePath(this.model.driveName, localPath);
     }
     try {
       const model = await this._manager.newUntitled(options);

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -253,9 +253,9 @@ export class FileBrowser extends SidePanel {
   private async _createNew(
     options: Contents.ICreateOptions
   ): Promise<Contents.IModel> {
-    // normalize the path if create a file from a custom drive
+    // normalize the path if the file is created from a custom drive
     if (options.path) {
-      options.path = this._toGlobalPath(this.model.driveName, options.path);
+      options.path = this._toDrivePath(this.model.driveName, options.path);
     }
     try {
       const model = await this._manager.newUntitled(options);
@@ -409,14 +409,15 @@ export class FileBrowser extends SidePanel {
   }
 
   /**
-   * Given a drive name and a local path
+   * Given a drive name and a local path, return the full
+   * drive path which includes the drive name and the local path.
    *
    * @param driveName: the name of the drive
    * @param localPath: the local path on the drive.
    *
-   * @returns the fully qualified path.
+   * @returns the full drive path
    */
-  private _toGlobalPath(driveName: string, localPath: string): string {
+  private _toDrivePath(driveName: string, localPath: string): string {
     if (driveName === '') {
       return localPath;
     } else {

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -2,6 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { showErrorMessage } from '@jupyterlab/apputils';
+import { PathExt } from '@jupyterlab/coreutils';
 import { IDocumentManager } from '@jupyterlab/docmanager';
 import { Contents, ServerConnection } from '@jupyterlab/services';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
@@ -252,6 +253,10 @@ export class FileBrowser extends SidePanel {
   private async _createNew(
     options: Contents.ICreateOptions
   ): Promise<Contents.IModel> {
+    // normalize the path if create a file from a custom drive
+    if (options.path) {
+      options.path = this._toGlobalPath(this.model.driveName, options.path);
+    }
     try {
       const model = await this._manager.newUntitled(options);
       await this.listing.selectItemByName(model.name, true);
@@ -400,6 +405,22 @@ export class FileBrowser extends SidePanel {
         this.model.path
       );
       void showErrorMessage(title, args);
+    }
+  }
+
+  /**
+   * Given a drive name and a local path
+   *
+   * @param driveName: the name of the drive
+   * @param localPath: the local path on the drive.
+   *
+   * @returns the fully qualified path.
+   */
+  private _toGlobalPath(driveName: string, localPath: string): string {
+    if (driveName === '') {
+      return localPath;
+    } else {
+      return `${driveName}:${PathExt.removeSlash(localPath)}`;
     }
   }
 

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -48,7 +48,10 @@ import { IDocumentManager } from '@jupyterlab/docmanager';
 import { ToolbarItems as DocToolbarItems } from '@jupyterlab/docmanager-extension';
 import { DocumentRegistry, IDocumentWidget } from '@jupyterlab/docregistry';
 import { ISearchProviderRegistry } from '@jupyterlab/documentsearch';
-import { IDefaultFileBrowser } from '@jupyterlab/filebrowser';
+import {
+  IDefaultFileBrowser,
+  IFileBrowserFactory
+} from '@jupyterlab/filebrowser';
 import { ILauncher } from '@jupyterlab/launcher';
 import {
   ILSPCodeExtractorsManager,
@@ -363,7 +366,8 @@ const trackerPlugin: JupyterFrontEndPlugin<INotebookTracker> = {
     ISettingRegistry,
     ISessionContextDialogs,
     ITranslator,
-    IFormRendererRegistry
+    IFormRendererRegistry,
+    IFileBrowserFactory
   ],
   activate: activateNotebookHandler,
   autoStart: true
@@ -1594,7 +1598,8 @@ function activateNotebookHandler(
   settingRegistry: ISettingRegistry | null,
   sessionDialogs_: ISessionContextDialogs | null,
   translator_: ITranslator | null,
-  formRegistry: IFormRendererRegistry | null
+  formRegistry: IFormRendererRegistry | null,
+  filebrowserFactory: IFileBrowserFactory | null
 ): INotebookTracker {
   const translator = translator_ ?? nullTranslator;
   const sessionDialogs =
@@ -1957,7 +1962,9 @@ function activateNotebookHandler(
     caption: trans.__('Create a new notebook'),
     icon: args => (args['isPalette'] ? undefined : notebookIcon),
     execute: args => {
-      const cwd = (args['cwd'] as string) || (defaultBrowser?.model.path ?? '');
+      const currentBrowser =
+        filebrowserFactory?.tracker.currentWidget ?? defaultBrowser;
+      const cwd = (args['cwd'] as string) || (currentBrowser?.model.path ?? '');
       const kernelId = (args['kernelId'] as string) || '';
       const kernelName = (args['kernelName'] as string) || '';
       return createNew(cwd, kernelId, kernelName);

--- a/packages/services/src/testutils.ts
+++ b/packages/services/src/testutils.ts
@@ -486,6 +486,7 @@ export const ContentsManagerMock = jest.fn<Contents.IManager, []>(() => {
     }),
     addDrive: jest.fn(drive => {
       dummy.addDrive(drive);
+      files.set(`${drive.name}:`, { ...baseModel, path: '', name: '' });
     }),
     dispose: jest.fn()
   };

--- a/packages/services/src/testutils.ts
+++ b/packages/services/src/testutils.ts
@@ -307,31 +307,48 @@ export const SessionConnectionMock = jest.fn<
  * A mock contents manager.
  */
 export const ContentsManagerMock = jest.fn<Contents.IManager, []>(() => {
-  const files = new Map<string, Contents.IModel>();
+  const files = new Map<string, Map<string, Contents.IModel>>();
   const dummy = new ContentsManager();
   const checkpoints = new Map<string, Contents.ICheckpointModel>();
   const checkPointContent = new Map<string, string>();
 
   const baseModel = Private.createFile({ type: 'directory' });
-  files.set('', { ...baseModel, path: '', name: '' });
+  // create the default drive
+  files.set(
+    '',
+    new Map<string, Contents.IModel>([
+      ['', { ...baseModel, path: '', name: '' }]
+    ])
+  );
 
   const thisObject: Contents.IManager = {
     ...jest.requireActual('@jupyterlab/services'),
     newUntitled: jest.fn(options => {
-      const model = Private.createFile(options || {});
-      files.set(model.path, model);
+      const driveName = dummy.driveName(options?.path || '');
+      const localPath = dummy.localPath(options?.path || '');
+      // create the test file without the drive name
+      const createOptions = { ...options, path: localPath };
+      const model = Private.createFile(createOptions || {});
+      // re-add the drive name to the model
+      const drivePath = driveName ? `${driveName}:${model.path}` : model.path;
+      const driveModel = {
+        ...model,
+        path: drivePath
+      };
+      files.get(driveName)!.set(model.path, driveModel);
       fileChangedSignal.emit({
         type: 'new',
         oldValue: null,
-        newValue: model
+        newValue: driveModel
       });
-      return Promise.resolve(model);
+      return Promise.resolve(driveModel);
     }),
     createCheckpoint: jest.fn(path => {
       const lastModified = new Date().toISOString();
       const data = { id: UUID.uuid4(), last_modified: lastModified };
       checkpoints.set(path, data);
-      checkPointContent.set(path, files.get(path)?.content);
+      // TODO: handle drives
+      checkPointContent.set(path, files.get('')!.get(path)?.content);
       return Promise.resolve(data);
     }),
     listCheckpoints: jest.fn(path => {
@@ -368,11 +385,14 @@ export const ContentsManagerMock = jest.fn<Contents.IManager, []>(() => {
       return dummy.resolvePath(root, path);
     }),
     get: jest.fn((path, options) => {
-      path = Private.fixSlash(path);
-      if (!files.has(path)) {
+      const driveName = dummy.driveName(path);
+      const localPath = dummy.localPath(path);
+      const drive = files.get(driveName)!;
+      path = Private.fixSlash(localPath);
+      if (!drive.has(path)) {
         return Private.makeResponseError(404);
       }
-      const model = files.get(path)!;
+      const model = drive.get(path)!;
       const overrides: { hash?: string; last_modified?: string } = {};
       if (path == 'random-hash.txt') {
         overrides.hash = Math.random().toString();
@@ -385,10 +405,11 @@ export const ContentsManagerMock = jest.fn<Contents.IManager, []>(() => {
       if (model.type === 'directory') {
         if (options?.content !== false) {
           const content: Contents.IModel[] = [];
-          files.forEach(fileModel => {
+          drive.forEach(fileModel => {
+            const localPath = dummy.localPath(fileModel.path);
             if (
               // If file path is under this directory, add it to contents array.
-              PathExt.dirname(fileModel.path) == model.path &&
+              PathExt.dirname(localPath) == model.path &&
               // But the directory should exclude itself from the contents array.
               fileModel !== model
             ) {
@@ -408,16 +429,20 @@ export const ContentsManagerMock = jest.fn<Contents.IManager, []>(() => {
       return dummy.driveName(path);
     }),
     rename: jest.fn((oldPath, newPath) => {
-      oldPath = Private.fixSlash(oldPath);
-      newPath = Private.fixSlash(newPath);
-      if (!files.has(oldPath)) {
+      const driveName = dummy.driveName(oldPath);
+      const drive = files.get(driveName)!;
+      let oldLocalPath = dummy.localPath(oldPath);
+      let newLocalPath = dummy.localPath(newPath);
+      oldLocalPath = Private.fixSlash(oldLocalPath);
+      newLocalPath = Private.fixSlash(newLocalPath);
+      if (!drive.has(oldLocalPath)) {
         return Private.makeResponseError(404);
       }
-      const oldValue = files.get(oldPath)!;
-      files.delete(oldPath);
-      const name = PathExt.basename(newPath);
-      const newValue = { ...oldValue, name, path: newPath };
-      files.set(newPath, newValue);
+      const oldValue = drive.get(oldPath)!;
+      drive.delete(oldPath);
+      const name = PathExt.basename(newLocalPath);
+      const newValue = { ...oldValue, name, path: newLocalPath };
+      drive.set(newPath, newValue);
       fileChangedSignal.emit({
         type: 'rename',
         oldValue,
@@ -445,7 +470,8 @@ export const ContentsManagerMock = jest.fn<Contents.IManager, []>(() => {
       }
       path = Private.fixSlash(path);
       const timeStamp = new Date().toISOString();
-      if (files.has(path)) {
+      const drive = files.get(dummy.driveName(path))!;
+      if (drive.has(path)) {
         const updates =
           path == 'frozen-time-and-hash.txt'
             ? {}
@@ -453,13 +479,13 @@ export const ContentsManagerMock = jest.fn<Contents.IManager, []>(() => {
                 last_modified: timeStamp,
                 hash: timeStamp
               };
-        files.set(path, {
-          ...files.get(path)!,
+        drive.set(path, {
+          ...drive.get(path)!,
           ...options,
           ...updates
         });
       } else {
-        files.set(path, {
+        drive.set(path, {
           path,
           name: PathExt.basename(path),
           content: '',
@@ -479,14 +505,19 @@ export const ContentsManagerMock = jest.fn<Contents.IManager, []>(() => {
         oldValue: null,
         newValue: files.get(path)!
       });
-      return Promise.resolve(files.get(path)!);
+      return Promise.resolve(drive.get(path)!);
     }),
     getDownloadUrl: jest.fn(path => {
       return dummy.getDownloadUrl(path);
     }),
     addDrive: jest.fn(drive => {
       dummy.addDrive(drive);
-      files.set(`${drive.name}:`, { ...baseModel, path: '', name: '' });
+      files.set(
+        drive.name,
+        new Map<string, Contents.IModel>([
+          ['', { ...baseModel, path: '', name: '' }]
+        ])
+      );
     }),
     dispose: jest.fn()
   };

--- a/packages/services/src/testutils.ts
+++ b/packages/services/src/testutils.ts
@@ -503,7 +503,7 @@ export const ContentsManagerMock = jest.fn<Contents.IManager, []>(() => {
       fileChangedSignal.emit({
         type: 'save',
         oldValue: null,
-        newValue: files.get(path)!
+        newValue: drive.get(path)!
       });
       return Promise.resolve(drive.get(path)!);
     }),

--- a/packages/services/src/testutils.ts
+++ b/packages/services/src/testutils.ts
@@ -369,7 +369,8 @@ export const ContentsManagerMock = jest.fn<Contents.IManager, []>(() => {
       if (!checkpoints.has(path)) {
         return Private.makeResponseError(404);
       }
-      (files.get(path) as any).content = checkPointContent.get(path);
+      // TODO: handle drives
+      (files.get('')!.get(path) as any).content = checkPointContent.get(path);
       return Promise.resolve();
     }),
     getSharedModelFactory: jest.fn(() => {

--- a/packages/services/src/testutils.ts
+++ b/packages/services/src/testutils.ts
@@ -451,12 +451,15 @@ export const ContentsManagerMock = jest.fn<Contents.IManager, []>(() => {
       return Promise.resolve(newValue);
     }),
     delete: jest.fn(path => {
-      path = Private.fixSlash(path);
-      if (!files.has(path)) {
+      const driveName = dummy.driveName(path);
+      const localPath = dummy.localPath(path);
+      const drive = files.get(driveName)!;
+      path = Private.fixSlash(localPath);
+      if (!drive.has(path)) {
         return Private.makeResponseError(404);
       }
-      const oldValue = files.get(path)!;
-      files.delete(path);
+      const oldValue = drive.get(path)!;
+      drive.delete(path);
       fileChangedSignal.emit({
         type: 'delete',
         oldValue,


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/15290
Fixes https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/issues/58
Fixes https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/issues/22
Fixes https://github.com/jupyterlab-contrib/jupyterlab-browser-storage/issues/1


## Code changes

The file browser widget should pass along its drive name when using the contents manager for manipulating files.

- [x] Fix creating new files from the context menu
- [x] Check other file manipulation operations such as delete, rename...
- [x] Fix creating notebooks
- [x] Fix `ContentsManagerMock` to have basic support for drives

## User-facing changes

**Before**

https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/assets/591645/2f64fd92-c346-45b6-8d41-5ffe6ffc2326

**After**

https://github.com/jupyterlab/jupyterlab/assets/591645/cfcf4962-416a-43df-8849-468f320fa043

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None
