### PR TITLE
Fix some flaky ui tests 

### DIFF
--- a/galata/src/helpers/notebook.ts
+++ b/galata/src/helpers/notebook.ts
@@ -1259,7 +1259,8 @@ export class NotebookHelper {
     }
 
     await this._setCellMode(cell, 'Edit');
-    await cell.getByRole('textbox').fill(source);
+    await cell.getByRole('textbox').press('Control+A');
+    await cell.getByRole('textbox').pressSequentially(source);
     await this._setCellMode(cell, 'Command');
 
     if (cellType === 'code') {

--- a/galata/src/helpers/notebook.ts
+++ b/galata/src/helpers/notebook.ts
@@ -1259,8 +1259,7 @@ export class NotebookHelper {
     }
 
     await this._setCellMode(cell, 'Edit');
-    await cell.getByRole('textbox').press('Control+A');
-    await cell.getByRole('textbox').type(source, { delay: 0 });
+    await cell.getByRole('textbox').fill(source);
     await this._setCellMode(cell, 'Command');
 
     if (cellType === 'code') {

--- a/galata/test/documentation/extension_manager.test.ts
+++ b/galata/test/documentation/extension_manager.test.ts
@@ -89,7 +89,7 @@ test.describe('Extension Manager', () => {
     await page
       .locator('.jp-extensionmanager-view')
       .getByRole('searchbox')
-      .type('drawio');
+      .fill('drawio');
 
     await page.evaluate(() => {
       (document.activeElement as HTMLElement).blur();

--- a/galata/test/jupyterlab/console.test.ts
+++ b/galata/test/jupyterlab/console.test.ts
@@ -42,7 +42,7 @@ test.describe('Console', () => {
     await expect.soft(cursor).toBeHidden();
 
     // Try to type something into the editor
-    await cellEditor.type('more text');
+    await cellEditor.pressSequentially('more text');
 
     // Expect the editor content to not change
     expect(await cellEditor.innerText()).toBe('2 + 2');

--- a/galata/test/jupyterlab/notebook-max-outputs.test.ts
+++ b/galata/test/jupyterlab/notebook-max-outputs.test.ts
@@ -20,7 +20,7 @@ test('Limit cell outputs', async ({ page }) => {
 
   await page.locator(
     '.jp-Cell-inputArea >> .cm-editor >> .cm-content[contenteditable="true"]'
-  ).type(`from IPython.display import display, Markdown
+  ).fill(`from IPython.display import display, Markdown
 
 for i in range(10):
     display(Markdown('_Markdown_ **text**'))
@@ -39,7 +39,7 @@ test("Don't limit cell outputs if input is requested", async ({ page }) => {
 
   await page.locator(
     '.jp-Cell-inputArea >> .cm-editor >> .cm-content[contenteditable="true"]'
-  ).type(`from IPython.display import display, Markdown
+  ).fill(`from IPython.display import display, Markdown
 
 for i in range(10):
     display(Markdown('_Markdown_ **text**'))
@@ -61,7 +61,7 @@ test('Display input value', async ({ page }) => {
 
   await page.locator(
     '.jp-Cell-inputArea >> .cm-editor >> .cm-content[contenteditable="true"]'
-  ).type(`from IPython.display import display, Markdown
+  ).fill(`from IPython.display import display, Markdown
 
 for i in range(10):
     display(Markdown('_Markdown_ **text**'))

--- a/galata/test/jupyterlab/notebook-search.test.ts
+++ b/galata/test/jupyterlab/notebook-search.test.ts
@@ -61,8 +61,8 @@ test.describe('Notebook Search', () => {
 
     await page.fill('[placeholder="Find"]', '14');
     await page.press('[placeholder="Find"]', 'ArrowLeft');
-    await page.type('[placeholder="Find"]', '2');
-    await page.type('[placeholder="Find"]', '3');
+    await page.locator('[placeholder="Find"]').pressSequentially('2');
+    await page.locator('[placeholder="Find"]').pressSequentially('3');
 
     await expect(page.locator('[placeholder="Find"]')).toHaveValue('1234');
   });

--- a/galata/test/jupyterlab/settings.test.ts
+++ b/galata/test/jupyterlab/settings.test.ts
@@ -52,7 +52,7 @@ test.describe('change font-size', () => {
     markdownFile: Locator
   ) => {
     await markdownFile.focus();
-    await markdownFile.type('markdown cell');
+    await markdownFile.pressSequentially('markdown cell');
     await page.keyboard.press('Control');
     await page.keyboard.press('s');
   };
@@ -214,7 +214,7 @@ test('Check codemirror settings can all be set at the same time.', async ({
     'Highlight trailing white space',
     'Highlight white space'
   ];
-  let locators = [];
+  let locators: Locator[] = [];
   for (const selectText of textList) {
     let locator = page.getByLabel(selectText);
     await locator.click();

--- a/galata/test/jupyterlab/texteditor.test.ts
+++ b/galata/test/jupyterlab/texteditor.test.ts
@@ -57,7 +57,6 @@ test.describe('Text Editor Tests', () => {
 
     await page.locator(`[role="main"] >> text=${DEFAULT_NAME}`).waitFor();
 
-    await page.pause();
     await page
       .locator('.jp-FileEditorCodeWrapper .cm-content')
       .pressSequentially(

--- a/galata/test/jupyterlab/texteditor.test.ts
+++ b/galata/test/jupyterlab/texteditor.test.ts
@@ -31,9 +31,9 @@ test.describe('Text Editor Tests', () => {
 
     // Add two rulers
     await page.locator('#root').getByRole('button', { name: 'Add' }).click();
-    await page.locator('input[id="root_rulers_0"]').type('50');
+    await page.locator('input[id="root_rulers_0"]').fill('50');
     await page.locator('#root').getByRole('button', { name: 'Add' }).click();
-    await page.locator('input[id="root_rulers_1"]').type('75');
+    await page.locator('input[id="root_rulers_1"]').fill('75');
 
     await page.activity.activateTab(DEFAULT_NAME);
 
@@ -57,10 +57,12 @@ test.describe('Text Editor Tests', () => {
 
     await page.locator(`[role="main"] >> text=${DEFAULT_NAME}`).waitFor();
 
-    await page.type(
-      '.cm-content',
-      'Not active\nActive line with >>selected text<<\nNot active'
-    );
+    await page.pause();
+    await page
+      .locator('.jp-FileEditorCodeWrapper .cm-content')
+      .pressSequentially(
+        'Not active\nActive line with >>selected text<<\nNot active'
+      );
 
     await page.keyboard.press('ArrowUp');
     await page.keyboard.press('End');
@@ -80,16 +82,17 @@ test.describe('Text Editor Tests', () => {
 
     await page.locator(`[role="main"] >> text=${DEFAULT_NAME}`).waitFor();
 
-    await page.type(
-      '.cm-content',
-      `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam urna
+    await page
+      .locator('.jp-FileEditorCodeWrapper .cm-content')
+      .pressSequentially(
+        `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam urna
 libero, dictum a egestas non, placerat vel neque. In imperdiet iaculis fermentum.
 Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia
 Curae; Cras augue tortor, tristique vitae varius nec, dictum eu lectus. Pellentesque
 id eleifend eros. In non odio in lorem iaculis sollicitudin. In faucibus ante ut
 arcu fringilla interdum. Maecenas elit nulla, imperdiet nec blandit et, consequat
 ut elit.`
-    );
+      );
 
     await page.evaluate(async () => {
       await window.jupyterapp.commands.execute('fileeditor:go-to-line', {
@@ -118,7 +121,9 @@ ut elit.`
       await page.menu.clickMenuItem('File>New>Text File');
 
       await page.locator(`[role="main"] >> text=${DEFAULT_NAME}`).waitFor();
-      await page.type('.cm-content', 'text editor');
+      await page
+        .locator('.jp-FileEditorCodeWrapper .cm-content')
+        .fill('text editor');
     };
     const changeFontSize = async (page: IJupyterLabPageFixture, menuOption) => {
       await page.click('text=Settings');

--- a/galata/test/jupyterlab/texteditor.test.ts
+++ b/galata/test/jupyterlab/texteditor.test.ts
@@ -59,9 +59,7 @@ test.describe('Text Editor Tests', () => {
 
     await page
       .locator('.jp-FileEditorCodeWrapper .cm-content')
-      .pressSequentially(
-        'Not active\nActive line with >>selected text<<\nNot active'
-      );
+      .fill('Not active\nActive line with >>selected text<<\nNot active');
 
     await page.keyboard.press('ArrowUp');
     await page.keyboard.press('End');
@@ -81,17 +79,15 @@ test.describe('Text Editor Tests', () => {
 
     await page.locator(`[role="main"] >> text=${DEFAULT_NAME}`).waitFor();
 
-    await page
-      .locator('.jp-FileEditorCodeWrapper .cm-content')
-      .pressSequentially(
-        `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam urna
+    await page.locator('.jp-FileEditorCodeWrapper .cm-content').fill(
+      `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam urna
 libero, dictum a egestas non, placerat vel neque. In imperdiet iaculis fermentum.
 Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia
 Curae; Cras augue tortor, tristique vitae varius nec, dictum eu lectus. Pellentesque
 id eleifend eros. In non odio in lorem iaculis sollicitudin. In faucibus ante ut
 arcu fringilla interdum. Maecenas elit nulla, imperdiet nec blandit et, consequat
 ut elit.`
-      );
+    );
 
     await page.evaluate(async () => {
       await window.jupyterapp.commands.execute('fileeditor:go-to-line', {

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -689,7 +689,7 @@ function addCommands(
   });
 
   commands.addCommand(CommandIDs.newUntitled, {
-    execute: args => {
+    execute: async args => {
       const errorTitle = (args['error'] as string) || trans.__('Error');
       const path =
         typeof args['path'] === 'undefined' ? '' : (args['path'] as string);
@@ -710,7 +710,7 @@ function addCommands(
   });
 
   commands.addCommand(CommandIDs.open, {
-    execute: args => {
+    execute: async args => {
       const path =
         typeof args['path'] === 'undefined' ? '' : (args['path'] as string);
       const factory = (args['factory'] as string) || void 0;


### PR DESCRIPTION
This PR may fix some flaky UI tests.

- replace some of the deprecated `Locator.type()` with `Locator.fill()`, to try to fix some tests writing in the cell input.
For example `test/jupyterlab/notebook-max-outputs.test.ts:37:5 › Don't limit cell outputs if input is requested` often fails due to indentation error in cell input.

![image](https://github.com/jupyterlab/jupyterlab/assets/32258950/8036193a-3e57-4b59-b1d8-31a61bd4e282)

In the screenshot above, the input should [not be indented](https://github.com/jupyterlab/jupyterlab/blob/228bd651ec924a2c5c8c1443bb5188c904e18ef3/galata/test/jupyterlab/notebook-max-outputs.test.ts#L47)

- set `'docmanager:open'` as `async`, according to VSCode warning "*This may be converted to an async function.ts(80006)*". 
  Not sure to understand why, but it seems to fix (locally) `test/jupyterlab/settings.test.ts:129:7 › change font-size › should Increase Content Font Size` and `test/jupyterlab/settings.test.ts:129:7 › change font-size › should Decrease Content Font Size`, which also often fails withe the following error:

![image](https://github.com/jupyterlab/jupyterlab/assets/32258950/f019d644-2d4f-46bf-86c8-0f601dc6a5eb)


## References

related to https://github.com/jupyterlab/jupyterlab/issues/14947

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None
