### PR TITLE
Ignore empty stdout data when logging in verdaccio

### DIFF
--- a/buildutils/src/local-repository.ts
+++ b/buildutils/src/local-repository.ts
@@ -173,6 +173,10 @@ packages:
     loginPs.stdout.on('data', (chunk: string) => {
       const data = Buffer.from(chunk, 'utf-8').toString().trim();
       console.log('stdout:', data);
+      if (!data) {
+        console.log('Ignoring empty stdout.');
+        return;
+      }
       if (data.indexOf('Logged in ') !== -1) {
         loginPs.stdin.end();
         // do not accept here yet, the token may not have been written
@@ -203,8 +207,11 @@ packages:
     loginPs.on('close', () => accept());
   });
 
-  await loggedIn;
-  loginPs.kill();
+  try {
+    await loggedIn;
+  } finally {
+    loginPs.kill();
+  }
 
   console.log('Running in', out_dir);
   ps.exit(0);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #16448
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Ignore empty stdout message when feeding prompt on verdaccio login.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None