### PR TITLE
Reconfigure the 4.0.x branch (4.1.x is new stable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Developers can now provide editor extensions, like themes and programming langua
 #### New extension manager
 
 Starting with JupyterLab 3, extensions can be installed via Python packages
-(or other providers of [prebuilt extensions](https://jupyterlab.readthedocs.io/en/stable/extension/extension_dev.html#prebuilt-extensions)).
+(or other providers of [prebuilt extensions](https://jupyterlab.readthedocs.io/en/4.0.x/extension/extension_dev.html#prebuilt-extensions)).
 
 In JupyterLab 4, building on this feature, the Extension Manager now includes extensions from [pypi.org](https://pypi.org/search/?c=Framework+%3A%3A+Jupyter+%3A%3A+JupyterLab).
 This removes the build step from installation of extension when using Extension Manager.
@@ -95,7 +95,7 @@ Here are the main tool updates that will benefit extension authors and developer
 
 We recommend using Node.js v18 or newer, because older versions will reach end of life in 2023 or earlier (see [Node release schedule](https://github.com/nodejs/release#release-schedule)).
 
-To ease code migration to JupyterLab 4, developers should review the [migration guide](https://jupyterlab.readthedocs.io/en/stable/extension/extension_migration.html). A few existing extensions have already been migrated and can be used as examples:
+To ease code migration to JupyterLab 4, developers should review the [migration guide](https://jupyterlab.readthedocs.io/en/4.0.x/extension/extension_migration.html). A few existing extensions have already been migrated and can be used as examples:
 - the [JupyterLab Extensions by Examples](https://github.com/jupyterlab/extension-examples/pull/232)
 - the [Jupyter MIME type renderers](https://github.com/jupyterlab/jupyter-renderers/pull/296)
 
@@ -575,9 +575,9 @@ To ease code migration to JupyterLab 4, developers should review the [migration 
 
 JupyterLab 4 is released! :tada:
 
-Check out the new features, improvements and bug fixes: https://jupyterlab.readthedocs.io/en/stable/getting_started/changelog.html#v4-0
+Check out the new features, improvements and bug fixes: https://jupyterlab.readthedocs.io/en/4.0.x/getting_started/changelog.html#v4-0
 
-For extension authors, there is a migration guide available to help you migrate your extensions to JupyterLab 4: https://jupyterlab.readthedocs.io/en/stable/extension/extension_migration.html#jupyterlab-3-x-to-4-x
+For extension authors, there is a migration guide available to help you migrate your extensions to JupyterLab 4: https://jupyterlab.readthedocs.io/en/4.0.x/extension/extension_migration.html#jupyterlab-3-x-to-4-x
 
 ______________________________________________________________________
 
@@ -2480,7 +2480,7 @@ No merged PRs
 
 ### Enhancements made
 
-- Add a menu entry to show/hide hidden files in the filebrowser [#11206](https://github.com/jupyterlab/jupyterlab/pull/11206) ([@loichuder](https://github.com/loichuder)) - activation instructions: [see documentation](https://jupyterlab.readthedocs.io/en/stable/user/files.html#displaying-hidden-files)
+- Add a menu entry to show/hide hidden files in the filebrowser [#11206](https://github.com/jupyterlab/jupyterlab/pull/11206) ([@loichuder](https://github.com/loichuder)) - activation instructions: [see documentation](https://jupyterlab.readthedocs.io/en/4.0.x/user/files.html#displaying-hidden-files)
 - Restore Copy shareable link use of `shareUrl` [#11188](https://github.com/jupyterlab/jupyterlab/pull/11188) ([@fcollonval](https://github.com/fcollonval))
 - Add Galata in JupyterLab [#11179](https://github.com/jupyterlab/jupyterlab/pull/11179) ([@fcollonval](https://github.com/fcollonval))
 - Responsive Toolbar [#11178](https://github.com/jupyterlab/jupyterlab/pull/11178) ([@3coins](https://github.com/3coins))
@@ -2926,9 +2926,9 @@ No merged PRs
 - From JupyterLab 3.1, file documents and notebooks have collaborative
   editing using the [Yjs shared editing framework](https://github.com/yjs/yjs).
   Editors are not collaborative by default; to activate it, start JupyterLab
-  with the `--collaborative` flag. See full documentation on [collaboration](https://jupyterlab.readthedocs.io/en/stable/user/rtc.html).
+  with the `--collaborative` flag. See full documentation on [collaboration](https://jupyterlab.readthedocs.io/en/4.0.x/user/rtc.html).
 - The undo/redo history in the notebook is now document-wide (tracking changes across all cells); the future verisions will enable restoring the previous behaviour of per-cell undo/redo.
-- Table of Contents recieved multiple new features and settings described in the [user documentation](https://jupyterlab.readthedocs.io/en/stable/user/toc.html).
+- Table of Contents recieved multiple new features and settings described in the [user documentation](https://jupyterlab.readthedocs.io/en/4.0.x/user/toc.html).
 - The debugger recived many improvements, including basic support for evaluating code at a breakpoint, and for variable inspection.
 - The closing bracket is no longer automatically added by default; the old behaviour can be re-enabled from the menu bar (`Settings` -> `Auto Close Brackets`) or from the Advanced Settings Editor.
 - A new visual indicator was introduced to highlight cells in which the code changed in the editor since last execution:
@@ -3549,21 +3549,21 @@ extensions does not require rebuilding JupyterLab and does not require
 having NodeJS installed. The previous way of distributing extensions as
 npm packages requiring rebuilding JupyterLab is still available as well.
 See the
-[documentation](https://jupyterlab.readthedocs.io/en/stable/user/extensions.html#extensions)
+[documentation](https://jupyterlab.readthedocs.io/en/4.0.x/user/extensions.html#extensions)
 for more details.
 
 #### The JupyterLab interface supports multiple languages
 
 JupyterLab now provides the ability to set the display language of the
 user interface. See the
-[documentation](https://jupyterlab.readthedocs.io/en/stable/user/language.html)
+[documentation](https://jupyterlab.readthedocs.io/en/4.0.x/user/language.html)
 for more details.
 
 #### A new visual debugger
 
 JupyterLab now ships with a debugger front-end by default, available for
 kernels that support the new debugging protocol. See the
-[documentation](https://jupyterlab.readthedocs.io/en/stable/user/debugger.html)
+[documentation](https://jupyterlab.readthedocs.io/en/4.0.x/user/debugger.html)
 for more details.
 
 #### Improvements to Simple Interface mode and Mobile

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,5 +4,5 @@ If you're reading this section, you're probably interested in contributing to
 JupyterLab. Welcome and thanks for your interest in contributing!
 
 Please take a look at Contributing to Jupyterlab on
-[Read the Docs](https://jupyterlab.readthedocs.io/en/stable/developer/contributing.html) or
+[Read the Docs](https://jupyterlab.readthedocs.io/en/4.0.x/developer/contributing.html) or
 [Repo docs](docs/source/developer/contributing.rst) (for the latest).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ via [PyPI](https://pypi.org/search/?q=jupyterlab&o=-created&c=Framework+%3A%3A+J
 conda, and other package managers. The _source_ extensions can be installed
 directly from npm (search for [jupyterlab-extension](https://www.npmjs.com/search?q=keywords:jupyterlab-extension)) but require an additional build step.
 You can also find JupyterLab extensions exploring GitHub topic [jupyterlab-extension](https://github.com/topics/jupyterlab-extension).
-To learn more about extensions, see the [user documentation](https://jupyterlab.readthedocs.io/en/stable/user/extensions.html).
+To learn more about extensions, see the [user documentation](https://jupyterlab.readthedocs.io/en/4.0.x/user/extensions.html).
 
 Read the current JupyterLab documentation on [ReadTheDocs](http://jupyterlab.readthedocs.io/en/stable/).
 
@@ -60,7 +60,7 @@ If you use [conda](https://docs.conda.io/en/latest/), [mamba](https://mamba.read
   ```
   If installing using `pip install --user`, you must add the user-level `bin` directory to your `PATH` environment variable in order to launch `jupyter lab`. If you are using a Unix derivative (e.g., FreeBSD, GNU/Linux, macOS), you can do this by running `export PATH="$HOME/.local/bin:$PATH"`. If you are using a macOS version that comes with Python 2, run `pip3` instead of `pip`.
 
-For more detailed instructions, consult the [installation guide](http://jupyterlab.readthedocs.io/en/stable/getting_started/installation.html). Project installation instructions from the git sources are available in the [contributor documentation](CONTRIBUTING.md).
+For more detailed instructions, consult the [installation guide](http://jupyterlab.readthedocs.io/en/4.0.x/getting_started/installation.html). Project installation instructions from the git sources are available in the [contributor documentation](CONTRIBUTING.md).
 
 #### Installing with Previous Versions of Jupyter Notebook
 
@@ -78,7 +78,7 @@ Start up JupyterLab using:
 jupyter lab
 ```
 
-JupyterLab will open automatically in the browser. See the [documentation](http://jupyterlab.readthedocs.io/en/stable/getting_started/starting.html) for additional details.
+JupyterLab will open automatically in the browser. See the [documentation](http://jupyterlab.readthedocs.io/en/4.0.x/getting_started/starting.html) for additional details.
 
 If you encounter an error like "Command 'jupyter' not found", please make sure `PATH` environment variable is set correctly. Alternatively, you can start up JupyterLab using `~/.local/bin/jupyter lab` without changing the `PATH` environment variable.
 
@@ -90,7 +90,7 @@ The latest versions of the following browsers are currently _known to work_:
 - Chrome
 - Safari
 
-See our [documentation](http://jupyterlab.readthedocs.io/en/stable/getting_started/installation.html) for additional details.
+See our [documentation](http://jupyterlab.readthedocs.io/en/4.0.x/getting_started/installation.html) for additional details.
 
 ---
 
@@ -100,7 +100,7 @@ We encourage you to ask questions on the [Discourse forum](https://discourse.jup
 
 ### Bug report
 
-To report a bug please read the [guidelines](https://jupyterlab.readthedocs.io/en/stable/getting_started/issue.html) and then open a [Github issue](https://github.com/jupyterlab/jupyterlab/issues/new?labels=bug%2C+status%3ANeeds+Triage&template=bug_report.md). To keep resolved issues self-contained, the [lock bot](https://github.com/apps/lock) will lock closed issues as resolved after a period of inactivity. If a related discussion is still needed after an issue is locked, please open a new issue and reference the old issue.
+To report a bug please read the [guidelines](https://jupyterlab.readthedocs.io/en/4.0.x/getting_started/issue.html) and then open a [Github issue](https://github.com/jupyterlab/jupyterlab/issues/new?labels=bug%2C+status%3ANeeds+Triage&template=bug_report.md). To keep resolved issues self-contained, the [lock bot](https://github.com/apps/lock) will lock closed issues as resolved after a period of inactivity. If a related discussion is still needed after an issue is locked, please open a new issue and reference the old issue.
 
 ### Feature request
 
@@ -112,11 +112,11 @@ We also welcome suggestions for new features as they help make the project more 
 
 ### Extending JupyterLab
 
-To start developing an extension for JupyterLab, see the [developer documentation](https://jupyterlab.readthedocs.io/en/stable/extension/extension_dev.html) and the [API docs](https://jupyterlab.readthedocs.io/en/stable/api/).
+To start developing an extension for JupyterLab, see the [developer documentation](https://jupyterlab.readthedocs.io/en/4.0.x/extension/extension_dev.html) and the [API docs](https://jupyterlab.readthedocs.io/en/4.0.x/api/).
 
 ### Contributing
 
-To contribute code or documentation to JupyterLab itself, please read the [contributor documentation](https://jupyterlab.readthedocs.io/en/stable/developer/contributing.html).
+To contribute code or documentation to JupyterLab itself, please read the [contributor documentation](https://jupyterlab.readthedocs.io/en/4.0.x/developer/contributing.html).
 
 JupyterLab follows the Jupyter [Community Guides](https://jupyter.readthedocs.io/en/latest/community/content-community.html).
 

--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -35,9 +35,9 @@ type CoreData = Map<string, any>;
 // Main should target latest
 // All other release branches should target a specific named version
 const URL_CONFIG = {
-  source: 'main',
+  source: '3.6.x',
   target: '4.0.x',
-  rtdVersion: 'stable'
+  rtdVersion: '4.0.x'
 };
 
 // Data to ignore.

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -251,7 +251,7 @@ bumped their major version (following semver convention). We want to point out p
      ``token.findByFileName(widget.context.path)?.name ?? ''``.
 - ``@jupyterlab/docprovider`` from 3.x to 4.x
    This package is no longer present in JupyterLab. For documentation related to Real-Time Collaboration, please check out
-   `RTC's documentation <https://jupyterlab.readthedocs.io/en/stable/user/rtc.html>`_
+   `RTC's documentation <https://jupyterlab.readthedocs.io/en/4.0.x/user/rtc.html>`_
 - ``@jupyterlab/docregistry`` from 3.x to 4.x
    * Removed the property ``docProviderFactory`` from the interface ``Context.IOptions``.
    * The constructor of the class ``DocumentModel`` receives a parameter ``DocumentModel.IOptions``.

--- a/docs/source/extension/internationalization.rst
+++ b/docs/source/extension/internationalization.rst
@@ -34,7 +34,7 @@ To internationalize your extension, the following tasks are required:
 
     Domain are normalized by replacing ``-`` with ``_`` characters.
 
-3. Wraps all translatable strings with one of the `gettext functions <https://jupyterlab.readthedocs.io/en/stable/api/modules/translation.html#translationbundle>`_.
+3. Wraps all translatable strings with one of the `gettext functions <https://jupyterlab.readthedocs.io/en/4.0.x/api/modules/translation.html#translationbundle>`_.
 
 Examples:
 

--- a/docs/source/getting_started/overview.rst
+++ b/docs/source/getting_started/overview.rst
@@ -6,7 +6,7 @@
 Get Started
 ===========
 
-`JupyterLab <https://jupyterlab.readthedocs.io/en/stable/>`_ is a next-generation web-based user interface for
+`JupyterLab <https://jupyterlab.readthedocs.io/en/4.0.x/>`_ is a next-generation web-based user interface for
 `Project Jupyter <https://docs.jupyter.org/en/latest/>`_.
 
 .. image:: ../images/interface-jupyterlab.png

--- a/docs/source/user/index.md
+++ b/docs/source/user/index.md
@@ -1,6 +1,6 @@
 # User Guide
 
-Use this page to navigate to in-depth guides, tutorials, and how-tos for using [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/).
+Use this page to navigate to in-depth guides, tutorials, and how-tos for using [JupyterLab](https://jupyterlab.readthedocs.io/en/4.0.x/).
 
 ```{toctree}
 :maxdepth: 2

--- a/packages/apputils-extension/src/announcements.ts
+++ b/packages/apputils-extension/src/announcements.ts
@@ -17,7 +17,7 @@ const COMMAND_HELP_OPEN = 'help:open';
 const NEWS_API_URL = '/lab/api/news';
 const UPDATE_API_URL = '/lab/api/update';
 const PRIVACY_URL =
-  'https://jupyterlab.readthedocs.io/en/stable/privacy_policies.html';
+  'https://jupyterlab.readthedocs.io/en/4.0.x/privacy_policies.html';
 
 /**
  * Call the announcement API

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -100,7 +100,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
               )}
               onClick={() =>
                 window.open(
-                  'https://jupyterlab.readthedocs.io/en/stable/user/extensions.html'
+                  'https://jupyterlab.readthedocs.io/en/4.0.x/user/extensions.html'
                 )
               }
             />
@@ -421,7 +421,7 @@ to work, this panel needs to fetch data from web services. Do you agree to
 activate this feature?`)}
           <br />
           <a
-            href="https://jupyterlab.readthedocs.io/en/stable/privacy_policies.html"
+            href="https://jupyterlab.readthedocs.io/en/4.0.x/privacy_policies.html"
             target="_blank"
             rel="noreferrer"
           >

--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -221,11 +221,11 @@ const resources: JupyterFrontEndPlugin<void> = {
     const resources = [
       {
         text: trans.__('JupyterLab Reference'),
-        url: 'https://jupyterlab.readthedocs.io/en/stable/'
+        url: 'https://jupyterlab.readthedocs.io/en/4.0.x/'
       },
       {
         text: trans.__('JupyterLab FAQ'),
-        url: 'https://jupyterlab.readthedocs.io/en/stable/getting_started/faq.html'
+        url: 'https://jupyterlab.readthedocs.io/en/4.0.x/getting_started/faq.html'
       },
       {
         text: trans.__('Jupyter Reference'),

--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -2,7 +2,7 @@
 
 Javascript client for the Jupyter services REST APIs
 
-[API Docs](https://jupyterlab.readthedocs.io/en/stable/api/)
+[API Docs](https://jupyterlab.readthedocs.io/en/4.0.x/api/)
 
 [REST API Docs](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter-server/jupyter_server/main/jupyter_server/services/api/api.yaml)
 

--- a/packages/ui-components/docs/source/intro.rst
+++ b/packages/ui-components/docs/source/intro.rst
@@ -1,7 +1,7 @@
 .. Copyright (c) Jupyter Development Team.
 .. Distributed under the terms of the Modified BSD License.
 
-The `@jupyterlab/ui-components <https://jupyterlab.readthedocs.io/en/stable/api/modules/ui_components.html>`__
+The `@jupyterlab/ui-components <https://jupyterlab.readthedocs.io/en/4.0.x/api/modules/ui_components.html>`__
 package provides UI elements that are widely used in JupyterLab core,
 and that can be reused in your own extensions.
 


### PR DESCRIPTION
4.0.x should no longer be labelled as stable. Sibling to https://github.com/jupyterlab/jupyterlab/pull/15848