### PR TITLE
Ignore links to GitHub user and organisation profiles

### DIFF
--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -154,4 +154,4 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
         with:
           ignore_glob: "docs/api packages/ui-components/docs/source/ui_components.rst images"
-          ignore_links: ".*/images/[\\w-]+.png https://docs.github.com/en/.* https://jupyterlab.github.io https://mybinder.org/v2/gh/jupyterlab/.*"
+          ignore_links: ".*/images/[\\w-]+.png https://docs.github.com/en/.* https://jupyterlab.github.io https://mybinder.org/v2/gh/jupyterlab/.* https://github.com/[^/]+/?$"


### PR DESCRIPTION
## References

https://github.com/jupyterlab/jupyterlab/issues/15776

## Code changes

Adds ignore pattern `https://github.com/[^/]+/?$` - same as in https://github.com/jupyterlab/maintainer-tools/pull/221 but rather than changing it for all repositories we can try this rule out only on `jupyterlab/jupyterlab` first.

## User-facing changes

None

## Backwards-incompatible changes

None
