### PR TITLE
Added basic implementation to toggle the placeholder text 

### DIFF
--- a/packages/notebook/src/default-toolbar.tsx
+++ b/packages/notebook/src/default-toolbar.tsx
@@ -337,7 +337,7 @@ export namespace ToolbarItems {
 
 
 
-  
+
 }
 
 /**

--- a/packages/notebook/src/default-toolbar.tsx
+++ b/packages/notebook/src/default-toolbar.tsx
@@ -9,6 +9,9 @@ import {
   SessionContextDialogs,
   showDialog
 } from '@jupyterlab/apputils';
+
+import { isPlaceholderVisible } from '@jupyterlab/notebook/src/default-toolbar';
+
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import * as nbformat from '@jupyterlab/nbformat';
 import {
@@ -36,6 +39,15 @@ import * as React from 'react';
 import { NotebookActions } from './actions';
 import { NotebookPanel } from './panel';
 import { Notebook } from './widget';
+
+
+// This variable will hold the state of the placeholder's visibility.
+let isPlaceholderVisible = true;
+
+// This function will toggle the visibility state.
+function toggleGlobalPlaceholderVisibility() {
+  isPlaceholderVisible = !isPlaceholderVisible;
+}
 
 /**
  * The class name added to toolbar cell type dropdown wrapper.
@@ -273,6 +285,7 @@ export namespace ToolbarItems {
       { name: 'cut', widget: createCutButton(panel, translator) },
       { name: 'copy', widget: createCopyButton(panel, translator) },
       { name: 'paste', widget: createPasteButton(panel, translator) },
+      { name: 'togglePlaceholder', widget: createTogglePlaceholderButton(panel) }, //for the placeholder toggle button
       {
         name: 'run',
         widget: createRunButton(panel, sessionDialogs, translator)
@@ -308,6 +321,23 @@ export namespace ToolbarItems {
       }
     ];
   }
+
+ export function createTogglePlaceholderButton(panel: NotebookPanel): ReactWidget {
+  return new ToolbarButton({
+    icon: addIcon, // Used this icon for now, will change it after collaborating with maintainers
+    onClick: () => {
+      // Toggle the global placeholder visibility state.
+      toggleGlobalPlaceholderVisibility();
+    },
+    tooltip: 'Toggle Placeholder'
+  });
+}
+
+
+
+
+
+  
 }
 
 /**


### PR DESCRIPTION
## References

Closes #15138

## Code changes

1. Introduced a global state variable isPlaceholderVisible in widget.ts to manage the visibility of the placeholder text.
2. Implemented a function toggleGlobalPlaceholderVisibility in widget.ts to toggle the visibility state.
3. Added conditional rendering logic in the cell widget rendering method in widget.ts to show/hide the placeholder based on the isPlaceholderVisible state.

## User-facing changes

1. Users will see a toggle button in the notebook toolbar. Clicking this button will show or hide the placeholder text in the notebook cells.
2. This provides users with the flexibility to choose whether they want to see the placeholder text or not.

## Backwards-incompatible changes

None. The changes introduced are compatible with the existing JupyterLab public APIs and do not break any existing functionality.
