### PR TITLE
Fix missing backtick in plugin manager docs

### DIFF
--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -380,7 +380,7 @@ running the ``jupyter labextension enable`` or ``jupyter labextension disable`` 
 
 Plugins can be enabled/disabled on ``system``, ``sys-prefix`` (default) or
 ``user`` level, which influences where the ``page_config.json`` configuration
-file is written to (see ``config` section in results of ``jupyter --paths``).
+file is written to (see ``config`` section in results of ``jupyter --paths``).
 To change the level for the plugin manager and the default extension manager
 use ``PluginManager.level`` trait (extension manager inherits from plugin manager).
 


### PR DESCRIPTION
## References

None

## Code changes

None

## User-facing changes

| Before | After |
|--|--|
| ![image](https://github.com/jupyterlab/jupyterlab/assets/5832902/94b21fd3-4f8d-4c17-9d54-6420fda4a182) | ![image](https://github.com/jupyterlab/jupyterlab/assets/5832902/95b076df-bcad-42f8-8760-7b84e775a9fa) |

## Backwards-incompatible changes

None