### PR TITLE
Clean up eslint scripts in the translation packages

### DIFF
--- a/packages/translation-extension/package.json
+++ b/packages/translation-extension/package.json
@@ -34,8 +34,6 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib tsconfig.tsbuildinfo",
-    "eslint": "eslint . --ext .ts,.tsx --fix",
-    "eslint:check": "eslint . --ext .ts,.tsx",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/translation/package.json
+++ b/packages/translation/package.json
@@ -31,8 +31,6 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib tsconfig.tsbuildinfo",
     "docs": "typedoc src",
-    "eslint": "eslint . --ext .ts,.tsx --fix",
-    "eslint:check": "eslint . --ext .ts,.tsx",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk ../../node_modules/.bin/jest --runInBand",


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

The `translation` and `translation-extension` packages still had some `eslint` and `eslint:check` scripts in their `package.json`.

Linting is handled at the top-level, so we can remove these scripts.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Script cleanup in:

- `translation`
- `translation-extension`

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
