### PR TITLE
Remove unnecessary requirement from codemirror service plugin

### DIFF
--- a/packages/codemirror-extension/src/services.tsx
+++ b/packages/codemirror-extension/src/services.tsx
@@ -239,11 +239,7 @@ export const servicesPlugin: JupyterFrontEndPlugin<IEditorServices> = {
   id: '@jupyterlab/codemirror-extension:services',
   description: 'Provides the service to instantiate CodeMirror editors.',
   provides: IEditorServices,
-  requires: [
-    IEditorLanguageRegistry,
-    IEditorExtensionRegistry,
-    IEditorThemeRegistry
-  ],
+  requires: [IEditorLanguageRegistry, IEditorExtensionRegistry],
   optional: [ITranslator],
   activate: (
     app: JupyterFrontEnd,


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/15360

## Code changes

- Remove unnecessary requirement (`IEditorThemeRegistry`) from `@jupyterlab/codemirror-extension:services` plugin

## User-facing changes

None

## Backwards-incompatible changes

None

