### PR TITLE
updated shutdown dialogue to display app.name

### DIFF
--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -375,7 +375,7 @@ function createFileMenu(
     execute: () => {
       return showDialog({
         title: trans.__('Shutdown confirmation'),
-        body: trans.__('Please confirm you want to shut down JupyterLab.'),
+        body: trans.__('Please confirm you want to shut down ' + app.name + '.'),
         buttons: [
           Dialog.cancelButton(),
           Dialog.warnButton({ label: trans.__('Shut Down') })


### PR DESCRIPTION
## References

https://github.com/jupyter/notebook/issues/7188 
"File > Shutdown in classic notebook ask if I want to shutdow JupyterLab"

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Edits shutdown dialogue body to ask if the user wants to shutdown <app.name>, instead of exclusively 'JupyterLab' 

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

User will be prompted to confirm shutdown of Jupyter Notebook, instead of JupyterLab, when using Jupyter Notebook