### PR TITLE
Fix `overrides.json` not working for shortcuts

### DIFF
--- a/.github/workflows/linuxjs-tests.yml
+++ b/.github/workflows/linuxjs-tests.yml
@@ -51,6 +51,7 @@ jobs:
             js-services,
             js-settingeditor,
             js-settingregistry,
+            js-shortcuts-extension,
             js-statedb,
             js-statusbar,
             js-testing,

--- a/packages/shortcuts-extension/package.json
+++ b/packages/shortcuts-extension/package.json
@@ -57,6 +57,7 @@
   "devDependencies": {
     "@jupyterlab/testing": "^4.1.0-rc.0",
     "@types/jest": "^29.2.0",
+    "jest": "^29.2.0",
     "rimraf": "~5.0.5",
     "typedoc": "~0.24.7",
     "typescript": "~5.1.6"

--- a/packages/shortcuts-extension/test/shortcuts.spec.ts
+++ b/packages/shortcuts-extension/test/shortcuts.spec.ts
@@ -6,6 +6,8 @@ import * as plugin from '@jupyterlab/shortcuts-extension';
 import { IDataConnector } from '@jupyterlab/statedb';
 import { CommandRegistry } from '@lumino/commands';
 import { Platform } from '@lumino/domutils';
+import { signalToPromise } from '@jupyterlab/testing';
+
 import pluginSchema from '../schema/shortcuts.json';
 
 describe('@jupyterlab/shortcut-extension', () => {
@@ -93,6 +95,153 @@ describe('@jupyterlab/shortcut-extension', () => {
         .composite) as ISettingRegistry.IShortcut[];
 
       expect(shortcuts).toHaveLength(Platform.IS_MAC ? 2 : 1);
+    });
+
+    it('should respect default shortcuts (e.g. from `overrides.json`)', async () => {
+      const shared: Omit<ISettingRegistry.IPlugin, 'id'> = {
+        data: {
+          composite: {},
+          user: {}
+        },
+        raw: '{}',
+        version: 'test'
+      };
+      const foo = {
+        ...shared,
+        id: 'foo:settings',
+        schema: {
+          type: 'object',
+          'jupyter.lab.shortcuts': [
+            {
+              command: 'application:close',
+              keys: ['Ctrl W'],
+              selector: 'body'
+            },
+            {
+              command: 'application:close-all',
+              keys: ['Alt W'],
+              selector: 'body'
+            }
+          ]
+        }
+      };
+      const bar = {
+        ...shared,
+        id: 'bar:settings',
+        schema: {
+          type: 'object',
+          'jupyter.lab.shortcuts': [
+            {
+              command: 'console:create',
+              keys: ['Ctrl T'],
+              selector: 'body'
+            },
+            {
+              command: 'console:inject',
+              keys: ['Ctrl I'],
+              selector: 'body'
+            }
+          ]
+        }
+      };
+      const defaults = {
+        ...shared,
+        id: plugin.default.id,
+        schema: {
+          ...(pluginSchema as any),
+          properties: {
+            shortcuts: {
+              default: [
+                {
+                  command: 'application:close',
+                  keys: ['Ctrl W'],
+                  selector: 'body',
+                  disabled: true
+                },
+                {
+                  command: 'console:inject',
+                  keys: ['Ctrl J'],
+                  selector: 'body'
+                },
+                {
+                  command: 'help:open',
+                  keys: ['Ctrl H'],
+                  selector: 'body'
+                }
+              ]
+            }
+          }
+        }
+      };
+
+      const connector: IDataConnector<
+        ISettingRegistry.IPlugin,
+        string,
+        string,
+        string
+      > = {
+        fetch: jest.fn().mockImplementation((id: string) => {
+          switch (id) {
+            case foo.id:
+              return foo;
+            case bar.id:
+              return bar;
+            case defaults.id:
+              return defaults;
+            default:
+              return {};
+          }
+        }),
+        list: jest.fn(),
+        save: jest.fn(),
+        remove: jest.fn()
+      };
+
+      const settingRegistry = new SettingRegistry({
+        connector
+      });
+
+      void plugin.default.activate(
+        {
+          commands: new CommandRegistry()
+        } as any,
+        settingRegistry
+      );
+
+      // Note: we are also testing that the shortcuts overrides are not lost
+      // when settings are fetched before or after the shortcuts settings.
+      await settingRegistry.load(foo.id);
+      const settings = await settingRegistry.load(plugin.default.id);
+      await settingRegistry.load(bar.id);
+
+      // Ensure the signal about loading has already propagated to listeners
+      await signalToPromise(settingRegistry.pluginChanged);
+
+      const shortcuts = (await settings.get('shortcuts')
+        .composite) as ISettingRegistry.IShortcut[];
+
+      const commandsWithShortcuts = shortcuts.map(shortcut => shortcut.command);
+
+      // `application:close` was disabled by override but `application:close-all` was not
+      expect(commandsWithShortcuts).not.toContain('application:close');
+      expect(commandsWithShortcuts).toContain('application:close-all');
+
+      // `help:open` was added by override
+      expect(commandsWithShortcuts).toContain('help:open');
+
+      // `console:inject` should now be accessible with both Ctrl + I and Ctrl + J
+      const injectBindings = shortcuts.filter(
+        s => s.command === 'console:inject'
+      );
+      expect(injectBindings.map(s => s.keys[0])).toContain('Ctrl J');
+      expect(injectBindings.map(s => s.keys[0])).toContain('Ctrl I');
+
+      // `console:create` should not be touched by the override
+      const createBindings = shortcuts.filter(
+        s => s.command === 'console:create'
+      );
+      expect(createBindings.length).toEqual(1);
+      expect(createBindings[0].keys[0]).toEqual('Ctrl T');
     });
 
     it('should ignore colliding shortcuts', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4693,6 +4693,7 @@ __metadata:
     "@lumino/keyboard": ^2.0.1
     "@lumino/widgets": ^2.3.1
     "@types/jest": ^29.2.0
+    jest: ^29.2.0
     react: ^18.2.0
     rimraf: ~5.0.5
     typedoc: ~0.24.7


### PR DESCRIPTION
## References

Fixes #15713

## Code changes

- [x] add test ensuring that the default settings (such as from `overrides.json`) are respected - it should fail in the <s>first</s> second commit (it seems this test group was not run on CI, second commit fixes it)
- [x] fix the overrides getting lost

## User-facing changes

Shortcuts modifications defined in `overrides.json` now work.

## Backwards-incompatible changes

None