### PR TITLE
Link to paths starting at Unix-style root in the tracebacks

### DIFF
--- a/packages/coreutils/src/url.ts
+++ b/packages/coreutils/src/url.ts
@@ -141,16 +141,18 @@ export namespace URLExt {
   /**
    * Test whether the url is a local url.
    *
+   * @param allowRoot - Whether the paths starting at Unix-style filesystem root (`/`) are permitted.
+   *
    * #### Notes
    * This function returns `false` for any fully qualified url, including
    * `data:`, `file:`, and `//` protocol URLs.
    */
-  export function isLocal(url: string): boolean {
+  export function isLocal(url: string, allowRoot: boolean = false): boolean {
     const { protocol } = parse(url);
 
     return (
       (!protocol || url.toLowerCase().indexOf(protocol) !== 0) &&
-      url.indexOf('/') !== 0
+      (allowRoot ? url.indexOf('//') !== 0 : url.indexOf('/') !== 0)
     );
   }
 

--- a/packages/coreutils/test/url.spec.ts
+++ b/packages/coreutils/test/url.spec.ts
@@ -106,6 +106,10 @@ describe('@jupyterlab/coreutils', () => {
         expect(URLExt.isLocal('foo/bar.txt')).toBe(true);
         expect(URLExt.isLocal('bar.txt')).toBe(true);
       });
+      it('should optionally allow references to root', () => {
+        expect(URLExt.isLocal('/foo/bar.txt', true)).toBe(true);
+        expect(URLExt.isLocal('//foo/bar.txt', true)).toBe(false);
+      });
     });
   });
 });

--- a/packages/rendermime-interfaces/src/index.ts
+++ b/packages/rendermime-interfaces/src/index.ts
@@ -488,12 +488,14 @@ export namespace IRenderMime {
      * Whether the URL should be handled by the resolver
      * or not.
      *
+     * @param allowRoot - Whether the paths starting at Unix-style filesystem root (`/`) are permitted.
+     *
      * #### Notes
      * This is similar to the `isLocal` check in `URLExt`,
      * but can also perform additional checks on whether the
      * resolver should handle a given URL.
      */
-    isLocal?: (url: string) => boolean;
+    isLocal?: (url: string, allowRoot?: boolean) => boolean;
 
     /**
      * Resolve a path from Jupyter kernel to a path:

--- a/packages/rendermime/src/registry.ts
+++ b/packages/rendermime/src/registry.ts
@@ -373,17 +373,22 @@ export namespace RenderMimeRegistry {
      * Whether the URL should be handled by the resolver
      * or not.
      *
+     * @param allowRoot - Whether the paths starting at Unix-style filesystem root (`/`) are permitted.
+     *
      * #### Notes
      * This is similar to the `isLocal` check in `URLExt`,
      * but it also checks whether the path points to any
      * of the `IDrive`s that may be registered with the contents
      * manager.
      */
-    isLocal(url: string): boolean {
+    isLocal(url: string, allowRoot: boolean = false): boolean {
       if (this.isMalformed(url)) {
         return false;
       }
-      return URLExt.isLocal(url) || !!this._contents.driveName(decodeURI(url));
+      return (
+        URLExt.isLocal(url, allowRoot) ||
+        !!this._contents.driveName(decodeURI(url))
+      );
     }
 
     /**

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -1270,10 +1270,11 @@ namespace Private {
     let locator = anchor.dataset.locator ? '#' + anchor.dataset.locator : '';
     delete anchor.dataset.path;
     delete anchor.dataset.locator;
+    const allowRoot = true;
 
     const isLocal = resolver.isLocal
-      ? resolver.isLocal(path)
-      : URLExt.isLocal(path);
+      ? resolver.isLocal(path, allowRoot)
+      : URLExt.isLocal(path, allowRoot);
 
     // Bail if:
     // - it is not a file-like url,


### PR DESCRIPTION
## References

Fixes #15513

## Code changes

- Adds an optional `allowRoot` argument `isLocal` methods/functions.
- Sets this argument to `true` for `handlePathAnchor` used exclusively in traceback renderer

## User-facing changes

Paths to files in Unix-style root in  traceback are linkified:


| Before | After |
|--|--|
| ![image](https://github.com/jupyterlab/jupyterlab/assets/5832902/403278f5-bf03-4398-ab35-779228e5245f) | ![image](https://github.com/jupyterlab/jupyterlab/assets/5832902/3d5a191a-1a42-45fb-9ee7-8bb98dfe1c4c) |

## Backwards-incompatible changes

None