### PR TITLE
Reactive toolbar: avoid simultaneous calls to _onResize()

### DIFF
--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -559,8 +559,8 @@ export class ReactiveToolbar extends Toolbar<Widget> {
     const toolbarPadding = 2 + 5;
     let width = opener.isHidden ? toolbarPadding : toolbarPadding + openerWidth;
 
-    this._getWidgetsToRemove(width, toolbarWidth, openerWidth)
-      .then(values => {
+    return this._getWidgetsToRemove(width, toolbarWidth, openerWidth)
+      .then(async values => {
         let { width, widgetsToRemove } = values;
         while (widgetsToRemove.length > 0) {
           // Insert the widget at the right position in the opener popup, relatively
@@ -626,7 +626,7 @@ export class ReactiveToolbar extends Toolbar<Widget> {
           opener.hide();
         }
         if (callTwice) {
-          void this._onResize();
+          await this._onResize();
         }
       })
       .catch(msg => {


### PR DESCRIPTION
This PR fixes an edge case where the `_onResize()` method of the `reactiveToolbar` can be called 2 times simultaneously.

Follows up https://github.com/jupyterlab/jupyterlab/pull/15553 

On the first load of a reactive toolbar, the `_onResize()` method need to be called twice, to ensure the proper organization of the widgets. But the second call was not properly awaited before this PR.
In parallel, if an item is added during the second call, the method can be invoked again and can run simultaneously, which result in conflicts in the items count and ordering (it doesn't seem to happen too often, though).

## References

Should fix https://github.com/jupyter/notebook/issues/7370

## Code changes

Add an await on the optional second call of `_onResize()`

## User-facing changes

None

## Backwards-incompatible changes

None


cc @jtpio 