### PR TITLE
Pin `actions/labeler` to v4 to fix failing CI action

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,6 +11,6 @@ jobs:
     name: Update PR Labels
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@main
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## References

This is a hotfix for #15488 until we have time to migrate to v5. Because the job runs from `main` branch it should not need a backport so tagging for 4.1.0.

## Code changes

```diff
-    - uses: actions/labeler@main
+    - uses: actions/labeler@v4
```

## User-facing changes

None

## Backwards-incompatible changes

None