### PR TITLE
Fix typing in editable elements inside of open shadow DOM

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -89,10 +89,12 @@ between cells, especially impacting users with accessibility needs.
 In JupyterLab 4.1+ the focus stays on the active cell when switching to command
 mode; this requires all shortcut selectors to be adjusted as follows:
 
-- ``.jp-Notebook:focus.jp-mod-commandMode`` should be replaced with ``.jp-Notebook.jp-mod-commandMode :focus:not(:read-write)``
-- ``.jp-Notebook:focus`` should be replaced with ``.jp-Notebook.jp-mod-commandMode :focus:not(:read-write)``
-- ``[data-jp-traversable]:focus`` should be replaced with ``.jp-Notebook.jp-mod-commandMode :focus:not(:read-write)``
-- ``[data-jp-kernel-user]:focus`` should be replaced with ``[data-jp-kernel-user] :focus:not(:read-write)``
+- ``.jp-Notebook:focus.jp-mod-commandMode``, ``.jp-Notebook:focus``, and ``[data-jp-traversable]:focus`` should be replaced with:
+  - ``.jp-Notebook.jp-mod-commandMode :focus:not(:read-write)`` for JupyterLab 4.1.0+
+  - ``.jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus`` for JupyterLab 4.1.1+
+- ``[data-jp-kernel-user]:focus`` should be replaced with:
+  - ``[data-jp-kernel-user] :focus:not(:read-write)`` for JupyterLab 4.1.0+
+  - ``[data-jp-kernel-user]:not(.jp-mod-readWrite) :focus`` for JupyterLab 4.1.1+
 
 Please note that ``:not(:read-write)`` fragment disables shortcuts
 when text fields  (such as cell editor) are focused to avoid intercepting
@@ -100,6 +102,17 @@ characters typed by the user into the text fields, however if your shortcut
 does not correspond to any key/typographic character (e.g. most shortcuts
 with :kbd:`Ctrl` modifier) you may prefer to drop this fragment
 if you want the shortcut to be active in text fields.
+
+Further, JupyterLab 4.1.1 introduced indicator class ``.jp-mod-readWrite``
+that is applied to the notebook node when the active element accepts
+keyboard input as defined by ``:read-write`` selector. This indicator
+class is required to detect ``:read-write`` elements which are nested
+within an *open* shadow DOM (such as Panel framework widgets).
+
+If your framework uses a *closed* shadow DOM, or expects keyboard
+interactions on elements that are not recognised as editable by browser
+heuristics of ``:read-write`` selector, you need to set a data attribute
+`lm-suppress-shortcuts` on the outer host element to suppress shortcuts.
 
 To prevent breaking the user experience these changes are made transparently
 in the background, but will emit a warning and extension developers should

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -94,7 +94,7 @@ mode; this requires all shortcut selectors to be adjusted as follows:
   - ``.jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus`` for JupyterLab 4.1.1+
 - ``[data-jp-kernel-user]:focus`` should be replaced with:
   - ``[data-jp-kernel-user] :focus:not(:read-write)`` for JupyterLab 4.1.0+
-  - ``[data-jp-kernel-user]:not(.jp-mod-readWrite) :focus`` for JupyterLab 4.1.1+
+  - ``[data-jp-kernel-user]:not(.jp-mod-readWrite) :focus:not(:read-write)`` for JupyterLab 4.1.1+
 
 Please note that ``:not(:read-write)`` fragment disables shortcuts
 when text fields  (such as cell editor) are focused to avoid intercepting

--- a/docs/source/extension/notebook.rst
+++ b/docs/source/extension/notebook.rst
@@ -190,12 +190,14 @@ enabling quick access to cell- and notebook-specific actions.
 These shortcuts are only active when the notebook is in command mode
 and the active element is non-editable,
 as signalled by absence of ``.jp-mod-readWrite`` class on the notebook node.
