### PR TITLE
Add an option to continue indentation, upgrade `@codemirror/commands`

### DIFF
--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -37,7 +37,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@codemirror/commands": "^6.3.3",
+    "@codemirror/commands": "^6.5.0",
     "@codemirror/lang-markdown": "^6.2.4",
     "@codemirror/language": "^6.10.1",
     "@codemirror/legacy-modes": "^6.3.3",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.15.0",
-    "@codemirror/commands": "^6.3.3",
+    "@codemirror/commands": "^6.5.0",
     "@codemirror/lang-cpp": "^6.0.2",
     "@codemirror/lang-css": "^6.2.1",
     "@codemirror/lang-html": "^6.4.8",

--- a/packages/codemirror/src/commands.ts
+++ b/packages/codemirror/src/commands.ts
@@ -8,10 +8,11 @@ import {
   indentMore,
   insertBlankLine,
   insertNewlineAndIndent,
+  insertNewlineKeepIndent,
   insertTab,
   simplifySelection
 } from '@codemirror/commands';
-import { EditorState, Transaction } from '@codemirror/state';
+import { EditorState, Facet, Transaction } from '@codemirror/state';
 import {
   COMPLETER_ACTIVE_CLASS,
   COMPLETER_ENABLED_CLASS
@@ -33,6 +34,19 @@ const TOOLTIP_OPENER_SELECTOR =
  */
 const ACTIVE_CELL_IN_EDIT_MODE_SELECTOR =
   '.jp-mod-editMode .jp-Cell.jp-mod-active';
+
+/**
+ * CodeMirror facets namespace
+ */
+export namespace CommandFacets {
+  /**
+   * Whether to always continue indentation when inserting a new line.
+   */
+  export const continueIndentation = Facet.define<boolean, boolean>({
+    combine: values => values.some(v => v),
+    static: true
+  });
+}
 
 /**
  * CodeMirror commands namespace
@@ -79,7 +93,11 @@ export namespace StateCommands {
     }
 
     const arg = { state: target.state, dispatch: target.dispatch };
-    return insertNewlineAndIndent(arg);
+    if (target.state.facet(CommandFacets.continueIndentation)) {
+      return insertNewlineKeepIndent(arg);
+    } else {
+      return insertNewlineAndIndent(arg);
+    }
   }
 
   /**

--- a/packages/codemirror/src/extension.ts
+++ b/packages/codemirror/src/extension.ts
@@ -35,7 +35,7 @@ import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { JSONExt, ReadonlyJSONObject } from '@lumino/coreutils';
 import { IObservableDisposable } from '@lumino/disposable';
 import { ISignal, Signal } from '@lumino/signaling';
-import { StateCommands } from './commands';
+import { CommandFacets, StateCommands } from './commands';
 import { customTheme, CustomTheme, rulers } from './extensions';
 import {
   IConfigurableExtension,
@@ -745,6 +745,21 @@ export namespace EditorExtensionRegistry {
         ],
         factory: () =>
           createConfigurableExtension<KeyBinding[]>(value => keymap.of(value))
+      }),
+      Object.freeze({
+        name: 'continueIndentation',
+        default: false,
+        factory: () =>
+          createConfigurableExtension((value: boolean) =>
+            CommandFacets.continueIndentation.of(value)
+          ),
+        schema: {
+          type: 'boolean',
+          title: trans.__('Continue Indentation'),
+          description: trans.__(
+            'Whether to always continue indentation when inserting a new line. When disabled, the editor will follow language-specific heuristics if available.'
+          )
+        }
       }),
       Object.freeze({
         name: 'lineNumbers',

--- a/packages/fileeditor-extension/package.json
+++ b/packages/fileeditor-extension/package.json
@@ -37,7 +37,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@codemirror/commands": "^6.3.3",
+    "@codemirror/commands": "^6.5.0",
     "@codemirror/search": "^6.5.6",
     "@jupyterlab/application": "^4.2.0-beta.3",
     "@jupyterlab/apputils": "^4.3.0-beta.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1355,15 +1355,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemirror/commands@npm:^6.3.3":
-  version: 6.3.3
-  resolution: "@codemirror/commands@npm:6.3.3"
+"@codemirror/commands@npm:^6.5.0":
+  version: 6.5.0
+  resolution: "@codemirror/commands@npm:6.5.0"
   dependencies:
     "@codemirror/language": ^6.0.0
     "@codemirror/state": ^6.4.0
     "@codemirror/view": ^6.0.0
     "@lezer/common": ^1.1.0
-  checksum: 7d23aecc973823969434b839aefa9a98bb47212d2ce0e6869ae903adbb5233aad22a760788fb7bb6eb45b00b01a4932fb93ad43bacdcbc0215e7500cf54b17bb
+  checksum: 27e49c5e0cb918b95d6a9f741bcc0e72cb76f963b0c829308edfb4491a37d8b12ae6fb96f9f1886b3189a22c82fec4434fbe65547dc3cd3e8dfb5222dfead2e7
   languageName: node
   linkType: hard
 
@@ -2518,7 +2518,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/codemirror-extension@workspace:packages/codemirror-extension"
   dependencies:
-    "@codemirror/commands": ^6.3.3
+    "@codemirror/commands": ^6.5.0
     "@codemirror/lang-markdown": ^6.2.4
     "@codemirror/language": ^6.10.1
     "@codemirror/legacy-modes": ^6.3.3
@@ -2548,7 +2548,7 @@ __metadata:
   resolution: "@jupyterlab/codemirror@workspace:packages/codemirror"
   dependencies:
     "@codemirror/autocomplete": ^6.15.0
-    "@codemirror/commands": ^6.3.3
+    "@codemirror/commands": ^6.5.0
     "@codemirror/lang-cpp": ^6.0.2
     "@codemirror/lang-css": ^6.2.1
     "@codemirror/lang-html": ^6.4.8
@@ -3396,7 +3396,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/fileeditor-extension@workspace:packages/fileeditor-extension"
   dependencies:
-    "@codemirror/commands": ^6.3.3
+    "@codemirror/commands": ^6.5.0
     "@codemirror/search": ^6.5.6
     "@jupyterlab/application": ^4.2.0-beta.3
     "@jupyterlab/apputils": ^4.3.0-beta.3


### PR DESCRIPTION
## References

Closes #16196

## Code changes

- [x] update `@codemirror/commands`
- [x] add an option to continue indentation
- [ ] add a test

## User-facing changes

New continue indentation option:

![image](https://github.com/jupyterlab/jupyterlab/assets/5832902/fcbd6945-c6c7-4cce-812e-829d64378cc5)

TBD, as the current behaviour of `insertNewlineKeepIndent` turned out to be different from what I thought it would do, see https://github.com/codemirror/dev/issues/1370#issuecomment-2079392856.

Depending on whether upstream (CodeMirror) reconsiders, we may need to do something different, for example always run `insertNewlineAndIndent` while comparing the indentation before and after and if it decreased at the end of the block we would re-add the indentation. Or maybe we need to vendor a modified copy of `insertNewlineAndIndent` which does not dedent at the end of the block (not sure if this is feasible). Or maybe we need to modify the Python language implementation only in which case this PR would be of little use in the current state.

## Backwards-incompatible changes

None
