### PR TITLE
Add Edge, remove IE 11 from browser support docs

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -106,14 +106,9 @@ The latest versions of the following browsers are currently known to work:
 -  Firefox
 -  Chrome
 -  Safari
+-  Edge
 
 Earlier browser versions may also work, but come with no guarantees.
-
-JupyterLab uses CSS Variables for styling, which is one reason for the
-minimum versions listed above.  IE 11+ or Edge 14 do not support
-CSS Variables, and are not directly supported at this time.
-A tool like `postcss <https://postcss.org/>`__ can be used to convert the CSS files in the
-``jupyterlab/build`` directory manually if desired.
 
 Installation problems
 ---------------------


### PR DESCRIPTION
Fixes #8030. Edge is now generally considered a modern, first-tier browser, with similar functionality to Chrome (and it uses the same engine). Removes mention of IE 11 and a very old version of Edge.