-This class is set if active element is editable as ascertained by matching
+This class is set if the active element is editable as ascertained by matching
 to the ``:read-write`` pseudo-selector, and accounts for any elements nested
 in the open shadow DOM, but not for the closed shadow DOM nor non-editable
 elements with custom key event handlers (such as
 ``<div contenteditable="false" onkeydown="alert()" tabindex="0"></div>``).
-If your output widget uses closed shadow DOM or non-editable elements with custom
+If your output widget (for example created with ``IPython.display.HTML``,
+or created by your MIME renderer on cell output in a notebook or console)
+uses closed shadow DOM or non-editable elements with custom
 key event handlers, you may wish to set ``lm-suppress-shortcuts`` data attribute
 on the host element to prevent side-effects from the command-mode actions, e.g:
 

--- a/docs/source/extension/notebook.rst
+++ b/docs/source/extension/notebook.rst
@@ -175,6 +175,41 @@ The ipywidgets widget manager is an example of an extension that adds a
 notebook-specific renderer, since rendering a widget depends on
 notebook-specific widget state.
 
+Keyboard interaction model
+""""""""""""""""""""""""""
+
+Multiple elements can receive focus in the Notebook:
+- the main toolbar,
+- cells,
+- cell components (editor, toolbar, outputs).
+
+When the focus is outside of the cell input editor,
+the Notebook switches to so-called "command" mode.
+In the command mode additional keyboard shortcuts are accessible to the user,
+enabling quick access to cell- and notebook-specific actions.
+These shortcuts are only active when the notebook is in command mode
+and the active element is non-editable,
+as signalled by absence of ``.jp-mod-readWrite`` class on the notebook node.
+This class is set if active element is editable as ascertained by matching
+to the ``:read-write`` pseudo-selector, and accounts for any elements nested
+in the open shadow DOM, but not for the closed shadow DOM nor non-editable
+elements with custom key event handlers (such as
+``<div contenteditable="false" onkeydown="alert()" tabindex="0"></div>``).
+If your output widget uses closed shadow DOM or non-editable elements with custom
+key event handlers, you may wish to set ``lm-suppress-shortcuts`` data attribute
+on the host element to prevent side-effects from the command-mode actions, e.g:
+
+.. code:: html
+
+   <div
+     contenteditable="false"
+     onkeydown="alert()"
+     tabindex="1"
+     data-lm-suppress-shortcuts="true"
+   >
+     Click on me and press "A" with and without "lm-suppress-shortcuts"
+   </div>
+
 .. _extend-notebook-plugin:
 
 How to extend the Notebook plugin

--- a/examples/notebook/src/commands.ts
+++ b/examples/notebook/src/commands.ts
@@ -396,17 +396,17 @@ export const setupCommands = (
       command: COMMAND_IDS.findPrevious
     },
     {
-      selector: '.jp-Notebook.jp-mod-commandMode :focus:not(:read-write)',
+      selector: '.jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus',
       keys: ['I', 'I'],
       command: COMMAND_IDS.interrupt
     },
     {
-      selector: '.jp-Notebook.jp-mod-commandMode :focus:not(:read-write)',
+      selector: '.jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus',
       keys: ['0', '0'],
       command: COMMAND_IDS.restart
     },
     {
-      selector: '.jp-Notebook.jp-mod-commandMode :focus:not(:read-write)',
+      selector: '.jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus',
       keys: ['Enter'],
       command: COMMAND_IDS.editMode
     },
@@ -416,7 +416,7 @@ export const setupCommands = (
       command: COMMAND_IDS.commandMode
     },
     {
-      selector: 'jp-Notebook.jp-mod-commandMode :focus:not(:read-write)',
+      selector: '.jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus',
       keys: ['Shift M'],
       command: COMMAND_IDS.merge
     },
