### PR TITLE
Scroll to the active cell when typing (in edit mode)

### DIFF
--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -896,34 +896,25 @@ export namespace NotebookActions {
       return;
     }
 
-    // Scroll first to the active widget in case it is not attached,
-    // in windowed notebook.
-    notebook
-      .scrollToItem(notebook.activeCellIndex)
-      .then(() => {
-        if (notebook.activeCellIndex === 0) {
-          return;
-        }
+    if (notebook.activeCellIndex === 0) {
+      return;
+    }
 
-        let possibleNextCellIndex = notebook.activeCellIndex - 1;
+    let possibleNextCellIndex = notebook.activeCellIndex - 1;
 
-        // find first non hidden cell above current cell
-        while (possibleNextCellIndex >= 0) {
-          const possibleNextCell = notebook.widgets[possibleNextCellIndex];
-          if (!possibleNextCell.inputHidden && !possibleNextCell.isHidden) {
-            break;
-          }
-          possibleNextCellIndex -= 1;
-        }
+    // find first non hidden cell above current cell
+    while (possibleNextCellIndex >= 0) {
+      const possibleNextCell = notebook.widgets[possibleNextCellIndex];
+      if (!possibleNextCell.inputHidden && !possibleNextCell.isHidden) {
+        break;
+      }
+      possibleNextCellIndex -= 1;
+    }
 
-        const state = Private.getState(notebook);
-        notebook.activeCellIndex = possibleNextCellIndex;
-        notebook.deselectAll();
-        void Private.handleState(notebook, state, true);
-      })
-      .catch(reason => {
-        // no-op
-      });
+    const state = Private.getState(notebook);
+    notebook.activeCellIndex = possibleNextCellIndex;
+    notebook.deselectAll();
+    void Private.handleState(notebook, state, true);
   }
 
   /**
@@ -951,36 +942,27 @@ export namespace NotebookActions {
       maxCellIndex -= 1;
     }
 
-    // Scroll first to the active widget in case it is not attached,
-    // in windowed notebook.
-    notebook
-      .scrollToItem(notebook.activeCellIndex)
-      .then(() => {
-        if (notebook.activeCellIndex === maxCellIndex) {
-          const footer = (notebook.layout as NotebookWindowedLayout).footer;
-          footer?.node.focus();
-          return;
-        }
+    if (notebook.activeCellIndex === maxCellIndex) {
+      const footer = (notebook.layout as NotebookWindowedLayout).footer;
+      footer?.node.focus();
+      return;
+    }
 
-        let possibleNextCellIndex = notebook.activeCellIndex + 1;
+    let possibleNextCellIndex = notebook.activeCellIndex + 1;
 
-        // find first non hidden cell below current cell
-        while (possibleNextCellIndex < maxCellIndex) {
-          let possibleNextCell = notebook.widgets[possibleNextCellIndex];
-          if (!possibleNextCell.inputHidden && !possibleNextCell.isHidden) {
-            break;
-          }
-          possibleNextCellIndex += 1;
-        }
+    // find first non hidden cell below current cell
+    while (possibleNextCellIndex < maxCellIndex) {
+      let possibleNextCell = notebook.widgets[possibleNextCellIndex];
+      if (!possibleNextCell.inputHidden && !possibleNextCell.isHidden) {
+        break;
+      }
+      possibleNextCellIndex += 1;
+    }
 
-        const state = Private.getState(notebook);
-        notebook.activeCellIndex = possibleNextCellIndex;
-        notebook.deselectAll();
-        void Private.handleState(notebook, state, true);
-      })
-      .catch(reason => {
-        // no-op
-      });
+    const state = Private.getState(notebook);
+    notebook.activeCellIndex = possibleNextCellIndex;
+    notebook.deselectAll();
+    void Private.handleState(notebook, state, true);
   }
 
   /** Insert new heading of same level above active cell.

--- a/packages/notebook/src/notebookfooter.ts
+++ b/packages/notebook/src/notebookfooter.ts
@@ -48,6 +48,8 @@ export class NotebookFooter extends Widget {
       this.notebook.activeCellIndex = this.notebook.widgets.length - 1;
     }
     NotebookActions.insertBelow(this.notebook);
+    // Focus on the created cell.
+    void NotebookActions.focusActiveCell(this.notebook);
   }
 
   /**

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1866,6 +1866,7 @@ export class Notebook extends StaticNotebook {
         }
         break;
       case 'keydown':
+        // This works because CodeMirror does not stop the event propagation
         this._ensureFocus(true);
         break;
       case 'dblclick':

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1865,6 +1865,9 @@ export class Notebook extends StaticNotebook {
           this._evtDocumentMousemove(event as MouseEvent);
         }
         break;
+      case 'keydown':
+        this._ensureFocus(true);
+        break;
       case 'dblclick':
         this._evtDblClick(event as MouseEvent);
         break;
@@ -2120,6 +2123,11 @@ export class Notebook extends StaticNotebook {
    * Ensure that the notebook has proper focus.
    */
   private _ensureFocus(force = false): void {
+    // No-op is the footer has the focus.
+    const footer = (this.layout as NotebookWindowedLayout).footer;
+    if (footer && document.activeElement === footer.node) {
+      return;
+    }
     const activeCell = this.activeCell;
     if (this.mode === 'edit' && activeCell) {
       // Test for !== true to cover hasFocus is false and editor is not yet rendered.
@@ -2734,8 +2742,6 @@ export class Notebook extends StaticNotebook {
             });
           });
       } else {
-        // If the active cell is not visible (because of full windowing), set the focus
-        // on the footer (always visible) to set focus on Notebook widget.
         (this.layout as NotebookWindowedLayout).footer?.node.focus({
           preventScroll: true
         });

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -19,7 +19,6 @@ import {
   acceptDialog,
   dismissDialog,
   JupyterServer,
-  signalToPromise,
   sleep
 } from '@jupyterlab/testing';
 import { JSONArray, JSONObject, UUID } from '@lumino/coreutils';
@@ -1123,153 +1122,75 @@ describe('@jupyterlab/notebook', () => {
     });
 
     describe('#selectAbove()', () => {
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(() => {
-          reject('expected timeout');
-        }, 5000);
-      });
-      timeoutPromise.catch(() => null);
-
-      it('should select the cell above the active cell', async () => {
+      it('should select the cell above the active cell', () => {
         widget.activeCellIndex = 1;
-        const waitForChange = signalToPromise(widget.stateChanged);
         NotebookActions.selectAbove(widget);
-        await waitForChange;
         expect(widget.activeCellIndex).toBe(0);
       });
 
-      it('should be a no-op if there is no model', async () => {
+      it('should be a no-op if there is no model', () => {
         widget.model = null;
-        const waitForChange = signalToPromise(widget.stateChanged);
         NotebookActions.selectAbove(widget);
-        // should timeout as there is no change.
-        let err: string = '';
-        try {
-          await Promise.race([waitForChange, timeoutPromise]);
-        } catch (e) {
-          err = e;
-        } finally {
-          expect(err).toMatch('expected timeout');
-        }
         expect(widget.activeCellIndex).toBe(-1);
       });
 
-      it('should not wrap around to the bottom', async () => {
-        const waitForChange = signalToPromise(widget.stateChanged);
+      it('should not wrap around to the bottom', () => {
         NotebookActions.selectAbove(widget);
-        // should timeout as there is no change.
-        let err: string = '';
-        try {
-          await Promise.race([waitForChange, timeoutPromise]);
-        } catch (e) {
-          err = e;
-        } finally {
-          expect(err).toMatch('expected timeout');
-        }
         expect(widget.activeCellIndex).toBe(0);
       });
 
-      it('should preserve the mode', async () => {
+      it('should preserve the mode', () => {
         widget.activeCellIndex = 2;
-        let waitForChange = signalToPromise(widget.stateChanged);
         NotebookActions.selectAbove(widget);
-        await waitForChange;
         expect(widget.mode).toBe('command');
         widget.mode = 'edit';
-        waitForChange = signalToPromise(widget.stateChanged);
         NotebookActions.selectAbove(widget);
-        await waitForChange;
         expect(widget.mode).toBe('edit');
       });
 
-      it('should skip collapsed cells in edit mode', async () => {
+      it('should skip collapsed cells in edit mode', () => {
         widget.activeCellIndex = 3;
         widget.mode = 'edit';
         widget.widgets[1].inputHidden = true;
         widget.widgets[2].inputHidden = true;
         widget.widgets[3].inputHidden = false;
-        const waitForChange = signalToPromise(widget.stateChanged);
         NotebookActions.selectAbove(widget);
-        await waitForChange;
         expect(widget.activeCellIndex).toBe(0);
       });
     });
 
     describe('#selectBelow()', () => {
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(() => {
-          reject('expected timeout');
-        }, 5000);
-      });
-      timeoutPromise.catch(() => null);
-
-      it('should select the cell below the active cell', async () => {
-        const waitForChange = signalToPromise(widget.stateChanged);
+      it('should select the cell below the active cell', () => {
         NotebookActions.selectBelow(widget);
-        await waitForChange;
         expect(widget.activeCellIndex).toBe(1);
       });
 
-      it('should be a no-op if there is no model', async () => {
+      it('should be a no-op if there is no model', () => {
         widget.model = null;
-        const waitForChange = signalToPromise(widget.stateChanged);
         NotebookActions.selectBelow(widget);
-        // should timeout as there is no change.
-        let err: string = '';
-        try {
-          await Promise.race([waitForChange, timeoutPromise]);
-        } catch (e) {
-          err = e;
-        } finally {
-          expect(err).toMatch('expected timeout');
-        }
         expect(widget.activeCellIndex).toBe(-1);
       });
 
-      it('should not wrap around to the top', async () => {
+      it('should not wrap around to the top', () => {
         widget.activeCellIndex = widget.widgets.length - 1;
-        const waitForChange = signalToPromise(widget.stateChanged);
         NotebookActions.selectBelow(widget);
-        // should timeout as there is no change.
-        let err: string = '';
-        try {
-          await Promise.race([waitForChange, timeoutPromise]);
-        } catch (e) {
-          err = e;
-        } finally {
-          expect(err).toMatch('expected timeout');
-        }
         expect(widget.activeCellIndex).not.toBe(0);
       });
 
-      it('should preserve the mode', async () => {
+      it('should preserve the mode', () => {
         widget.activeCellIndex = 2;
-        let waitForChange = signalToPromise(widget.stateChanged);
         NotebookActions.selectBelow(widget);
-        await waitForChange;
         expect(widget.mode).toBe('command');
         widget.mode = 'edit';
-        waitForChange = signalToPromise(widget.stateChanged);
         NotebookActions.selectBelow(widget);
-        await waitForChange;
         expect(widget.mode).toBe('edit');
       });
 
-      it('should not change if in edit mode and no non-collapsed cells below', async () => {
+      it('should not change if in edit mode and no non-collapsed cells below', () => {
         widget.activeCellIndex = widget.widgets.length - 2;
         widget.mode = 'edit';
         widget.widgets[widget.widgets.length - 1].inputHidden = true;
-        const waitForChange = signalToPromise(widget.stateChanged);
         NotebookActions.selectBelow(widget);
-        // should timeout as there is no change.
-        let err: string = '';
-        try {
-          await Promise.race([waitForChange, timeoutPromise]);
-        } catch (e) {
-          err = e;
-        } finally {
-          expect(err).toMatch('expected timeout');
-        }
         expect(widget.activeCellIndex).toBe(widget.widgets.length - 2);
       });
     });


### PR DESCRIPTION
## References

Follow up https://github.com/jupyterlab/jupyterlab/pull/14115

https://github.com/jupyterlab/jupyterlab/pull/14115 removed the scroll to the active cell on keydown event. 
When the notebook is in edit mode and the active cell is not visible, using the keyboard should scroll to the active cell.

This PR restores this behavior, and removes some complexity included in the PR above.

## Code changes

- scroll to the active cell on keydown event on the notebook in edit mode
- `selectAbove()` and `selectBelow()` notebook actions are not asynchronous anymore, which simplifies some tests.

> This results in reverting asynchronous methods introduced in #15413

## User-facing changes

Scroll to the active cell when typing, as previously.

## Backwards-incompatible changes

None

cc @gabalafou @krassowski who worked on the related PR