### PR TITLE
Fix outputarea package from not detecting updates

### DIFF
--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -515,7 +515,9 @@ export class OutputArea extends Widget {
     }
     const panel = this.layout.widgets[index] as Panel;
     const renderer = (
-      panel.widgets ? panel.widgets.filter(it => "renderModel" in it).pop() : panel
+      panel.widgets
+        ? panel.widgets.filter(it => 'renderModel' in it).pop()
+        : panel
     ) as IRenderMime.IRenderer;
     // Check whether it is safe to reuse renderer:
     // - Preferred mime type has not changed

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -513,10 +513,7 @@ export class OutputArea extends Widget {
     if (index >= this._maxNumberOutputs) {
       return;
     }
-    const panel = this.layout.widgets[index] as Panel;
-    const renderer = (
-      panel.widgets ? panel.widgets[1] : panel
-    ) as IRenderMime.IRenderer;
+    const renderer = this.layout.widgets[index] as IRenderMime.IRenderer;
     // Check whether it is safe to reuse renderer:
     // - Preferred mime type has not changed
     // - Isolation has not changed

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -513,7 +513,10 @@ export class OutputArea extends Widget {
     if (index >= this._maxNumberOutputs) {
       return;
     }
-    const renderer = this.layout.widgets[index] as IRenderMime.IRenderer;
+    const panel = this.layout.widgets[index] as Panel;
+    const renderer = (
+      panel.widgets ? panel.widgets.filter(it => "renderModel" in it).pop() : panel
+    ) as IRenderMime.IRenderer;
     // Check whether it is safe to reuse renderer:
     // - Preferred mime type has not changed
     // - Isolation has not changed

--- a/packages/outputarea/test/widget.spec.ts
+++ b/packages/outputarea/test/widget.spec.ts
@@ -6,7 +6,8 @@ import { createSessionContext } from '@jupyterlab/apputils/lib/testutils';
 import {
   IOutputAreaModel,
   OutputArea,
-  OutputAreaModel
+  OutputAreaModel,
+  SimplifiedOutputArea
 } from '@jupyterlab/outputarea';
 import { KernelManager } from '@jupyterlab/services';
 import { JupyterServer } from '@jupyterlab/testing';
@@ -435,6 +436,27 @@ describe('outputarea/widget', () => {
         expect(reply2!.content.status).toBe('ok');
         widget1.dispose();
         await ipySessionContext.shutdown();
+      });
+
+      it('should continuously render delayed outputs', async () => {
+        const model0 = new OutputAreaModel({ trusted: true });
+        const widget0 = new SimplifiedOutputArea({
+          model: model0,
+          rendermime: rendermime
+        });
+        let ipySessionContext: SessionContext;
+        ipySessionContext = await createSessionContext({
+          kernelPreference: { name: 'python3' }
+        });
+        await ipySessionContext.initialize();
+        const code = [
+          "import time",
+          "for i in range(3):",
+          "    print(f\"Hello Jupyter! {i}\")",
+          "    time.sleep(1)"
+        ].join('\n');
+        await SimplifiedOutputArea.execute(code, widget0, ipySessionContext);
+        expect(model0.toJSON()[0].text).toBe(widget0.node.textContent)
       });
     });
 

--- a/packages/outputarea/test/widget.spec.ts
+++ b/packages/outputarea/test/widget.spec.ts
@@ -450,13 +450,13 @@ describe('outputarea/widget', () => {
         });
         await ipySessionContext.initialize();
         const code = [
-          "import time",
-          "for i in range(3):",
-          "    print(f\"Hello Jupyter! {i}\")",
-          "    time.sleep(1)"
+          'import time',
+          'for i in range(3):',
+          '    print(f"Hello Jupyter! {i}")',
+          '    time.sleep(1)'
         ].join('\n');
         await SimplifiedOutputArea.execute(code, widget0, ipySessionContext);
-        expect(model0.toJSON()[0].text).toBe(widget0.node.textContent)
+        expect(model0.toJSON()[0].text).toBe(widget0.node.textContent);
       });
     });
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
https://github.com/jupyterlab/jupyterlab/issues/15633 https://github.com/jupyterlab/jupyterlab/issues/15004
Changes introduced in https://github.com/jupyterlab/jupyterlab/pull/14911

## Code changes

The code updates the renderer retrieval in the OutputArea widget by directly accessing the renderer from the layout.widgets array. 

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Output panels are still able to display plots as raised in https://github.com/jupyterlab/jupyterlab/issues/14564#issuecomment-1554097391 while still able to detect ongoing output streams.

https://github.com/jupyterlab/jupyterlab/assets/68586800/433dc5cb-3cf5-4a4f-9159-5def7af7b71b




<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
