### PR TITLE
Disable (shift + ) alt + number shortcuts on Mac

### DIFF
--- a/packages/application-extension/schema/commands.json
+++ b/packages/application-extension/schema/commands.json
@@ -50,6 +50,7 @@
     {
       "command": "application:toggle-side-tabbar",
       "keys": ["Alt 1"],
+      "macKeys": [""],
       "selector": "body",
       "args": {
         "side": "left",
@@ -59,6 +60,7 @@
     {
       "command": "application:toggle-side-tabbar",
       "keys": ["Alt 2"],
+      "macKeys": [""],
       "selector": "body",
       "args": {
         "side": "left",
@@ -68,6 +70,7 @@
     {
       "command": "application:toggle-side-tabbar",
       "keys": ["Alt 3"],
+      "macKeys": [""],
       "selector": "body",
       "args": {
         "side": "left",
@@ -77,6 +80,7 @@
     {
       "command": "application:toggle-side-tabbar",
       "keys": ["Alt 4"],
+      "macKeys": [""],
       "selector": "body",
       "args": {
         "side": "left",
@@ -86,6 +90,7 @@
     {
       "command": "application:toggle-side-tabbar",
       "keys": ["Alt 5"],
+      "macKeys": [""],
       "selector": "body",
       "args": {
         "side": "left",
@@ -95,6 +100,7 @@
     {
       "command": "application:toggle-side-tabbar",
       "keys": ["Alt 6"],
+      "macKeys": [""],
       "selector": "body",
       "args": {
         "side": "left",
@@ -104,6 +110,7 @@
     {
       "command": "application:toggle-side-tabbar",
       "keys": ["Alt 7"],
+      "macKeys": [""],
       "selector": "body",
       "args": {
         "side": "left",
@@ -113,6 +120,7 @@
     {
       "command": "application:toggle-side-tabbar",
       "keys": ["Alt 8"],
+      "macKeys": [""],
       "selector": "body",
       "args": {
         "side": "left",
@@ -122,6 +130,7 @@
     {
       "command": "application:toggle-side-tabbar",
       "keys": ["Alt 9"],
+      "macKeys": [""],
       "selector": "body",
       "args": {
         "side": "left",
@@ -131,6 +140,7 @@
     {
       "command": "application:toggle-side-tabbar",
       "keys": ["Alt 0"],
+      "macKeys": [""],
       "selector": "body",
       "args": {
         "side": "left",
@@ -140,6 +150,7 @@
     {
       "command": "application:toggle-side-tabbar",
       "keys": ["Alt Shift 1"],
+      "macKeys": [""],
       "selector": "body",
       "args": {
         "side": "right",
@@ -149,6 +160,7 @@
     {
       "command": "application:toggle-side-tabbar",
       "keys": ["Alt Shift 2"],
+      "macKeys": [""],
       "selector": "body",
       "args": {
         "side": "right",
@@ -158,6 +170,7 @@
     {
       "command": "application:toggle-side-tabbar",
       "keys": ["Alt Shift 3"],
+      "macKeys": [""],
       "selector": "body",
       "args": {
         "side": "right",
@@ -167,6 +180,7 @@
     {
       "command": "application:toggle-side-tabbar",
       "keys": ["Alt Shift 4"],
+      "macKeys": [""],
       "selector": "body",
       "args": {
         "side": "right",
@@ -176,6 +190,7 @@
     {
       "command": "application:toggle-side-tabbar",
       "keys": ["Alt Shift 5"],
+      "macKeys": [""],
       "selector": "body",
       "args": {
         "side": "right",
@@ -185,6 +200,7 @@
     {
       "command": "application:toggle-side-tabbar",
       "keys": ["Alt Shift 6"],
+      "macKeys": [""],
       "selector": "body",
       "args": {
         "side": "right",
@@ -194,6 +210,7 @@
     {
       "command": "application:toggle-side-tabbar",
       "keys": ["Alt Shift 7"],
+      "macKeys": [""],
       "selector": "body",
       "args": {
         "side": "right",
@@ -203,6 +220,7 @@
     {
       "command": "application:toggle-side-tabbar",
       "keys": ["Alt Shift 8"],
+      "macKeys": [""],
       "selector": "body",
       "args": {
         "side": "right",
@@ -212,6 +230,7 @@
     {
       "command": "application:toggle-side-tabbar",
       "keys": ["Alt Shift 9"],
+      "macKeys": [""],
       "selector": "body",
       "args": {
         "side": "right",
@@ -221,6 +240,7 @@
     {
       "command": "application:toggle-side-tabbar",
       "keys": ["Alt Shift 0"],
+      "macKeys": [""],
       "selector": "body",
       "args": {
         "side": "right",


### PR DESCRIPTION
## References

Fixes #15744 

## Code changes

Adds `"macKeys": [""],` to problematic shortcuts. Note that the keys list has to be non-empty to be picked up over OS-agnostic `"keys"` list (because of [this logic](https://github.com/jupyterlab/lumino/blob/c0ee4a71c3db03817617a9e51cb6bf4e331eed27/packages/commands/src/index.ts#L1195-L1200) in lumino).

## User-facing changes

Shortcuts which are problematic on Mac are no longer enabled by default on Mac; users can still enable them if they like so.

## Backwards-incompatible changes

None