### PR TITLE
Keyboard shortcut screen reader

### DIFF
--- a/packages/apputils-extension/src/shortcuts.tsx
+++ b/packages/apputils-extension/src/shortcuts.tsx
@@ -48,6 +48,20 @@ export function displayShortcuts(options: IOptions) {
   const { commands, trans, activeElement } = options;
   const elt = activeElement ?? document.activeElement;
 
+  function keyAriaLabel(ch: string) {
+    const keyToText: { [key: string]: string } = {
+      ']': 'Closing bracket',
+      '[': 'Opening bracket',
+      ',': 'Comma',
+      '.': 'Full stop',
+      "'": 'Single quote',
+      '-': 'Hyphen-minus'
+    };
+    if (Object.keys(keyToText).includes(ch)) {
+      return keyToText[ch];
+    }
+  }
+
   /**
    * Find the distance from the target node to the first matching node.
    *
@@ -66,7 +80,11 @@ export function displayShortcuts(options: IOptions) {
       const container: JSX.Element[] = [];
       key.split(' ').forEach((ch, chIndex) => {
         container.push(
-          <span className={SHORTCUT_KEY_CLASS} key={`ch-${chIndex}`}>
+          <span
+            className={SHORTCUT_KEY_CLASS}
+            key={`ch-${chIndex}`}
+            aria-label={keyAriaLabel(ch)}
+          >
             <kbd>{ch}</kbd>
           </span>,
           <React.Fragment key={`fragment-${chIndex}`}> + </React.Fragment>

--- a/packages/shortcuts-extension/test/shortcuts.spec.ts
+++ b/packages/shortcuts-extension/test/shortcuts.spec.ts
@@ -165,3 +165,26 @@ describe('@jupyterlab/shortcut-extension', () => {
     });
   });
 });
+
+describe('shorcuts list', () => {
+  it('should add punctuation aria-label', () => {
+    const keyboardShortcuts = document.getElementsByClassName(
+      'jp-contextualShortcut-key'
+    );
+    for (let i = 0; i < keyboardShortcuts.length; i++) {
+      const keyboardLabelAria = keyboardShortcuts[i].getAttribute('aria-label');
+      const keyboardLabelText = keyboardShortcuts[i].innerHTML;
+      const punctuation = ",}{.'-";
+      if (punctuation.includes(keyboardLabelText)) {
+        expect(keyboardLabelAria).toEqual([
+          'Comma',
+          'Closing bracket',
+          'Opening bracket',
+          'Full stop',
+          'Single quote',
+          'Hyphen-minus'
+        ]);
+      }
+    }
+  });
+});

--- a/packages/shortcuts-extension/test/shortcuts.spec.ts
+++ b/packages/shortcuts-extension/test/shortcuts.spec.ts
@@ -7,6 +7,7 @@ import { IDataConnector } from '@jupyterlab/statedb';
 import { CommandRegistry } from '@lumino/commands';
 import { Platform } from '@lumino/domutils';
 import pluginSchema from '../schema/shortcuts.json';
+import expect from 'expect';
 
 describe('@jupyterlab/shortcut-extension', () => {
   const pluginId = 'test-plugin:settings';


### PR DESCRIPTION
## References
Issue 15497 - [Screen reader doesn't read all keyboard shortcut punctuation](https://github.com/jupyterlab/jupyterlab/issues/15497)

## Code changes
- Function added to render aria labels for punctuation key symbols within the keyboard shortcut dialog module
- Test added to assert punctuation keys include aria-label

## User-facing changes
none visible. 
For screen reader users, keyboard shortcuts that include punctuation will be announced by default when focused.
