### PR TITLE
Fix highlight sequencing when replacing text in code cells

### DIFF
--- a/packages/codemirror/src/searchprovider.ts
+++ b/packages/codemirror/src/searchprovider.ts
@@ -321,7 +321,7 @@ export abstract class EditorSearchProvider<
    * calling `replaceCurrentMatch()` attribute `this.currentIndex` is null.
    * It is necesary to let the caller handle highlighting because this
    * method is used in composition pattern (search engine of notebook cells)
-   * and highligthing on the composer (notebook) level needs to switch to next
+   * and highlighting on the composer (notebook) level needs to switch to next
    * engine (cell) with matches.
    *
    * @param newText The replacement text.

--- a/packages/codemirror/src/searchprovider.ts
+++ b/packages/codemirror/src/searchprovider.ts
@@ -348,10 +348,24 @@ export abstract class EditorSearchProvider<
         this.currentIndex = null;
       } else {
         this.cmHandler.matches.splice(this.currentIndex, 1);
-        this.currentIndex =
-          this.currentIndex < this.cmHandler.matches.length
-            ? Math.max(this.currentIndex - 1, 0)
-            : null;
+        const cmMatchesRemaining = this.cmHandler.matches.length;
+
+        // If there are no remaining matches, make nothing selected.
+        if (cmMatchesRemaining === 0) {
+          this.currentIndex = null;
+        }
+        else {
+        // Move to the next match, wrapping around if necessary.
+        if (loop) {
+            this.currentIndex = (this.currentIndex) % cmMatchesRemaining;
+          }
+          else {
+            // End at the end of the CodeMirror matches list; do not loop
+            this.currentIndex = this.currentIndex < cmMatchesRemaining
+              ? this.currentIndex
+              : null;
+          }
+        }
         const substitutedText = options?.regularExpression
           ? match!.text.replace(this.query!, newText)
           : newText;

--- a/packages/codemirror/src/searchprovider.ts
+++ b/packages/codemirror/src/searchprovider.ts
@@ -343,26 +343,17 @@ export abstract class EditorSearchProvider<
       this.currentIndex < this.cmHandler.matches.length
     ) {
       const match = this.getCurrentMatch();
-      // If cursor there is no match selected, highlight the next match
       if (!match) {
         this.currentIndex = null;
       } else {
         this.cmHandler.matches.splice(this.currentIndex, 1);
         const cmMatchesRemaining = this.cmHandler.matches.length;
 
-        // If there are no remaining matches, make nothing selected.
-        if (cmMatchesRemaining === 0) {
-          this.currentIndex = null;
-        } else {
-          // Move to the next match, wrapping around if necessary.
-          if (loop) {
-            this.currentIndex = this.currentIndex % cmMatchesRemaining;
-          } else {
-            // End at the end of the CodeMirror matches list; do not loop
-            this.currentIndex =
-              this.currentIndex < cmMatchesRemaining ? this.currentIndex : null;
-          }
-        }
+        // End at the end of the CodeMirror matches list; do not loop
+        // Let the caller call highlightNext if we've reached the end of the current code cell
+        this.currentIndex =
+          this.currentIndex < cmMatchesRemaining ? this.currentIndex : null;
+
         const substitutedText = options?.regularExpression
           ? match!.text.replace(this.query!, newText)
           : newText;

--- a/packages/codemirror/src/searchprovider.ts
+++ b/packages/codemirror/src/searchprovider.ts
@@ -319,7 +319,7 @@ export abstract class EditorSearchProvider<
    *
    * The caller of this method is expected to call `highlightNext` if after
    * calling `replaceCurrentMatch()` attribute `this.currentIndex` is null.
-   * It is necesary to let the caller handle highlighting because this
+   * It is necessary to let the caller handle highlighting because this
    * method is used in composition pattern (search engine of notebook cells)
    * and highlighting on the composer (notebook) level needs to switch to next
    * engine (cell) with matches.

--- a/packages/codemirror/src/searchprovider.ts
+++ b/packages/codemirror/src/searchprovider.ts
@@ -353,17 +353,14 @@ export abstract class EditorSearchProvider<
         // If there are no remaining matches, make nothing selected.
         if (cmMatchesRemaining === 0) {
           this.currentIndex = null;
-        }
-        else {
-        // Move to the next match, wrapping around if necessary.
-        if (loop) {
-            this.currentIndex = (this.currentIndex) % cmMatchesRemaining;
-          }
-          else {
+        } else {
+          // Move to the next match, wrapping around if necessary.
+          if (loop) {
+            this.currentIndex = this.currentIndex % cmMatchesRemaining;
+          } else {
             // End at the end of the CodeMirror matches list; do not loop
-            this.currentIndex = this.currentIndex < cmMatchesRemaining
-              ? this.currentIndex
-              : null;
+            this.currentIndex =
+              this.currentIndex < cmMatchesRemaining ? this.currentIndex : null;
           }
         }
         const substitutedText = options?.regularExpression

--- a/packages/notebook/test/searchprovider.spec.ts
+++ b/packages/notebook/test/searchprovider.spec.ts
@@ -49,7 +49,7 @@ describe('@jupyterlab/notebook', () => {
       panel = utils.createNotebookPanel(context);
       provider = new TestProvider(panel);
       panel.model!.sharedModel.insertCells(0, [
-        { cell_type: 'markdown', source: 'test1 test2' },
+        { cell_type: 'markdown', source: 'test1 test2 test4' },
         { cell_type: 'code', source: 'test3' }
       ]);
     });
@@ -210,7 +210,22 @@ describe('@jupyterlab/notebook', () => {
         let replaced = await provider.replaceCurrentMatch('bar');
         expect(replaced).toBe(true);
         const source = panel.model!.cells.get(0).sharedModel.getSource();
-        expect(source).toBe('bar test2');
+        expect(source).toBe('bar test2 test4');
+        expect(provider.currentMatchIndex).toBe(0);
+      });
+
+      it('should start in the middle, replace, and highlight next', async () => {
+        // Pick the spot before the second element.
+        await panel.content.activeCell!.editor!.setCursorPosition({
+          line: 0,
+          column: 'test1 '.length,
+        });
+        await provider.startQuery(/test\d/, undefined);
+        expect(provider.currentMatchIndex).toBe(0);
+        let replaced = await provider.replaceCurrentMatch('bar');
+        expect(replaced).toBe(true);
+        const source = panel.model!.cells.get(0).sharedModel.getSource();
+        expect(source).toBe('test1 bar test4');
         expect(provider.currentMatchIndex).toBe(0);
       });
 
@@ -226,7 +241,7 @@ describe('@jupyterlab/notebook', () => {
         );
         expect(replaced).toBe(true);
         const source = panel.model!.cells.get(0).sharedModel.getSource();
-        expect(source).toBe('test1 2st_bar (was test2)');
+        expect(source).toBe('test1 2st_bar (was test2) test4');
       });
 
       it('should not substitute if regular expression toggle is off', async () => {
@@ -239,7 +254,7 @@ describe('@jupyterlab/notebook', () => {
         );
         expect(replaced).toBe(true);
         const source = panel.model!.cells.get(0).sharedModel.getSource();
-        expect(source).toBe('$1st_bar (was $&) test2');
+        expect(source).toBe('$1st_bar (was $&) test2 test4');
       });
 
       it('should replace with a longer text and highlight next', async () => {
@@ -248,13 +263,13 @@ describe('@jupyterlab/notebook', () => {
         let replaced = await provider.replaceCurrentMatch('rabarbar');
         expect(replaced).toBe(true);
         let source = panel.model!.cells.get(0).sharedModel.getSource();
-        expect(source).toBe('rabarbar test2');
+        expect(source).toBe('rabarbar test2 test4');
         expect(provider.currentMatchIndex).toBe(0);
 
         replaced = await provider.replaceCurrentMatch('rabarbar');
         expect(replaced).toBe(true);
         source = panel.model!.cells.get(0).sharedModel.getSource();
-        expect(source).toBe('rabarbar rabarbar');
+        expect(source).toBe('rabarbar rabarbar test4');
         expect(provider.currentMatchIndex).toBe(0);
 
         replaced = await provider.replaceCurrentMatch('rabarbar');
@@ -272,7 +287,7 @@ describe('@jupyterlab/notebook', () => {
         const replaced = await provider.replaceAllMatches('test0');
         expect(replaced).toBe(true);
         let source = panel.model!.cells.get(0).sharedModel.getSource();
-        expect(source).toBe('test0 test0');
+        expect(source).toBe('test0 test0 test0');
         source = panel.model!.cells.get(1).sharedModel.getSource();
         expect(source).toBe('test0');
         expect(provider.currentMatchIndex).toBe(null);
@@ -287,7 +302,7 @@ describe('@jupyterlab/notebook', () => {
         const replaced = await provider.replaceAllMatches('bar');
         expect(replaced).toBe(true);
         let source = panel.model!.cells.get(0).sharedModel.getSource();
-        expect(source).toBe('bar1 bar2');
+        expect(source).toBe('bar1 bar2 bar4');
         source = panel.model!.cells.get(1).sharedModel.getSource();
         expect(source).toBe('test3');
         await provider.endQuery();
@@ -301,7 +316,7 @@ describe('@jupyterlab/notebook', () => {
         const replaced = await provider.replaceAllMatches('bar');
         expect(replaced).toBe(true);
         let source = panel.model!.cells.get(0).sharedModel.getSource();
-        expect(source).toBe('test1 test2');
+        expect(source).toBe('test1 test2 test4');
         source = panel.model!.cells.get(1).sharedModel.getSource();
         expect(source).toBe('bar3');
         await provider.endQuery();

--- a/packages/notebook/test/searchprovider.spec.ts
+++ b/packages/notebook/test/searchprovider.spec.ts
@@ -49,8 +49,8 @@ describe('@jupyterlab/notebook', () => {
       panel = utils.createNotebookPanel(context);
       provider = new TestProvider(panel);
       panel.model!.sharedModel.insertCells(0, [
-        { cell_type: 'markdown', source: 'test1 test2 test4' },
-        { cell_type: 'code', source: 'test3' }
+        { cell_type: 'markdown', source: 'test1 test2' },
+        { cell_type: 'code', source: 'test3 test4 test5' }
       ]);
     });
 
@@ -210,23 +210,27 @@ describe('@jupyterlab/notebook', () => {
         let replaced = await provider.replaceCurrentMatch('bar');
         expect(replaced).toBe(true);
         const source = panel.model!.cells.get(0).sharedModel.getSource();
-        expect(source).toBe('bar test2 test4');
+        expect(source).toBe('bar test2');
         expect(provider.currentMatchIndex).toBe(0);
       });
 
-      it('should start in the middle, replace, and highlight next', async () => {
+      it('should start in the middle of a code cell, replace, and highlight next', async () => {
+        await provider.startQuery(/test\d/, { selection: true });
+        panel.content.mode = 'command';
+        panel.content.activeCellIndex = 1;
+        await provider.cellChangeHandled;
+
         // Pick the spot before the second element.
         await panel.content.activeCell!.editor!.setCursorPosition({
           line: 0,
-          column: 'test1 '.length,
+          column: 'test3 '.length,
         });
-        await provider.startQuery(/test\d/, undefined);
-        expect(provider.currentMatchIndex).toBe(0);
+        expect(provider.currentMatchIndex).toBe(1);
         let replaced = await provider.replaceCurrentMatch('bar');
         expect(replaced).toBe(true);
-        const source = panel.model!.cells.get(0).sharedModel.getSource();
-        expect(source).toBe('test1 bar test4');
-        expect(provider.currentMatchIndex).toBe(0);
+        const source = panel.model!.cells.get(1).sharedModel.getSource();
+        expect(source).toBe('test3 bar test5');
+        expect(provider.currentMatchIndex).toBe(1);
       });
 
       it('should substitute groups in regular expressions', async () => {
@@ -241,7 +245,7 @@ describe('@jupyterlab/notebook', () => {
         );
         expect(replaced).toBe(true);
         const source = panel.model!.cells.get(0).sharedModel.getSource();
-        expect(source).toBe('test1 2st_bar (was test2) test4');
+        expect(source).toBe('test1 2st_bar (was test2)');
       });
 
       it('should not substitute if regular expression toggle is off', async () => {
@@ -254,7 +258,7 @@ describe('@jupyterlab/notebook', () => {
         );
         expect(replaced).toBe(true);
         const source = panel.model!.cells.get(0).sharedModel.getSource();
-        expect(source).toBe('$1st_bar (was $&) test2 test4');
+        expect(source).toBe('$1st_bar (was $&) test2');
       });
 
       it('should replace with a longer text and highlight next', async () => {
@@ -263,19 +267,19 @@ describe('@jupyterlab/notebook', () => {
         let replaced = await provider.replaceCurrentMatch('rabarbar');
         expect(replaced).toBe(true);
         let source = panel.model!.cells.get(0).sharedModel.getSource();
-        expect(source).toBe('rabarbar test2 test4');
+        expect(source).toBe('rabarbar test2');
         expect(provider.currentMatchIndex).toBe(0);
 
         replaced = await provider.replaceCurrentMatch('rabarbar');
         expect(replaced).toBe(true);
         source = panel.model!.cells.get(0).sharedModel.getSource();
-        expect(source).toBe('rabarbar rabarbar test4');
+        expect(source).toBe('rabarbar rabarbar');
         expect(provider.currentMatchIndex).toBe(0);
 
         replaced = await provider.replaceCurrentMatch('rabarbar');
         expect(replaced).toBe(true);
         source = panel.model!.cells.get(1).sharedModel.getSource();
-        expect(source).toBe('rabarbar');
+        expect(source).toBe('rabarbar test4 test5');
         expect(provider.currentMatchIndex).toBe(null);
       });
     });
@@ -287,9 +291,9 @@ describe('@jupyterlab/notebook', () => {
         const replaced = await provider.replaceAllMatches('test0');
         expect(replaced).toBe(true);
         let source = panel.model!.cells.get(0).sharedModel.getSource();
-        expect(source).toBe('test0 test0 test0');
+        expect(source).toBe('test0 test0');
         source = panel.model!.cells.get(1).sharedModel.getSource();
-        expect(source).toBe('test0');
+        expect(source).toBe('test0 test0 test0');
         expect(provider.currentMatchIndex).toBe(null);
       });
 
@@ -302,9 +306,9 @@ describe('@jupyterlab/notebook', () => {
         const replaced = await provider.replaceAllMatches('bar');
         expect(replaced).toBe(true);
         let source = panel.model!.cells.get(0).sharedModel.getSource();
-        expect(source).toBe('bar1 bar2 bar4');
+        expect(source).toBe('bar1 bar2');
         source = panel.model!.cells.get(1).sharedModel.getSource();
-        expect(source).toBe('test3');
+        expect(source).toBe('test3 test4 test5');
         await provider.endQuery();
       });
 
@@ -316,9 +320,9 @@ describe('@jupyterlab/notebook', () => {
         const replaced = await provider.replaceAllMatches('bar');
         expect(replaced).toBe(true);
         let source = panel.model!.cells.get(0).sharedModel.getSource();
-        expect(source).toBe('test1 test2 test4');
+        expect(source).toBe('test1 test2');
         source = panel.model!.cells.get(1).sharedModel.getSource();
-        expect(source).toBe('bar3');
+        expect(source).toBe('bar3 bar4 bar5');
         await provider.endQuery();
       });
 

--- a/packages/notebook/test/searchprovider.spec.ts
+++ b/packages/notebook/test/searchprovider.spec.ts
@@ -50,7 +50,7 @@ describe('@jupyterlab/notebook', () => {
       provider = new TestProvider(panel);
       panel.model!.sharedModel.insertCells(0, [
         { cell_type: 'markdown', source: 'test1 test2' },
-        { cell_type: 'code', source: 'test3 test4 test5' }
+        { cell_type: 'code', source: 'test3' }
       ]);
     });
 
@@ -215,21 +215,27 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should start in the middle of a code cell, replace, and highlight next', async () => {
-        await provider.startQuery(/test\d/, { selection: true });
-        panel.content.mode = 'command';
-        panel.content.activeCellIndex = 1;
+        panel.model!.sharedModel.deleteCellRange(0, 2);
+        panel.model!.sharedModel.insertCells(0, [
+          { cell_type: 'code', source: 'test1 test2 test3' }
+        ]);
+        panel.content.activeCellIndex = 0;
         await provider.cellChangeHandled;
+        panel.content.mode = 'edit';
 
         // Pick the spot before the second element.
         await panel.content.activeCell!.editor!.setCursorPosition({
           line: 0,
-          column: 'test3 '.length
+          column: 'test1 '.length
         });
+
+        await provider.startQuery(/test\d/, { selection: true });
+
         expect(provider.currentMatchIndex).toBe(1);
         let replaced = await provider.replaceCurrentMatch('bar');
         expect(replaced).toBe(true);
-        const source = panel.model!.cells.get(1).sharedModel.getSource();
-        expect(source).toBe('test3 bar test5');
+        const source = panel.model!.cells.get(0).sharedModel.getSource();
+        expect(source).toBe('test1 bar test3');
         expect(provider.currentMatchIndex).toBe(1);
       });
 
@@ -279,7 +285,7 @@ describe('@jupyterlab/notebook', () => {
         replaced = await provider.replaceCurrentMatch('rabarbar');
         expect(replaced).toBe(true);
         source = panel.model!.cells.get(1).sharedModel.getSource();
-        expect(source).toBe('rabarbar test4 test5');
+        expect(source).toBe('rabarbar');
         expect(provider.currentMatchIndex).toBe(null);
       });
     });
@@ -293,7 +299,7 @@ describe('@jupyterlab/notebook', () => {
         let source = panel.model!.cells.get(0).sharedModel.getSource();
         expect(source).toBe('test0 test0');
         source = panel.model!.cells.get(1).sharedModel.getSource();
-        expect(source).toBe('test0 test0 test0');
+        expect(source).toBe('test0');
         expect(provider.currentMatchIndex).toBe(null);
       });
 
@@ -308,7 +314,7 @@ describe('@jupyterlab/notebook', () => {
         let source = panel.model!.cells.get(0).sharedModel.getSource();
         expect(source).toBe('bar1 bar2');
         source = panel.model!.cells.get(1).sharedModel.getSource();
-        expect(source).toBe('test3 test4 test5');
+        expect(source).toBe('test3');
         await provider.endQuery();
       });
 
@@ -322,7 +328,7 @@ describe('@jupyterlab/notebook', () => {
         let source = panel.model!.cells.get(0).sharedModel.getSource();
         expect(source).toBe('test1 test2');
         source = panel.model!.cells.get(1).sharedModel.getSource();
-        expect(source).toBe('bar3 bar4 bar5');
+        expect(source).toBe('bar3');
         await provider.endQuery();
       });
 

--- a/packages/notebook/test/searchprovider.spec.ts
+++ b/packages/notebook/test/searchprovider.spec.ts
@@ -223,7 +223,7 @@ describe('@jupyterlab/notebook', () => {
         // Pick the spot before the second element.
         await panel.content.activeCell!.editor!.setCursorPosition({
           line: 0,
-          column: 'test3 '.length,
+          column: 'test3 '.length
         });
         expect(provider.currentMatchIndex).toBe(1);
         let replaced = await provider.replaceCurrentMatch('bar');


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes #15657.

## Code changes

After replacing a match in the middle of a code cell, with matches before and after the cursor position, the next highlight (if any remain) is selected.

Adds a notebook search unit test, which indirectly invokes the search provider, that starts in the middle of a cell.

## User-facing changes

Start a code cell with:

```
29, 29, 29, 29, 29, 29
```

Put the cursor before the 2 in the third `29`. Search for `29` and replace with `86`. Replace one instance. You should see:

```
29, 29, 86, 29, 29, 29
```

… with the fourth item (the third 29) selected. Replace another instance. You should see:

```
29, 29, 86, 86, 29, 29
```

Repeat until all items are replaced. No item should be selected.

```
86, 86, 86, 86, 86, 86
```

## Backwards-incompatible changes

None.
