### PR TITLE
Remove `node-fetch` dependency

### DIFF
--- a/.github/workflows/linuxjs-tests.yml
+++ b/.github/workflows/linuxjs-tests.yml
@@ -71,8 +71,6 @@ jobs:
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-        with:
-          node_version: '20.x'
 
       - name: Install dependencies
         env:

--- a/.github/workflows/linuxjs-tests.yml
+++ b/.github/workflows/linuxjs-tests.yml
@@ -71,6 +71,8 @@ jobs:
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          node_version: '20.x'
 
       - name: Install dependencies
         env:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -25,7 +25,7 @@ tasks:
       EOT
       source /workspace/bin/activate-env.sh
       micromamba config append channels conda-forge
-      micromamba install -n base -y python=3.10 nodejs=18 yarn
+      micromamba install -n base -y python=3.10 nodejs=20 yarn
       source /workspace/bin/activate-env.sh
       python -m pip install -e ".[dev,docs,test]" && jlpm install && jlpm run build
       gp sync-done setup

--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -120,7 +120,6 @@ const UNUSED: Dict<string[]> = {
     '@babel/core',
     '@babel/preset-env',
     'fs-extra',
-    'node-fetch',
     'identity-obj-proxy',
     'jest-environment-jsdom',
     'jest-junit'

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -309,7 +309,7 @@ Installing Node.js and jlpm
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Building JupyterLab from its GitHub source code requires Node.js. The
-development version requires Node.js version 18+, as defined in the
+development version requires Node.js version 20+, as defined in the
 ``engines`` specification in
 `dev_mode/package.json <https://github.com/jupyterlab/jupyterlab/blob/main/dev_mode/package.json>`__.
 

--- a/docs/source/extension/extension_tutorial.rst
+++ b/docs/source/extension/extension_tutorial.rst
@@ -66,7 +66,7 @@ new environment named ``jupyterlab-ext``.
 
 .. code:: bash
 
-    conda create -n jupyterlab-ext --override-channels --strict-channel-priority -c conda-forge -c nodefaults jupyterlab=4 nodejs=18 git copier=7 jinja2-time
+    conda create -n jupyterlab-ext --override-channels --strict-channel-priority -c conda-forge -c nodefaults jupyterlab=4 nodejs=20 git copier=7 jinja2-time
 
 Now activate the new environment so that all further commands you run
 work out of that environment.

--- a/packages/docregistry/test/context.spec.ts
+++ b/packages/docregistry/test/context.spec.ts
@@ -259,7 +259,7 @@ describe('docregistry/context', () => {
         });
 
         await expect(context.initialize(true)).rejects.toThrow(
-          'Invalid response: 403 '
+          /Invalid response: 403/
         );
         expect(called).toBe(2);
         expect(checked).toBe('failed');

--- a/packages/docregistry/test/context.spec.ts
+++ b/packages/docregistry/test/context.spec.ts
@@ -259,7 +259,7 @@ describe('docregistry/context', () => {
         });
 
         await expect(context.initialize(true)).rejects.toThrow(
-          'Invalid response: 403 Forbidden'
+          'Invalid response: 403 '
         );
         expect(called).toBe(2);
         expect(checked).toBe('failed');

--- a/packages/services/test/config/config.spec.ts
+++ b/packages/services/test/config/config.spec.ts
@@ -50,9 +50,7 @@ describe('config', () => {
         name: randomName(),
         serverSettings
       });
-      await expect(configPromise).rejects.toThrow(
-        /Invalid response: 201 Created/
-      );
+      await expect(configPromise).rejects.toThrow(/Invalid response: 201 /);
     });
   });
 
@@ -83,7 +81,7 @@ describe('config', () => {
       const config = await ConfigSection.create({ name: randomName() });
       handleRequest(config, 201, {});
       const update = config.update({ foo: 'baz' });
-      await expect(update).rejects.toThrow(/Invalid response: 201 Created/);
+      await expect(update).rejects.toThrow(/Invalid response: 201 /);
     });
   });
 });
@@ -198,7 +196,7 @@ describe('jupyter.services - ConfigWithDefaults', () => {
       const config = new ConfigWithDefaults({ section });
       const set = config.set('foo', 'bar');
       expect(section.data['foo']).toBe('bar');
-      await expectFailure(set, 'Invalid response: 201 Created');
+      await expectFailure(set, 'Invalid response: 201 ');
     });
   });
 });

