### PR TITLE
Advertise the color scheme based on the theme

### DIFF
--- a/packages/apputils-extension/src/themesplugins.ts
+++ b/packages/apputils-extension/src/themesplugins.ts
@@ -86,6 +86,9 @@ export const themesPlugin: JupyterFrontEndPlugin<IThemeManager> = {
         manager.isLight(currentTheme)
       );
       document.body.dataset.jpThemeName = currentTheme;
+      document.body.style.colorScheme = manager.isLight(currentTheme)
+        ? 'light'
+        : 'dark';
       if (
         document.body.dataset.jpThemeScrollbars !==
         String(manager.themeScrollbars(currentTheme))


### PR DESCRIPTION
## References

Closes https://github.com/jupyterlab/jupyterlab/issues/16299

## Code changes

Set [`color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme) style on `<body>` to `dark` if the current theme is dark, and to `light` if the current theme is light.

## User-facing changes

- Scrollbars and other UI elements (not styled by JupyterLab) in dark mode will use the system dark theme if available
- SVG icons for kernels which include [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) directive will correctly render with high contrast in dark theme


With "Theme Scrollbars" option **disabled** (default):

| Before | After |
|--------|--------|
|![Screenshot from 2024-05-07 14-45-26](https://github.com/jupyterlab/jupyterlab/assets/5832902/d8ca982e-afb2-4a96-a33e-e27d3718842d) | ![Screenshot from 2024-05-07 14-45-00](https://github.com/jupyterlab/jupyterlab/assets/5832902/023e376d-109e-4dad-a34f-0da532fe5895) |



## Backwards-incompatible changes

None
