### PR TITLE
Enable `noUncheckedIndexedAccess`

### DIFF
--- a/packages/coreutils/src/markdowncodeblocks.ts
+++ b/packages/coreutils/src/markdowncodeblocks.ts
@@ -57,8 +57,7 @@ export namespace MarkdownCodeBlocks {
     const lines = text.split('\n');
     const codeBlocks: MarkdownCodeBlock[] = [];
     let currentBlock = null;
-    for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
-      const line = lines[lineIndex];
+    for (let [lineIndex, line] of lines.entries()) {
       const lineContainsMarker = line.indexOf(CODE_BLOCK_MARKER) === 0;
       const constructingBlock = currentBlock != null;
       // Skip this line if it is not part of any code block and doesn't contain a marker.

--- a/tsconfigbase.json
+++ b/tsconfigbase.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
   "compilerOptions": {
+    "noUncheckedIndexedAccess": true,
     "allowSyntheticDefaultImports": true,
     "composite": true,
     "declaration": true,


### PR DESCRIPTION
## References

A number of errors in the codebase such as https://github.com/jupyterlab/jupyterlab/issues/15103#issuecomment-2063421265 could be prevented by enabling `noUncheckedIndexedAccess`.

Trying to evaluate the benefit/cost ratio in this PR

## Code changes

TBD

## User-facing changes

None

## Backwards-incompatible changes

None