### PR TITLE
Allow to invoke inline completer anywhere (not only at the end of line)

### DIFF
--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -459,7 +459,10 @@ export class CompletionHandler implements IDisposable {
     }
 
     const line = editor.getLine(position.line);
-    if (typeof line === 'undefined' || position.column < line.length) {
+    if (
+      trigger === InlineCompletionTriggerKind.Automatic &&
+      (typeof line === 'undefined' || position.column < line.length)
+    ) {
       // only auto-trigger on end of line
       return;
     }


### PR DESCRIPTION
## References

Fixes #16295

## Code changes

The inline completer prevents automatic running of the completer when not at the end of a line of code, but it is also applying this when invoked manually, which was unintended. This addresses that bug.

## User-facing changes

Allows a user to manually invoke the inline completer anywhere in their code

