### PR TITLE
Make the default drive in the Contents Service configurable

### DIFF
--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -669,7 +669,9 @@ export class ContentsManager implements Contents.IManager {
     let drive = this._additionalDrives.get(driveName);
     if (drive) {
       // Remove the signal from the previous default drive.
-      this._defaultDrive.fileChanged.disconnect(this._onFileChanged);
+      if (this._defaultDrive) {
+        this._defaultDrive.fileChanged.disconnect(this._onFileChanged);
+      }
       // Set the new Drive.
       this._defaultDrive = drive;
       this._defaultDrive.fileChanged.connect(this._onFileChanged, this);

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -295,6 +295,9 @@ export namespace Contents {
      */
     readonly serverSettings: ServerConnection.ISettings;
 
+    /**
+     * Set the default `IDrive` in the manager.
+     */
     setDefaultDrive(driveName: string): void;
 
     /**
@@ -642,8 +645,9 @@ export class ContentsManager implements Contents.IManager {
     // Create a drive for the Jupyter Server REST API.
     let contentsDrive = new Drive({ serverSettings, name: 'contents' });
     this._additionalDrives.set('contents', contentsDrive);
-    // If a different drive as given in options, also add it.
+    // If a different drive is given in options, also add it here.
     let defaultDriveName = 'contents';
+    // Set the default drive based on the given options.
     if (options.defaultDrive) {
       defaultDriveName = options.defaultDrive.name;
       this._additionalDrives.set(
@@ -654,10 +658,17 @@ export class ContentsManager implements Contents.IManager {
     this.setDefaultDrive(defaultDriveName);
   }
 
+  /**
+   * Set the default drive of the contents manager. This can be changed
+   * at any time.
+   *
+   * The default drive does not use its drive prefix when displaying
+   * paths.
+   */
   setDefaultDrive(driveName: string): void {
     let drive = this._additionalDrives.get(driveName);
     if (drive) {
-      // Remove old signal.
+      // Remove the signal from the previous default drive.
       this._defaultDrive.fileChanged.disconnect(this._onFileChanged);
       // Set the new Drive.
       this._defaultDrive = drive;
@@ -1541,6 +1552,9 @@ export namespace ContentsManager {
   export interface IOptions {
     /**
      * The default drive backend for the contents manager.
+     *
+     * The default drive means all implicit paths (i.e. no drive prefix)
+     * will use this drive by default.
      */
     defaultDrive?: Contents.IDrive;
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes #16099.


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->


This PR makes two changes:
* _always_ creates a drive named "contents" to connect the server REST API
* defaults to making this drive the `defaultDrive`. The default drive doesn't need a prefix when a file path is given.
* adds a method, `setDefaultDrive` to update the default drive. 

Adds a public API to set/change the defaultDrive in the contents service. 

Leaving this in draft state for now to discuss.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

There are no user-facing changes by default. 

This allows extensions like `jupyter-collaboration` to set the default drive to something other than the REST API. In the RTC case, it uses the ydoc APIs. 

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

None.

@martinRenou @SylvainCorlay @davidbrochart @dlqqq @jzhang20133 @jtpio 