### PR TITLE
Do not update filebrowser breadcrumbs when not needed

### DIFF
--- a/packages/filebrowser/test/crumbs.spec.ts
+++ b/packages/filebrowser/test/crumbs.spec.ts
@@ -223,6 +223,59 @@ describe('filebrowser/model', () => {
         expect(items.length).toBe(3);
         model.dispose();
       });
+
+      it('should trigger DOM updates if state changes', async () => {
+        const model = new FileBrowserModel({ manager });
+        crumbs = new LogCrumbs({ model });
+        let modifications = 0;
+        const observer = new MutationObserver(() => modifications++);
+        observer.observe(crumbs.node, {
+          attributes: true,
+          childList: true,
+          subtree: true
+        });
+
+        // Should modify the DOM once
+        await model.cd(path);
+        crumbs.update();
+        await framePromise();
+        expect(modifications).toBe(1);
+
+        // Should modify the DOM once
+        await model.cd('..');
+        crumbs.update();
+        await framePromise();
+        expect(modifications).toBe(2);
+
+        observer.disconnect();
+        model.dispose();
+      });
+
+      it('should not touch DOM if state is unchanged', async () => {
+        const model = new FileBrowserModel({ manager });
+        crumbs = new LogCrumbs({ model });
+        let modifications = 0;
+        const observer = new MutationObserver(() => modifications++);
+        observer.observe(crumbs.node, {
+          attributes: true,
+          childList: true,
+          subtree: true
+        });
+
+        // Should modify the DOM once
+        await model.cd(path);
+        crumbs.update();
+        await framePromise();
+        expect(modifications).toBe(1);
+
+        // Should not increase the number of modifications
+        crumbs.update();
+        await framePromise();
+        expect(modifications).toBe(1);
+
+        observer.disconnect();
+        model.dispose();
+      });
     });
   });
 });


### PR DESCRIPTION
This slightly improves performance by eliminating spurious DOM updates, and prevents jitter on idle update when the breadcrumbs height is modified in extensions.

## References

Fixes #15365 (the JupyterLab side of the issue)

## Code changes

Split state out the private arguments, check if state changed before proceeding with the update.

## User-facing changes

Users of third party extensions will not see jitter when the breadcrumbs widget updates without change in the content.

## Backwards-incompatible changes

None