### PR TITLE
Add drives to the filebrowser

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,8 @@
     "yjs": "^13.5.40"
   },
   "dependencies": {
+    "@jupyter/react-components": "^0.13.2",
+    "@jupyter/web-components": "^0.13.2",
     "@typescript-eslint/eslint-plugin": "~5.55.0",
     "@typescript-eslint/parser": "~5.55.0",
     "eslint": "~8.36.0",

--- a/packages/filebrowser-extension/package.json
+++ b/packages/filebrowser-extension/package.json
@@ -38,6 +38,8 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
+    "@jupyter/react-components": "~0.13.2",
+    "@jupyter/web-components": "~0.13.2",
     "@jupyterlab/application": "^4.1.0-alpha.2",
     "@jupyterlab/apputils": "^4.2.0-alpha.2",
     "@jupyterlab/coreutils": "^6.1.0-alpha.2",
@@ -52,7 +54,8 @@
     "@jupyterlab/ui-components": "^4.1.0-alpha.2",
     "@lumino/algorithm": "^2.0.1",
     "@lumino/commands": "^2.1.3",
-    "@lumino/widgets": "^2.3.1-alpha.0"
+    "@lumino/widgets": "^2.3.1-alpha.0",
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "rimraf": "~3.0.0",

--- a/packages/filebrowser-extension/schema/widget.json
+++ b/packages/filebrowser-extension/schema/widget.json
@@ -10,6 +10,11 @@
       },
       { "name": "uploader", "rank": 20 },
       { "name": "refresh", "command": "filebrowser:refresh", "rank": 30 },
+      {
+        "name": "drive",
+        "command": "filebrowser:open-drives-dialog",
+        "rank": 35
+      },
       { "name": "fileNameSearcher", "rank": 40 }
     ]
   },

