### PR TITLE
Comments in nested markdown code blocks incorrectly being identified as TOC headings

### DIFF
--- a/packages/toc/src/utils/markdown.ts
+++ b/packages/toc/src/utils/markdown.ts
@@ -75,6 +75,7 @@ export function getHeadings(text: string): IMarkdownHeading[] {
   // Iterate over the lines to get the header level and text for each line:
   const headings = new Array<IMarkdownHeading>();
   let isCodeBlock;
+  let startBackticks = 0;
   let lineIdx = 0;
 
   // Don't check for Markdown headings if in a YAML frontmatter block.
@@ -105,7 +106,16 @@ export function getHeadings(text: string): IMarkdownHeading[] {
 
     // Don't check for Markdown headings if in a code block
     if (line.startsWith('```')) {
-      isCodeBlock = !isCodeBlock;
+      const endBackticks = extractLeadingBackticks(line);
+      if (endBackticks === 0) continue;
+      else if (startBackticks === 0) {
+        isCodeBlock = !isCodeBlock;
+        startBackticks = endBackticks;
+        continue;
+      } else if (endBackticks !== 0 && endBackticks >= startBackticks) {
+        isCodeBlock = !isCodeBlock;
+        startBackticks = 0;
+      }
     }
     if (isCodeBlock) {
       continue;
@@ -121,6 +131,11 @@ export function getHeadings(text: string): IMarkdownHeading[] {
     }
   }
   return headings;
+}
+
+function extractLeadingBackticks(line: string) {
+  const match = line.match(/^(`{3,})/);
+  return match ? match[0].length : 0;
 }
 
 const MARKDOWN_MIME_TYPE = [

--- a/packages/toc/src/utils/markdown.ts
+++ b/packages/toc/src/utils/markdown.ts
@@ -106,13 +106,13 @@ export function getHeadings(text: string): IMarkdownHeading[] {
 
     // Don't check for Markdown headings if in a code block
     if (line.startsWith('```')) {
-      const endBackticks = extractLeadingBackticks(line);
-      if (endBackticks === 0) continue;
+      const backticks = extractLeadingBackticks(line);
+      if (backticks === 0) continue;
       else if (startBackticks === 0) {
         isCodeBlock = !isCodeBlock;
-        startBackticks = endBackticks;
+        startBackticks = backticks;
         continue;
-      } else if (endBackticks !== 0 && endBackticks >= startBackticks) {
+      } else if (backticks !== 0 && backticks >= startBackticks) {
         isCodeBlock = !isCodeBlock;
         startBackticks = 0;
       }

--- a/packages/toc/test/markdown.spec.ts
+++ b/packages/toc/test/markdown.spec.ts
@@ -323,6 +323,48 @@ front: matter
       });
     });
 
+    it.each<[string, TableOfContentsUtils.Markdown.IMarkdownHeading[]]>([
+      [
+        '# Title',
+        [
+          {
+            text: 'Title',
+            level: 1,
+            line: 0,
+            raw: '# Title',
+            prefix: '1. ',
+            skip: false
+          }
+        ]
+      ],
+      ['````\n```# Title-1\n```\n````', []],
+      [
+        '````\n```# Title-1\n```\n````\n# Title-2\n````\n`````',
+        [
+          {
+            text: 'Title-2',
+            level: 1,
+            line: 4,
+            raw: '# Title-2',
+            prefix: '1. ',
+            skip: false
+          }
+        ]
+      ]
+    ])('should skip the heading from %s', (src, headers) => {
+      const headings = TableOfContentsUtils.filterHeadings(
+        TableOfContentsUtils.Markdown.getHeadings(src),
+        {
+          maximalDepth: 6,
+          numberHeaders: true
+        }
+      );
+      expect(headings).toHaveLength(headers.length);
+      for (let i = 0; i < headers.length; i++) {
+        expect(headings[i]).toEqual(headers[i]);
+      }
+    });
+
     it.each<[string]>([
       ['### Title <a class="tocSkip"></a>'],
       ['### Title <a title="noisy title" class="jp-toc-ignore"></a>'],

--- a/packages/toc/test/markdown.spec.ts
+++ b/packages/toc/test/markdown.spec.ts
@@ -351,7 +351,7 @@ front: matter
           }
         ]
       ]
-    ])('should skip the heading from %s', (src, headers) => {
+    ])('should verify comments in nested codeblocks in %s', (src, headers) => {
       const headings = TableOfContentsUtils.filterHeadings(
         TableOfContentsUtils.Markdown.getHeadings(src),
         {


### PR DESCRIPTION
Fix for https://github.com/jupyterlab/jupyterlab/issues/16403