### PR TITLE
Disable next/previous match buttons when no text is in Find box

### DIFF
--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -39,9 +39,6 @@ const INPUT_BUTTON_CLASS_ON = 'jp-DocumentSearch-input-button-on';
 const INDEX_COUNTER_CLASS = 'jp-DocumentSearch-index-counter';
 const UP_DOWN_BUTTON_WRAPPER_CLASS = 'jp-DocumentSearch-up-down-wrapper';
 const UP_DOWN_BUTTON_CLASS = 'jp-DocumentSearch-up-down-button';
-const DISABLED_UP_DOWN_BUTTON_CLASS =
-  'jp-DocumentSearch-disabled-up-down-button';
-
 const FILTER_BUTTON_CLASS = 'jp-DocumentSearch-filter-button';
 const FILTER_BUTTON_ENABLED_CLASS = 'jp-DocumentSearch-filter-button-enabled';
 const REGEX_ERROR_CLASS = 'jp-DocumentSearch-regex-error';
@@ -56,8 +53,6 @@ const TOGGLE_WRAPPER = 'jp-DocumentSearch-toggle-wrapper';
 const TOGGLE_PLACEHOLDER = 'jp-DocumentSearch-toggle-placeholder';
 const BUTTON_CONTENT_CLASS = 'jp-DocumentSearch-button-content';
 const BUTTON_WRAPPER_CLASS = 'jp-DocumentSearch-button-wrapper';
