### PR TITLE
Fix accepting completion with `Enter`

### DIFF
--- a/galata/test/jupyterlab/completer.test.ts
+++ b/galata/test/jupyterlab/completer.test.ts
@@ -13,7 +13,9 @@ test.describe('Completer', () => {
       await page.notebook.createNew(fileName);
     });
 
-    test('Open completer on notebook', async ({ page }) => {
+    test('Open completer on notebook and accept suggestion', async ({
+      page
+    }) => {
       await page.notebook.setCell(
         0,
         'code',
@@ -35,7 +37,11 @@ test.describe('Completer', () => {
       completer = page.locator(COMPLETER_SELECTOR);
       await completer.waitFor();
       const imageName = 'completer.png';
-      expect(await completer.screenshot()).toMatchSnapshot(imageName);
+      expect.soft(await completer.screenshot()).toMatchSnapshot(imageName);
+      // Accept the completion
+      await page.keyboard.press('Enter');
+      const textAfter = await page.notebook.getCellTextInput(1);
+      expect(textAfter).toBe('option_1');
     });
 
     test('Show documentation panel', async ({ page, tmpPath }) => {

--- a/packages/codemirror/src/commands.ts
+++ b/packages/codemirror/src/commands.ts
@@ -74,8 +74,8 @@ export namespace StateCommands {
     dispatch: (transaction: Transaction) => void;
   }): boolean {
     if (target.dom.parentElement?.classList.contains(COMPLETER_ACTIVE_CLASS)) {
-      // return true to avoid handling the default Enter from codemirror defaultKeymap.
-      return true;
+      // do not prevent default to allow completer `enter` action
+      return false;
     }
 
     const arg = { state: target.state, dispatch: target.dispatch };

--- a/packages/codemirror/src/extension.ts
+++ b/packages/codemirror/src/extension.ts
@@ -726,12 +726,15 @@ export namespace EditorExtensionRegistry {
             //   as these as handled by lumino command
             // - Disable Escape handler because it prevents default and we
             //   want to run a cell action (switch to command mode) on Esc
+            // - Disable default Enter handler because it prevents us from
+            //   accepting a completer suggestion with Enter.
             return ![
               'Mod-Enter',
               'Shift-Mod-k',
               'Mod-/',
               'Alt-A',
-              'Escape'
+              'Escape',
+              'Enter'
             ].includes(binding.key as string);
           }),
           {


### PR DESCRIPTION
## References

Fixes #16150

## Code changes

- [x] Adds a test for accepting completion with <kbd>Enter</kbd>
- [x] Fixes the issue by removing the default Enter handler and returning `false` from our custom handler.

## User-facing changes

Accepting completion with Enter works

## Backwards-incompatible changes

None