### PR TITLE
Adds title to close button of search and replace box

### DIFF
--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -729,7 +729,7 @@ class SearchOverlay extends React.Component<ISearchOverlayProps> {
             className={BUTTON_WRAPPER_CLASS}
             onClick={() => this._onClose()}
             tabIndex={0}
-            title={trans.__('Close Search and Replace')}
+            title={trans.__('Close Search Box')}
           >
             <closeIcon.react
               className="jp-icon-hover"

--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -729,6 +729,7 @@ class SearchOverlay extends React.Component<ISearchOverlayProps> {
             className={BUTTON_WRAPPER_CLASS}
             onClick={() => this._onClose()}
             tabIndex={0}
+            title={trans.__('Close Search and Replace')}
           >
             <closeIcon.react
               className="jp-icon-hover"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes #15815.

## Code changes

Adds tooltip (title) to the close button of the search and replace box.

## User-facing changes

The tooltip "Close Search and Replace" now appears when the user hovers over or focuses the close button on the find and replace panel.

![image](https://github.com/jupyterlab/jupyterlab/assets/93281816/8972f874-bdce-48f0-b9dd-6b5713426535)

## Backwards-incompatible changes

None.
