### PR TITLE
Align extension migration docs with the latest extension template

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -189,7 +189,7 @@ Or with ``conda``:
 
 .. code:: bash
 
-   conda install -c conda-forge jupyterlab=4 "copier=8" jinja2-time tomli-w "pydantic<2" "pyyaml-include<2.0"
+   conda install -c conda-forge jupyterlab=4 "copier=9" jinja2-time
 
 
 Then at the root folder of the extension, run:

--- a/docs/source/extension/notebook.rst
+++ b/docs/source/extension/notebook.rst
@@ -248,10 +248,10 @@ Start from the extension template.
 
 .. code-block:: shell
 
-    pip install "copier~=8.0" jinja2-time
+    pip install "copier~=9" jinja2-time
     mkdir myextension
     cd myextension
-    copier copy --UNSAFE https://github.com/jupyterlab/extension-template .
+    copier copy --trust https://github.com/jupyterlab/extension-template .
 
 Install the dependencies. Note that extensions are built against the
 released npm packages, not the development versions.

--- a/jupyterlab/upgrade_extension.py
+++ b/jupyterlab/upgrade_extension.py
@@ -341,7 +341,7 @@ if __name__ == "__main__":
     if answer_file.exists():
         msg = "This script won't do anything for copier template, instead execute in your extension directory:\n\n    copier update"
         if tuple(copier.__version__.split(".")) >= ("8", "0", "0"):
-            msg += " --UNSAFE"
+            msg += " --trust"
         print(msg)
     else:
         update_extension(args.path, args.vcs_ref, args.no_input is False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ dev = [
 ]
 upgrade-extension = [
     "pyyaml-include<3.0",
-    "copier>=8,<10",
+    "copier>=9,<10",
     "jinja2-time<0.3",
     "pydantic<3.0",
     "tomli-w<2.0"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/16414

There is another place in the docs where the `copier` dependencies are mentioned: https://jupyterlab.readthedocs.io/en/latest/extension/extension_migration.html#upgrading-extension-using-the-upgrade-script

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Extension migration docs update.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
