### PR TITLE
Handles a focus on the toolbar button on mousedown

### DIFF
--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -312,8 +312,8 @@ export class Toolbar<T extends Widget = Widget> extends Widget {
    */
   handleEvent(event: Event): void {
     switch (event.type) {
-      case 'click':
-        this.handleClick(event);
+      case 'mousedown':
+        this.handleMousedown(event);
         break;
       default:
         break;
@@ -321,11 +321,12 @@ export class Toolbar<T extends Widget = Widget> extends Widget {
   }
 
   /**
-   * Handle a DOM click event.
+   * Handle a DOM mousedown event.
    */
-  protected handleClick(event: Event): void {
-    // Stop propagating the click outside the toolbar
-    event.stopPropagation();
+  protected handleMousedown(event: Event): void {
+    // Set the focus to the target, to allow a potential WidgetTracker to trigger a
+    // focus change on the widget or a ancestor node.
+    (event.target as HTMLElement)?.focus();
 
     // Clicking a label focuses the corresponding control
     // that is linked with `for` attribute, so let it be.
@@ -351,14 +352,14 @@ export class Toolbar<T extends Widget = Widget> extends Widget {
    * Handle `after-attach` messages for the widget.
    */
   protected onAfterAttach(msg: Message): void {
-    this.node.addEventListener('click', this);
+    this.node.addEventListener('mousedown', this, true);
   }
 
   /**
    * Handle `before-detach` messages for the widget.
    */
   protected onBeforeDetach(msg: Message): void {
-    this.node.removeEventListener('click', this);
+    this.node.removeEventListener('mousedown', this, true);
   }
 }
 

--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -315,6 +315,9 @@ export class Toolbar<T extends Widget = Widget> extends Widget {
       case 'mousedown':
         this.handleMousedown(event);
         break;
+      case 'click':
+        this.handleClick(event);
+        break;
       default:
         break;
     }
@@ -325,8 +328,16 @@ export class Toolbar<T extends Widget = Widget> extends Widget {
    */
   protected handleMousedown(event: Event): void {
     // Set the focus to the target, to allow a potential WidgetTracker to trigger a
-    // focus change on the widget or a ancestor node.
+    // focus change on the widget or an ancestor node.
     (event.target as HTMLElement)?.focus();
+  }
+
+  /**
+   * Handle a DOM click event.
+   */
+  protected handleClick(event: Event): void {
+    // Stop propagating the click outside the toolbar
+    event.stopPropagation();
 
     // Clicking a label focuses the corresponding control
     // that is linked with `for` attribute, so let it be.
@@ -352,6 +363,7 @@ export class Toolbar<T extends Widget = Widget> extends Widget {
    * Handle `after-attach` messages for the widget.
    */
   protected onAfterAttach(msg: Message): void {
+    this.node.addEventListener('click', this);
     this.node.addEventListener('mousedown', this, true);
   }
 
@@ -359,6 +371,7 @@ export class Toolbar<T extends Widget = Widget> extends Widget {
    * Handle `before-detach` messages for the widget.
    */
   protected onBeforeDetach(msg: Message): void {
+    this.node.removeEventListener('click', this);
     this.node.removeEventListener('mousedown', this, true);
   }
 }


### PR DESCRIPTION
This PR fixes https://github.com/jupyterlab/jupyterlab/issues/15629, but can bring some unexpected changes.

The issue mentioned above comes from https://github.com/jupyterlab/jupyterlab/pull/12281, when the filebrowser panel became a `SidePanel` and its toolbar customizable.

The command to create a new directory get the current browser widget using the tracker. The tracker is updated when an `onClick` event is triggered on an element of the browser.
But this tracker is not yet updated when clicking on a button because the command is triggered [`onMousedown`](https://github.com/jupyterlab/jupyterlab/blob/963cbd6e76fd3a7b4be640662405e62a68268376/packages/ui-components/src/components/toolbar.tsx#L817).

To avoid this behavior, this PR change the focus to a toolbar element `onmousedown`, in `capture` mode to ensure it is triggered before the command.

Not sure about the consequences of this change yet.

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/15629

## Code changes

Focus the toolbar element on mouse down.

## User-facing changes

None

## Backwards-incompatible changes

None

cc. @jtpio 