### PR TITLE
Support collaborative stdin output

### DIFF
--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -69,7 +69,8 @@
     "@lumino/signaling": "^2.1.2",
     "@lumino/virtualdom": "^2.0.1",
     "@lumino/widgets": "^2.3.2",
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "yjs": "^13.5.40"
   },
   "devDependencies": {
     "@jupyterlab/testing": "^4.3.0-alpha.0",

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -3,9 +3,9 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-import { Extension } from '@codemirror/state';
+import { Extension, StateCommand } from '@codemirror/state';
 
-import { EditorView } from '@codemirror/view';
+import { EditorView, KeyBinding, keymap } from '@codemirror/view';
 
 import { ElementExt } from '@lumino/domutils';
 
@@ -20,6 +20,10 @@ import { CodeEditor, CodeEditorWrapper } from '@jupyterlab/codeeditor';
 import { DirListing } from '@jupyterlab/filebrowser';
 
 import * as nbformat from '@jupyterlab/nbformat';
+
+import * as Y from 'yjs';
+
+import { ybinding } from '@jupyterlab/codemirror';
 
 import {
   IOutputPrompt,
@@ -39,7 +43,7 @@ import {
 
 import { Kernel, KernelMessage } from '@jupyterlab/services';
 
-import { IMapChange } from '@jupyter/ydoc';
+import { IMapChange, YCodeCell } from '@jupyter/ydoc';
 
 import { TableOfContentsUtils } from '@jupyterlab/toc';
 
@@ -182,6 +186,14 @@ const RENDER_TIMEOUT = 1000;
  * The mime type for a rich contents drag object.
  */
 const CONTENTS_MIME_RICH = 'application/x-jupyter-icontentsrich';
+
+const OUTPUT_AREA_ITEM_CLASS = 'jp-OutputArea-child';
+const OUTPUT_AREA_STDIN_ITEM_CLASS = 'jp-OutputArea-stdin-item';
+const OUTPUT_AREA_PROMPT_CLASS = 'jp-OutputArea-prompt';
+const OUTPUT_AREA_OUTPUT_CLASS = 'jp-OutputArea-output';
+const STDIN_CLASS = 'jp-Stdin';
+const STDIN_PROMPT_CLASS = 'jp-Stdin-prompt';
+const STDIN_INPUT_CLASS = 'jp-Stdin-input';
 
 /** ****************************************************************************
  * Cell
@@ -1100,7 +1112,53 @@ export class CodeCell extends Cell<ICodeCellModel> {
     model.outputs.changed.connect(this.onOutputChanged, this);
     model.outputs.stateChanged.connect(this.onOutputChanged, this);
     model.stateChanged.connect(this.onStateChanged, this);
+    model.sharedModel.changed.connect(this.handleStdin, this);
+    const youtputs = (model.sharedModel as YCodeCell).ymodel.get('outputs');
+    for (const youtput of youtputs) {
+      if (youtput instanceof Y.Map && youtput.get('output_type') === 'stdin') {
+        const prompt = youtput.get('prompt');
+        const password = youtput.get('password');
+        this.createInputWidget(prompt, password, youtput);
+      }
+    }
   }
+
+  handleStdin(sender: any, args: any): void {
+    if (
+      args.outputsChange !== undefined &&
+      args.outputsChange[0].insert !== undefined
+    ) {
+      const newOutput = args.outputsChange[0].insert[0];
+      const output_type = newOutput.get('output_type');
+      if (output_type === 'stdin') {
+        const prompt = newOutput.get('prompt');
+        const password = newOutput.get('password');
+        this.createInputWidget(prompt, password, newOutput);
+      }
+    }
+  }
+
+  createInputWidget = (
+    prompt: string,
+    password: boolean,
+    stdinOutput: Y.Map<any>
+  ) => {
+    const inputWidget = new InputWidget(
+      prompt,
+      password,
+      stdinOutput,
+      (this.model.sharedModel as YCodeCell).awareness
+    );
+    const panel = new Panel();
+    panel.addClass(OUTPUT_AREA_ITEM_CLASS);
+    panel.addClass(OUTPUT_AREA_STDIN_ITEM_CLASS);
+    const outputPrompt = new OutputPrompt();
+    outputPrompt.addClass(OUTPUT_AREA_PROMPT_CLASS);
+    panel.addWidget(outputPrompt);
+    inputWidget.addClass(OUTPUT_AREA_OUTPUT_CLASS);
+    panel.addWidget(inputWidget);
+    this.outputArea.layout.addWidget(panel);
+  };
 
   /**
    * Detect the movement of the caret in the output area.
@@ -2564,4 +2622,45 @@ export namespace RawCell {
    * An options object for initializing a base cell widget.
    */
   export interface IOptions extends Cell.IOptions<IRawCellModel> {}
+}
+
+class InputWidget extends Widget {
+  constructor(
+    prompt: string,
+    password: boolean,
+    stdinOutput: any,
+    awareness: any
+  ) {
+    const node = document.createElement('div');
+    const promptNode = document.createElement('pre');
+    promptNode.className = STDIN_PROMPT_CLASS;
+    promptNode.textContent = prompt;
+    const input1 = document.createElement('div');
+    input1.className = STDIN_INPUT_CLASS;
+    input1.style.border = 'thin solid';
+    const input2 = document.createElement('div');
+    if (password === true) {
+      (input2.style as any).webkitTextSecurity = 'disc';
+    }
+    input1.appendChild(input2);
+    node.appendChild(promptNode);
+    promptNode.appendChild(input1);
+    const stdin = stdinOutput.get('value');
+    const ybind = ybinding({ ytext: stdin });
+    const submit: StateCommand = ({ state, dispatch }) => {
+      stdinOutput.set('submitted', true);
+      return true;
+    };
+    const submitWithEnter: KeyBinding = {
+      key: 'Enter',
+      run: submit
+    };
+    new EditorView({
+      doc: stdin.toString(),
+      extensions: [keymap.of([submitWithEnter]), ybind],
+      parent: input2
+    });
+    super({ node });
+    this.addClass(STDIN_CLASS);
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2467,6 +2467,7 @@ __metadata:
     react: ^18.2.0
     rimraf: ~5.0.5
     typescript: ~5.1.6
+    yjs: ^13.5.40
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## References

In https://github.com/jupyterlab/jupyter-collaboration/pull/307 and [jupyter-server-nbmodel](https://github.com/datalayer/jupyter-server-nbmodel), @fcollonval and @echarles are working on adding support for input requests in server-side execution. While the proposed solution is an improvement over the [initial PR](https://github.com/jupyterlab/jupyter-collaboration/pull/279), it is not based on CRDTs and thus suffers from not being recoverable: if a user closes their browser window after executing a cell with an input request, and reopens it, the input widget is not displayed and the notebook is deadlocked. Also, the input widget is only shown to the user who executed the cell.
This PR goes all the way with a CRDT-based input widget, making it recoverable and collaborative, as shown below:

https://github.com/jupyterlab/jupyterlab/assets/4711805/b0951037-968a-42b9-829e-fee368f8e7bc

This currently works with Jupyverse (through [this PR](https://github.com/jupyter-server/jupyverse/pull/415)), but the changes here shouldn't have any effect when not running in server-side execution mode.
When implemented in [jupyter-server](https://github.com/jupyter-server/jupyter_server), this PR will be needed: https://github.com/jupyter-server/jupyter_ydoc/pull/233.

## Code changes

The cell shared model outputs are watched and if an output of type `stdin` is added, a CodeMirror input widget is shown. When the input is entered, the stdin output's `submitted` field is set to `true`.
The backend watches the stdin output, and when the `submitted` field is set to `true`, it replaces the `stdin` output with a `stream` output.

## User-facing changes

The user can use inputs in server-side execution. Inputs are collaborative and recoverable.

## Backwards-incompatible changes

None.