### PR TITLE
Add `4.0.x` and `4.1.x` to the documentation switcher

### DIFF
--- a/docs/source/_static/switcher.json
+++ b/docs/source/_static/switcher.json
@@ -25,43 +25,8 @@
     "url": "https://jupyterlab.readthedocs.io/en/3.6.x/"
   },
   {
-    "name": "3.5.x",
-    "version": "3.5.x",
-    "url": "https://jupyterlab.readthedocs.io/en/3.5.x/"
-  },
-  {
-    "name": "3.4.x",
-    "version": "3.4.x",
-    "url": "https://jupyterlab.readthedocs.io/en/3.4.x/"
-  },
-  {
-    "name": "3.3.x",
-    "version": "3.3.x",
-    "url": "https://jupyterlab.readthedocs.io/en/3.3.x/"
-  },
-  {
-    "name": "3.2.x",
-    "version": "3.2.x",
-    "url": "https://jupyterlab.readthedocs.io/en/3.2.x/"
-  },
-  {
-    "name": "3.1.x",
-    "version": "3.1.x",
-    "url": "https://jupyterlab.readthedocs.io/en/3.1.x/"
-  },
-  {
-    "name": "3.0.x",
-    "version": "3.0.x",
-    "url": "https://jupyterlab.readthedocs.io/en/3.0.x/"
-  },
-  {
     "name": "2.2.x",
     "version": "2.2.x",
     "url": "https://jupyterlab.readthedocs.io/en/2.2.x/"
-  },
-  {
-    "name": "1.2.x",
-    "version": "1.2.x",
-    "url": "https://jupyterlab.readthedocs.io/en/1.2.x/"
   }
 ]

--- a/docs/source/_static/switcher.json
+++ b/docs/source/_static/switcher.json
@@ -10,6 +10,16 @@
     "url": "https://jupyterlab.readthedocs.io/en/stable/"
   },
   {
+    "name": "4.1.x",
+    "version": "4.1.x",
+    "url": "https://jupyterlab.readthedocs.io/en/4.1.x/"
+  },
+  {
+    "name": "4.0.x",
+    "version": "4.0.x",
+    "url": "https://jupyterlab.readthedocs.io/en/4.0.x/"
+  },
+  {
     "name": "3.6.x",
     "version": "3.6.x",
     "url": "https://jupyterlab.readthedocs.io/en/3.6.x/"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Some versions were missing from the switcher on the documentation page: https://jupyterlab.readthedocs.io/en/latest/

![image](https://github.com/jupyterlab/jupyterlab/assets/591645/8d2b7d54-4e80-43ba-b50e-d8df4b370212)


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Documentation config update.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Make more versions available via the switcher in the docs.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes


None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
