### PR TITLE
Declare Webpack loaders with `require.resolve()`

### DIFF
--- a/builder/src/build.ts
+++ b/builder/src/build.ts
@@ -205,7 +205,7 @@ export namespace Build {
           rules: [
             {
               test: /\.css$/,
-              use: [MiniCssExtractPlugin.loader, 'css-loader']
+              use: [MiniCssExtractPlugin.loader, require.resolve('css-loader')]
             },
             {
               test: /\.svg/,

--- a/builder/src/extensionConfig.ts
+++ b/builder/src/extensionConfig.ts
@@ -257,7 +257,7 @@ function generateConfig({
     rules.push({
       test: /\.js$/,
       enforce: 'pre',
-      use: ['source-map-loader']
+      use: [require.resolve('source-map-loader')]
     });
   }
 

--- a/builder/src/webpack.config.base.ts
+++ b/builder/src/webpack.config.base.ts
@@ -5,7 +5,10 @@ import miniSVGDataURI from 'mini-svg-data-uri';
 
 const rules = [
   { test: /\.raw\.css$/, type: 'asset/source' },
-  { test: /(?<!\.raw)\.css$/, use: ['style-loader', 'css-loader'] },
+  {
+    test: /(?<!\.raw)\.css$/,
+    use: [require.resolve('style-loader'), require.resolve('css-loader')]
+  },
   { test: /\.txt$/, type: 'asset/source' },
   { test: /\.md$/, type: 'asset/source' },
   { test: /\.(jpg|png|gif)$/, type: 'asset/resource' },


### PR DESCRIPTION
Fix #15298 by ensuring that loaders are resolved from `@jupyterlab/builder` instead of from the package being built.

This will allow to get rid of [`css-loader` and `style-loader` in the `devDependencies` of `extension-cookiecutter-ts`](https://github.com/jupyterlab/extension-cookiecutter-ts/blob/0ba10b8e268135a9c4c0283c8498a5d8f4a62c8f/%7B%7Bcookiecutter.python_name%7D%7D/package.json).

By the way, [`worker-loader` seems unused](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab%20worker-loader&type=code). Can we remove it?