--- a/packages/services/test/config/config.spec.ts
+++ b/packages/services/test/config/config.spec.ts
@@ -50,7 +50,7 @@ describe('config', () => {
         name: randomName(),
         serverSettings
       });
-      await expect(configPromise).rejects.toThrow(/Invalid response: 201 /);
+      await expect(configPromise).rejects.toThrow(/Invalid response: 201/);
     });
   });
 
@@ -81,7 +81,7 @@ describe('config', () => {
       const config = await ConfigSection.create({ name: randomName() });
       handleRequest(config, 201, {});
       const update = config.update({ foo: 'baz' });
-      await expect(update).rejects.toThrow(/Invalid response: 201 /);
+      await expect(update).rejects.toThrow(/Invalid response: 201/);
     });
   });
 });
@@ -196,7 +196,7 @@ describe('jupyter.services - ConfigWithDefaults', () => {
       const config = new ConfigWithDefaults({ section });
       const set = config.set('foo', 'bar');
       expect(section.data['foo']).toBe('bar');
-      await expectFailure(set, 'Invalid response: 201 ');
+      await expectFailure(set, 'Invalid response: 201');
     });
   });
 });

--- a/packages/services/test/contents/index.spec.ts
+++ b/packages/services/test/contents/index.spec.ts
@@ -260,7 +260,7 @@ describe('contents', () => {
     it('should fail for an incorrect response', async () => {
       handleRequest(contents, 201, DEFAULT_DIR);
       const get = contents.get('/foo');
-      await expect(get).rejects.toThrow(/Invalid response: 201 Created/);
+      await expect(get).rejects.toThrow(/Invalid response: 201 /);
     });
 
     it('should store original server path for directory', async () => {
@@ -393,7 +393,7 @@ describe('contents', () => {
     it('should fail for an incorrect response', async () => {
       handleRequest(contents, 200, DEFAULT_DIR);
       const newDir = contents.newUntitled();
-      await expect(newDir).rejects.toThrow(/Invalid response: 200 OK/);
+      await expect(newDir).rejects.toThrow(/Invalid response: 200 /);
     });
   });
 
@@ -428,7 +428,7 @@ describe('contents', () => {
     it('should fail for an incorrect response', async () => {
       handleRequest(contents, 200, {});
       const del = contents.delete('/foo/bar.txt');
-      await expect(del).rejects.toThrow(/Invalid response: 200 OK/);
+      await expect(del).rejects.toThrow(/Invalid response: 200 /);
     });
 
     it('should throw a specific error', async () => {
@@ -488,7 +488,7 @@ describe('contents', () => {
     it('should fail for an incorrect response', async () => {
       handleRequest(contents, 201, DEFAULT_FILE);
       const rename = contents.rename('/foo/bar.txt', '/foo/baz.txt');
-      await expect(rename).rejects.toThrow(/Invalid response: 201 Created/);
+      await expect(rename).rejects.toThrow(/Invalid response: 201 /);
     });
   });
 
@@ -540,7 +540,7 @@ describe('contents', () => {
     it('should fail for an incorrect response', async () => {
       handleRequest(contents, 204, DEFAULT_FILE);
       const save = contents.save('/foo', { type: 'file', name: 'test' });
-      await expect(save).rejects.toThrow(/Invalid response: 204 No Content/);
+      await expect(save).rejects.toThrow(/Invalid response: 204/);
     });
   });
 
@@ -583,7 +583,7 @@ describe('contents', () => {
     it('should fail for an incorrect response', async () => {
       handleRequest(contents, 200, DEFAULT_FILE);
       const copy = contents.copy('/foo/bar.txt', '/baz');
-      await expect(copy).rejects.toThrow(/Invalid response: 200 OK/);
+      await expect(copy).rejects.toThrow(/Invalid response: 200 /);
     });
   });
 
@@ -615,7 +615,7 @@ describe('contents', () => {
     it('should fail for an incorrect response', async () => {
       handleRequest(contents, 200, DEFAULT_CP);
       const checkpoint = contents.createCheckpoint('/foo/bar.txt');
-      await expect(checkpoint).rejects.toThrow(/Invalid response: 200 OK/);
+      await expect(checkpoint).rejects.toThrow(/Invalid response: 200 /);
     });
   });
 
@@ -650,9 +650,7 @@ describe('contents', () => {
     it('should fail for an incorrect response', async () => {
       handleRequest(contents, 201, {});
       const checkpoints = contents.listCheckpoints('/foo/bar.txt');
-      await expect(checkpoints).rejects.toThrow(
-        /Invalid response: 201 Created/
-      );
+      await expect(checkpoints).rejects.toThrow(/Invalid response: 201 /);
     });
   });
 
@@ -683,7 +681,7 @@ describe('contents', () => {
         '/foo/bar.txt',
         DEFAULT_CP.id
       );
-      await expect(checkpoint).rejects.toThrow(/Invalid response: 200 OK/);
+      await expect(checkpoint).rejects.toThrow(/Invalid response: 200 /);
     });
   });
 
@@ -710,7 +708,7 @@ describe('contents', () => {
         '/foo/bar.txt',
         DEFAULT_CP.id
       );
-      await expect(checkpoint).rejects.toThrow(/Invalid response: 200 OK/);
+      await expect(checkpoint).rejects.toThrow(/Invalid response: 200 /);
     });
   });
 });
