### PR TITLE
Preventing changing cell type when input is pending to avoid kernel deadlock

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -420,7 +420,7 @@ export class SessionContext implements ISessionContext {
   }
 
   /**
-   * A flag indicating if the session has ending input, proxied from the kernel.
+   * A flag indicating if the session has pending input, proxied from the kernel.
    */
   get pendingInput(): boolean {
     return this._pendingInput;

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -2556,7 +2556,11 @@ function addCommands(
       const current = getCurrent(tracker, shell, args);
 
       if (current) {
-        return NotebookActions.changeCellType(current.content, 'code');
+        return NotebookActions.changeCellType(
+          current.content,
+          'code',
+          translator
+        );
       }
     },
     isEnabled
@@ -2567,7 +2571,11 @@ function addCommands(
       const current = getCurrent(tracker, shell, args);
 
       if (current) {
-        return NotebookActions.changeCellType(current.content, 'markdown');
+        return NotebookActions.changeCellType(
+          current.content,
+          'markdown',
+          translator
+        );
       }
     },
     isEnabled
@@ -2578,7 +2586,11 @@ function addCommands(
       const current = getCurrent(tracker, shell, args);
 
       if (current) {
-        return NotebookActions.changeCellType(current.content, 'raw');
+        return NotebookActions.changeCellType(
+          current.content,
+          'raw',
+          translator
+        );
       }
     },
     isEnabled
@@ -3184,7 +3196,11 @@ function addCommands(
       const current = getCurrent(tracker, shell, args);
 
       if (current) {
-        return NotebookActions.setMarkdownHeader(current.content, 1);
+        return NotebookActions.setMarkdownHeader(
+          current.content,
+          1,
+          translator
+        );
       }
     },
     isEnabled
@@ -3195,7 +3211,11 @@ function addCommands(
       const current = getCurrent(tracker, shell, args);
 
       if (current) {
-        return NotebookActions.setMarkdownHeader(current.content, 2);
+        return NotebookActions.setMarkdownHeader(
+          current.content,
+          2,
+          translator
+        );
       }
     },
     isEnabled
@@ -3206,7 +3226,11 @@ function addCommands(
       const current = getCurrent(tracker, shell, args);
 
       if (current) {
-        return NotebookActions.setMarkdownHeader(current.content, 3);
+        return NotebookActions.setMarkdownHeader(
+          current.content,
+          3,
+          translator
+        );
       }
     },
     isEnabled
@@ -3217,7 +3241,11 @@ function addCommands(
       const current = getCurrent(tracker, shell, args);
 
       if (current) {
-        return NotebookActions.setMarkdownHeader(current.content, 4);
+        return NotebookActions.setMarkdownHeader(
+          current.content,
+          4,
+          translator
+        );
       }
     },
     isEnabled
@@ -3228,7 +3256,11 @@ function addCommands(
       const current = getCurrent(tracker, shell, args);
 
       if (current) {
-        return NotebookActions.setMarkdownHeader(current.content, 5);
+        return NotebookActions.setMarkdownHeader(
+          current.content,
+          5,
+          translator
+        );
       }
     },
     isEnabled
@@ -3239,7 +3271,11 @@ function addCommands(
       const current = getCurrent(tracker, shell, args);
 
       if (current) {
-        return NotebookActions.setMarkdownHeader(current.content, 6);
+        return NotebookActions.setMarkdownHeader(
+          current.content,
+          6,
+          translator
+        );
       }
     },
     isEnabled

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -18,6 +18,7 @@ import {
   NotebookModel,
   StaticNotebook
 } from '@jupyterlab/notebook';
+import { Stdin } from '@jupyterlab/outputarea';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { ISharedCodeCell } from '@jupyter/ydoc';
 import {
@@ -25,7 +26,8 @@ import {
   dismissDialog,
   JupyterServer,
   signalToPromise,
-  sleep
+  sleep,
+  waitForDialog
 } from '@jupyterlab/testing';
 import { JSONArray, JSONObject, UUID } from '@lumino/coreutils';
 import * as utils from './utils';
@@ -682,9 +684,14 @@ describe('@jupyterlab/notebook', () => {
         // Cell type should stay unchanged.
         expect(widget.activeCell).toBeInstanceOf(CodeCell);
 
+        // Should show a dialog informing user why cell type could not be changed
+        await waitForDialog();
+        await acceptDialog();
+
         // Submit the input
-        const input = stdin.node.querySelector('input')!;
-        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+        (stdin as Stdin).handleEvent(
+          new KeyboardEvent('keydown', { key: 'Enter' })
+        );
         await donePromise;
 
         // Try to change cell type again, it should work now

--- a/packages/services/src/kernel/future.ts
+++ b/packages/services/src/kernel/future.ts
@@ -189,6 +189,8 @@ export abstract class KernelFutureHandler<
       // is waiting for the promise to resolve. This prevents the error from
       // being displayed in the console, but does not prevent it from being
       // caught by a client who is waiting for it.
+      // Note: any `.then` and `.finally` attached to the `done` promise
+      // will cause the error to be thrown as uncaught anyways.
       this._done.promise.catch(() => {
         /* no-op */
       });


### PR DESCRIPTION
## References

Fixes #15981

## Code changes

- adds a `pendingInput` flag on `OutputArea`
- checks this flag before changing cell type
- if the flag is set, aborts and displays the same message as displayed in execution guard (adjusted to refer to cell type change rather than execution)

## User-facing changes

Accidentally typing `m` or `r` or digits from `1` to `6` in command mode on a cell with pending input does not cause a kernel deadlock anymore.

![input-guard](https://github.com/jupyterlab/jupyterlab/assets/5832902/888a2246-dc4a-446e-be41-41b533b35e68)

The dialog:

![Screenshot from 2024-03-20 13-15-34](https://github.com/jupyterlab/jupyterlab/assets/5832902/b2df26c2-6065-4a69-a131-42162e604120)

## Backwards-incompatible changes

None
