### PR TITLE
Use `dependency_type: minimum` for Minimum Versions check

### DIFF
--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -89,8 +89,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         with:
           python_version: "3.8"
-      - name: Install minimum versions
-        uses: jupyterlab/maintainer-tools/.github/actions/install-minimums@v1
+          dependency_type: minimum
       - name: Install dependencies
         run: |
           bash ./scripts/ci_install.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "jupyterlab_server>=2.19.0,<3",
     "notebook_shim>=0.2",
     "packaging",
-    "tomli;python_version<\"3.11\"",
+    "tomli>=1.2.2;python_version<\"3.11\"",
     "tornado>=6.2.0",
     "traitlets>=3.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "packaging",
     "tomli;python_version<\"3.11\"",
     "tornado>=6.2.0",
-    "traitlets",
+    "traitlets>=3.0",
 ]
 dynamic = [
     "version",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "httpx>=0.25.0",
     "importlib-metadata>=4.8.3;python_version<\"3.10\"",
     "importlib-resources>=1.4;python_version<\"3.9\"",
-    "ipykernel",
+    "ipykernel>=6.5.0",
     "jinja2>=3.0.3",
     "jupyter_core",
     "jupyter_server>=2.4.0,<3",


### PR DESCRIPTION
## References

Should fix some of the CI failures (https://github.com/jupyterlab/maintainer-tools/issues/227).

## Code changes

- Removes use of action which was removed from maintainer-tools in a point release
- passes `dependency_type: minimum` to base setup action

## User-facing changes

None

## Backwards-incompatible changes

None