### PR TITLE
update to mermaid 10.7.0

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - hatchling >=1.5.0
   # run
   - async-lru >=1.0.0
+  - httpx >=0.25.0
   - ipykernel
   - jinja2 >=3.0.3
   - jupyter_core

--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -46,7 +46,7 @@
     "@jupyterlab/rendermime-interfaces": "^3.9.0-beta.0",
     "@lumino/coreutils": "^2.1.2",
     "@lumino/widgets": "^2.3.1",
-    "mermaid": "^10.6.0"
+    "mermaid": "^10.7.0"
   },
   "devDependencies": {
     "@types/jest": "^29.2.0",

--- a/packages/mermaid/src/manager.ts
+++ b/packages/mermaid/src/manager.ts
@@ -286,6 +286,7 @@ namespace Private {
       theme,
       fontFamily,
       maxTextSize: 100000,
+      maxEdges: 100000,
       startOnLoad: false
     });
     return true;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,20 +35,20 @@ classifiers = [
 ]
 dependencies = [
     "async_lru>=1.0.0",
+    "httpx>=0.25.0",
     "importlib-metadata>=4.8.3;python_version<\"3.10\"",
     "importlib-resources>=1.4;python_version<\"3.9\"",
     "ipykernel",
     "jinja2>=3.0.3",
     "jupyter_core",
-    "jupyter-lsp>=2.0.0",
     "jupyter_server>=2.4.0,<3",
+    "jupyter-lsp>=2.0.0",
     "jupyterlab_server>=2.19.0,<3",
     "notebook_shim>=0.2",
     "packaging",
-    "traitlets",
-    "tornado>=6.2.0",
     "tomli;python_version<\"3.11\"",
-    "httpx>=0.25.0",
+    "tornado>=6.2.0",
+    "traitlets",
 ]
 dynamic = [
     "version",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4007,7 +4007,7 @@ __metadata:
     "@lumino/widgets": ^2.3.1
     "@types/jest": ^29.2.0
     jest: ^29.2.0
-    mermaid: ^10.6.0
+    mermaid: ^10.7.0
     rimraf: ~5.0.5
     typedoc: ~0.24.7
     typescript: ~5.1.6
@@ -11056,10 +11056,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elkjs@npm:^0.8.2":
-  version: 0.8.2
-  resolution: "elkjs@npm:0.8.2"
-  checksum: ed615c485fa4ac1e858af509df24fdc9f61f2c6576df5f79f6a31c733fda69f235f53cd36af037aa9d2b8a935cb4f823fbd89d784b67f6e51be5100306ea1b39
+"elkjs@npm:^0.9.0":
+  version: 0.9.1
+  resolution: "elkjs@npm:0.9.1"
+  checksum: c8813d6d9574b7d7e68e83d3d2bf0ba6a2f71bf121808d00e7a641f985c093de5ef6f0746101bf4dd74ea2242504d048a87684d5fdfe3dc3be5b1ce79f204cfb
   languageName: node
   linkType: hard
 
@@ -15534,9 +15534,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mermaid@npm:^10.6.0":
-  version: 10.6.0
-  resolution: "mermaid@npm:10.6.0"
+"mermaid@npm:^10.7.0":
+  version: 10.7.0
+  resolution: "mermaid@npm:10.7.0"
   dependencies:
     "@braintree/sanitize-url": ^6.0.1
     "@types/d3-scale": ^4.0.3
@@ -15549,7 +15549,7 @@ __metadata:
     dagre-d3-es: 7.0.10
     dayjs: ^1.11.7
     dompurify: ^3.0.5
-    elkjs: ^0.8.2
+    elkjs: ^0.9.0
     khroma: ^2.0.0
     lodash-es: ^4.17.21
     mdast-util-from-markdown: ^1.3.0
@@ -15558,7 +15558,7 @@ __metadata:
     ts-dedent: ^2.2.0
     uuid: ^9.0.0
     web-worker: ^1.2.0
-  checksum: 7dd4789aaba2ecf42aa51bea5e4d884d9fc1cc58e87de1a3cb8c14e4551cd9be895155954c8bb5f391d3f6dd6a11a82987ef1fe7937ec79ccdf599ca140d95be
+  checksum: 5cc4be164c3a4272240cd093369382d7880e7fe13cea0bc2966ae5a8160a7b42ff117c256ab942b7dcbd0f341d2e19780251b334e0b23e906404a108547eed82
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## References

- n/a

## Code changes

- [x] bump to mermaid 10.7.0
  - [ ] update `maxEdges` to a large number
- [x] add `httpx` to binder
- [x] sort deps in `pyproject.toml` 

## User-facing changes

- larger diagrams will be able to draw correctly (albeit slowly)

## Backwards-incompatible changes

- n/a (`maxEdges` be overloaded in a drawing config if an author _wants_ their diagram to fail to draw)