### PR TITLE
Disable Scan mode notification for screen reader users

### DIFF
--- a/packages/apputils-extension/src/announcements.ts
+++ b/packages/apputils-extension/src/announcements.ts
@@ -153,6 +153,16 @@ export const announcements: JupyterFrontEndPlugin<void> = {
             ]
           }
         );
+        const alertId = Notification.emit(
+          trans.__(
+            'For best user experience when using screenreader, turn off scan mode. Use the command: "Modifier Key + Spacebar." For ORCA use: "Insert+A"'
+          ),
+          'default',
+          {
+            autoClose: false
+          }
+        );
+        return alertId;
       } else {
         await fetchNews();
       }

--- a/packages/apputils-extension/src/notificationplugin.tsx
+++ b/packages/apputils-extension/src/notificationplugin.tsx
@@ -871,7 +871,7 @@ namespace Private {
         : message;
     return (
       <>
-        <div className="jp-toast-message">
+        <div className="jp-toast-message" role="alert" aria-live="assertive">
           {shortenMessage.split('\n').map((part, index) => (
             <React.Fragment key={`part-${index}`}>
               {index > 0 ? <br /> : null}


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

15303- [Accessibility - Keyboard Navigation using a Screen Reader](https://github.com/jupyterlab/jupyterlab/issues/15303#top) 


## Code changes

New notification message added in the `jupyterlab/packages/apputils-extension/src/announcements.ts` file .
Also added `aria-live="assertive"` and `role="alert" ` to ensure the screen-reader announces the text first thing as you load Jupyterlab.


## User-facing changes
Notification popups to let user know which command to use to turn off scan mode when using a screen reader to ensure effective interactions with cells and files in notebook (check issue referenced above). 

## Backwards-incompatible changes
None

