### PR TITLE
Don't show default value for objects in Settings Editor

### DIFF
--- a/packages/ui-components/src/components/form.tsx
+++ b/packages/ui-components/src/components/form.tsx
@@ -575,14 +575,18 @@ const CustomTemplateFactory = (options: FormComponent.ILabCustomizerProps) =>
                 {schema.description}
               </div>
             )}
-            {isModified && defaultValue !== undefined && schema.type !== 'object' && (
-              <div className="jp-FormGroup-default">
-                {trans.__(
-                  'Default: %1',
-                  defaultValue !== null ? defaultValue.toLocaleString() : 'null'
-                )}
-              </div>
-            )}
+            {isModified &&
+              defaultValue !== undefined &&
+              schema.type !== 'object' && (
+                <div className="jp-FormGroup-default">
+                  {trans.__(
+                    'Default: %1',
+                    defaultValue !== null
+                      ? defaultValue.toLocaleString()
+                      : 'null'
+                  )}
+                </div>
+              )}
             <div className="validationErrors">{errors}</div>
           </div>
         </div>

--- a/packages/ui-components/src/components/form.tsx
+++ b/packages/ui-components/src/components/form.tsx
@@ -575,7 +575,7 @@ const CustomTemplateFactory = (options: FormComponent.ILabCustomizerProps) =>
                 {schema.description}
               </div>
             )}
-            {isModified && defaultValue !== undefined && (
+            {isModified && defaultValue !== undefined && schema.type !== 'object' && (
               <div className="jp-FormGroup-default">
                 {trans.__(
                   'Default: %1',


### PR DESCRIPTION
## References

Fixes #15323 

## Code changes

Don't show default for `objects` in form UI component, the result of which will always be "Object". I'm not entirely sure where else this component is used, but I don't think the "Default: [object Object]" message would be useful in any case.

## User-facing changes

After changing a setting that is part of an object, the message "Default: [object Object]" no longer appears below the settings section for the object.

## Backwards-incompatible changes

None as far as I know.
