### PR TITLE
Exclude ipynb files in prettier pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,7 @@ repos:
         entry: 'npm run prettier:files'
         language: node
         types_or: [json, ts, tsx, javascript, jsx, css]
+        exclude: \.ipynb$
       - id: eslint
         name: eslint
         entry: 'npm run eslint:files'


### PR DESCRIPTION
## References

On my side, I'm not able to commit if there is a notebook file in the commit (`.ipynb`).

It may be related to https://github.com/jupyterlab/jupyterlab/pull/15358 which update pre-commit to 4.5.0.

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None