### PR TITLE
nbformat should have "type": "module" to use import statements, etc.

### DIFF
--- a/packages/nbformat/package.json
+++ b/packages/nbformat/package.json
@@ -17,6 +17,7 @@
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "type": "module",
   "directories": {
     "lib": "lib/"
   },


### PR DESCRIPTION
## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->
https://github.com/jupyterlab/jupyterlab/issues/15484

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Simply added the `"type": "module"` to `package.json`.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->
None

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None
