### PR TITLE
Support server-side execution

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -499,6 +499,10 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
         {"LabApp": {"custom_css": True}},
         "Load custom CSS in template html files. Default is False",
     )
+    flags["server-side-execution"] = (
+        {"LabApp": {"server-side-execution": True}},
+        """Whether to execute notebooks in the server using the REST API, not using the kernel protocol over WebSocket. The frontend only interacts with the notebook through its shared model. This execution mode requires jupyter-collaboration.""",
+    )
 
     subcommands = {
         "build": (LabBuildApp, LabBuildApp.description.splitlines()[0]),
@@ -601,6 +605,12 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
             python -m pip install jupyter_collaboration
 
         This flag is now deprecated and will be removed in JupyterLab v5.""",
+    )
+
+    server_side_execution = Bool(
+        False,
+        config=True,
+        help="""Whether to execute notebooks in the server using the REST API, not using the kernel protocol over WebSocket. The frontend only interacts with the notebook through its shared model. This execution mode requires jupyter-collaboration.""",
     )
 
     news_url = Unicode(


### PR DESCRIPTION
## References

Closes #2833.
Closes #12867.

Needs:
- ~~https://github.com/jupyterlab/jupyter-collaboration/pull/217~~
- ~~https://github.com/jupyter-server/jupyter_ydoc/pull/198~~
- ~~https://github.com/jupyter-server/jupyter_ydoc/pull/201~~
- `jupyter-collaboration >=2.0`
- `jupyverse >=0.4.0`

Currently, the only Jupyter server that supports this execution mode is [Jupyverse](https://github.com/jupyter-server/jupyverse).

## Code changes

A new `server-side-execution` flag allows to execute a notebook server-side (false by default). In this execution mode, the frontend doesn't use the kernel protocol over WebSocket, but interacts with the notebook only through its shared model. Thus, this mode needs [jupyter-collaboration](https://github.com/jupyterlab/jupyter-collaboration).

## User-facing changes

The user can close their JupyterLab browser window, reopen it later and recover the notebook state, including (live) cell outputs.

## Backwards-incompatible changes

None.