### PR TITLE
Replace Promise.all() with Promise.allSettled()

### DIFF
--- a/packages/completer/src/reconciliator.ts
+++ b/packages/completer/src/reconciliator.ts
@@ -43,7 +43,9 @@ export class ProviderReconciliator implements IProviderReconciliator {
     const isApplicablePromises = this._providers.map(p =>
       p.isApplicable(this._context)
     );
-    const applicableProviders = await Promise.all(isApplicablePromises);
+    const applicableProviders = await Promise.allSettled(isApplicablePromises).then((providers)=>{
+      providers.forEach((provider) => { provider.status == 'rejected' && console.log(`Error: ${provider.reason}`) }
+    });
     return this._providers.filter((_, idx) => applicableProviders[idx]);
   }
 


### PR DESCRIPTION
race() was not used because it rejects if the first promise rejects. Instead allSettled() allows each promise to settle and then you find which providers rejected.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

This is for Issue #15441.

## Code changes

Promise.all() was swapped to Promise.allSettled(), so that each promise can settle independent of the eithers and the once rejected are logged to console. 

## User-facing changes

N/A

## Backwards-incompatible changes

N/A
