### PR TITLE
Windows platforms, erratic pasting of text into Markdown field

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1776,7 +1776,9 @@ export abstract class AttachmentsCell<
             continue;
           }
           items[i].getAsString(text => {
-            this.editor!.replaceSelection?.((text.replace(/\r\n/g, '\n')).replace(/\r/g, '\n'));
+            this.editor!.replaceSelection?.(
+              text.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+            );
           });
         }
         this._attachFiles(event.clipboardData.items);

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1776,7 +1776,7 @@ export abstract class AttachmentsCell<
             continue;
           }
           items[i].getAsString(text => {
-            this.editor!.replaceSelection?.(text.replace(/\r\n/g, '\n'));
+            this.editor!.replaceSelection?.((text.replace(/\r\n/g, '\n')).replace(/\r/g, '\n'));
           });
         }
         this._attachFiles(event.clipboardData.items);

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1776,7 +1776,7 @@ export abstract class AttachmentsCell<
             continue;
           }
           items[i].getAsString(text => {
-            this.editor!.replaceSelection?.(text);
+            this.editor!.replaceSelection?.(text.replace(/\r\n/g,"\n"));
           });
         }
         this._attachFiles(event.clipboardData.items);

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1776,7 +1776,7 @@ export abstract class AttachmentsCell<
             continue;
           }
           items[i].getAsString(text => {
-            this.editor!.replaceSelection?.(text.replace(/\r\n/g, "\n"));
+            this.editor!.replaceSelection?.(text.replace(/\r\n/g, '\n'));
           });
         }
         this._attachFiles(event.clipboardData.items);

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1776,7 +1776,7 @@ export abstract class AttachmentsCell<
             continue;
           }
           items[i].getAsString(text => {
-            this.editor!.replaceSelection?.(text.replace(/\r\n/g,"\n"));
+            this.editor!.replaceSelection?.(text.replace(/\r\n/g, "\n"));
           });
         }
         this._attachFiles(event.clipboardData.items);

--- a/packages/cells/test/widget.spec.ts
+++ b/packages/cells/test/widget.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { createStandaloneCell, YCodeCell } from '@jupyter/ydoc';
+import { createStandaloneCell, YCodeCell, YMarkdownCell } from '@jupyter/ydoc';
 import { ISessionContext, SessionContext } from '@jupyterlab/apputils';
 import { createSessionContext } from '@jupyterlab/apputils/lib/testutils';
 import {
@@ -995,6 +995,33 @@ describe('cells/widget', () => {
         });
         widget.initializeState();
         expect(widget.model.mimeType).toEqual('text/x-ipythongfm');
+      });
+    });
+
+    describe('#getEditorOptions()', () => {
+      it('should normalise line endings on paste', () => {
+        const model = new MarkdownCellModel({
+          sharedModel: createStandaloneCell({
+            cell_type: 'markdown'
+          }) as YMarkdownCell
+        });
+        const widget = new MarkdownCell({
+          model,
+          rendermime,
+          contentFactory,
+          placeholder: false
+        });
+        widget.initializeState();
+        document.body.appendChild(widget.node);
+        // todo: replace with user-event
+        const dt = new DataTransfer();
+        dt.setData('text/plain', '\r\nTest\r\nString\r\n.\r\n');
+        const event = new ClipboardEvent('paste', { clipboardData: dt });
+        widget.editor!.host.querySelector('.cm-content')!.dispatchEvent(event);
+
+        expect(widget.model.sharedModel.getSource()).toEqual(
+          '\nTest\nString\n.\n'
+        );
       });
     });
 


### PR DESCRIPTION
Due to different line ending in windows display and data got corrupted. Fixed by correcting paste handling of text in
packages/cells/src/widgets.ts

fixes: https://github.com/jupyterlab/jupyterlab/issues/14752

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