@@ -821,7 +819,7 @@ describe('drive', () => {
       const drive = new Drive();
       handleRequest(drive, 201, DEFAULT_DIR);
       const get = drive.get('/foo');
-      await expect(get).rejects.toThrow(/Invalid response: 201 Created/);
+      await expect(get).rejects.toThrow(/Invalid response: 201 /);
     });
   });
 
@@ -918,7 +916,7 @@ describe('drive', () => {
       const drive = new Drive();
       handleRequest(drive, 200, DEFAULT_DIR);
       const newDir = drive.newUntitled();
-      await expect(newDir).rejects.toThrow(/Invalid response: 200 OK/);
+      await expect(newDir).rejects.toThrow(/Invalid response: 200 /);
     });
   });
 
@@ -953,7 +951,7 @@ describe('drive', () => {
       const drive = new Drive();
       handleRequest(drive, 200, {});
       const del = drive.delete('/foo/bar.txt');
-      await expect(del).rejects.toThrow(/Invalid response: 200 OK/);
+      await expect(del).rejects.toThrow(/Invalid response: 200 /);
     });
 
     it('should throw a specific error', async () => {
@@ -1015,7 +1013,7 @@ describe('drive', () => {
       const drive = new Drive();
       handleRequest(drive, 201, DEFAULT_FILE);
       const rename = drive.rename('/foo/bar.txt', '/foo/baz.txt');
-      await expect(rename).rejects.toThrow(/Invalid response: 201 Created/);
+      await expect(rename).rejects.toThrow(/Invalid response: 201 /);
     });
   });
 
@@ -1071,7 +1069,7 @@ describe('drive', () => {
       const drive = new Drive();
       handleRequest(drive, 204, DEFAULT_FILE);
       const save = drive.save('/foo', { type: 'file', name: 'test' });
-      await expect(save).rejects.toThrow(/Invalid response: 204 No Content/);
+      await expect(save).rejects.toThrow(/Invalid response: 204/);
     });
   });
 
@@ -1117,7 +1115,7 @@ describe('drive', () => {
       const drive = new Drive();
       handleRequest(drive, 200, DEFAULT_FILE);
       const copy = drive.copy('/foo/bar.txt', '/baz');
-      await expect(copy).rejects.toThrow(/Invalid response: 200 OK/);
+      await expect(copy).rejects.toThrow(/Invalid response: 200 /);
     });
   });
 
@@ -1151,7 +1149,7 @@ describe('drive', () => {
       const drive = new Drive();
       handleRequest(drive, 200, DEFAULT_CP);
       const checkpoint = drive.createCheckpoint('/foo/bar.txt');
-      await expect(checkpoint).rejects.toThrow(/Invalid response: 200 OK/);
+      await expect(checkpoint).rejects.toThrow(/Invalid response: 200 /);
     });
   });
 
@@ -1188,9 +1186,7 @@ describe('drive', () => {
       const drive = new Drive();
       handleRequest(drive, 201, {});
       const checkpoints = drive.listCheckpoints('/foo/bar.txt');
-      await expect(checkpoints).rejects.toThrow(
-        /Invalid response: 201 Created/
-      );
+      await expect(checkpoints).rejects.toThrow(/Invalid response: 201 /);
     });
   });
 
