### PR TITLE
Fix scrolling to output area inputs on caret movement

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -2120,17 +2120,20 @@ export class Notebook extends StaticNotebook {
         // Nothing to do if scroll request was already handled.
         return;
       }
+      // Node which allows to scroll the notebook
+      const scroller = this.outerNode;
+
       if (cell.inViewport) {
         // If cell got scrolled to the viewport in the meantime,
         // proceed with scrolling within the cell.
-        return scrollRequest.scrollWithinCell();
+        return scrollRequest.scrollWithinCell({ scroller });
       }
       // If cell is not in the viewport and needs scrolling,
       // first scroll to the cell and then scroll within the cell.
       this.scrollToItem(this.activeCellIndex)
         .then(() => {
           void cell.ready.then(() => {
-            scrollRequest.scrollWithinCell();
+            scrollRequest.scrollWithinCell({ scroller });
           });
         })
         .catch(reason => {


### PR DESCRIPTION
## References

- Fixes #16007
- Follow-up to https://github.com/jupyterlab/jupyterlab/pull/16006

## Code changes

Cells will emit `scrollRequested` when there is a caret movement induced by keyboard event (`keydown`) in any of the inputs/textareas/etc of the cell's output area.

## User-facing changes

In windowed notebook typing in a character, or moving cursor with arrow keys, Home/End, Pg Down/up causes scrolling to the active input element, the same way as in non-windowed notebook.

## Backwards-incompatible changes

None