### PR TITLE
Long items should not wrap

### DIFF
--- a/packages/completer/style/base.css
+++ b/packages/completer/style/base.css
@@ -64,7 +64,7 @@
   display: grid;
   grid-template-columns: min-content 1fr min-content;
   position: relative;
-  whitespace: nowrap;
+  white-space: nowrap;
 }
 
 .jp-Completer-item .jp-Completer-match {

--- a/packages/completer/style/base.css
+++ b/packages/completer/style/base.css
@@ -64,7 +64,6 @@
   display: grid;
   grid-template-columns: min-content 1fr min-content;
   position: relative;
-  white-space: nowrap;
 }
 
 .jp-Completer-item .jp-Completer-match {
@@ -75,6 +74,7 @@
   font-family: var(--jp-code-font-family);
   font-size: var(--jp-code-font-size);
   line-height: var(--jp-private-completer-item-height);
+  white-space: nowrap;
 }
 
 .jp-Completer-deprecated .jp-Completer-match {

--- a/packages/completer/style/base.css
+++ b/packages/completer/style/base.css
@@ -64,6 +64,7 @@
   display: grid;
   grid-template-columns: min-content 1fr min-content;
   position: relative;
+  whitespace: nowrap;
 }
 
 .jp-Completer-item .jp-Completer-match {


### PR DESCRIPTION
If they wrap, it causes the text to overlap with the text on the next line, and can happen for instance if tab completing directories that contain a hyphen.

