### PR TITLE
Catch errors attempting to access `document.cookie`

### DIFF
--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -1169,7 +1169,13 @@ export class Drive implements Contents.IDrive {
   getDownloadUrl(localPath: string): Promise<string> {
     const baseUrl = this.serverSettings.baseUrl;
     let url = URLExt.join(baseUrl, FILES_URL, URLExt.encodeParts(localPath));
-    const xsrfTokenMatch = document.cookie.match('\\b_xsrf=([^;]*)\\b');
+    let cookie = '';
+    try {
+      cookie = document.cookie;
+    } catch (e) {
+      // e.g. SecurityError in case of CSP Sandbox
+    }
+    const xsrfTokenMatch = cookie.match('\\b_xsrf=([^;]*)\\b');
     if (xsrfTokenMatch) {
       const fullUrl = new URL(url);
       fullUrl.searchParams.append('_xsrf', xsrfTokenMatch[1]);

--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -306,7 +306,7 @@ namespace Private {
       authenticated = true;
       request.headers.append('Authorization', `token ${settings.token}`);
     }
-    if (typeof document !== 'undefined' && document?.cookie) {
+    if (typeof document !== 'undefined') {
       const xsrfToken = getCookie('_xsrf');
       if (xsrfToken !== undefined) {
         authenticated = true;
@@ -334,7 +334,14 @@ namespace Private {
    */
   function getCookie(name: string): string | undefined {
     // From http://www.tornadoweb.org/en/stable/guide/security.html
-    const matches = document.cookie.match('\\b' + name + '=([^;]*)\\b');
+    let cookie = '';
+    try {
+      cookie = document.cookie;
+    } catch (e) {
+      // e.g. SecurityError in case of CSP Sandbox
+      return;
+    }
+    const matches = cookie.match('\\b' + name + '=([^;]*)\\b');
     return matches?.[1];
   }
 }


### PR DESCRIPTION
behave as if cookie is empty if cookie cannot be read for sandbox reasons.

Attempting to access `document.cookie` can raise SecurityError if page is served with `Content-Security-Policy: sandbox`. Because this is accessed unconditionally, ~any page with JupyterLab js served with CSP sandbox crashes when attempting to build URLs instead of behaving as if xsrf token is unknown.

## References

[CSP: sandbox](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox)

## Code changes

If accessing `document.cookie` throws an error, behave as if cookie is empty, rather than error.

## User-facing changes

Loading JupyterLab javascript should no longer crash when loaded in a page with CSP: Sandbox. XSRF token will be unavailable, but is not required.


## Backwards-incompatible changes

None