### PR TITLE
Set aria-label to title if no label for

### DIFF
--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -843,6 +843,9 @@ export function ToolbarButtonComponent(
     }
   };
 
+  const title = getTooltip();
+  const disabled = props.enabled === false;
+
   return (
     <Button
       appearance="stealth"
@@ -851,14 +854,15 @@ export function ToolbarButtonComponent(
           ? props.className + ' jp-ToolbarButtonComponent'
           : 'jp-ToolbarButtonComponent'
       }
+      aria-disabled={disabled}
+      aria-label={props.label || title}
       aria-pressed={props.pressed}
-      aria-disabled={props.enabled === false}
       {...props.dataset}
-      disabled={props.enabled === false}
+      disabled={disabled}
       onClick={handleClick}
       onMouseDown={handleMouseDown}
       onKeyDown={handleKeyDown}
-      title={getTooltip()}
+      title={title}
       minimal
     >
       {(props.icon || props.iconClass) && (


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #16263 
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Set explicitly the aria-label from the title when no label is defined on a toolbar button


## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
| Before (4.1.2) | After |
| --- | --- |
|![image](https://github.com/jupyterlab/jupyterlab/assets/8435071/f09e88e6-ac73-4217-b539-9c118ef09f01) |![image](https://github.com/jupyterlab/jupyterlab/assets/8435071/4af1124a-88af-4617-8e09-ac1bce20fa3a) |
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None