### PR TITLE
Revert "Bump actions/labeler from 4 to 5"

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,6 +11,6 @@ jobs:
     name: Update PR Labels
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Reverts jupyterlab/jupyterlab#15582

New version issue tracked in https://github.com/jupyterlab/jupyterlab/issues/15488