### PR TITLE
Ignore `ipython` in dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,5 @@ updates:
       # Check for updates to GitHub Actions every month
       # Align with pre-commit configuration .pre-commit-config.yaml
       interval: "monthly"
+    ignore:
+    - dependency-name: "ipython"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,4 @@ updates:
     # Prevent the UI tests from failing, as the version number of ipython is visible
     # in some of the Galata snapshots
     - dependency-name: "ipython"
+    - update-types: ["version-update:semver-minor", "version-update:semver-patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,4 +14,6 @@ updates:
       # Align with pre-commit configuration .pre-commit-config.yaml
       interval: "monthly"
     ignore:
+    # Prevent the UI tests from failing, as the version number of ipython is visible
+    # in some of the Galata snapshots
     - dependency-name: "ipython"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

As noticed in https://github.com/jupyterlab/jupyterlab/pull/15476 dependabot sometimes bumps `ipython`, and the `ipython` version number is visible on the snapshots. This can cause a snapshot mismatch and make the UI test fail, requiring updating the snapshots.

![image](https://github.com/jupyterlab/jupyterlab/assets/591645/de65fab3-41a6-48ae-a994-c33ab7234aac)

![image](https://github.com/jupyterlab/jupyterlab/assets/591645/e75a0ded-132a-4c61-b3ae-d99dcf8d59d9)

As suggested by @fcollonval in https://github.com/jupyterlab/jupyterlab/pull/15476#discussion_r1421403465, one solution can be to ignore updating `ipython`.

## Code changes

Ignore `ipython` updates in `dependabot.yml`.

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
