### PR TITLE
Fix typos in `jupyter-collaboration`-missing error message

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -925,11 +925,11 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
             except ImportError:
                 self.log.critical(
                     """\
-Juptyer Lab cannot start, because `jupyter_collaboration` was configured but cannot be `import`ed.
+Jupyter Lab cannot start, because `jupyter_collaboration` was configured but cannot be `import`ed.
 
 To fix this, either:
 
-1) install the extension `jupyter_collaboration`; for example: `python -m pip install jupyter_collaboration`
+1) install the extension `jupyter-collaboration`; for example: `python -m pip install jupyter-collaboration`
 
 2) disable collaboration; for example, remove the `--collaborative` flag from the commandline.  To see more ways to adjust the collaborative behavior, see https://jupyterlab-realtime-collaboration.readthedocs.io/en/latest/configuration.html .
 """


### PR DESCRIPTION
## References
N/A

## Code changes

Update the content of the `log.critical` message about `jupyter-collaboration` being missing

## User-facing changes

- The name `Jupyter` is spelled correctly
- The reference to `jupyter-collaboration` can now be copy-pasted by users to fix the issue (prior usage of `jupyter_collaboration` was different to the conda and pip package names)

## Backwards-incompatible changes

N/A


## Notes

CI is failing with 
```
Select at least one triage label:
[ 'bug', 'enhancement', 'feature', 'maintenance', 'documentation' ]
```

but I lack the permissions to do so