### PR TITLE
Fix execution in console in terminal interaction mode

### DIFF
--- a/galata/test/jupyterlab/console.test.ts
+++ b/galata/test/jupyterlab/console.test.ts
@@ -1,28 +1,34 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { expect, test } from '@jupyterlab/galata';
+import {
+  expect,
+  galata,
+  IJupyterLabPageFixture,
+  test
+} from '@jupyterlab/galata';
 
 const CELL_EDITOR_SELECTOR = '.jp-InputArea-editor';
 const CODE_MIRROR_CURSOR = '.cm-cursor';
+const EXECUTED_CELL = '[aria-label="Code Cell Content with Output"]';
+
+async function setupConsole(page: IJupyterLabPageFixture) {
+  await page.menu.clickMenuItem('File>New>Console');
+
+  await page.click('button:has-text("Select")');
+
+  await page.locator('[aria-label="Code Cell Content"]').waitFor();
+  await page.locator('text=| Idle').waitFor();
+}
 
 test.describe('Console', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.menu.clickMenuItem('File>New>Console');
-
-    await page.click('button:has-text("Select")');
-
-    await page.locator('[aria-label="Code Cell Content"]').waitFor();
-    await page.locator('text=| Idle').waitFor();
-  });
+  test.beforeEach(async ({ page }) => setupConsole(page));
 
   test('Executed cells should become read-only', async ({ page }) => {
     await page.keyboard.type('2 + 2');
     await page.keyboard.press('Shift+Enter');
 
-    const executedCell = page.locator(
-      '[aria-label="Code Cell Content with Output"]'
-    );
+    const executedCell = page.locator(EXECUTED_CELL);
     await executedCell.waitFor();
 
     const cellEditor = executedCell.locator(CELL_EDITOR_SELECTOR);
@@ -40,5 +46,29 @@ test.describe('Console', () => {
 
     // Expect the editor content to not change
     expect(await cellEditor.innerText()).toBe('2 + 2');
+  });
+});
+
+test.describe('Console (terminal mode)', () => {
+  test.use({
+    mockSettings: {
+      ...galata.DEFAULT_SETTINGS,
+      '@jupyterlab/console-extension:tracker': {
+        ...galata.DEFAULT_SETTINGS['@jupyterlab/console-extension:tracker'],
+        interactionMode: 'terminal'
+      }
+    }
+  });
+
+  test.beforeEach(async ({ page }) => setupConsole(page));
+
+  test('Cells get executed with Enter ', async ({ page }) => {
+    await page.keyboard.type('2**22');
+    await page.keyboard.press('Enter');
+
+    const executedCell = page.locator(EXECUTED_CELL);
+    await executedCell.waitFor();
+
+    await expect(executedCell).toContainText('4194304');
   });
 });

--- a/packages/codemirror/src/commands.ts
+++ b/packages/codemirror/src/commands.ts
@@ -23,6 +23,11 @@ import {
 const CODE_RUNNER_SELECTOR = '[data-jp-code-runner]';
 
 /**
+ * Selector for a widget that can run code in terminal mode.
+ */
+const TERMINAL_CODE_RUNNER_SELECTOR = '[data-jp-interaction-mode="terminal"]';
+
+/**
  * Selector for a widget that can open a tooltip.
  */
 const TOOLTIP_OPENER_SELECTOR =
@@ -75,6 +80,10 @@ export namespace StateCommands {
   }): boolean {
     if (target.dom.parentElement?.classList.contains(COMPLETER_ACTIVE_CLASS)) {
       // do not prevent default to allow completer `enter` action
+      return false;
+    }
+    if (target.dom.closest(TERMINAL_CODE_RUNNER_SELECTOR)) {
+      // do not prevent default to allow for the cell to run
       return false;
     }
 

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -42,8 +42,6 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@codemirror/state": "^6.4.1",
-    "@codemirror/view": "^6.26.3",
     "@jupyter/ydoc": "^2.0.1",
     "@jupyterlab/apputils": "^4.3.0",
     "@jupyterlab/cells": "^4.2.0",

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { Prec } from '@codemirror/state';
-import { EditorView } from '@codemirror/view';
 import { createStandaloneCell, ISharedRawCell } from '@jupyter/ydoc';
 import { DOMUtils, ISessionContext } from '@jupyterlab/apputils';
 import {
@@ -94,11 +92,6 @@ const JUPYTER_CELL_MIME = 'application/vnd.jupyter.cells';
  * The data attribute added to a widget that can undo.
  */
 const UNDOER = 'jpUndoer';
-/**
- * The data attribute Whether the console interaction mimics the notebook
- * or terminal keyboard shortcuts.
- */
-const INTERACTION_MODE = 'jpInteractionMode';
 
 /**
  * A widget containing a Jupyter console.
@@ -788,33 +781,17 @@ export class CodeConsole extends Widget {
    * Create the options used to initialize a code cell widget.
    */
   private _createCodeCellOptions(): CodeCell.IOptions {
-    const { node } = this;
     const contentFactory = this.contentFactory;
     const modelFactory = this.modelFactory;
     const model = modelFactory.createCodeCell({});
     const rendermime = this.rendermime;
     const editorConfig = this.editorConfig;
 
-    // Suppress the default "Enter" key handling.
-    const onKeyDown = EditorView.domEventHandlers({
-      keydown: (event: KeyboardEvent, view: EditorView) => {
-        if (
-          event.keyCode === 13 &&
-          node.dataset[INTERACTION_MODE] === 'terminal'
-        ) {
-          event.preventDefault();
-          return true;
-        }
-        return false;
-      }
-    });
-
     return {
       model,
       rendermime,
       contentFactory,
       editorConfig,
-      editorExtensions: [Prec.high(onKeyDown)],
       placeholder: false,
       translator: this._translator
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2670,8 +2670,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/console@workspace:packages/console"
   dependencies:
-    "@codemirror/state": ^6.4.1
-    "@codemirror/view": ^6.26.3
     "@jupyter/ydoc": ^2.0.1
     "@jupyterlab/apputils": ^4.3.0
     "@jupyterlab/cells": ^4.2.0


### PR DESCRIPTION
## References

Fixes #16339

## Code changes

- [x] adds a test for executing console cells in terminal interaction mode (should fail in first commit)
- [x] fixes the issue

## User-facing changes

Executing cells in console in terminal interaction mode works

## Backwards-incompatible changes

None
