### PR TITLE
Fix browser-test.js

### DIFF
--- a/jupyterlab/browser-test.js
+++ b/jupyterlab/browser-test.js
@@ -65,9 +65,9 @@ async function main() {
   console.log('Waiting for page content..');
 
   try {
-    await page.locator('#jupyter-config-data').waitFor();
+    await page.locator('#jupyter-config-data').waitFor({ state: 'attached' });
   } catch (reason) {
-    console.error('Error loading JupyterLab page:');
+    console.error('Error loading JupyterLab page', reason);
     // Limit to 1000 characters
     console.error((await page.content()).substring(0, 1000));
   }

--- a/jupyterlab/browser-test.js
+++ b/jupyterlab/browser-test.js
@@ -28,6 +28,7 @@ if (OUTPUT) {
 async function main() {
   /* eslint-disable no-console */
   console.info(`Starting headless ${BROWSER}...`);
+  let testError = null;
 
   const pwBrowser = playwright[BROWSER];
   const browser = await pwBrowser.launch({
@@ -70,6 +71,7 @@ async function main() {
     console.error('Error loading JupyterLab page:', reason);
     // Limit to 1000 characters
     console.error((await page.content()).substring(0, 1000));
+    testError = reason;
   }
 
   console.log('Waiting for #main selector...');
@@ -81,7 +83,6 @@ async function main() {
     state: 'attached'
   });
   console.log('Waiting for application to start...');
-  let testError = null;
 
   try {
     await page.waitForSelector('.completed', { state: 'attached' });

--- a/jupyterlab/browser-test.js
+++ b/jupyterlab/browser-test.js
@@ -67,7 +67,7 @@ async function main() {
   try {
     await page.locator('#jupyter-config-data').waitFor({ state: 'attached' });
   } catch (reason) {
-    console.error('Error loading JupyterLab page', reason);
+    console.error('Error loading JupyterLab page:', reason);
     // Limit to 1000 characters
     console.error((await page.content()).substring(0, 1000));
   }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
In browser-test, playwright fails to wait for `jupyter-config-data` because it is not meant to be visible.

Seen when debugging https://github.com/jupyterlab-contrib/jupyter-ui-toolkit/actions/runs/8112258105/job/22173089074?pr=90
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Wait only for the element to be attached to the DOM.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None

> Dev should see less false positive failure of browser check
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None