### PR TITLE
disable placeholder for password input object

### DIFF
--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -1124,9 +1124,13 @@ export class Stdin extends Widget implements IStdin {
 
     this._input = this.node.getElementsByTagName('input')[0];
     // make users aware of the line history feature
-    this._input.placeholder = this._trans.__(
-      '↑↓ for history. Search history with c-↑/c-↓'
-    );
+    if (!this._password) {
+      this._input.placeholder = this._trans.__(
+        '↑↓ for history. Search history with c-↑/c-↓'
+      );
+    } else {
+      this._input.placeholder = this._trans.__('');
+    }
 
     // initialize line history
     if (!Stdin._history.has(this._historyKey)) {


### PR DESCRIPTION
## References
Fixes https://github.com/jupyterlab/jupyterlab/issues/15977

## Code changes
Setting line history placeholder conditionally on whether options.password is set for input widget

## User-facing changes
Users will not see line history placeholder text in a password input field after the change

## Backwards-incompatible changes
None
