### PR TITLE
Fix `jupyter labextension watch --help`

### DIFF
--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -308,9 +308,9 @@ class WatchLabExtensionApp(BaseExtensionApp):
     )
 
     aliases = {
-        "development": "BuildLabExtensionApp.development",
-        "source-map": "BuildLabExtensionApp.source_map",
-        "core-path": "BuildLabExtensionApp.core_path",
+        "core-path": "WatchLabExtensionApp.core_path",
+        "development": "WatchLabExtensionApp.development",
+        "source-map": "WatchLabExtensionApp.source_map",
     }
 
     def run_task(self):


### PR DESCRIPTION
## References

Fixes #15540

## Code changes

This PR fixes the mis-copy-pasted dict of `aliases` so `--help` works.

h/t @jtpio in https://github.com/jupyterlab/jupyterlab/issues/15540#issuecomment-1862384521 for the tip :)

## <del>User</del> Extension developer facing changes

`--help` that actually works.

## Backwards-incompatible changes

None.