### PR TITLE
Add missing `workspaces-extension` package to examples, add migration note

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -19,6 +19,14 @@ API updates
 - ``CodeEditor.getCoordinateForPosition`` return type was corrected to clarify that it can return
   ``null``; previously ``null`` could be returned despite the return type indicating it would always
   return a non-null ``ICoordinate`` value.
+- The ``@jupyterlab/apputils-extension:workspaces`` plugin  now depends on the new
+  ``@jupyterlab/workspaces-extension`` package which defines the workspace-related commands
+  and provides a new ``IWorkspaceCommands`` token.  Applications authors who relied
+  on the old plugin to define the ``workspace-ui:save`` and ``workspace-ui:save-as``
+  commands should now use ``@jupyterlab/workspaces-extension:commands`` instead.
+  The ``@jupyterlab/apputils-extension:workspaces`` plugin now only defines the
+  workspace MIME type renderer used to open files with ``.jupyterlab-workspace``
+  extension as JupyterLab workspaces.
 
 
 JupyterLab 4.0 to 4.1

--- a/examples/app/package.json
+++ b/examples/app/package.json
@@ -40,6 +40,7 @@
     "@jupyterlab/translation": "^4.2.0-alpha.2",
     "@jupyterlab/translation-extension": "^4.2.0-alpha.2",
     "@jupyterlab/ui-components-extension": "^4.2.0-alpha.2",
+    "@jupyterlab/workspaces-extension": "^4.2.0-alpha.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
@@ -88,7 +89,8 @@
       "@jupyterlab/toc-extension",
       "@jupyterlab/tooltip-extension",
       "@jupyterlab/translation-extension",
-      "@jupyterlab/ui-components-extension"
+      "@jupyterlab/ui-components-extension",
+      "@jupyterlab/workspaces-extension"
     ]
   }
 }

--- a/examples/federated/core_package/package.json
+++ b/examples/federated/core_package/package.json
@@ -79,6 +79,7 @@
     "@jupyterlab/ui-components": "~4.1.0-alpha.0",
     "@jupyterlab/ui-components-extension": "~4.2.0-alpha.2",
     "@jupyterlab/vega5-extension": "~4.2.0-alpha.2",
+    "@jupyterlab/workspaces-extension": "^4.2.0-alpha.2",
     "@lumino/algorithm": "^2.0.0",
     "@lumino/application": "^2.3.0-alpha.0",
     "@lumino/commands": "^2.0.1",
@@ -136,7 +137,8 @@
     "@jupyterlab/translation": "^4.2.0-alpha.2",
     "@jupyterlab/translation-extension": "^4.2.0-alpha.2",
     "@jupyterlab/ui-components-extension": "^4.2.0-alpha.2",
-    "@jupyterlab/vega5-extension": "^4.2.0-alpha.2"
+    "@jupyterlab/vega5-extension": "^4.2.0-alpha.2",
+    "@jupyterlab/workspaces-extension": "^4.2.0-alpha.2"
   },
   "devDependencies": {
     "@jupyterlab/builder": "^4.2.0-alpha.2",
@@ -243,7 +245,8 @@
       "@jupyterlab/tooltip-extension",
       "@jupyterlab/translation-extension",
       "@jupyterlab/ui-components-extension",
-      "@jupyterlab/vega5-extension"
+      "@jupyterlab/vega5-extension",
+      "@jupyterlab/workspaces-extension"
     ]
   }
 }


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/16057

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/15946

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None