### PR TITLE
Fix console cells not becoming read-only after execution

### DIFF
--- a/galata/test/jupyterlab/console.test.ts
+++ b/galata/test/jupyterlab/console.test.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { expect, test } from '@jupyterlab/galata';
+
+const CELL_EDITOR_SELECTOR = '.jp-InputArea-editor';
+const CODE_MIRROR_CURSOR = '.cm-cursor';
+
+test.describe('Console', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.menu.clickMenuItem('File>New>Console');
+
+    await page.click('button:has-text("Select")');
+
+    await page.locator('[aria-label="Code Cell Content"]').waitFor();
+    await page.locator('text=| Idle').waitFor();
+  });
+
+  test('Executed cells should become read-only', async ({ page }) => {
+    await page.keyboard.type('2 + 2');
+    await page.keyboard.press('Shift+Enter');
+
+    const executedCell = page.locator(
+      '[aria-label="Code Cell Content with Output"]'
+    );
+    await executedCell.waitFor();
+
+    const cellEditor = executedCell.locator(CELL_EDITOR_SELECTOR);
+    expect(await cellEditor.innerText()).toBe('2 + 2');
+
+    // Focus the editor
+    await cellEditor.click();
+
+    // Should not display the cursor
+    const cursor = cellEditor.locator(CODE_MIRROR_CURSOR);
+    await expect.soft(cursor).toBeHidden();
+
+    // Try to type something into the editor
+    await cellEditor.type('more text');
+
+    // Expect the editor content to not change
+    expect(await cellEditor.innerText()).toBe('2 + 2');
+  });
+});

--- a/packages/codemirror/style/base.css
+++ b/packages/codemirror/style/base.css
@@ -43,9 +43,14 @@
   }
 }
 
-.cm-editor.jp-mod-readOnly .cm-cursor {
+/* stylelint-disable selector-max-class */
+
+/* We need all this classes for higher specificity to override CodeMirror's rule */
+.cm-editor.jp-mod-readOnly > .cm-scroller > .cm-cursorLayer .cm-cursor {
   display: none;
 }
+
+/* stylelint-enable selector-max-class */
 
 .jp-CollaboratorCursor {
   border-left: 5px solid transparent;

--- a/packages/console/test/widget.spec.ts
+++ b/packages/console/test/widget.spec.ts
@@ -280,6 +280,19 @@ describe('console/widget', () => {
           expect.arrayContaining(['newPromptCell'])
         );
       });
+
+      it('should make previous cell read-only after execution', async () => {
+        Widget.attach(widget, document.body);
+
+        const old = widget.promptCell;
+        const force = true;
+        expect(old).toBeInstanceOf(CodeCell);
+
+        await (widget.sessionContext as SessionContext).initialize();
+        await widget.execute(force);
+
+        expect(old!.editor!.getOption('readOnly')).toBe(true);
+      });
     });
 
     describe('#onActivateRequest()', () => {


### PR DESCRIPTION
## References

Fixes #15772

## Code changes

- [x] adds a unit test (passing) and integration test (failing in first commit) demonstrating issues with read-only mode not being applied and cursor not being properly hidden
- [x] delays processing of pending signals before clearing signal connections on the console cell being moved to the history
- [x] fixes specificity of the cursor visibility override for the editors in readonly mode

## User-facing changes

| Before | After |
|--|--|
| ![before](https://github.com/jupyterlab/jupyterlab/assets/5832902/d3010ad1-df9b-44fc-878a-78cdfbcf3475) | ![after](https://github.com/jupyterlab/jupyterlab/assets/5832902/efaf7b3b-eb60-4e5b-9e53-bc410253fc2d) |



## Backwards-incompatible changes

None