### PR TITLE
Fix search highlights removal on clearing input box

### DIFF
--- a/galata/test/jupyterlab/notebook-search.test.ts
+++ b/galata/test/jupyterlab/notebook-search.test.ts
@@ -177,6 +177,28 @@ test.describe('Notebook Search', () => {
     await page.waitForSelector('text=1/2');
   });
 
+  test('Clear search when box is empty', async ({ page }) => {
+    // Open search box
+    await page.keyboard.press('Control+f');
+
+    // Search for "test"
+    await page.keyboard.press('Control+f');
+    await page.fill('[placeholder="Find"]', 'test');
+
+    // Should find "test" matches
+    await page.locator('text=1/2').waitFor();
+    await expect(page.locator('[placeholder="Find"]')).toHaveValue('test');
+
+    // Remove the "test" query
+    for (let i = 0; i < 4; i++) {
+      await page.press('[placeholder="Find"]', 'Backspace');
+    }
+    await expect(page.locator('[placeholder="Find"]')).toHaveValue('');
+
+    // Should reset the search to a clean state
+    await page.locator('text=-/-').waitFor();
+  });
+
   test('Close with Escape', async ({ page }) => {
     // Open search box
     await page.keyboard.press('Control+f');

--- a/packages/documentsearch/src/searchmodel.ts
+++ b/packages/documentsearch/src/searchmodel.ts
@@ -357,9 +357,12 @@ export class SearchDocumentModel
       if (query) {
         this._searchActive = true;
         await this.searchProvider.startQuery(query, this._filters);
-        // Emit state change as the index needs to be updated
-        this.stateChanged.emit();
+      } else {
+        this._searchActive = false;
+        await this.searchProvider.endQuery();
       }
+      // Emit state change as the index needs to be updated
+      this.stateChanged.emit();
     } catch (reason) {
       this._parsingError = reason.toString();
       this.stateChanged.emit();


### PR DESCRIPTION
## References

Fixes #15688

## Code changes

- add integration test
- add unit test
- fix the problem by ending search when input query is empty

## User-facing changes

Clearing search box clears active search.

| Before | After |
|--|--|
| ![before](https://github.com/jupyterlab/jupyterlab/assets/5832902/cd93145a-d8d2-4b24-adf8-67dc457b9c9c)| ![after](https://github.com/jupyterlab/jupyterlab/assets/5832902/cbcf53b2-3db3-4fce-a195-d067fb86a14f) |



## Backwards-incompatible changes

None