### PR TITLE
Store the real position of the item in reactive toolbar

### DIFF
--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -452,11 +452,23 @@ export class ReactiveToolbar extends Toolbar<Widget> {
     if (widget instanceof ToolbarPopupOpener) {
       status = super.insertItem(index, name, widget);
     } else {
-      index = Math.max(
+      // Insert the widget in the toolbar at axpected index if possible, otherwise
+      // before the popup opener. This position may change when invoking the resizer
+      // at the end of this function.
+      const j = Math.max(
         0,
         Math.min(index, (this.layout as ToolbarLayout).widgets.length - 1)
       );
-      status = super.insertItem(index, name, widget);
+      status = super.insertItem(j, name, widget);
+
+      if (j !== index) {
+        // This happens if the widget has been inserted at a wrong position:
+        // - not enough widgets in the toolbar to insert it at the expected index
+        // - the widget at the expected index should be in the popup
+        // In the first situation, the stored index should be changed to match a
+        // realistic index.
+        index = Math.max(0, Math.min(index, this._widgetPositions.size));
+      }
     }
 
     // Save the widgets position when a widget is inserted or moved.

--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -452,11 +452,11 @@ export class ReactiveToolbar extends Toolbar<Widget> {
     if (widget instanceof ToolbarPopupOpener) {
       status = super.insertItem(index, name, widget);
     } else {
-      const j = Math.max(
+      index = Math.max(
         0,
         Math.min(index, (this.layout as ToolbarLayout).widgets.length - 1)
       );
-      status = super.insertItem(j, name, widget);
+      status = super.insertItem(index, name, widget);
     }
 
     // Save the widgets position when a widget is inserted or moved.

--- a/packages/ui-components/test/toolbar.spec.ts
+++ b/packages/ui-components/test/toolbar.spec.ts
@@ -426,6 +426,39 @@ describe('@jupyterlab/ui-components', () => {
         ).toEqual(-1);
       });
     });
+
+    describe('#storedPositions', () => {
+      it('should store the correct position of items', () => {
+        const w = new Widget();
+        const names = ['test0', 'test1', 'test2', 'test3'];
+        for (let i = 0; i < 3; i++) {
+          toolbar.insertItem(i, names[i], w);
+        }
+        toolbar.insertItem(1, names[3], w);
+        const positions = (toolbar as any)._widgetPositions;
+        let stored: number[] = [];
+        for (let i = 0; i < 4; i++) {
+          stored.push(positions.get(names[i]));
+        }
+        expect(stored).toEqual([0, 2, 3, 1]);
+      });
+
+      it('should not store unexpected index', () => {
+        const w = new Widget();
+        const names = ['test0', 'test1', 'test2', 'test3'];
+        for (let i = 0; i < 2; i++) {
+          toolbar.insertItem(i, names[i], w);
+        }
+        toolbar.insertItem(-5, names[2], w);
+        toolbar.insertItem(10, names[3], w);
+        const positions = (toolbar as any)._widgetPositions;
+        let stored: number[] = [];
+        for (let i = 0; i < 4; i++) {
+          stored.push(positions.get(names[i]));
+        }
+        expect(stored).toEqual([1, 2, 0, 3]);
+      });
+    });
   });
 
   describe('ToolbarButton', () => {


### PR DESCRIPTION
When an item is inserted in a reactive toolbar, its position is stored. This storage is used when the item moves between the main toolbar and the popup toolbar, to position them correctly.

For example if the expected position is 8 but there are only 2 widgets, it will be added at position 3. The stored position was 8 instead of 3, which cause errors on later computation.

## References

Should fix https://github.com/jupyter/notebook/issues/7311.

## Code changes

Store the real insertion index.

## User-facing changes

Avoid flickering items in reactive toolbar when some items have not been inserted at the expected position.

## Backwards-incompatible changes

None

cc. @jtpio
