### PR TITLE
Define `ICodeCellModel.executionState`, deprecate `setPrompt()`

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -404,8 +404,19 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
 
   /**
    * Set the prompt for the widget.
+   * @deprecated - set the `executionState` on the model instead.
    */
   setPrompt(value: string): void {
+    return this._setPrompt(value);
+  }
+
+  /**
+   * Set the prompt for the widget.
+   *
+   * Note: this method is protected because it is needed in the CodeCell subclass,
+   * but it cannot be defined there because input is private to Cell class.
+   */
+  protected _setPrompt(value: string): void {
     this.prompt = value;
     this._input?.setPrompt(value);
   }
@@ -1176,7 +1187,7 @@ export class CodeCell extends Cell<ICodeCellModel> {
 
     super.initializeDOM();
 
-    this.setPrompt(this.prompt);
+    this._updatePrompt();
 
     // Insert the output before the cell footer.
     const outputWrapper = (this._outputWrapper = new Panel());
@@ -1269,7 +1280,7 @@ export class CodeCell extends Cell<ICodeCellModel> {
     super.initializeState();
     this.loadScrolledState();
 
-    this.setPrompt(`${this.model.executionCount || ''}`);
+    this._updatePrompt();
     return this;
   }
 
@@ -1579,7 +1590,11 @@ export class CodeCell extends Cell<ICodeCellModel> {
   protected onStateChanged(model: ICellModel, args: IChangedArgs<any>): void {
     switch (args.name) {
       case 'executionCount':
-        this.setPrompt(`${(model as ICodeCellModel).executionCount || ''}`);
+        this.model.executionState = 'idle';
+        this._updatePrompt();
+        break;
+      case 'executionState':
+        this._updatePrompt();
         break;
       case 'isDirty':
         if ((model as ICodeCellModel).isDirty) {
@@ -1633,6 +1648,16 @@ export class CodeCell extends Cell<ICodeCellModel> {
         break;
     }
     super.onMetadataChanged(model, args);
+  }
+
+  private _updatePrompt(): void {
+    let prompt: string;
+    if (this.model.executionState == 'running') {
+      prompt = '*';
+    } else {
+      prompt = `${this.model.executionCount || ''}`;
+    }
+    this._setPrompt(prompt);
   }
 
   /**
@@ -1713,7 +1738,8 @@ export namespace CodeCell {
       model.clearExecution();
       cell.outputHidden = false;
     }, false);
-    cell.setPrompt('*');
+    // note: in future we would like to distinguish running from scheduled
+    model.executionState = 'running';
     model.trusted = true;
     let future:
       | Kernel.IFuture<
@@ -1784,7 +1810,7 @@ export namespace CodeCell {
       // If we started executing, and the cell is still indicating this
       // execution, clear the prompt.
       if (future && !cell.isDisposed && cell.outputArea.future === future) {
-        cell.setPrompt('');
+        cell.model.executionState = 'idle';
         if (recordTiming && future.isDisposed) {
           // Record the time when the cell execution was aborted
           const timingInfo: any = Object.assign(

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -742,7 +742,7 @@ export class CodeConsole extends Widget {
         if (args.error) {
           for (const cell of this._cells) {
             if ((cell.model as ICodeCellModel).executionCount === null) {
-              cell.setPrompt('');
+              (cell.model as ICodeCellModel).executionState = 'idle';
             }
           }
         }

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2434,7 +2434,7 @@ namespace Private {
               cell.model.type === 'code' &&
               (cell as CodeCell).model.executionCount == null
             ) {
-              cell.setPrompt('');
+              (cell.model as ICodeCellModel).executionState = 'idle';
             }
           });
         } else {


### PR DESCRIPTION
## References

- required for https://github.com/jupyterlab/jupyterlab/issues/16332
- discussed in https://github.com/jupyter-server/jupyter_ydoc/issues/169
- in future may be refactored to:
   - use `sharedModel` as source of truth if https://github.com/jupyter-server/jupyter_ydoc/pull/197 is merged, or
   - be computed based on `pending_requests` if https://github.com/jupyter-server/jupyter_ydoc/pull/227 is merged

## Code changes

- adds `ICodeCellModel.executionState: 'idle' | 'running'`. In future we may want to add more states such as `'errored'` or `'scheduled'`.
- deprecates the use of `CodeCell.setPrompt(value: string)` method which was circumventing the model

## User-facing changes

None

## Backwards-incompatible changes

None