@@ -1213,7 +1209,7 @@ describe('drive', () => {
       const drive = new Drive();
       handleRequest(drive, 200, {});
       const checkpoint = drive.restoreCheckpoint('/foo/bar.txt', DEFAULT_CP.id);
-      await expect(checkpoint).rejects.toThrow(/Invalid response: 200 OK/);
+      await expect(checkpoint).rejects.toThrow(/Invalid response: 200 /);
     });
   });
 
@@ -1238,7 +1234,7 @@ describe('drive', () => {
       const drive = new Drive();
       handleRequest(drive, 200, {});
       const checkpoint = drive.deleteCheckpoint('/foo/bar.txt', DEFAULT_CP.id);
-      await expect(checkpoint).rejects.toThrow(/Invalid response: 200 OK/);
+      await expect(checkpoint).rejects.toThrow(/Invalid response: 200 /);
     });
   });
 

--- a/packages/services/test/contents/index.spec.ts
+++ b/packages/services/test/contents/index.spec.ts
@@ -260,7 +260,7 @@ describe('contents', () => {
     it('should fail for an incorrect response', async () => {
       handleRequest(contents, 201, DEFAULT_DIR);
       const get = contents.get('/foo');
-      await expect(get).rejects.toThrow(/Invalid response: 201 /);
+      await expect(get).rejects.toThrow(/Invalid response: 201/);
     });
 
     it('should store original server path for directory', async () => {
@@ -393,7 +393,7 @@ describe('contents', () => {
     it('should fail for an incorrect response', async () => {
       handleRequest(contents, 200, DEFAULT_DIR);
       const newDir = contents.newUntitled();
-      await expect(newDir).rejects.toThrow(/Invalid response: 200 /);
+      await expect(newDir).rejects.toThrow(/Invalid response: 200/);
     });
   });
 
@@ -428,7 +428,7 @@ describe('contents', () => {
     it('should fail for an incorrect response', async () => {
       handleRequest(contents, 200, {});
       const del = contents.delete('/foo/bar.txt');
-      await expect(del).rejects.toThrow(/Invalid response: 200 /);
+      await expect(del).rejects.toThrow(/Invalid response: 200/);
     });
 
     it('should throw a specific error', async () => {
@@ -488,7 +488,7 @@ describe('contents', () => {
     it('should fail for an incorrect response', async () => {
       handleRequest(contents, 201, DEFAULT_FILE);
       const rename = contents.rename('/foo/bar.txt', '/foo/baz.txt');
-      await expect(rename).rejects.toThrow(/Invalid response: 201 /);
+      await expect(rename).rejects.toThrow(/Invalid response: 201/);
     });
   });
 
@@ -583,7 +583,7 @@ describe('contents', () => {
     it('should fail for an incorrect response', async () => {
       handleRequest(contents, 200, DEFAULT_FILE);
       const copy = contents.copy('/foo/bar.txt', '/baz');
-      await expect(copy).rejects.toThrow(/Invalid response: 200 /);
+      await expect(copy).rejects.toThrow(/Invalid response: 200/);
     });
   });
 
@@ -615,7 +615,7 @@ describe('contents', () => {
     it('should fail for an incorrect response', async () => {
       handleRequest(contents, 200, DEFAULT_CP);
       const checkpoint = contents.createCheckpoint('/foo/bar.txt');
-      await expect(checkpoint).rejects.toThrow(/Invalid response: 200 /);
+      await expect(checkpoint).rejects.toThrow(/Invalid response: 200/);
     });
   });
 
@@ -650,7 +650,7 @@ describe('contents', () => {
     it('should fail for an incorrect response', async () => {
       handleRequest(contents, 201, {});
       const checkpoints = contents.listCheckpoints('/foo/bar.txt');
-      await expect(checkpoints).rejects.toThrow(/Invalid response: 201 /);
+      await expect(checkpoints).rejects.toThrow(/Invalid response: 201/);
     });
   });
 
@@ -681,7 +681,7 @@ describe('contents', () => {
         '/foo/bar.txt',
         DEFAULT_CP.id
       );
-      await expect(checkpoint).rejects.toThrow(/Invalid response: 200 /);
+      await expect(checkpoint).rejects.toThrow(/Invalid response: 200/);
     });
   });
 
@@ -708,7 +708,7 @@ describe('contents', () => {
         '/foo/bar.txt',
         DEFAULT_CP.id
       );
-      await expect(checkpoint).rejects.toThrow(/Invalid response: 200 /);
+      await expect(checkpoint).rejects.toThrow(/Invalid response: 200/);
     });
   });
 });
