### PR TITLE
Run Mermaid tests on CI

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -276,6 +276,14 @@ pkg:mathjax:
     - packages/mathjax-extension/**/*
     - packages/mathjax-extension/*
 
+pkg:mermaid:
+- changed-files:
+  - any-glob-to-any-file:
+    - packages/mermaid/**/*
+    - packages/mermaid/*
+    - packages/mermaid-extension/**/*
+    - packages/mermaid-extension/*
+
 pkg:notebook:
 - changed-files:
   - any-glob-to-any-file:

--- a/.github/workflows/linuxjs-tests.yml
+++ b/.github/workflows/linuxjs-tests.yml
@@ -40,6 +40,7 @@ jobs:
             js-logconsole,
             js-lsp,
             js-mainmenu,
+            js-mermaid,
             js-metadataform,
             js-metapackage,
             js-nbformat,

--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -32,6 +32,7 @@
   ],
   "scripts": {
     "build": "tsc -b",
+    "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
     "test": "jest",


### PR DESCRIPTION
## References

#15716 highlighted that not all packages are tested on CI; while it handles the missing `shortcuts-extension` group (which will need to be backported) I also found that `mermaid` was missing (by using [this search](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab+%22%5C%22test%5C%22%3A+%5C%22jest%5C%22%22&type=code)) which is what this PR is fixing. Mermaid was only added in 4.1 so no need for backporting.

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None