### PR TITLE
Bump `sanitize-html` to latest v2.12.1

### DIFF
--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -65,12 +65,12 @@
     "@lumino/widgets": "^2.3.1",
     "@types/react": "^18.0.26",
     "react": "^18.2.0",
-    "sanitize-html": "~2.7.3"
+    "sanitize-html": "~2.12.1"
   },
   "devDependencies": {
     "@jupyterlab/testing": "^4.1.2",
     "@types/jest": "^29.2.0",
-    "@types/sanitize-html": "^2.3.1",
+    "@types/sanitize-html": "^2.11.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
     "typedoc": "~0.24.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2291,11 +2291,11 @@ __metadata:
     "@lumino/widgets": ^2.3.1
     "@types/jest": ^29.2.0
     "@types/react": ^18.0.26
-    "@types/sanitize-html": ^2.3.1
+    "@types/sanitize-html": ^2.11.0
     jest: ^29.2.0
     react: ^18.2.0
     rimraf: ~5.0.5
-    sanitize-html: ~2.7.3
+    sanitize-html: ~2.12.1
     typedoc: ~0.24.7
     typescript: ~5.1.6
   languageName: unknown
@@ -7151,12 +7151,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/sanitize-html@npm:^2.3.1":
-  version: 2.8.1
-  resolution: "@types/sanitize-html@npm:2.8.1"
+"@types/sanitize-html@npm:^2.11.0":
+  version: 2.11.0
+  resolution: "@types/sanitize-html@npm:2.11.0"
   dependencies:
     htmlparser2: ^8.0.0
-  checksum: 9c07d3a9d925e291472f74b097fb179b32659ea01834f728887811e5fc75cf2b17d844e32e97c0e583eba993af86a3f8250c82c8fa3152abf9ff2a8582972906
+  checksum: a901d55d31cd946a7fce0130cc7cf6bcf56602af9c87291be77d8149c60e7afc47c83ca74c67c2d84e6ba029fe9bbd6f14f89a8cb30fbd185766eebc5722c251
   languageName: node
   linkType: hard
 
@@ -12933,7 +12933,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"htmlparser2@npm:^6.0.0, htmlparser2@npm:^6.1.0":
+"htmlparser2@npm:^6.1.0":
   version: 6.1.0
   resolution: "htmlparser2@npm:6.1.0"
   dependencies:
@@ -18679,17 +18679,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sanitize-html@npm:~2.7.3":
-  version: 2.7.3
-  resolution: "sanitize-html@npm:2.7.3"
+"sanitize-html@npm:~2.12.1":
+  version: 2.12.1
+  resolution: "sanitize-html@npm:2.12.1"
   dependencies:
     deepmerge: ^4.2.2
     escape-string-regexp: ^4.0.0
-    htmlparser2: ^6.0.0
+    htmlparser2: ^8.0.0
     is-plain-object: ^5.0.0
     parse-srcset: ^1.0.2
     postcss: ^8.3.11
-  checksum: 2399d1fdbbc3a263fb413c1fe1971b3dc2b51abc6cc5cb49490624539d1c57a8fe31e2b21408c118e2a957f4e673e3169b1f9a5807654408f17b130a9d78aed7
+  checksum: fb96ea7170d51b5af2607f5cfd84464c78fc6f47e339407f55783e781c6a0288a8d40bbf97ea6a8758924ba9b2d33dcc4846bb94caacacd90d7f2de10ed8541a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## References

Fixes #15876

## Code changes

Updates pin on `sanitize-html` to latest version v2.12.1.

- https://github.com/apostrophecms/sanitize-html/compare/2.7.3...2.12.1
- https://github.com/apostrophecms/sanitize-html/blob/main/CHANGELOG.md#2121-2024-02-22

## User-facing changes

Nothing major, but pulling some bug fixes which will manifest in the user space.

## Backwards-incompatible changes

None