### PR TITLE
Show toast notification for running code cell while kernel initializing

### DIFF
--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -671,6 +671,12 @@
     }
   },
   "properties": {
+    "enableKernelInitNotification": {
+      "title": "Notify about code execution while kernel initializing",
+      "description": "Display notification if code cells are run while kernel is initializing.",
+      "type": "boolean",
+      "default": true
+    },
     "codeCellConfig": {
       "title": "Code Cell Configuration",
       "description": "The configuration for all code cells; it will override the CodeMirror default configuration.",

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -672,10 +672,10 @@
   },
   "properties": {
     "enableKernelInitNotification": {
-      "title": "Notify about code execution while kernel initializing",
+      "title": "Notify about code execution while kernel is initializing",
       "description": "Display notification if code cells are run while kernel is initializing.",
       "type": "boolean",
-      "default": true
+      "default": false
     },
     "codeCellConfig": {
       "title": "Code Cell Configuration",

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -672,7 +672,7 @@
   },
   "properties": {
     "enableKernelInitNotification": {
-      "title": "Notify about code execution while kernel is initializing",
+      "title": "Notify about code execution if kernel is initializing",
       "description": "Display notification if code cells are run while kernel is initializing.",
       "type": "boolean",
       "default": false

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1810,6 +1810,8 @@ function activateNotebookHandler(
 
     factory.editorConfig = { code, markdown, raw };
     factory.notebookConfig = {
+      enableKernelInitNotification: settings.get('enableKernelInitNotification')
+        .composite as boolean,
       showHiddenCellsButton: settings.get('showHiddenCellsButton')
         .composite as boolean,
       scrollPastEnd: settings.get('scrollPastEnd').composite as boolean,

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2336,8 +2336,6 @@ namespace Private {
     notebook.mode = 'command';
 
     let initializingDialogShown = false;
-    translator = translator || nullTranslator;
-    const trans = translator.load('jupyterlab');
     return Promise.all(
       cells.map(cell => {
         if (
@@ -2348,6 +2346,8 @@ namespace Private {
           !initializingDialogShown
         ) {
           initializingDialogShown = true;
+          translator = translator || nullTranslator;
+          const trans = translator.load('jupyterlab');
           Notification.emit(
             trans.__(
               `Kernel '${sessionContext.kernelDisplayName}' for '${sessionContext.path}' is still initializing, code cells will not be executed.`
@@ -2357,6 +2357,13 @@ namespace Private {
               autoClose: false
             }
           );
+          return Promise.resolve(false);
+        }
+        if (
+          cell.model.type === 'code' &&
+          notebook.notebookConfig.enableKernelInitNotification &&
+          initializingDialogShown
+        ) {
           return Promise.resolve(false);
         }
         return runCell(

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2340,21 +2340,32 @@ namespace Private {
     const trans = translator.load('jupyterlab');
     return Promise.all(
       cells.map(cell => {
-        if (cell.model.type === "code" && sessionContext &&
-            sessionContext.kernelDisplayStatus === 'initializing' && !initializingDialogShown) {
+        if (
+          cell.model.type === 'code' &&
+          notebook.notebookConfig.enableKernelInitNotification &&
+          sessionContext &&
+          sessionContext.kernelDisplayStatus === 'initializing' &&
+          !initializingDialogShown
+        ) {
           initializingDialogShown = true;
           Notification.emit(
-              trans.__(
-                  `Kernel '${sessionContext.kernelDisplayName}' for '${sessionContext.path}' is still initializing, code cells will not be executed.`
-              ),
-              'warning',
-              {
-                autoClose: false
-              }
+            trans.__(
+              `Kernel '${sessionContext.kernelDisplayName}' for '${sessionContext.path}' is still initializing, code cells will not be executed.`
+            ),
+            'warning',
+            {
+              autoClose: false
+            }
           );
           return Promise.resolve(false);
         }
-        return runCell(notebook, cell, sessionContext, sessionDialogs, translator)
+        return runCell(
+          notebook,
+          cell,
+          sessionContext,
+          sessionDialogs,
+          translator
+        );
       })
     )
       .then(results => {

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2341,7 +2341,7 @@ namespace Private {
     return Promise.all(
       cells.map(cell => {
         if (cell.model.type === "code" && sessionContext &&
-            sessionContext.kernelDisplayStatus === 'idle' && !initializingDialogShown) {
+            sessionContext.kernelDisplayStatus === 'initializing' && !initializingDialogShown) {
           initializingDialogShown = true;
           Notification.emit(
               trans.__(

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2350,7 +2350,7 @@ namespace Private {
           const trans = translator.load('jupyterlab');
           Notification.emit(
             trans.__(
-              `Kernel '${sessionContext.kernelDisplayName}' for '${sessionContext.path}' is still initializing, code cells will not be executed.`
+              `Kernel '${sessionContext.kernelDisplayName}' for '${sessionContext.path}' is still initializing. You can run code cells when the kernel has initialized.`
             ),
             'warning',
             {

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2354,7 +2354,7 @@ namespace Private {
           );
           return Promise.resolve(false);
         }
-        runCell(notebook, cell, sessionContext, sessionDialogs, translator)
+        return runCell(notebook, cell, sessionContext, sessionDialogs, translator)
       })
     )
       .then(results => {

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1131,6 +1131,11 @@ export namespace StaticNotebook {
     disableDocumentWideUndoRedo: boolean;
 
     /**
+     * Whether to display notification if code cell is run while kernel is still initializing.
+     */
+    enableKernelInitNotification: boolean;
+
+    /**
      * Defines the maximum number of outputs per cell.
      */
     maxNumberOutputs: number;
@@ -1207,6 +1212,7 @@ export namespace StaticNotebook {
    * Default configuration options for notebooks.
    */
   export const defaultNotebookConfig: INotebookConfig = {
+    enableKernelInitNotification: true,
     showHiddenCellsButton: true,
     scrollPastEnd: true,
     defaultCell: 'code',

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1212,7 +1212,7 @@ export namespace StaticNotebook {
    * Default configuration options for notebooks.
    */
   export const defaultNotebookConfig: INotebookConfig = {
-    enableKernelInitNotification: true,
+    enableKernelInitNotification: false,
     showHiddenCellsButton: true,
     scrollPastEnd: true,
     defaultCell: 'code',


### PR DESCRIPTION
Display notification conditionally when runCell() is triggered. The additional argument is passed to ensure that only one notification is emitted per code cell running action, otherwise a notification will be emitted for each code cell the user is trying to run in one action.

Targeted version for this change is 3.6.x.

Relevant issue: https://github.com/jupyterlab/jupyterlab/issues/15420

![image](https://github.com/jupyterlab/jupyterlab/assets/43950604/fc647837-1102-4a17-b8f7-aa21e0767e56)


