### PR TITLE
Notebook minimap in the virtual scrollbar

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1321,7 +1321,7 @@ class ScrollbarItem implements WindowedList.IRenderer.IScrollbarItem {
       this._notebook.selectionChanged.connect(this._updateSelection);
       if (this._model.type === 'code') {
         const model = this._model as ICodeCellModel;
-        model.outputs.changed.connect(this._updateOutput);
+        model.outputs.changed.connect(this._updatePrompt);
         model.stateChanged.connect(this._updateState);
       }
     }
@@ -1338,7 +1338,7 @@ class ScrollbarItem implements WindowedList.IRenderer.IScrollbarItem {
 
     this._updateActive();
     this._updateSelection();
-    this._updateOutput();
+    this._updatePrompt();
     this._updateDirty();
     return this._element;
   };
@@ -1372,7 +1372,7 @@ class ScrollbarItem implements WindowedList.IRenderer.IScrollbarItem {
     if (this._model.type === 'code') {
       const model = this._model as ICodeCellModel;
       if (model.outputs) {
-        model.outputs.changed.disconnect(this._updateOutput);
+        model.outputs.changed.disconnect(this._updatePrompt);
         model.stateChanged.disconnect(this._updateState);
       }
     }
@@ -1413,11 +1413,7 @@ class ScrollbarItem implements WindowedList.IRenderer.IScrollbarItem {
     }
   }
 
-  private _updateOutput = () => {
-    this._updatePrompt();
-  };
-
-  private _updatePrompt() {
+  private _updatePrompt = () => {
     if (this._model.type !== 'code') {
       return;
     }
@@ -1448,7 +1444,7 @@ class ScrollbarItem implements WindowedList.IRenderer.IScrollbarItem {
     if (this._element!.dataset.output !== state) {
       this._element!.dataset.output = state;
     }
-  }
+  };
 
   private _createElement() {
     const li = document.createElement('li');

--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -474,14 +474,69 @@ div.jp-Cell-Placeholder-content-3 {
 | Virtual scrollbar
 |----------------------------------------------------------------------------*/
 
-.jp-Notebook .jp-WindowedPanel-scrollbar-content .jp-mod-selected {
+.jp-Notebook .jp-WindowedPanel-scrollbar-item[data-output='error'] {
+  background: var(--jp-error-color3);
+}
+
+.jp-Notebook .jp-WindowedPanel-scrollbar-item[data-output='error']:hover {
+  background: var(--jp-error-color2);
+}
+
+.jp-Notebook .jp-WindowedPanel-scrollbar-content > .jp-mod-dirty {
+  background: var(--jp-warn-color3);
+}
+
+.jp-Notebook .jp-WindowedPanel-scrollbar-content > .jp-mod-dirty:hover {
+  background: var(--jp-warn-color2);
+}
+
+.jp-Notebook .jp-WindowedPanel-scrollbar-content > .jp-mod-selected {
   background: var(--jp-brand-color2);
   color: var(--jp-ui-inverse-font-color2);
 }
 
-.jp-Notebook .jp-WindowedPanel-scrollbar-content .jp-mod-active {
+.jp-Notebook .jp-WindowedPanel-scrollbar-content > .jp-mod-selected:hover {
+  background: var(--jp-brand-color1);
+}
+
+.jp-Notebook .jp-WindowedPanel-scrollbar-content > .jp-mod-active {
   background: var(--jp-brand-color1);
   color: var(--jp-ui-inverse-font-color1);
+}
+
+.jp-Notebook .jp-WindowedPanel-scrollbar-content > .jp-mod-active:hover {
+  background: var(--jp-brand-color0);
+}
+
+.jp-Notebook .jp-WindowedPanel-scrollbar-item {
+  max-width: 60px;
+  display: flex;
+}
+
+.jp-Notebook .jp-scrollbarItem-executionIndicator {
+  display: inline-block;
+  font-family: monospace;
+  font-size: 80%;
+  line-height: 100%;
+  position: relative;
+  top: 1px;
+  margin-left: -1px;
+  padding-right: 1px;
+  text-wrap: nowrap; /* stylelint-disable-line csstree/validator */
+}
+
+.jp-Notebook .jp-scrollbarItem-source {
+  display: inline-block;
+  font-size: 3px;
+  vertical-align: middle;
+  max-height: 10em;
+  overflow: hidden;
+}
+
+.jp-Notebook
+  .jp-WindowedPanel-scrollbar-item[data-type='code']
+  > .jp-scrollbarItem-source {
+  white-space: pre;
 }
 
 /*-----------------------------------------------------------------------------

--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -539,6 +539,12 @@ div.jp-Cell-Placeholder-content-3 {
   white-space: pre;
 }
 
+.jp-Notebook
+  .jp-WindowedPanel-scrollbar-item[data-type='markdown']
+  > .jp-scrollbarItem-source {
+  white-space: pre-line;
+}
+
 /*-----------------------------------------------------------------------------
 | Printing
 |----------------------------------------------------------------------------*/

--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -518,8 +518,6 @@ div.jp-Cell-Placeholder-content-3 {
   font-family: monospace;
   font-size: 80%;
   line-height: 100%;
-  position: relative;
-  top: 1px;
   margin-left: -1px;
   padding-right: 1px;
   text-wrap: nowrap; /* stylelint-disable-line csstree/validator */


### PR DESCRIPTION
## References

- closes https://github.com/jupyterlab/jupyterlab/issues/16332
- closes https://github.com/jupyterlab/jupyterlab/issues/3738

For now this PR includes two PRs on which it depends:
- https://github.com/jupyterlab/jupyterlab/pull/16392
- https://github.com/jupyterlab/jupyterlab/pull/16431

## Code changes

Creates a private (non-exported) `ScrollbarItem` class which implements reactive scrollbar item allowing for high-performance rendering of minimap even in very large notebooks.

## User-facing changes

The virtual scrollbar now exposes information on whether the cell:
- is running/scheduled (`[*]`), idle (`[ ]`) or was already run (e.g. `[1]`)
- was modified since it was last executed ("dirty") - orange background - thank you @srdas for the suggestion
- has output contains an error (traceback) - red background
- is markdown/code (`[X]` for code, nothing for markdown)
- roughly what text content does it contain

![wip](https://github.com/jupyterlab/jupyterlab/assets/5832902/9e11ba3b-d2e6-4db1-bb02-97f7b2a57f02)

![running-and-modified](https://github.com/jupyterlab/jupyterlab/assets/5832902/efedaa46-772a-4951-ad4c-c54844e9ff24)

## Plan

Depending on feedback:

- [ ] make the display of source code configurable?
   - [ ] allow to configure maximum number of lines or height shown?
- [ ] make the entire thing configurable, allowing fallback to previous simpler implementation?

Ideas for future improvements:
- option for viewport to be always visible
- option to show headings as a line with bold?

## Backwards-incompatible changes

None