### PR TITLE
Check if editor exists before checking if it is disposed

### DIFF
--- a/packages/lsp/src/adapters/editorAdapter.ts
+++ b/packages/lsp/src/adapters/editorAdapter.ts
@@ -51,8 +51,8 @@ export class EditorAdapter implements IDisposable {
    * Setup the editor.
    */
   private _injectExtensions(editor: Document.IEditor): void {
-    const codeEditor = editor.getEditor()!;
-    if (codeEditor.isDisposed) {
+    const codeEditor = editor.getEditor();
+    if (!codeEditor || codeEditor.isDisposed) {
       return;
     }
 


### PR DESCRIPTION
## References

Fixes #15864

## Code changes

Check non-null rather than asserting because sometimes things move fast.

## User-facing changes

None

## Backwards-incompatible changes

None