### PR TITLE
Improve cell toolbar tracker

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -27,6 +27,7 @@ jupyterlab/geckodriver
 jupyterlab/staging/yarn.js
 jupyterlab/staging/index.js
 jupyterlab/staging/webpack.config.js
+packages/codemirror/test/foo*.js
 packages/extensionmanager-extension/examples/listings
 packages/nbconvert-css/raw.js
 packages/services/dist

--- a/packages/cell-toolbar/src/celltoolbartracker.ts
+++ b/packages/cell-toolbar/src/celltoolbartracker.ts
@@ -192,7 +192,8 @@ export class CellToolbarTracker implements IDisposable {
       // Wait for all the buttons to be rendered before attaching the toolbar.
       Promise.all(promises)
         .then(() => {
-          if (cell.isDisposed) {
+          if (cell.isDisposed || this._panel?.content.activeCell !== cell) {
+            toolbarWidget.dispose();
             return;
           }
 

--- a/packages/cell-toolbar/src/celltoolbartracker.ts
+++ b/packages/cell-toolbar/src/celltoolbartracker.ts
@@ -151,11 +151,11 @@ export class CellToolbarTracker implements IDisposable {
   private _addToolbar(model: ICellModel): void {
     const cell = this._getCell(model);
 
-    if (cell) {
+    if (cell && !cell.isDisposed) {
       const toolbarWidget = new Toolbar();
       toolbarWidget.addClass(CELL_MENU_CLASS);
 
-      const promises: Promise<void>[] = [];
+      const promises: Promise<void>[] = [cell.ready];
       for (const { name, widget } of this._toolbar) {
         toolbarWidget.addItem(name, widget);
         if (
@@ -170,6 +170,10 @@ export class CellToolbarTracker implements IDisposable {
       // Wait for all the buttons to be rendered before attaching the toolbar.
       Promise.all(promises)
         .then(() => {
+          if (cell.isDisposed) {
+            return;
+          }
+
           toolbarWidget.addClass(CELL_TOOLBAR_CLASS);
           (cell.layout as PanelLayout).insertWidget(0, toolbarWidget);
 
@@ -201,7 +205,7 @@ export class CellToolbarTracker implements IDisposable {
 
   private _removeToolbar(model: ICellModel): void {
     const cell = this._getCell(model);
-    if (cell) {
+    if (cell && !cell.isDisposed) {
       this._findToolbarWidgets(cell).forEach(widget => {
         widget.dispose();
       });

--- a/packages/cell-toolbar/src/celltoolbartracker.ts
+++ b/packages/cell-toolbar/src/celltoolbartracker.ts
@@ -2,7 +2,11 @@
 | Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
-import { createDefaultFactory, ToolbarRegistry } from '@jupyterlab/apputils';
+import {
+  createDefaultFactory,
+  setToolbar,
+  ToolbarRegistry
+} from '@jupyterlab/apputils';
 import {
   Cell,
   CellModel,
@@ -34,6 +38,7 @@ const TEXT_MIME_TYPES = [
  * Widget cell toolbar classes
  */
 const CELL_TOOLBAR_CLASS = 'jp-cell-toolbar';
+// @deprecated to be removed
 const CELL_MENU_CLASS = 'jp-cell-menu';
 
 /**
@@ -45,45 +50,59 @@ const TOOLBAR_OVERLAP_CLASS = 'jp-toolbar-overlap';
  * Watch a notebook so that a cell toolbar appears on the active cell
  */
 export class CellToolbarTracker implements IDisposable {
+  /**
+   * CellToolbarTracker constructor
+   *
+   * @param panel The notebook panel
+   * @param toolbar The toolbar; deprecated use {@link toolbarFactory} instead
+   * @param toolbarFactory The toolbar factory
+   */
   constructor(
     panel: NotebookPanel,
-    toolbar: IObservableList<ToolbarRegistry.IToolbarItem>
+    toolbar?: IObservableList<ToolbarRegistry.IToolbarItem>,
+    toolbarFactory?: (
+      widget: Cell
+    ) => IObservableList<ToolbarRegistry.IToolbarItem>
   ) {
     this._panel = panel;
     this._previousActiveCell = this._panel.content.activeCell;
-    this._toolbar = toolbar;
+    this._toolbarItems = toolbar ?? null;
+    this._toolbarFactory = toolbarFactory ?? null;
 
-    this._onToolbarChanged();
-    this._toolbar.changed.connect(this._onToolbarChanged, this);
+    if (this._toolbarItems === null && this._toolbarFactory === null) {
+      throw Error('You must provide the toolbarFactory or the toolbar items.');
+    }
+
+    // deprecated to be removed when we remove toolbar from input arguments
+    if (!this._toolbarFactory && this._toolbarItems) {
+      this._onToolbarChanged();
+      this._toolbarItems.changed.connect(this._onToolbarChanged, this);
+    }
 
     // Only add the toolbar to the notebook's active cell (if any) once it has fully rendered and been revealed.
     void panel.revealed.then(() => {
-      // Wait one frame (at 60 fps) for the panel to render the first cell, then display the cell toolbar on it if possible.
-      setTimeout(() => {
-        this._onActiveCellChanged(panel.content);
-      }, 1000 / 60);
-    });
+      requestAnimationFrame(() => {
+        const notebook = panel.content;
+        this._onActiveCellChanged(notebook);
+        // Handle subsequent changes of active cell.
+        notebook.activeCellChanged.connect(this._onActiveCellChanged, this);
 
-    // Check whether the toolbar should be rendered upon a layout change
-    panel.content.renderingLayoutChanged.connect(
-      this._onActiveCellChanged,
-      this
-    );
+        // Check whether the toolbar should be rendered upon a layout change
+        notebook.renderingLayoutChanged.connect(
+          this._onActiveCellChanged,
+          this
+        );
 
-    // Handle subsequent changes of active cell.
-    panel.content.activeCellChanged.connect(this._onActiveCellChanged, this);
-    panel.content.activeCell?.model.metadataChanged.connect(
-      this._onMetadataChanged,
-      this
-    );
-    panel.disposed.connect(() => {
-      panel.content.activeCellChanged.disconnect(this._onActiveCellChanged);
-      panel.content.activeCell?.model.metadataChanged.disconnect(
-        this._onMetadataChanged
-      );
+        notebook.disposed.connect(() => {
+          notebook.activeCellChanged.disconnect(this._onActiveCellChanged);
+        });
+      });
     });
   }
 
+  /**
+   * @deprecated Will become protected in JupyterLab 5
+   */
   _onMetadataChanged(model: CellModel, args: IMapChange) {
     if (args.key === 'jupyter') {
       if (
@@ -104,6 +123,10 @@ export class CellToolbarTracker implements IDisposable {
       }
     }
   }
+
+  /**
+   * @deprecated Will become protected in JupyterLab 5
+   */
   _onActiveCellChanged(notebook: Notebook): void {
     if (this._previousActiveCell && !this._previousActiveCell.isDisposed) {
       // Disposed cells do not have a model anymore.
@@ -134,14 +157,8 @@ export class CellToolbarTracker implements IDisposable {
     }
     this._isDisposed = true;
 
-    this._toolbar.changed.disconnect(this._onToolbarChanged, this);
-
-    const cells = this._panel?.context.model.cells;
-    if (cells) {
-      for (const model of cells) {
-        this._removeToolbar(model);
-      }
-    }
+    this._toolbarItems?.changed.disconnect(this._onToolbarChanged, this);
+    this._toolbar?.dispose();
 
     this._panel = null;
 
@@ -152,18 +169,23 @@ export class CellToolbarTracker implements IDisposable {
     const cell = this._getCell(model);
 
     if (cell && !cell.isDisposed) {
-      const toolbarWidget = new Toolbar();
+      const toolbarWidget = (this._toolbar = new Toolbar());
+      // deprecated on those classes are useless
       toolbarWidget.addClass(CELL_MENU_CLASS);
-
+      toolbarWidget.addClass(CELL_TOOLBAR_CLASS);
       const promises: Promise<void>[] = [cell.ready];
-      for (const { name, widget } of this._toolbar) {
-        toolbarWidget.addItem(name, widget);
-        if (
-          widget instanceof ReactWidget &&
-          (widget as ReactWidget).renderPromise !== undefined
-        ) {
-          (widget as ReactWidget).update();
-          promises.push((widget as ReactWidget).renderPromise!);
+      if (this._toolbarFactory) {
+        setToolbar(cell, this._toolbarFactory, toolbarWidget);
+      } else {
+        for (const { name, widget } of this._toolbarItems!) {
+          toolbarWidget.addItem(name, widget);
+          if (
+            widget instanceof ReactWidget &&
+            (widget as ReactWidget).renderPromise !== undefined
+          ) {
+            (widget as ReactWidget).update();
+            promises.push((widget as ReactWidget).renderPromise!);
+          }
         }
       }
 
@@ -174,7 +196,6 @@ export class CellToolbarTracker implements IDisposable {
             return;
           }
 
-          toolbarWidget.addClass(CELL_TOOLBAR_CLASS);
           (cell.layout as PanelLayout).insertWidget(0, toolbarWidget);
 
           // For rendered markdown, watch for resize events.
@@ -196,27 +217,22 @@ export class CellToolbarTracker implements IDisposable {
     return this._panel?.content.widgets.find(widget => widget.model === model);
   }
 
-  private _findToolbarWidgets(cell: Cell): Widget[] {
-    const widgets = (cell.layout as PanelLayout).widgets;
-
-    // Search for header using the CSS class or use the first one if not found.
-    return widgets.filter(widget => widget.hasClass(CELL_TOOLBAR_CLASS)) || [];
-  }
-
   private _removeToolbar(model: ICellModel): void {
     const cell = this._getCell(model);
     if (cell && !cell.isDisposed) {
-      this._findToolbarWidgets(cell).forEach(widget => {
-        widget.dispose();
-      });
       // Attempt to remove the resize and changed event handlers.
       cell.displayChanged.disconnect(this._resizeEventCallback, this);
     }
     model.contentChanged.disconnect(this._changedEventCallback, this);
+    if (this._toolbar?.parent === cell && this._toolbar?.isDisposed === false) {
+      this._toolbar.dispose();
+    }
   }
 
   /**
    * Call back on settings changes
+   *
+   * @deprecated To remove when toolbar can not be provided directly to the tracker
    */
   private _onToolbarChanged(): void {
     // Reset toolbar when settings changes
@@ -266,8 +282,10 @@ export class CellToolbarTracker implements IDisposable {
     const cellType = activeCell.model.type;
 
     // If the toolbar is too large for the current cell, hide it.
-    const cellLeft = this._cellEditorWidgetLeft(activeCell);
-    const cellRight = this._cellEditorWidgetRight(activeCell);
+
+    const editorRect = activeCell.editorWidget?.node.getBoundingClientRect();
+    const cellLeft = editorRect?.left ?? 0;
+    const cellRight = editorRect?.right ?? 0;
     const toolbarLeft = this._cellToolbarLeft(activeCell);
 
     if (toolbarLeft === null) {
@@ -389,20 +407,11 @@ export class CellToolbarTracker implements IDisposable {
     return toolbarLeft === null ? false : lineRight > toolbarLeft;
   }
 
-  private _cellEditorWidgetLeft(activeCell: Cell<ICellModel>): number {
-    return activeCell.editorWidget?.node.getBoundingClientRect().left ?? 0;
-  }
-
-  private _cellEditorWidgetRight(activeCell: Cell<ICellModel>): number {
-    return activeCell.editorWidget?.node.getBoundingClientRect().right ?? 0;
-  }
-
   private _cellToolbarRect(activeCell: Cell<ICellModel>): DOMRect | null {
-    const toolbarWidgets = this._findToolbarWidgets(activeCell);
-    if (toolbarWidgets.length < 1) {
+    if (this._toolbar?.parent !== activeCell) {
       return null;
     }
-    const activeCellToolbar = toolbarWidgets[0].node;
+    const activeCellToolbar = this._toolbar.node;
 
     return activeCellToolbar.getBoundingClientRect();
   }
@@ -414,7 +423,12 @@ export class CellToolbarTracker implements IDisposable {
   private _isDisposed = false;
   private _panel: NotebookPanel | null;
   private _previousActiveCell: Cell<ICellModel> | null;
-  private _toolbar: IObservableList<ToolbarRegistry.IToolbarItem>;
+  private _toolbar: Widget | null = null;
+  private _toolbarItems: IObservableList<ToolbarRegistry.IToolbarItem> | null =
+    null;
+  private _toolbarFactory:
+    | ((widget: Cell) => IObservableList<ToolbarRegistry.IToolbarItem>)
+    | null = null;
 }
 
 const defaultToolbarItems: ToolbarRegistry.IWidget[] = [
@@ -449,7 +463,7 @@ const defaultToolbarItems: ToolbarRegistry.IWidget[] = [
  * created.
  */
 export class CellBarExtension implements DocumentRegistry.WidgetExtension {
-  static FACTORY_NAME = 'Cell';
+  static readonly FACTORY_NAME = 'Cell';
 
   constructor(
     commands: CommandRegistry,
@@ -477,7 +491,7 @@ export class CellBarExtension implements DocumentRegistry.WidgetExtension {
   }
 
   createNew(panel: NotebookPanel): IDisposable {
-    return new CellToolbarTracker(panel, this._toolbarFactory(panel));
+    return new CellToolbarTracker(panel, undefined, this._toolbarFactory);
   }
 
   private _commands: CommandRegistry;

--- a/packages/cell-toolbar/src/celltoolbartracker.ts
+++ b/packages/cell-toolbar/src/celltoolbartracker.ts
@@ -176,6 +176,10 @@ export class CellToolbarTracker implements IDisposable {
       const promises: Promise<void>[] = [cell.ready];
       if (this._toolbarFactory) {
         setToolbar(cell, this._toolbarFactory, toolbarWidget);
+        // FIXME toolbarWidget.update() - strangely this does not work
+        (toolbarWidget.layout as PanelLayout).widgets.forEach(w => {
+          w.update();
+        });
       } else {
         for (const { name, widget } of this._toolbarItems!) {
           toolbarWidget.addItem(name, widget);

--- a/packages/cell-toolbar/src/celltoolbartracker.ts
+++ b/packages/cell-toolbar/src/celltoolbartracker.ts
@@ -170,7 +170,7 @@ export class CellToolbarTracker implements IDisposable {
 
     if (cell && !cell.isDisposed) {
       const toolbarWidget = (this._toolbar = new Toolbar());
-      // deprecated on those classes are useless
+      // Note: CELL_MENU_CLASS is deprecated.
       toolbarWidget.addClass(CELL_MENU_CLASS);
       toolbarWidget.addClass(CELL_TOOLBAR_CLASS);
       const promises: Promise<void>[] = [cell.ready];

--- a/packages/cell-toolbar/style/base.css
+++ b/packages/cell-toolbar/style/base.css
@@ -33,25 +33,20 @@
 
 /* Overrides for mobile view hiding cell toolbar */
 @media only screen and (width <= 760px) {
-  .jp-cell-menu.jp-cell-toolbar {
+  .jp-cell-toolbar {
     display: none;
   }
 }
 
-.jp-cell-menu {
-  display: flex;
-  flex-direction: row;
-}
-
-.jp-cell-menu button.jp-ToolbarButtonComponent {
+.jp-cell-toolbar button.jp-ToolbarButtonComponent {
   cursor: pointer;
 }
 
-.jp-cell-menu .jp-ToolbarButton button {
+.jp-cell-toolbar .jp-ToolbarButton button {
   display: none;
 }
 
-.jp-cell-menu .jp-ToolbarButton .jp-cell-all,
+.jp-cell-toolbar .jp-ToolbarButton .jp-cell-all,
 .jp-CodeCell .jp-ToolbarButton .jp-cell-code,
 .jp-MarkdownCell .jp-ToolbarButton .jp-cell-markdown,
 .jp-RawCell .jp-ToolbarButton .jp-cell-raw {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #14481
Closes #14139  
A new toolbar is generated when the active cell changes - this is the only way we will be able to address feature like #13153; or to be able to customize the button depending on the cell model (like the type or tags)
Fixes #14380
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
- Pass the toolbar factory instead of a list of toolbar items
- Generate a toolbar each time the active cell changes.
- Various improvements; like remove usage of two classes.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None