### PR TITLE
Fix failing link check (point to  JAWS on Wikipedia)

### DIFF
--- a/docs/source/getting_started/accessibility.rst
+++ b/docs/source/getting_started/accessibility.rst
@@ -73,7 +73,7 @@ JupyterLab is not compatible with
 
 **Assistive technology:**
 
-* `JAWS <https://www.freedomscientific.com/products/software/jaws/>`_
+* `JAWS <https://en.wikipedia.org/wiki/JAWS_(screen_reader)>`_
 * `NVDA <https://assistivlabs.com/assistive-tech/screen-readers/nvda>`_
 * `VoiceOver <https://www.apple.com/accessibility/vision/>`_
 * Narrator


### PR DESCRIPTION
## References

Follow up to https://github.com/jupyterlab/jupyterlab/pull/16351

## Code changes

Change link to JAWS to point to Wikipedia as manufacturer website fails on link check

## User-facing changes

None

## Backwards-incompatible changes

None