### PR TITLE
Dev deps: Resolve to as-of-yet-unreleased node-canvas version

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
   "resolutions": {
     "@jupyterlab/services/ws": "8.12.0",
     "@types/react": "^18.0.26",
+    "canvas": "automattic/node-canvas#2c4d2a7dc61252913825cf9204730381051f0eba",
     "react": "^18.2.0",
     "yjs": "^13.5.40"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9123,15 +9123,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"canvas@npm:^2.11.2":
-  version: 2.11.2
-  resolution: "canvas@npm:2.11.2"
+"canvas@automattic/node-canvas#2c4d2a7dc61252913825cf9204730381051f0eba":
+  version: 3.0.0
+  resolution: "canvas@https://github.com/automattic/node-canvas.git#commit=2c4d2a7dc61252913825cf9204730381051f0eba"
   dependencies:
     "@mapbox/node-pre-gyp": ^1.0.0
-    nan: ^2.17.0
-    node-gyp: latest
+    node-addon-api: ^7.0.0
     simple-get: ^3.0.3
-  checksum: 61e554aef80022841dc836964534082ec21435928498032562089dfb7736215f039c7d99ee546b0cf10780232d9bf310950f8b4d489dc394e0fb6f6adfc97994
+  checksum: cd2d227ac1832a18e0443fa3c30470dd57a17e83b92f0e43df902af124f3b22c252205fdaee52cca9c3389d1081aa80655d783938eeb576e0337ff1a99e7f62d
   languageName: node
   linkType: hard
 
@@ -16217,15 +16216,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nan@npm:^2.17.0":
-  version: 2.17.0
-  resolution: "nan@npm:2.17.0"
-  dependencies:
-    node-gyp: latest
-  checksum: ec609aeaf7e68b76592a3ba96b372aa7f5df5b056c1e37410b0f1deefbab5a57a922061e2c5b369bae9c7c6b5e6eecf4ad2dac8833a1a7d3a751e0a7c7f849ed
-  languageName: node
-  linkType: hard
-
 "nanoclone@npm:^0.2.1":
   version: 0.2.1
   resolution: "nanoclone@npm:0.2.1"
@@ -16295,6 +16285,15 @@ __metadata:
   dependencies:
     node-gyp: latest
   checksum: 2369986bb0881ccd9ef6bacdf39550e07e089a9c8ede1cbc5fc7712d8e2faa4d50da0e487e333d4125f8c7a616c730131d1091676c9d499af1d74560756b4a18
+  languageName: node
+  linkType: hard
+
+"node-addon-api@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "node-addon-api@npm:7.0.0"
+  dependencies:
+    node-gyp: latest
+  checksum: 4349465d737e284b280fc0e5fd2384f9379bca6b7f2a5a1460bea676ba5b90bf563e7d02a9254c35b9ed808641c81d9b4ca9e1da17d2849cd07727660b00b332
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## References

No referenced issue, but the gist of it is that you can't do `pip install -e .` on certain unlucky combinations of Python version, Node version and CPU architecture, because:

* node-canvas has no pre-built packages for recent Node ABIs and/or CPU architectures:
  ```
  node-pre-gyp WARN Pre-built binaries not installable for canvas@2.11.2 and node@21.1.0 (node-v120 ABI, unknown) (falling back to source compile with node-gyp)
  ```
* `gyp` fails to work on Python 3.12 if `setuptools` isn't separately installed in the ambient environment (related: https://github.com/nodejs/gyp-next/pull/214/files)
* even if `gyp` worked on Python 3.12, building node-canvas against node-v120 ABI fails because of API changes that `nan` isn't aware of:
  ```
  /Users/akx/Library/Caches/node-gyp/21.1.0/include/node/v8-local-handle.h:253:5: error: static assertion failed due to requirement 'std::is_base_of<v8::Value, v8::Data>::value': type check
      static_assert(std::is_base_of<T, S>::value, "type check");
      ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ../../nan/nan_callbacks_12_inl.h:175:20: note: in instantiation of function template specialization 'v8::Local<v8::Value>::Local<v8::Data>' requested here
        cbinfo(info, obj->GetInternalField(kDataIndex));
  ```

This leads to `pip install -e .` failing because `canvas` is a development dependency:

```
$ pip install -e ".[dev,test]"
Obtaining file:///Users/akx/build/jupyterlab
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Installing backend dependencies ... done
  Preparing editable metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Preparing editable metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [157 lines of output]
      INFO:hatch_jupyter_builder.utils:Running jupyter-builder
      WARNING:hatch_jupyter_builder.utils:Refusing to overwrite pre-commit hook
      INFO:hatch_jupyter_builder.utils:Building with buildapi.builder
      INFO:hatch_jupyter_builder.utils:With kwargs: {'build_cmd': 'build', 'source_dir': 'packages', 'build_dir': 'dev_mode/static', 'npm': ['node', 'jupyterlab/staging/yarn.js']}
      INFO:hatch_jupyter_builder.utils:Installing build dependencies with npm.  This may take a while...
      INFO:hatch_jupyter_builder.utils:> /opt/homebrew/bin/node jupyterlab/staging/yarn.js install
      [...snip...]
      ➤ YN0000: ┌ Link step
      ➤ YN0009: │ canvas@npm:2.11.2 couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/nz/6mg9yzdj1kq8lg2tsc5y9rlc0000gn/T/xfs-e51483d2/build.log)
      ➤ YN0000: └ Completed in 1s 423ms
      ➤ YN0000: Failed with errors in 1s 986ms
$
```

Using the newer (unreleased) version fixes this since they've switched to the new more version-agnostic n-api API: https://github.com/Automattic/node-canvas/pull/2235

I don't know if/when the node-canvas folks are going to release node-canvas 3.0, but this should work in the meantime...

## Code changes

No code changes, just a dependency resolution change.

## User-facing changes

None.

## Backwards-incompatible changes

None. 