### PR TITLE
Add an explicit default for inline completer providers

### DIFF
--- a/packages/completer-extension/schema/inline-completer.json
+++ b/packages/completer-extension/schema/inline-completer.json
@@ -29,7 +29,8 @@
   "properties": {
     "providers": {
       "title": "Inline completion providers",
-      "type": "object"
+      "type": "object",
+      "default": {}
     },
     "showWidget": {
       "title": "Show widget",


### PR DESCRIPTION
## References

Should fix #15895

## Code changes

```diff
+      "default": {}
```

## User-facing changes

Specifying "providers" in `overrides.json`for inline completer should no longer break jupyterlab-server.

## Backwards-incompatible changes

None