### PR TITLE
Fix syntax error in benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: Execute benchmark tests
-    if: ${{ github.event.issue.pull_request && (contains(github.event.comment.body, 'please run benchmarks') }}
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, 'please run benchmarks') }}
 
     runs-on: ubuntu-22.04
 


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/15569

Follow up to https://github.com/jupyterlab/jupyterlab/pull/15523

## Code changes

remove spurious `(`

## User-facing changes

None

## Backwards-incompatible changes

None