@@ -819,7 +819,7 @@ describe('drive', () => {
       const drive = new Drive();
       handleRequest(drive, 201, DEFAULT_DIR);
       const get = drive.get('/foo');
-      await expect(get).rejects.toThrow(/Invalid response: 201 /);
+      await expect(get).rejects.toThrow(/Invalid response: 201/);
     });
   });
 
@@ -916,7 +916,7 @@ describe('drive', () => {
       const drive = new Drive();
       handleRequest(drive, 200, DEFAULT_DIR);
       const newDir = drive.newUntitled();
-      await expect(newDir).rejects.toThrow(/Invalid response: 200 /);
+      await expect(newDir).rejects.toThrow(/Invalid response: 200/);
     });
   });
 
@@ -951,7 +951,7 @@ describe('drive', () => {
       const drive = new Drive();
       handleRequest(drive, 200, {});
       const del = drive.delete('/foo/bar.txt');
-      await expect(del).rejects.toThrow(/Invalid response: 200 /);
+      await expect(del).rejects.toThrow(/Invalid response: 200/);
     });
 
     it('should throw a specific error', async () => {
@@ -1013,7 +1013,7 @@ describe('drive', () => {
       const drive = new Drive();
       handleRequest(drive, 201, DEFAULT_FILE);
       const rename = drive.rename('/foo/bar.txt', '/foo/baz.txt');
-      await expect(rename).rejects.toThrow(/Invalid response: 201 /);
+      await expect(rename).rejects.toThrow(/Invalid response: 201/);
     });
   });
 
@@ -1115,7 +1115,7 @@ describe('drive', () => {
       const drive = new Drive();
       handleRequest(drive, 200, DEFAULT_FILE);
       const copy = drive.copy('/foo/bar.txt', '/baz');
-      await expect(copy).rejects.toThrow(/Invalid response: 200 /);
+      await expect(copy).rejects.toThrow(/Invalid response: 200/);
     });
   });
 
@@ -1149,7 +1149,7 @@ describe('drive', () => {
       const drive = new Drive();
       handleRequest(drive, 200, DEFAULT_CP);
       const checkpoint = drive.createCheckpoint('/foo/bar.txt');
-      await expect(checkpoint).rejects.toThrow(/Invalid response: 200 /);
+      await expect(checkpoint).rejects.toThrow(/Invalid response: 200/);
     });
   });
 
@@ -1186,7 +1186,7 @@ describe('drive', () => {
       const drive = new Drive();
       handleRequest(drive, 201, {});
       const checkpoints = drive.listCheckpoints('/foo/bar.txt');
-      await expect(checkpoints).rejects.toThrow(/Invalid response: 201 /);
+      await expect(checkpoints).rejects.toThrow(/Invalid response: 201/);
     });
   });
 
@@ -1209,7 +1209,7 @@ describe('drive', () => {
       const drive = new Drive();
       handleRequest(drive, 200, {});
       const checkpoint = drive.restoreCheckpoint('/foo/bar.txt', DEFAULT_CP.id);
-      await expect(checkpoint).rejects.toThrow(/Invalid response: 200 /);
+      await expect(checkpoint).rejects.toThrow(/Invalid response: 200/);
     });
   });
 
@@ -1234,7 +1234,7 @@ describe('drive', () => {
       const drive = new Drive();
       handleRequest(drive, 200, {});
       const checkpoint = drive.deleteCheckpoint('/foo/bar.txt', DEFAULT_CP.id);
-      await expect(checkpoint).rejects.toThrow(/Invalid response: 200 /);
+      await expect(checkpoint).rejects.toThrow(/Invalid response: 200/);
     });
   });
 

--- a/packages/services/test/kernel/ikernel.spec.ts
+++ b/packages/services/test/kernel/ikernel.spec.ts
@@ -620,7 +620,7 @@ describe('Kernel.IKernel', () => {
         name: defaultKernel.name
       });
       const interrupt = defaultKernel.interrupt();
