### PR TITLE
Enable default file browsers with different properties (aria label, title...)

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -311,15 +311,15 @@ const defaultFileBrowser: JupyterFrontEndPlugin<IDefaultFileBrowser> = {
   id: '@jupyterlab/filebrowser-extension:default-file-browser',
   description: 'Provides the default file browser',
   provides: IDefaultFileBrowser,
-  requires: [IFileBrowserFactory, ITranslator],
-  optional: [IRouter, JupyterFrontEnd.ITreeResolver, ILabShell],
+  requires: [IFileBrowserFactory],
+  optional: [IRouter, JupyterFrontEnd.ITreeResolver, ILabShell, ITranslator],
   activate: async (
     app: JupyterFrontEnd,
     fileBrowserFactory: IFileBrowserFactory,
-    translator: ITranslator,
     router: IRouter | null,
     tree: JupyterFrontEnd.ITreeResolver | null,
-    labShell: ILabShell | null
+    labShell: ILabShell | null,
+    translator: ITranslator
   ): Promise<IDefaultFileBrowser> => {
     const { commands } = app;
     const trans = translator.load('jupyterlab');

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -319,10 +319,10 @@ const defaultFileBrowser: JupyterFrontEndPlugin<IDefaultFileBrowser> = {
     router: IRouter | null,
     tree: JupyterFrontEnd.ITreeResolver | null,
     labShell: ILabShell | null,
-    translator: ITranslator
+    translator: ITranslator | null
   ): Promise<IDefaultFileBrowser> => {
     const { commands } = app;
-    const trans = translator.load('jupyterlab');
+    const trans = (translator ?? nullTranslator).load('jupyterlab');
 
     // Manually restore and load the default file browser.
     const defaultBrowser = fileBrowserFactory.createFileBrowser('filebrowser', {

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -780,7 +780,7 @@ const openBrowserTabPlugin: JupyterFrontEndPlugin<void> = {
           )
         );
       },
-      icon: folderIcon.bindprops({ stylesheet: 'menuItem' }),
+      icon: addIcon.bindprops({ stylesheet: 'menuItem' }),
       label: args =>
         args['mode'] === 'single-document'
           ? trans.__('Open in Simple Mode')
@@ -1125,7 +1125,7 @@ function addCommands(
         // ...or leave the icon blank
         return ft?.icon?.bindprops({ stylesheet: 'menuItem' });
       } else {
-        return addIcon.bindprops({ stylesheet: 'menuItem' });
+        return folderIcon.bindprops({ stylesheet: 'menuItem' });
       }
     },
     label: args =>

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -40,7 +40,7 @@ import { Contents } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IStateDB } from '@jupyterlab/statedb';
 import { IStatusBar } from '@jupyterlab/statusbar';
-import { ITranslator } from '@jupyterlab/translation';
+import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import {
   addIcon,
   closeIcon,

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -336,7 +336,7 @@ const defaultFileBrowser: JupyterFrontEndPlugin<IDefaultFileBrowser> = {
       'aria-label',
       trans.__('File Browser Section')
     );
-    defaultBrowser.node.setAttribute('title', trans.__('Default Filebrowser'));
+    defaultBrowser.node.setAttribute('title', trans.__('File Browser'));
     defaultBrowser.title.icon = folderIcon;
 
     // Show the current file browser shortcut in its title.
@@ -346,12 +346,9 @@ const defaultFileBrowser: JupyterFrontEndPlugin<IDefaultFileBrowser> = {
       );
       if (binding) {
         const ks = binding.keys.map(CommandRegistry.formatKeystroke).join(', ');
-        defaultBrowser.title.caption = trans.__(
-          'Default File Browser (%1)',
-          ks
-        );
+        defaultBrowser.title.caption = trans.__('File Browser (%1)', ks);
       } else {
-        defaultBrowser.title.caption = trans.__('Default File Browser');
+        defaultBrowser.title.caption = trans.__('File Browser');
       }
     };
     updateBrowserTitle();


### PR DESCRIPTION
In the filebrowser-extension, this PR aims at modfiying the defaultFileBrowser and in the browserWidget plugins to enable to replace the default filebrowser by a custom one having different properties such as aria label, icon etc...

cc @afshin @DenisaCG 

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes issue #15689

## Code changes

Move some parts of codes from the widgetBrowser plugin to the defaultFileBrowser one.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
