### PR TITLE
Check the command is registered before calling `notifyCommandChanged()`

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -3567,7 +3567,7 @@ function addCommands(
   const skip = [CommandIDs.createNew, CommandIDs.createOutputView];
   const notify = () => {
     Object.values(CommandIDs)
-      .filter(id => !skip.includes(id))
+      .filter(id => !skip.includes(id) && app.commands.hasCommand(id))
       .forEach(id => app.commands.notifyCommandChanged(id));
   };
   tracker.currentChanged.connect(notify);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

https://github.com/jupyterlab/jupyterlab/issues/16113.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Implement the suggestion from @krassowski in https://github.com/jupyterlab/jupyterlab/pull/16138#discussion_r1555892452.

Still not sure it's the "right" fix, but maybe it can already help limit the amount of errors seen in the dev tools console when using Notebook 7.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

This should help fix the following errors showing up in the dev tools console when using Notebook 7:

![image](https://github.com/jupyterlab/jupyterlab/assets/591645/78c1fb60-ef54-401d-99e2-26fac346044b)

![image](https://github.com/jupyterlab/jupyterlab/assets/591645/c8d4050c-809f-4897-a65a-36d9edd495ab)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
