### PR TITLE
Add the toolbar again when updating the title of PanelWithToolbar

### DIFF
--- a/packages/ui-components/src/components/accordiontoolbar.ts
+++ b/packages/ui-components/src/components/accordiontoolbar.ts
@@ -64,8 +64,7 @@ class AccordionToolbarLayout extends AccordionLayout {
   }
 
   /**
-   * Function is called when updating the title. Updating the title build a new Title
-   * widget, we need to attach again the toolbar node to it.
+   * Called when a title attribute has changed, to attach again the toolbar node.
    */
   updateTitle(index: number, widget: Widget): void {
     super.updateTitle(index, widget);

--- a/packages/ui-components/src/components/accordiontoolbar.ts
+++ b/packages/ui-components/src/components/accordiontoolbar.ts
@@ -64,6 +64,15 @@ class AccordionToolbarLayout extends AccordionLayout {
   }
 
   /**
+   * Function is called when updating the title. Updating the title build a new Title
+   * widget, we need to attach again the toolbar node to it.
+   */
+  updateTitle(index: number, widget: Widget): void {
+    super.updateTitle(index, widget);
+    this._addToolbar(index, widget);
+  }
+
+  /**
    * Attach a widget to the parent's DOM node.
    *
    * @param index - The current index of the widget in the layout.
@@ -72,22 +81,7 @@ class AccordionToolbarLayout extends AccordionLayout {
    */
   protected attachWidget(index: number, widget: Widget): void {
     super.attachWidget(index, widget);
-
-    const toolbar = this._toolbars.get(widget);
-    if (toolbar) {
-      // Send a `'before-attach'` message if the parent is attached.
-      if (this.parent!.isAttached) {
-        MessageLoop.sendMessage(toolbar, Widget.Msg.BeforeAttach);
-      }
-
-      // Insert the toolbar in the title node.
-      this.titles[index].appendChild(toolbar.node);
-
-      // Send an `'after-attach'` message if the parent is attached.
-      if (this.parent!.isAttached) {
-        MessageLoop.sendMessage(toolbar, Widget.Msg.AfterAttach);
-      }
-    }
+    this._addToolbar(index, widget);
   }
 
   /**
@@ -175,6 +169,27 @@ class AccordionToolbarLayout extends AccordionLayout {
   protected onAfterDetach(msg: Message): void {
     super.onAfterDetach(msg);
     this.notifyToolbars(msg);
+  }
+
+  /**
+   * Add the toolbar to the title widget.
+   */
+  private _addToolbar(index: number, widget: Widget): void {
+    const toolbar = this._toolbars.get(widget);
+    if (toolbar) {
+      // Send a `'before-attach'` message if the parent is attached.
+      if (this.parent!.isAttached) {
+        MessageLoop.sendMessage(toolbar, Widget.Msg.BeforeAttach);
+      }
+
+      // Insert the toolbar in the title node.
+      this.titles[index].appendChild(toolbar.node);
+
+      // Send an `'after-attach'` message if the parent is attached.
+      if (this.parent!.isAttached) {
+        MessageLoop.sendMessage(toolbar, Widget.Msg.AfterAttach);
+      }
+    }
   }
 
   private notifyToolbars(msg: Message): void {

--- a/packages/ui-components/test/sidepanel.spec.ts
+++ b/packages/ui-components/test/sidepanel.spec.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { framePromise } from '@jupyterlab/testing';
+import { PanelWithToolbar, SidePanel } from '@jupyterlab/ui-components';
+import { Widget } from '@lumino/widgets';
+
+describe('#SidePanel', () => {
+  describe('AccordionToolbarLayout', () => {
+    it('should restore the toolbar when updating the title', async () => {
+      const sidebar = new SidePanel();
+      const panel = new PanelWithToolbar();
+      panel.title.label = 'Initial';
+
+      const toolbarWidget = new Widget();
+      panel.toolbar.addItem('toolbar-widget', toolbarWidget);
+
+      sidebar.addWidget(panel);
+
+      Widget.attach(sidebar, document.body);
+      await framePromise();
+
+      let title = sidebar.node.getElementsByTagName('h3').item(0);
+      expect(
+        title?.getElementsByClassName('lm-AccordionPanel-titleLabel').item(0)
+          ?.textContent
+      ).toBe('Initial');
+      expect(
+        title?.getElementsByClassName('jp-AccordionPanel-toolbar')
+      ).toHaveLength(1);
+
+      panel.title.label = 'Updated';
+      await framePromise();
+
+      title = sidebar.node.getElementsByTagName('h3').item(0);
+      expect(
+        title?.getElementsByClassName('lm-AccordionPanel-titleLabel').item(0)
+          ?.textContent
+      ).toBe('Updated');
+      expect(
+        title?.getElementsByClassName('jp-AccordionPanel-toolbar')
+      ).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
This PR restore the toolbar of a `PanelWithToolbar` when the title is updated.

When any update occurs on a Lumino `AccordionPanel`, the title node is built from scratch https://github.com/jupyterlab/lumino/blob/63a0e8d581795342a1d416c8a47d344b3f5f4743/packages/widgets/src/accordionlayout.ts#L80

But the toolbar of a panel with toolbar is only added when the panel is attached the first time https://github.com/jupyterlab/jupyterlab/blob/b2ff3fbbe60e1d08d23f6a4738d4f2d76f175152/packages/ui-components/src/components/accordiontoolbar.ts#L84

After this PR, the toolbar node is attached to the new title node after update.

## References

None

## Code changes

- adds an `updateTitle()` function in `AccordionToolbarLayout` to restore the toolbar after any update in the title.
- add a test on it.

## User-facing changes

None

## Backwards-incompatible changes

None
