### PR TITLE
Adds description for disabled search filter

### DIFF
--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -646,21 +646,15 @@ class SearchOverlay extends React.Component<ISearchOverlayProps> {
       <div className={SEARCH_OPTIONS_CLASS}>
         {Object.keys(filters).map(name => {
           const filter = filters[name];
-
-          const isEnabled = !showReplace || filter.supportReplace;
-          // Show an alternate description, if one exists, when a filter is disabled in replace mode.
-          const description = isEnabled
-            ? filter.description
-            : (filter.disabledDescription ?? filter.description);
           return (
             <FilterSelection
               key={name}
               title={filter.title}
               description={
-                description +
+                filter.description +
                 (name == 'selection' ? selectionKeyHint : '')
               }
-              isEnabled={isEnabled}
+              isEnabled={!showReplace || filter.supportReplace}
               onToggle={async () => {
                 await this.props.onFilterChanged(
                   name,

--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -651,14 +651,13 @@ class SearchOverlay extends React.Component<ISearchOverlayProps> {
           // Show an alternate description, if one exists, when a filter is disabled in replace mode.
           const description = isEnabled
             ? filter.description
-            : (filter.disabledDescription ?? filter.description);
+            : filter.disabledDescription ?? filter.description;
           return (
             <FilterSelection
               key={name}
               title={filter.title}
               description={
-                description +
-                (name == 'selection' ? selectionKeyHint : '')
+                description + (name == 'selection' ? selectionKeyHint : '')
               }
               isEnabled={isEnabled}
               onToggle={async () => {

--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -646,15 +646,21 @@ class SearchOverlay extends React.Component<ISearchOverlayProps> {
       <div className={SEARCH_OPTIONS_CLASS}>
         {Object.keys(filters).map(name => {
           const filter = filters[name];
+
+          const isEnabled = !showReplace || filter.supportReplace;
+          // Show an alternate description, if one exists, when a filter is disabled in replace mode.
+          const description = isEnabled
+            ? filter.description
+            : (filter.disabledDescription ?? filter.description);
           return (
             <FilterSelection
               key={name}
               title={filter.title}
               description={
-                filter.description +
+                description +
                 (name == 'selection' ? selectionKeyHint : '')
               }
-              isEnabled={!showReplace || filter.supportReplace}
+              isEnabled={isEnabled}
               onToggle={async () => {
                 await this.props.onFilterChanged(
                   name,

--- a/packages/documentsearch/src/tokens.ts
+++ b/packages/documentsearch/src/tokens.ts
@@ -30,6 +30,10 @@ export interface IFilter {
    */
   description: string;
   /**
+   * Filter description to be used when the filter is disabled in replace mode.
+   */
+  disabledDescription?: string;
+  /**
    * Default value
    */
   default: boolean;

--- a/packages/documentsearch/src/tokens.ts
+++ b/packages/documentsearch/src/tokens.ts
@@ -30,10 +30,6 @@ export interface IFilter {
    */
   description: string;
   /**
-   * Filter description to be used when the filter is disabled in replace mode.
-   */
-  disabledDescription?: string;
-  /**
    * Default value
    */
   default: boolean;

--- a/packages/notebook/src/searchprovider.ts
+++ b/packages/notebook/src/searchprovider.ts
@@ -236,6 +236,7 @@ export class NotebookSearchProvider extends SearchProvider<NotebookPanel> {
       output: {
         title: trans.__('Search Cell Outputs'),
         description: trans.__('Search in the cell outputs.'),
+        disabledDescription: trans.__('Search in the cell outputs. (Not available in find and replace mode.)'),
         default: false,
         supportReplace: false
       },

--- a/packages/notebook/src/searchprovider.ts
+++ b/packages/notebook/src/searchprovider.ts
@@ -237,7 +237,7 @@ export class NotebookSearchProvider extends SearchProvider<NotebookPanel> {
         title: trans.__('Search Cell Outputs'),
         description: trans.__('Search in the cell outputs.'),
         disabledDescription: trans.__(
-          'Search in the cell outputs. (Not available in find and replace mode.)'
+          'Search in the cell outputs (not available when replace options are shown).'
         ),
         default: false,
         supportReplace: false

--- a/packages/notebook/src/searchprovider.ts
+++ b/packages/notebook/src/searchprovider.ts
@@ -236,7 +236,9 @@ export class NotebookSearchProvider extends SearchProvider<NotebookPanel> {
       output: {
         title: trans.__('Search Cell Outputs'),
         description: trans.__('Search in the cell outputs.'),
-        disabledDescription: trans.__('Search in the cell outputs. (Not available in find and replace mode.)'),
+        disabledDescription: trans.__(
+          'Search in the cell outputs. (Not available in find and replace mode.)'
+        ),
         default: false,
         supportReplace: false
       },

--- a/packages/notebook/src/searchprovider.ts
+++ b/packages/notebook/src/searchprovider.ts
@@ -236,7 +236,6 @@ export class NotebookSearchProvider extends SearchProvider<NotebookPanel> {
       output: {
         title: trans.__('Search Cell Outputs'),
         description: trans.__('Search in the cell outputs.'),
-        disabledDescription: trans.__('Search in the cell outputs. (Not available in find and replace mode.)'),
         default: false,
         supportReplace: false
       },


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes #13167.

## Code changes

Adds a "disabled description" field to search filters, to provide an alternate description when the filter is disabled in "find and replace" mode.

## User-facing changes

When the user is in "find and replace" mode and opens the filter options in the search box, the "search cell outputs" filter is disabled. Mousing over it now displays an alternate title:

![Screenshot 2024-02-23 at 2 16 16 PM](https://github.com/jupyterlab/jupyterlab/assets/93281816/54683bd2-e1f1-49ba-be6c-3dc7bb4c0d7f)

## Backwards-incompatible changes

None.
