### PR TITLE
Fix running kernels listing for kernels without icons

### DIFF
--- a/packages/running/src/index.tsx
+++ b/packages/running/src/index.tsx
@@ -192,13 +192,13 @@ function Item(props: {
             ) : (
               <caretDownIcon.react tag="span" stylesheet="runningItem" />
             ))}
-          {typeof icon === 'string' ? (
-            icon ? (
+          {icon ? (
+            typeof icon === 'string' ? (
               <img src={icon} />
-            ) : undefined
-          ) : (
-            <icon.react tag="span" stylesheet="runningItem" />
-          )}
+            ) : (
+              <icon.react tag="span" stylesheet="runningItem" />
+            )
+          ) : undefined}
           <span
             className={ITEM_LABEL_CLASS}
             title={title}


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Issue #14962

## Code changes

This patch prevents a  crash in running kernels panel jupyterlab component (packages/running) in case of use of kernels that do not provide an icon (like "all the kernels" kernel).

## User-facing changes

Kernels tha do not provide an icon should be visible as text only.

## Backwards-incompatible changes

None
