### PR TITLE
Update migration guide about the Toolbar selector

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -50,7 +50,7 @@ See https://github.com/jupyterlab/team-compass/issues/143 for more context on th
 
   - The DOM of ``Toolbar`` is now a ``jp-toolbar`` component instead of a ``div``.
 
-  - The DOM of ``ToolbarButtonComponent`` are now ``jp-button`` elements instead of ``button``.
+  - The DOM of ``ToolbarButtonComponent`` is now ``jp-button`` element instead of a ``button``.
 
     This must be taken into account since the button itself is in the shadow DOM of the ``jp-button`` component,
     and cannot be accessed as a child of the toolbar component.

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -46,11 +46,13 @@ and is based on `FAST <https://www.fast.design/>` library by Microsoft.
 
 See https://github.com/jupyterlab/team-compass/issues/143 for more context on the change.
 
-- Changes the selectors of the ``ToolbarButtonComponent``.
+- Changes the selectors of the ``Toolbar`` and ``ToolbarButtonComponent``.
 
-  - The ``ToolbarButtonComponent`` have now the tag ``jp-button`` instead of ``button``.
+  - The DOM of ``Toolbar`` is now a ``jp-toolbar`` component instead of a ``div``.
 
-    This has be taken into account since the button itself is in the shadow DOM of the ``jp-button`` component,
+  - The DOM of ``ToolbarButtonComponent`` are now ``jp-button`` elements instead of ``button``.
+
+    This must be taken into account since the button itself is in the shadow DOM of the ``jp-button`` component,
     and cannot be accessed as a child of the toolbar component.
 
   - The icon in the ``ToolbarButtonComponent`` is a direct child of the ``jp-button`` component.

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -39,10 +39,10 @@ Use of UI toolkit for Toolbar and ToolbarButtonComponent
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The Toolbar and ToolbarButtonComponent (from the package *ui-components*) now relies on the external library
-:ref:`jupyter-ui-toolkit <https://github.com/jupyterlab-contrib/jupyter-ui-toolkit>`.
+`jupyter-ui-toolkit <https://github.com/jupyterlab-contrib/jupyter-ui-toolkit>`_.
 
 This library uses the web component technology (https://developer.mozilla.org/en-US/docs/Web/API/Web_components),
-and is based on :ref:`FAST <https://www.fast.design/>` library by Microsoft.
+and is based on `FAST <https://www.fast.design/>`_ library by Microsoft.
 
 See https://github.com/jupyterlab/team-compass/issues/143 for more context on the change.
 

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -46,19 +46,32 @@ and is based on `FAST <https://www.fast.design/>` library by Microsoft.
 
 See https://github.com/jupyterlab/team-compass/issues/143 for more context on the change.
 
-If you are using jest to test your extension, some new ES6 packages dependencies are added to JupyterLab.
-They need to be ignored when transforming the code with Jest. You will need to update the
-``transformIgnorePatterns`` to add:
+- Changes the selectors of the ``ToolbarButtonComponent``.
 
-.. code::
+  - The ``ToolbarButtonComponent`` have now the tag ``jp-button`` instead of ``button``.
 
-   const esModules = [
-     '@microsoft',
-     '@jupyter/react-components',
-     '@jupyter/web-components',
-     'exenv-es6',
-     ...
-   ].join('|');
+    This has be taken into account since the button itself is in the shadow DOM of the ``jp-button`` component,
+    and cannot be accessed as a child of the toolbar component.
+
+  - The icon in the ``ToolbarButtonComponent`` is a direct child of the ``jp-button`` component.
+
+    The icon was previously encapsulated in a span with the class ``.jp-ToolbarButtonComponent-icon``.
+    Accessing that icon to change its properties require now something like ``jp-button > svg``.
+
+- If you are using jest to test your extension, some new ES6 packages dependencies are added to JupyterLab.
+
+  They need to be ignored when transforming the code with Jest. You will need to update the
+  ``transformIgnorePatterns`` to add:
+
+  .. code::
+
+    const esModules = [
+      '@microsoft',
+      '@jupyter/react-components',
+      '@jupyter/web-components',
+      'exenv-es6',
+      ...
+    ].join('|');
 
 
 JupyterLab 3.x to 4.x

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -39,10 +39,10 @@ Use of UI toolkit for Toolbar and ToolbarButtonComponent
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The Toolbar and ToolbarButtonComponent (from the package *ui-components*) now relies on the external library
-`jupyter-ui-toolkit <https://github.com/jupyterlab-contrib/jupyter-ui-toolkit>`.
+:ref:`jupyter-ui-toolkit <https://github.com/jupyterlab-contrib/jupyter-ui-toolkit>`.
 
 This library uses the web component technology (https://developer.mozilla.org/en-US/docs/Web/API/Web_components),
-and is based on `FAST <https://www.fast.design/>` library by Microsoft.
+and is based on :ref:`FAST <https://www.fast.design/>` library by Microsoft.
 
 See https://github.com/jupyterlab/team-compass/issues/143 for more context on the change.
 


### PR DESCRIPTION
This PR adds some documentation in the migration guide about the `Toolbar` and `ToolbarButtonComponent` selectors.

## References

https://github.com/jupyterlab/jupyterlab/pull/15021 includes web components, which change the DOM of the `Toolbar` and `ToolbarButtonComponent`.

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None