### PR TITLE
Fix migration script, use extras for its dependencies

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -179,15 +179,14 @@ First, make sure to update to JupyterLab 4 and install ``copier`` and some depen
 
 .. code:: bash
 
-   pip install -U jupyterlab
-   pip install "copier~=8.0" jinja2-time tomli-w
+   pip install -U jupyterlab[upgrade-extension]
 
 
 Or with ``conda``:
 
 .. code:: bash
 
-   conda install -c conda-forge jupyterlab=4 "copier=8" jinja2-time tomli-w
+   conda install -c conda-forge jupyterlab=4 "copier=8" jinja2-time tomli-w "pydantic<2" "pyyaml-include<2.0"
 
 
 Then at the root folder of the extension, run:

--- a/jupyterlab/upgrade_extension.py
+++ b/jupyterlab/upgrade_extension.py
@@ -22,8 +22,8 @@ from pathlib import Path
 
 try:
     import copier
-except ImportError:
-    msg = "Please install copier and jinja2-time"
+except ModuleNotFoundError:
+    msg = "Please install copier; you can use `pip install jupyterlab[upgrade-extension]`"
     raise RuntimeError(msg) from None
 
 # List of files recommended to be overridden

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,13 @@ dev = [
     "bump2version",
     "ruff==0.3.0",
 ]
+upgrade-extension = [
+    "pyyaml-include<2.0",
+    "copier~=8.0",
+    "jinja2-time<0.3",
+    "pydantic<2.0",
+    "tomli-w<2.0"
+]
 
 [tool.check-wheel-contents]
 ignore = ["W002", "W004"]

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -259,7 +259,7 @@ if [[ $GROUP == usage ]]; then
     jlpm run get:dependency react-native
 
     # Use the extension upgrade script
-    python -m pip install jupyterlab[upgrade-extension]
+    python -m pip install .[upgrade-extension]
     python -m jupyterlab.upgrade_extension --no-input jupyterlab/tests/mock_packages/extension
 fi
 

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -259,7 +259,7 @@ if [[ $GROUP == usage ]]; then
     jlpm run get:dependency react-native
 
     # Use the extension upgrade script
-    python -m pip install copier jinja2-time "pydantic<2"
+    python -m pip install jupyterlab[upgrade-extension]
     python -m jupyterlab.upgrade_extension --no-input jupyterlab/tests/mock_packages/extension
 fi
 


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/16086

## Code changes

- move upgrade script dependencies to pyproject,
- add `pyyaml-include` pin,
- correct exception handling

## User-facing changes

None

## Backwards-incompatible changes

None
