### PR TITLE
Migrate shortcuts search to use `FilterBox`

### DIFF
--- a/packages/shortcuts-extension/src/components/TopNav.tsx
+++ b/packages/shortcuts-extension/src/components/TopNav.tsx
@@ -4,7 +4,7 @@
  */
 
 import { ITranslator } from '@jupyterlab/translation';
-import { InputGroup } from '@jupyterlab/ui-components';
+import { FilterBox } from '@jupyterlab/ui-components';
 import * as React from 'react';
 
 import { ShortcutTitleItem } from './ShortcutTitleItem';
@@ -109,15 +109,13 @@ export class TopNav extends React.Component<ITopNavProps> {
       <div className="jp-Shortcuts-Top">
         <div className="jp-Shortcuts-TopNav">
           <Symbols />
-          <InputGroup
-            className="jp-Shortcuts-Search"
+          <FilterBox
             aria-label={trans.__('Search shortcuts')}
-            type="text"
-            onChange={event =>
-              this.props.updateSearchQuery(event.target['value'])
+            updateFilter={(_, query) =>
+              this.props.updateSearchQuery(query ?? '')
             }
             placeholder={trans.__('Search…')}
-            rightIcon="ui-components:search"
+            useFuzzyFilter={false}
           />
           <AdvancedOptions
             toggleSelectors={this.props.toggleSelectors}

--- a/packages/shortcuts-extension/style/base.css
+++ b/packages/shortcuts-extension/style/base.css
@@ -215,6 +215,7 @@
   border-radius: var(--jp-border-radius);
   padding: 5px 6px;
   margin: 3px 0;
+  cursor: pointer;
 }
 
 .jp-Shortcuts-Or {
@@ -248,6 +249,7 @@
   margin: 3px 0;
   padding: 5px 6px;
   color: var(--jp-ui-inverse-font-color1);
+  cursor: pointer;
 }
 
 .jp-Shortcuts-Plus:hover {
@@ -336,25 +338,15 @@
   padding-right: 10px;
 }
 
-.jp-Shortcuts-Search {
-  height: 30px;
-}
-
-.jp-Shortcuts-Search > input {
-  box-shadow: none;
-}
-
-.jp-Shortcuts-AdvancedOptionsSmall {
-  width: 30%;
-}
-
-.jp-Shortcuts-AdvancedOptionsRight {
-  margin-top: 8px;
+.jp-Shortcuts-AdvancedOptions {
+  padding-left: 12px;
 }
 
 .jp-Shortcuts-AdvancedOptionsLink {
   color: var(--jp-content-link-color);
   margin-right: 15px;
+  display: inline-block;
+  cursor: pointer;
 }
 
 .jp-Shortcuts-AdvancedOptionsLink:hover {


### PR DESCRIPTION
## References

Fixes #16215

## Code changes

- makes use of `FilterBox` which uses `jupyter-ui-tookit` for search component in shortcuts UI (follow up to https://github.com/jupyterlab/jupyterlab/pull/16046)
- fixes style of advanced options links,
- adds missing cursor pointer styles
- removes unused `jp-Shortcuts-AdvancedOptionsSmall` and `jp-Shortcuts-AdvancedOptionsRight` styles

## User-facing changes

| Before | After |
|---|---|
|  ![image](https://github.com/jupyterlab/jupyterlab/assets/5832902/db2bd7e5-6292-47b8-91a9-118fe1582357) | ![Screenshot from 2024-04-20 22-02-18](https://github.com/jupyterlab/jupyterlab/assets/5832902/1e597899-f42b-4bd9-a159-fb7a3b5a53c7) |

Filtered down, small window (see how previously "Reset All" was oddly spread across two lines - now fixed by adding `display: inline-block`)

| Before | After |
|---|---|
| ![image](https://github.com/jupyterlab/jupyterlab/assets/5832902/ed437808-0d15-4bff-b022-83e73b8ee8e0) | ![image](https://github.com/jupyterlab/jupyterlab/assets/5832902/b1b40377-fc04-4a04-a217-533757f76148) |


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
