### PR TITLE
Decrease top menu padding for high zoom / narrow screen

### DIFF
--- a/packages/application/style/menus.css
+++ b/packages/application/style/menus.css
@@ -31,7 +31,12 @@
 }
 
 .lm-MenuBar-item {
-  padding: 0 8px;
+  /* TODO: remove ignore directive when fixed: https://github.com/csstree/csstree/issues/164 */
+  /* stylelint-disable-next-line csstree/validator */
+  padding: 0 min(calc(4vw - 11.2px), 8px); /* The use of min(), calc() and vw units
+    has the effect that as the screen drops below 480px, horizontal padding will
+    steadily decrease so that the standard menu items fit in a 320px wide screen
+    (equivalent to zooming to 400% from 1280px) */
   border-left: var(--jp-border-width) solid transparent;
   border-right: var(--jp-border-width) solid transparent;
   border-top: var(--jp-border-width) solid transparent;


### PR DESCRIPTION
### References

PR #15855.

This is the first of a series of PRs breaking up #15855 into individual CSS changes, with the hope that this will make it easier to tackle the issues that we've been having with Playwright Galata snapshot testing.

### Code changes

Updates the padding rule for the `.lm-MenuBar-item` CSS selector so that menu bar items will all fit within narrow or zoomed-in screens.

### User-facing changes

See above.

### Backwards-incompatible changes

n/a

### How to test

Load JupyterLab. Drag window wide, drag window narrow. Observe how it affects padding in the menu bar. At 480px, padding should start to decrease. At 320px, the top menu bar items (File, Edit, View, Run, Kernel, Tabs, Settings, Help) will be scrunched together but should all be visible, as the following screenshot shows:

![](https://github.com/jupyterlab/jupyterlab/assets/317883/889a5629-d886-4c5a-a86a-2438c58b138c)

Alternatively, set your browser window to 1280px, then zoom in to 400%. Again, the menu items will be tightly spaced but should fit within the width of your browser window.