### PR TITLE
Fix Shift + L not working in stdin

### DIFF
--- a/galata/test/jupyterlab/outputarea-stdin.test.ts
+++ b/galata/test/jupyterlab/outputarea-stdin.test.ts
@@ -3,6 +3,10 @@
 
 import { expect, test } from '@jupyterlab/galata';
 
+test.use({
+  locale: 'en-US'
+});
+
 test.describe('Stdin for ipdb', () => {
   test.beforeEach(async ({ page }) => {
     await page.notebook.createNew();
@@ -51,5 +55,31 @@ test.describe('Stdin for ipdb', () => {
     // Check that the input remains focused and cursor is at the end.
     await page.keyboard.insertText('x');
     await expect(page.locator('.jp-Stdin-input')).toHaveValue('foofoox');
+  });
+
+  test('Typing in stdin box', async ({ page }) => {
+    // Test to ensure that notebook shortcuts do not capture text typed into inputs.
+    // This may not be sufficient to ensure no conflicts with other languages but
+    // should catch the most severe issues.
+    const alphabet = 'abcdefghijklmnopqrstuvwxyz';
+    const digits = '0123456789';
+    await page.notebook.setCell(0, 'code', 'input()');
+    // Run the selected (only) cell without proceeding and without waiting
+    // for it to complete (as it should stay waiting for input).
+    await page.keyboard.press('Control+Enter');
+
+    await page.waitForSelector('.jp-Stdin-input');
+    for (const letter of alphabet) {
+      await page.keyboard.press(`Key${letter.toUpperCase()}`);
+    }
+    for (const letter of alphabet) {
+      await page.keyboard.press(`Shift+Key${letter.toUpperCase()}`);
+    }
+    for (const digit of digits) {
+      await page.keyboard.press(`Digit${digit}`);
+    }
+    await expect(page.locator('.jp-Stdin-input')).toHaveValue(
+      alphabet + alphabet.toUpperCase() + digits
+    );
   });
 });

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -629,11 +629,6 @@
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {
-      "command": "notebook:toggle-all-cell-line-numbers",
-      "keys": ["Shift L"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
-    },
-    {
       "command": "notebook:undo-cell-action",
       "keys": ["Z"],
       "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -611,7 +611,7 @@
     {
       "command": "viewmenu:line-numbering",
       "keys": ["Shift L"],
-      "selector": ".jp-Notebook.jp-mod-commandMode"
+      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
     },
     {
       "command": "viewmenu:match-brackets",


### PR DESCRIPTION
## References

Fixes #15429

## Code changes

Adds selector that should have been added before.

## User-facing changes

When input box is focused, shift + l types "L" rather than toggling line numbers

## Backwards-incompatible changes

None