### PR TITLE
Install Firefox from brew on Mac on CI

### DIFF
--- a/.github/workflows/macostests.yml
+++ b/.github/workflows/macostests.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Setup firefox
         run: brew install --cask firefox
 
+      - name: Setup cairo and pango
+        run: brew install cairo pango
+
       - name: Install dependencies
         env:
           GROUP: ${{ matrix.group }}

--- a/.github/workflows/macostests.yml
+++ b/.github/workflows/macostests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Setup firefox
-        uses: browser-actions/setup-firefox@latest
+        run: brew install --cask firefox
 
       - name: Install dependencies
         env:


### PR DESCRIPTION
## References

Fixes #16244 

## Code changes

Install `firefox`, `cairo` and `pango` from brew.

## User-facing changes

None

## Backwards-incompatible changes

None