### PR TITLE
Show the notification center if the status bar is disabled

### DIFF
--- a/packages/apputils-extension/src/notificationplugin.tsx
+++ b/packages/apputils-extension/src/notificationplugin.tsx
@@ -40,6 +40,7 @@ import {
   ReadonlyJSONObject,
   ReadonlyJSONValue
 } from '@lumino/coreutils';
+import { Widget } from '@lumino/widgets';
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
 import type {
@@ -629,6 +630,15 @@ export const notificationPlugin: JupyterFrontEndPlugin<void> = {
         align: 'right',
         rank: -1
       });
+    } else {
+      // if the status bar is not available, position the notification
+      // status in the bottom right corner of the page
+      notificationStatus.node.style.position = 'fixed';
+      notificationStatus.node.style.bottom = '0';
+      // 10px is the default padding for the status bar
+      notificationStatus.node.style.right = '10px';
+      Widget.attach(notificationStatus, document.body);
+      notificationStatus.show();
     }
   }
 };


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/15567

[jupyterlab-notification-center-no-statusbar.webm](https://github.com/jupyterlab/jupyterlab/assets/591645/7fc7b2e4-28dd-467d-b5bb-8395048a8030)


## Code changes

If the status bar is not available, still position the `notificationStatus` widget on the page, so it can be used as the anchor for the popup.

## User-facing changes

Notebook 7 users will be able to open the notification center via the same `View > Show Notifications` menu entry as in JupyterLab: https://github.com/jupyter/notebook/issues/7195

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
