### PR TITLE
Fix Theme color is not applied to SwitchKernel ToolbarButton

### DIFF
--- a/galata/test/jupyterlab/toolbars.test.ts
+++ b/galata/test/jupyterlab/toolbars.test.ts
@@ -37,3 +37,23 @@ toolbars.forEach(([plugin, parameter]) => {
     expect(missingCommands).toEqual([]);
   });
 });
+
+test('Render Switch Kernel ToolbarButton', async ({ page }) => {
+  await page.notebook.createNew();
+
+  const label = await page.$(
+    'jp-button.jp-Toolbar-kernelName .jp-ToolbarButtonComponent-label'
+  );
+  const labelColor = await page.evaluate(
+    el => getComputedStyle(el).color,
+    label
+  );
+
+  const color = await page.evaluate(() =>
+    getComputedStyle(document.body)
+      .getPropertyValue('--jp-ui-font-color1')
+      .trim()
+  );
+
+  expect(labelColor).toEqual(color);
+});

--- a/packages/ui-components/style/toolbar.css
+++ b/packages/ui-components/style/toolbar.css
@@ -74,6 +74,10 @@ button.jp-ToolbarButtonComponent .jp-ToolbarButtonComponent-label {
   font-family: var(--jp-ui-font-family);
 }
 
+jp-button.jp-Toolbar-kernelName {
+  color: var(--jp-ui-font-color1);
+}
+
 .jp-ToolbarButtonComponent::part(content) {
   display: flex;
   align-items: center;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

Fixes:https://github.com/jupyterlab/jupyterlab/issues/15786

## Code changes

<!-- Describe the code changes and how they address the issue. -->

![截屏2024-03-06 11 40 56](https://github.com/jupyterlab/jupyterlab/assets/49218295/32424ead-713f-43eb-9f00-f4bf622d4a5d)

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

The color of `Python 3 (ipykernel)` use `var(--neutral-foreground-rest)`

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

The color of `Python 3 (ipykernel)`  use `var(--jp-ui-font-color1)`
