### PR TITLE
Short-circuit `selectItemByName()` if already selected

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -647,6 +647,11 @@ export class DirListing extends Widget {
    * @returns A promise that resolves when the name is selected.
    */
   async selectItemByName(name: string, focus: boolean = false): Promise<void> {
+    if (this.isSelected(name)) {
+      // Avoid API polling and DOM updates if already selected
+      return;
+    }
+
     // Make sure the file is available.
     await this.model.refresh();
 

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -647,7 +647,24 @@ export class DirListing extends Widget {
    * @returns A promise that resolves when the name is selected.
    */
   async selectItemByName(name: string, focus: boolean = false): Promise<void> {
-    if (this.isSelected(name)) {
+    return this._selectItemByName(name, focus);
+  }
+
+  /**
+   * Select an item by name.
+   *
+   * @param name - The name of the item to select.
+   * @param focus - Whether to move focus to the selected item.
+   * @param force - Whether to proceed with selection even if the file was already selected.
+   *
+   * @returns A promise that resolves when the name is selected.
+   */
+  private async _selectItemByName(
+    name: string,
+    focus: boolean = false,
+    force: boolean = false
+  ): Promise<void> {
+    if (!force && this.isSelected(name)) {
       // Avoid API polling and DOM updates if already selected
       return;
     }
@@ -667,7 +684,6 @@ export class DirListing extends Widget {
     MessageLoop.sendMessage(this, Widget.Msg.UpdateRequest);
     ElementExt.scrollIntoViewIfNeeded(this.contentNode, this._items[index]);
   }
-
   /**
    * Handle the DOM events for the directory listing.
    *
@@ -1940,7 +1956,7 @@ export class DirListing extends Widget {
       this.selection[item.path]
     ) {
       try {
-        await this.selectItemByName(finalFilename, true);
+        await this._selectItemByName(finalFilename, true, true);
       } catch {
         // do nothing
         console.warn('After rename, failed to select file', finalFilename);

--- a/packages/filebrowser/test/listing.spec.ts
+++ b/packages/filebrowser/test/listing.spec.ts
@@ -7,7 +7,7 @@ import { DocumentManager } from '@jupyterlab/docmanager';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { DocumentWidgetOpenerMock } from '@jupyterlab/docregistry/lib/testutils';
 import { ServiceManagerMock } from '@jupyterlab/services/lib/testutils';
-import { signalToPromise } from '@jupyterlab/testing';
+import { framePromise, signalToPromise } from '@jupyterlab/testing';
 import { Signal } from '@lumino/signaling';
 import { Widget } from '@lumino/widgets';
 import expect from 'expect';
@@ -98,6 +98,42 @@ describe('filebrowser/listing', () => {
         expect(
           dirListing.node.querySelector('[data-lm-dragscroll]')
         ).toBeDefined();
+      });
+    });
+
+    describe('#selectItemByName()', () => {
+      it('should select item in the current directory by name', async () => {
+        const name = [...dirListing.sortedItems()][2].name;
+        expect(dirListing.isSelected(name)).toBe(false);
+        await dirListing.selectItemByName(name);
+        expect(dirListing.isSelected(name)).toBe(true);
+      });
+
+      it('should trigger update when selecting an item', async () => {
+        const name = [...dirListing.sortedItems()][2].name;
+        let updateEmitted = false;
+        const listener = () => {
+          updateEmitted = true;
+        };
+        dirListing.updated.connect(listener);
+        await dirListing.selectItemByName(name);
+        await framePromise();
+        dirListing.updated.disconnect(listener);
+        expect(updateEmitted).toBe(true);
+      });
+
+      it('should be a no-op if the item is already selected', async () => {
+        const name = [...dirListing.sortedItems()][2].name;
+        await dirListing.selectItemByName(name);
+        let updateEmitted = false;
+        const listener = () => {
+          updateEmitted = true;
+        };
+        dirListing.updated.connect(listener);
+        await dirListing.selectItemByName(name);
+        await framePromise();
+        dirListing.updated.disconnect(listener);
+        expect(updateEmitted).toBe(false);
       });
     });
 


### PR DESCRIPTION
## References

Fixes #15465

## Code changes

Do not query API nor modify the DOM when calling `selectItemByName` if the item is already selected.

## User-facing changes

Better performance for notebook actions and other actions that activate the underlying widget which causes the browser to select an item by name.

## Backwards-incompatible changes

None
