### PR TITLE
Fix `ServerApp.token` deprecation warnings

### DIFF
--- a/binder/jupyter_config.py
+++ b/binder/jupyter_config.py
@@ -9,7 +9,7 @@ common = [
     "--debug",
     "--port={port}",
     "--ServerApp.ip=127.0.0.1",
-    '--ServerApp.token=""',
+    '--IdentityProvider.token=""',
     # Disable dns rebinding protection here, since our 'Host' header
     # is not going to be localhost when coming from hub.mybinder.org
     "--ServerApp.allow_remote_access=True",

--- a/jupyterlab/galata/__init__.py
+++ b/jupyterlab/galata/__init__.py
@@ -34,7 +34,7 @@ def configure_jupyter_server(c):
     c.ServerApp.root_dir = os.environ.get(
         "JUPYTERLAB_GALATA_ROOT_DIR", mkdtemp(prefix="galata-test-")
     )
-    c.ServerApp.token = ""
+    c.IdentityProvider.token = ""
     c.ServerApp.password = ""
     c.ServerApp.disable_check_xsrf = True
     c.LabApp.expose_app_in_browser = True

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -734,7 +734,7 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
         page_config.setdefault("buildAvailable", not self.core_mode and not self.dev_mode)
         page_config.setdefault("buildCheck", not self.core_mode and not self.dev_mode)
         page_config["devMode"] = self.dev_mode
-        page_config["token"] = self.serverapp.token
+        page_config["token"] = self.serverapp.identity_provider.token
         page_config["exposeAppInBrowser"] = self.expose_app_in_browser
         page_config["quitButton"] = self.serverapp.quit_button
         page_config["allow_hidden_files"] = self.serverapp.contents_manager.allow_hidden


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

This should fix the following warnings, noticed on some CI runs:

```
jupyterlab/tests/test_jupyterlab.py::test_load_extension
  /opt/hostedtoolcache/Python/3.11.8/x64/lib/python3.11/site-packages/traitlets/traitlets.py:1897: DeprecationWarning: ServerApp.token config is deprecated in jupyter-server 2.0. Use IdentityProvider.token
    return t.cast(Sentinel, self._get_trait_default_generator(names[0])(self))
```

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Use `IdentityProvider` to get and set the token, as suggested in the warning.

For reference the warning was added in https://github.com/jupyter-server/jupyter_server/pull/825

And JupyterLab depends on Jupyter Server 2 as the minimum version: https://github.com/jupyterlab/jupyterlab/blob/9eea31bc38c7118cfe725e2f60a808f0a3e4c05e/pyproject.toml#L44

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
