### PR TITLE
Fixes the order of items in notebook toolbar

### DIFF
--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -572,7 +572,7 @@ export class ReactiveToolbar extends Toolbar<Widget> {
           opener.hide();
         }
         if (twiceCall) {
-          this._onResize();
+          void this._onResize();
         }
       })
       .catch(msg => {

--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -282,6 +282,9 @@ export class Toolbar<T extends Widget = Widget> extends Widget {
     return this.insertRelative(at, 0, name, widget);
   }
 
+  /**
+   * Insert an item relatively to an other item.
+   */
   protected insertRelative(
     at: string,
     offset: number,

--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -525,8 +525,11 @@ export class ReactiveToolbar extends Toolbar<Widget> {
             // Insert the widget in the right position in the toolbar.
             const widget = widgetsToAdd.shift()!;
             const name = Private.nameProperty.get(widget);
-            const index = this._widgetPositions.get(name) ?? 0;
-            this.insertItem(index, name, widget);
+            if (this._widgetPositions.has(name)) {
+              this.insertItem(this._widgetPositions.get(name)!, name, widget);
+            } else {
+              this.addItem(name, widget);
+            }
           }
         }
 

--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -374,8 +374,8 @@ export class ReactiveToolbar extends Toolbar<Widget> {
     super();
     this.insertItem(0, TOOLBAR_OPENER_NAME, this.popupOpener);
     this.popupOpener.hide();
-    this._resizer = new Throttler(async (twiceCall = false) => {
-      await this._onResize(twiceCall);
+    this._resizer = new Throttler(async (callTwice = false) => {
+      await this._onResize(callTwice);
     }, 300);
   }
 
@@ -508,7 +508,19 @@ export class ReactiveToolbar extends Toolbar<Widget> {
     }
   }
 
-  private async _onResize(twiceCall = false) {
+  /**
+   * Move the toolbar items between the reactive toolbar and the popup toolbar,
+   * depending on the width of the toolbar and the width of each item.
+   *
+   * @param callTwice - whether to call the function twice.
+   *
+   * **NOTES**
+   * The `callTwice` parameter is useful when the toolbar is displayed the first time,
+   * because the size of the items is unknown before their first rendering. The first
+   * call will usually add all the items in the main toolbar, and the second call will
+   * reorganize the items between the main toolbar and the popup toolbar.
+   */
+  private async _onResize(callTwice = false) {
     if (!(this.parent && this.parent.isAttached)) {
       return;
     }
@@ -571,7 +583,7 @@ export class ReactiveToolbar extends Toolbar<Widget> {
         } else {
           opener.hide();
         }
-        if (twiceCall) {
+        if (callTwice) {
           void this._onResize();
         }
       })

--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -419,7 +419,7 @@ export class ReactiveToolbar extends Toolbar<Widget> {
   }
 
   /**
-   * insert an item relatively to an other item.
+   * Insert an item relatively to an other item.
    */
   protected insertRelative(
     at: string,


### PR DESCRIPTION
https://github.com/jupyterlab/jupyterlab/pull/15021 changes some logic in the reactive toolbar (the one used as Notebook toolbar), to compute the items position when resizing the toolbar.

This change included a side effect when displaying a notebook loaded at startup but not displayed (in an other tab of the main area): the order of items in toolbar was reversed.

As far as I understand, for hidden notebook, the items are not added in the toolbar at startup because the toolbar was not rendered. These items were added to the responsive toolbar, and it uses the resize event to add them when the Notebook is displayed. This was not working with the new logic to order the items.

This PR also fixes the relative insert in the reactive toolbar (see https://github.com/jupyterlab/jupyterlab/issues/15509#issuecomment-1866479457 for context). This fixes the debugger item position in the toolbar when the notebook is not displayed.

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/15509

## Code changes

Changes in the reactive toolbar:
- add a relative insert method
- do not force items index to 0 if it does not have a known position

## User-facing changes

Restore the correct order of items in Notebook toolbar.

## Backwards-incompatible changes

None