### PR TITLE
Fix ctrl+s notification incorrectly showing up in RTC mode

### DIFF
--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -876,7 +876,10 @@ function addCommands(
           if (saveInProgress.has(context)) {
             return;
           }
-          if (!context.contentsModel?.writable) {
+          if (
+            !context.contentsModel?.writable &&
+            !context.model.collaborative
+          ) {
             let type = (args._luminoEvent as ReadonlyPartialJSONObject)?.type;
             if (args._luminoEvent && type === 'keybinding') {
               readonlyNotification(context.path);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

#15547 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Adds a check to verify that a document is not rtc mode along with the check on if a document is not writable for raising a notification that a document is read-only.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

The user will no longer see an improper notification that a file is read-only when they use the keybinding "ctrl+s" when in rtc mode

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
