### PR TITLE
Keyboard navigation to sidebar tests

### DIFF
--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -226,7 +226,7 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
     }
     await page.keyboard.press('Enter');
 
-    expect(await page.sidebar.isTabOpen('jp-property-inspector')).toEqual(true);
+    expect(await page.sidebar.isTabOpen('jp-running-sessions')).toEqual(true);
   });
 
   test('Open table of contents tab', async ({ page }) => {
@@ -305,7 +305,7 @@ test('Close then open File Browser tab', async ({ page }) => {
   }
   await page.keyboard.press('Enter');
 
-  expect(await page.sidebar.isTabOpen('filebrowser')).toEqual(false);
+  expect(await page.sidebar.isTabOpen('filebrowser')).toEqual(false); //doesn't work, you can't close it on enter!
 
   // eslint-disable-next-line no-constant-condition
   while (true) {

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -203,12 +203,12 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
   test('Open Running Terminals and Kernels tab', async ({ page }) => {
     await page.goto();
 
-    const fileBrowserTab = page.getByRole('tab', {
-      name: 'File Browser (Ctrl+Shift+F)'
-    });
-    const TerminalsAndKernelsTab = page.getByRole('tab', {
-      name: 'Running Terminals and Kernels'
-    });
+    // const fileBrowserTab = page.getByRole('tab', {
+    //   name: 'File Browser (Ctrl+Shift+F)'
+    // });
+    // const TerminalsAndKernelsTab = page.getByRole('tab', {
+    //   name: 'Running Terminals and Kernels'
+    // });
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
@@ -221,7 +221,6 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
         break;
       }
     }
-    await page.keyboard.press('Enter');
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
@@ -244,18 +243,20 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
   test('Open table of contents tab', async ({ page }) => {
     await page.goto();
 
-    const fileBrowserTab = document.getElementById('tab-key-1-6');
-    const tableOFContentsTab = document.getElementById('tab-key-1-4');
+    // const fileBrowserTab = document.getElementById('tab-key-1-6');
+    // const tableOFContentsTab = document.getElementById('tab-key-1-4');
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
       await page.keyboard.press('Tab');
-      let fileBrowserIsFocused = document.activeElement === fileBrowserTab;
-      if (fileBrowserIsFocused) {
+      let fileBrowserIsFocused = await page.evaluate(
+        () => document.activeElement
+      );
+      fileBrowserIsFocused?.getAttribute;
+      if (fileBrowserIsFocused?.getAttribute('data-id') === 'filebrowser') {
         break;
       }
     }
-    await page.keyboard.press('Enter');
 
     // eslint-disable-next-line no-constant-condition
     while (true) {

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -207,10 +207,9 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
     while (true) {
       await page.keyboard.press('Tab');
       let fileBrowserIsFocused = await page.evaluate(
-        () => document.activeElement
+        () => document.activeElement?.getAttribute('data-id')
       );
-
-      if (fileBrowserIsFocused?.getAttribute('data-id') === 'filebrowser') {
+      if (fileBrowserIsFocused === 'filebrowser') {
         break;
       }
     }
@@ -219,12 +218,9 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
     while (true) {
       await page.keyboard.press('ArrowDown');
       let TerminalsAndKernelsIsFocused = await page.evaluate(
-        () => document.activeElement
+        () => document.activeElement?.getAttribute('data-id')
       );
-      if (
-        TerminalsAndKernelsIsFocused?.getAttribute('data-id') ===
-        'jp-running-sessions'
-      ) {
+      if (TerminalsAndKernelsIsFocused === 'jp-running-sessions') {
         break;
       }
     }
@@ -240,9 +236,9 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
     while (true) {
       await page.keyboard.press('Tab');
       let fileBrowserIsFocused = await page.evaluate(
-        () => document.activeElement
+        () => document.activeElement?.getAttribute('data-id')
       );
-      if (fileBrowserIsFocused?.getAttribute('data-id') === 'filebrowser') {
+      if (fileBrowserIsFocused === 'filebrowser') {
         break;
       }
     }
@@ -251,12 +247,9 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
     while (true) {
       await page.keyboard.press('ArrowDown');
       let tableOFContentsIsFocused = await page.evaluate(
-        () => document.activeElement
+        () => document.activeElement?.getAttribute('data-id')
       );
-      if (
-        tableOFContentsIsFocused?.getAttribute('data-id') ===
-        'table-of-contents'
-      ) {
+      if (tableOFContentsIsFocused === 'table-of-contents') {
         break;
       }
     }
@@ -267,10 +260,6 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
 
   test('Open Extension Manager tab', async ({ page }) => {
     await page.goto();
-
-    const fileBrowserTab = page.getByRole('tab', {
-      name: 'File Browser (Ctrl+Shift+F)'
-    });
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
@@ -301,18 +290,16 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
   });
 });
 
-test('Open File Browser tab', async ({ page }) => {
+test('Close then open File Browser tab', async ({ page }) => {
   await page.goto();
-
-  const fileBrowserTab = page.getByRole('tab', {
-    name: 'File Browser (Ctrl+Shift+F)'
-  });
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
     await page.keyboard.press('Tab');
-    let isFocused = page.locator(':focus');
-    if (fileBrowserTab === isFocused) {
+    let fileBrowserIsFocused = await page.evaluate(
+      () => document.activeElement?.getAttribute('data-id')
+    );
+    if (fileBrowserIsFocused === 'filebrowser') {
       break;
     }
   }
@@ -323,8 +310,10 @@ test('Open File Browser tab', async ({ page }) => {
   // eslint-disable-next-line no-constant-condition
   while (true) {
     await page.keyboard.press('Tab');
-    let isFocused = page.locator(':focus');
-    if (fileBrowserTab === isFocused) {
+    let fileBrowserIsFocused = await page.evaluate(
+      () => document.activeElement?.getAttribute('data-id')
+    );
+    if (fileBrowserIsFocused === 'filebrowser') {
       break;
     }
   }

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -220,8 +220,17 @@ const accordionPanelAriaLabels = [
   'Callstack Section',
   'Breakpoints Section',
   'Source Section',
-  'Kernel Sources Section'
+  'Kernel Sources Section',
+  'Warning Section',
+  'Installed Section',
+  'Discover Section'
 ];
+
+// const extensionAccordionAriaLabels = [
+//   'Warning Section',
+//   'Installed Section',
+//   'Discover Section',
+// ]
 
 test.describe('Sidebar keyboard navigation @a11y', () => {
   leftSidebarIds.forEach(leftSidebarId => {
@@ -302,7 +311,10 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
       await page.goto();
 
       await page.sidebar.openTab('jp-running-sessions');
-      await page.sidebar.openTab('jp-property-inspector');
+
+      await page.sidebar.openTab('jp-debugger-sidebar');
+
+      await page.sidebar.openTab('extensionmanager.main-view');
 
       // eslint-disable-next-line no-constant-condition
       while (true) {
@@ -324,4 +336,33 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
       expect(isExpanded).toBeTruthy();
     });
   });
+
+  // extensionAccordionAriaLabels.forEach((accordionPanelAriaLabel) => {
+  // test(`Open Extension manager ${extensionAccordionAriaLabel} via keyboard navigation`, async ({
+  //   page,
+  // }) => {
+  //   await page.goto();
+
+  //   await page.sidebar.openTab('jp-running-sessions');
+  //   await page.sidebar.openTab('jp-property-inspector');
+
+  //   // eslint-disable-next-line no-constant-condition
+  //   while (true) {
+  //     await page.keyboard.press('Tab');
+  //     let IsFocused = await page.evaluate(() =>
+  //       document.activeElement?.getAttribute('aria-label')
+  //     );
+  //     if (IsFocused === extensionAccordionAriaLabel) {
+  //       break;
+  //     }
+  //   }
+
+  //   await page.keyboard.press('Enter');
+
+  //   const isExpanded = await page.evaluate(() =>
+  //     document.activeElement?.getAttribute('aria-expanded')
+  //   );
+
+  //   expect(isExpanded).toBeTruthy();
+  // });
 });

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -229,20 +229,16 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
       // eslint-disable-next-line no-constant-condition
       while (true) {
         await page.keyboard.press('Tab');
-        let fileBrowserIsFocused = await page.evaluate(
+        let IsFocused = await page.evaluate(
           () => document.activeElement?.getAttribute('data-id')
         );
-        if (fileBrowserIsFocused === 'filebrowser') {
+        if (IsFocused === 'filebrowser') {
           break;
         }
-        while (leftSidebarId !== 'filebrowser') {
-          await page.keyboard.press('ArrowDown');
-          let IsFocused = await page.evaluate(
-            () => document.activeElement?.getAttribute('data-id')
-          );
-          if (IsFocused === leftSidebarId) {
-            break;
-          }
+        await page.keyboard.press('ArrowDown');
+
+        if (IsFocused === leftSidebarId) {
+          break;
         }
       }
 
@@ -326,56 +322,3 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
     });
   });
 });
-
-//   test(`Open Terminals and Kernels Accordion Panel sections keyboard navigation`, async ({
-//     page,
-//   }) => {
-//     await page.goto();
-
-//     await page.sidebar.openTab('jp-running-sessions');
-
-//     // eslint-disable-next-line no-constant-condition
-//     while (true) {
-//       await page.keyboard.press('Tab');
-//       let IsFocused = await page.evaluate(() =>
-//         document.activeElement?.getAttribute('id')
-//       );
-//       if (IsFocused === 'title-key-2-3') {
-//         break;
-//       }
-//     }
-
-//     await page.keyboard.press('Enter');
-
-//     const isExpanded = await page.evaluate(() =>
-//       document.activeElement?.getAttribute('aria-expanded')
-//     );
-
-//     expect(isExpanded).toBeTruthy();
-//   });
-
-//   test(`Open Terminals and Kernels (Kernels submenu)`, async ({ page }) => {
-//     await page.goto();
-
-//     await page.sidebar.openTab('jp-running-sessions');
-
-//     // eslint-disable-next-line no-constant-condition
-//     while (true) {
-//       await page.keyboard.press('Tab');
-//       let IsFocused = await page.evaluate(() =>
-//         document.activeElement?.getAttribute('id')
-//       );
-//       if (IsFocused === 'title-key-2-4') {
-//         break;
-//       }
-//     }
-
-//     await page.keyboard.press('Enter');
-
-//     const isExpanded = await page.evaluate(() =>
-//       document.activeElement?.getAttribute('aria-expanded')
-//     );
-
-//     expect(isExpanded).toBeTruthy();
-//   });
-// });

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -205,6 +205,7 @@ const leftSidebarIds: galata.SidebarTabId[] = [
   'table-of-contents',
   'extensionmanager.main-view'
 ];
+
 const rightSidebarIds: galata.SidebarTabId[] = [
   'jp-property-inspector',
   'jp-debugger-sidebar'

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -214,7 +214,12 @@ const accordionPanelAriaLabels = [
   'Open Tabs Section',
   'Kernels Section',
   'Language servers Section',
-  'Terminals Section'
+  'Terminals Section',
+  'Variables Section',
+  'Callstack Section',
+  'Breakpoints Section',
+  'Source Section',
+  'Kernel Sources Section'
 ];
 
 test.describe('Sidebar keyboard navigation @a11y', () => {
@@ -235,10 +240,14 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
         if (IsFocused === 'filebrowser') {
           break;
         }
-        await page.keyboard.press('ArrowDown');
-
-        if (IsFocused === leftSidebarId) {
-          break;
+        while (leftSidebarId !== 'filebrowser') {
+          await page.keyboard.press('ArrowDown');
+          let IsFocused = await page.evaluate(
+            () => document.activeElement?.getAttribute('data-id')
+          );
+          if (IsFocused === leftSidebarId) {
+            break;
+          }
         }
       }
 
@@ -251,7 +260,7 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
       //   if (IsFocused === leftSidebarId) {
       //     break;
       //   }
-      // }
+
       await page.keyboard.press('Enter');
 
       expect(await page.sidebar.isTabOpen(leftSidebarId)).toEqual(true);
@@ -300,6 +309,7 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
       await page.goto();
 
       await page.sidebar.openTab('jp-running-sessions');
+      await page.sidebar.openTab('jp-property-inspector');
 
       // eslint-disable-next-line no-constant-condition
       while (true) {

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -203,8 +203,49 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
   test('Open Running Terminals and Kernels tab', async ({ page }) => {
     await page.goto();
 
+    const fileBrowserTab = page.getByRole('tab', {
+      name: 'File Browser (Ctrl+Shift+F)'
+    });
+    const TerminalsAndKernelsTab = page.getByRole('tab', {
+      name: 'Running Terminals and Kernels'
+    });
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      await page.keyboard.press('Tab');
+      let fileBrowserIsFocused = await page.evaluate(
+        () => document.activeElement
+      );
+      fileBrowserIsFocused?.getAttribute;
+      if (fileBrowserIsFocused?.getAttribute('data-id') === 'filebrowser') {
+        break;
+      }
+    }
+    await page.keyboard.press('Enter');
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      await page.keyboard.press('ArrowDown');
+      let TerminalsAndKernelsIsFocused = await page.evaluate(
+        () => document.activeElement
+      );
+      if (
+        TerminalsAndKernelsIsFocused?.getAttribute('data-id') ===
+        'jp-running-sessions'
+      ) {
+        break;
+      }
+    }
+    await page.keyboard.press('Enter');
+
+    expect(await page.sidebar.isTabOpen('jp-property-inspector')).toEqual(true);
+  });
+
+  test('Open table of contents tab', async ({ page }) => {
+    await page.goto();
+
     const fileBrowserTab = document.getElementById('tab-key-1-6');
-    const TerminalsAndKernelsTab = document.getElementById('tab-key-1-2');
+    const tableOFContentsTab = document.getElementById('tab-key-1-4');
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
@@ -219,14 +260,18 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
     // eslint-disable-next-line no-constant-condition
     while (true) {
       await page.keyboard.press('ArrowDown');
-      let TerminalsAndKernelsIsFocused =
-        document.activeElement === TerminalsAndKernelsTab;
-      if (TerminalsAndKernelsIsFocused) {
+      let tableOFContentsIsFocused = await page.evaluate(
+        () => document.activeElement
+      );
+      if (
+        tableOFContentsIsFocused?.getAttribute('data-id') ===
+        'table-of-contents'
+      ) {
         break;
       }
     }
     await page.keyboard.press('Enter');
 
-    expect(await page.sidebar.isTabOpen('jp-property-inspector')).toEqual(true);
+    expect(await page.sidebar.isTabOpen('table-of-contents')).toEqual(true);
   });
 });

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -226,12 +226,6 @@ const accordionPanelAriaLabels = [
   'Discover Section'
 ];
 
-// const extensionAccordionAriaLabels = [
-//   'Warning Section',
-//   'Installed Section',
-//   'Discover Section',
-// ]
-
 test.describe('Sidebar keyboard navigation @a11y', () => {
   leftSidebarIds.forEach(leftSidebarId => {
     test(`Open Sidebar tab ${leftSidebarId} via keyboard navigation`, async ({
@@ -310,11 +304,24 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
     }) => {
       await page.goto();
 
-      await page.sidebar.openTab('jp-running-sessions');
-
-      await page.sidebar.openTab('jp-debugger-sidebar');
-
-      await page.sidebar.openTab('extensionmanager.main-view');
+      if (
+        accordionPanelAriaLabel === 'Open Tabs Section' ||
+        accordionPanelAriaLabel === 'Kernels Section' ||
+        accordionPanelAriaLabel === 'Language servers Section' ||
+        accordionPanelAriaLabel === 'Terminals Section'
+      ) {
+        await page.sidebar.openTab('jp-running-sessions');
+      } else if (
+        accordionPanelAriaLabel === 'Variables Section' ||
+        accordionPanelAriaLabel === 'Callstack Section' ||
+        accordionPanelAriaLabel === 'Breakpoints Section' ||
+        accordionPanelAriaLabel === 'Source Section' ||
+        accordionPanelAriaLabel === 'Kernel Sources Section'
+      ) {
+        await page.sidebar.openTab('jp-debugger-sidebar');
+      } else {
+        await page.sidebar.openTab('extensionmanager.main-view');
+      }
 
       // eslint-disable-next-line no-constant-condition
       while (true) {
@@ -336,33 +343,4 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
       expect(isExpanded).toBeTruthy();
     });
   });
-
-  // extensionAccordionAriaLabels.forEach((accordionPanelAriaLabel) => {
-  // test(`Open Extension manager ${extensionAccordionAriaLabel} via keyboard navigation`, async ({
-  //   page,
-  // }) => {
-  //   await page.goto();
-
-  //   await page.sidebar.openTab('jp-running-sessions');
-  //   await page.sidebar.openTab('jp-property-inspector');
-
-  //   // eslint-disable-next-line no-constant-condition
-  //   while (true) {
-  //     await page.keyboard.press('Tab');
-  //     let IsFocused = await page.evaluate(() =>
-  //       document.activeElement?.getAttribute('aria-label')
-  //     );
-  //     if (IsFocused === extensionAccordionAriaLabel) {
-  //       break;
-  //     }
-  //   }
-
-  //   await page.keyboard.press('Enter');
-
-  //   const isExpanded = await page.evaluate(() =>
-  //     document.activeElement?.getAttribute('aria-expanded')
-  //   );
-
-  //   expect(isExpanded).toBeTruthy();
-  // });
 });

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -205,10 +205,16 @@ const leftSidebarIds: galata.SidebarTabId[] = [
   'table-of-contents',
   'extensionmanager.main-view'
 ];
+const rightSidebarIds: galata.SidebarTabId[] = [
+  'jp-property-inspector',
+  'jp-debugger-sidebar'
+];
 
 test.describe('Sidebar keyboard navigation @a11y', () => {
   leftSidebarIds.forEach(leftSidebarId => {
-    test(`Open Sidebar tab ${leftSidebarId}`, async ({ page }) => {
+    test(`Open Sidebar tab ${leftSidebarId} via keyboard navigation`, async ({
+      page
+    }) => {
       await page.goto();
 
       await page.sidebar.close('left');
@@ -239,125 +245,38 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
       expect(await page.sidebar.isTabOpen(leftSidebarId)).toEqual(true);
     });
   });
+  rightSidebarIds.forEach(rightSidebarId => {
+    test(`Open Sidebar tab ${rightSidebarId} via keyboard navigation`, async ({
+      page
+    }) => {
+      await page.goto();
+
+      await page.sidebar.close('right');
+
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        await page.keyboard.press('Tab');
+        let propertyInspectorIsFocused = await page.evaluate(
+          () => document.activeElement?.getAttribute('data-id')
+        );
+        if (propertyInspectorIsFocused === 'jp-property-inspector') {
+          break;
+        }
+      }
+
+      // eslint-disable-next-line no-constant-condition
+      while (rightSidebarId !== 'jp-property-inspector') {
+        await page.keyboard.press('ArrowDown');
+        let IsFocused = await page.evaluate(
+          () => document.activeElement?.getAttribute('data-id')
+        );
+        if (IsFocused === rightSidebarId) {
+          break;
+        }
+      }
+      await page.keyboard.press('Enter');
+
+      expect(await page.sidebar.isTabOpen(rightSidebarId)).toEqual(true);
+    });
+  });
 });
-
-// test.describe('Sidebar keyboard navigation @a11y', () => {
-//   test('Open Running Terminals and Kernels tab', async ({ page }) => {
-//     await page.goto();
-
-//     // eslint-disable-next-line no-constant-condition
-//     while (true) {
-//       await page.keyboard.press('Tab');
-//       let fileBrowserIsFocused = await page.evaluate(() =>
-//         document.activeElement?.getAttribute('data-id')
-//       );
-//       if (fileBrowserIsFocused === 'filebrowser') {
-//         break;
-//       }
-//     }
-
-//     // eslint-disable-next-line no-constant-condition
-//     while (true) {
-//       await page.keyboard.press('ArrowDown');
-//       let TerminalsAndKernelsIsFocused = await page.evaluate(() =>
-//         document.activeElement?.getAttribute('data-id')
-//       );
-//       if (TerminalsAndKernelsIsFocused === 'jp-running-sessions') {
-//         break;
-//       }
-//     }
-//     await page.keyboard.press('Enter');
-
-//     expect(await page.sidebar.isTabOpen('jp-running-sessions')).toEqual(true);
-//   });
-
-//   test('Open table of contents tab', async ({ page }) => {
-//     await page.goto();
-
-//     // eslint-disable-next-line no-constant-condition
-//     while (true) {
-//       await page.keyboard.press('Tab');
-//       let fileBrowserIsFocused = await page.evaluate(() =>
-//         document.activeElement?.getAttribute('data-id')
-//       );
-//       if (fileBrowserIsFocused === 'filebrowser') {
-//         break;
-//       }
-//     }
-
-//     // eslint-disable-next-line no-constant-condition
-//     while (true) {
-//       await page.keyboard.press('ArrowDown');
-//       let tableOFContentsIsFocused = await page.evaluate(() =>
-//         document.activeElement?.getAttribute('data-id')
-//       );
-//       if (tableOFContentsIsFocused === 'table-of-contents') {
-//         break;
-//       }
-//     }
-//     await page.keyboard.press('Enter');
-
-//     expect(await page.sidebar.isTabOpen('table-of-contents')).toEqual(true);
-//   });
-
-//   test('Open Extension Manager tab', async ({ page }) => {
-//     await page.goto();
-
-//     // eslint-disable-next-line no-constant-condition
-//     while (true) {
-//       await page.keyboard.press('Tab');
-//       let fileBrowserIsFocused = await page.evaluate(() =>
-//         document.activeElement?.getAttribute('data-id')
-//       );
-//       if (fileBrowserIsFocused === 'filebrowser') {
-//         break;
-//       }
-//     }
-
-//     // eslint-disable-next-line no-constant-condition
-//     while (true) {
-//       await page.keyboard.press('ArrowDown');
-//       let tableOFContentsIsFocused = await page.evaluate(() =>
-//         document.activeElement?.getAttribute('data-id')
-//       );
-//       if (tableOFContentsIsFocused === 'extensionmanager.main-view') {
-//         break;
-//       }
-//     }
-//     await page.keyboard.press('Enter');
-
-//     expect(await page.sidebar.isTabOpen('extensionmanager.main-view')).toEqual(
-//       true
-//     );
-//   });
-// });
-
-// test('Close then open File Browser tab', async ({ page }) => {
-//   await page.goto();
-
-//   await page.sidebar.close('left');
-
-//   // eslint-disable-next-line no-constant-condition
-//   while (true) {
-//     await page.keyboard.press('Tab');
-//     let fileBrowserIsFocused = await page.evaluate(() =>
-//       document.activeElement?.getAttribute('data-id')
-//     );
-//     if (fileBrowserIsFocused === 'filebrowser') {
-//       break;
-//     }
-//   }
-//   await page.keyboard.press('Enter');
-
-//   expect(await page.sidebar.isTabOpen('filebrowser')).toEqual(true);
-// });
-
-// test('Is file browser open/closed tab', async ({ page }) => {
-//   await page.goto();
-
-//   expect(await page.sidebar.isTabOpen('filebrowser')).toEqual(true);
-
-//   await page.sidebar.close('left');
-
-//   expect(await page.sidebar.isTabOpen('filebrowser')).toEqual(false);
-// });

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -228,23 +228,33 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
         if (fileBrowserIsFocused === 'filebrowser') {
           break;
         }
-      }
-
-      // eslint-disable-next-line no-constant-condition
-      while (leftSidebarId !== 'filebrowser') {
-        await page.keyboard.press('ArrowDown');
-        let IsFocused = await page.evaluate(
-          () => document.activeElement?.getAttribute('data-id')
-        );
-        if (IsFocused === leftSidebarId) {
-          break;
+        while (leftSidebarId !== 'filebrowser') {
+          await page.keyboard.press('ArrowDown');
+          let IsFocused = await page.evaluate(
+            () => document.activeElement?.getAttribute('data-id')
+          );
+          if (IsFocused === leftSidebarId) {
+            break;
+          }
         }
       }
+
+      // // eslint-disable-next-line no-constant-condition
+      // while (leftSidebarId !== 'filebrowser') {
+      //   await page.keyboard.press('ArrowDown');
+      //   let IsFocused = await page.evaluate(
+      //     () => document.activeElement?.getAttribute('data-id')
+      //   );
+      //   if (IsFocused === leftSidebarId) {
+      //     break;
+      //   }
+      // }
       await page.keyboard.press('Enter');
 
       expect(await page.sidebar.isTabOpen(leftSidebarId)).toEqual(true);
     });
   });
+
   rightSidebarIds.forEach(rightSidebarId => {
     test(`Open Sidebar tab ${rightSidebarId} via keyboard navigation`, async ({
       page
@@ -279,6 +289,7 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
       expect(await page.sidebar.isTabOpen(rightSidebarId)).toEqual(true);
     });
   });
+
   test(`Open Terminals and Kernels Accordion Panel sections keyboard navigation`, async ({
     page
   }) => {
@@ -293,6 +304,31 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
         () => document.activeElement?.getAttribute('id')
       );
       if (IsFocused === 'title-key-2-3') {
+        break;
+      }
+    }
+
+    await page.keyboard.press('Enter');
+
+    const isExpanded = await page.evaluate(
+      () => document.activeElement?.getAttribute('aria-expanded')
+    );
+
+    expect(isExpanded).toBeTruthy();
+  });
+
+  test(`Open Terminals and Kernels (Kernels submenu)`, async ({ page }) => {
+    await page.goto();
+
+    await page.sidebar.openTab('jp-running-sessions');
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      await page.keyboard.press('Tab');
+      let IsFocused = await page.evaluate(
+        () => document.activeElement?.getAttribute('id')
+      );
+      if (IsFocused === 'title-key-2-4') {
         break;
       }
     }

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -210,6 +210,13 @@ const rightSidebarIds: galata.SidebarTabId[] = [
   'jp-debugger-sidebar'
 ];
 
+const accordionPanelAriaLabels = [
+  'Open Tabs Section',
+  'Kernels Section',
+  'Language servers Section',
+  'Terminals Section'
+];
+
 test.describe('Sidebar keyboard navigation @a11y', () => {
   leftSidebarIds.forEach(leftSidebarId => {
     test(`Open Sidebar tab ${leftSidebarId} via keyboard navigation`, async ({
@@ -290,55 +297,85 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
     });
   });
 
-  test(`Open Terminals and Kernels Accordion Panel sections keyboard navigation`, async ({
-    page
-  }) => {
-    await page.goto();
+  accordionPanelAriaLabels.forEach(accordionPanelAriaLabel => {
+    test(`Open Terminals and Kernels ${accordionPanelAriaLabel} via keyboard navigation`, async ({
+      page
+    }) => {
+      await page.goto();
 
-    await page.sidebar.openTab('jp-running-sessions');
+      await page.sidebar.openTab('jp-running-sessions');
 
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      await page.keyboard.press('Tab');
-      let IsFocused = await page.evaluate(
-        () => document.activeElement?.getAttribute('id')
-      );
-      if (IsFocused === 'title-key-2-3') {
-        break;
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        await page.keyboard.press('Tab');
+        let IsFocused = await page.evaluate(
+          () => document.activeElement?.getAttribute('aria-label')
+        );
+        if (IsFocused === accordionPanelAriaLabel) {
+          break;
+        }
       }
-    }
 
-    await page.keyboard.press('Enter');
+      await page.keyboard.press('Enter');
 
-    const isExpanded = await page.evaluate(
-      () => document.activeElement?.getAttribute('aria-expanded')
-    );
-
-    expect(isExpanded).toBeTruthy();
-  });
-
-  test(`Open Terminals and Kernels (Kernels submenu)`, async ({ page }) => {
-    await page.goto();
-
-    await page.sidebar.openTab('jp-running-sessions');
-
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      await page.keyboard.press('Tab');
-      let IsFocused = await page.evaluate(
-        () => document.activeElement?.getAttribute('id')
+      const isExpanded = await page.evaluate(
+        () => document.activeElement?.getAttribute('aria-expanded')
       );
-      if (IsFocused === 'title-key-2-4') {
-        break;
-      }
-    }
 
-    await page.keyboard.press('Enter');
-
-    const isExpanded = await page.evaluate(
-      () => document.activeElement?.getAttribute('aria-expanded')
-    );
-
-    expect(isExpanded).toBeTruthy();
+      expect(isExpanded).toBeTruthy();
+    });
   });
 });
+
+//   test(`Open Terminals and Kernels Accordion Panel sections keyboard navigation`, async ({
+//     page,
+//   }) => {
+//     await page.goto();
+
+//     await page.sidebar.openTab('jp-running-sessions');
+
+//     // eslint-disable-next-line no-constant-condition
+//     while (true) {
+//       await page.keyboard.press('Tab');
+//       let IsFocused = await page.evaluate(() =>
+//         document.activeElement?.getAttribute('id')
+//       );
+//       if (IsFocused === 'title-key-2-3') {
+//         break;
+//       }
+//     }
+
+//     await page.keyboard.press('Enter');
+
+//     const isExpanded = await page.evaluate(() =>
+//       document.activeElement?.getAttribute('aria-expanded')
+//     );
+
+//     expect(isExpanded).toBeTruthy();
+//   });
+
+//   test(`Open Terminals and Kernels (Kernels submenu)`, async ({ page }) => {
+//     await page.goto();
+
+//     await page.sidebar.openTab('jp-running-sessions');
+
+//     // eslint-disable-next-line no-constant-condition
+//     while (true) {
+//       await page.keyboard.press('Tab');
+//       let IsFocused = await page.evaluate(() =>
+//         document.activeElement?.getAttribute('id')
+//       );
+//       if (IsFocused === 'title-key-2-4') {
+//         break;
+//       }
+//     }
+
+//     await page.keyboard.press('Enter');
+
+//     const isExpanded = await page.evaluate(() =>
+//       document.activeElement?.getAttribute('aria-expanded')
+//     );
+
+//     expect(isExpanded).toBeTruthy();
+//   });
+// });

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -198,3 +198,35 @@ test.describe('Sidebars', () => {
     expect(tableOfContentsElementRole).toEqual('region');
   });
 });
+
+test.describe('Sidebar keyboard navigation @a11y', () => {
+  test('Open Running Terminals and Kernels tab', async ({ page }) => {
+    await page.goto();
+
+    const fileBrowserTab = document.getElementById('tab-key-1-6');
+    const TerminalsAndKernelsTab = document.getElementById('tab-key-1-2');
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      await page.keyboard.press('Tab');
+      let fileBrowserIsFocused = document.activeElement === fileBrowserTab;
+      if (fileBrowserIsFocused) {
+        break;
+      }
+    }
+    await page.keyboard.press('Enter');
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      await page.keyboard.press('ArrowDown');
+      let TerminalsAndKernelsIsFocused =
+        document.activeElement === TerminalsAndKernelsTab;
+      if (TerminalsAndKernelsIsFocused) {
+        break;
+      }
+    }
+    await page.keyboard.press('Enter');
+
+    expect(await page.sidebar.isTabOpen('jp-property-inspector')).toEqual(true);
+  });
+});

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -240,26 +240,18 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
         if (IsFocused === 'filebrowser') {
           break;
         }
-        while (leftSidebarId !== 'filebrowser') {
-          await page.keyboard.press('ArrowDown');
-          let IsFocused = await page.evaluate(
-            () => document.activeElement?.getAttribute('data-id')
-          );
-          if (IsFocused === leftSidebarId) {
-            break;
-          }
-        }
       }
 
-      // // eslint-disable-next-line no-constant-condition
-      // while (leftSidebarId !== 'filebrowser') {
-      //   await page.keyboard.press('ArrowDown');
-      //   let IsFocused = await page.evaluate(
-      //     () => document.activeElement?.getAttribute('data-id')
-      //   );
-      //   if (IsFocused === leftSidebarId) {
-      //     break;
-      //   }
+      // eslint-disable-next-line no-constant-condition
+      while (leftSidebarId !== 'filebrowser') {
+        await page.keyboard.press('ArrowDown');
+        let IsFocused = await page.evaluate(
+          () => document.activeElement?.getAttribute('data-id')
+        );
+        if (IsFocused === leftSidebarId) {
+          break;
+        }
+      }
 
       await page.keyboard.press('Enter');
 

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -279,4 +279,30 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
       expect(await page.sidebar.isTabOpen(rightSidebarId)).toEqual(true);
     });
   });
+  test(`Open Terminals and Kernels Accordion Panel sections keyboard navigation`, async ({
+    page
+  }) => {
+    await page.goto();
+
+    await page.sidebar.openTab('jp-running-sessions');
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      await page.keyboard.press('Tab');
+      let IsFocused = await page.evaluate(
+        () => document.activeElement?.getAttribute('id')
+      );
+      if (IsFocused === 'title-key-2-3') {
+        break;
+      }
+    }
+
+    await page.keyboard.press('Enter');
+
+    const isExpanded = await page.evaluate(
+      () => document.activeElement?.getAttribute('aria-expanded')
+    );
+
+    expect(isExpanded).toBeTruthy();
+  });
 });

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -268,13 +268,17 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
   test('Open Extension Manager tab', async ({ page }) => {
     await page.goto();
 
+    const fileBrowserTab = page.getByRole('tab', {
+      name: 'File Browser (Ctrl+Shift+F)'
+    });
+
     // eslint-disable-next-line no-constant-condition
     while (true) {
       await page.keyboard.press('Tab');
       let fileBrowserIsFocused = await page.evaluate(
-        () => document.activeElement
+        () => document.activeElement?.getAttribute('data-id')
       );
-      if (fileBrowserIsFocused?.getAttribute('data-id') === 'filebrowser') {
+      if (fileBrowserIsFocused === 'filebrowser') {
         break;
       }
     }
@@ -283,12 +287,9 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
     while (true) {
       await page.keyboard.press('ArrowDown');
       let tableOFContentsIsFocused = await page.evaluate(
-        () => document.activeElement
+        () => document.activeElement?.getAttribute('data-id')
       );
-      if (
-        tableOFContentsIsFocused?.getAttribute('data-id') ===
-        'extensionmanager.main-view'
-      ) {
+      if (tableOFContentsIsFocused === 'extensionmanager.main-view') {
         break;
       }
     }

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -303,13 +303,15 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
 test('Open File Browser tab', async ({ page }) => {
   await page.goto();
 
+  const fileBrowserTab = page.getByRole('tab', {
+    name: 'File Browser (Ctrl+Shift+F)'
+  });
+
   // eslint-disable-next-line no-constant-condition
   while (true) {
     await page.keyboard.press('Tab');
-    let fileBrowserIsFocused = await page.evaluate(
-      () => document.activeElement
-    );
-    if (fileBrowserIsFocused?.getAttribute('data-id') === 'filebrowser') {
+    let isFocused = page.locator(':focus');
+    if (fileBrowserTab === isFocused) {
       break;
     }
   }
@@ -320,10 +322,8 @@ test('Open File Browser tab', async ({ page }) => {
   // eslint-disable-next-line no-constant-condition
   while (true) {
     await page.keyboard.press('Tab');
-    let fileBrowserIsFocused = await page.evaluate(
-      () => document.activeElement
-    );
-    if (fileBrowserIsFocused?.getAttribute('data-id') === 'filebrowser') {
+    let isFocused = page.locator(':focus');
+    if (fileBrowserTab === isFocused) {
       break;
     }
   }

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -293,19 +293,7 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
 test('Close then open File Browser tab', async ({ page }) => {
   await page.goto();
 
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    await page.keyboard.press('Tab');
-    let fileBrowserIsFocused = await page.evaluate(
-      () => document.activeElement?.getAttribute('data-id')
-    );
-    if (fileBrowserIsFocused === 'filebrowser') {
-      break;
-    }
-  }
-  await page.keyboard.press('Enter');
-
-  expect(await page.sidebar.isTabOpen('filebrowser')).toEqual(false); //doesn't work, you can't close it on enter!
+  await page.sidebar.close('left');
 
   // eslint-disable-next-line no-constant-condition
   while (true) {

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -203,20 +203,13 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
   test('Open Running Terminals and Kernels tab', async ({ page }) => {
     await page.goto();
 
-    // const fileBrowserTab = page.getByRole('tab', {
-    //   name: 'File Browser (Ctrl+Shift+F)'
-    // });
-    // const TerminalsAndKernelsTab = page.getByRole('tab', {
-    //   name: 'Running Terminals and Kernels'
-    // });
-
     // eslint-disable-next-line no-constant-condition
     while (true) {
       await page.keyboard.press('Tab');
       let fileBrowserIsFocused = await page.evaluate(
         () => document.activeElement
       );
-      fileBrowserIsFocused?.getAttribute;
+
       if (fileBrowserIsFocused?.getAttribute('data-id') === 'filebrowser') {
         break;
       }
@@ -243,16 +236,12 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
   test('Open table of contents tab', async ({ page }) => {
     await page.goto();
 
-    // const fileBrowserTab = document.getElementById('tab-key-1-6');
-    // const tableOFContentsTab = document.getElementById('tab-key-1-4');
-
     // eslint-disable-next-line no-constant-condition
     while (true) {
       await page.keyboard.press('Tab');
       let fileBrowserIsFocused = await page.evaluate(
         () => document.activeElement
       );
-      fileBrowserIsFocused?.getAttribute;
       if (fileBrowserIsFocused?.getAttribute('data-id') === 'filebrowser') {
         break;
       }
@@ -275,4 +264,80 @@ test.describe('Sidebar keyboard navigation @a11y', () => {
 
     expect(await page.sidebar.isTabOpen('table-of-contents')).toEqual(true);
   });
+
+  test('Open Extension Manager tab', async ({ page }) => {
+    await page.goto();
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      await page.keyboard.press('Tab');
+      let fileBrowserIsFocused = await page.evaluate(
+        () => document.activeElement
+      );
+      if (fileBrowserIsFocused?.getAttribute('data-id') === 'filebrowser') {
+        break;
+      }
+    }
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      await page.keyboard.press('ArrowDown');
+      let tableOFContentsIsFocused = await page.evaluate(
+        () => document.activeElement
+      );
+      if (
+        tableOFContentsIsFocused?.getAttribute('data-id') ===
+        'extensionmanager.main-view'
+      ) {
+        break;
+      }
+    }
+    await page.keyboard.press('Enter');
+
+    expect(await page.sidebar.isTabOpen('extensionmanager.main-view')).toEqual(
+      true
+    );
+  });
+});
+
+test('Open File Browser tab', async ({ page }) => {
+  await page.goto();
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    await page.keyboard.press('Tab');
+    let fileBrowserIsFocused = await page.evaluate(
+      () => document.activeElement
+    );
+    if (fileBrowserIsFocused?.getAttribute('data-id') === 'filebrowser') {
+      break;
+    }
+  }
+  await page.keyboard.press('Enter');
+
+  expect(await page.sidebar.isTabOpen('filebrowser')).toEqual(false);
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    await page.keyboard.press('Tab');
+    let fileBrowserIsFocused = await page.evaluate(
+      () => document.activeElement
+    );
+    if (fileBrowserIsFocused?.getAttribute('data-id') === 'filebrowser') {
+      break;
+    }
+  }
+  await page.keyboard.press('Enter');
+
+  expect(await page.sidebar.isTabOpen('filebrowser')).toEqual(true);
+});
+
+test('Is file browser open/closed tab', async ({ page }) => {
+  await page.goto();
+
+  expect(await page.sidebar.isTabOpen('filebrowser')).toEqual(true);
+
+  await page.sidebar.close('left');
+
+  expect(await page.sidebar.isTabOpen('filebrowser')).toEqual(false);
 });

--- a/galata/test/jupyterlab/sidebars.test.ts
+++ b/galata/test/jupyterlab/sidebars.test.ts
@@ -199,123 +199,165 @@ test.describe('Sidebars', () => {
   });
 });
 
+const leftSidebarIds: galata.SidebarTabId[] = [
+  'filebrowser',
+  'jp-running-sessions',
+  'table-of-contents',
+  'extensionmanager.main-view'
+];
+
 test.describe('Sidebar keyboard navigation @a11y', () => {
-  test('Open Running Terminals and Kernels tab', async ({ page }) => {
-    await page.goto();
+  leftSidebarIds.forEach(leftSidebarId => {
+    test(`Open Sidebar tab ${leftSidebarId}`, async ({ page }) => {
+      await page.goto();
 
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      await page.keyboard.press('Tab');
-      let fileBrowserIsFocused = await page.evaluate(
-        () => document.activeElement?.getAttribute('data-id')
-      );
-      if (fileBrowserIsFocused === 'filebrowser') {
-        break;
+      await page.sidebar.close('left');
+
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        await page.keyboard.press('Tab');
+        let fileBrowserIsFocused = await page.evaluate(
+          () => document.activeElement?.getAttribute('data-id')
+        );
+        if (fileBrowserIsFocused === 'filebrowser') {
+          break;
+        }
       }
-    }
 
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      await page.keyboard.press('ArrowDown');
-      let TerminalsAndKernelsIsFocused = await page.evaluate(
-        () => document.activeElement?.getAttribute('data-id')
-      );
-      if (TerminalsAndKernelsIsFocused === 'jp-running-sessions') {
-        break;
+      // eslint-disable-next-line no-constant-condition
+      while (leftSidebarId !== 'filebrowser') {
+        await page.keyboard.press('ArrowDown');
+        let IsFocused = await page.evaluate(
+          () => document.activeElement?.getAttribute('data-id')
+        );
+        if (IsFocused === leftSidebarId) {
+          break;
+        }
       }
-    }
-    await page.keyboard.press('Enter');
+      await page.keyboard.press('Enter');
 
-    expect(await page.sidebar.isTabOpen('jp-running-sessions')).toEqual(true);
-  });
-
-  test('Open table of contents tab', async ({ page }) => {
-    await page.goto();
-
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      await page.keyboard.press('Tab');
-      let fileBrowserIsFocused = await page.evaluate(
-        () => document.activeElement?.getAttribute('data-id')
-      );
-      if (fileBrowserIsFocused === 'filebrowser') {
-        break;
-      }
-    }
-
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      await page.keyboard.press('ArrowDown');
-      let tableOFContentsIsFocused = await page.evaluate(
-        () => document.activeElement?.getAttribute('data-id')
-      );
-      if (tableOFContentsIsFocused === 'table-of-contents') {
-        break;
-      }
-    }
-    await page.keyboard.press('Enter');
-
-    expect(await page.sidebar.isTabOpen('table-of-contents')).toEqual(true);
-  });
-
-  test('Open Extension Manager tab', async ({ page }) => {
-    await page.goto();
-
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      await page.keyboard.press('Tab');
-      let fileBrowserIsFocused = await page.evaluate(
-        () => document.activeElement?.getAttribute('data-id')
-      );
-      if (fileBrowserIsFocused === 'filebrowser') {
-        break;
-      }
-    }
-
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      await page.keyboard.press('ArrowDown');
-      let tableOFContentsIsFocused = await page.evaluate(
-        () => document.activeElement?.getAttribute('data-id')
-      );
-      if (tableOFContentsIsFocused === 'extensionmanager.main-view') {
-        break;
-      }
-    }
-    await page.keyboard.press('Enter');
-
-    expect(await page.sidebar.isTabOpen('extensionmanager.main-view')).toEqual(
-      true
-    );
+      expect(await page.sidebar.isTabOpen(leftSidebarId)).toEqual(true);
+    });
   });
 });
 
-test('Close then open File Browser tab', async ({ page }) => {
-  await page.goto();
+// test.describe('Sidebar keyboard navigation @a11y', () => {
+//   test('Open Running Terminals and Kernels tab', async ({ page }) => {
+//     await page.goto();
 
-  await page.sidebar.close('left');
+//     // eslint-disable-next-line no-constant-condition
+//     while (true) {
+//       await page.keyboard.press('Tab');
+//       let fileBrowserIsFocused = await page.evaluate(() =>
+//         document.activeElement?.getAttribute('data-id')
+//       );
+//       if (fileBrowserIsFocused === 'filebrowser') {
+//         break;
+//       }
+//     }
 
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    await page.keyboard.press('Tab');
-    let fileBrowserIsFocused = await page.evaluate(
-      () => document.activeElement?.getAttribute('data-id')
-    );
-    if (fileBrowserIsFocused === 'filebrowser') {
-      break;
-    }
-  }
-  await page.keyboard.press('Enter');
+//     // eslint-disable-next-line no-constant-condition
+//     while (true) {
+//       await page.keyboard.press('ArrowDown');
+//       let TerminalsAndKernelsIsFocused = await page.evaluate(() =>
+//         document.activeElement?.getAttribute('data-id')
+//       );
+//       if (TerminalsAndKernelsIsFocused === 'jp-running-sessions') {
+//         break;
+//       }
+//     }
+//     await page.keyboard.press('Enter');
 
-  expect(await page.sidebar.isTabOpen('filebrowser')).toEqual(true);
-});
+//     expect(await page.sidebar.isTabOpen('jp-running-sessions')).toEqual(true);
+//   });
 
-test('Is file browser open/closed tab', async ({ page }) => {
-  await page.goto();
+//   test('Open table of contents tab', async ({ page }) => {
+//     await page.goto();
 
-  expect(await page.sidebar.isTabOpen('filebrowser')).toEqual(true);
+//     // eslint-disable-next-line no-constant-condition
+//     while (true) {
+//       await page.keyboard.press('Tab');
+//       let fileBrowserIsFocused = await page.evaluate(() =>
+//         document.activeElement?.getAttribute('data-id')
+//       );
+//       if (fileBrowserIsFocused === 'filebrowser') {
+//         break;
+//       }
+//     }
 
-  await page.sidebar.close('left');
+//     // eslint-disable-next-line no-constant-condition
+//     while (true) {
+//       await page.keyboard.press('ArrowDown');
+//       let tableOFContentsIsFocused = await page.evaluate(() =>
+//         document.activeElement?.getAttribute('data-id')
+//       );
+//       if (tableOFContentsIsFocused === 'table-of-contents') {
+//         break;
+//       }
+//     }
+//     await page.keyboard.press('Enter');
 
-  expect(await page.sidebar.isTabOpen('filebrowser')).toEqual(false);
-});
+//     expect(await page.sidebar.isTabOpen('table-of-contents')).toEqual(true);
+//   });
+
+//   test('Open Extension Manager tab', async ({ page }) => {
+//     await page.goto();
+
+//     // eslint-disable-next-line no-constant-condition
+//     while (true) {
+//       await page.keyboard.press('Tab');
+//       let fileBrowserIsFocused = await page.evaluate(() =>
+//         document.activeElement?.getAttribute('data-id')
+//       );
+//       if (fileBrowserIsFocused === 'filebrowser') {
+//         break;
+//       }
+//     }
+
+//     // eslint-disable-next-line no-constant-condition
+//     while (true) {
+//       await page.keyboard.press('ArrowDown');
+//       let tableOFContentsIsFocused = await page.evaluate(() =>
+//         document.activeElement?.getAttribute('data-id')
+//       );
+//       if (tableOFContentsIsFocused === 'extensionmanager.main-view') {
+//         break;
+//       }
+//     }
+//     await page.keyboard.press('Enter');
+
+//     expect(await page.sidebar.isTabOpen('extensionmanager.main-view')).toEqual(
+//       true
+//     );
+//   });
+// });
+
+// test('Close then open File Browser tab', async ({ page }) => {
+//   await page.goto();
+
+//   await page.sidebar.close('left');
+
+//   // eslint-disable-next-line no-constant-condition
+//   while (true) {
+//     await page.keyboard.press('Tab');
+//     let fileBrowserIsFocused = await page.evaluate(() =>
+//       document.activeElement?.getAttribute('data-id')
+//     );
+//     if (fileBrowserIsFocused === 'filebrowser') {
+//       break;
+//     }
+//   }
+//   await page.keyboard.press('Enter');
+
+//   expect(await page.sidebar.isTabOpen('filebrowser')).toEqual(true);
+// });
+
+// test('Is file browser open/closed tab', async ({ page }) => {
+//   await page.goto();
+
+//   expect(await page.sidebar.isTabOpen('filebrowser')).toEqual(true);
+
+//   await page.sidebar.close('left');
+
+//   expect(await page.sidebar.isTabOpen('filebrowser')).toEqual(false);
+// });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
#15437 Improve sidebar accessibility test coverage.

#15303 Issues noting keyboard navigation not as expected.


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Adding these tests will validate that the side bar tabs and accordion panel items within tabs can be opened using only keyboard navigation (Tabbing/Arrow keys/Enter - not keyboard shortcuts) to prevent regression.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
none
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes
none
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
