### PR TITLE
Avoid concurrency when computing the items in notebook toolbar

### DIFF
--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -486,7 +486,7 @@ export class ReactiveToolbar extends Toolbar<Widget> {
       // Invokes resizing to ensure correct display of items after an addition, only
       // if the toolbar is rendered.
       if (this.isVisible) {
-        void this._onResize();
+        void this._resizer.invoke();
       }
     }
     return status;


### PR DESCRIPTION
This PR is an(other) follow up of https://github.com/jupyterlab/jupyterlab/pull/15843 

## References

Fixes https://github.com/jupyter/notebook/pull/7291

## Code changes

When a widget is added to the notebook toolbar, invoke the throttler instead of calling directly the `_onResize()` method.
This avoids concurrency if the toolbar is rendered quickly.

See [this comment](https://github.com/jupyter/notebook/pull/7291#issuecomment-1985808055) for details.

## User-facing changes

The notebook toolbar should be correctly initialized.

## Backwards-incompatible changes

None