@@ -426,42 +426,42 @@ export const setupCommands = (
       command: COMMAND_IDS.split
     },
     {
-      selector: 'jp-Notebook.jp-mod-commandMode :focus:not(:read-write)',
+      selector: '.jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus',
       keys: ['J'],
       command: COMMAND_IDS.selectBelow
     },
     {
-      selector: 'jp-Notebook.jp-mod-commandMode :focus:not(:read-write)',
+      selector: '.jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus',
       keys: ['ArrowDown'],
       command: COMMAND_IDS.selectBelow
     },
     {
-      selector: 'jp-Notebook.jp-mod-commandMode :focus:not(:read-write)',
+      selector: '.jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus',
       keys: ['K'],
       command: COMMAND_IDS.selectAbove
     },
     {
-      selector: 'jp-Notebook.jp-mod-commandMode :focus:not(:read-write)',
+      selector: '.jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus',
       keys: ['ArrowUp'],
       command: COMMAND_IDS.selectAbove
     },
     {
-      selector: 'jp-Notebook.jp-mod-commandMode :focus:not(:read-write)',
+      selector: '.jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus',
       keys: ['Shift K'],
       command: COMMAND_IDS.extendAbove
     },
     {
-      selector: 'jp-Notebook.jp-mod-commandMode :focus:not(:read-write)',
+      selector: '.jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus',
       keys: ['Shift J'],
       command: COMMAND_IDS.extendBelow
     },
     {
-      selector: 'jp-Notebook.jp-mod-commandMode :focus:not(:read-write)',
+      selector: '.jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus',
       keys: ['Z'],
       command: COMMAND_IDS.undo
     },
     {
-      selector: 'jp-Notebook.jp-mod-commandMode :focus:not(:read-write)',
+      selector: '.jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus',
       keys: ['Y'],
       command: COMMAND_IDS.redo
     }

--- a/galata/test/jupyterlab/outputarea-stdin.test.ts
+++ b/galata/test/jupyterlab/outputarea-stdin.test.ts
@@ -73,11 +73,11 @@ test.describe('Stdin for ipdb', () => {
     await expect(page.locator(ACTIVE_INPUT)).toHaveValue('foofoox');
   });
 
