### PR TITLE
Allow setting `ServerConnection.appendToken` via `PageConfig`

### DIFF
--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -246,6 +246,18 @@ namespace Private {
     // Otherwise fall back on the default wsUrl.
     wsUrl = wsUrl ?? pageWsUrl;
 
+    const appendTokenConfig = PageConfig.getOption('appendToken').toLowerCase();
+    let appendToken;
+    if (appendTokenConfig === '') {
+      appendToken =
+        typeof window === 'undefined' ||
+        (typeof process !== 'undefined' &&
+          process?.env?.JEST_WORKER_ID !== undefined) ||
+        URLExt.getHostName(pageBaseUrl) !== URLExt.getHostName(wsUrl);
+    } else {
+      appendToken = appendTokenConfig === 'true';
+    }
+
     return {
       init: { cache: 'no-store', credentials: 'same-origin' },
       fetch,
@@ -254,11 +266,7 @@ namespace Private {
       WebSocket: WEBSOCKET,
       token: PageConfig.getToken(),
       appUrl: PageConfig.getOption('appUrl'),
-      appendToken:
-        typeof window === 'undefined' ||
-        (typeof process !== 'undefined' &&
-          process?.env?.JEST_WORKER_ID !== undefined) ||
-        URLExt.getHostName(pageBaseUrl) !== URLExt.getHostName(wsUrl),
+      appendToken,
       serializer: { serialize, deserialize },
       ...options,
       baseUrl,


### PR DESCRIPTION
allows explicit override in cases where default may not be desirable.

## References

#9070, #9898 and other related issues where the default logic to appendToken have been incorrect in some situations.

## Code changes

`ServerConnection.appendToken` will be derived from `PageConfig.appendToken` if defined.

It's unclear from the name alone that this is an option only affecting websockets. I considered calling the config `wsAppendToken`, but I thought it was probably better for the key to match.

## User-facing changes

Deployments may override `ServerConnection.appendToken`, if they wish.

## Backwards-incompatible changes

None