### PR TITLE
Fix new line getting inserted when running cells with `Ctrl` + `Enter`

### DIFF
--- a/galata/test/galata/notebook.spec.ts
+++ b/galata/test/galata/notebook.spec.ts
@@ -25,6 +25,9 @@ test.describe('Notebook Tests', () => {
     await page.notebook.setCell(0, 'markdown', '## This is a markdown cell');
     expect(await page.notebook.getCellCount()).toBe(1);
     expect(await page.notebook.getCellType(0)).toBe('markdown');
+    expect(await page.notebook.getCellTextInput(0)).toBe(
+      '## This is a markdown cell'
+    );
 
     // Wait for kernel to be idle
     await page.locator('#jp-main-statusbar').getByText('Idle').waitFor();
@@ -40,6 +43,7 @@ test.describe('Notebook Tests', () => {
     await page.notebook.addCell('raw', 'This is a raw cell');
     expect(await page.notebook.getCellCount()).toBe(2);
     expect(await page.notebook.getCellType(1)).toBe('raw');
+    expect(await page.notebook.getCellTextInput(1)).toBe('This is a raw cell');
 
     // Wait for kernel to be idle and the debug switch to appear
     await Promise.all([
@@ -58,6 +62,7 @@ test.describe('Notebook Tests', () => {
     await page.notebook.addCell('code', '2 + 2');
     expect(await page.notebook.getCellCount()).toBe(2);
     expect(await page.notebook.getCellType(1)).toBe('code');
+    expect(await page.notebook.getCellTextInput(1)).toBe('2 + 2');
 
     // Wait for kernel to be idle
     await page.locator('#jp-main-statusbar').getByText('Idle').waitFor();
@@ -65,6 +70,13 @@ test.describe('Notebook Tests', () => {
     expect(await page.getByRole('main').screenshot()).toMatchSnapshot(
       'code-cell.png'
     );
+  });
+
+  test('Should copy cell input content with new lines', async ({ page }) => {
+    await page.notebook.createNew();
+
+    await page.notebook.setCell(0, 'code', 'a\nb\nc');
+    expect(await page.notebook.getCellTextInput(0)).toBe('a\nb\nc');
   });
 
   test('Run Cells', async ({ page }) => {

--- a/galata/test/jupyterlab/cells.test.ts
+++ b/galata/test/jupyterlab/cells.test.ts
@@ -32,3 +32,25 @@ test.describe('Cells', () => {
     );
   });
 });
+
+test.describe('Run Cells With Keyboard', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.notebook.createNew();
+  });
+
+  test('Run code cell with Ctrl + Enter', async ({ page }) => {
+    await page.notebook.setCell(0, 'code', '2**32');
+    await page.notebook.enterCellEditingMode(0);
+    const initialOutput = await page.notebook.getCellTextOutput(0);
+    expect(initialOutput).toBe(null);
+    await page.keyboard.press('Control+Enter');
+
+    // Confirm that the cell has be executed by checking output
+    const output = await page.notebook.getCellTextOutput(0);
+    expect(output).toEqual(['4294967296']);
+
+    // Expect the input to NOT include an extra line;
+    const text = await page.notebook.getCellTextInput(0);
+    expect(text).toBe('2**32');
+  });
+});

--- a/packages/codemirror/src/commands.ts
+++ b/packages/codemirror/src/commands.ts
@@ -15,6 +15,11 @@ import {
 } from '@jupyterlab/codeeditor';
 
 /**
+ * Selector for a widget that can run code.
+ */
+const CODE_RUNNER_SELECTOR = '[data-jp-code-runner]';
+
+/**
  * CodeMirror commands namespace
  */
 export namespace StateCommands {
@@ -60,5 +65,15 @@ export namespace StateCommands {
 
     const arg = { state: target.state, dispatch: target.dispatch };
     return insertNewlineAndIndent(arg);
+  }
+
+  /**
+   * Prevent insertion of new line when running cell with Ctrl/Command + Enter
+   */
+  export function preventNewLineOnRun(target: { dom: HTMLElement }): boolean {
+    if (target.dom.closest(CODE_RUNNER_SELECTOR)) {
+      return true;
+    }
+    return false;
   }
 }

--- a/packages/codemirror/src/extension.ts
+++ b/packages/codemirror/src/extension.ts
@@ -704,6 +704,10 @@ export namespace EditorExtensionRegistry {
         name: 'keymap',
         default: [
           {
+            key: 'Mod-Enter',
+            run: StateCommands.preventNewLineOnRun
+          },
+          {
             key: 'Enter',
             run: StateCommands.completerOrInsertNewLine
           },


### PR DESCRIPTION
## References

Fixes #15605

## Code changes

- [x] add `getCellTextInput()` helper to galata; I found needing it again and again (previously e.g. in inline completer tests) and the naive solution of using `.textContent()` does not capture line breaks (details explained in code comments)
- [x] add a test showing the new line is incorrectly inserted (the test in the first commit is expected to fail to demonstrate it works)
- [x] fix the issue by suppressing CodeMirror default handler on <kbd>Ctrl</kbd> + <kbd>Enter</kbd> / <kbd>Command</kbd> + <kbd>Enter</kbd> for editors embedded in code runners

## User-facing changes

| Before | After |
|--|--|
| ![before](https://github.com/jupyterlab/jupyterlab/assets/5832902/6bee9062-477e-421c-809f-320500d98e73) | ![after](https://github.com/jupyterlab/jupyterlab/assets/5832902/2cc4c7a0-cce9-4620-9421-cb02134aa5d6) |



## Backwards-incompatible changes

None