### PR TITLE
Fix scrolling past long outputs in presence of un-rendered headings

### DIFF
--- a/galata/src/helpers/notebook.ts
+++ b/galata/src/helpers/notebook.ts
@@ -787,7 +787,10 @@ export class NotebookHelper {
   }
 
   /**
-   * Whether the cell is in editing mode or not
+   * Whether the cell is in editing mode or not.
+   *
+   * This method is not suitable for checking if a cell is unrendered
+   * as it will return false when the cell is not active (not focused).
    *
    * @param cellIndex Cell index
    * @returns Editing mode

--- a/galata/test/jupyterlab/notebook-scroll.test.ts
+++ b/galata/test/jupyterlab/notebook-scroll.test.ts
@@ -65,6 +65,10 @@ test.describe('Notebook scroll over long outputs', () => {
     await page.notebook.activate(outputAndHeading);
   });
 
+  test.afterEach(async ({ page, tmpPath }) => {
+    await page.contents.deleteDirectory(tmpPath);
+  });
+
   test('should scroll smoothly without snapping to headings', async ({
     page
   }) => {

--- a/galata/test/jupyterlab/notebook-scroll.test.ts
+++ b/galata/test/jupyterlab/notebook-scroll.test.ts
@@ -52,3 +52,54 @@ test.describe('Notebook Scroll', () => {
     });
   }
 });
+
+test.describe('Notebook scroll over long outputs', () => {
+  const outputAndHeading = 'long_output_and_headings.ipynb';
+  test.beforeEach(async ({ page, tmpPath }) => {
+    await page.contents.uploadFile(
+      path.resolve(__dirname, `./notebooks/${outputAndHeading}`),
+      `${tmpPath}/${outputAndHeading}`
+    );
+
+    await page.notebook.openByPath(`${tmpPath}/${outputAndHeading}`);
+    await page.notebook.activate(outputAndHeading);
+  });
+
+  test('should scroll over long output smoothly', async ({ page }) => {
+    const renderedMarkdownLocator = page.locator(
+      '.jp-Cell .jp-RenderedMarkdown:has-text("Before")'
+    );
+    // Wait until Markdown cells are rendered
+    await renderedMarkdownLocator.waitFor({ timeout: 100 });
+    // Un-render the "before" markdown cell
+    await renderedMarkdownLocator.dblclick();
+    // Make the first cell active
+    await page.notebook.selectCells(0);
+    // Check that that the markdown cell is un-rendered
+    await renderedMarkdownLocator.waitFor({ state: 'hidden', timeout: 100 });
+
+    // Scroll to the last cell
+    const lastCell = await page.notebook.getCell(10);
+    await lastCell.scrollIntoViewIfNeeded();
+
+    // Get the outer window
+    const outer = page.locator('.jp-WindowedPanel-outer');
+
+    let previousOffset = await outer.evaluate(node => node.scrollTop);
+    expect(previousOffset).toBeGreaterThan(1000);
+
+    // Scroll piece by piece checking that there is no jump
+    while (previousOffset > 75) {
+      await page.mouse.wheel(0, -100);
+      // Explicit wait because mouse wheel does not wait for scrolling.
+      await page.waitForTimeout(150);
+      const offset = await outer.evaluate(node => node.scrollTop);
+      const diff = previousOffset - offset;
+      // The scroll should be by about 100px, but because wheel event
+      // does not wait we allow for some wiggle room (+/-25px).
+      expect(diff).toBeLessThanOrEqual(125);
+      expect(diff).toBeGreaterThan(75);
+      previousOffset = offset;
+    }
+  });
+});

--- a/galata/test/jupyterlab/notebook-scroll.test.ts
+++ b/galata/test/jupyterlab/notebook-scroll.test.ts
@@ -65,7 +65,9 @@ test.describe('Notebook scroll over long outputs', () => {
     await page.notebook.activate(outputAndHeading);
   });
 
-  test('should scroll over long output smoothly', async ({ page }) => {
+  test('should scroll smoothly without snapping to headings', async ({
+    page
+  }) => {
     const renderedMarkdownLocator = page.locator(
       '.jp-Cell .jp-RenderedMarkdown:has-text("Before")'
     );

--- a/galata/test/jupyterlab/notebooks/long_output_and_headings.ipynb
+++ b/galata/test/jupyterlab/notebooks/long_output_and_headings.ipynb
@@ -1,0 +1,230 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "61b4490f-af96-4e09-94fa-8de641547698",
+   "metadata": {},
+   "source": [
+    "Active cell."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39eaf05d-3a87-4320-b722-06c57c2cd25a",
+   "metadata": {},
+   "source": [
+    "# before"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "194ec3b5-1085-4ff9-9ede-9b6795c126d7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-11-05T16:27:02.889334Z",
+     "iopub.status.busy": "2023-11-05T16:27:02.888808Z",
+     "iopub.status.idle": "2023-11-05T16:27:02.903710Z",
+     "shell.execute_reply": "2023-11-05T16:27:02.902631Z",
+     "shell.execute_reply.started": "2023-11-05T16:27:02.889294Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0\n",
+      "1\n",
+      "2\n",
+      "3\n",
+      "4\n",
+      "5\n",
+      "6\n",
+      "7\n",
+      "8\n",
+      "9\n",
+      "10\n",
+      "11\n",
+      "12\n",
+      "13\n",
+      "14\n",
+      "15\n",
+      "16\n",
+      "17\n",
+      "18\n",
+      "19\n",
+      "20\n",
+      "21\n",
+      "22\n",
+      "23\n",
+      "24\n",
+      "25\n",
+      "26\n",
+      "27\n",
+      "28\n",
+      "29\n",
+      "30\n",
+      "31\n",
+      "32\n",
+      "33\n",
+      "34\n",
+      "35\n",
+      "36\n",
+      "37\n",
+      "38\n",
+      "39\n",
+      "40\n",
+      "41\n",
+      "42\n",
+      "43\n",
+      "44\n",
+      "45\n",
+      "46\n",
+      "47\n",
+      "48\n",
+      "49\n",
+      "50\n",
+      "51\n",
+      "52\n",
+      "53\n",
+      "54\n",
+      "55\n",
+      "56\n",
+      "57\n",
+      "58\n",
+      "59\n",
+      "60\n",
+      "61\n",
+      "62\n",
+      "63\n",
+      "64\n",
+      "65\n",
+      "66\n",
+      "67\n",
+      "68\n",
+      "69\n",
+      "70\n",
+      "71\n",
+      "72\n",
+      "73\n",
+      "74\n",
+      "75\n",
+      "76\n",
+      "77\n",
+      "78\n",
+      "79\n",
+      "80\n",
+      "81\n",
+      "82\n",
+      "83\n",
+      "84\n",
+      "85\n",
+      "86\n",
+      "87\n",
+      "88\n",
+      "89\n",
+      "90\n",
+      "91\n",
+      "92\n",
+      "93\n",
+      "94\n",
+      "95\n",
+      "96\n",
+      "97\n",
+      "98\n",
+      "99\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('\\n'.join(str(i) for i in range(100)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6475f01e-273c-4fde-81d4-66b1c9cb4c23",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "479b1c22-96dd-47cc-83a2-913d657f088c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4a6a953-4397-480b-b52e-38fecc9c6117",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d10fb1f-97ff-4f71-8be7-8cd263f1a0cf",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "228273a6-264e-46af-8ecb-17548f2dfdd2",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9eea2c6d-2364-4dee-bc95-c4e3e051d943",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92d3c01c-8fa3-44e6-9097-25a71d9f2b8d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a45dd6e-aa7d-49e4-b8a5-9416f2ef3997",
+   "metadata": {},
+   "source": [
+    "Last cell"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -2253,10 +2253,13 @@ export class MarkdownCell extends AttachmentsCell<IMarkdownCellModel> {
         .getSource()
         .match(/^#+/g) || [''])[0].length;
       if (numHashAtStart > 0) {
-        this.inputArea!.editor.setCursorPosition({
-          column: numHashAtStart + 1,
-          line: 0
-        });
+        this.inputArea!.editor.setCursorPosition(
+          {
+            column: numHashAtStart + 1,
+            line: 0
+          },
+          { scroll: false }
+        );
       }
     }
   }

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -257,11 +257,15 @@ export namespace CodeEditor {
      * Set the primary position of the cursor.
      *
      * @param position - The new primary position.
+     * @param options - Adjustment options allowing to disable scrolling.
      *
      * #### Notes
      * This will remove any secondary cursors.
      */
-    setCursorPosition(position: IPosition): void;
+    setCursorPosition(
+      position: IPosition,
+      options?: { scroll?: boolean }
+    ): void;
 
     /**
      * Returns the primary selection, never `null`.

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -403,7 +403,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
     const offset = this.getOffsetAt(position);
     this.editor.dispatch({
       selection: { anchor: offset },
-      scrollIntoView: true
+      scrollIntoView: options?.scroll === false ? false : true
     });
     // If the editor does not have focus, this cursor change
     // will get screened out in _onCursorsChanged(). Make an


### PR DESCRIPTION
## References

Fixes #15352

## Code changes

- do not scroll to newly attached un-rendered markdown cell with a heading
- exposes `options` in `setCursorPosition` API (already present - but not previously functional - in `CodeMirrorEditor` implementation)

## User-facing changes

Scrolling past long cell outputs in full windowing mode works ok even if there are unrendered markdown cells.

## Backwards-incompatible changes

None