### PR TITLE
Add end of maintenance date to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ To learn more about extensions, see the [user documentation](https://jupyterlab.
 
 Read the current JupyterLab documentation on [ReadTheDocs](http://jupyterlab.readthedocs.io/en/stable/).
 
-**JupyterLab 3 will reach its end of maintenance date on May 15, 2024, anywhere on Earth.** To help us make this transition, fixes for critical issues will still be backported until December 31, 2024. If you are still running JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible.** For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.
+> [!IMPORTANT]
+> JupyterLab 3 will reach its end of maintenance date on May 15, 2024, anywhere on Earth. To help us make this transition, fixes for critical issues will still be backported until December 31, 2024. If you are still running JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible.** For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Read the current JupyterLab documentation on [ReadTheDocs](http://jupyterlab.rea
 > [!IMPORTANT]
 > JupyterLab 3 will reach its end of maintenance date on May 15, 2024, anywhere on Earth. To help us make this transition, fixes for critical issues will still be backported until December 31, 2024. If you are still running JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible.** For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.
 
-
 ---
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ To learn more about extensions, see the [user documentation](https://jupyterlab.
 
 Read the current JupyterLab documentation on [ReadTheDocs](http://jupyterlab.readthedocs.io/en/stable/).
 
+**JupyterLab 3 will reach its end of maintenance date on May 15, 2024, anywhere on Earth.** To help us make this transition, fixes for critical issues will still be backported until December 31, 2024. If you are still running JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible.** For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.
+
+
 ---
 
 ## Getting started


### PR DESCRIPTION
Updates README to mention that JupyterLab 3 is reaching end of maintenance soon:

> **JupyterLab 3 will reach its end of maintenance date on May 15, 2024, anywhere on Earth.** To help us make this transition, fixes for critical issues will still be backported until December 31, 2024. If you are still running JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible.** For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.