### PR TITLE
Restore previous Galata `page.filebrowser.refresh()` timeout logic

### DIFF
--- a/galata/src/helpers/filebrowser.ts
+++ b/galata/src/helpers/filebrowser.ts
@@ -216,7 +216,9 @@ export class FileBrowserHelper {
         '.jp-ToolbarButtonComponent[data-command="filebrowser:refresh"]'
       );
 
-    // wait for network response or timeout
+    // Use Promise.race to manage the network response timeout
+    // This is useful for lab-based applications not using the Jupyter Server Contents API.
+    // such as JupyterLite, to avoid having the waitForAPIResponse call fail.
     await Promise.race([
       page.waitForTimeout(2000),
       this.contents.waitForAPIResponse(async () => {

--- a/galata/src/helpers/filebrowser.ts
+++ b/galata/src/helpers/filebrowser.ts
@@ -217,12 +217,12 @@ export class FileBrowserHelper {
       );
 
     // wait for network response or timeout
-    await this.contents.waitForAPIResponse(
-      async () => {
+    await Promise.race([
+      page.waitForTimeout(2000),
+      this.contents.waitForAPIResponse(async () => {
         await item.click();
-      },
-      { timeout: 2000 }
-    );
+      })
+    ]);
     // wait for DOM rerender
     await page.waitForTimeout(200);
   }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

As noticed in https://github.com/jupyterlite/jupyterlite/pull/1263#issuecomment-1878410761, https://github.com/jupyterlab/jupyterlab/pull/15021 seems to have changed the logic of the `page.filebrowser.refresh()` Galata helper, more than just updating the selector.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Restore the previous timeout logic, to allow for using this helper in lab-based applications using a different contents API (like in JupyterLite storing files in the browser).

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