--- a/packages/filebrowser-extension/src/drivelistmanager.tsx
+++ b/packages/filebrowser-extension/src/drivelistmanager.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react';
+import { VDomModel, VDomRenderer } from '@jupyterlab/ui-components';
+import {
+  Button,
+  /*DataGrid,
+  DataGridCell,
+  DataGridRow,*/
+  Search
+} from '@jupyter/react-components';
+import { useState } from 'react';
+
+interface IProps {
+  model: DriveListModel;
+}
+
+/*export function CustomDataGrid() {
+
+
+  return (
+    <div id="data-grid-added-drives">
+      <DataGrid grid-template-columns=  "1f 1fr" >
+        <DataGridRow row-type="header">
+          <DataGridCell grid-column="1">Header 1</DataGridCell>
+          <DataGridCell grid-column="2">Header 2</DataGridCell>
+        </DataGridRow>
+        <DataGridRow>
+          <DataGridCell grid-column="1">1.1</DataGridCell>
+          <DataGridCell grid-column="2">1.2</DataGridCell>
+        </DataGridRow>
+        <DataGridRow>
+          <DataGridCell grid-column="1">2.1</DataGridCell>
+          <DataGridCell grid-column="2">2.2</DataGridCell>
+        </DataGridRow>
+      </DataGrid>
+    </div>
+  );
+}*/
+
+export function DriveListComponent(props: IProps) {
+  const { model } = props;
+  const [filteredList, setFilteredList] = useState(['']);
+
+  const filterBySearch = (event: any) => {
+    const query = event.target.value;
+    let updatedList = [...model.driveList];
+    updatedList = updatedList.filter(item => {
+      return item.toLowerCase().indexOf(query.toLowerCase()) !== -1;
+    });
+    setFilteredList(updatedList);
+    console.log('updatedList:', updatedList);
+  };
+
+  const addDriveToTree = (item: string) => {
+    const list: Array<string> = [];
+    list.push(item);
+    console.log('list is:', list);
+  };
+
+  return (
+    <div>
+      <div className="jp-AddDrive-Header">
+        <h3> Add drives to your filebrowser </h3>
+      </div>
+      <p> Enter a driveUrl </p>
+      <Search />
+      <p>Select drive(s) from list</p>
+      <Search onInput={filterBySearch} />
+
+      <div id="item-list">
+        <ol>
+          {filteredList.map((item, index) => (
+            <li key={index}>
+              {item}
+              <Button onClick={() => addDriveToTree(item)} type="submit">
+                add drive
+              </Button>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </div>
+  );
+}
+
+export class DriveListModel extends VDomModel {
+  public driveList: string[];
+
+  constructor(driveList: string[]) {
+    super();
+    this.driveList = driveList;
+  }
+}
+
+export class DriveListView extends VDomRenderer<DriveListModel> {
+  constructor(model: DriveListModel) {
+    super(model);
+    this.model = model;
+  }
+  render() {
+    return (
+      <>
+        <DriveListComponent model={this.model} />
+      </>
+    );
+  }
+}

--- a/packages/filebrowser-extension/src/drivelistmanager.tsx
+++ b/packages/filebrowser-extension/src/drivelistmanager.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
 import * as React from 'react';
 import { VDomModel, VDomRenderer } from '@jupyterlab/ui-components';
 import {

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -47,6 +47,7 @@ import {
   copyIcon,
   cutIcon,
   downloadIcon,
+  driveIcon,
   editIcon,
   fileIcon,
   FilenameSearcher,
@@ -62,9 +63,13 @@ import {
   stopIcon,
   textEditorIcon
 } from '@jupyterlab/ui-components';
+
 import { find, map } from '@lumino/algorithm';
 import { CommandRegistry } from '@lumino/commands';
 import { ContextMenu } from '@lumino/widgets';
+import { /*Dialog,*/ showDialog } from '@jupyterlab/apputils';
+import { DriveListModel, DriveListView } from './drivelistmanager';
+import { addJupyterLabThemeChangeListener } from '@jupyter/web-components';
 
 const FILE_BROWSER_FACTORY = 'FileBrowser';
 const FILE_BROWSER_PLUGIN_ID = '@jupyterlab/filebrowser-extension:browser';
@@ -145,6 +150,8 @@ namespace CommandIDs {
   export const toggleHiddenFiles = 'filebrowser:toggle-hidden-files';
 
   export const toggleFileCheckboxes = 'filebrowser:toggle-file-checkboxes';
+
+  export const openDrivesDialog = 'filebrowser:open-drives-dialog';
 }
 
 /**
@@ -899,6 +906,70 @@ const openUrlPlugin: JupyterFrontEndPlugin<void> = {
   }
 };
 
+const openDriveDialogPlugin: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlab/filebrowser-extension:open-drive-dialog',
+  description: 'Open a dialog to select drives to be added in the filebrowser.',
+  requires: [IFileBrowserFactory, ITranslator],
+  autoStart: true,
+  activate: (
+    app: JupyterFrontEnd,
+    factory: IFileBrowserFactory,
+    translator: ITranslator
+  ): void => {
+    addJupyterLabThemeChangeListener();
+    const { commands } = app;
+    const trans = translator.load('jupyterlab');
+    const { tracker } = factory;
+
+    commands.addCommand(CommandIDs.openDrivesDialog, {
+      execute: args => {
+        const widget = tracker.currentWidget;
+        const driveList = [
+          'BananaDrive',
+          'RaspberryDrive',
+          'PineAppleDrive',
+          'PomeloDrive',
+          'OrangeDrive',
+          'TomatoDrive',
+          'AvocadoDrive'
+        ];
+
+        const model = new DriveListModel(driveList);
+
+        if (widget) {
+          /*const selectButton = Dialog.okButton({
+            label: trans.__('Select Drives'),
+            actions: ['select']
+          });
+          const clearButton = Dialog.okButton({
+            label: trans.__('Clear Filter(s)'),
+            actions: ['clear']
+          });*/
+          showDialog({
+            body: new DriveListView(model)
+            //body: new DrivePalette(driveList)
+            //buttons: [Dialog.cancelButton(), selectButton, clearButton]
+            //buttons:[Dialog.cancelButton()]
+          });
+          /*.then(result => {
+              if (result.button.actions.includes('select')) {
+                console.log('You have clicked on select button');
+              }
+              if (result.button.actions.includes('clear')) {
+                console.log('You have clicked on cancel button');
+              }
+            })
+            .catch(error => window.alert('No button has been pressed!'));*/
+        }
+      },
+
+      icon: driveIcon.bindprops({ stylesheet: 'menuItem' }),
+      caption: trans.__('Add drives to filebrowser.'),
+      label: trans.__('Add Drives To Filebrowser')
+    });
+  }
+};
+
 /**
  * Add the main file browser commands to the application's command registry.
  */
@@ -1344,6 +1415,7 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   browserWidget,
   openWithPlugin,
   openBrowserTabPlugin,
+  openDriveDialogPlugin,
   openUrlPlugin
 ];
 export default plugins;

