### PR TITLE
Update `@lumino/dragdrop` package

### DIFF
--- a/builder/package.json
+++ b/builder/package.json
@@ -39,7 +39,7 @@
     "@lumino/coreutils": "^2.1.2",
     "@lumino/disposable": "^2.1.2",
     "@lumino/domutils": "^2.0.1",
-    "@lumino/dragdrop": "^2.1.3",
+    "@lumino/dragdrop": "^2.1.4",
     "@lumino/messaging": "^2.0.1",
     "@lumino/properties": "^2.0.1",
     "@lumino/signaling": "^2.1.2",

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -64,7 +64,7 @@
     "@lumino/algorithm": "^2.0.1",
     "@lumino/coreutils": "^2.1.2",
     "@lumino/domutils": "^2.0.1",
-    "@lumino/dragdrop": "^2.1.3",
+    "@lumino/dragdrop": "^2.1.4",
     "@lumino/messaging": "^2.0.1",
     "@lumino/polling": "^2.1.2",
     "@lumino/signaling": "^2.1.2",

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -52,7 +52,7 @@
     "@jupyterlab/ui-components": "^4.0.8",
     "@lumino/coreutils": "^2.1.2",
     "@lumino/disposable": "^2.1.2",
-    "@lumino/dragdrop": "^2.1.3",
+    "@lumino/dragdrop": "^2.1.4",
     "@lumino/messaging": "^2.0.1",
     "@lumino/signaling": "^2.1.2",
     "@lumino/widgets": "^2.3.0",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -58,7 +58,7 @@
     "@jupyterlab/ui-components": "^4.0.8",
     "@lumino/coreutils": "^2.1.2",
     "@lumino/disposable": "^2.1.2",
-    "@lumino/dragdrop": "^2.1.3",
+    "@lumino/dragdrop": "^2.1.4",
     "@lumino/messaging": "^2.0.1",
     "@lumino/signaling": "^2.1.2",
     "@lumino/widgets": "^2.3.0"

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -55,7 +55,7 @@
     "@lumino/coreutils": "^2.1.2",
     "@lumino/disposable": "^2.1.2",
     "@lumino/domutils": "^2.0.1",
-    "@lumino/dragdrop": "^2.1.3",
+    "@lumino/dragdrop": "^2.1.4",
     "@lumino/messaging": "^2.0.1",
     "@lumino/polling": "^2.1.2",
     "@lumino/signaling": "^2.1.2",

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -62,7 +62,7 @@
     "@lumino/algorithm": "^2.0.1",
     "@lumino/coreutils": "^2.1.2",
     "@lumino/domutils": "^2.0.1",
-    "@lumino/dragdrop": "^2.1.3",
+    "@lumino/dragdrop": "^2.1.4",
     "@lumino/messaging": "^2.0.1",
     "@lumino/properties": "^2.0.1",
     "@lumino/signaling": "^2.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2287,7 +2287,7 @@ __metadata:
     "@lumino/coreutils": ^2.1.2
     "@lumino/disposable": ^2.1.2
     "@lumino/domutils": ^2.0.1
-    "@lumino/dragdrop": ^2.1.3
+    "@lumino/dragdrop": ^2.1.4
     "@lumino/messaging": ^2.0.1
     "@lumino/properties": ^2.0.1
     "@lumino/signaling": ^2.1.2
@@ -2427,7 +2427,7 @@ __metadata:
     "@lumino/algorithm": ^2.0.1
     "@lumino/coreutils": ^2.1.2
     "@lumino/domutils": ^2.0.1
-    "@lumino/dragdrop": ^2.1.3
+    "@lumino/dragdrop": ^2.1.4
     "@lumino/messaging": ^2.0.1
     "@lumino/polling": ^2.1.2
     "@lumino/signaling": ^2.1.2
@@ -2474,7 +2474,7 @@ __metadata:
     "@jupyterlab/ui-components": ^4.0.8
     "@lumino/coreutils": ^2.1.2
     "@lumino/disposable": ^2.1.2
-    "@lumino/dragdrop": ^2.1.3
+    "@lumino/dragdrop": ^2.1.4
     "@lumino/messaging": ^2.0.1
     "@lumino/signaling": ^2.1.2
     "@lumino/widgets": ^2.3.0
@@ -2655,7 +2655,7 @@ __metadata:
     "@jupyterlab/ui-components": ^4.0.8
     "@lumino/coreutils": ^2.1.2
     "@lumino/disposable": ^2.1.2
-    "@lumino/dragdrop": ^2.1.3
+    "@lumino/dragdrop": ^2.1.4
     "@lumino/messaging": ^2.0.1
     "@lumino/signaling": ^2.1.2
     "@lumino/widgets": ^2.3.0
@@ -3353,7 +3353,7 @@ __metadata:
     "@lumino/coreutils": ^2.1.2
     "@lumino/disposable": ^2.1.2
     "@lumino/domutils": ^2.0.1
-    "@lumino/dragdrop": ^2.1.3
+    "@lumino/dragdrop": ^2.1.4
     "@lumino/messaging": ^2.0.1
     "@lumino/polling": ^2.1.2
     "@lumino/signaling": ^2.1.2
@@ -4205,7 +4205,7 @@ __metadata:
     "@lumino/algorithm": ^2.0.1
     "@lumino/coreutils": ^2.1.2
     "@lumino/domutils": ^2.0.1
-    "@lumino/dragdrop": ^2.1.3
+    "@lumino/dragdrop": ^2.1.4
     "@lumino/messaging": ^2.0.1
     "@lumino/properties": ^2.0.1
     "@lumino/signaling": ^2.1.2
@@ -5175,13 +5175,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/dragdrop@npm:^2.1.3":
-  version: 2.1.3
-  resolution: "@lumino/dragdrop@npm:2.1.3"
+"@lumino/dragdrop@npm:^2.1.3, @lumino/dragdrop@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "@lumino/dragdrop@npm:2.1.4"
   dependencies:
     "@lumino/coreutils": ^2.1.2
     "@lumino/disposable": ^2.1.2
-  checksum: d5f7eb4cc9f9a084cb9af10f02d6741b25d683350878ecbc324e24ba9d4b5246451a410e2ca5fff227aab1c191d1e73a2faf431f93e13111d67a4e426e126258
+  checksum: 43d82484b13b38b612e7dfb424a840ed6a38d0db778af10655c4ba235c67b5b12db1683929b35a36ab2845f77466066dfd1ee25c1c273e8e175677eba9dc560d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## References

Partial backport of #15405 to pickup the fix for #14881

## Code changes

`"@lumino/dragdrop": "^2.1.3"` →  `"@lumino/dragdrop": "^2.1.4"`

## User-facing changes

None

## Backwards-incompatible changes

None