### PR TITLE
Fix Theme color is not applied to Toolbar Button

### DIFF
--- a/galata/test/jupyterlab/toolbars.test.ts
+++ b/galata/test/jupyterlab/toolbars.test.ts
@@ -37,23 +37,47 @@ toolbars.forEach(([plugin, parameter]) => {
     expect(missingCommands).toEqual([]);
   });
 });
+test.describe('Toolbar Button', () => {
+  test.beforeEach(async ({ page, tmpPath }) => {
+    await page.notebook.createNew();
+  });
 
-test('Render Switch Kernel ToolbarButton', async ({ page }) => {
-  await page.notebook.createNew();
+  test('Render Switch Kernel ToolbarButton in default theme', async ({
+    page
+  }) => {
+    const label = await page.$(
+      'jp-button.jp-Toolbar-kernelName .jp-ToolbarButtonComponent-label'
+    );
+    const labelColor = await page.evaluate(
+      el => getComputedStyle(el).color,
+      label
+    );
 
-  const label = await page.$(
-    'jp-button.jp-Toolbar-kernelName .jp-ToolbarButtonComponent-label'
-  );
-  const labelColor = await page.evaluate(
-    el => getComputedStyle(el).color,
-    label
-  );
+    const color = await page.evaluate(() =>
+      getComputedStyle(document.body)
+        .getPropertyValue('--jp-ui-font-color1')
+        .trim()
+    );
 
-  const color = await page.evaluate(() =>
-    getComputedStyle(document.body)
-      .getPropertyValue('--jp-ui-font-color1')
-      .trim()
-  );
+    expect(labelColor).toEqual(color);
+  });
 
-  expect(labelColor).toEqual(color);
+  test('Render Switch Kernel ToolbarButton in dark theme', async ({ page }) => {
+    await page.theme.setDarkTheme();
+    const label = await page.$(
+      'jp-button.jp-Toolbar-kernelName .jp-ToolbarButtonComponent-label'
+    );
+    const labelColor = await page.evaluate(
+      el => getComputedStyle(el).color,
+      label
+    );
+
+    const color = await page.evaluate(() =>
+      getComputedStyle(document.body)
+        .getPropertyValue('--jp-ui-font-color1')
+        .trim()
+    );
+
+    expect(labelColor).toEqual(color);
+  });
 });

--- a/packages/ui-components/style/toolbar.css
+++ b/packages/ui-components/style/toolbar.css
@@ -74,7 +74,7 @@ button.jp-ToolbarButtonComponent .jp-ToolbarButtonComponent-label {
   font-family: var(--jp-ui-font-family);
 }
 
-jp-button.jp-Toolbar-kernelName {
+.jp-Toolbar .jp-ToolbarButtonComponent {
   color: var(--jp-ui-font-color1);
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes:https://github.com/jupyterlab/jupyterlab/issues/15786

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
![截屏2024-03-10 22 05 35](https://github.com/jupyterlab/jupyterlab/assets/49218295/26dbc4e3-a2f2-4fdf-8c10-4713bc7098cf)

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

The color of `.jp-Toolbar .jp-ToolbarButtonComponent` use `var(--neutral-foreground-rest)`

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

If there is no higher weight, the color of `.jp-Toolbar .jp-ToolbarButtonComponent` use `var(--jp-ui-font-color1)`
