### PR TITLE
Fix missing signals in file editor adapter

### DIFF
--- a/packages/fileeditor/src/fileeditorlspadapter.ts
+++ b/packages/fileeditor/src/fileeditorlspadapter.ts
@@ -45,6 +45,9 @@ export class FileEditorAdapter extends WidgetLSPAdapter<
       .then(async () => {
         await this.initOnceReady();
         this._readyDelegate.resolve();
+        this._editorAdded.emit({
+          editor: this._virtualEditor
+        });
       })
       .catch(console.error);
   }
@@ -151,6 +154,9 @@ export class FileEditorAdapter extends WidgetLSPAdapter<
     if (this.isDisposed) {
       return;
     }
+    this._editorRemoved.emit({
+      editor: this._virtualEditor
+    });
     this.editor.model.mimeTypeChanged.disconnect(this.reloadConnection);
     super.dispose();
   }


### PR DESCRIPTION
## References

Fixes #15868

## Code changes

Emit signal `editorAdded` and `editorRemoved` signals in file editor so that `EditorAdapter` gets created.

## User-facing changes

LSP features will work in file editor.

## Backwards-incompatible changes

None