### PR TITLE
Implement `level` trait for plugin/extension managers

### DIFF
--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -377,6 +377,13 @@ running the ``jupyter labextension enable`` or ``jupyter labextension disable`` 
    :class: jp-screenshot
    :alt: An example search result in the plugin extension listing.
 
+
+Plugins can be enabled/disabled on ``system``, ``sys-prefix`` (default) or
+``user`` level, which influences where the ``page_config.json`` configuration
+file is written to (see ``config` section in results of ``jupyter --paths``).
+To change the level for the plugin manager and the default extension manager
+use ``PluginManager.level`` trait (extension manager inherits from plugin manager).
+
 .. _locking_plugins:
 
 Locking and Unlocking Plugins

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -867,6 +867,7 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
                                 "lock_rules": lock_rules,
                                 "all_locked": self.lock_all_plugins,
                             },
+                            parent=self,
                         )
                     },
                 )

--- a/jupyterlab/tests/test_extensions.py
+++ b/jupyterlab/tests/test_extensions.py
@@ -8,7 +8,7 @@ import pytest
 from traitlets.config import Config, Configurable
 
 from jupyterlab.extensions import PyPIExtensionManager, ReadOnlyExtensionManager
-from jupyterlab.extensions.manager import ExtensionManager, ExtensionPackage
+from jupyterlab.extensions.manager import ExtensionManager, ExtensionPackage, PluginManager
 
 from . import fake_client_factory
 
@@ -340,3 +340,32 @@ async def test_PyPiExtensionManager_custom_server_url():
     manager = PyPIExtensionManager(parent=parent)
 
     assert manager.base_url == BASE_URL
+
+
+LEVELS = ["user", "sys_prefix", "system"]
+
+
+@pytest.mark.parametrize("level", LEVELS)
+async def test_PyPiExtensionManager_custom_level(level):
+    parent = Configurable(config=Config({"PyPIExtensionManager": {"level": level}}))
+    manager = PyPIExtensionManager(parent=parent)
+    assert manager.level == level
+
+
+@pytest.mark.parametrize("level", LEVELS)
+async def test_PyPiExtensionManager_inherits_custom_level(level):
+    parent = Configurable(config=Config({"PluginManager": {"level": level}}))
+    manager = PyPIExtensionManager(parent=parent)
+    assert manager.level == level
+
+
+@pytest.mark.parametrize("level", LEVELS)
+async def test_PluginManager_custom_level(level):
+    parent = Configurable(config=Config({"PluginManager": {"level": level}}))
+    manager = PluginManager(parent=parent)
+    assert manager.level == level
+
+
+async def test_PluginManager_default_level():
+    manager = PluginManager()
+    assert manager.level == "sys_prefix"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,7 +213,7 @@ npm = ["node", "yarn.js"]
 
 [tool.pytest.ini_options]
 testpaths = "jupyterlab/tests"
-norecursedirs = "node_modules .git _build"
+norecursedirs = "node_modules .git _build .ipynb_checkpoints"
 addopts = "--pdbcls=IPython.terminal.debugger:Pdb -v --junitxml=junit.xml"
 ignore = "tests examples"
 


### PR DESCRIPTION
## References

Fixes #15486

## Code changes

- adds `level` trait for plugin manager (and extension manager by inheritance) which matches the `level` trait of `jupyter labextension` sub-commands.
- do not collect tests from `.ipynb_checkpoints`.

## User-facing changes

The new trait can be set from CLI (or config file), for example:

```sh
jupyter lab --PluginManager.level user  # this has effect on both plugin and extension manager
```

or:

```sh
jupyter lab --PyPIExtensionManager.level user  # this only has an effect on extension manager
```

## Backwards-incompatible changes

None