### PR TITLE
Fix saving of item positions in reactive toolbar

### DIFF
--- a/galata/src/helpers/sidebar.ts
+++ b/galata/src/helpers/sidebar.ts
@@ -270,12 +270,10 @@ export class SidebarHelper {
   /**
    * Set the sidebar width
    *
-   * @param page Page object
    * @param width Sidebar width in pixels
    * @param side Which sidebar to set: 'left' or 'right'
    */
   async setWidth(
-    page: Page,
     width = 251,
     side: galata.SidebarPosition = 'left'
   ): Promise<boolean> {
@@ -283,7 +281,7 @@ export class SidebarHelper {
       return false;
     }
 
-    const handles = page.locator(
+    const handles = this.page.locator(
       '#jp-main-split-panel > .lm-SplitPanel-handle:not(.lm-mod-hidden)'
     );
     const splitHandle =
@@ -292,18 +290,18 @@ export class SidebarHelper {
         : await handles.last().elementHandle();
     const handleBBox = await splitHandle!.boundingBox();
 
-    await page.mouse.move(
+    await this.page.mouse.move(
       handleBBox!.x + 0.5 * handleBBox!.width,
       handleBBox!.y + 0.5 * handleBBox!.height
     );
-    await page.mouse.down();
-    await page.mouse.move(
+    await this.page.mouse.down();
+    await this.page.mouse.move(
       side === 'left'
         ? 33 + width
         : this.page.viewportSize()!.width - 33 - width,
       handleBBox!.y + 0.5 * handleBBox!.height
     );
-    await page.mouse.up();
+    await this.page.mouse.up();
 
     return true;
   }

--- a/galata/src/helpers/sidebar.ts
+++ b/galata/src/helpers/sidebar.ts
@@ -268,6 +268,47 @@ export class SidebarHelper {
   }
 
   /**
+   * Set the sidebar width
+   *
+   * @param page Page object
+   * @param width Sidebar width in pixels
+   * @param side Which sidebar to set: 'left' or 'right'
+   */
+  async setWidth(
+    page: Page,
+    width = 251,
+    side: galata.SidebarPosition = 'left'
+  ): Promise<boolean> {
+    if (!this.isOpen(side)) {
+      return false;
+    }
+
+    const handles = page.locator(
+      '#jp-main-split-panel > .lm-SplitPanel-handle:not(.lm-mod-hidden)'
+    );
+    const splitHandle =
+      side === 'left'
+        ? await handles.first().elementHandle()
+        : await handles.last().elementHandle();
+    const handleBBox = await splitHandle!.boundingBox();
+
+    await page.mouse.move(
+      handleBBox!.x + 0.5 * handleBBox!.width,
+      handleBBox!.y + 0.5 * handleBBox!.height
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      side === 'left'
+        ? 33 + width
+        : this.page.viewportSize()!.width - 33 - width,
+      handleBBox!.y + 0.5 * handleBBox!.height
+    );
+    await page.mouse.up();
+
+    return true;
+  }
+
+  /**
    * Get the selector for a given tab
    *
    * @param id Tab id

--- a/galata/src/helpers/sidebar.ts
+++ b/galata/src/helpers/sidebar.ts
@@ -279,7 +279,7 @@ export class SidebarHelper {
     width = 251,
     side: galata.SidebarPosition = 'left'
   ): Promise<boolean> {
-    if (!this.isOpen(side)) {
+    if (!(await this.isOpen(side))) {
       return false;
     }
 

--- a/galata/test/documentation/customization.test.ts
+++ b/galata/test/documentation/customization.test.ts
@@ -2,7 +2,6 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { expect, galata, test } from '@jupyterlab/galata';
-import { setSidebarWidth } from './utils';
 
 test.use({
   autoGoto: false,
@@ -23,7 +22,7 @@ test.describe('Default', () => {
       }`
     });
 
-    await setSidebarWidth(page);
+    await page.sidebar.setWidth(page);
 
     await page.menu.clickMenuItem('File>New>Terminal');
 
@@ -42,7 +41,7 @@ test.describe('Default', () => {
       }`
     });
 
-    await setSidebarWidth(page);
+    await page.sidebar.setWidth(page);
 
     await page.dblclick(
       '[aria-label="File Browser Section"] >> text=notebooks'
@@ -75,7 +74,7 @@ test.describe('Default', () => {
       }`
     });
 
-    await setSidebarWidth(page);
+    await page.sidebar.setWidth(page);
 
     await page.click('text=Tabs');
 
@@ -95,7 +94,7 @@ test.describe('Default', () => {
       }`
     });
 
-    await setSidebarWidth(page);
+    await page.sidebar.setWidth(page);
 
     await page.dblclick(
       '[aria-label="File Browser Section"] >> text=notebooks'
@@ -199,13 +198,13 @@ test.describe('Customized', () => {
       }`
     });
 
-    await setSidebarWidth(page);
+    await page.sidebar.setWidth(page);
 
     await page.menu.clickMenuItem('File>New>Terminal');
 
     await page.waitForSelector('.jp-Terminal');
 
-    await setSidebarWidth(page, 271, 'right');
+    await page.sidebar.setWidth(page, 271, 'right');
 
     expect(await page.screenshot()).toMatchSnapshot(
       'customized-terminal-position-single.png'
@@ -220,7 +219,7 @@ test.describe('Customized', () => {
       }`
     });
 
-    await setSidebarWidth(page);
+    await page.sidebar.setWidth(page);
 
     await page.dblclick(
       '[aria-label="File Browser Section"] >> text=notebooks'
@@ -247,7 +246,7 @@ test.describe('Customized', () => {
       }`
     });
 
-    await setSidebarWidth(page);
+    await page.sidebar.setWidth(page);
 
     await page.click('text=Tabs');
 
@@ -267,7 +266,7 @@ test.describe('Customized', () => {
       }`
     });
 
-    await setSidebarWidth(page);
+    await page.sidebar.setWidth(page);
 
     await page.dblclick(
       '[aria-label="File Browser Section"] >> text=notebooks'

--- a/galata/test/documentation/customization.test.ts
+++ b/galata/test/documentation/customization.test.ts
@@ -22,7 +22,7 @@ test.describe('Default', () => {
       }`
     });
 
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
 
     await page.menu.clickMenuItem('File>New>Terminal');
 
@@ -41,7 +41,7 @@ test.describe('Default', () => {
       }`
     });
 
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
 
     await page.dblclick(
       '[aria-label="File Browser Section"] >> text=notebooks'
@@ -74,7 +74,7 @@ test.describe('Default', () => {
       }`
     });
 
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
 
     await page.click('text=Tabs');
 
@@ -94,7 +94,7 @@ test.describe('Default', () => {
       }`
     });
 
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
 
     await page.dblclick(
       '[aria-label="File Browser Section"] >> text=notebooks'
@@ -198,13 +198,13 @@ test.describe('Customized', () => {
       }`
     });
 
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
 
     await page.menu.clickMenuItem('File>New>Terminal');
 
     await page.waitForSelector('.jp-Terminal');
 
-    await page.sidebar.setWidth(page, 271, 'right');
+    await page.sidebar.setWidth(271, 'right');
 
     expect(await page.screenshot()).toMatchSnapshot(
       'customized-terminal-position-single.png'
@@ -219,7 +219,7 @@ test.describe('Customized', () => {
       }`
     });
 
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
 
     await page.dblclick(
       '[aria-label="File Browser Section"] >> text=notebooks'
@@ -246,7 +246,7 @@ test.describe('Customized', () => {
       }`
     });
 
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
 
     await page.click('text=Tabs');
 
@@ -266,7 +266,7 @@ test.describe('Customized', () => {
       }`
     });
 
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
 
     await page.dblclick(
       '[aria-label="File Browser Section"] >> text=notebooks'

--- a/galata/test/documentation/debugger.test.ts
+++ b/galata/test/documentation/debugger.test.ts
@@ -43,7 +43,7 @@ test.describe('Debugger', () => {
 
     await page.debugger.switchOn();
     await page.waitForCondition(() => page.debugger.isOpen());
-    await page.sidebar.setWidth(page, 251, 'right');
+    await page.sidebar.setWidth(251, 'right');
 
     expect(
       await page.screenshot({ clip: { y: 62, x: 780, width: 210, height: 32 } })
@@ -57,7 +57,7 @@ test.describe('Debugger', () => {
 
     await page.debugger.switchOn();
     await page.waitForCondition(() => page.debugger.isOpen());
-    await page.sidebar.setWidth(page, 251, 'right');
+    await page.sidebar.setWidth(251, 'right');
 
     await setBreakpoint(page);
 
@@ -105,7 +105,7 @@ test.describe('Debugger', () => {
 
     await page.debugger.switchOn();
     await page.waitForCondition(() => page.debugger.isOpen());
-    await page.sidebar.setWidth(page, 251, 'right');
+    await page.sidebar.setWidth(251, 'right');
 
     await setBreakpoint(page);
 
@@ -131,7 +131,7 @@ test.describe('Debugger', () => {
 
     await page.debugger.switchOn();
     await page.waitForCondition(() => page.debugger.isOpen());
-    await page.sidebar.setWidth(page, 251, 'right');
+    await page.sidebar.setWidth(251, 'right');
 
     await expect(
       page.locator('jp-button.jp-PauseOnExceptions')
@@ -201,7 +201,7 @@ test.describe('Debugger', () => {
       '[data-id="jp-debugger-sidebar"]'
     );
     await sidebar.click();
-    await page.sidebar.setWidth(page, 251, 'right');
+    await page.sidebar.setWidth(251, 'right');
 
     // Inject mouse pointer
     await page.evaluate(
@@ -225,7 +225,7 @@ test.describe('Debugger', () => {
 
     await page.debugger.switchOn();
     await page.waitForCondition(() => page.debugger.isOpen());
-    await page.sidebar.setWidth(page, 251, 'right');
+    await page.sidebar.setWidth(251, 'right');
 
     await setBreakpoint(page);
 
@@ -252,7 +252,7 @@ test.describe('Debugger', () => {
 
     await page.debugger.switchOn();
     await page.waitForCondition(() => page.debugger.isOpen());
-    await page.sidebar.setWidth(page, 251, 'right');
+    await page.sidebar.setWidth(251, 'right');
 
     await setBreakpoint(page);
 
@@ -283,7 +283,7 @@ test.describe('Debugger', () => {
 
     await page.debugger.switchOn();
     await page.waitForCondition(() => page.debugger.isOpen());
-    await page.sidebar.setWidth(page, 251, 'right');
+    await page.sidebar.setWidth(251, 'right');
 
     await setBreakpoint(page);
 
@@ -313,7 +313,7 @@ test.describe('Debugger', () => {
 
     await page.debugger.switchOn();
     await page.waitForCondition(() => page.debugger.isOpen());
-    await page.sidebar.setWidth(page, 251, 'right');
+    await page.sidebar.setWidth(251, 'right');
 
     await setBreakpoint(page);
 
@@ -340,7 +340,7 @@ test.describe('Debugger', () => {
 async function createNotebook(page: IJupyterLabPageFixture) {
   await page.notebook.createNew();
 
-  await page.sidebar.setWidth(page);
+  await page.sidebar.setWidth();
 
   await page.waitForSelector('text=Python 3 (ipykernel) | Idle');
 }

--- a/galata/test/documentation/debugger.test.ts
+++ b/galata/test/documentation/debugger.test.ts
@@ -7,7 +7,7 @@ import {
   IJupyterLabPageFixture,
   test
 } from '@jupyterlab/galata';
-import { positionMouseOver, setSidebarWidth } from './utils';
+import { positionMouseOver } from './utils';
 
 test.use({
   autoGoto: false,
@@ -43,7 +43,7 @@ test.describe('Debugger', () => {
 
     await page.debugger.switchOn();
     await page.waitForCondition(() => page.debugger.isOpen());
-    await setSidebarWidth(page, 251, 'right');
+    await page.sidebar.setWidth(page, 251, 'right');
 
     expect(
       await page.screenshot({ clip: { y: 62, x: 780, width: 210, height: 32 } })
@@ -57,7 +57,7 @@ test.describe('Debugger', () => {
 
     await page.debugger.switchOn();
     await page.waitForCondition(() => page.debugger.isOpen());
-    await setSidebarWidth(page, 251, 'right');
+    await page.sidebar.setWidth(page, 251, 'right');
 
     await setBreakpoint(page);
 
@@ -105,7 +105,7 @@ test.describe('Debugger', () => {
 
     await page.debugger.switchOn();
     await page.waitForCondition(() => page.debugger.isOpen());
-    await setSidebarWidth(page, 251, 'right');
+    await page.sidebar.setWidth(page, 251, 'right');
 
     await setBreakpoint(page);
 
@@ -131,7 +131,7 @@ test.describe('Debugger', () => {
 
     await page.debugger.switchOn();
     await page.waitForCondition(() => page.debugger.isOpen());
-    await setSidebarWidth(page, 251, 'right');
+    await page.sidebar.setWidth(page, 251, 'right');
 
     await expect(
       page.locator('jp-button.jp-PauseOnExceptions')
@@ -201,7 +201,7 @@ test.describe('Debugger', () => {
       '[data-id="jp-debugger-sidebar"]'
     );
     await sidebar.click();
-    await setSidebarWidth(page, 251, 'right');
+    await page.sidebar.setWidth(page, 251, 'right');
 
     // Inject mouse pointer
     await page.evaluate(
@@ -225,7 +225,7 @@ test.describe('Debugger', () => {
 
     await page.debugger.switchOn();
     await page.waitForCondition(() => page.debugger.isOpen());
-    await setSidebarWidth(page, 251, 'right');
+    await page.sidebar.setWidth(page, 251, 'right');
 
     await setBreakpoint(page);
 
@@ -252,7 +252,7 @@ test.describe('Debugger', () => {
 
     await page.debugger.switchOn();
     await page.waitForCondition(() => page.debugger.isOpen());
-    await setSidebarWidth(page, 251, 'right');
+    await page.sidebar.setWidth(page, 251, 'right');
 
     await setBreakpoint(page);
 
@@ -283,7 +283,7 @@ test.describe('Debugger', () => {
 
     await page.debugger.switchOn();
     await page.waitForCondition(() => page.debugger.isOpen());
-    await setSidebarWidth(page, 251, 'right');
+    await page.sidebar.setWidth(page, 251, 'right');
 
     await setBreakpoint(page);
 
@@ -313,7 +313,7 @@ test.describe('Debugger', () => {
 
     await page.debugger.switchOn();
     await page.waitForCondition(() => page.debugger.isOpen());
-    await setSidebarWidth(page, 251, 'right');
+    await page.sidebar.setWidth(page, 251, 'right');
 
     await setBreakpoint(page);
 
@@ -340,7 +340,7 @@ test.describe('Debugger', () => {
 async function createNotebook(page: IJupyterLabPageFixture) {
   await page.notebook.createNew();
 
-  await setSidebarWidth(page);
+  await page.sidebar.setWidth(page);
 
   await page.waitForSelector('text=Python 3 (ipykernel) | Idle');
 }

--- a/galata/test/documentation/export_notebook.test.ts
+++ b/galata/test/documentation/export_notebook.test.ts
@@ -13,7 +13,7 @@ test.describe('Export Notebook', () => {
   test('Export Menu', async ({ page }) => {
     await page.goto();
 
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
 
     await page.dblclick(
       '[aria-label="File Browser Section"] >> text=notebooks'
@@ -39,7 +39,7 @@ test.describe('Export Notebook', () => {
   test('Slides', async ({ page }) => {
     await page.goto();
 
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
 
     await page
       .locator('[aria-label="File Browser Section"]')

--- a/galata/test/documentation/export_notebook.test.ts
+++ b/galata/test/documentation/export_notebook.test.ts
@@ -2,7 +2,6 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { expect, galata, test } from '@jupyterlab/galata';
-import { setSidebarWidth } from './utils';
 
 test.use({
   autoGoto: false,
@@ -14,7 +13,7 @@ test.describe('Export Notebook', () => {
   test('Export Menu', async ({ page }) => {
     await page.goto();
 
-    await setSidebarWidth(page);
+    await page.sidebar.setWidth(page);
 
     await page.dblclick(
       '[aria-label="File Browser Section"] >> text=notebooks'
@@ -40,7 +39,7 @@ test.describe('Export Notebook', () => {
   test('Slides', async ({ page }) => {
     await page.goto();
 
-    await setSidebarWidth(page);
+    await page.sidebar.setWidth(page);
 
     await page
       .locator('[aria-label="File Browser Section"]')

--- a/galata/test/documentation/extension_manager.test.ts
+++ b/galata/test/documentation/extension_manager.test.ts
@@ -7,7 +7,7 @@ import {
   IJupyterLabPageFixture,
   test
 } from '@jupyterlab/galata';
-import { setSidebarWidth, stubGitHubUserIcons } from './utils';
+import { stubGitHubUserIcons } from './utils';
 import { default as extensionsList } from './data/extensions.json';
 import { default as allExtensionsList } from './data/extensions-search-all.json';
 import { default as drawioExtensionsList } from './data/extensions-search-drawio.json';
@@ -198,5 +198,5 @@ async function openExtensionSidebar(page: IJupyterLabPageFixture) {
     '.jp-extensionmanager-view >> .jp-AccordionPanel-title[aria-expanded="false"] >> text=Warning'
   );
 
-  await setSidebarWidth(page);
+  await page.sidebar.setWidth(page);
 }

--- a/galata/test/documentation/extension_manager.test.ts
+++ b/galata/test/documentation/extension_manager.test.ts
@@ -198,5 +198,5 @@ async function openExtensionSidebar(page: IJupyterLabPageFixture) {
     '.jp-extensionmanager-view >> .jp-AccordionPanel-title[aria-expanded="false"] >> text=Warning'
   );
 
-  await page.sidebar.setWidth(page);
+  await page.sidebar.setWidth();
 }

--- a/galata/test/documentation/general.test.ts
+++ b/galata/test/documentation/general.test.ts
@@ -3,12 +3,7 @@
 
 import { expect, galata, test } from '@jupyterlab/galata';
 import path from 'path';
-import {
-  generateArrow,
-  positionMouse,
-  positionMouseOver,
-  setSidebarWidth
-} from './utils';
+import { generateArrow, positionMouse, positionMouseOver } from './utils';
 
 test.use({
   autoGoto: false,
@@ -26,7 +21,7 @@ test.describe('General', () => {
       }`
     });
 
-    await setSidebarWidth(page);
+    await page.sidebar.setWidth(page);
 
     // README.md in preview
     await page.click('text=README.md', {
@@ -89,7 +84,7 @@ test.describe('General', () => {
       }`
     });
 
-    await setSidebarWidth(page);
+    await page.sidebar.setWidth(page);
 
     await page.dblclick('[aria-label="File Browser Section"] >> text=data');
     // Wait for the `data` folder to load to have something to blur
@@ -114,7 +109,7 @@ test.describe('General', () => {
 
     await page.notebook.createNew();
     await page.click('[title="Property Inspector"]');
-    await setSidebarWidth(page, 251, 'right');
+    await page.sidebar.setWidth(page, 251, 'right');
 
     expect(
       await page.screenshot({
@@ -294,7 +289,7 @@ test.describe('General', () => {
       }`
     });
 
-    await setSidebarWidth(page);
+    await page.sidebar.setWidth(page);
 
     await page.dblclick(
       '[aria-label="File Browser Section"] >> text=notebooks'
@@ -375,7 +370,7 @@ test.describe('General', () => {
       }`
     });
 
-    await setSidebarWidth(page);
+    await page.sidebar.setWidth(page);
 
     // Open jupyterlab.md
     await page.dblclick(
@@ -402,7 +397,7 @@ test.describe('General', () => {
       }`
     });
 
-    await setSidebarWidth(page);
+    await page.sidebar.setWidth(page);
 
     // Open Data.ipynb
     await page.dblclick(
@@ -466,7 +461,7 @@ test.describe('General', () => {
 
   test('Heading anchor', async ({ page }, testInfo) => {
     await page.goto();
-    await setSidebarWidth(page);
+    await page.sidebar.setWidth(page);
 
     // Open Data.ipynb
     await page.dblclick(
@@ -516,7 +511,7 @@ test.describe('General', () => {
       }`
     });
 
-    await setSidebarWidth(page);
+    await page.sidebar.setWidth(page);
 
     // Open Data.ipynb
     await page.dblclick(
@@ -551,7 +546,7 @@ test.describe('General', () => {
       }`
     });
 
-    await setSidebarWidth(page);
+    await page.sidebar.setWidth(page);
 
     // Open a terminal
     await page.click('text=File');
@@ -607,7 +602,7 @@ test.describe('General', () => {
       }`
     });
 
-    await setSidebarWidth(page);
+    await page.sidebar.setWidth(page);
 
     await page.dblclick('[aria-label="File Browser Section"] >> text=data');
     await page.click('text=README.md', {

--- a/galata/test/documentation/general.test.ts
+++ b/galata/test/documentation/general.test.ts
@@ -21,7 +21,7 @@ test.describe('General', () => {
       }`
     });
 
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
 
     // README.md in preview
     await page.click('text=README.md', {
@@ -84,7 +84,7 @@ test.describe('General', () => {
       }`
     });
 
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
 
     await page.dblclick('[aria-label="File Browser Section"] >> text=data');
     // Wait for the `data` folder to load to have something to blur
@@ -109,7 +109,7 @@ test.describe('General', () => {
 
     await page.notebook.createNew();
     await page.click('[title="Property Inspector"]');
-    await page.sidebar.setWidth(page, 251, 'right');
+    await page.sidebar.setWidth(251, 'right');
 
     expect(
       await page.screenshot({
@@ -289,7 +289,7 @@ test.describe('General', () => {
       }`
     });
 
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
 
     await page.dblclick(
       '[aria-label="File Browser Section"] >> text=notebooks'
@@ -370,7 +370,7 @@ test.describe('General', () => {
       }`
     });
 
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
 
     // Open jupyterlab.md
     await page.dblclick(
@@ -397,7 +397,7 @@ test.describe('General', () => {
       }`
     });
 
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
 
     // Open Data.ipynb
     await page.dblclick(
@@ -461,7 +461,7 @@ test.describe('General', () => {
 
   test('Heading anchor', async ({ page }, testInfo) => {
     await page.goto();
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
 
     // Open Data.ipynb
     await page.dblclick(
@@ -511,7 +511,7 @@ test.describe('General', () => {
       }`
     });
 
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
 
     // Open Data.ipynb
     await page.dblclick(
@@ -546,7 +546,7 @@ test.describe('General', () => {
       }`
     });
 
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
 
     // Open a terminal
     await page.click('text=File');
@@ -602,7 +602,7 @@ test.describe('General', () => {
       }`
     });
 
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
 
     await page.dblclick('[aria-label="File Browser Section"] >> text=data');
     await page.click('text=README.md', {

--- a/galata/test/documentation/internationalization.test.ts
+++ b/galata/test/documentation/internationalization.test.ts
@@ -2,7 +2,6 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { expect, galata, test } from '@jupyterlab/galata';
-import { setSidebarWidth } from './utils';
 
 test.use({
   autoGoto: false,
@@ -14,7 +13,7 @@ test.describe('Internationalization', () => {
   test('Menu', async ({ page }) => {
     await page.goto();
 
-    await setSidebarWidth(page);
+    await page.sidebar.setWidth(page);
 
     await page.click('text=Settings');
     await page.click('.lm-Menu ul[role="menu"] >> text=Language');
@@ -27,7 +26,7 @@ test.describe('Internationalization', () => {
   test('Confirm language', async ({ page }) => {
     await page.goto();
 
-    await setSidebarWidth(page);
+    await page.sidebar.setWidth(page);
 
     await page.click('text=Settings');
     await page.click('.lm-Menu ul[role="menu"] >> text=Language');
@@ -69,7 +68,7 @@ test.describe('Internationalization', () => {
     // Wait for the launcher to be loaded
     await page.waitForSelector('text=README.md');
 
-    await setSidebarWidth(page);
+    await page.sidebar.setWidth(page);
 
     expect(await page.screenshot()).toMatchSnapshot('language_chinese.png');
   });

--- a/galata/test/documentation/internationalization.test.ts
+++ b/galata/test/documentation/internationalization.test.ts
@@ -13,7 +13,7 @@ test.describe('Internationalization', () => {
   test('Menu', async ({ page }) => {
     await page.goto();
 
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
 
     await page.click('text=Settings');
     await page.click('.lm-Menu ul[role="menu"] >> text=Language');
@@ -26,7 +26,7 @@ test.describe('Internationalization', () => {
   test('Confirm language', async ({ page }) => {
     await page.goto();
 
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
 
     await page.click('text=Settings');
     await page.click('.lm-Menu ul[role="menu"] >> text=Language');
@@ -68,7 +68,7 @@ test.describe('Internationalization', () => {
     // Wait for the launcher to be loaded
     await page.waitForSelector('text=README.md');
 
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
 
     expect(await page.screenshot()).toMatchSnapshot('language_chinese.png');
   });

--- a/galata/test/documentation/overview.test.ts
+++ b/galata/test/documentation/overview.test.ts
@@ -55,7 +55,7 @@ async function openOverview(page) {
     }`
   });
 
-  await page.sidebar.setWidth(page);
+  await page.sidebar.setWidth();
 
   // Open Data.ipynb
   await page.dblclick('[aria-label="File Browser Section"] >> text=notebooks');

--- a/galata/test/documentation/overview.test.ts
+++ b/galata/test/documentation/overview.test.ts
@@ -2,7 +2,6 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { expect, galata, test } from '@jupyterlab/galata';
-import { setSidebarWidth } from './utils';
 
 test.use({
   autoGoto: false,
@@ -56,7 +55,7 @@ async function openOverview(page) {
     }`
   });
 
-  await setSidebarWidth(page);
+  await page.sidebar.setWidth(page);
 
   // Open Data.ipynb
   await page.dblclick('[aria-label="File Browser Section"] >> text=notebooks');

--- a/galata/test/documentation/utils.ts
+++ b/galata/test/documentation/utils.ts
@@ -93,39 +93,6 @@ export async function positionMouseOver(
   });
 }
 
-/**
- * Set the sidebar width
- *
- * @param page Page object
- * @param width Sidebar width in pixels
- * @param side Which sidebar to set: 'left' or 'right'
- */
-export async function setSidebarWidth(
-  page: Page,
-  width = 251,
-  side: 'left' | 'right' = 'left'
-): Promise<void> {
-  const handles = page.locator(
-    '#jp-main-split-panel > .lm-SplitPanel-handle:not(.lm-mod-hidden)'
-  );
-  const splitHandle =
-    side === 'left'
-      ? await handles.first().elementHandle()
-      : await handles.last().elementHandle();
-  const handleBBox = await splitHandle.boundingBox();
-
-  await page.mouse.move(
-    handleBBox.x + 0.5 * handleBBox.width,
-    handleBBox.y + 0.5 * handleBBox.height
-  );
-  await page.mouse.down();
-  await page.mouse.move(
-    side === 'left' ? 33 + width : page.viewportSize().width - 33 - width,
-    handleBBox.y + 0.5 * handleBBox.height
-  );
-  await page.mouse.up();
-}
-
 export async function stubGitHubUserIcons(page: Page): Promise<void> {
   // stub out github user icons
   // only first and last icon for now

--- a/galata/test/jupyterlab/notebook-toolbar.test.ts
+++ b/galata/test/jupyterlab/notebook-toolbar.test.ts
@@ -210,7 +210,7 @@ test.describe('Reactive toolbar', () => {
       toolbar.locator('.jp-Toolbar-responsive-opener')
     ).not.toBeVisible();
 
-    await page.sidebar.setWidth(page, 520);
+    await page.sidebar.setWidth(520);
 
     await expect(
       toolbar.locator('.jp-Toolbar-responsive-opener')
@@ -224,7 +224,7 @@ test.describe('Reactive toolbar', () => {
   }) => {
     const toolbar = page.locator('.jp-NotebookPanel-toolbar');
 
-    await page.sidebar.setWidth(page, 520);
+    await page.sidebar.setWidth(520);
 
     await toolbar.locator('.jp-Toolbar-responsive-opener').click();
 
@@ -274,7 +274,7 @@ test.describe('Reactive toolbar', () => {
       'cellType'
     );
 
-    await page.sidebar.setWidth(page, 600);
+    await page.sidebar.setWidth(600);
     await toolbar.locator('.jp-Toolbar-responsive-opener').click();
 
     // A 'visible' selector is added because there is another response popup element
@@ -287,7 +287,7 @@ test.describe('Reactive toolbar', () => {
 
     await expect(popupToolbarItems.nth(1)).toHaveText('new item 1');
 
-    await page.sidebar.setWidth(page);
+    await page.sidebar.setWidth();
     const toolbarItems = toolbar.locator('.jp-Toolbar-item:visible');
     await expect(toolbarItems.nth(10)).toHaveText('new item 1');
   });
@@ -297,7 +297,7 @@ test.describe('Reactive toolbar', () => {
   }) => {
     const toolbar = page.locator('.jp-NotebookPanel-toolbar');
 
-    await page.sidebar.setWidth(page, 600);
+    await page.sidebar.setWidth(600);
 
     await addWidgetsInNotebookToolbar(
       page,

--- a/galata/test/jupyterlab/notebook-toolbar.test.ts
+++ b/galata/test/jupyterlab/notebook-toolbar.test.ts
@@ -206,7 +206,9 @@ test.describe('Reactive toolbar', () => {
   }) => {
     const toolbar = page.locator('.jp-NotebookPanel-toolbar');
     await expect(toolbar.locator('.jp-Toolbar-item:visible')).toHaveCount(14);
-    expect(toolbar.locator('.jp-Toolbar-responsive-opener')).not.toBeVisible();
+    await expect(
+      toolbar.locator('.jp-Toolbar-responsive-opener')
+    ).not.toBeVisible();
 
     await page.sidebar.setWidth(page, 520);
 
@@ -214,7 +216,7 @@ test.describe('Reactive toolbar', () => {
       toolbar.locator('.jp-Toolbar-responsive-opener')
     ).toBeVisible();
 
-    expect(toolbar.locator('.jp-Toolbar-item:visible')).toHaveCount(12);
+    await expect(toolbar.locator('.jp-Toolbar-item:visible')).toHaveCount(12);
   });
 
   test('Items in popup toolbar should have the same order', async ({
@@ -242,9 +244,9 @@ test.describe('Reactive toolbar', () => {
     ];
 
     for (let i = 0; i < (await popupToolbarItems.count()); i++) {
-      expect(popupToolbarItems.nth(i).locator(itemChildClasses[i])).toHaveCount(
-        1
-      );
+      await expect(
+        popupToolbarItems.nth(i).locator(itemChildClasses[i])
+      ).toHaveCount(1);
     }
   });
 
@@ -260,7 +262,7 @@ test.describe('Reactive toolbar', () => {
     );
 
     const toolbarItems = toolbar.locator('.jp-Toolbar-item:visible');
-    expect(toolbarItems.nth(10)).toHaveText('new item 1');
+    await expect(toolbarItems.nth(10)).toHaveText('new item 1');
   });
 
   test('Item should be correctly placed after resize', async ({ page }) => {
@@ -283,11 +285,11 @@ test.describe('Reactive toolbar', () => {
     );
     const popupToolbarItems = popupToolbar.locator('.jp-Toolbar-item:visible');
 
-    expect(popupToolbarItems.nth(1)).toHaveText('new item 1');
+    await expect(popupToolbarItems.nth(1)).toHaveText('new item 1');
 
     await page.sidebar.setWidth(page);
     const toolbarItems = toolbar.locator('.jp-Toolbar-item:visible');
-    expect(toolbarItems.nth(10)).toHaveText('new item 1');
+    await expect(toolbarItems.nth(10)).toHaveText('new item 1');
   });
 
   test('Item added from extension should be correctly placed in popup toolbar', async ({
@@ -314,6 +316,6 @@ test.describe('Reactive toolbar', () => {
     );
     const popupToolbarItems = popupToolbar.locator('.jp-Toolbar-item:visible');
 
-    expect(popupToolbarItems.nth(1)).toHaveText('new item 1');
+    await expect(popupToolbarItems.nth(1)).toHaveText('new item 1');
   });
 });

--- a/galata/test/jupyterlab/notebook-toolbar.test.ts
+++ b/galata/test/jupyterlab/notebook-toolbar.test.ts
@@ -14,6 +14,60 @@ async function populateNotebook(page: IJupyterLabPageFixture) {
   await page.notebook.addCell('code', '2 ** 3');
 }
 
+/**
+ * Adds an item in notebook toolbar using the extension system.
+ */
+async function addWidgetsInNotebookToolbar(
+  page: IJupyterLabPageFixture,
+  notebook: string,
+  content: string,
+  afterElem: string
+) {
+  await page.notebook.activate(notebook);
+  await page.evaluate(
+    options => {
+      const { content, afterElem } = options;
+
+      // A minimal widget class, with required field for adding an item in toolbar.
+      class MinimalWidget {
+        constructor(node) {
+          this.node = node;
+        }
+        addClass() {}
+        node = null;
+        processMessage() {}
+        hasClass(name) {
+          return false;
+        }
+        _parent = null;
+        get parent() {
+          return this._parent;
+        }
+        set parent(p) {
+          this._parent?.layout.removeWidget(this);
+          this._parent = p;
+        }
+      }
+
+      const plugin = {
+        id: 'my-test-plugin',
+        activate: app => {
+          const toolbar = app.shell.activeWidget.toolbar;
+          const node = document.createElement('div');
+          node.classList.add('jp-CommandToolbarButton');
+          node.classList.add('jp-Toolbar-item');
+          node.textContent = content;
+          const widget = new MinimalWidget(node);
+          toolbar.insertAfter(afterElem, content, widget);
+        }
+      };
+      jupyterapp.registerPlugin(plugin);
+      jupyterapp.activatePlugin('my-test-plugin');
+    },
+    { content, afterElem }
+  );
+}
+
 test.describe('Notebook Toolbar', () => {
   test.beforeEach(async ({ page }) => {
     await page.notebook.createNew(fileName);
@@ -140,4 +194,126 @@ test('Toolbar items act on owner widget', async ({ page }) => {
   const classlistEnd = await tab1.getAttribute('class');
   expect(classlistEnd.split(' ')).toContain('jp-mod-current');
   expect(await page.notebook.getCellCount()).toEqual(2);
+});
+
+test.describe('Reactive toolbar', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.notebook.createNew(fileName);
+  });
+
+  test('Reducing toolbar width should display opener item', async ({
+    page
+  }) => {
+    const toolbar = page.locator('.jp-NotebookPanel-toolbar');
+    await expect(toolbar.locator('.jp-Toolbar-item:visible')).toHaveCount(14);
+    expect(toolbar.locator('.jp-Toolbar-responsive-opener')).not.toBeVisible();
+
+    await page.sidebar.setWidth(page, 500);
+
+    await expect(
+      toolbar.locator('.jp-Toolbar-responsive-opener')
+    ).toBeVisible();
+
+    expect(toolbar.locator('.jp-Toolbar-item:visible')).toHaveCount(12);
+  });
+
+  test('Items in popup toolbar should have the same order', async ({
+    page
+  }) => {
+    const toolbar = page.locator('.jp-NotebookPanel-toolbar');
+
+    await page.sidebar.setWidth(page, 500);
+
+    await toolbar.locator('.jp-Toolbar-responsive-opener').click();
+
+    // A 'visible' selector is added because there is another response popup element
+    // when running in playwright (don't know where it come from, it is an empty
+    // toolbar).
+    const popupToolbar = page.locator(
+      'body > .jp-Toolbar-responsive-popup:visible'
+    );
+    const popupToolbarItems = popupToolbar.locator('.jp-Toolbar-item:visible');
+    await expect(popupToolbarItems).toHaveCount(3);
+
+    const itemChildClasses = [
+      '.jp-DebuggerBugButton',
+      '.jp-Toolbar-kernelName',
+      '.jp-Notebook-ExecutionIndicator'
+    ];
+
+    for (let i = 0; i < (await popupToolbarItems.count()); i++) {
+      expect(popupToolbarItems.nth(i).locator(itemChildClasses[i])).toHaveCount(
+        1
+      );
+    }
+  });
+
+  test('Item added from extension should be correctly placed', async ({
+    page
+  }) => {
+    const toolbar = page.locator('.jp-NotebookPanel-toolbar');
+    await addWidgetsInNotebookToolbar(
+      page,
+      'notebook.ipynb',
+      'new item 1',
+      'cellType'
+    );
+
+    const toolbarItems = toolbar.locator('.jp-Toolbar-item:visible');
+    expect(toolbarItems.nth(10)).toHaveText('new item 1');
+  });
+
+  test('Item should be correctly placed after resize', async ({ page }) => {
+    const toolbar = page.locator('.jp-NotebookPanel-toolbar');
+    await addWidgetsInNotebookToolbar(
+      page,
+      'notebook.ipynb',
+      'new item 1',
+      'cellType'
+    );
+
+    await page.sidebar.setWidth(page, 600);
+    await toolbar.locator('.jp-Toolbar-responsive-opener').click();
+
+    // A 'visible' selector is added because there is another response popup element
+    // when running in playwright (don't know where it come from, it is an empty
+    // toolbar).
+    const popupToolbar = page.locator(
+      'body > .jp-Toolbar-responsive-popup:visible'
+    );
+    const popupToolbarItems = popupToolbar.locator('.jp-Toolbar-item:visible');
+
+    expect(popupToolbarItems.nth(1)).toHaveText('new item 1');
+
+    await page.sidebar.setWidth(page);
+    const toolbarItems = toolbar.locator('.jp-Toolbar-item:visible');
+    expect(toolbarItems.nth(10)).toHaveText('new item 1');
+  });
+
+  test('Item added from extension should be correctly placed in popup toolbar', async ({
+    page
+  }) => {
+    const toolbar = page.locator('.jp-NotebookPanel-toolbar');
+
+    await page.sidebar.setWidth(page, 600);
+
+    await addWidgetsInNotebookToolbar(
+      page,
+      'notebook.ipynb',
+      'new item 1',
+      'cellType'
+    );
+
+    await toolbar.locator('.jp-Toolbar-responsive-opener').click();
+
+    // A 'visible' selector is added because there is another response popup element
+    // when running in playwright (don't know where it come from, it is an empty
+    // toolbar).
+    const popupToolbar = page.locator(
+      'body > .jp-Toolbar-responsive-popup:visible'
+    );
+    const popupToolbarItems = popupToolbar.locator('.jp-Toolbar-item:visible');
+
+    expect(popupToolbarItems.nth(1)).toHaveText('new item 1');
+  });
 });

--- a/galata/test/jupyterlab/notebook-toolbar.test.ts
+++ b/galata/test/jupyterlab/notebook-toolbar.test.ts
@@ -208,7 +208,7 @@ test.describe('Reactive toolbar', () => {
     await expect(toolbar.locator('.jp-Toolbar-item:visible')).toHaveCount(14);
     expect(toolbar.locator('.jp-Toolbar-responsive-opener')).not.toBeVisible();
 
-    await page.sidebar.setWidth(page, 500);
+    await page.sidebar.setWidth(page, 520);
 
     await expect(
       toolbar.locator('.jp-Toolbar-responsive-opener')
@@ -222,7 +222,7 @@ test.describe('Reactive toolbar', () => {
   }) => {
     const toolbar = page.locator('.jp-NotebookPanel-toolbar');
 
-    await page.sidebar.setWidth(page, 500);
+    await page.sidebar.setWidth(page, 520);
 
     await toolbar.locator('.jp-Toolbar-responsive-opener').click();
 

--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -376,7 +376,7 @@ export class ReactiveToolbar extends Toolbar<Widget> {
     this.popupOpener.hide();
     this._resizer = new Throttler(async (callTwice = false) => {
       await this._onResize(callTwice);
-    }, 300);
+    }, 500);
   }
 
   /**
@@ -429,11 +429,6 @@ export class ReactiveToolbar extends Toolbar<Widget> {
   ): boolean {
     const targetPosition = this._widgetPositions.get(at);
     const position = (targetPosition ?? 0) + offset;
-    this._widgetPositions.forEach((value, key) => {
-      if (key !== TOOLBAR_OPENER_NAME && value >= position) {
-        this._widgetPositions.set(key, value + 1);
-      }
-    });
     return this.insertItem(position, name, widget);
   }
 
@@ -465,15 +460,34 @@ export class ReactiveToolbar extends Toolbar<Widget> {
       status = super.insertItem(j, name, widget);
     }
 
-    // Save the widgets position when a new widget is inserted.
+    // Save the widgets position when a widget is inserted or moved.
     if (
       name !== TOOLBAR_OPENER_NAME &&
-      this._widgetPositions.get(name) === undefined
+      this._widgetPositions.get(name) !== index
     ) {
-      this._widgetPositions.clear();
-      (this.layout as ToolbarLayout).widgets.forEach((widget, index) => {
-        this._widgetPositions.set(Private.nameProperty.get(widget), index);
+      // If the widget is inserted, set its current position as last.
+      const currentPosition =
+        this._widgetPositions.get(name) ?? this._widgetPositions.size;
+
+      // Change the position of moved widgets.
+      this._widgetPositions.forEach((value, key) => {
+        if (key !== TOOLBAR_OPENER_NAME) {
+          if (value >= index && value < currentPosition) {
+            this._widgetPositions.set(key, value + 1);
+          } else if (value <= index && value > currentPosition) {
+            this._widgetPositions.set(key, value - 1);
+          }
+        }
       });
+
+      // Save the new position of the widget.
+      this._widgetPositions.set(name, index);
+
+      // Invokes resizing to ensure correct display of items after an addition, only
+      // if the toolbar is rendered.
+      if (this.isVisible) {
+        void this._onResize();
+      }
     }
     return status;
   }
@@ -529,7 +543,7 @@ export class ReactiveToolbar extends Toolbar<Widget> {
     }
     const toolbarWidth = this.node.clientWidth;
     const opener = this.popupOpener;
-    const openerWidth = 30;
+    const openerWidth = 32;
     // left and right padding.
     const toolbarPadding = 2 + 5;
     let width = opener.isHidden ? toolbarPadding : toolbarPadding + openerWidth;
@@ -538,13 +552,27 @@ export class ReactiveToolbar extends Toolbar<Widget> {
       .then(values => {
         let { width, widgetsToRemove } = values;
         while (widgetsToRemove.length > 0) {
-          // Insert the widget in the right position in the opener popup.
+          // Insert the widget at the right position in the opener popup, relatively
+          // to the saved position of the first item of the popup toolbar.
+
+          // Get the saved position of the widget to insert.
           const widget = widgetsToRemove.pop() as Widget;
           const name = Private.nameProperty.get(widget);
-          width -= this._widgetWidths![name];
+          width -= this._widgetWidths.get(name) || 0;
           const position = this._widgetPositions.get(name) ?? 0;
-          const index =
-            opener.widgetCount() + position - this._widgetPositions.size;
+
+          // Get the saved position of the first item in the popup toolbar.
+          // If there is no widget, set the value at last item.
+          let openerFirstIndex = this._widgetPositions.size;
+          const openerFirst = opener.widgetAt(0);
+          if (openerFirst) {
+            const openerFirstName = Private.nameProperty.get(openerFirst);
+            openerFirstIndex =
+              this._widgetPositions.get(openerFirstName) ?? openerFirstIndex;
+          }
+
+          // Insert the widget in the popup toolbar.
+          const index = position - openerFirstIndex;
           opener.insertWidget(index, widget);
         }
         if (opener.widgetCount() > 0) {
@@ -609,17 +637,19 @@ export class ReactiveToolbar extends Toolbar<Widget> {
     let index = 0;
     while (index < toIndex) {
       const widget = layout.widgets[index];
+      const name = Private.nameProperty.get(widget);
       // Compute the widget size only if
       // - the zoom has changed.
       // - the widget size has not been computed yet.
       let widgetWidth: number;
       if (this._zoomChanged) {
-        widgetWidth = await this._saveWidgetWidth(widget);
+        widgetWidth = await this._saveWidgetWidth(name, widget);
       } else {
         // The widget widths can be 0px if it has been added to the toolbar but
         // not rendered, this is why we must use '||' instead of '??'.
         widgetWidth =
-          this._getWidgetWidth(widget) || (await this._saveWidgetWidth(widget));
+          this._getWidgetWidth(widget) ||
+          (await this._saveWidgetWidth(name, widget));
       }
       width += widgetWidth;
       if (
@@ -629,12 +659,18 @@ export class ReactiveToolbar extends Toolbar<Widget> {
       ) {
         width += openerWidth;
       }
-      if (width > toolbarWidth) {
+      // Remove the widget if it is out of the toolbar or incorrectly positioned.
+      // Incorrect positioning can occur when the widget is added after the toolbar
+      // has been rendered and should be in the popup. E.g. debugger icon with a
+      // narrow notebook toolbar.
+      if (
+        width > toolbarWidth ||
+        (this._widgetPositions.get(name) ?? 0) > index
+      ) {
         widgetsToRemove.push(widget);
       }
       index++;
     }
-
     this._zoomChanged = false;
     return {
       width: width,
@@ -642,27 +678,28 @@ export class ReactiveToolbar extends Toolbar<Widget> {
     };
   }
 
-  private async _saveWidgetWidth(widget: Widget): Promise<number> {
+  private async _saveWidgetWidth(
+    name: string,
+    widget: Widget
+  ): Promise<number> {
     if (widget instanceof ReactWidget) {
       await widget.renderPromise;
     }
-    const widgetName = Private.nameProperty.get(widget);
-
     const widgetWidth = widget.hasClass(TOOLBAR_SPACER_CLASS)
       ? 2
       : widget.node.clientWidth;
-    this._widgetWidths![widgetName] = widgetWidth;
+    this._widgetWidths.set(name, widgetWidth);
     return widgetWidth;
   }
 
   private _getWidgetWidth(widget: Widget): number {
     const widgetName = Private.nameProperty.get(widget);
-    return this._widgetWidths![widgetName];
+    return this._widgetWidths.get(widgetName) || 0;
   }
 
   protected readonly popupOpener: ToolbarPopupOpener = new ToolbarPopupOpener();
-  private readonly _widgetWidths: { [key: string]: number } = {};
   private readonly _resizer: Throttler;
+  private readonly _widgetWidths = new Map<string, number>();
   private _widgetPositions = new Map<string, number>();
   // The zoom property is not the real browser zoom, but a value proportional to
   // the zoom, which is modified when the zoom changes.

--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -470,7 +470,10 @@ export class ReactiveToolbar extends Toolbar<Widget> {
       name !== TOOLBAR_OPENER_NAME &&
       this._widgetPositions.get(name) === undefined
     ) {
-      this._widgetPositions.set(name, index);
+      this._widgetPositions.clear();
+      (this.layout as ToolbarLayout).widgets.forEach((widget, index) => {
+        this._widgetPositions.set(Private.nameProperty.get(widget), index);
+      });
     }
     return status;
   }


### PR DESCRIPTION
This PR fixes the inconsistent item order in reactive toolbar.

Follow up https://github.com/jupyterlab/jupyterlab/pull/15553 and https://github.com/jupyterlab/jupyterlab/pull/15021

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/15676
Fixes https://github.com/jupyterlab/jupyterlab/issues/15758

## Code changes

- Fix the position of items in the toolbar

  When an item is inserted in the reactive toolbar, its position in the toolbar is saved in a Map.
This allows items to be restores to their correct positions when moving between the `ToolbarPopup` and the `ReactiveToolbar` 
(when resizing). But the position of previously inserted items was not updated after an insertion, resulting in duplicate 
positions in the map (and inconsistent behavior).
 
  This PR compute the position of all items every time a new item is inserted in the toolbar.

- Add tests on notebook toolbar

  This PR also adds a function in the sidebar helper of galata, to change the width of a sidebar. this function has been moved from *documentation -> utils.ts` to the sidebar helper.

## User-facing changes

Fixes the inconsistent position of items.

## Backwards-incompatible changes

None

## TODO

- [x] add tests on reactive toolbar