### PR TITLE
Don't play with the focus when handling focus event

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1359,12 +1359,29 @@ export class Notebook extends StaticNotebook {
     return this._mode;
   }
   set mode(newValue: NotebookMode) {
+    this.setMode(newValue);
+  }
+
+  /**
+   * Set the notebook mode.
+   *
+   * @param newValue Notebook mode
+   * @param options Control mode side-effect
+   * @param options.focus Whether to ensure focus (default) or not when setting the mode.
+   */
+  protected setMode(
+    newValue: NotebookMode,
+    options: { focus?: boolean } = {}
+  ): void {
+    const setFocus = options.focus ?? true;
     const activeCell = this.activeCell;
     if (!activeCell) {
       newValue = 'command';
     }
     if (newValue === this._mode) {
-      this._ensureFocus();
+      if (setFocus) {
+        this._ensureFocus();
+      }
       return;
     }
     // Post an update request.
@@ -1383,18 +1400,22 @@ export class Notebook extends StaticNotebook {
       }
       activeCell!.inputHidden = false;
     } else {
-      void NotebookActions.focusActiveCell(this, {
-        // Do not await the active cell because that creates a bug. If the user
-        // is editing a code cell and presses Accel Shift C to open the command
-        // palette, then the command palette opens before
-        // activeCell.node.focus() is called, which closes the command palette.
-        // To the end user, it looks as if all the keyboard shortcut did was
-        // move focus from the cell editor to the cell as a whole.
-        waitUntilReady: false
-      });
+      if (setFocus) {
+        void NotebookActions.focusActiveCell(this, {
+          // Do not await the active cell because that creates a bug. If the user
+          // is editing a code cell and presses Accel Shift C to open the command
+          // palette, then the command palette opens before
+          // activeCell.node.focus() is called, which closes the command palette.
+          // To the end user, it looks as if all the keyboard shortcut did was
+          // move focus from the cell editor to the cell as a whole.
+          waitUntilReady: false
+        });
+      }
     }
     this._stateChanged.emit({ name: 'mode', oldValue, newValue });
-    this._ensureFocus();
+    if (setFocus) {
+      this._ensureFocus();
+    }
   }
 
   /**
@@ -2696,21 +2717,23 @@ export class Notebook extends StaticNotebook {
   private _evtFocusIn(event: FocusEvent): void {
     const target = event.target as HTMLElement;
     const index = this._findCell(target);
+    console.log(`In _evtFocusIn idx ${index}`);
     if (index !== -1) {
       const widget = this.widgets[index];
       // If the editor itself does not have focus, ensure command mode.
       if (widget.editorWidget && !widget.editorWidget.node.contains(target)) {
-        this.mode = 'command';
+        this.setMode('command', { focus: false });
       }
       // If the editor has focus, ensure edit mode.
       const node = widget.editorWidget?.node;
       if (node?.contains(target)) {
-        this.mode = 'edit';
+        this.setMode('edit', { focus: false });
       }
+      // This will set the focus
       this.activeCellIndex = index;
     } else {
       // No cell has focus, ensure command mode.
-      this.mode = 'command';
+      this.setMode('command', { focus: false });
 
       // Prevents the parent element to get the focus.
       event.preventDefault();
@@ -2767,13 +2790,7 @@ export class Notebook extends StaticNotebook {
 
     // Otherwise enter command mode if not already.
     if (this.mode !== 'command') {
-      this.mode = 'command';
-
-      // Switching to command mode currently focuses the active cell, so
-      // refocus the relatedTarget so the focus actually switches as intended.
-      if (relatedTarget) {
-        relatedTarget.focus();
-      }
+      this.setMode('command', { focus: false });
     }
   }
 

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -2717,7 +2717,6 @@ export class Notebook extends StaticNotebook {
   private _evtFocusIn(event: FocusEvent): void {
     const target = event.target as HTMLElement;
     const index = this._findCell(target);
-    console.log(`In _evtFocusIn idx ${index}`);
     if (index !== -1) {
       const widget = this.widgets[index];
       // If the editor itself does not have focus, ensure command mode.

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -1348,7 +1348,7 @@ describe('@jupyter/notebook', () => {
       });
 
       describe('focusout', () => {
-        it('should switch to command mode', () => {
+        it('should switch to command mode', async () => {
           simulate(widget.node, 'focusin');
           widget.mode = 'edit';
           const event = generate('focusout');
@@ -1356,6 +1356,8 @@ describe('@jupyter/notebook', () => {
           widget.node.dispatchEvent(event);
           expect(widget.mode).toBe('command');
           MessageLoop.sendMessage(widget, Widget.Msg.ActivateRequest);
+          // Wait for the activeCell to be focused
+          await framePromise();
           expect(widget.mode).toBe('command');
           expect(widget.activeCell!.editor!.hasFocus()).toBe(false);
         });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #15407

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Create a new protected method `setMode` that allow to turn off some side-effect related to focus
Turn off focus actions when changing mode in focus event handlers.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
In full windowing mode, we can switch to any cell even if the active cell is not in the view.
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None