### PR TITLE
Fix Pressing enter in console with console run keystroke set to enter creates a newline and runs

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -310,13 +310,6 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
   }
 
   /**
-   * Editor Extensions
-   */
-  get editorExtensions(): Extension[] {
-    return this._editorExtensions;
-  }
-
-  /**
    * Cell headings
    */
   get headings(): Cell.IHeading[] {
@@ -623,7 +616,7 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
    * @returns Editor options
    */
   protected getEditorOptions(): InputArea.IOptions['editorOptions'] {
-    return { config: this.editorConfig, extensions: this.editorExtensions };
+    return { config: this.editorConfig, extensions: this._editorExtensions };
   }
 
   /**

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -204,6 +204,7 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
 
     // For cells disable searching with CodeMirror search panel.
     this._editorConfig = { searchWithCM: false, ...options.editorConfig };
+    this._editorExtensions = options.editorExtensions ?? [];
     this._placeholder = true;
     this._inViewport = false;
     this.placeholder = options.placeholder ?? true;
@@ -306,6 +307,13 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
    */
   get editorConfig(): Record<string, any> {
     return this._editorConfig;
+  }
+
+  /**
+   * Editor Extensions
+   */
+  get editorExtensions(): Extension[] {
+    return this._editorExtensions;
   }
 
   /**
@@ -615,7 +623,7 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
    * @returns Editor options
    */
   protected getEditorOptions(): InputArea.IOptions['editorOptions'] {
-    return { config: this.editorConfig };
+    return { config: this.editorConfig, extensions: this.editorExtensions };
   }
 
   /**
@@ -694,6 +702,7 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
   protected _displayChanged = new Signal<this, void>(this);
 
   private _editorConfig: Record<string, any> = {};
+  private _editorExtensions: Extension[] = [];
   private _input: InputArea | null;
   private _inputHidden = false;
   private _inputWrapper: Widget | null;

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -92,6 +92,11 @@ const JUPYTER_CELL_MIME = 'application/vnd.jupyter.cells';
  * The data attribute added to a widget that can undo.
  */
 const UNDOER = 'jpUndoer';
+/**
+ * The data attribute Whether the console interaction mimics the notebook
+ * or terminal keyboard shortcuts.
+ */
+const INTERACTION_MODE = 'jpInteractionMode';
 
 /**
  * A widget containing a Jupyter console.
@@ -789,6 +794,7 @@ export class CodeConsole extends Widget {
    * Create the options used to initialize a code cell widget.
    */
   private _createCodeCellOptions(): CodeCell.IOptions {
+    const { node } = this;
     const contentFactory = this.contentFactory;
     const modelFactory = this.modelFactory;
     const model = modelFactory.createCodeCell({});
@@ -798,7 +804,10 @@ export class CodeConsole extends Widget {
     // Suppress the default "Enter" key handling.
     const onKeyDown = EditorView.domEventHandlers({
       keydown: (event: KeyboardEvent, view: EditorView) => {
-        if (event.keyCode === 13) {
+        if (
+          event.keyCode === 13 &&
+          node.dataset[INTERACTION_MODE] === 'terminal'
+        ) {
           event.preventDefault();
           return true;
         }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

Fixes: https://github.com/jupyterlab/jupyterlab/issues/15835

## Code changes

<!-- Describe the code changes and how they address the issue. -->

1. Add extensions options in the getEditorOptions function and provide them to the InputArea of ​​the cells module.
2. Only when INTERACTION_MODE is terminal, prevent the default event of the enter key.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->
before change

https://github.com/jupyterlab/jupyterlab/assets/49218295/0e78f27d-8b56-4bbe-b295-ac6258751249

after change

https://github.com/jupyterlab/jupyterlab/assets/49218295/296e2533-ee3a-49a6-801b-c49476ed41d3


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
none