### PR TITLE
Only show focus ring around file name when needed

### DIFF
--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -276,14 +276,14 @@
   user-select: none;
 }
 
-.jp-DirListing-itemText:focus {
+.jp-DirListing-itemText:focus-visible {
   outline-width: 2px;
   outline-color: var(--jp-inverse-layout-color1);
   outline-style: solid;
   outline-offset: 1px;
 }
 
-.jp-DirListing-item.jp-mod-selected .jp-DirListing-itemText:focus {
+.jp-DirListing-item.jp-mod-selected .jp-DirListing-itemText:focus-visible {
   outline-color: var(--jp-layout-color1);
 }
 


### PR DESCRIPTION
## References

Alleviates #14678

## Code changes

```diff
- :focus
+ :focus-visible
```

[:focus-visible](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible) is widely available across all modern browsers.

## User-facing changes

| Before | After |
|--|--|
| ![focus-always](https://github.com/jupyterlab/jupyterlab/assets/5832902/8baa61dc-5a24-4b64-9726-f8ced7e11714) | ![no-focus-ring-on-click](https://github.com/jupyterlab/jupyterlab/assets/5832902/a42483db-b9d3-4963-9adf-ec4ff484a377) |

## Backwards-incompatible changes

None