### PR TITLE
Fix cell toolbar getting stuck when using collapse cell

### DIFF
--- a/packages/cell-toolbar/src/celltoolbartracker.ts
+++ b/packages/cell-toolbar/src/celltoolbartracker.ts
@@ -137,7 +137,7 @@ export class CellToolbarTracker implements IDisposable {
     }
 
     const activeCell = notebook.activeCell;
-    // change previous active cell
+    // Change previously active cell.
     this._previousActiveCell = activeCell;
     if (activeCell === null || activeCell.inputHidden) {
       return;

--- a/packages/cell-toolbar/src/celltoolbartracker.ts
+++ b/packages/cell-toolbar/src/celltoolbartracker.ts
@@ -137,6 +137,8 @@ export class CellToolbarTracker implements IDisposable {
     }
 
     const activeCell = notebook.activeCell;
+    // change previous active cell
+    this._previousActiveCell = activeCell;
     if (activeCell === null || activeCell.inputHidden) {
       return;
     }
@@ -144,7 +146,6 @@ export class CellToolbarTracker implements IDisposable {
     activeCell.model.metadataChanged.connect(this._onMetadataChanged, this);
 
     this._addToolbar(activeCell.model);
-    this._previousActiveCell = activeCell;
   }
 
   get isDisposed(): boolean {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->
Fixes https://github.com/jupyterlab/jupyterlab/issues/15671

## Code changes

<!-- Describe the code changes and how they address the issue. -->
The reason for the bug is that after the folded cell is clicked, the `_onActiveCellChanged` function is triggered, but because the`inputHidden` attribute of the folded cell activeCell is true, the `_previousActiveCell` variable is not updated.
After that, clicking other cells cannot destroy the previous active cell toolbar

<img width="1288" alt="截屏2024-02-02 08 25 32" src="https://github.com/jupyterlab/jupyterlab/assets/49218295/ee2e966e-ac3e-481b-8ed2-3dfeb7d419d5">

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Before the change

https://github.com/jupyterlab/jupyterlab/assets/49218295/f34f61e8-0049-4ef4-9d97-bcec72023e18

After the change

https://github.com/jupyterlab/jupyterlab/assets/49218295/5da68ee0-2d7b-4cff-bd98-4237cb0f2b07


<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
nothing