### PR TITLE
Fix manager isDisposed is not set

### DIFF
--- a/packages/services/src/basemanager.ts
+++ b/packages/services/src/basemanager.ts
@@ -86,6 +86,7 @@ export abstract class BaseManager implements IManager {
     if (this.isDisposed) {
       return;
     }
+    this._isDisposed = true;
     this._disposed.emit(undefined);
     Signal.clearData(this);
   }

--- a/packages/services/src/basemanager.ts
+++ b/packages/services/src/basemanager.ts
@@ -86,7 +86,7 @@ export abstract class BaseManager implements IManager {
     if (this.isDisposed) {
       return;
     }
-    // this._isDisposed = true;
+    this._isDisposed = true;
     this._disposed.emit(undefined);
     Signal.clearData(this);
   }

--- a/packages/services/src/basemanager.ts
+++ b/packages/services/src/basemanager.ts
@@ -86,7 +86,7 @@ export abstract class BaseManager implements IManager {
     if (this.isDisposed) {
       return;
     }
-    this._isDisposed = true;
+    // this._isDisposed = true;
     this._disposed.emit(undefined);
     Signal.clearData(this);
   }

--- a/packages/services/test/kernelspec/manager.spec.ts
+++ b/packages/services/test/kernelspec/manager.spec.ts
@@ -59,6 +59,17 @@ describe('kernel/manager', () => {
       });
     });
 
+    describe('#isDisposed', () => {
+      it('should be false when instantiating', () => {
+        expect(manager.isDisposed).toBe(false);
+      })
+
+      it('should true when disposing', () => {
+        manager.dispose()
+        expect(manager.isDisposed).toBe(true);
+      })
+    })
+
     describe('#serverSettings', () => {
       it('should get the server settings', () => {
         manager.dispose();

--- a/packages/services/test/kernelspec/manager.spec.ts
+++ b/packages/services/test/kernelspec/manager.spec.ts
@@ -65,7 +65,7 @@ describe('kernel/manager', () => {
       });
 
       it('should true when disposing', () => {
-        manager.dispose()
+        manager.dispose();
         expect(manager.isDisposed).toBe(true);
       });
     });

--- a/packages/services/test/kernelspec/manager.spec.ts
+++ b/packages/services/test/kernelspec/manager.spec.ts
@@ -62,13 +62,13 @@ describe('kernel/manager', () => {
     describe('#isDisposed', () => {
       it('should be false when instantiating', () => {
         expect(manager.isDisposed).toBe(false);
-      })
+      });
 
       it('should true when disposing', () => {
         manager.dispose()
         expect(manager.isDisposed).toBe(true);
-      })
-    })
+      });
+    });
 
     describe('#serverSettings', () => {
       it('should get the server settings', () => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Seen when analyzind the code.
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Set _isDisposed to true when calling `dispose`. Otherwise it is never done as the attribute is private

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None