### PR TITLE
Fix missing default property breaking codemirror `overrides.json`

### DIFF
--- a/packages/codemirror-extension/schema/plugin.json
+++ b/packages/codemirror-extension/schema/plugin.json
@@ -5,6 +5,7 @@
   "description": "Text editor settings for all CodeMirror editors.",
   "properties": {
     "defaultConfig": {
+      "default": {},
       "title": "Default editor configuration",
       "description": "Base configuration used by all CodeMirror editors.",
       "type": "object"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

fix server error 500 on trying to settings override "@jupyterlab/codemirror-extension:plugin" for all users:

```log
Nov 02 03:54:57 jupyterhub jupyterhub-singleuser[1817]: [W 2023-11-02 03:54:57.430 LabApp] wrote error: 'Unhandled error'
Nov 02 03:54:57 jupyterhub jupyterhub-singleuser[1817]:     Traceback (most recent call last):
Nov 02 03:54:57 jupyterhub jupyterhub-singleuser[1817]:       File "/opt/tljh/user/lib/python3.10/site-packages/tornado/web.py", line 1784, in _execute
Nov 02 03:54:57 jupyterhub jupyterhub-singleuser[1817]:         result = method(*self.path_args, **self.path_kwargs)
Nov 02 03:54:57 jupyterhub jupyterhub-singleuser[1817]:       File "/opt/tljh/user/lib/python3.10/site-packages/tornado/web.py", line 3290, in wrapper
Nov 02 03:54:57 jupyterhub jupyterhub-singleuser[1817]:         return method(self, *args, **kwargs)
Nov 02 03:54:57 jupyterhub jupyterhub-singleuser[1817]:       File "/opt/tljh/user/lib/python3.10/site-packages/jupyterlab_server/settings_handler.py", line 48, in get
Nov 02 03:54:57 jupyterhub jupyterhub-singleuser[1817]:         result, warnings = get_settings(
Nov 02 03:54:57 jupyterhub jupyterhub-singleuser[1817]:       File "/opt/tljh/user/lib/python3.10/site-packages/jupyterlab_server/settings_utils.py", line 377, in get_settings
Nov 02 03:54:57 jupyterhub jupyterhub-singleuser[1817]:         settings_list, warnings = _list_settings(
Nov 02 03:54:57 jupyterhub jupyterhub-singleuser[1817]:       File "/opt/tljh/user/lib/python3.10/site-packages/jupyterlab_server/settings_utils.py", line 168, in _list_settings
Nov 02 03:54:57 jupyterhub jupyterhub-singleuser[1817]:         schema, version = _get_schema(schemas_dir, schema_name, overrides, None)
Nov 02 03:54:57 jupyterhub jupyterhub-singleuser[1817]:       File "/opt/tljh/user/lib/python3.10/site-packages/jupyterlab_server/settings_utils.py", line 57, in _get_schema
Nov 02 03:54:57 jupyterhub jupyterhub-singleuser[1817]:         schema = _override(schema_name, schema, overrides)
Nov 02 03:54:57 jupyterhub jupyterhub-singleuser[1817]:       File "/opt/tljh/user/lib/python3.10/site-packages/jupyterlab_server/settings_utils.py", line 232, in _override
Nov 02 03:54:57 jupyterhub jupyterhub-singleuser[1817]:         new_defaults = schema["properties"][key]["default"]
Nov 02 03:54:57 jupyterhub jupyterhub-singleuser[1817]:     KeyError: 'default'
```

## Code changes

<!-- Describe the code changes and how they address the issue. -->

added key "default"

## User-facing changes

[this](https://tljh.jupyter.org/en/latest/howto/user-env/override-lab-settings.html#step-2-determine-your-personal-settings-configuration) finally works as advertised

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

:shrug: 
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
