### PR TITLE
Restore notebook scrolling on dragging a cell to the viewport edge

### DIFF
--- a/galata/test/jupyterlab/notebook-scroll.test.ts
+++ b/galata/test/jupyterlab/notebook-scroll.test.ts
@@ -5,6 +5,7 @@ import { expect, galata, test } from '@jupyterlab/galata';
 import * as path from 'path';
 
 import {
+  dragCellTo,
   notebookViewportRatio,
   positionCellPartiallyBelowViewport
 } from './utils';
@@ -60,6 +61,106 @@ test.describe('Notebook scroll on navigation (with windowing)', () => {
       await expect(lastCellLocator).toBeInViewport();
     });
   }
+});
+
+test.describe('Notebook scroll on dragging cells (with windowing)', () => {
+  test.beforeEach(async ({ page, tmpPath }) => {
+    await page.contents.uploadFile(
+      path.resolve(__dirname, `./notebooks/${fileName}`),
+      `${tmpPath}/${fileName}`
+    );
+
+    await page.notebook.openByPath(`${tmpPath}/${fileName}`);
+    await page.notebook.activate(fileName);
+  });
+  const NOTEBOOK_SCROLLER = '.jp-WindowedPanel-outer';
+  const NOTEBOOK_CONTENT = '.jp-WindowedPanel-inner';
+  const EDGE_MARGIN = 10;
+
+  test.afterEach(async ({ page, tmpPath }) => {
+    await page.contents.deleteDirectory(tmpPath);
+  });
+
+  test('Scroll down on dragging cell to the bottom edge', async ({ page }) => {
+    const firstCellLocator = page.locator(
+      '.jp-Cell[data-windowed-list-index="0"]'
+    );
+    const lastCellLocator = page.locator(
+      '.jp-Cell[data-windowed-list-index="19"]'
+    );
+    const scroller = page.locator(NOTEBOOK_SCROLLER);
+    await firstCellLocator.scrollIntoViewIfNeeded();
+
+    const scrollerBBox = await scroller.boundingBox();
+    const notebookContentHeight = (
+      await page.locator(NOTEBOOK_CONTENT).boundingBox()
+    ).height;
+
+    // Ensure the notebook is scrolled correctly and last cell is not visible
+    const before = await scroller.evaluate(node => node.scrollTop);
+    expect(before).toBe(0);
+    await expect(lastCellLocator).not.toBeInViewport();
+
+    // Emulate drag and drop
+    await dragCellTo(page, {
+      cell: firstCellLocator,
+      x: scrollerBBox.x + 0.5 * scrollerBBox.width,
+      y: scrollerBBox.y + scrollerBBox.height - EDGE_MARGIN,
+      stopCondition: async () => {
+        const scrollTop = await scroller.evaluate(node => node.scrollTop);
+        return scrollTop >= notebookContentHeight - 100;
+      }
+    });
+
+    // The notebook should have scrolled down and the last cell should be visible
+    const after = await scroller.evaluate(node => node.scrollTop);
+    expect(after).toBeGreaterThan(before);
+    await expect(lastCellLocator).toBeInViewport();
+  });
+
+  test('Scroll up on dragging cell to the top edge', async ({ page }) => {
+    const firstCellLocator = page.locator(
+      '.jp-Cell[data-windowed-list-index="0"]'
+    );
+    const lastCellLocator = page.locator(
+      '.jp-Cell[data-windowed-list-index="19"]'
+    );
+
+    const scroller = page.locator(NOTEBOOK_SCROLLER);
+    const scrollerBBox = await scroller.boundingBox();
+    const notebookContentHeight = (
+      await page.locator(NOTEBOOK_CONTENT).boundingBox()
+    ).height;
+
+    // Scroll notebook to the bottom, leaving top 200px visible
+    await page.mouse.move(
+      scrollerBBox.x + 0.5 * scrollerBBox.width,
+      scrollerBBox.y + 0.5 * scrollerBBox.height
+    );
+    await page.mouse.wheel(0, notebookContentHeight - 200);
+    await lastCellLocator.scrollIntoViewIfNeeded();
+
+    // Ensure the notebook is scrolled correctly and first cell is not visible
+    const before = await scroller.evaluate(node => node.scrollTop);
+    expect(before).toBeGreaterThan(notebookContentHeight * 0.75);
+    await expect(firstCellLocator).not.toBeInViewport();
+
+    // Emulate drag and drop
+    await dragCellTo(page, {
+      cell: lastCellLocator,
+      x: scrollerBBox.x + 0.5 * scrollerBBox.width,
+      y: scrollerBBox.y + EDGE_MARGIN,
+      stopCondition: async () => {
+        const scrollTop = await scroller.evaluate(node => node.scrollTop);
+        return scrollTop <= 50;
+      }
+    });
+
+    // The notebook should have scrolled up and the first cell should be visible
+    const after = await scroller.evaluate(node => node.scrollTop);
+    expect(after).toBeLessThan(before);
+    await expect(firstCellLocator).toBeInViewport();
+  });
 });
 
 test.describe('Notebook scroll on execution (with windowing)', () => {

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1334,7 +1334,7 @@ export class Notebook extends StaticNotebook {
       ...options
     });
     // Allow the node to scroll while dragging items.
-    this.node.setAttribute('data-lm-dragscroll', 'true');
+    this.outerNode.setAttribute('data-lm-dragscroll', 'true');
     this.activeCellChanged.connect(this._updateSelectedCells, this);
     this.jumped.connect((_, index: number) => (this.activeCellIndex = index));
     this.selectionChanged.connect(this._updateSelectedCells, this);


### PR DESCRIPTION
## References

Fixes #15777

## Code changes

- [x] add integration test for scrolling on dragging cell to the top and bottom edges of notebook viewport (warranted because it regressed twice in the 4.x development)
   - note there is a copy for windowing and no-windowing; I do wish to reconciliate these duplicated test files but this requires a change in galata config so it will be a 4.2.0 PR; this also why the `dragCellTo` goes to private `utils` rather than to galata itself (for now!)
- [x] move the `data-lm-dragscroll` attribute from the main notebook widget node to the outer node which became the scroller in 4.1.0

## User-facing changes

| Before | After |
|--|--|
| ![before](https://github.com/jupyterlab/jupyterlab/assets/5832902/4420d55c-4907-4d72-bd32-749afa3d87b3) | ![after](https://github.com/jupyterlab/jupyterlab/assets/5832902/156a3588-31dc-4d0a-b572-bd7015128cf4) |

## Backwards-incompatible changes

None