### PR TITLE
Dynamic title for expander/collapser button

### DIFF
--- a/galata/test/jupyterlab/notebook-replace.test.ts
+++ b/galata/test/jupyterlab/notebook-replace.test.ts
@@ -30,7 +30,7 @@ test.describe('Notebook Search and Replace', () => {
 
     await page.waitForSelector('text=1/21');
 
-    await page.click('button[title="Toggle Replace"]');
+    await page.click('button[title="Show Replace"]');
 
     await page.fill('[placeholder="Replace"]', 'egg');
 
@@ -50,7 +50,7 @@ test.describe('Notebook Search and Replace', () => {
     await page.fill('[placeholder="Find"]', 'text/(\\w+)');
     await page.waitForSelector('text=1/3');
 
-    await page.click('button[title="Toggle Replace"]');
+    await page.click('button[title="Show Replace"]');
     await page.fill('[placeholder="Replace"]', 'script/$1');
     const cell = await page.notebook.getCell(2);
     await expect(page.locator('body')).not.toContainText('script/plain');
@@ -75,7 +75,7 @@ test.describe('Notebook Search and Replace', () => {
       clickCount: 4
     });
 
-    await page.click('button[title="Toggle Replace"]');
+    await page.click('button[title="Show Replace"]');
 
     await page.fill('[placeholder="Replace"]', 'egg');
 
@@ -98,7 +98,7 @@ test.describe('Notebook Search and Replace', () => {
 
     await page.waitForSelector('text=1/21');
 
-    await page.click('button[title="Toggle Replace"]');
+    await page.click('button[title="Show Replace"]');
 
     await page.fill('[placeholder="Replace"]', 'egg');
 
@@ -120,7 +120,7 @@ test.describe('Notebook Search and Replace', () => {
     await page.keyboard.press('Control+f');
     await page.fill('[placeholder="Find"]', 'test');
 
-    await page.click('button[title="Toggle Replace"]');
+    await page.click('button[title="Show Replace"]');
     await page.fill('[placeholder="Replace"]', 'egg');
 
     // TODO: Next Match press count should be one less

--- a/galata/test/jupyterlab/notebook-search.test.ts
+++ b/galata/test/jupyterlab/notebook-search.test.ts
@@ -94,7 +94,7 @@ test.describe('Notebook Search', () => {
     await page.waitForSelector('text=1/1');
 
     // Show replace buttons to check for visual regressions
-    await page.click('button[title="Toggle Replace"]');
+    await page.click('button[title="Show Replace"]');
     await page.fill('[placeholder="Replace"]', 'line1\nline2');
 
     const overlay = page.locator('.jp-DocumentSearch-overlay');

--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -682,7 +682,11 @@ class SearchOverlay extends React.Component<ISearchOverlayProps> {
               className={TOGGLE_WRAPPER}
               onClick={() => this._onReplaceToggled()}
               tabIndex={0}
-              title={showReplace ? trans.__('Hide Replace') : trans.__('Show Replace')}
+              title={
+                showReplace
+                  ? trans.__('Hide Replace')
+                  : trans.__('Show Replace')
+              }
             >
               <icon.react
                 className={`${REPLACE_TOGGLE_CLASS} ${BUTTON_CONTENT_CLASS}`}

--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -682,7 +682,7 @@ class SearchOverlay extends React.Component<ISearchOverlayProps> {
               className={TOGGLE_WRAPPER}
               onClick={() => this._onReplaceToggled()}
               tabIndex={0}
-              title={trans.__('Toggle Replace')}
+              title={showReplace ? trans.__('Hide Replace') : trans.__('Show Replace')}
             >
               <icon.react
                 className={`${REPLACE_TOGGLE_CLASS} ${BUTTON_CONTENT_CLASS}`}


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes #15814.

## Code changes

Makes the "Toggle Replace" title dynamic. Updates unit tests.

## User-facing changes

Makes the title of the expand/collapse button in the search box be "Show Replace" when "Replace" is not visible:

<img width="427" alt="image" src="https://github.com/jupyterlab/jupyterlab/assets/93281816/a312b730-e6c6-40f5-9d31-2d239b9bbfba">

… and "Hide Replace" when "Replace" is visible:

<img width="432" alt="image" src="https://github.com/jupyterlab/jupyterlab/assets/93281816/9981b215-304c-46c9-8526-ab947b34f17d">

The functionality of this button is otherwise unchanged.

## Backwards-incompatible changes

None.
