### PR TITLE
Do not install cairo/pango on Mac in CI

### DIFF
--- a/.github/workflows/macostests.yml
+++ b/.github/workflows/macostests.yml
@@ -31,9 +31,6 @@ jobs:
       - name: Setup firefox
         run: brew install --cask firefox
 
-      - name: Setup cairo and pango
-        run: brew install cairo pango
-
       - name: Install dependencies
         env:
           GROUP: ${{ matrix.group }}


### PR DESCRIPTION
## References

Follow up to https://github.com/jupyterlab/jupyterlab/pull/16314

## Code changes

Remove no longer needed cairo/pango install step from CI for MacOS

## User-facing changes

None

## Backwards-incompatible changes

None