### PR TITLE
coreutils: add required TS intl libraries

### DIFF
--- a/packages/coreutils/src/time.ts
+++ b/packages/coreutils/src/time.ts
@@ -17,7 +17,7 @@ const UNITS: { name: Intl.RelativeTimeFormatUnit; milliseconds: number }[] = [
  * The namespace for date functions.
  */
 export namespace Time {
-  export type HumanStyle = Intl.ResolvedRelativeTimeFormatOptions["style"];
+  export type HumanStyle = Intl.ResolvedRelativeTimeFormatOptions['style'];
 
   /**
    * Convert a timestring to a human readable string (e.g. 'two minutes ago').

--- a/packages/coreutils/src/time.ts
+++ b/packages/coreutils/src/time.ts
@@ -17,9 +17,7 @@ const UNITS: { name: Intl.RelativeTimeFormatUnit; milliseconds: number }[] = [
  * The namespace for date functions.
  */
 export namespace Time {
-  // Intl.RelativeTimeFormatStyle contains these, but it requires `ES2020.Intl`.
-  // We currently compile to an `ES2018` target.
-  export type HumanStyle = 'long' | 'short' | 'narrow';
+  export type HumanStyle = Intl.ResolvedRelativeTimeFormatOptions["style"];
 
   /**
    * Convert a timestring to a human readable string (e.g. 'two minutes ago').

--- a/packages/coreutils/tsconfig.json
+++ b/packages/coreutils/tsconfig.json
@@ -4,7 +4,8 @@
     "outDir": "lib",
     "rootDir": "src",
     "module": "commonjs",
-    "types": ["node"]
+    "types": ["node"],
+    "lib": ["DOM", "ES2018", "ES2020.Intl", "ES2021.Intl"]
   },
   "include": ["src/*"],
   "references": []

--- a/tsconfigbase.json
+++ b/tsconfigbase.json
@@ -7,6 +7,7 @@
     "esModuleInterop": true,
     "incremental": true,
     "jsx": "react",
+    "lib": ["DOM", "DOM.Iterable", "ES2018", "ES2020.Intl"],
     "module": "esnext",
     "moduleResolution": "node",
     "noEmitOnError": true,


### PR DESCRIPTION
## References

Resolves #16283.

## Code changes

Explicitly adds the es2020.intl library, required for RelativeTimeFormat and its ancillary types, to tsconfigbase.

Also pre-emptively adds es2021.intl to the coreutils tsconfig, which will be required to avoid build errors in time.ts if/when the DateTimeFormat option properties `dateStyle` and `timeStyle` are moved there from es2020.intl.

## User-facing changes

Nil. (It's no longer necessary to explicitly define a `HumanStyle` type, but as it's an exported namespace type, it's left as-is.)

## Backwards-incompatible changes

Nil.
