### PR TITLE
Use locale-based sorting in the table of shortcuts

### DIFF
--- a/packages/shortcuts-extension/src/components/ShortcutUI.tsx
+++ b/packages/shortcuts-extension/src/components/ShortcutUI.tsx
@@ -438,14 +438,13 @@ export class ShortcutUI
     shortcuts.sort((a: IShortcutTarget, b: IShortcutTarget) => {
       const compareA: string = getValue(a);
       const compareB: string = getValue(b);
-      if (compareA < compareB) {
-        return -1;
-      } else if (compareA > compareB) {
-        return 1;
+      const compareResult = compareA.localeCompare(compareB);
+      if (compareResult) {
+        return compareResult;
       } else {
         const aLabel = a['label'] ?? '';
         const bLabel = b['label'] ?? '';
-        return aLabel < bLabel ? -1 : aLabel > bLabel ? 1 : 0;
+        return aLabel.localeCompare(bLabel);
       }
     });
     this.setState({ filteredShortcutList: shortcuts });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

* Fixes issue #16073 for locale-specific sorting of keyboard shortcuts using any criteria. 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

* Fix uses `String.prototype.localeCompare` to compare the `IShortcutTarget`s  in the `Array.sort` comparator. 
* As before, still compares either the `IShortcutTarget[sortCriteria]` value returned from `getValue` function, or else uses `IShortcutTarget.label` by default for the comparison.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

* None.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

* None.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
