### PR TITLE
Add a title to the Plugin Manager widget

### DIFF
--- a/packages/pluginmanager-extension/src/index.ts
+++ b/packages/pluginmanager-extension/src/index.ts
@@ -97,6 +97,7 @@ const pluginmanager: JupyterFrontEndPlugin<IPluginManager> = {
       });
       content.title.label = widgetLabel;
       content.title.icon = extensionIcon;
+      content.title.caption = trans.__('Plugin Manager');
       const main = new MainAreaWidget({ content, reveal: model.ready });
 
       main.toolbar.addItem(


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Similar to https://github.com/jupyterlab/jupyterlab/pull/14681

Noticed in https://github.com/jupyter/notebook/pull/7198

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Add `widget.title.caption` to the Plugin Manager widget.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

This will mostly be useful if the widget can be opened from a menu item in Notebook 7:

![image](https://github.com/jupyterlab/jupyterlab/assets/591645/c2d507e6-c2b9-4fc0-b7b2-6eab5650150e)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