-  const typingScecnarios = [
+  const typingScenarios = [
     { name: 'stdin box', code: 'input()', selector: '.jp-Stdin-input' },
     { name: 'shadow DOM input', code: openShadowDOM, selector: '#shadow-input' }
   ];
-  for (const testCase of typingScecnarios) {
+  for (const testCase of typingScenarios) {
     test(`Typing in ${testCase.name}`, async ({ page }) => {
       // Test to ensure that notebook shortcuts do not capture text typed into inputs.
       // This may not be sufficient to ensure no conflicts with other languages but

--- a/galata/test/jupyterlab/outputarea-stdin.test.ts
+++ b/galata/test/jupyterlab/outputarea-stdin.test.ts
@@ -14,6 +14,12 @@ print('before sleep')
 sleep(0.1)
 print('after sleep')`;
 
+const openShadowDOM = `\
+from IPython.display import HTML
+HTML("""<div id='root'></div><script>
+document.querySelector('#root').attachShadow({mode: 'open'}).innerHTML = '<input id="shadow-input"/>';
+</script>""")`;
+
 const ACTIVE_INPUT =
   '.jp-OutputArea-stdin-item:not(.jp-OutputArea-stdin-hiding) .jp-Stdin-input';
 
@@ -67,31 +73,39 @@ test.describe('Stdin for ipdb', () => {
     await expect(page.locator(ACTIVE_INPUT)).toHaveValue('foofoox');
   });
 
-  test('Typing in stdin box', async ({ page }) => {
-    // Test to ensure that notebook shortcuts do not capture text typed into inputs.
-    // This may not be sufficient to ensure no conflicts with other languages but
-    // should catch the most severe issues.
-    const alphabet = 'abcdefghijklmnopqrstuvwxyz';
-    const digits = '0123456789';
-    await page.notebook.setCell(0, 'code', 'input()');
-    // Run the selected (only) cell without proceeding and without waiting
-    // for it to complete (as it should stay waiting for input).
-    await page.keyboard.press('Control+Enter');
+  const typingScecnarios = [
+    { name: 'stdin box', code: 'input()', selector: '.jp-Stdin-input' },
+    { name: 'shadow DOM input', code: openShadowDOM, selector: '#shadow-input' }
+  ];
+  for (const testCase of typingScecnarios) {
+    test(`Typing in ${testCase.name}`, async ({ page }) => {
+      // Test to ensure that notebook shortcuts do not capture text typed into inputs.
+      // This may not be sufficient to ensure no conflicts with other languages but
+      // should catch the most severe issues.
+      const alphabet = 'abcdefghijklmnopqrstuvwxyz';
+      const digits = '0123456789';
+      await page.notebook.setCell(0, 'code', testCase.code);
+      // Run the selected (only) cell without proceeding and without waiting
+      // for it to complete (as it should stay waiting for input).
+      await page.keyboard.press('Control+Enter');
 
-    await page.waitForSelector('.jp-Stdin-input');
-    for (const letter of alphabet) {
-      await page.keyboard.press(`Key${letter.toUpperCase()}`);
-    }
-    for (const letter of alphabet) {
-      await page.keyboard.press(`Shift+Key${letter.toUpperCase()}`);
-    }
-    for (const digit of digits) {
-      await page.keyboard.press(`Digit${digit}`);
-    }
-    await expect(page.locator('.jp-Stdin-input')).toHaveValue(
-      alphabet + alphabet.toUpperCase() + digits
-    );
-  });
+      await page.waitForSelector(testCase.selector);
+      await page.focus(testCase.selector);
+
+      for (const letter of alphabet) {
+        await page.keyboard.press(`Key${letter.toUpperCase()}`);
+      }
+      for (const letter of alphabet) {
+        await page.keyboard.press(`Shift+Key${letter.toUpperCase()}`);
+      }
+      for (const digit of digits) {
+        await page.keyboard.press(`Digit${digit}`);
+      }
+      await expect(page.locator(testCase.selector)).toHaveValue(
+        alphabet + alphabet.toUpperCase() + digits
+      );
+    });
+  }
 
   test('Subsequent execution in short succession', async ({ page }) => {
     await page.notebook.setCell(0, 'code', loopedInput);

--- a/packages/apputils/src/domutils.ts
+++ b/packages/apputils/src/domutils.ts
@@ -50,4 +50,22 @@ export namespace DOMUtils {
   export function createDomID(): string {
     return `id-${UUID.uuid4()}`;
   }
+
+  /**
+   * Check whether the active element descendant from given parent is editable.
+   * When checking active elements it includes elements in the open shadow DOM.
+   */
+  export function hasActiveEditableElement(
+    parent: Node | DocumentFragment,
+    root: ShadowRoot | Document = document
+  ): boolean {
+    const element = root.activeElement;
+    return !!(
+      element &&
+      parent.contains(element) &&
+      (element.matches(':read-write') ||
+        (element.shadowRoot &&
+          hasActiveEditableElement(element.shadowRoot, element.shadowRoot)))
+    );
+  }
 }

--- a/packages/apputils/test/domutils.spec.ts
+++ b/packages/apputils/test/domutils.spec.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { DOMUtils } from '@jupyterlab/apputils';
+
+describe('@jupyterlab/apputils', () => {
+  describe('DOMUtils', () => {
+    describe('hasActiveEditableElement', () => {
+      const testCases = [
+        // editable elements
+        ['.input', true],
+        ['.textarea', true],
+        ['.div-editable', true],
+        // non-editable elements
+        ['.input-readonly', false],
+        ['.textarea-readonly', false],
+        ['.div', false]
+      ];
+
+      const div = document.createElement('div');
+      div.innerHTML = `
+        <div class="light-host">
+          <input class="input" />
+          <input class="input-readonly" readonly />
+          <textarea class="textarea"></textarea>
+          <textarea class="textarea-readonly" readonly></textarea>
+          <div class="div" tabindex="1"></div>
+          <div class="div-editable" contenteditable="true" tabindex="1"></div>
+        </div>
+        <div class="shadow-host">
+        </div>
+      `;
+      document.body.appendChild(div);
+
+      const lightHost = div.querySelector('.light-host')!;
+      const shadowHost = div.querySelector('.shadow-host')!;
+      const shadowRoot = shadowHost.attachShadow({ mode: 'open' });
+      // mirror test cases from light DOM in the shadow DOM
+      shadowRoot.innerHTML = lightHost.innerHTML;
+
+      it.each(testCases)(
+        'should work in light DOM: `%s` element should result in `%s`',
+        (selector, expected) => {
+          const element = lightHost.querySelector(
+            selector as string
+          ) as HTMLElement;
+          element.focus();
+
+          const result = DOMUtils.hasActiveEditableElement(div);
+          expect(result).toBe(expected);
+        }
+      );
+
+      it.each(testCases)(
+        'should work in shadow DOM: `%s` element should result in `%s`',
+        (selector, expected) => {
+          const element = shadowRoot.querySelector(
+            selector as string
+          ) as HTMLElement;
+          element.focus();
+
+          const result = DOMUtils.hasActiveEditableElement(div);
+          expect(result).toBe(expected);
+        }
+      );
+    });
+  });
+});

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -884,7 +884,7 @@ export class CodeConsole extends Widget {
    * Update the console node with class indicating read-write state.
    */
   private _updateReadWrite(): void {
-    // TODO: de-duplicate with code in console/src/widget.ts
+    // TODO: de-duplicate with code in notebook/src/widget.ts
     const inReadWrite = DOMUtils.hasActiveEditableElement(this.node);
     this.node.classList.toggle(READ_WRITE_CLASS, inReadWrite);
     }

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -887,7 +887,6 @@ export class CodeConsole extends Widget {
     // TODO: de-duplicate with code in notebook/src/widget.ts
     const inReadWrite = DOMUtils.hasActiveEditableElement(this.node);
     this.node.classList.toggle(READ_WRITE_CLASS, inReadWrite);
-    }
   }
 
   private _banner: RawCell | null = null;

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -71,7 +71,8 @@ const CONTENT_CLASS = 'jp-CodeConsole-content';
 const INPUT_CLASS = 'jp-CodeConsole-input';
 
 /**
- * The class name added to the notebook when the focused notebook element takes keyboard input.
+ * The class name added to the console when an element within it is focused
+ * and takes keyboard input, such as <input> and <div contenteditable>
  *
  * This class is also effective when the focused element is in shadow DOM.
  */
@@ -885,11 +886,7 @@ export class CodeConsole extends Widget {
   private _updateReadWrite(): void {
     // TODO: de-duplicate with code in console/src/widget.ts
     const inReadWrite = DOMUtils.hasActiveEditableElement(this.node);
-    const hasReadWriteClass = this.node.classList.contains(READ_WRITE_CLASS);
-    if (inReadWrite && !hasReadWriteClass) {
-      this.node.classList.add(READ_WRITE_CLASS);
-    } else if (!inReadWrite && hasReadWriteClass) {
-      this.node.classList.remove(READ_WRITE_CLASS);
+    this.node.classList.toggle(READ_WRITE_CLASS, inReadWrite);
     }
   }
 

--- a/packages/mainmenu-extension/schema/plugin.json
+++ b/packages/mainmenu-extension/schema/plugin.json
@@ -270,22 +270,22 @@
     {
       "command": "kernelmenu:interrupt",
       "keys": ["I", "I"],
-      "selector": "[data-jp-kernel-user] :focus:not(:read-write)"
+      "selector": "[data-jp-kernel-user]:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "kernelmenu:restart",
       "keys": ["0", "0"],
-      "selector": "[data-jp-kernel-user] :focus:not(:read-write)"
+      "selector": "[data-jp-kernel-user]:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "kernelmenu:restart-and-clear",
       "keys": [""],
-      "selector": "[data-jp-kernel-user] :focus:not(:read-write)"
+      "selector": "[data-jp-kernel-user]:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "kernelmenu:shutdown",
       "keys": [""],
-      "selector": "[data-jp-kernel-user] :focus:not(:read-write)"
+      "selector": "[data-jp-kernel-user]:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "runmenu:restart-and-run-all",

--- a/packages/mainmenu-extension/schema/plugin.json
+++ b/packages/mainmenu-extension/schema/plugin.json
@@ -270,22 +270,22 @@
     {
       "command": "kernelmenu:interrupt",
       "keys": ["I", "I"],
-      "selector": "[data-jp-kernel-user]:not(.jp-mod-readWrite) :focus"
+      "selector": "[data-jp-kernel-user]:not(.jp-mod-readWrite) :focus:not(:read-write)"
     },
     {
       "command": "kernelmenu:restart",
       "keys": ["0", "0"],
-      "selector": "[data-jp-kernel-user]:not(.jp-mod-readWrite) :focus"
+      "selector": "[data-jp-kernel-user]:not(.jp-mod-readWrite) :focus:not(:read-write)"
     },
     {
       "command": "kernelmenu:restart-and-clear",
       "keys": [""],
-      "selector": "[data-jp-kernel-user]:not(.jp-mod-readWrite) :focus"
+      "selector": "[data-jp-kernel-user]:not(.jp-mod-readWrite) :focus:not(:read-write)"
     },
     {
       "command": "kernelmenu:shutdown",
       "keys": [""],
-      "selector": "[data-jp-kernel-user]:not(.jp-mod-readWrite) :focus"
+      "selector": "[data-jp-kernel-user]:not(.jp-mod-readWrite) :focus:not(:read-write)"
     },
     {
       "command": "runmenu:restart-and-run-all",

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -369,62 +369,62 @@
     {
       "command": "notebook:change-cell-to-code",
       "keys": ["Y"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-1",
       "keys": ["1"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-2",
       "keys": ["2"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-3",
       "keys": ["3"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-4",
       "keys": ["4"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-5",
       "keys": ["5"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-6",
       "keys": ["6"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-markdown",
       "keys": ["M"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-raw",
       "keys": ["R"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:copy-cell",
       "keys": ["C"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:cut-cell",
       "keys": ["X"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:delete-cell",
       "keys": ["D", "D"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:enter-command-mode",
@@ -454,123 +454,123 @@
     {
       "command": "notebook:extend-marked-cells-above",
       "keys": ["Shift ArrowUp"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:extend-marked-cells-above",
       "keys": ["Shift K"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:extend-marked-cells-top",
       "keys": ["Shift Home"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:extend-marked-cells-below",
       "keys": ["Shift ArrowDown"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:extend-marked-cells-bottom",
       "keys": ["Shift End"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:extend-marked-cells-below",
       "keys": ["Shift J"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:insert-cell-above",
       "keys": ["A"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:insert-cell-below",
       "keys": ["B"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:merge-cells",
       "keys": ["Shift M"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:merge-cell-above",
       "keys": ["Ctrl Backspace"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:merge-cell-below",
       "keys": ["Ctrl Shift M"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cursor-down",
       "keys": ["ArrowDown"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cursor-down",
       "keys": ["J"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cursor-up",
       "keys": ["ArrowUp"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cursor-up",
       "keys": ["K"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cursor-heading-above-or-collapse",
       "keys": ["ArrowLeft"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cursor-heading-below-or-expand",
       "keys": ["ArrowRight"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:insert-heading-above",
       "keys": ["Shift A"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:insert-heading-below",
       "keys": ["Shift B"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:collapse-all-headings",
       "keys": ["Ctrl Shift ArrowLeft"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:expand-all-headings",
       "keys": ["Ctrl Shift ArrowRight"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:paste-cell-below",
       "keys": ["V"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:redo-cell-action",
       "keys": ["Shift Z"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:run-cell",
       "macKeys": ["Ctrl Enter"],
       "keys": [],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:run-cell",
@@ -581,7 +581,7 @@
     {
       "command": "notebook:run-cell",
       "keys": ["Accel Enter"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:run-cell",
@@ -591,7 +591,7 @@
     {
       "command": "notebook:run-cell-and-insert-below",
       "keys": ["Alt Enter"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:run-cell-and-insert-below",
@@ -611,7 +611,7 @@
     {
       "command": "viewmenu:line-numbering",
       "keys": ["Shift L"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "viewmenu:match-brackets",
@@ -621,7 +621,7 @@
     {
       "command": "notebook:select-all",
       "keys": ["Accel A"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:split-cell-at-cursor",
@@ -631,22 +631,22 @@
     {
       "command": "notebook:undo-cell-action",
       "keys": ["Z"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:toggle-render-side-by-side-current",
       "keys": ["Shift R"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cell-up",
       "keys": ["Ctrl Shift ArrowUp"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cell-down",
       "keys": ["Ctrl Shift ArrowDown"],
-      "selector": ".jp-Notebook.jp-mod-commandMode :focus:not(:read-write)"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     }
   ],
   "title": "Notebook",

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -2784,12 +2784,7 @@ export class Notebook extends StaticNotebook {
    */
   private _updateReadWrite(): void {
     const inReadWrite = DOMUtils.hasActiveEditableElement(this.node);
-    const hasReadWriteClass = this.node.classList.contains(READ_WRITE_CLASS);
-    if (inReadWrite && !hasReadWriteClass) {
-      this.node.classList.add(READ_WRITE_CLASS);
-    } else if (!inReadWrite && hasReadWriteClass) {
-      this.node.classList.remove(READ_WRITE_CLASS);
-    }
+    this.node.classList.toggle(READ_WRITE_CLASS, inReadWrite);
   }
 
   /**

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -94,7 +94,8 @@ const OTHER_SELECTED_CLASS = 'jp-mod-multiSelected';
 const UNCONFINED_CLASS = 'jp-mod-unconfined';
 
 /**
- * The class name added to the notebook when the focused notebook element takes keyboard input.
+ * The class name added to the notebook when an element within it is focused
+ * and takes keyboard input, such as focused <input> or <div contenteditable>.
  *
  * This class is also effective when the focused element is in shadow DOM.
  */

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import { DOMUtils } from '@jupyterlab/apputils';
 import {
   Cell,
   CodeCell,
@@ -2782,7 +2783,7 @@ export class Notebook extends StaticNotebook {
    * Update the notebook node with class indicating read-write state.
    */
   private _updateReadWrite(): void {
-    const inReadWrite = Private.inReadWrite(document, this.node);
+    const inReadWrite = DOMUtils.hasActiveEditableElement(this.node);
     const hasReadWriteClass = this.node.classList.contains(READ_WRITE_CLASS);
     if (inReadWrite && !hasReadWriteClass) {
       this.node.classList.add(READ_WRITE_CLASS);
@@ -2852,7 +2853,7 @@ export class Notebook extends StaticNotebook {
   /**
    * Handle `focusout` events for the notebook.
    */
-  private _evtFocusOut(event: MouseEvent): void {
+  private _evtFocusOut(event: FocusEvent): void {
     // Update read-write class state.
     this._updateReadWrite();
 
@@ -3077,23 +3078,6 @@ namespace Private {
         );
       }
     }
-  }
-
-  /**
-   * Check whether the active element, including elements in shadow DOM, matches `:read-write` selector.
-   */
-  export function inReadWrite(
-    root: ShadowRoot | Document,
-    parent: Node | DocumentFragment
-  ): boolean {
-    const element = root.activeElement;
-    return !!(
-      element &&
-      parent.contains(element) &&
-      (element.matches(':read-write') ||
-        (element.shadowRoot &&
-          inReadWrite(element.shadowRoot, element.shadowRoot)))
-    );
   }
 
   /**

--- a/packages/settingregistry/src/settingregistry.ts
+++ b/packages/settingregistry/src/settingregistry.ts
@@ -1563,7 +1563,7 @@ namespace Private {
       },
       {
         old: '[data-jp-kernel-user] :focus:not(:read-write)',
-        new: '[data-jp-kernel-user]:not(.jp-mod-readWrite) :focus',
+        new: '[data-jp-kernel-user]:not(.jp-mod-readWrite) :focus:not(:read-write)',
         versionDeprecated: 'JupyterLab 4.1.1'
       }
     ];

--- a/packages/settingregistry/src/settingregistry.ts
+++ b/packages/settingregistry/src/settingregistry.ts
@@ -1558,7 +1558,7 @@ namespace Private {
       },
       {
         old: '[data-jp-kernel-user]:focus',
-        new: '[data-jp-kernel-user]:not(.jp-mod-readWrite) :focus',
+        new: '[data-jp-kernel-user]:not(.jp-mod-readWrite) :focus:not(:read-write)',
         versionDeprecated: 'JupyterLab 4.1'
       },
       {

--- a/packages/settingregistry/src/settingregistry.ts
+++ b/packages/settingregistry/src/settingregistry.ts
@@ -1538,23 +1538,33 @@ namespace Private {
     const changes = [
       {
         old: '.jp-Notebook:focus.jp-mod-commandMode',
-        new: '.jp-Notebook.jp-mod-commandMode :focus:not(:read-write)',
+        new: '.jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus',
         versionDeprecated: 'JupyterLab 4.1'
       },
       {
+        old: '.jp-Notebook.jp-mod-commandMode :focus:not(:read-write)',
+        new: '.jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus',
+        versionDeprecated: 'JupyterLab 4.1.1'
+      },
+      {
         old: '.jp-Notebook:focus',
-        new: '.jp-Notebook.jp-mod-commandMode :focus:not(:read-write)',
+        new: '.jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus',
         versionDeprecated: 'JupyterLab 4.1'
       },
       {
         old: '[data-jp-traversable]:focus',
-        new: '.jp-Notebook.jp-mod-commandMode :focus:not(:read-write)',
+        new: '.jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus',
         versionDeprecated: 'JupyterLab 4.1'
       },
       {
         old: '[data-jp-kernel-user]:focus',
-        new: '[data-jp-kernel-user] :focus:not(:read-write)',
+        new: '[data-jp-kernel-user]:not(.jp-mod-readWrite) :focus',
         versionDeprecated: 'JupyterLab 4.1'
+      },
+      {
+        old: '[data-jp-kernel-user] :focus:not(:read-write)',
+        new: '[data-jp-kernel-user]:not(.jp-mod-readWrite) :focus',
+        versionDeprecated: 'JupyterLab 4.1.1'
       }
     ];
     const upgraded = shortcuts.map(shortcut => {


### PR DESCRIPTION
## References

Fixes #15757

## Code changes

- adds an integration test ensuring that typing works in open shadow DOM (should fail in the first commit)
- adds a new `jp-mod-readWrite` class that is added to the notebook node on focus change when the active element (or active element within active shadow DOM) is editable
- updates selectors for command-mode commands accordingly
- updates migration script and migration documentation to reflect the above
- documents the `lm-suppress-shortcuts` data attribute
- `hasActiveEditableElement` utility gets added to `DOMUtils`; this function checks the current `activeElement` (and all elements within active shadow DOM) against `:read-write` selector, but in the future could be extended for additional heuristics such as checking if the active element has a key event handler.

## User-facing changes

| Before | After |
|--|--|
| [before.webm](https://github.com/jupyterlab/jupyterlab/assets/5832902/ac7668a2-1531-4e44-b619-77478f3db358) | [after.webm](https://github.com/jupyterlab/jupyterlab/assets/5832902/c0fe312c-44e7-436e-be90-adac0b52e933) |


## Backwards-incompatible changes

None