### PR TITLE
Tackle flaky readonly notification and workspaces context menu snapshots

### DIFF
--- a/galata/test/documentation/workspaces.test.ts
+++ b/galata/test/documentation/workspaces.test.ts
@@ -43,6 +43,8 @@ test.describe('Workspaces sidebar', () => {
       )
       .waitFor();
 
+    await galata.Mock.mockRunners(page, new Map(), 'sessions');
+
     // Create additional workspaces for the shot
     await page.evaluate(async () => {
       for (const workspaceName of ['my-coding-space', 'default']) {

--- a/galata/test/jupyterlab/readonly.test.ts
+++ b/galata/test/jupyterlab/readonly.test.ts
@@ -5,11 +5,8 @@
 
 import { expect, galata, test } from '@jupyterlab/galata';
 
-test.describe('Readonly status', () => {
-  // Use shorter tmpPath name to capture full text of the notification
-  test.use({ tmpPath: 'test-readonly-status' });
-
-  test('Readonly status notification', async ({ page }) => {
+test.describe('test readonly status', () => {
+  test('test readonly status', async ({ page }) => {
     await page.notebook.createNew('notebook.ipynb');
     // We need to save the notebook to preserve the default kernel choice
     // otherwise when we reopen it, it would show "Select Kernel" dialog,

--- a/galata/test/jupyterlab/readonly.test.ts
+++ b/galata/test/jupyterlab/readonly.test.ts
@@ -5,10 +5,20 @@
 
 import { expect, galata, test } from '@jupyterlab/galata';
 
-test.describe('test readonly status', () => {
-  test('test readonly status', async ({ page }) => {
-    await galata.Mock.makeNotebookReadonly(page);
+test.describe('Readonly status', () => {
+  test('Readonly status notification', async ({ page }) => {
     await page.notebook.createNew('notebook.ipynb');
+    // We need to save the notebook to preserve the default kernel choice
+    // otherwise when we reopen it, it would show "Select Kernel" dialog,
+    // which adds a semi-transparent layer above the notification.
+    const notSavedIndicator = page
+      .getByRole('main')
+      .getByRole('tablist')
+      .locator('.jp-mod-dirty');
+    await notSavedIndicator.waitFor();
+    await page.notebook.save();
+
+    await galata.Mock.makeNotebookReadonly(page);
 
     // have to open and close notebook for notification to show up
     await page.notebook.close();
@@ -18,10 +28,11 @@ test.describe('test readonly status', () => {
 
     const imageName = 'readonly.png';
     const toast = page.locator('.Toastify__toast');
+    const toastAnimation = page.locator('.Toastify--animate');
     await toast.waitFor({ state: 'attached' });
-    // For some reason even `{animations: "disabled"}` is flaky.
-    // Instead we just wait a short while.
-    await page.waitForTimeout(2000);
+    await toastAnimation.waitFor({ state: 'attached' });
+    await toastAnimation.waitFor({ state: 'detached' });
+
     expect(await toast.screenshot()).toMatchSnapshot(imageName);
   });
 });

--- a/galata/test/jupyterlab/readonly.test.ts
+++ b/galata/test/jupyterlab/readonly.test.ts
@@ -6,6 +6,9 @@
 import { expect, galata, test } from '@jupyterlab/galata';
 
 test.describe('Readonly status', () => {
+  // Use shorter tmpPath name to capture full text of the notification
+  test.use({ tmpPath: 'test-readonly-status' });
+
   test('Readonly status notification', async ({ page }) => {
     await page.notebook.createNew('notebook.ipynb');
     // We need to save the notebook to preserve the default kernel choice


### PR DESCRIPTION
## References

Addresses some cases from https://github.com/jupyterlab/jupyterlab/issues/14947

## Code changes

- Replace explicit wait with an a wait for toast animation to complete
- Mock sessions late in the test to avoid kernels showing up in the workspaces snapshot

## User-facing changes

None

## Backwards-incompatible changes

None