### PR TITLE
Fix `Shift + Tab` contextual help inspector tooltip regression

### DIFF
--- a/galata/test/jupyterlab/inspector-tooltip.test.ts
+++ b/galata/test/jupyterlab/inspector-tooltip.test.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { expect, test } from '@jupyterlab/galata';
+
+const fileName = 'notebook.ipynb';
+const TOOLTIP_SELECTOR = '.jp-Tooltip';
+
+test.describe('Inspector (contextual help) tooltip', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.notebook.createNew(fileName);
+  });
+
+  test('Should show up on Shift + Tab', async ({ page }) => {
+    await page.notebook.setCell(0, 'code', 'int');
+    await page.notebook.enterCellEditingMode(0);
+    // Ensure the cursor is at the end of the cell, after "int"
+    await page.keyboard.press('End');
+    // Ensure kernel is ready
+    await page.locator('text=| Idle').waitFor();
+    const tooltip = page.locator(TOOLTIP_SELECTOR);
+    // There should be no tooltip yet
+    await expect(tooltip).toHaveCount(0);
+    // Invoke the tooltip
+    await page.keyboard.press('Shift+Tab');
+    // There should be a tooltip now
+    await expect(tooltip).toHaveCount(1);
+    await expect(tooltip).toContainText('int');
+  });
+});

--- a/packages/codemirror/src/commands.ts
+++ b/packages/codemirror/src/commands.ts
@@ -141,7 +141,7 @@ export namespace StateCommands {
     dispatch: (transaction: Transaction) => void;
   }): boolean {
     if (target.dom.closest(TOOLTIP_OPENER_SELECTOR)) {
-      return true;
+      return false;
     }
     return indentLess(target);
   }


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/16319

## Code changes

- [x] adds an integration test case
- [x] fixes the issue by not preventing default (i.e. not returning `true`) in the `dedentIfNotLaunchingTooltip` handler

## User-facing changes

Shift + Tab works again

## Backwards-incompatible changes

None