### PR TITLE
Adjust search test assertion to allow both Node 18 and 20+

### DIFF
--- a/packages/documentsearch/test/searchmodel.spec.ts
+++ b/packages/documentsearch/test/searchmodel.spec.ts
@@ -87,9 +87,12 @@ describe('documentsearch/searchmodel', () => {
         expect(model.parsingError).toEqual('');
         model.searchExpression = 'query\\';
         await signalToPromise(model.stateChanged);
-        expect(model.parsingError).toEqual(
-          'SyntaxError: Invalid regular expression: /query\\/: \\ at end of pattern'
-        );
+        expect([
+          // Node 18.x and older
+          'SyntaxError: Invalid regular expression: /query\\/: \\ at end of pattern',
+          // Node 20.x and newer
+          'SyntaxError: Invalid regular expression: /query\\/gim: \\ at end of pattern'
+        ]).toContain(model.parsingError);
       });
     });
 


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/16023, while allowing contributors to continue using Node 18 for now.

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None