### PR TITLE
Revert traitlets pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "packaging",
     "tomli>=1.2.2;python_version<\"3.11\"",
     "tornado>=6.2.0",
-    "traitlets>=3.0",
+    "traitlets",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION


## References

- reverts pins added in https://github.com/jupyterlab/jupyterlab/pull/16105
- to fix https://github.com/jupyterlab/jupyterlab/issues/16115
- because `maintainer-tools` changes were reverted, see https://github.com/jupyterlab/maintainer-tools/issues/230

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None