-const DISABLED_BUTTON_WRAPPER_CLASS =
-  'jp-DocumentSearch-disabled-button-wrapper';
 const SPACER_CLASS = 'jp-DocumentSearch-spacer';
 
 interface ISearchInputProps {
@@ -310,57 +305,33 @@ function UpDownButtons(props: IUpDownProps) {
   const prevShortcut = prevKeys ? ` (${prevKeys})` : '';
   const nextShortcut = nextKeys ? ` (${nextKeys})` : '';
 
-  const upButtonTitle = `${props.trans.__('Previous Match')}${prevShortcut}`;
-  const upButton = props.isEnabled ? (
+  const upButton =
     <button
       className={BUTTON_WRAPPER_CLASS}
-      onClick={() => props.onHighlightPrevious()}
+      onClick={() => props.isEnabled ? props.onHighlightPrevious() : false}
       tabIndex={0}
-      title={upButtonTitle}
+      title={`${props.trans.__('Previous Match')}${prevShortcut}`}
+      disabled={!props.isEnabled}
     >
       <caretUpEmptyThinIcon.react
         className={classes(UP_DOWN_BUTTON_CLASS, BUTTON_CONTENT_CLASS)}
         tag="span"
       />
-    </button>
-  ) : (
-    <button
-      className={DISABLED_BUTTON_WRAPPER_CLASS}
-      title={upButtonTitle}
-      disabled={true}
-    >
-      <caretUpEmptyThinIcon.react
-        className={classes(DISABLED_UP_DOWN_BUTTON_CLASS, BUTTON_CONTENT_CLASS)}
-        tag="span"
-      />
-    </button>
-  );
+    </button>;
 
-  const downButtonTitle = `${props.trans.__('Next Match')}${nextShortcut}`;
-  const downButton = props.isEnabled ? (
+  const downButton =
     <button
       className={BUTTON_WRAPPER_CLASS}
-      onClick={() => props.onHighlightNext()}
+      onClick={() => props.isEnabled ? props.onHighlightNext() : false}
       tabIndex={0}
-      title={downButtonTitle}
+      title={`${props.trans.__('Next Match')}${nextShortcut}`}
+      disabled={!props.isEnabled}
     >
       <caretDownEmptyThinIcon.react
         className={classes(UP_DOWN_BUTTON_CLASS, BUTTON_CONTENT_CLASS)}
         tag="span"
       />
-    </button>
-  ) : (
-    <button
-      className={DISABLED_BUTTON_WRAPPER_CLASS}
-      title={downButtonTitle}
-      disabled={true}
-    >
-      <caretDownEmptyThinIcon.react
-        className={classes(DISABLED_UP_DOWN_BUTTON_CLASS, BUTTON_CONTENT_CLASS)}
-        tag="span"
-      />
-    </button>
-  );
+    </button>;
 
   return (
     <div className={UP_DOWN_BUTTON_WRAPPER_CLASS}>

--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -39,6 +39,8 @@ const INPUT_BUTTON_CLASS_ON = 'jp-DocumentSearch-input-button-on';
 const INDEX_COUNTER_CLASS = 'jp-DocumentSearch-index-counter';
 const UP_DOWN_BUTTON_WRAPPER_CLASS = 'jp-DocumentSearch-up-down-wrapper';
 const UP_DOWN_BUTTON_CLASS = 'jp-DocumentSearch-up-down-button';
+const DISABLED_UP_DOWN_BUTTON_CLASS = 'jp-DocumentSearch-disabled-up-down-button';
+
 const FILTER_BUTTON_CLASS = 'jp-DocumentSearch-filter-button';
 const FILTER_BUTTON_ENABLED_CLASS = 'jp-DocumentSearch-filter-button-enabled';
 const REGEX_ERROR_CLASS = 'jp-DocumentSearch-regex-error';
@@ -53,6 +55,7 @@ const TOGGLE_WRAPPER = 'jp-DocumentSearch-toggle-wrapper';
 const TOGGLE_PLACEHOLDER = 'jp-DocumentSearch-toggle-placeholder';
 const BUTTON_CONTENT_CLASS = 'jp-DocumentSearch-button-content';
 const BUTTON_WRAPPER_CLASS = 'jp-DocumentSearch-button-wrapper';
+const DISABLED_BUTTON_WRAPPER_CLASS = 'jp-DocumentSearch-disabled-button-wrapper';
 const SPACER_CLASS = 'jp-DocumentSearch-spacer';
 
 interface ISearchInputProps {
@@ -305,32 +308,59 @@ function UpDownButtons(props: IUpDownProps) {
   const prevShortcut = prevKeys ? ` (${prevKeys})` : '';
   const nextShortcut = nextKeys ? ` (${nextKeys})` : '';
 
-  return (
-    <div className={UP_DOWN_BUTTON_WRAPPER_CLASS}>
-      <button
+  const upButtonTitle = `${props.trans.__('Previous Match')}${prevShortcut}`;
+  // Only use "real" buttons if the buttons are enabled
+  const upButton = props.isEnabled
+    ? <button
         className={BUTTON_WRAPPER_CLASS}
-        onClick={props.isEnabled ? () => props.onHighlightPrevious() : () => false}
+        onClick={() => props.onHighlightPrevious()}
         tabIndex={0}
-        title={`${props.trans.__('Previous Match')}${prevShortcut}`}
-        disabled={!props.isEnabled}
+        title={upButtonTitle}
       >
         <caretUpEmptyThinIcon.react
           className={classes(UP_DOWN_BUTTON_CLASS, BUTTON_CONTENT_CLASS)}
           tag="span"
         />
       </button>
-      <button
+    : <button
+        className={DISABLED_BUTTON_WRAPPER_CLASS}
+        title={upButtonTitle}
+        disabled={true}
+      >
+        <caretUpEmptyThinIcon.react
+          className={classes(DISABLED_UP_DOWN_BUTTON_CLASS, BUTTON_CONTENT_CLASS)}
+          tag="span"
+        />
+      </button>;
+
+  const downButtonTitle = `${props.trans.__('Next Match')}${nextShortcut}`;
+  const downButton = props.isEnabled
+    ? <button
         className={BUTTON_WRAPPER_CLASS}
-        onClick={props.isEnabled ? () => props.onHighlightNext() : () => false}
+        onClick={() => props.onHighlightNext()}
         tabIndex={0}
-        title={`${props.trans.__('Next Match')}${nextShortcut}`}
-        disabled={!props.isEnabled}
+        title={downButtonTitle}
       >
         <caretDownEmptyThinIcon.react
           className={classes(UP_DOWN_BUTTON_CLASS, BUTTON_CONTENT_CLASS)}
           tag="span"
         />
       </button>
+    : <button
+        className={DISABLED_BUTTON_WRAPPER_CLASS}
+        title={downButtonTitle}
+        disabled={true}
+      >
+        <caretDownEmptyThinIcon.react
+          className={classes(DISABLED_UP_DOWN_BUTTON_CLASS, BUTTON_CONTENT_CLASS)}
+          tag="span"
+        />
+      </button>;
+
+  return (
+    <div className={UP_DOWN_BUTTON_WRAPPER_CLASS}>
+      {upButton}
+      {downButton}
     </div>
   );
 }

--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -288,6 +288,7 @@ interface IUpDownProps {
   onHighlightPrevious: () => void;
   onHighlightNext: () => void;
   trans: TranslationBundle;
+  isEnabled: boolean;
 }
 
 function UpDownButtons(props: IUpDownProps) {
@@ -308,9 +309,10 @@ function UpDownButtons(props: IUpDownProps) {
     <div className={UP_DOWN_BUTTON_WRAPPER_CLASS}>
       <button
         className={BUTTON_WRAPPER_CLASS}
-        onClick={() => props.onHighlightPrevious()}
+        onClick={props.isEnabled ? () => props.onHighlightPrevious() : () => false}
         tabIndex={0}
         title={`${props.trans.__('Previous Match')}${prevShortcut}`}
+        disabled={!props.isEnabled}
       >
         <caretUpEmptyThinIcon.react
           className={classes(UP_DOWN_BUTTON_CLASS, BUTTON_CONTENT_CLASS)}
@@ -319,9 +321,10 @@ function UpDownButtons(props: IUpDownProps) {
       </button>
       <button
         className={BUTTON_WRAPPER_CLASS}
-        onClick={() => props.onHighlightNext()}
+        onClick={props.isEnabled ? () => props.onHighlightNext() : () => false}
         tabIndex={0}
         title={`${props.trans.__('Next Match')}${nextShortcut}`}
+        disabled={!props.isEnabled}
       >
         <caretDownEmptyThinIcon.react
           className={classes(UP_DOWN_BUTTON_CLASS, BUTTON_CONTENT_CLASS)}
@@ -724,6 +727,7 @@ class SearchOverlay extends React.Component<ISearchOverlayProps> {
             }}
             trans={trans}
             keyBindings={this.props.keyBindings}
+            isEnabled={!!(this.props.searchInputRef.current?.value)}
           />
           <button
             className={BUTTON_WRAPPER_CLASS}

--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -305,10 +305,10 @@ function UpDownButtons(props: IUpDownProps) {
   const prevShortcut = prevKeys ? ` (${prevKeys})` : '';
   const nextShortcut = nextKeys ? ` (${nextKeys})` : '';
 
-  const upButton =
+  const upButton = (
     <button
       className={BUTTON_WRAPPER_CLASS}
-      onClick={() => props.isEnabled ? props.onHighlightPrevious() : false}
+      onClick={() => (props.isEnabled ? props.onHighlightPrevious() : false)}
       tabIndex={0}
       title={`${props.trans.__('Previous Match')}${prevShortcut}`}
       disabled={!props.isEnabled}
@@ -317,12 +317,13 @@ function UpDownButtons(props: IUpDownProps) {
         className={classes(UP_DOWN_BUTTON_CLASS, BUTTON_CONTENT_CLASS)}
         tag="span"
       />
-    </button>;
+    </button>
+  );
 
-  const downButton =
+  const downButton = (
     <button
       className={BUTTON_WRAPPER_CLASS}
-      onClick={() => props.isEnabled ? props.onHighlightNext() : false}
+      onClick={() => (props.isEnabled ? props.onHighlightNext() : false)}
       tabIndex={0}
       title={`${props.trans.__('Next Match')}${nextShortcut}`}
       disabled={!props.isEnabled}
@@ -331,7 +332,8 @@ function UpDownButtons(props: IUpDownProps) {
         className={classes(UP_DOWN_BUTTON_CLASS, BUTTON_CONTENT_CLASS)}
         tag="span"
       />
-    </button>;
+    </button>
+  );
 
   return (
     <div className={UP_DOWN_BUTTON_WRAPPER_CLASS}>

--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -309,7 +309,6 @@ function UpDownButtons(props: IUpDownProps) {
   const nextShortcut = nextKeys ? ` (${nextKeys})` : '';
 
   const upButtonTitle = `${props.trans.__('Previous Match')}${prevShortcut}`;
-  // Only use "real" buttons if the buttons are enabled
   const upButton = props.isEnabled
     ? <button
         className={BUTTON_WRAPPER_CLASS}

--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -39,7 +39,8 @@ const INPUT_BUTTON_CLASS_ON = 'jp-DocumentSearch-input-button-on';
 const INDEX_COUNTER_CLASS = 'jp-DocumentSearch-index-counter';
 const UP_DOWN_BUTTON_WRAPPER_CLASS = 'jp-DocumentSearch-up-down-wrapper';
 const UP_DOWN_BUTTON_CLASS = 'jp-DocumentSearch-up-down-button';
-const DISABLED_UP_DOWN_BUTTON_CLASS = 'jp-DocumentSearch-disabled-up-down-button';
+const DISABLED_UP_DOWN_BUTTON_CLASS =
+  'jp-DocumentSearch-disabled-up-down-button';
 
 const FILTER_BUTTON_CLASS = 'jp-DocumentSearch-filter-button';
 const FILTER_BUTTON_ENABLED_CLASS = 'jp-DocumentSearch-filter-button-enabled';
@@ -55,7 +56,8 @@ const TOGGLE_WRAPPER = 'jp-DocumentSearch-toggle-wrapper';
 const TOGGLE_PLACEHOLDER = 'jp-DocumentSearch-toggle-placeholder';
 const BUTTON_CONTENT_CLASS = 'jp-DocumentSearch-button-content';
 const BUTTON_WRAPPER_CLASS = 'jp-DocumentSearch-button-wrapper';
-const DISABLED_BUTTON_WRAPPER_CLASS = 'jp-DocumentSearch-disabled-button-wrapper';
+const DISABLED_BUTTON_WRAPPER_CLASS =
+  'jp-DocumentSearch-disabled-button-wrapper';
 const SPACER_CLASS = 'jp-DocumentSearch-spacer';
 
 interface ISearchInputProps {
@@ -309,52 +311,56 @@ function UpDownButtons(props: IUpDownProps) {
   const nextShortcut = nextKeys ? ` (${nextKeys})` : '';
 
   const upButtonTitle = `${props.trans.__('Previous Match')}${prevShortcut}`;
-  const upButton = props.isEnabled
-    ? <button
-        className={BUTTON_WRAPPER_CLASS}
-        onClick={() => props.onHighlightPrevious()}
-        tabIndex={0}
-        title={upButtonTitle}
-      >
-        <caretUpEmptyThinIcon.react
-          className={classes(UP_DOWN_BUTTON_CLASS, BUTTON_CONTENT_CLASS)}
-          tag="span"
-        />
-      </button>
-    : <button
-        className={DISABLED_BUTTON_WRAPPER_CLASS}
-        title={upButtonTitle}
-        disabled={true}
-      >
-        <caretUpEmptyThinIcon.react
-          className={classes(DISABLED_UP_DOWN_BUTTON_CLASS, BUTTON_CONTENT_CLASS)}
-          tag="span"
-        />
-      </button>;
+  const upButton = props.isEnabled ? (
+    <button
+      className={BUTTON_WRAPPER_CLASS}
+      onClick={() => props.onHighlightPrevious()}
+      tabIndex={0}
+      title={upButtonTitle}
+    >
+      <caretUpEmptyThinIcon.react
+        className={classes(UP_DOWN_BUTTON_CLASS, BUTTON_CONTENT_CLASS)}
+        tag="span"
+      />
+    </button>
+  ) : (
+    <button
+      className={DISABLED_BUTTON_WRAPPER_CLASS}
+      title={upButtonTitle}
+      disabled={true}
+    >
+      <caretUpEmptyThinIcon.react
+        className={classes(DISABLED_UP_DOWN_BUTTON_CLASS, BUTTON_CONTENT_CLASS)}
+        tag="span"
+      />
+    </button>
+  );
 
   const downButtonTitle = `${props.trans.__('Next Match')}${nextShortcut}`;
-  const downButton = props.isEnabled
-    ? <button
-        className={BUTTON_WRAPPER_CLASS}
-        onClick={() => props.onHighlightNext()}
-        tabIndex={0}
-        title={downButtonTitle}
-      >
-        <caretDownEmptyThinIcon.react
-          className={classes(UP_DOWN_BUTTON_CLASS, BUTTON_CONTENT_CLASS)}
-          tag="span"
-        />
-      </button>
-    : <button
-        className={DISABLED_BUTTON_WRAPPER_CLASS}
-        title={downButtonTitle}
-        disabled={true}
-      >
-        <caretDownEmptyThinIcon.react
-          className={classes(DISABLED_UP_DOWN_BUTTON_CLASS, BUTTON_CONTENT_CLASS)}
-          tag="span"
-        />
-      </button>;
+  const downButton = props.isEnabled ? (
+    <button
+      className={BUTTON_WRAPPER_CLASS}
+      onClick={() => props.onHighlightNext()}
+      tabIndex={0}
+      title={downButtonTitle}
+    >
+      <caretDownEmptyThinIcon.react
+        className={classes(UP_DOWN_BUTTON_CLASS, BUTTON_CONTENT_CLASS)}
+        tag="span"
+      />
+    </button>
+  ) : (
+    <button
+      className={DISABLED_BUTTON_WRAPPER_CLASS}
+      title={downButtonTitle}
+      disabled={true}
+    >
+      <caretDownEmptyThinIcon.react
+        className={classes(DISABLED_UP_DOWN_BUTTON_CLASS, BUTTON_CONTENT_CLASS)}
+        tag="span"
+      />
+    </button>
+  );
 
   return (
     <div className={UP_DOWN_BUTTON_WRAPPER_CLASS}>
@@ -756,7 +762,7 @@ class SearchOverlay extends React.Component<ISearchOverlayProps> {
             }}
             trans={trans}
             keyBindings={this.props.keyBindings}
-            isEnabled={!!(this.props.searchInputRef.current?.value)}
+            isEnabled={!!this.props.searchInputRef.current?.value}
           />
           <button
             className={BUTTON_WRAPPER_CLASS}

--- a/packages/documentsearch/style/base.css
+++ b/packages/documentsearch/style/base.css
@@ -34,7 +34,7 @@
   outline: 0;
 }
 
-.jp-DocumentSearch-overlay button.jp-DocumentSearch-button-wrapper:disabled {
+.jp-DocumentSearch-button-wrapper:disabled > .jp-DocumentSearch-button-content {
   opacity: 0.6;
   cursor: not-allowed;
 }

--- a/packages/documentsearch/style/base.css
+++ b/packages/documentsearch/style/base.css
@@ -164,7 +164,7 @@ button:not(:disabled) > .jp-DocumentSearch-up-down-button:hover {
   background-color: var(--jp-layout-color2);
 }
 
-button:not(:disabled) .jp-DocumentSearch-up-down-button:active {
+button:not(:disabled) > .jp-DocumentSearch-up-down-button:active {
   background-color: var(--jp-layout-color3);
 }
 

--- a/packages/documentsearch/style/base.css
+++ b/packages/documentsearch/style/base.css
@@ -34,17 +34,15 @@
   outline: 0;
 }
 
-.jp-DocumentSearch-overlay button.jp-DocumentSearch-disabled-button-wrapper {
+.jp-DocumentSearch-overlay button.jp-DocumentSearch-button-wrapper:disabled {
   opacity: 0.6;
 }
 
-.jp-DocumentSearch-overlay
-  button:not(.jp-DocumentSearch-disabled-button-wrapper):hover {
+.jp-DocumentSearch-overlay button:not(:disabled):hover {
   background-color: var(--jp-layout-color2);
 }
 
-.jp-DocumentSearch-overlay
-  button:not(.jp-DocumentSearch-disabled-button-wrapper):active {
+.jp-DocumentSearch-overlay button:not(:disabled):active {
   background-color: var(--jp-layout-color3);
 }
 
@@ -79,8 +77,7 @@
 }
 
 .jp-DocumentSearch-toggle-wrapper,
-.jp-DocumentSearch-button-wrapper,
-.jp-DocumentSearch-disabled-button-wrapper {
+.jp-DocumentSearch-button-wrapper {
   all: initial;
   overflow: hidden;
   display: inline-block;
@@ -94,8 +91,7 @@
   height: 14px;
 }
 
-.jp-DocumentSearch-button-wrapper,
-.jp-DocumentSearch-disabled-button-wrapper {
+.jp-DocumentSearch-button-wrapper {
   flex-shrink: 0;
   width: var(--jp-private-document-search-button-height);
   height: var(--jp-private-document-search-button-height);
@@ -110,7 +106,6 @@
 
 .jp-DocumentSearch-toggle-wrapper,
 .jp-DocumentSearch-button-wrapper,
-.jp-DocumentSearch-disabled-button-wrapper,
 .jp-DocumentSearch-button-content:focus {
   outline: none;
 }

--- a/packages/documentsearch/style/base.css
+++ b/packages/documentsearch/style/base.css
@@ -35,7 +35,7 @@
 }
 
 .jp-DocumentSearch-overlay button.jp-DocumentSearch-disabled-button-wrapper {
-  opacity: 0.7;
+  opacity: 0.6;
 }
 
 .jp-DocumentSearch-overlay

--- a/packages/documentsearch/style/base.css
+++ b/packages/documentsearch/style/base.css
@@ -36,6 +36,7 @@
 
 .jp-DocumentSearch-overlay button.jp-DocumentSearch-button-wrapper:disabled {
   opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .jp-DocumentSearch-overlay button:not(:disabled):hover {

--- a/packages/documentsearch/style/base.css
+++ b/packages/documentsearch/style/base.css
@@ -159,11 +159,11 @@
   margin: 1px 5px 2px;
 }
 
-.jp-DocumentSearch-up-down-button:hover {
+button:not(:disabled) .jp-DocumentSearch-up-down-button:hover {
   background-color: var(--jp-layout-color2);
 }
 
-.jp-DocumentSearch-up-down-button:active {
+button:not(:disabled) .jp-DocumentSearch-up-down-button:active {
   background-color: var(--jp-layout-color3);
 }
 

--- a/packages/documentsearch/style/base.css
+++ b/packages/documentsearch/style/base.css
@@ -160,7 +160,7 @@
   margin: 1px 5px 2px;
 }
 
-button:not(:disabled) .jp-DocumentSearch-up-down-button:hover {
+button:not(:disabled) > .jp-DocumentSearch-up-down-button:hover {
   background-color: var(--jp-layout-color2);
 }
 

--- a/packages/documentsearch/style/base.css
+++ b/packages/documentsearch/style/base.css
@@ -34,11 +34,17 @@
   outline: 0;
 }
 
-.jp-DocumentSearch-overlay button:hover {
+.jp-DocumentSearch-overlay button.jp-DocumentSearch-disabled-button-wrapper {
+  opacity: 0.7;
+}
+
+.jp-DocumentSearch-overlay
+  button:not(.jp-DocumentSearch-disabled-button-wrapper):hover {
   background-color: var(--jp-layout-color2);
 }
 
-.jp-DocumentSearch-overlay button:active {
+.jp-DocumentSearch-overlay
+  button:not(.jp-DocumentSearch-disabled-button-wrapper):active {
   background-color: var(--jp-layout-color3);
 }
 
@@ -73,7 +79,8 @@
 }
 
 .jp-DocumentSearch-toggle-wrapper,
-.jp-DocumentSearch-button-wrapper {
+.jp-DocumentSearch-button-wrapper,
+.jp-DocumentSearch-disabled-button-wrapper {
   all: initial;
   overflow: hidden;
   display: inline-block;
@@ -87,7 +94,8 @@
   height: 14px;
 }
 
-.jp-DocumentSearch-button-wrapper {
+.jp-DocumentSearch-button-wrapper,
+.jp-DocumentSearch-disabled-button-wrapper {
   flex-shrink: 0;
   width: var(--jp-private-document-search-button-height);
   height: var(--jp-private-document-search-button-height);
@@ -102,6 +110,7 @@
 
 .jp-DocumentSearch-toggle-wrapper,
 .jp-DocumentSearch-button-wrapper,
+.jp-DocumentSearch-disabled-button-wrapper,
 .jp-DocumentSearch-button-content:focus {
   outline: none;
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes #15813.

## Code changes

Disables the next and previous match buttons when there is no text in the Find box.

## User-facing changes

When no text is in the Find box, the next and previous match buttons are disabled, do nothing when clicked, and appear with 60% opacity, the same level used for disabled commands in the command palette:

<img width="755" alt="Screenshot 2024-02-22 at 9 43 02 AM" src="https://github.com/jupyterlab/jupyterlab/assets/93281816/2a687af6-0454-4a80-955a-027b5d6beba4">

When there is text in the Find box, the next and previous match buttons are enabled and work the same way as before:

<img width="759" alt="Screenshot 2024-02-22 at 9 43 16 AM" src="https://github.com/jupyterlab/jupyterlab/assets/93281816/00889911-7690-4510-9400-e376242c9add">




## Backwards-incompatible changes

None.
