### PR TITLE
Added aria-live announcement when a notebook cell is taking a long time to process. 

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -412,6 +412,13 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     hboxPanel.addWidget(vsplitPanel);
     hboxPanel.addWidget(rightHandler.sideBar);
 
+    const ariaLiveRegion = document.createElement('div');
+    ariaLiveRegion.setAttribute('aria-live', 'polite');
+    ariaLiveRegion.setAttribute('role', 'region');
+    ariaLiveRegion.setAttribute('id', 'notify-user-aria-live');
+    ariaLiveRegion.className = 'jp-ContentPanel-ariaLive';
+    hboxPanel.node.appendChild(ariaLiveRegion);
+
     rootLayout.direction = 'top-to-bottom';
     rootLayout.spacing = 0; // TODO make this configurable?
     // Use relative sizing to set the width of the side panels.

--- a/packages/application/src/status.ts
+++ b/packages/application/src/status.ts
@@ -73,13 +73,22 @@ export class LabStatus implements ILabStatus {
    */
   setBusy(): IDisposable {
     const oldBusy = this.isBusy;
+    const ariaLiveRegion = document.getElementById('notify-user-aria-live');
+    let timeout: any;
     this._busyCount++;
     if (this.isBusy !== oldBusy) {
       this._busySignal.emit(this.isBusy);
+      timeout = setTimeout(() => {
+        ariaLiveRegion!.append(
+          'A notebook cell is processing. Kernel status is busy.'
+        );
+      }, 10000);
     }
     return new DisposableDelegate(() => {
       const oldBusy = this.isBusy;
       this._busyCount--;
+      clearTimeout(timeout);
+      ariaLiveRegion!.append('Processing complete. Kernel status is idle.');
       if (this.isBusy !== oldBusy) {
         this._busySignal.emit(this.isBusy);
       }

--- a/packages/application/style/core.css
+++ b/packages/application/style/core.css
@@ -90,3 +90,8 @@ body {
   display: flex;
   align-items: center;
 }
+
+.jp-ContentPanel-ariaLive {
+  width: 0;
+  overflow: hidden;
+}


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
 [Accessibility Issues Needing Addressing for WCAG 2.1 compliance (As of Version 2.2.6)](https://github.com/jupyterlab/jupyterlab/issues/9399) - Extra Credit Issue Area # 1

Long waiting times or screens without text should inform the users with screen readers what the system is doing so they don’t think think it crashed or computer black screened (so they don’t turn restart their computer).

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
I have added an aria-live region that appends to the main content panel as that is high up in the DOM and never hidden. When the user runs a notebook cell the kernel status changes to busy and a 10 second timer is set. If this timer expires, text is append to the live region which will be announced by a screen reader. If the timer does not reach the end it is cancelled when the kernel status changes back to idle. 

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
No visual changes. Users with screen readers will get an announcement that the kernel status is busy if a notebook cell takes more than 10 seconds to complete. 

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None
