### PR TITLE
Fix scrolling on editor interactions when active cell is out of view in windowed mode

### DIFF
--- a/galata/test/jupyterlab/windowed-notebook.test.ts
+++ b/galata/test/jupyterlab/windowed-notebook.test.ts
@@ -286,6 +286,8 @@ test.describe('Scrolling on keyboard interaction when active editor is above the
       // Press the key as many times as requested
       for (let i = 0; i < testCase.times; i++) {
         await page.keyboard.press(testCase.key);
+        // Allow for small delay between pressing keys
+        await page.waitForTimeout(100);
       }
 
       if (testCase.showCell === 'neither') {

--- a/galata/test/jupyterlab/windowed-notebook.test.ts
+++ b/galata/test/jupyterlab/windowed-notebook.test.ts
@@ -208,33 +208,99 @@ for (const cellType of ['code', 'markdown']) {
   });
 }
 
-test('should scroll back to the cell below the active cell on arrow down key', async ({
-  page,
-  tmpPath
-}) => {
-  await page.notebook.openByPath(`${tmpPath}/${fileName}`);
+const scrollOnKeyPressCases: {
+  key: string;
+  showCell: 'first' | 'second' | 'neither';
+  times: number;
+  enterEditor: boolean;
+}[] = [
+  {
+    // When pressing arrow down the second cell should become selected.
+    key: 'ArrowDown',
+    showCell: 'second',
+    times: 1,
+    enterEditor: false
+  },
+  {
+    // Pressing Alt does not cause any input nor cursor movement so it should
+    // not cause any scrolling. This test in particular tests against an easy
+    // mistake of force-focusing the active editor which is out of view which
+    // can cause partial scrolling in the direction of the editor. Because the
+    // scrolling is only partial multiple presses are needed.
+    key: 'Alt',
+    showCell: 'neither',
+    times: 10,
+    enterEditor: true
+  },
+  {
+    // Because the cursor starts at the beginning of the first cell, a single
+    // press of PageDown should just move the cursor to the end, which should
+    // reveal the editor by scrolling to the first cell.
+    key: 'PageDown',
+    showCell: 'first',
+    times: 1,
+    enterEditor: true
+  },
+  {
+    // Pressing `PageDown` multiple times should scroll the notebook in a way
+    // which hides both cells (even though the first press would reveal them).
+    key: 'PageDown',
+    showCell: 'neither',
+    times: 10,
+    enterEditor: true
+  }
+];
+test.describe('Scrolling on keyboard interaction when active editor is above the viewport', () => {
+  for (const testCase of scrollOnKeyPressCases) {
+    test(`Show ${testCase.showCell} cell on pressing ${testCase.key} ${testCase.times} times`, async ({
+      page,
+      tmpPath
+    }) => {
+      await page.notebook.openByPath(`${tmpPath}/${fileName}`);
 
-  // Activate the first cell.
-  await page.notebook.selectCells(0);
-  const h = await page.notebook.getNotebookInPanelLocator();
-  const firstCell = h!.locator('.jp-Cell[data-windowed-list-index="0"]');
-  const secondCell = h!.locator('.jp-Cell[data-windowed-list-index="1"]');
-  await firstCell.waitFor();
-  await secondCell.waitFor();
+      // Activate the first cell.
+      await page.notebook.selectCells(0);
+      const h = await page.notebook.getNotebookInPanelLocator();
+      const firstCell = h!.locator('.jp-Cell[data-windowed-list-index="0"]');
+      const secondCell = h!.locator('.jp-Cell[data-windowed-list-index="1"]');
+      await firstCell.waitFor();
+      await secondCell.waitFor();
 
-  const bbox = await h!.boundingBox();
-  await page.mouse.move(bbox!.x, bbox!.y);
-  await Promise.all([
-    firstCell.waitFor({ state: 'hidden' }),
-    secondCell.waitFor({ state: 'hidden' }),
-    page.mouse.wheel(0, 1200)
-  ]);
+      if (testCase.enterEditor) {
+        await page.notebook.enterCellEditingMode(0);
+        // Move cursor in the first cell to the beginning of the source code
+        await page.keyboard.press('Home');
+      }
 
-  // Select cell below the active cell
-  await page.keyboard.press('ArrowDown');
+      // Position the mouse in the bounding box to allow for scrolling with mouse wheel
+      const bbox = await h!.boundingBox();
+      await page.mouse.move(bbox!.x, bbox!.y);
 
-  // Expect the second cell to become visible again.
-  await secondCell.waitFor({ state: 'visible' });
+      // Scroll down to hide the first and second cell
+      await Promise.all([
+        firstCell.waitFor({ state: 'hidden' }),
+        secondCell.waitFor({ state: 'hidden' }),
+        page.mouse.wheel(0, 1200)
+      ]);
+
+      // Press the key as many times as requested
+      for (let i = 0; i < testCase.times; i++) {
+        await page.keyboard.press(testCase.key);
+      }
+
+      if (testCase.showCell === 'neither') {
+        // For negative test case we need to add an explicit timeout to test
+        // against the possibility of the scroll happening with a small delay.
+        await page.waitForTimeout(400);
+        await expect(firstCell).toBeHidden();
+        await expect(secondCell).toBeHidden();
+      } else {
+        const cell = testCase.showCell === 'first' ? firstCell : secondCell;
+        // Expect the cell to become visible again.
+        await cell.waitFor({ state: 'visible' });
+      }
+    });
+  }
 });
 
 test('should detach a markdown code cell when scrolling out of the viewport', async ({

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -205,8 +205,9 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
     // For cells disable searching with CodeMirror search panel.
     this._editorConfig = { searchWithCM: false, ...options.editorConfig };
     this._editorExtensions = options.editorExtensions ?? [];
+    this._editorExtensions.push(this._scrollHandlerExtension);
     this._placeholder = true;
-    this._inViewport = false;
+    this._inViewport = null;
     this.placeholder = options.placeholder ?? true;
 
     model.metadataChanged.connect(this.onMetadataChanged, this);
@@ -239,9 +240,14 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
 
   /**
    * Whether the cell is in viewport or not.
+   *
+   * #### Notes
+   * This property is managed by the windowed container which holds the cell.
+   * When a cell is not in a windowed container, it always returns `false`,
+   * but this may change in the future major version.
    */
   get inViewport(): boolean {
-    return this._inViewport;
+    return this._inViewport ?? false;
   }
   set inViewport(v: boolean) {
     if (this._inViewport !== v) {
@@ -553,6 +559,13 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
   }
 
   /**
+   * Signal emitted when cell editor requests scrolling.
+   */
+  get editorScrollRequested(): ISignal<Cell, Cell.IEditorScrollRequest> {
+    return this._editorScrollRequested;
+  }
+
+  /**
    * Create children widgets.
    */
   protected initializeDOM(): void {
@@ -694,13 +707,44 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
   protected translator: ITranslator;
   protected _displayChanged = new Signal<this, void>(this);
 
+  /**
+   * Editor extension emitting `editorScrollRequested` signal on scroll.
+   *
+   * Scrolling within editor will be prevented when a cell is out out viewport.
+   * Windowed containers including cells should listen to the scroll request
+   * signal and invoke the `scrollEditor()` callback after scrolling the cell
+   * back into the view (and after updating the `inViewport` property).
+   */
+  private _scrollHandlerExtension = EditorView.scrollHandler.of(
+    (view, range, options) => {
+      // When cell is in the viewport we can scroll within the editor immediately.
+      // When cell is out of viewport, the windowed container needs to first
+      // scroll the cell into the viewport (otherwise CodeMirror is unable to
+      // calculate the correct scroll delta) before invoking scrolling in editor.
+      const inWindowedContainer = this._inViewport !== null;
+      const preventDefault = inWindowedContainer && !this._inViewport;
+      this._editorScrollRequested.emit({
+        defaultPrevented: preventDefault,
+        scrollEditor: () => {
+          view.dispatch({
+            effects: EditorView.scrollIntoView(range, options)
+          });
+        }
+      });
+      return preventDefault;
+    }
+  );
+
   private _editorConfig: Record<string, any> = {};
+  private _editorScrollRequested = new Signal<Cell, Cell.IEditorScrollRequest>(
+    this
+  );
   private _editorExtensions: Extension[] = [];
   private _input: InputArea | null;
   private _inputHidden = false;
   private _inputWrapper: Widget | null;
   private _inputPlaceholder: InputPlaceholder | null;
-  private _inViewport: boolean;
+  private _inViewport: boolean | null;
   private _inViewportChanged: Signal<Cell, boolean> = new Signal<Cell, boolean>(
     this
   );
@@ -902,6 +946,25 @@ export namespace Cell {
        */
       editorFactory: CodeEditor.Factory;
     }
+  }
+
+  /**
+   * Value of the signal emitted by cell on editor scroll request.
+   */
+  export interface IEditorScrollRequest {
+    /**
+     * A method which scrolls the editor, fulfilling the scroll request.
+     *
+     * ### Notes
+     * This method is intended for use by windowed containers that
+     * require the cell to be first scrolled into the viewport and
+     * to allow for proper scrolling of the editor.
+     */
+    scrollEditor: () => void;
+    /**
+     * Whether the default scrolling was prevented due to the cell being out of viewport.
+     */
+    defaultPrevented: boolean;
   }
 }
 

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -559,10 +559,10 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
   }
 
   /**
-   * Signal emitted when cell editor requests scrolling.
+   * Signal emitted when cell requests scrolling to its element.
    */
-  get editorScrollRequested(): ISignal<Cell, Cell.IEditorScrollRequest> {
-    return this._editorScrollRequested;
+  get scrollRequested(): ISignal<Cell, Cell.IScrollRequest> {
+    return this._scrollRequested;
   }
 
   /**
@@ -708,11 +708,11 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
   protected _displayChanged = new Signal<this, void>(this);
 
   /**
-   * Editor extension emitting `editorScrollRequested` signal on scroll.
+   * Editor extension emitting `scrollRequested` signal on scroll.
    *
    * Scrolling within editor will be prevented when a cell is out out viewport.
    * Windowed containers including cells should listen to the scroll request
-   * signal and invoke the `scrollEditor()` callback after scrolling the cell
+   * signal and invoke the `scrollWithinCell()` callback after scrolling the cell
    * back into the view (and after updating the `inViewport` property).
    */
   private _scrollHandlerExtension = EditorView.scrollHandler.of(
@@ -723,9 +723,9 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
       // calculate the correct scroll delta) before invoking scrolling in editor.
       const inWindowedContainer = this._inViewport !== null;
       const preventDefault = inWindowedContainer && !this._inViewport;
-      this._editorScrollRequested.emit({
+      this._scrollRequested.emit({
         defaultPrevented: preventDefault,
-        scrollEditor: () => {
+        scrollWithinCell: () => {
           view.dispatch({
             effects: EditorView.scrollIntoView(range, options)
           });
@@ -736,9 +736,7 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
   );
 
   private _editorConfig: Record<string, any> = {};
-  private _editorScrollRequested = new Signal<Cell, Cell.IEditorScrollRequest>(
-    this
-  );
+  private _scrollRequested = new Signal<Cell, Cell.IScrollRequest>(this);
   private _editorExtensions: Extension[] = [];
   private _input: InputArea | null;
   private _inputHidden = false;
@@ -951,16 +949,16 @@ export namespace Cell {
   /**
    * Value of the signal emitted by cell on editor scroll request.
    */
-  export interface IEditorScrollRequest {
+  export interface IScrollRequest {
     /**
-     * A method which scrolls the editor, fulfilling the scroll request.
+     * Scrolls to the target cell part, fulfilling the scroll request.
      *
      * ### Notes
      * This method is intended for use by windowed containers that
-     * require the cell to be first scrolled into the viewport and
-     * to allow for proper scrolling of the editor.
+     * require the cell to be first scrolled into the viewport to
+     * then enable proper scrolling within cell.
      */
-    scrollEditor: () => void;
+    scrollWithinCell: () => void;
     /**
      * Whether the default scrolling was prevented due to the cell being out of viewport.
      */

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -2132,31 +2132,28 @@ export class Notebook extends StaticNotebook {
         cell.editor!.edgeRequested.connect(this._onEdgeRequest, this);
       }
     });
-    cell.editorScrollRequested.connect((_emitter, scrollRequest) => {
+    cell.scrollRequested.connect((_emitter, scrollRequest) => {
       if (cell !== this.activeCell) {
         // Do nothing for cells other than the active cell
         // to avoid scroll requests from editor extensions
-        // from stealing user focus (this may be revisited).
+        // stealing user focus (this may be revisited).
         return;
       }
       if (!scrollRequest.defaultPrevented) {
-        // Nothing to do if cell editor was already scrolled.
+        // Nothing to do if scroll request was already handled.
         return;
       }
       if (cell.inViewport) {
         // If cell got scrolled to the viewport in the meantime,
-        // proceed with scrolling in the editor.
-        return scrollRequest.scrollEditor();
+        // proceed with scrolling within the cell.
+        return scrollRequest.scrollWithinCell();
       }
-      // If cell is not in the viewport and needs scrolling in editor,
-      // first scroll to the cell and then scroll within the editor.
+      // If cell is not in the viewport and needs scrolling,
+      // first scroll to the cell and then scroll within the cell.
       this.scrollToItem(this.activeCellIndex)
         .then(() => {
           void cell.ready.then(() => {
-            if (!cell.editor) {
-              return;
-            }
-            scrollRequest.scrollEditor();
+            scrollRequest.scrollWithinCell();
           });
         })
         .catch(reason => {

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -2132,6 +2132,37 @@ export class Notebook extends StaticNotebook {
         cell.editor!.edgeRequested.connect(this._onEdgeRequest, this);
       }
     });
+    cell.editorScrollRequested.connect((_emitter, scrollRequest) => {
+      if (cell !== this.activeCell) {
+        // Do nothing for cells other than the active cell
+        // to avoid scroll requests from editor extensions
+        // from stealing user focus (this may be revisited).
+        return;
+      }
+      if (!scrollRequest.defaultPrevented) {
+        // Nothing to do if cell editor was already scrolled.
+        return;
+      }
+      if (cell.inViewport) {
+        // If cell got scrolled to the viewport in the meantime,
+        // proceed with scrolling in the editor.
+        return scrollRequest.scrollEditor();
+      }
+      // If cell is not in the viewport and needs scrolling in editor,
+      // first scroll to the cell and then scroll within the editor.
+      this.scrollToItem(this.activeCellIndex)
+        .then(() => {
+          void cell.ready.then(() => {
+            if (!cell.editor) {
+              return;
+            }
+            scrollRequest.scrollEditor();
+          });
+        })
+        .catch(reason => {
+          // no-op
+        });
+    });
     // If the insertion happened above, increment the active cell
     // index, otherwise it stays the same.
     this.activeCellIndex =
@@ -2212,7 +2243,7 @@ export class Notebook extends StaticNotebook {
     const activeCell = this.activeCell;
     if (this.mode === 'edit' && activeCell) {
       // Test for !== true to cover hasFocus is false and editor is not yet rendered.
-      if (activeCell.editor?.hasFocus() !== true || !activeCell.inViewport) {
+      if (activeCell.editor?.hasFocus() !== true) {
         if (activeCell.inViewport) {
           activeCell.editor?.focus();
         } else {


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/15594

## Code changes

- [x] Adds test cases for scrolling (should fail in the first commit)
- [x] Fixes scrolling on editor interactions, taking advantage of new `EditorView.scrollHandler`:
   - old logic focused editors that were out of view in windowed mode upon any keypress; it was also used to ensure scrolling, but it had a bad side effect of scrolling on non-input and non-selection key presses, such as <kbd>Alt</kbd>; now the condition permitting this code path when active cell is out of view was removed in favour of dedicated `scrollRequested` logic (see below)
   - when `Cell` is out of viewport (in windowed mode) and the editor requests scrolling it does not attempt to scroll as this is futile (the editor does not know by how much to scroll the virtualized container); instead it emits a new `scrollRequested` signal,
   - the windowed notebook receives the `scrollRequested` signal, scrolls the cell into the view and then scrolls the editor as requested.

## User-facing changes

Interacting with out-of view cells in windowed mode is more predictable and reflects the interaction model seen in non-windowed mode.

## Backwards-incompatible changes

None