### PR TITLE
Fix autobrackets and other default CM extension

### DIFF
--- a/packages/codemirror/src/extension.ts
+++ b/packages/codemirror/src/extension.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { closeBrackets } from '@codemirror/autocomplete';
+import { closeBrackets, closeBracketsKeymap } from '@codemirror/autocomplete';
 import { defaultKeymap, indentLess } from '@codemirror/commands';
 import {
   bracketMatching,
@@ -13,6 +13,7 @@ import {
   Compartment,
   EditorState,
   Extension,
+  Prec,
   StateEffect
 } from '@codemirror/state';
 import {
@@ -715,7 +716,12 @@ export namespace EditorExtensionRegistry {
       Object.freeze({
         name: 'matchBrackets',
         default: true,
-        factory: () => createConditionalExtension(bracketMatching()),
+        factory: () =>
+          createConditionalExtension([
+          bracketMatching(), 
+          // closeBracketsKeymap must have higher precedence over defaultKeymap
+            Prec.high(keymap.of(closeBracketsKeymap)),
+          ]),
         schema: {
           type: 'boolean',
           title: trans.__('Match Brackets')

--- a/packages/codemirror/src/extension.ts
+++ b/packages/codemirror/src/extension.ts
@@ -21,6 +21,7 @@ import {
   drawSelection,
   EditorView,
   highlightActiveLine,
+  highlightSpecialChars,
   highlightTrailingWhitespace,
   highlightWhitespace,
   KeyBinding,
@@ -644,6 +645,15 @@ export namespace EditorExtensionRegistry {
         }
       }),
       Object.freeze({
+        name: 'highlightSpecialCharacters',
+        default: true,
+        factory: () => createConditionalExtension(highlightSpecialChars()),
+        schema: {
+          type: 'boolean',
+          title: trans.__('Highlight special characters')
+        }
+      }),
+      Object.freeze({
         name: 'highlightTrailingWhitespace',
         default: false,
         factory: () =>
@@ -718,9 +728,9 @@ export namespace EditorExtensionRegistry {
         default: true,
         factory: () =>
           createConditionalExtension([
-          bracketMatching(), 
-          // closeBracketsKeymap must have higher precedence over defaultKeymap
-            Prec.high(keymap.of(closeBracketsKeymap)),
+            bracketMatching(),
+            // closeBracketsKeymap must have higher precedence over defaultKeymap
+            Prec.high(keymap.of(closeBracketsKeymap))
           ]),
         schema: {
           type: 'boolean',


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #14559

looking at the [basic setup](https://github.com/codemirror/basic-setup/blob/b3be7cd30496ee578005bd11b1fa6a8b21fcbece/src/codemirror.ts#L69) from CM, this adds also:
- [highlightSpecialCharacters](https://codemirror.net/docs/ref/#view.highlightSpecialChars)

There is one I'm unsure about:
- [highlightSelectionMatches](https://codemirror.net/docs/ref/#search.highlightSelectionMatches)

I'm not confident about that one as it won't work for notebook (only for file editor). And I guess the LSP extension as something better for it.

cc @krassowski

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Add CM extensions: `closeBracketsKeymap`, `highlightSpecialChars`

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
- Backspace between two brackets deletes both if auto closing option is on
- [Special characters](https://github.com/codemirror/view/blob/e6a55a6515521a84e709f02b4eb32e57aebbbfba/src/special-chars.ts) will now be highlighted with red dots, e.g. `­؜​‎‏  `

Before
![Screenshot from 2023-10-26 21-51-01](https://github.com/jupyterlab/jupyterlab/assets/5832902/751993e9-6897-4fb0-8846-ac9cd8485870)

After
![Screenshot from 2023-10-26 21-51-08](https://github.com/jupyterlab/jupyterlab/assets/5832902/2ee7b9e7-d357-4b7e-b5f3-4400fddb2c6d)


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None