### PR TITLE
Add Signal to proxy all Completer selected Signals

### DIFF
--- a/packages/completer/src/manager.ts
+++ b/packages/completer/src/manager.ts
@@ -10,6 +10,7 @@ import { CompletionHandler } from './handler';
 import { CompleterModel } from './model';
 import { InlineCompleter } from './inline';
 import {
+  ICompleterSelection,
   ICompletionContext,
   ICompletionProvider,
   ICompletionProviderManager,
@@ -36,7 +37,10 @@ export class CompletionProviderManager implements ICompletionProviderManager {
     this._activeProvidersChanged = new Signal<ICompletionProviderManager, void>(
       this
     );
-    this._selected = new Signal<ICompletionProviderManager, string>(this);
+    this._selected = new Signal<
+      ICompletionProviderManager,
+      ICompleterSelection
+    >(this);
     this._inlineCompleterFactory = null;
   }
 
@@ -50,7 +54,7 @@ export class CompletionProviderManager implements ICompletionProviderManager {
   /**
    * Signal emitted when a selection is made from a completer menu.
    */
-  get selected(): ISignal<ICompletionProviderManager, string> {
+  get selected(): ISignal<ICompletionProviderManager, ICompleterSelection> {
     return this._selected;
   }
 
@@ -180,8 +184,8 @@ export class CompletionProviderManager implements ICompletionProviderManager {
       // Create a new handler.
       const handler = await this._generateHandler(newCompleterContext, options);
       this._panelHandlers.set(widget.id, handler);
-      handler.completer.selected.connect((sender, value) =>
-        this._selected.emit(value)
+      handler.completer.selected.connect((completer, text) =>
+        this._selected.emit({ text })
       );
       widget.disposed.connect(old => {
         this.disposeHandler(old.id, handler);
@@ -421,7 +425,7 @@ export class CompletionProviderManager implements ICompletionProviderManager {
   private _autoCompletion: boolean;
 
   private _activeProvidersChanged: Signal<ICompletionProviderManager, void>;
-  private _selected: Signal<ICompletionProviderManager, string>;
+  private _selected: Signal<ICompletionProviderManager, ICompleterSelection>;
   private _inlineCompleterFactory: IInlineCompleterFactory | null;
   private _inlineCompleterSettings = InlineCompleter.defaultSettings;
 }

--- a/packages/completer/src/manager.ts
+++ b/packages/completer/src/manager.ts
@@ -36,6 +36,7 @@ export class CompletionProviderManager implements ICompletionProviderManager {
     this._activeProvidersChanged = new Signal<ICompletionProviderManager, void>(
       this
     );
+    this._selected = new Signal<ICompletionProviderManager, string>(this);
     this._inlineCompleterFactory = null;
   }
 
@@ -44,6 +45,13 @@ export class CompletionProviderManager implements ICompletionProviderManager {
    */
   get activeProvidersChanged(): ISignal<ICompletionProviderManager, void> {
     return this._activeProvidersChanged;
+  }
+
+  /**
+   * Signal emitted when a selection is made from a completer menu.
+   */
+  get selected(): ISignal<ICompletionProviderManager, string> {
+    return this._selected;
   }
 
   /**
@@ -172,6 +180,9 @@ export class CompletionProviderManager implements ICompletionProviderManager {
       // Create a new handler.
       const handler = await this._generateHandler(newCompleterContext, options);
       this._panelHandlers.set(widget.id, handler);
+      handler.completer.selected.connect((sender, value) =>
+        this._selected.emit(value)
+      );
       widget.disposed.connect(old => {
         this.disposeHandler(old.id, handler);
         this._mostRecentContext.delete(id);
@@ -410,6 +421,7 @@ export class CompletionProviderManager implements ICompletionProviderManager {
   private _autoCompletion: boolean;
 
   private _activeProvidersChanged: Signal<ICompletionProviderManager, void>;
+  private _selected: Signal<ICompletionProviderManager, string>;
   private _inlineCompleterFactory: IInlineCompleterFactory | null;
   private _inlineCompleterSettings = InlineCompleter.defaultSettings;
 }

--- a/packages/completer/src/manager.ts
+++ b/packages/completer/src/manager.ts
@@ -184,8 +184,8 @@ export class CompletionProviderManager implements ICompletionProviderManager {
       // Create a new handler.
       const handler = await this._generateHandler(newCompleterContext, options);
       this._panelHandlers.set(widget.id, handler);
-      handler.completer.selected.connect((completer, text) =>
-        this._selected.emit({ text })
+      handler.completer.selected.connect((completer, insertText) =>
+        this._selected.emit({ insertText })
       );
       widget.disposed.connect(old => {
         this.disposeHandler(old.id, handler);

--- a/packages/completer/src/tokens.ts
+++ b/packages/completer/src/tokens.ts
@@ -370,7 +370,7 @@ export interface ICompletionProviderManager {
   /**
    * Signal emitted when a selection is made from a completer menu.
    */
-  selected: ISignal<ICompletionProviderManager, string>;
+  selected: ISignal<ICompletionProviderManager, ICompleterSelection>;
 
   /**
    * Inline completer actions.
@@ -381,6 +381,13 @@ export interface ICompletionProviderManager {
    * Inline providers information.
    */
   inlineProviders?: IInlineCompletionProviderInfo[];
+}
+
+export interface ICompleterSelection {
+  /**
+   * The text selected by the completer.
+   */
+  text: string;
 }
 
 export interface IInlineCompleterActions {

--- a/packages/completer/src/tokens.ts
+++ b/packages/completer/src/tokens.ts
@@ -368,6 +368,11 @@ export interface ICompletionProviderManager {
   activeProvidersChanged: ISignal<ICompletionProviderManager, void>;
 
   /**
+   * Signal emitted when a selection is made from a completer menu.
+   */
+  selected: ISignal<ICompletionProviderManager, string>;
+
+  /**
    * Inline completer actions.
    */
   inline?: IInlineCompleterActions;

--- a/packages/completer/src/tokens.ts
+++ b/packages/completer/src/tokens.ts
@@ -387,7 +387,7 @@ export interface ICompleterSelection {
   /**
    * The text selected by the completer.
    */
-  text: string;
+  insertText: string;
 }
 
 export interface IInlineCompleterActions {


### PR DESCRIPTION
## References

Fixes #16294

## Code changes

`Completer` currently emits a signal (`_selected`) when a completion is selected. This PR creates a new signal in `CompletionProviderManager`, which proxies the `Completer` signal from every `CompletionHandler` that is generated.

This will allow extensions to know when a selection is made by any Completer. Currently there are edge cases (as listed in  #16294) where a selection can be made without calling a command that can be connected to.

