### PR TITLE
Fix code sample in identity API example

### DIFF
--- a/docs/source/extension/identity.rst
+++ b/docs/source/extension/identity.rst
@@ -27,7 +27,7 @@ to the signal ``userChanged``.
       id: 'jupyterlab-extension',
       autoStart: true,
       activate: (app: JupyterFrontEnd) => {
-         const user = app.services.user;
+         const user = app.serviceManager.user;
          user.ready.then(() => {
             console.debug("Identity:", user.identity);
             console.debug("Permissions:", user.permissions);


### PR DESCRIPTION
## References

`app.services` does not exist, it is `app.serviceManager` [as seen in `collaboration-extension`](https://github.com/jupyterlab/jupyter-collaboration/blob/6bb0298165586bce6c1134cd0b29825503097243/packages/collaboration-extension/src/collaboration.ts#L69).

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None