### PR TITLE
Case insensitive match for completion items filtering

### DIFF
--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -390,7 +390,7 @@ export class CompleterModel implements Completer.IModel {
         index > -1
           ? originalItem.label.substring(0, index)
           : originalItem.label;
-      const match = StringExt.matchSumOfSquares(escapeHTML(text), query);
+      const match = StringExt.matchSumOfSquares(escapeHTML(text.toLowerCase()), query.toLowerCase());
       // Filter non-matching items.
       if (match) {
         // Highlight label text if there's a match


### PR DESCRIPTION
Missing a letter is allowed by matchSumOfSquares so it makes more sense to make filtering case insensitive.
