### PR TITLE
Faster galata/UI tests

### DIFF
--- a/galata/src/helpers/activity.ts
+++ b/galata/src/helpers/activity.ts
@@ -51,13 +51,11 @@ export class ActivityHelper {
       return activeTab === name;
     } else {
       const tab = await this.getTab(name);
-      return (
-        (tab &&
-          (await tab.evaluate((tab: Element) =>
-            tab.classList.contains('jp-mod-current')
-          ))) ??
-        false
-      );
+      if (!tab) {
+        return false;
+      }
+      const classes = ((await tab.getAttribute('class')) ?? '').split(' ');
+      return classes.includes('jp-mod-current');
     }
   }
 


### PR DESCRIPTION
## References

When developing tests against https://github.com/jupyterlab/jupyterlab/issues/15330 and other issues I faced a problem where this code path would freeze the test in an infinite loop.

From an experiment on my fork it appears that this little change could cut the runtime for galata tests by 50%. From about 44 minutes down to about 22 minutes.

## Code changes

Use playwright `getAttribute` instead of evaluation to get class name.

## User-facing changes

None

## Backwards-incompatible changes

None