### PR TITLE
backport disabling custom keyboard JS in html docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -284,6 +284,8 @@ html_theme_options = {
         ),
         "version_match": os.environ.get("READTHEDOCS_VERSION", "latest"),
     },
+    # rely on browser-native accessibility features instead of custom JS
+    "navigation_with_keys": False,
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
## References

Fixes #15309

- minor backport of #15302 docs config change

## Code changes
     

- [x] docs
  - [x] disable custom JS keyboard navigation in pydata-sphinx-theme (also raises warning)

## User-facing changes

Users of the documentation website will have their expected keyboard shortcuts for arrow keys instead of custom ones.

## Backwards-incompatible changes

- n/a