### PR TITLE
Remove the add cell button from the tabbable item

### DIFF
--- a/packages/notebook/src/notebookfooter.ts
+++ b/packages/notebook/src/notebookfooter.ts
@@ -21,6 +21,7 @@ export class NotebookFooter extends Widget {
     super({ node: document.createElement('button') });
     const trans = notebook.translator.load('jupyterlab');
     this.addClass(NOTEBOOK_FOOTER_CLASS);
+    this.node.setAttribute('tabindex', '-1');
     this.node.innerText = trans.__('Click to add a cell.');
   }
 


### PR DESCRIPTION
This PR set the "add cell" button (in the notebook footer) as not reachable using tab key.

The button should now be reached using arrow keys only, when navigating between the cells of the notebook.

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/15611

## Code changes

Add attribute `tabindex=-1` to the "add cell" button.

## User-facing changes

The button is not reached anymore using tab key, to avoid scrolling to the bottom of the notebook unintentionally.

## Backwards-incompatible changes

None