### PR TITLE
Restore some CSS rules for backward compatibility

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -75,6 +75,12 @@ See https://github.com/jupyterlab/team-compass/issues/143 for more context on th
       ...
     ].join('|');
 
+- Some CSS rules for ``button`` with the class ``.jp-ToolbarButtonComponent`` has been kept for backward compatibility.
+
+  These rules are now **deprecated** and will be removed in Jupyterlab 5.
+  The ``button`` elements in toolbars must be updated to ``jp-button``, from
+  `jupyter-ui-toolkit <https://github.com/jupyterlab-contrib/jupyter-ui-toolkit>`_.
+
 
 JupyterLab 3.x to 4.x
 ---------------------

--- a/packages/ui-components/style/toolbar.css
+++ b/packages/ui-components/style/toolbar.css
@@ -108,3 +108,36 @@ button.jp-ToolbarButtonComponent .jp-ToolbarButtonComponent-label {
   border: none;
   box-shadow: none;
 }
+
+/* @deprecated dead code to be removed in JupyterLab 5
+  Button in toolbar should use the ui-toolkit
+  https://github.com/jupyterlab-contrib/jupyter-ui-toolkit.
+*/
+button.jp-ToolbarButtonComponent {
+  background: var(--jp-layout-color1);
+  border: none;
+  box-sizing: border-box;
+  outline: none;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  padding: 0 6px;
+  margin: 0;
+  height: 24px;
+  border-radius: var(--jp-border-radius);
+  display: flex;
+  align-items: center;
+  text-align: center;
+  font-size: var(--jp-ui-font-size0);
+  min-width: unset;
+  min-height: unset;
+}
+
+button.jp-ToolbarButtonComponent:disabled {
+  opacity: 0.4;
+}
+
+button.jp-ToolbarButtonComponent > span {
+  padding: 0;
+  flex: 0 0 auto;
+}


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/15511

Restores some CSS rules that has been removed in https://github.com/jupyterlab/jupyterlab/pull/15021.
These rules concerns `button` elements in toolbar, and are deprecated.

## Code changes

Add some deprecated CSS rules.

## User-facing changes

Restore an expected behavior for extensions.

## Backwards-incompatible changes

None