### PR TITLE
400% zoom low vision

### DIFF
--- a/packages/application/style/menus.css
+++ b/packages/application/style/menus.css
@@ -31,7 +31,8 @@
 }
 
 .lm-MenuBar-item {
-  padding: 0 8px;
+  /* stylelint-disable-next-line csstree/validator */
+  padding: 0 min(calc(1.2vw - 2px), 8px);
   border-left: var(--jp-border-width) solid transparent;
   border-right: var(--jp-border-width) solid transparent;
   border-top: var(--jp-border-width) solid transparent;

--- a/packages/application/style/sidepanel.css
+++ b/packages/application/style/sidepanel.css
@@ -45,7 +45,8 @@
 }
 
 .jp-SideBar .lm-TabBar-tab {
-  padding: 16px 0;
+  /* stylelint-disable-next-line csstree/validator */
+  padding: min(5vh, 16px) 0; /* Using min() and vh allows the top and bottom padding to shrink when the screen is small or when the user increases browser zoom level, making room to show more content in the sidebar */
   border: none;
   overflow: visible;
   flex-direction: column;

--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -129,7 +129,8 @@
 }
 
 .jp-DirListing-headerItem {
-  padding: 4px 12px 2px;
+  /* stylelint-disable-next-line csstree/validator */
+  padding: min(1vh, 4px) min(6vw, 12px) min(1vh, 2px);
   font-weight: 500;
 }
 

--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -47,7 +47,8 @@
 }
 
 .jp-BreadCrumbs-item {
-  margin: 0 2px;
+  /* stylelint-disable-next-line csstree/validator */
+  margin: min(3vh, 8px) min(2vw, 12px);
   padding: 0 2px;
   border-radius: var(--jp-border-radius);
   cursor: pointer;

--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -25,7 +25,8 @@
 .jp-FileBrowser-toolbar.jp-Toolbar {
   border-bottom: none;
   height: auto;
-  margin: 8px 12px 0;
+  /* stylelint-disable-next-line csstree/validator */
+  margin: min(5vh, 8px) min(1.5vw, 12px) 0;
   box-shadow: none;
   padding: 0;
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
#14626
#14766

#10004 This PR covers Full low Vision Support (400% Zoom) (Mobile/Tablet-Responsive Support).
It resolves most of the failing screenshots that where present in #14766. The approach used was to isolate each code change in the previous PR to see what/ If the code changes are breaking screenshots.

Isolated Code changes and their effects on Screenshots 

- [padding changes to menu bar & padding changes to side panel](https://github.com/g547315/jupyterlab/pull/3)
- [margin changes to .jp-FileBrowser-toolbar.jp-Toolbar](https://github.com/jupyterlab/jupyterlab/commit/1a0b5918e31dd2b2f2564ca4a05a441261fc21b8)
- [padding chnages to .jp-DirListing-headerItem](https://github.com/g547315/jupyterlab/pull/1/files?file-filters%5B%5D=.png&show-viewed-files=true)
- [margin changes for .jp-BreadCrumbs](https://github.com/g547315/jupyterlab/pull/2/files?file-filters%5B%5D=.css&file-filters%5B%5D=.png&show-viewed-files=true)

@g547315

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Changed padding and spacing to use min CSS function alongside vh (viewport-height) and vw(viewport-width) to reduce proportional spacing at high zoom and increase useful screen real estate usage.

## User-facing changes
Currently with the 400% zoom at 1280px the help main menu bar does not appear and within the file-browser tab bar only half of one 'dir-listing' shows up.

The changes I have made now allows for the help dropdown to be shown in the main menu. I found that when trying to check the changes the sidebar 'Extension Manger' disappears from view, so this was also changes so that users that needs this implemented would be able to have access to it without zooming back out.
Furthermore, within the file-browser tab, users would now be able to see least 2 notebook directory listed below than before.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
