### PR TITLE
Note changes to statusbar items behaviour in extension migration guide

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -79,6 +79,11 @@ CSS class name change in the ``WindowedList`` superclass of ``StaticNotebook``
 - The notebook scroll container is now ``.jp-WindowedPanel-outer`` rather than ``.jp-Notebook``
 - Galata notebook helpers `getCell` and `getCellCount` were updated accordingly
 
+Visibility of StatusBar elements at high magnifications
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+- Statusbar items are by default now hidden at high magnification/low resolution to prevent overlap for those using the application at high magnifications. 
+- An additional ``priority`` property has been added to the function ``statusBar.registerStatusItem`` to allow them to remain visible, intended usage is for small statusbar items that either add functionality that would be particularly useful at high zoom or is inaccessible otherwise.
+
 JupyterLab 3.x to 4.x
 ---------------------
 

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -81,7 +81,7 @@ CSS class name change in the ``WindowedList`` superclass of ``StaticNotebook``
 
 Visibility of StatusBar elements at high magnifications
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-- Statusbar items are by default now hidden at high magnification/low resolution to prevent overlap for those using the application at high magnifications.
+- Statusbar items are now hidden by default at high magnification/low resolution to prevent overlap for those using the application at high magnifications.
 - An additional ``priority`` property has been added to the function ``statusBar.registerStatusItem`` to allow them to remain visible, intended usage is for small statusbar items that either add functionality that would be particularly useful at high zoom or is inaccessible otherwise.
 
 JupyterLab 3.x to 4.x

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -81,7 +81,7 @@ CSS class name change in the ``WindowedList`` superclass of ``StaticNotebook``
 
 Visibility of StatusBar elements at high magnifications
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-- Statusbar items are by default now hidden at high magnification/low resolution to prevent overlap for those using the application at high magnifications. 
+- Statusbar items are by default now hidden at high magnification/low resolution to prevent overlap for those using the application at high magnifications.
 - An additional ``priority`` property has been added to the function ``statusBar.registerStatusItem`` to allow them to remain visible, intended usage is for small statusbar items that either add functionality that would be particularly useful at high zoom or is inaccessible otherwise.
 
 JupyterLab 3.x to 4.x

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -79,7 +79,7 @@ CSS class name change in the ``WindowedList`` superclass of ``StaticNotebook``
 - The notebook scroll container is now ``.jp-WindowedPanel-outer`` rather than ``.jp-Notebook``
 - Galata notebook helpers `getCell` and `getCellCount` were updated accordingly
 
-Visibility of StatusBar elements at high magnifications
+Visibility of ``StatusBar`` elements at high magnifications
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Statusbar items are now hidden by default at high magnification/low resolution to prevent overlap for those using the application at high magnifications.
 - An additional ``priority`` property has been added to the options of ``IStatusBar.registerStatusItem`` method to allow the status bar item to remain visible; the intended usage is for small statusbar items that either add functionality that would be particularly useful at high zoom or is inaccessible otherwise.

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -80,7 +80,7 @@ CSS class name change in the ``WindowedList`` superclass of ``StaticNotebook``
 - Galata notebook helpers `getCell` and `getCellCount` were updated accordingly
 
 Visibility of ``StatusBar`` elements at high magnifications
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Statusbar items are now hidden by default at high magnification/low resolution to prevent overlap for those using the application at high magnifications.
 - An additional ``priority`` property has been added to the options of ``IStatusBar.registerStatusItem`` method to allow the status bar item to remain visible; the intended usage is for small statusbar items that either add functionality that would be particularly useful at high zoom or is inaccessible otherwise.
 

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -82,7 +82,7 @@ CSS class name change in the ``WindowedList`` superclass of ``StaticNotebook``
 Visibility of StatusBar elements at high magnifications
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Statusbar items are now hidden by default at high magnification/low resolution to prevent overlap for those using the application at high magnifications.
-- An additional ``priority`` property has been added to the function ``statusBar.registerStatusItem`` to allow them to remain visible, intended usage is for small statusbar items that either add functionality that would be particularly useful at high zoom or is inaccessible otherwise.
+- An additional ``priority`` property has been added to the options of ``IStatusBar.registerStatusItem`` method to allow the status bar item to remain visible; the intended usage is for small statusbar items that either add functionality that would be particularly useful at high zoom or is inaccessible otherwise.
 
 JupyterLab 3.x to 4.x
 ---------------------


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

[Make status bar accessible at 400% zoom by hiding items with priority of zero (default)](https://github.com/jupyterlab/jupyterlab/pull/14854#top))

## Code changes
Adding note on a new `priority` argument which defaults to 0 to ensure that when application window is narrow (less or equal to 630 pixels, which is a heuristic for 400% zoom) the items with priority of zero get hidden so that the higher priority items remain visible.

## User-facing changes
None 

## Backwards-incompatible changes

None