### PR TITLE
Fix link to yarn docs in extension migration guide

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -161,7 +161,7 @@ package configuration.
 .. note::
 
    You can find more information on upgrading Yarn from version 1 to version 3 in
-   [Yarn documentation](https://v3.yarnpkg.com/getting-started/migration).
+   `Yarn documentation <https://v3.yarnpkg.com/getting-started/migration>`_.
 
 If you are hit by multiple versions of the same packages (like ``@lumino/widgets``),
 TypeScript may complain that the types are not matching. One possible solution


### PR DESCRIPTION
## References

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/14989

## Code changes

Fixes link incorrectly using markdown rather than RST syntax.

## User-facing changes

Before:

![image](https://github.com/jupyterlab/jupyterlab/assets/5832902/d5634d81-f118-49a5-a9f6-9cb850731e66)

After:

![image](https://github.com/jupyterlab/jupyterlab/assets/5832902/c5a31c70-39d6-4a07-8036-6c57d949561c)

## Backwards-incompatible changes

None