### PR TITLE
Fix spurious dedent when opening inspector tooltip

### DIFF
--- a/packages/codemirror/src/commands.ts
+++ b/packages/codemirror/src/commands.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+  indentLess,
   indentMore,
   insertNewlineAndIndent,
   insertTab
@@ -18,6 +19,12 @@ import {
  * Selector for a widget that can run code.
  */
 const CODE_RUNNER_SELECTOR = '[data-jp-code-runner]';
+
+/**
+ * Selector for a widget that can open a tooltip.
+ */
+const TOOLTIP_OPENER_SELECTOR =
+  '.jp-CodeMirrorEditor:not(.jp-mod-has-primary-selection):not(.jp-mod-in-leading-whitespace):not(.jp-mod-completer-active)';
 
 /**
  * CodeMirror commands namespace
@@ -75,5 +82,23 @@ export namespace StateCommands {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Prevent dedenting when launching inspection request (a.k.a tooltip).
+   *
+   * This function should be removed once a better way to prevent default
+   * CodeMirror commands is implemented, as tracked in
+   * https://github.com/jupyterlab/jupyterlab/issues/15897
+   */
+  export function dedentIfNotLaunchingTooltip(target: {
+    dom: HTMLElement;
+    state: EditorState;
+    dispatch: (transaction: Transaction) => void;
+  }): boolean {
+    if (target.dom.closest(TOOLTIP_OPENER_SELECTOR)) {
+      return true;
+    }
+    return indentLess(target);
   }
 }

--- a/packages/codemirror/src/extension.ts
+++ b/packages/codemirror/src/extension.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { closeBrackets, closeBracketsKeymap } from '@codemirror/autocomplete';
-import { defaultKeymap, indentLess } from '@codemirror/commands';
+import { defaultKeymap } from '@codemirror/commands';
 import {
   bracketMatching,
   foldGutter,
@@ -715,7 +715,7 @@ export namespace EditorExtensionRegistry {
           {
             key: 'Tab',
             run: StateCommands.indentMoreOrInsertTab,
-            shift: indentLess
+            shift: StateCommands.dedentIfNotLaunchingTooltip
           }
         ],
         factory: () =>


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/15821

Related to https://github.com/jupyterlab/jupyterlab/issues/15897

## Code changes

Checks if editor node is within a node matching tooltip opener before allowing dedent (`indentLess`) command to proceed.

## User-facing changes

| Before (tooltip + dedent) | After (only tooltip, as in 4.0 and 3.x) |
|--|--|
| ![before](https://github.com/jupyterlab/jupyterlab/assets/5832902/cc8eddb9-4b23-4600-84bd-b0fdd8a4e8d9) | ![after](https://github.com/jupyterlab/jupyterlab/assets/5832902/d0d7bfaa-3be3-464d-a867-34a635091513) |

Without change: dedent works when any text fragment is selected:

![dedent-with-selection-works](https://github.com/jupyterlab/jupyterlab/assets/5832902/d0fa10ae-3de9-4e1c-938b-33f0e1c04227)


## Backwards-incompatible changes

None