### PR TITLE
Update links to the Jupyter Frontends team compass

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,4 +180,4 @@ Anyone is welcome to attend, if they would like to discuss a topic or just liste
 - Where: [`jovyan` Zoom](https://zoom.us/my/jovyan?pwd=c0JZTHlNdS9Sek9vdzR3aTJ4SzFTQT09)
 - What: [Meeting notes](https://hackmd.io/Y7fBMQPSQ1C08SDGI-fwtg?both)
 
-> Notes are archived on [GitHub JupyterLab team compass](https://github.com/jupyterlab/team-compass/issues).
+> Notes are archived on [GitHub Jupyter Frontends team compass](https://github.com/jupyterlab/frontends-team-compass/issues).

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -229,7 +229,7 @@ furthers the goals of the Jupyter project.
 * The issue represents work that one developer can commit to owning, even if
   they collaborate with other developers for feedback. Excessively large issues
   should be split into multiple issues, each triaged individually, or into
-  `team-compass <https://github.com/jupyterlab/team-compass>`__ issues to discuss
+  `team-compass <https://github.com/jupyterlab/frontends-team-compass>`__ issues to discuss
   more substantive changes.
 
 Labels Used by Triagers

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -36,7 +36,7 @@ The Toolbar and ToolbarButtonComponent (from the package *ui-components*) now re
 This library uses the web component technology (https://developer.mozilla.org/en-US/docs/Web/API/Web_components),
 and is based on `FAST <https://www.fast.design/>`_ library by Microsoft.
 
-See https://github.com/jupyterlab/team-compass/issues/143 for more context on the change.
+See https://github.com/jupyterlab/frontends-team-compass/issues/143 for more context on the change.
 
 - Changes the selectors of the ``Toolbar`` and ``ToolbarButtonComponent``.
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlab/frontends-team-compass/pull/246 and https://github.com/jupyter/governance/pull/200

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update links to the team compass to point to https://github.com/jupyterlab/frontends-team-compass.

Although https://github.com/jupyterlab/team-compass should still redirect to https://github.com/jupyterlab/frontends-team-compass.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Team compass link update.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
