### PR TITLE
Reactive toolbar computation, again...

### DIFF
--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -640,14 +640,14 @@ export class ReactiveToolbar extends Toolbar<Widget> {
     openerWidth: number
   ) {
     const opener = this.popupOpener;
-    const layout = this.layout as ToolbarLayout;
-    const toIndex = layout.widgets.length - 1;
+    const widgets = [...(this.layout as ToolbarLayout).widgets];
+    const toIndex = widgets.length - 1;
 
     const widgetsToRemove = [];
 
     let index = 0;
     while (index < toIndex) {
-      const widget = layout.widgets[index];
+      const widget = widgets[index];
       const name = Private.nameProperty.get(widget);
       // Compute the widget size only if
       // - the zoom has changed.


### PR DESCRIPTION
There is still an issue with the reactive toolbar, which can occur when an item is inserted during `_onResize()` execution.

https://github.com/jupyter/notebook/issues/7370#issuecomment-2128791005

This PR uses a static view of the items in the layout, to avoid some changes in the items list during computation.

A way to fix it is to make a copy of the existing items before starting computation, and use only that copy instead of the widget in the layout (that may change).

## References

Should fix https://github.com/jupyter/notebook/issues/7370.

## Code changes

Copy the list of widgets in the toolbar layout to avoid issue if the widgets list change during computation.

## User-facing changes

None

## Backwards-incompatible changes

None

cc. @jtpio 