### PR TITLE
Fix workspace context menu incorrectly showing up in other sidebar sections

### DIFF
--- a/packages/workspaces-extension/schema/sidebar.json
+++ b/packages/workspaces-extension/schema/sidebar.json
@@ -35,12 +35,12 @@
       },
       {
         "command": "workspace-ui:import",
-        "selector": ".jp-RunningSessions:has(.jp-mod-workspace)",
+        "selector": ".jp-RunningSessions-section:has(.jp-mod-workspace)",
         "rank": 6
       },
       {
         "command": "workspace-ui:create-new",
-        "selector": ".jp-RunningSessions:has(.jp-mod-workspace)",
+        "selector": ".jp-RunningSessions-section:has(.jp-mod-workspace)",
         "rank": 7
       }
     ]


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/16345

## Code changes

Update the context menu item selector `.jp-RunningSessions` → `.jp-RunningSessions-section`

## User-facing changes

| Before | After |
|--|--|
| ![image](https://github.com/jupyterlab/jupyterlab/assets/5832902/ad07ea91-46a5-43d9-aca0-705de35e32f9) | ![Screenshot from 2024-05-20 14-11-11](https://github.com/jupyterlab/jupyterlab/assets/5832902/26cf2be8-bd7c-4013-8fe2-3a550bec5ac6) |




No changes in the workspaces section:

![image](https://github.com/jupyterlab/jupyterlab/assets/5832902/97cc92dc-4ffc-4bfb-988c-85366a813e3d)

![image](https://github.com/jupyterlab/jupyterlab/assets/5832902/c0ac0d2f-24ac-46a6-b03a-b73b0433c5cb)


## Backwards-incompatible changes

None