### PR TITLE
Add lowercase proxy vars and make priority consistent with other tools

### DIFF
--- a/jupyterlab/extensions/pypi.py
+++ b/jupyterlab/extensions/pypi.py
@@ -52,6 +52,8 @@ class ProxiedTransport(xmlrpc.client.Transport):
 xmlrpc_transport_override = None
 
 all_proxy_url = environ.get("ALL_PROXY")
+# For historical reasons, we also support the lowercase environment variables.
+# Info: https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/
 http_proxy_url = environ.get("http_proxy") or environ.get("HTTP_PROXY") or all_proxy_url
 https_proxy_url = (
     environ.get("https_proxy") or environ.get("HTTPS_PROXY") or http_proxy_url or all_proxy_url

--- a/jupyterlab/extensions/pypi.py
+++ b/jupyterlab/extensions/pypi.py
@@ -52,8 +52,10 @@ class ProxiedTransport(xmlrpc.client.Transport):
 xmlrpc_transport_override = None
 
 all_proxy_url = environ.get("ALL_PROXY")
-http_proxy_url = environ.get("HTTP_PROXY") or all_proxy_url
-https_proxy_url = environ.get("HTTPS_PROXY") or all_proxy_url or http_proxy_url
+http_proxy_url = environ.get("http_proxy") or environ.get("HTTP_PROXY") or all_proxy_url
+https_proxy_url = (
+    environ.get("https_proxy") or environ.get("HTTPS_PROXY") or http_proxy_url or all_proxy_url
+)
 proxies = None
 
 if http_proxy_url:


### PR DESCRIPTION
## References

Resolves #16286

## Code changes

This modifies the code for obtaining a proxy URL from the environment to first check `http_proxy`/`https_proxy`, consistent with discussion and recommendations from [this Gitlab engineering blog post](https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/).  

The recommendation from the linked post following a discussion of issues that can arise is:

> Prefer lowercase forms over uppercase variables (e.g. `http_proxy` should be searched before `HTTP_PROXY`).

This also slightly changes the priority of HTTP vs "ALL" proxy environment variables to favor more specificity. If only `HTTP_PROXY` is set, behavior will be as before. If both are set, the value of `http_proxy` will be used. 

## User-facing changes

This won't have any changed effect if only `HTTP_PROXY` is set, but it will now detect the more-common `http_proxy`. If both upper- and lower-case variants are set and have different values (why?) the lower-case variant will be preferred, consistent with other tools. Additionally, if both `ALL_PROXY` and `HTTP_PROXY` are set to different values, this code will change the resulting HTTPS proxy to be the URL from `HTTP_PROXY` and not `ALL_PROXY`, again consistent with other tools.

## Backwards-incompatible changes

No backwards incompatibility, only minor changes in behavior in edge cases. The resulting behavior should be more consistent with that of other tools.
