### PR TITLE
Backport ruff/black/pre-commit updates to align versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,17 +27,17 @@ repos:
         exclude: (.bumpversion.cfg|yarn.js)
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.23.1
+    rev: 0.27.0
     hooks:
       - id: check-github-workflows
 
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.9.1
     hooks:
       - id: black
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.282
+    rev: v0.0.292
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1053,7 +1053,7 @@ class _AppHandler:
 
         found = None
         for name, source in linked.items():
-            if path in (name, source):
+            if path in {name, source}:
                 found = name
 
         if found:
@@ -1061,7 +1061,7 @@ class _AppHandler:
         else:
             local = config.setdefault("local_extensions", {})
             for name, source in local.items():
-                if path in (name, source):
+                if path in {name, source}:
                     found = name
             if found:
                 del local[found]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,8 +115,8 @@ dev = [
     "coverage",
     "hatch",
     "bump2version",
-    "ruff==0.0.286",
-    "black[jupyter]==23.7.0"
+    "ruff==0.0.292",
+    "black[jupyter]==23.10.1"
 ]
 
 [tool.check-wheel-contents]


### PR DESCRIPTION
Manual backport for:
- [pre-commit.ci] pre-commit autoupdate #15210
- [pre-commit.ci] pre-commit autoupdate #15078
- Bump ruff from 0.0.287 to 0.0.291 #15190
- Bump black[jupyter] from 23.7.0 to 23.10.1 #15336