-      await expect(interrupt).rejects.toThrow(/Invalid response: 200 /);
+      await expect(interrupt).rejects.toThrow(/Invalid response: 200/);
     });
 
     it('should throw an error for an error response', async () => {
@@ -737,7 +737,7 @@ describe('Kernel.IKernel', () => {
         name: 'foo'
       });
       const shutdown = defaultKernel.shutdown();
-      await expect(shutdown).rejects.toThrow(/Invalid response: 200 /);
+      await expect(shutdown).rejects.toThrow(/Invalid response: 200/);
     });
 
     it('should handle a 404 error', async () => {

--- a/packages/services/test/kernel/ikernel.spec.ts
+++ b/packages/services/test/kernel/ikernel.spec.ts
@@ -620,7 +620,7 @@ describe('Kernel.IKernel', () => {
         name: defaultKernel.name
       });
       const interrupt = defaultKernel.interrupt();
-      await expect(interrupt).rejects.toThrow(/Invalid response: 200 OK/);
+      await expect(interrupt).rejects.toThrow(/Invalid response: 200 /);
     });
 
     it('should throw an error for an error response', async () => {
@@ -737,7 +737,7 @@ describe('Kernel.IKernel', () => {
         name: 'foo'
       });
       const shutdown = defaultKernel.shutdown();
-      await expect(shutdown).rejects.toThrow(/Invalid response: 200 OK/);
+      await expect(shutdown).rejects.toThrow(/Invalid response: 200 /);
     });
 
     it('should handle a 404 error', async () => {

--- a/packages/services/test/kernel/ikernel.spec.ts
+++ b/packages/services/test/kernel/ikernel.spec.ts
@@ -668,7 +668,7 @@ describe('Kernel.IKernel', () => {
       const { id, name } = defaultKernel;
       handleRequest(defaultKernel, 205, { id, name });
       await expect(defaultKernel.restart()).rejects.toThrow(
-        /Invalid response: 205 Reset Content/
+        /Invalid response: 205/
       );
     });
 

--- a/packages/services/test/kernel/kernel.spec.ts
+++ b/packages/services/test/kernel/kernel.spec.ts
@@ -65,7 +65,7 @@ describe('kernel', () => {
     it('should throw an error for an invalid response', async () => {
       const settings = getRequestHandler(201, {});
       const promise = KernelAPI.listRunning(settings);
-      await expect(promise).rejects.toThrow(/Invalid response: 201 Created/);
+      await expect(promise).rejects.toThrow(/Invalid response: 201 /);
     });
 
     it('should throw an error for an error response', async () => {
@@ -116,7 +116,7 @@ describe('kernel', () => {
       const data = { id: UUID.uuid4(), name: 'foo' };
       const serverSettings = getRequestHandler(200, data);
       const kernelPromise = KernelAPI.startNew({}, serverSettings);
-      await expect(kernelPromise).rejects.toThrow(/Invalid response: 200 OK/);
+      await expect(kernelPromise).rejects.toThrow(/Invalid response: 200 /);
     });
 
     it('should throw an error for an error response', async () => {

--- a/packages/services/test/kernel/kernel.spec.ts
+++ b/packages/services/test/kernel/kernel.spec.ts
@@ -65,7 +65,7 @@ describe('kernel', () => {
     it('should throw an error for an invalid response', async () => {
       const settings = getRequestHandler(201, {});
       const promise = KernelAPI.listRunning(settings);
-      await expect(promise).rejects.toThrow(/Invalid response: 201 /);
+      await expect(promise).rejects.toThrow(/Invalid response: 201/);
     });
 
     it('should throw an error for an error response', async () => {
@@ -116,7 +116,7 @@ describe('kernel', () => {
       const data = { id: UUID.uuid4(), name: 'foo' };
       const serverSettings = getRequestHandler(200, data);
       const kernelPromise = KernelAPI.startNew({}, serverSettings);
-      await expect(kernelPromise).rejects.toThrow(/Invalid response: 200 /);
+      await expect(kernelPromise).rejects.toThrow(/Invalid response: 200/);
     });
 
     it('should throw an error for an error response', async () => {

--- a/packages/services/test/kernelspec/kernelspec.spec.ts
+++ b/packages/services/test/kernelspec/kernelspec.spec.ts
@@ -121,7 +121,7 @@ describe('kernel', () => {
     it('should throw an error for an invalid response', async () => {
       const serverSettings = getRequestHandler(201, {});
       const promise = KernelSpecAPI.getSpecs(serverSettings);
-      await expect(promise).rejects.toThrow(/Invalid response: 201 Created/);
+      await expect(promise).rejects.toThrow(/Invalid response: 201 /);
     });
 
     it('should handle metadata', async () => {

--- a/packages/services/test/kernelspec/kernelspec.spec.ts
+++ b/packages/services/test/kernelspec/kernelspec.spec.ts
@@ -121,7 +121,7 @@ describe('kernel', () => {
     it('should throw an error for an invalid response', async () => {
       const serverSettings = getRequestHandler(201, {});
       const promise = KernelSpecAPI.getSpecs(serverSettings);
-      await expect(promise).rejects.toThrow(/Invalid response: 201 /);
+      await expect(promise).rejects.toThrow(/Invalid response: 201/);
     });
 
     it('should handle metadata', async () => {

--- a/packages/services/test/serverconnection.spec.ts
+++ b/packages/services/test/serverconnection.spec.ts
@@ -87,7 +87,7 @@ describe('ServerConnection', () => {
         settings
       );
       const err = new ServerConnection.ResponseError(response);
-      expect(err.message).toBe('Invalid response: 200 OK');
+      expect(err.message).toBe('Invalid response: 200 ');
     });
   });
 

--- a/packages/services/test/serverconnection.spec.ts
+++ b/packages/services/test/serverconnection.spec.ts
@@ -26,7 +26,7 @@ describe('ServerConnection', () => {
         {},
         settings
       );
-      expect(response.statusText).toBe('OK');
+      expect(response.status).toBe(200);
       const data = await response.json();
       expect(data).toBe('hello');
     });

--- a/packages/services/test/utils.ts
+++ b/packages/services/test/utils.ts
@@ -135,7 +135,8 @@ export function handleRequest(item: IService, status: number, body: any): void {
     if (typeof body !== 'string') {
       body = JSON.stringify(body);
     }
-    if (status === 204) {
+    // Body should be null for these status codes
+    if (status === 204 || status === 205) {
       body = null;
     }
 

--- a/packages/services/test/utils.ts
+++ b/packages/services/test/utils.ts
@@ -135,6 +135,9 @@ export function handleRequest(item: IService, status: number, body: any): void {
     if (typeof body !== 'string') {
       body = JSON.stringify(body);
     }
+    if (status === 204) {
+      body = null;
+    }
 
     // Create the response and return it as a promise.
     const response = new Response(body, { status });

--- a/packages/services/test/utils.ts
+++ b/packages/services/test/utils.ts
@@ -100,7 +100,7 @@ export function getRequestHandler(
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   body: any
 ): ServerConnection.ISettings {
-  const fetch = (info: RequestInfo, init: RequestInit) => {
+  const customFetch = (info: RequestInfo, init?: RequestInit) => {
     // Normalize the body.
     body = JSON.stringify(body);
 
@@ -108,7 +108,7 @@ export function getRequestHandler(
     const response = new Response(body, { status });
     return Promise.resolve(response as any);
   };
-  return ServerConnection.makeSettings({ fetch });
+  return ServerConnection.makeSettings({ fetch: customFetch });
 }
 
 /**

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -44,14 +44,12 @@
     "jest": "^29.2.0",
     "jest-environment-jsdom": "^29.3.0",
     "jest-junit": "^15.0.0",
-    "node-fetch": "^2.6.0",
     "simulate-event": "~1.4.0",
     "ts-jest": "^29.1.0"
   },
   "devDependencies": {
     "@types/jest": "^29.2.0",
     "@types/node": "^18.11.18",
-    "@types/node-fetch": "^2.6.2",
     "rimraf": "~5.0.5",
     "typescript": "~5.1.6"
   },

--- a/packages/testing/src/jest-config.ts
+++ b/packages/testing/src/jest-config.ts
@@ -22,7 +22,7 @@ const esModules = [
 
 module.exports = function (baseDir: string) {
   return {
-    testEnvironment: 'jsdom',
+    testEnvironment: '@jupyterlab/testing/lib/jest-env.js',
     moduleNameMapper: {
       '\\.(css|less|sass|scss)$': 'identity-obj-proxy',
       '\\.(gif|ttf|eot)$': '@jupyterlab/testing/lib/jest-file-mock.js'

--- a/packages/testing/src/jest-env.ts
+++ b/packages/testing/src/jest-env.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+// From: https://github.com/jsdom/jsdom/issues/1724#issuecomment-1446858041
+
+import JSDOMEnvironment from 'jest-environment-jsdom';
+
+// https://github.com/facebook/jest/blob/v29.4.3/website/versioned_docs/version-29.4/Configuration.md#testenvironment-string
+export default class FixJSDOMEnvironment extends JSDOMEnvironment {
+  constructor(...args: ConstructorParameters<typeof JSDOMEnvironment>) {
+    super(...args);
+
+    // FIXME https://github.com/jsdom/jsdom/issues/1724
+    this.global.fetch = fetch;
+    this.global.Headers = Headers;
+    this.global.Request = Request;
+    this.global.Response = Response;
+  }
+}

--- a/packages/testing/src/jest-shim.ts
+++ b/packages/testing/src/jest-shim.ts
@@ -18,11 +18,6 @@ if (
   globalThis.TextEncoder = util.TextEncoder;
 }
 
-const fetchMod = ((window as any).fetch = require('node-fetch'));
-(window as any).Request = fetchMod.Request;
-(window as any).Headers = fetchMod.Headers;
-(window as any).Response = fetchMod.Response;
-
 globalThis.Image = (window as any).Image;
 globalThis.Range = function Range() {
   /* no-op */

--- a/packages/testing/test/start_jupyter_server.spec.ts
+++ b/packages/testing/test/start_jupyter_server.spec.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-const fetch = require('node-fetch');
-
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 import { JupyterServer } from '@jupyterlab/testing';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4825,14 +4825,12 @@ __metadata:
     "@lumino/signaling": ^2.1.2
     "@types/jest": ^29.2.0
     "@types/node": ^18.11.18
-    "@types/node-fetch": ^2.6.2
     deepmerge: ^4.2.2
     fs-extra: ^10.1.0
     identity-obj-proxy: ^3.0.0
     jest: ^29.2.0
     jest-environment-jsdom: ^29.3.0
     jest-junit: ^15.0.0
-    node-fetch: ^2.6.0
     rimraf: ~5.0.5
     simulate-event: ~1.4.0
     ts-jest: ^29.1.0
@@ -7047,16 +7045,6 @@ __metadata:
   version: 0.7.31
   resolution: "@types/ms@npm:0.7.31"
   checksum: daadd354aedde024cce6f5aa873fefe7b71b22cd0e28632a69e8b677aeb48ae8caa1c60e5919bb781df040d116b01cb4316335167a3fc0ef6a63fa3614c0f6da
-  languageName: node
-  linkType: hard
-
-"@types/node-fetch@npm:^2.6.2":
-  version: 2.6.2
-  resolution: "@types/node-fetch@npm:2.6.2"
-  dependencies:
-    "@types/node": "*"
-    form-data: ^3.0.0
-  checksum: 6f73b1470000d303d25a6fb92875ea837a216656cb7474f66cdd67bb014aa81a5a11e7ac9c21fe19bee9ecb2ef87c1962bceeaec31386119d1ac86e4c30ad7a6
   languageName: node
   linkType: hard
 
@@ -12039,17 +12027,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "form-data@npm:3.0.1"
-  dependencies:
-    asynckit: ^0.4.0
-    combined-stream: ^1.0.8
-    mime-types: ^2.1.12
-  checksum: b019e8d35c8afc14a2bd8a7a92fa4f525a4726b6d5a9740e8d2623c30e308fbb58dc8469f90415a856698933c8479b01646a9dff33c87cc4e76d72aedbbf860d
-  languageName: node
-  linkType: hard
-
 "form-data@npm:^4.0.0":
   version: 4.0.0
   resolution: "form-data@npm:4.0.0"
@@ -16291,7 +16268,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"node-fetch@npm:2.6.7, node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.7, node-fetch@npm:cjs":
+"node-fetch@npm:2.6.7, node-fetch@npm:^2.6.7, node-fetch@npm:cjs":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
   dependencies:


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/13838

Looking into cleaning up test dependencies.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- Remove `node-fetch` dependency from `@jupyterlab/testing`
- Recommend Node.js 20 for development

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