--- a/packages/ui-components/src/icon/iconimports.ts
+++ b/packages/ui-components/src/icon/iconimports.ts
@@ -38,6 +38,7 @@ import copyrightSvgstr from '../../style/icons/licenses/copyright.svg';
 import cutSvgstr from '../../style/icons/toolbar/cut.svg';
 import deleteSvgstr from '../../style/icons/toolbar/delete.svg';
 import downloadSvgstr from '../../style/icons/toolbar/download.svg';
+import driveSvgstr from '../../style/icons/toolbar/drive.svg';
 import duplicateSvgstr from '../../style/icons/toolbar/duplicate.svg';
 import editSvgstr from '../../style/icons/toolbar/edit.svg';
 import ellipsesSvgstr from '../../style/icons/toolbar/ellipses.svg';
@@ -143,6 +144,7 @@ export const copyrightIcon = new LabIcon({ name: 'ui-components:copyright', svgs
 export const cutIcon = new LabIcon({ name: 'ui-components:cut', svgstr: cutSvgstr });
 export const deleteIcon = new LabIcon({ name: 'ui-components:delete', svgstr: deleteSvgstr });
 export const downloadIcon = new LabIcon({ name: 'ui-components:download', svgstr: downloadSvgstr });
+export const driveIcon = new LabIcon({ name: 'ui-components:drive', svgstr: driveSvgstr });
 export const duplicateIcon = new LabIcon({ name: 'ui-components:duplicate', svgstr: duplicateSvgstr });
 export const editIcon = new LabIcon({ name: 'ui-components:edit', svgstr: editSvgstr });
 export const ellipsesIcon = new LabIcon({ name: 'ui-components:ellipses', svgstr: ellipsesSvgstr });

--- a/packages/ui-components/style/deprecated.css
+++ b/packages/ui-components/style/deprecated.css
@@ -42,6 +42,7 @@
   --jp-icon-cut: url('icons/toolbar/cut.svg');
   --jp-icon-delete: url('icons/toolbar/delete.svg');
   --jp-icon-download: url('icons/toolbar/download.svg');
+  --jp-icon-drive: url('icons/toolbar/drive.svg');
   --jp-icon-duplicate: url('icons/toolbar/duplicate.svg');
   --jp-icon-edit: url('icons/toolbar/edit.svg');
   --jp-icon-ellipses: url('icons/toolbar/ellipses.svg');
@@ -237,6 +238,10 @@
 
 .jp-DownloadIcon {
   background-image: var(--jp-icon-download);
+}
+
+.jp-DriveIcon {
+  background-image: var(--jp-icon-drive);
 }
 
 .jp-DuplicateIcon {

--- a/packages/ui-components/style/icons/toolbar/drive.svg
+++ b/packages/ui-components/style/icons/toolbar/drive.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+
+<svg
+   viewBox="0 0 24 16"
+   width="16"
+   version="1.1"
+   id="svg619"
+   height="16"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs623" />
+  <g
+     class="jp-icon3"
+     fill="#616161"
+     id="g617"
+     transform="matrix(1.1651014,0,0,1.1651014,-0.76608721,-3.7597785)"
+     style="stroke:none;stroke-width:2.15904;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+    <g
+       id="g266"
+       transform="matrix(0.04,0,0,0.04,-0.05616541,0.0448711)"
+       style="stroke:none;stroke-width:53.976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+      <g
+         id="g140"
+         style="stroke:none;stroke-width:66.8504;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+        <g
+           id="g138"
+           style="stroke:none;stroke-width:66.8504;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <g
+         id="g152"
+         style="stroke:none;stroke-width:66.8504;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+        <g
+           id="g150"
+           style="stroke:none;stroke-width:66.8504;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <rect
+         style="fill:#999999;fill-opacity:1;stroke:none;stroke-width:66.8504;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect3165"
+         width="514.97662"
+         height="514.97662"
+         x="17.842344"
+         y="-6.2762976" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:577.866px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:779.774"
+         x="18.662781"
+         y="484.6319"
+         id="text8569"
+         transform="scale(1.0907066,0.91683685)"><tspan
+           id="tspan8567"
+           style="stroke-width:779.774"
+           x="18.662781"
+           y="484.6319">D</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2051,6 +2051,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyter/react-components@npm:^0.13.2, @jupyter/react-components@npm:~0.13.2":
+  version: 0.13.2
+  resolution: "@jupyter/react-components@npm:0.13.2"
+  dependencies:
+    "@jupyter/web-components": ^0.13.2
+    "@microsoft/fast-react-wrapper": ^0.3.18
+    react: ">=17.0.0 <19.0.0"
+  checksum: e96cb59ad6909a107b5874e3538acec0e29d7466521a5133dd40645f07dbe44ef8f31afdaaf53d1cf56c7c69e890baee8f18f37741ba37c28247f4bf37783706
+  languageName: node
+  linkType: hard
+
+"@jupyter/web-components@npm:^0.13.2, @jupyter/web-components@npm:~0.13.2":
+  version: 0.13.2
+  resolution: "@jupyter/web-components@npm:0.13.2"
+  dependencies:
+    "@microsoft/fast-colors": ^5.3.1
+    "@microsoft/fast-components": ^2.30.6
+    "@microsoft/fast-element": ^1.12.0
+    "@microsoft/fast-foundation": ^2.49.0
+    "@microsoft/fast-web-utilities": ^6.0.0
+  checksum: 720ab85cdd30942919902bb3d6e09c9a81f71acd67d01b7f8a7bee36cd0f1f70f1919f57963e015f11edcedf8ec61b3d528df1e793beed0e82c55ab2821976ca
+  languageName: node
+  linkType: hard
+
 "@jupyter/ydoc@npm:^1.1.1":
   version: 1.1.1
   resolution: "@jupyter/ydoc@npm:1.1.1"
@@ -3326,6 +3350,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/filebrowser-extension@workspace:packages/filebrowser-extension"
   dependencies:
+    "@jupyter/react-components": ~0.13.2
+    "@jupyter/web-components": ~0.13.2
     "@jupyterlab/application": ^4.1.0-alpha.2
     "@jupyterlab/apputils": ^4.2.0-alpha.2
     "@jupyterlab/coreutils": ^6.1.0-alpha.2
@@ -3341,6 +3367,7 @@ __metadata:
     "@lumino/algorithm": ^2.0.1
     "@lumino/commands": ^2.1.3
     "@lumino/widgets": ^2.3.1-alpha.0
+    react: ^18.2.0
     rimraf: ~3.0.0
     typedoc: ~0.24.7
     typescript: ~5.0.4
@@ -4458,6 +4485,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/repo-top@workspace:."
   dependencies:
+    "@jupyter/react-components": ^0.13.2
+    "@jupyter/web-components": ^0.13.2
     "@typescript-eslint/eslint-plugin": ~5.55.0
     "@typescript-eslint/parser": ~5.55.0
     eslint: ~8.36.0
@@ -5378,6 +5407,75 @@ __metadata:
   bin:
     node-pre-gyp: bin/node-pre-gyp
   checksum: 1a98db05d955b74dad3814679593df293b9194853698f3f5f1ed00ecd93128cdd4b14fb8767fe44ac6981ef05c23effcfdc88710e7c1de99ccb6f647890597c8
+  languageName: node
+  linkType: hard
+
+"@microsoft/fast-colors@npm:^5.3.0, @microsoft/fast-colors@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "@microsoft/fast-colors@npm:5.3.1"
+  checksum: ff87f402faadb4b5aeee3d27762566c11807f927cd4012b8bbc7f073ca68de0e2197f95330ff5dfd7038f4b4f0e2f51b11feb64c5d570f5c598d37850a5daf60
+  languageName: node
+  linkType: hard
+
+"@microsoft/fast-components@npm:^2.30.6":
+  version: 2.30.6
+  resolution: "@microsoft/fast-components@npm:2.30.6"
+  dependencies:
+    "@microsoft/fast-colors": ^5.3.0
+    "@microsoft/fast-element": ^1.10.1
+    "@microsoft/fast-foundation": ^2.46.2
+    "@microsoft/fast-web-utilities": ^5.4.1
+    tslib: ^1.13.0
+  checksum: 1fbf3b7c265bcbf6abcae4d2f72430f7f871104a3d8344f16667a4cc7b123698cdf2bab8b760cbed92ef761c4db350a67f570665c76b132d6996990ac93cbd4f
+  languageName: node
+  linkType: hard
+
+"@microsoft/fast-element@npm:^1.10.1, @microsoft/fast-element@npm:^1.12.0":
+  version: 1.12.0
+  resolution: "@microsoft/fast-element@npm:1.12.0"
+  checksum: bbff4e9c83106d1d74f3eeedc87bf84832429e78fee59c6a4ae8164ee4f42667503f586896bea72341b4d2c76c244a3cb0d4fd0d5d3732755f00357714dd609e
+  languageName: node
+  linkType: hard
+
+"@microsoft/fast-foundation@npm:^2.46.2, @microsoft/fast-foundation@npm:^2.49.0, @microsoft/fast-foundation@npm:^2.49.2":
+  version: 2.49.2
+  resolution: "@microsoft/fast-foundation@npm:2.49.2"
+  dependencies:
+    "@microsoft/fast-element": ^1.12.0
+    "@microsoft/fast-web-utilities": ^5.4.1
+    tabbable: ^5.2.0
+    tslib: ^1.13.0
+  checksum: b582bd2012fa366d417c26c2e7c80ecc860664e796cfe52ed9ecee1089d73da5bdf1730aad3a30fbd5fa4ea80782259cf45e8500c358bb246b893ec103d00d9e
+  languageName: node
+  linkType: hard
+
+"@microsoft/fast-react-wrapper@npm:^0.3.18":
+  version: 0.3.20
+  resolution: "@microsoft/fast-react-wrapper@npm:0.3.20"
+  dependencies:
+    "@microsoft/fast-element": ^1.12.0
+    "@microsoft/fast-foundation": ^2.49.2
+  peerDependencies:
+    react: ">=16.9.0"
+  checksum: 3ced25465f1f53c18d6cf62fa75118f66d4b6c75a622bda2e7ecdfcfda3fb8347b147573665de486951b86d70312dbbf63c3faeb5cf002fa263561d3feb4d1a2
+  languageName: node
+  linkType: hard
+
+"@microsoft/fast-web-utilities@npm:^5.4.1":
+  version: 5.4.1
+  resolution: "@microsoft/fast-web-utilities@npm:5.4.1"
+  dependencies:
+    exenv-es6: ^1.1.1
+  checksum: 303e87847f962944f474e3716c3eb305668243916ca9e0719e26bb9a32346144bc958d915c103776b3e552cea0f0f6233f839fad66adfdf96a8436b947288ca7
+  languageName: node
+  linkType: hard
+
+"@microsoft/fast-web-utilities@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@microsoft/fast-web-utilities@npm:6.0.0"
+  dependencies:
+    exenv-es6: ^1.1.1
+  checksum: b4b906dbbf626212446d5952c160b1f7e7ce72dd33087c7ed634cb2745c31767bab7d17fba0e9fc32e42984fc5bc0a9929b4f05cbbcbe52869abe3666b5bfa39
   languageName: node
   linkType: hard
 
@@ -11422,6 +11520,13 @@ __metadata:
     signal-exit: ^3.0.7
     strip-final-newline: ^3.0.0
   checksum: 21fa46fc69314ace4068cf820142bdde5b643a5d89831c2c9349479c1555bff137a291b8e749e7efca36535e4e0a8c772c11008ca2e84d2cbd6ca141a3c8f937
+  languageName: node
+  linkType: hard
+
+"exenv-es6@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "exenv-es6@npm:1.1.1"
+  checksum: 7f2aa12025e6f06c48dc286f380cf3183bb19c6017b36d91695034a3e5124a7235c4f8ff24ca2eb88ae801322f0f99605cedfcfd996a5fcbba7669320e2a448e
   languageName: node
   linkType: hard
 
@@ -19365,6 +19470,13 @@ __metadata:
     systeminformation: lib/cli.js
   checksum: 302b8b430a5b0a7009be95c086b1bc43db3ecfd6ecab6cf654ae3312240f616823505f15a080a70f2335a9e5aab45d789aaba018843c9a9f8f18117aa32dce8a
   conditions: (os=darwin | os=linux | os=win32 | os=freebsd | os=openbsd | os=netbsd | os=sunos | os=android)
+  languageName: node
+  linkType: hard
+
+"tabbable@npm:^5.2.0":
+  version: 5.3.3
+  resolution: "tabbable@npm:5.3.3"
+  checksum: 1aa56e1bb617cc10616c407f4e756f0607f3e2d30f9803664d70b85db037ca27e75918ed1c71443f3dc902e21dc9f991ce4b52d63a538c9b69b3218d3babcd70
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add a plugin that enables to add drives to the filebrowser. Through a button in the dedicated toolbar, you can access a dialog and add drives, that will be added to the filebrowser tree system.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Add a plugin named `OpenDriveDialogPlugin` in `packages/filebrowser-extension/src/index.ts`
Add a `driveListManager.tsx` defining the components used in the Dialog.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
