### PR TITLE
Do not notify the `notebook:create-output-view` command

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -3564,7 +3564,7 @@ function addCommands(
 
   // All commands with isEnabled defined directly or in a semantic commands
   // To simplify here we added all commands as most of them have isEnabled
-  const skip = [CommandIDs.createNew];
+  const skip = [CommandIDs.createNew, CommandIDs.createOutputView];
   const notify = () => {
     Object.values(CommandIDs)
       .filter(id => !skip.includes(id))


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Partial fix for https://github.com/jupyterlab/jupyterlab/issues/16113



<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Just skip `notebook:create-output-view` for now.

The comment above mentions that all commands are added for simplicity:

https://github.com/jupyterlab/jupyterlab/blob/6152e3a5f94d728ccd2727d6d8413f12ddafb669/packages/notebook-extension/src/index.ts#L3566

But this should likely be reconsidered. It looks like only the plugins that register the commands should then call `app.commands.notifyCommandChanged()` for these particular commands.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None for most users. Should fix one error in the dev tools console when running Notebook 7: https://github.com/jupyter/notebook/pull/7312

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
