### PR TITLE
Updated wording in "Change Kernel" settings

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -1392,9 +1392,9 @@ export class SessionContextDialogs implements ISessionContext.IDialogs {
       buttons,
       checkbox: hasCheckbox
         ? {
-            label: trans.__('Always start the preferred kernel'),
+            label: trans.__('During this session start the selected kernel'),
             caption: trans.__(
-              'Remember my choice and always start the preferred kernel'
+              'Remember my choice for the duration of this session and start the selected kernel'
             ),
             checked: autoStartDefault
           }

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -694,8 +694,8 @@
       "default": "code"
     },
     "autoStartDefaultKernel": {
-      "title": "Automatically Start Preferred Kernel",
-      "description": "Whether to automatically start the preferred kernel.",
+      "title": "Automatically Start Selected Kernel",
+      "description": "Whether to automatically start the Selected kernel. Kernel selection is made within the toolbar in the 'Kernel' window under the option 'Change Kernel...'.",
       "type": "boolean",
       "default": false
     },


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
Issue #16340 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Made the requesting wording changes to better describe the function of the checkbox within the "Change Kernel" setting.
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
When changing the kernel, user will now see the updated text next to the checkbox. Rather than using the word "Always", it now says "During" implying the selection only lasts for the duration of the session. Also changed "preferred" to "selected" to better match the wording in the rest of the popup.

For added clarity, the tooltip explicitly says, "Remember my choice for the duration of this session and start the selected kernel".

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->
Before:
![before](https://github.com/jupyterlab/jupyterlab/assets/147757414/e409ddad-3d39-45a7-8c52-67428701944f)

After:
![after](https://github.com/jupyterlab/jupyterlab/assets/147757414/8060546a-0931-419e-b548-f4bb7fa7d86a)


## Backwards-incompatible changes
N/A
