### PR TITLE
Fix markdown getting un-rendered when focusing on a different cell

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -2781,13 +2781,16 @@ export class Notebook extends StaticNotebook {
       if (widget.editorWidget && !widget.editorWidget.node.contains(target)) {
         this.setMode('command', { focus: false });
       }
+
+      // Cell index needs to be updated before changing mode,
+      // otherwise the previous cell may get un-rendered.
+      this.activeCellIndex = index;
+
       // If the editor has focus, ensure edit mode.
       const node = widget.editorWidget?.node;
       if (node?.contains(target)) {
         this.setMode('edit', { focus: false });
       }
-      // This will set the focus
-      this.activeCellIndex = index;
     } else {
       // No cell has focus, ensure command mode.
       this.setMode('command', { focus: false });

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -1345,6 +1345,24 @@ describe('@jupyter/notebook', () => {
           expect(widget.events).toEqual(expect.arrayContaining(['focusin']));
           expect(widget.mode).toBe('command');
         });
+
+        it('should not unrender previously active markdown cell', async () => {
+          widget.model!.sharedModel.insertCell(0, {
+            cell_type: 'markdown',
+            source: '# Hello'
+          });
+          const mdCell = widget.widgets[0] as MarkdownCell;
+          if (!mdCell.inViewport) {
+            await signalToPromise(mdCell.inViewportChanged);
+          }
+          widget.activeCellIndex = 0;
+          expect(mdCell.rendered).toBe(true);
+          const cellToActivate = widget.widgets[1];
+          expect(widget.mode).toBe('command');
+          simulate(cellToActivate.editorWidget!.node, 'focusin');
+          expect(widget.mode).toBe('edit');
+          expect(mdCell.rendered).toBe(true);
+        });
       });
 
       describe('focusout', () => {


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/15595

## Code changes

- Add regression unit test
- Move change of active index ahead of mode enforcement as it assumes the active index is already set

## User-facing changes

| Before | After |
|--|--|
| ![before](https://github.com/jupyterlab/jupyterlab/assets/5832902/215828ef-3c4b-4c98-bda7-27571ac761ed) | ![after](https://github.com/jupyterlab/jupyterlab/assets/5832902/a3cdfdd5-6ddc-45e4-8db4-931df793c601) |

## Backwards-incompatible changes

None
