### PR TITLE
Fix `FormComponent` showing error indicators in all fields when using a `customValidate` function

### DIFF
--- a/packages/ui-components/src/components/form.tsx
+++ b/packages/ui-components/src/components/form.tsx
@@ -507,7 +507,7 @@ const CustomTemplateFactory = (options: FormComponent.ILabCustomizerProps) =>
           }`}
         >
           {!hasCustomField &&
-            (rawErrors ? (
+            (rawErrors?.length ? (
               // Shows a red indicator for fields that have validation errors
               <div className="jp-modifiedIndicator jp-errorIndicator" />
             ) : (


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
Fixes: #15447
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Also check the length of `rawErrors` since `rawErrors` will be an empty array rather than `undefined` when a `customValidate` function is passed to `FormComponent`.
<!-- Describe the code changes and how they address the issue. -->