### PR TITLE
Manually trigger benchmark tests instead of running them on `pull_request_review`

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,13 +1,13 @@
 name: Benchmark Tests
 
 on:
-  schedule:
-    - cron: '12 1 * * 0'
+  issue_comment:
+    types: [created, edited]
 
 jobs:
   test:
     name: Execute benchmark tests
-    if: github.event_name == 'schedule' || (github.event_name == 'pull_request_review' && (github.event.review.state == 'approved' || contains(github.event.review.body, 'please run benchmark')))
+    if: ${{ github.event.issue.pull_request && (contains(github.event.comment.body, 'please run benchmarks') }}
 
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,9 +1,8 @@
 name: Benchmark Tests
 
 on:
-  # schedule:
-  #   - cron: '12 1 * * 0'
-  pull_request_review:
+  schedule:
+    - cron: '12 1 * * 0'
 
 jobs:
   test:


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Hoping to fix https://github.com/jupyterlab/jupyterlab/issues/15089

And progressively get CI to pass again consistently.

The benchmarks checks have been failing for many months on CI.

These jobs are run on PR approval, and may take a very long time to complete. Which means that in theory a maintainer would have to wait again for a new job to complete (and succeed) before hitting the merge button. Overall this adds a lot of maintenance fatigue and makes it difficult to merge PRs. To the point that it seems that it's just been ignored for the past months?

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Run the benchmark on `schedule` instead of `pull_request_review` to get these runs out of the review workflow.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
