### PR TITLE
Implement viewport tracking and reactive rendering in scrollbar

### DIFF
--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -474,16 +474,14 @@ div.jp-Cell-Placeholder-content-3 {
 | Virtual scrollbar
 |----------------------------------------------------------------------------*/
 
-.jp-Notebook
-  .jp-WindowedPanel-scrollbar-content
-  .jp-mod-active.jp-mod-selected {
-  background: var(--jp-brand-color1);
-  color: var(--jp-ui-inverse-font-color1);
-}
-
 .jp-Notebook .jp-WindowedPanel-scrollbar-content .jp-mod-selected {
   background: var(--jp-brand-color2);
   color: var(--jp-ui-inverse-font-color2);
+}
+
+.jp-Notebook .jp-WindowedPanel-scrollbar-content .jp-mod-active {
+  background: var(--jp-brand-color1);
+  color: var(--jp-ui-inverse-font-color1);
 }
 
 /*-----------------------------------------------------------------------------

--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -1284,7 +1284,7 @@ export class WindowedList<
         const scrollbarItems = this._renderScrollbar();
         const first = scrollbarItems[firstVisibleIndex];
         const last = scrollbarItems[lastVisibleIndex];
-        this._viewportIndicator.style.top = first.offsetTop + 'px';
+        this._viewportIndicator.style.top = (first.offsetTop - 1) + 'px';
         this._viewportIndicator.style.height =
           last.offsetTop - first.offsetTop + last.offsetHeight + 'px';
       }

--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -1284,7 +1284,7 @@ export class WindowedList<
         const scrollbarItems = this._renderScrollbar();
         const first = scrollbarItems[firstVisibleIndex];
         const last = scrollbarItems[lastVisibleIndex];
-        this._viewportIndicator.style.top = (first.offsetTop - 1) + 'px';
+        this._viewportIndicator.style.top = first.offsetTop - 1 + 'px';
         this._viewportIndicator.style.height =
           last.offsetTop - first.offsetTop + last.offsetHeight + 'px';
       }

--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -792,6 +792,13 @@ export class WindowedList<
     const scrollbarElement = node.appendChild(document.createElement('div'));
     scrollbarElement.classList.add('jp-WindowedPanel-scrollbar');
 
+    const indicator = scrollbarElement.appendChild(
+      renderer.createScrollbarViewportIndicator
+        ? renderer.createScrollbarViewportIndicator()
+        : WindowedList.defaultRenderer.createScrollbarViewportIndicator()
+    );
+    indicator.classList.add('jp-WindowedPanel-scrollbar-viewportIndicator');
+
     const list = scrollbarElement.appendChild(renderer.createScrollbar());
     list.classList.add('jp-WindowedPanel-scrollbar-content');
 
@@ -810,6 +817,7 @@ export class WindowedList<
     super.layout = options.layout ?? new WindowedLayout();
     this.renderer = renderer;
 
+    this._viewportIndicator = indicator;
     this._innerElement = innerElement;
     this._isScrolling = null;
     this._outerElement = outerElement;
@@ -828,6 +836,7 @@ export class WindowedList<
 
     this.viewModel.stateChanged.connect(this.onStateChanged, this);
   }
+  private _viewportIndicator: HTMLElement;
 
   /**
    * Whether the parent is hidden or not.
@@ -1134,9 +1143,6 @@ export class WindowedList<
    * The default implementation of this handler is a no-op.
    */
   protected onUpdateRequest(msg: Message): void {
-    if (this.scrollbar) {
-      this._renderScrollbar();
-    }
     if (this.viewModel.windowingActive) {
       // Throttle update request
       if (this._scrollRepaint === null) {
@@ -1271,7 +1277,18 @@ export class WindowedList<
     const newWindowIndex = this.viewModel.getRangeToRender();
 
     if (newWindowIndex !== null) {
-      const [startIndex, stopIndex] = newWindowIndex;
+      const [startIndex, stopIndex, firstVisibleIndex, lastVisibleIndex] =
+        newWindowIndex;
+
+      if (this.scrollbar) {
+        const scrollbarItems = this._renderScrollbar();
+        const first = scrollbarItems[firstVisibleIndex];
+        const last = scrollbarItems[lastVisibleIndex];
+        this._viewportIndicator.style.top = first.offsetTop + 'px';
+        this._viewportIndicator.style.height =
+          last.offsetTop - first.offsetTop + last.offsetHeight + 'px';
+      }
+
       const toAdd: Widget[] = [];
       if (stopIndex >= 0) {
         for (let index = startIndex; index <= stopIndex; index++) {
@@ -1438,24 +1455,67 @@ export class WindowedList<
   /**
    * Render virtual scrollbar.
    */
-  private _renderScrollbar(): void {
+  private _renderScrollbar(): HTMLElement[] {
     const { node, renderer, viewModel } = this;
     const content = node.querySelector('.jp-WindowedPanel-scrollbar-content')!;
 
-    while (content.firstChild) {
-      content.removeChild(content.firstChild);
-    }
+    const elements: HTMLElement[] = [];
+
+    const getElement = (
+      item: ReturnType<WindowedList.IRenderer['createScrollbarItem']>,
+      index: number
+    ) => {
+      if (item instanceof HTMLElement) {
+        return item;
+      } else {
+        visitedKeys.add(item.key);
+        const props = { index };
+        const cachedItem = this._scrollbarItems[item.key];
+        if (cachedItem && !cachedItem.isDisposed) {
+          return cachedItem.render(props);
+        } else {
+          this._scrollbarItems[item.key] = item;
+          const element = item.render(props);
+          return element;
+        }
+      }
+    };
 
     const list = viewModel.itemsList;
     const count = list?.length ?? viewModel.widgetCount;
+    const visitedKeys = new Set<string>();
     for (let index = 0; index < count; index += 1) {
-      const item = list?.get?.(index);
-      const element = renderer.createScrollbarItem(this, index, item);
+      const model = list?.get?.(index);
+      const item = renderer.createScrollbarItem(this, index, model);
+      const element: HTMLElement = getElement(item, index);
       element.classList.add('jp-WindowedPanel-scrollbar-item');
       element.dataset.index = `${index}`;
-      content.appendChild(element);
+      elements.push(element);
     }
+
+    // dispose of any elements which are no longer in the scrollbar
+    const keysNotSeen = Object.keys(this._scrollbarItems).filter(
+      key => !visitedKeys.has(key)
+    );
+    for (const key of keysNotSeen) {
+      this._scrollbarItems[key].dispose();
+      delete this._scrollbarItems[key];
+    }
+
+    const oldNodes = [...content.childNodes];
+    if (
+      oldNodes.length !== elements.length ||
+      !oldNodes.every((node, index) => elements[index] === node)
+    ) {
+      content.replaceChildren(...elements);
+    }
+
+    return elements;
   }
+  private _scrollbarItems: Record<
+    string,
+    WindowedList.IRenderer.IScrollbarItem
+  > = {};
 
   /**
    * Handle `pointerdown` events on the virtual scrollbar.
@@ -1680,6 +1740,13 @@ export namespace WindowedList {
      */
     createScrollbar(): HTMLOListElement {
       return document.createElement('ol');
+    }
+
+    /**
+     * Create the virtual scrollbar viewport indicator.
+     */
+    createScrollbarViewportIndicator(): HTMLElement {
+      return document.createElement('div');
     }
 
     /**
@@ -1944,18 +2011,43 @@ export namespace WindowedList {
     createScrollbar(): HTMLElement;
 
     /**
+     * Create the virtual scrollbar viewport indicator.
+     */
+    createScrollbarViewportIndicator?(): HTMLElement;
+
+    /**
      * Create an individual item rendered in the scrollbar.
      */
     createScrollbarItem(
       list: WindowedList,
       index: number,
       item: T | undefined
-    ): HTMLElement;
+    ): HTMLElement | IRenderer.IScrollbarItem;
 
     /**
      * Create the viewport element into which virtualized children are added.
      */
     createViewport(): HTMLElement;
+  }
+
+  /**
+   * Renderer statics.
+   */
+  export namespace IRenderer {
+    /**
+     * Scrollbar item.
+     */
+    export interface IScrollbarItem extends IDisposable {
+      /**
+       * Render the scrollbar item as an HTML element.
+       */
+      render: (props: { index: number }) => HTMLElement;
+
+      /**
+       * Unique item key used for caching.
+       */
+      key: string;
+    }
   }
 
   /**

--- a/packages/ui-components/style/windowedlist.css
+++ b/packages/ui-components/style/windowedlist.css
@@ -22,6 +22,7 @@
 
 .jp-WindowedPanel-scrollbar {
   display: none;
+  position: relative;
 }
 
 .jp-WindowedPanel.jp-mod-virtual-scrollbar > .jp-WindowedPanel-scrollbar {
@@ -30,6 +31,7 @@
   display: block;
   position: fixed;
   overflow-y: auto;
+  overflow-x: hidden;
   top: 0;
   bottom: 0;
   right: 0;
@@ -38,19 +40,33 @@
 }
 
 .jp-WindowedPanel-scrollbar-content {
-  background-color: var(--jp-layout-color1);
+  background-color: transparent;
   list-style-type: none;
   margin: 0;
   padding: 0;
+  position: relative;
+  z-index: 3;
 }
 
 .jp-WindowedPanel-scrollbar-content > .jp-WindowedPanel-scrollbar-item {
   border-bottom: 1px solid var(--jp-layout-color3);
+  background-color: rgb(from var(--jp-layout-color1) r g b / 50%);
   padding: 2px;
   text-align: left;
+  margin: 2px;
 }
 
 .jp-WindowedPanel-scrollbar-content > .jp-WindowedPanel-scrollbar-item:hover {
   cursor: pointer;
-  background-color: var(--jp-layout-color2);
+  background-color: var(--jp-layout-color3);
+}
+
+.jp-WindowedPanel-scrollbar-viewportIndicator {
+  position: absolute;
+  background: var(--jp-layout-color2);
+  border: 1px solid var(--jp-layout-color4);
+  width: 100%;
+  z-index: 2;
+  border-radius: 2px;
+  box-sizing: border-box;
 }

--- a/packages/ui-components/style/windowedlist.css
+++ b/packages/ui-components/style/windowedlist.css
@@ -53,7 +53,7 @@
   background-color: rgb(from var(--jp-layout-color1) r g b / 50%);
   padding: 2px;
   text-align: left;
-  margin: 2px;
+  margin: 0 2px;
 }
 
 .jp-WindowedPanel-scrollbar-content > .jp-WindowedPanel-scrollbar-item:hover {


### PR DESCRIPTION
## References

- a step towards https://github.com/jupyterlab/jupyterlab/issues/16332

## Code changes

- `WindowedList.IRenderer.createScrollbarItem` can now return either `HTMLElement` (as before) or `IScrollbarItem` defined as:
  ```ts
  interface IScrollbarItem extends IDisposable {
    /**
     * Render the scrollbar item as an HTML element.
     */
    render: (props: { index: number }) => HTMLElement;
  
    /**
     * Unique item key used for caching.
     */
    key: string;
  }
  ```
- The entire scrollbar is no longer re-rendered on each update of the notebook; this enables adding more reactive information and updating only the cells that have changed; instead `IScrollbarItem.render` is called to modify the node reactively
- a new viewport indicator element is added which shows which cells are visible in the viewport (styling subject to change); this element is independent of cells to avoid scrolling causing re-render of items

## User-facing changes

![viewport-indicator](https://github.com/jupyterlab/jupyterlab/assets/5832902/02af61a0-1358-486f-83a9-55a7c5f2eca7)


## Backwards-incompatible changes

None