### PR TITLE
Add the command to toggle the virtual scrollbar to the palette

### DIFF
--- a/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
+++ b/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
@@ -2083,8 +2083,8 @@
   },
   {
     "id": "notebook:toggle-virtual-scrollbar",
-    "label": "Virtual Scrollbar",
-    "caption": "Toggle virtual scrollbar (enabled with windowing mode: full)",
+    "label": "Show Virtual Scrollbar",
+    "caption": "Show virtual scrollbar (enabled with windowing mode: full)",
     "shortcuts": []
   },
   {

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -3554,8 +3554,8 @@ function addCommands(
         (settings?.composite.windowingMode === 'full' ?? false);
       return enabled;
     },
-    isToggled: args => {
-      const current = getCurrent(tracker, shell, args);
+    isToggled: () => {
+      const current = tracker.currentWidget;
       return current?.content.scrollbar ?? false;
     },
     isVisible: args => {

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -3609,7 +3609,8 @@ function populatePalette(
     CommandIDs.collapseAllCmd,
     CommandIDs.expandAllCmd,
     CommandIDs.accessPreviousHistory,
-    CommandIDs.accessNextHistory
+    CommandIDs.accessNextHistory,
+    CommandIDs.virtualScrollbar
   ].forEach(command => {
     palette.addItem({ command, category });
   });

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -3536,9 +3536,9 @@ function addCommands(
   });
 
   commands.addCommand(CommandIDs.virtualScrollbar, {
-    label: trans.__('Virtual Scrollbar'),
+    label: trans.__('Show Virtual Scrollbar'),
     caption: trans.__(
-      'Toggle virtual scrollbar (enabled with windowing mode: full)'
+      'Show virtual scrollbar (enabled with windowing mode: full)'
     ),
     execute: args => {
       const current = getCurrent(tracker, shell, args);
@@ -3553,6 +3553,10 @@ function addCommands(
         (args.toolbar ? true : isEnabled()) &&
         (settings?.composite.windowingMode === 'full' ?? false);
       return enabled;
+    },
+    isToggled: args => {
+      const current = getCurrent(tracker, shell, args);
+      return current?.content.scrollbar ?? false;
     },
     isVisible: args => {
       const visible =


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

This makes it easier to toggle the virtual scrollbar with the keyboard only.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Add the `notebook:toggle-virtual-scrollbar` command to the command palette

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

**Before**

![image](https://github.com/jupyterlab/jupyterlab/assets/591645/acefcc78-e8c0-4e71-9b2c-c889534924e7)


**After**

![image](https://github.com/jupyterlab/jupyterlab/assets/591645/e2bb9949-8d5a-4d81-afbc-2a9e2d4001d1)

![image](https://github.com/jupyterlab/jupyterlab/assets/591645/8fbb64dc-3a1f-4d7a-9e3e-cccbfafdb9d1)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
