### PR TITLE
Deprecates collaborative flag, with improved error message that makes clear the process is exiting and why (#14774)

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -897,13 +897,14 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
                 import jupyter_collaboration  # noqa
             except ImportError:
                 self.log.critical(
-                    """
-To enable real-time collaboration, you must install the extension `jupyter_collaboration`.
-You can install it using pip for example:
+                    """\
+Juptyer Lab cannot start, because `jupyter_collaboration` was configured but cannot be `import`ed.
 
-  python -m pip install jupyter_collaboration
+To fix this, either:
 
-This flag is now deprecated and will be removed in JupyterLab v5.
+1) install the extension `jupyter_collaboration`; for example: `python -m pip install jupyter_collaboration`
+
+2) disable collaboration; for example, remove the `--collaborative` flag from the commandline.  To see more ways to adjust the collaborative behavior, see https://jupyterlab-realtime-collaboration.readthedocs.io/en/latest/configuration.html .
 """
                 )
                 sys.exit(1)


### PR DESCRIPTION

Updates error message from fix to [#14774](https://github.com/jupyterlab/jupyterlab/issues/14774)

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

References issue #14774 

## Code changes

Adds to the error message so user knows:

1. the process was forcibly exited
2. the obvious fix (remove any `--collaborative` command line flag)
3. the not-so-obvious fixes (other command line / config flags -- which don't have the string "collaborat" in them at all -- and/or disable / remove related extensions)


## User-facing changes

Same as "Code changes" section.

## Backwards-incompatible changes

None