### PR TITLE
Add option to dismiss "Server Connection Error" dialog for the duration of the session

### DIFF
--- a/packages/application/src/connectionlost.ts
+++ b/packages/application/src/connectionlost.ts
@@ -24,7 +24,7 @@ export const ConnectionLost: IConnectionLost = async function (
   );
   const buttons = [Dialog.okButton({ label: trans.__('Dismiss') })];
 
-  if (!getDisplayConnection()) {
+  if (!Private.displayConnectionLost) {
     return;
   }
 

--- a/packages/application/src/connectionlost.ts
+++ b/packages/application/src/connectionlost.ts
@@ -50,7 +50,7 @@ export const ConnectionLost: IConnectionLost = async function (
   })
     .then(result => {
       if (result.isChecked) {
-        disableConnectionLostDialog();
+        Private.displayConnectionLost = false;
       }
       return;
     })

--- a/packages/application/src/connectionlost.ts
+++ b/packages/application/src/connectionlost.ts
@@ -42,7 +42,7 @@ export const ConnectionLost: IConnectionLost = async function (
         title: title,
         body: networkMsg,
         checkbox: {
-          label: trans.__('Do not show this message again.'),
+          label: trans.__('Do not show this message again in this session.'),
           caption: trans.__(
             'If checked, you will not see a dialog informing you about an issue with server connection in the future.'
           )

--- a/packages/application/src/connectionlost.ts
+++ b/packages/application/src/connectionlost.ts
@@ -6,26 +6,6 @@ import { ServerConnection, ServiceManager } from '@jupyterlab/services';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { IConnectionLost } from './tokens';
 
-export function getDisplayConnection(): boolean {
-  return Private.displayConnectionLost;
-}
-
-export function disableConnectionLostDialog(): void {
-  Private.displayConnectionLost = false;
-}
-
-export function getServerConnectionLost():
-  | Promise<void | Dialog.IResult<string>>
-  | undefined {
-  return Private.serverConnectionLost;
-}
-
-export function setServerConnectionLost(
-  connectionLostDialog: Promise<void | Dialog.IResult<string>> | undefined
-): void {
-  Private.serverConnectionLost = connectionLostDialog;
-}
-
 /**
  * A default connection lost handler, which brings up an error dialog.
  */

--- a/packages/application/src/connectionlost.ts
+++ b/packages/application/src/connectionlost.ts
@@ -31,7 +31,7 @@ export const ConnectionLost: IConnectionLost = async function (
     return;
   }
 
-  const key = title + '----' + networkMsg;
+  const key = 'server-connection-error';
   const promise = connectionLostCachePromise[key];
 
   if (promise) {

--- a/packages/application/src/connectionlost.ts
+++ b/packages/application/src/connectionlost.ts
@@ -29,7 +29,7 @@ export const ConnectionLost: IConnectionLost = async function (
   }
 
   let connectionDialog: Promise<void | Dialog.IResult<string>> | undefined =
-    getServerConnectionLost();
+    Private.serverConnectionLost;
 
   if (connectionDialog) {
     // Wait for the pre-existing promise to complete

--- a/packages/application/src/connectionlost.ts
+++ b/packages/application/src/connectionlost.ts
@@ -22,18 +22,14 @@ export const ConnectionLost: IConnectionLost = async function (
       'JupyterLab will continue trying to reconnect.\n' +
       'Check your network connection or Jupyter server configuration.\n'
   );
-  const buttons = [Dialog.okButton({ label: trans.__('Dismiss') })];
 
   if (!Private.displayConnectionLost) {
     return;
   }
 
-  let connectionDialog: Promise<void | Dialog.IResult<string>> | undefined =
-    Private.serverConnectionLost;
-
-  if (connectionDialog) {
+  if (Private.serverConnectionLost) {
     // Wait for the pre-existing promise to complete
-    await connectionDialog;
+    await Private.serverConnectionLost;
     return;
   }
 
@@ -46,7 +42,7 @@ export const ConnectionLost: IConnectionLost = async function (
         'If checked, you will not see a dialog informing you about an issue with server connection in this session.'
       )
     },
-    buttons: buttons
+    buttons: [Dialog.okButton({ label: trans.__('Dismiss') })]
   })
     .then(result => {
       if (result.isChecked) {
@@ -62,8 +58,6 @@ export const ConnectionLost: IConnectionLost = async function (
     });
 
   Private.serverConnectionLost = dialog;
-
-  return;
 };
 
 /**

--- a/packages/application/src/connectionlost.ts
+++ b/packages/application/src/connectionlost.ts
@@ -63,7 +63,7 @@ export const ConnectionLost: IConnectionLost = async function (
       await errorDialogPromise;
       return;
     } catch (error) {
-      console.error('An error occurred while showing the dialog:', error);
+      console.error('An error occurred while showing the dialog: ', error);
     }
   }
 };

--- a/packages/application/src/connectionlost.ts
+++ b/packages/application/src/connectionlost.ts
@@ -43,7 +43,7 @@ export const ConnectionLost: IConnectionLost = async function (
     checkbox: {
       label: trans.__('Do not show this message again in this session.'),
       caption: trans.__(
-        'If checked, you will not see a dialog informing you about an issue with server connection in the future.'
+        'If checked, you will not see a dialog informing you about an issue with server connection in this session.'
       )
     },
     buttons: buttons

--- a/packages/application/src/connectionlost.ts
+++ b/packages/application/src/connectionlost.ts
@@ -61,7 +61,7 @@ export const ConnectionLost: IConnectionLost = async function (
       Private.serverConnectionLost = undefined;
     });
 
-  setServerConnectionLost(dialog);
+  Private.serverConnectionLost = dialog;
 
   return;
 };

--- a/packages/application/src/connectionlost.ts
+++ b/packages/application/src/connectionlost.ts
@@ -58,7 +58,7 @@ export const ConnectionLost: IConnectionLost = async function (
       console.error('An error occurred while showing the dialog: ', error);
     })
     .finally(() => {
-      setServerConnectionLost(undefined);
+      Private.serverConnectionLost = undefined;
     });
 
   setServerConnectionLost(dialog);


### PR DESCRIPTION
## References

Related to https://github.com/jupyterlab/jupyterlab/issues/8374

## Code changes

This PR uses the `showDialog` function to display an error message with a checkbox giving the user the option to dismiss the popup dialog for the remainder of their tab session.

## User-facing changes

The user will now see a clickable checkbox that allows them to dismiss the error dialog informing them their connection to the server was lost.


![Screenshot 2024-05-01 at 12 10 47 AM](https://github.com/jupyterlab/jupyterlab/assets/12378147/453fb2d2-e688-4aa5-a49c-7d277b62c73d)

## Backwards-incompatible changes
Not applicable