### PR TITLE
Remove unused `IDefaultFileBrowser` dependency from `launcher-extension`

### DIFF
--- a/packages/launcher-extension/src/index.ts
+++ b/packages/launcher-extension/src/index.ts
@@ -11,10 +11,7 @@ import {
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 import { ICommandPalette, MainAreaWidget } from '@jupyterlab/apputils';
-import {
-  FileBrowserModel,
-  IDefaultFileBrowser
-} from '@jupyterlab/filebrowser';
+import { FileBrowserModel, IDefaultFileBrowser } from '@jupyterlab/filebrowser';
 import { ILauncher, Launcher, LauncherModel } from '@jupyterlab/launcher';
 import { ITranslator } from '@jupyterlab/translation';
 import { addIcon, launcherIcon } from '@jupyterlab/ui-components';
@@ -37,11 +34,7 @@ const plugin: JupyterFrontEndPlugin<ILauncher> = {
   id: '@jupyterlab/launcher-extension:plugin',
   description: 'Provides the launcher tab service.',
   requires: [ITranslator],
-  optional: [
-    ILabShell,
-    ICommandPalette,
-    IDefaultFileBrowser
-  ],
+  optional: [ILabShell, ICommandPalette, IDefaultFileBrowser],
   provides: ILauncher,
   autoStart: true
 };

--- a/packages/launcher-extension/src/index.ts
+++ b/packages/launcher-extension/src/index.ts
@@ -13,8 +13,7 @@ import {
 import { ICommandPalette, MainAreaWidget } from '@jupyterlab/apputils';
 import {
   FileBrowserModel,
-  IDefaultFileBrowser,
-  IFileBrowserFactory
+  IDefaultFileBrowser
 } from '@jupyterlab/filebrowser';
 import { ILauncher, Launcher, LauncherModel } from '@jupyterlab/launcher';
 import { ITranslator } from '@jupyterlab/translation';
@@ -41,8 +40,7 @@ const plugin: JupyterFrontEndPlugin<ILauncher> = {
   optional: [
     ILabShell,
     ICommandPalette,
-    IDefaultFileBrowser,
-    IFileBrowserFactory
+    IDefaultFileBrowser
   ],
   provides: ILauncher,
   autoStart: true
@@ -61,8 +59,7 @@ function activate(
   translator: ITranslator,
   labShell: ILabShell | null,
   palette: ICommandPalette | null,
-  defaultBrowser: IDefaultFileBrowser | null,
-  factory: IFileBrowserFactory | null
+  defaultBrowser: IDefaultFileBrowser | null
 ): ILauncher {
   const { commands, shell } = app;
   const trans = translator.load('jupyterlab');


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/16165

## Code changes

Remove unused `IDefaultFileBrowser` dependency from `launcher-extension`

## User-facing changes

None

## Backwards-incompatible changes

None