### PR TITLE
Add a notice for Windows users to activate symbolic links in contributing section

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -431,16 +431,6 @@ includes a ``Vagrantfile``, the bootstrap files and additional documentation.
 Installing JupyterLab
 ---------------------
 
-Important for Windows users
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. important::
-
-   On Windows, symbolic links need to be activated on Windows 10 or above for Python version 3.8 or higher
-   by activating the 'Developer Mode'. That may not be allowed by your administrators.
-   See `Activate Developer Mode on Windows <https://docs.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development>`__
-   for instructions.
-
 Fork the JupyterLab
 `repository <https://github.com/jupyterlab/jupyterlab>`__.
 
@@ -464,7 +454,16 @@ Additionally, you might want to execute the following optional commands:
    # Build the app dir assets (optional)
    jupyter lab build
 
-Notes:
+Frequent issues
+^^^^^^^^^^^^^^^
+
+.. important::
+
+   On Windows, symbolic links need to be activated on Windows 10 or above for Python version 3.8 or higher
+   by activating the 'Developer Mode'. That may not be allowed by your administrators.
+   See `Activate Developer Mode on Windows <https://docs.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development>`__
+   for instructions.
+.. Note: The same important section is present in the extension/extension_tutorial.rst too. If you modify it here, ensure to update it there as well.
 
 -  A few of the scripts will run "python". If your target python is
    called something else (such as "python3") then parts of the build

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -431,6 +431,16 @@ includes a ``Vagrantfile``, the bootstrap files and additional documentation.
 Installing JupyterLab
 ---------------------
 
+Important for Windows users
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. important::
+
+   On Windows, symbolic links need to be activated on Windows 10 or above for Python version 3.8 or higher
+   by activating the 'Developer Mode'. That may not be allowed by your administrators.
+   See `Activate Developer Mode on Windows <https://docs.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development>`__
+   for instructions.
+
 Fork the JupyterLab
 `repository <https://github.com/jupyterlab/jupyterlab>`__.
 

--- a/docs/source/extension/extension_tutorial.rst
+++ b/docs/source/extension/extension_tutorial.rst
@@ -207,6 +207,7 @@ Important for Windows users
    by activating the 'Developer Mode'. That may not be allowed by your administrators.
    See `Activate Developer Mode on Windows <https://docs.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development>`__
    for instructions.
+.. Note: The same important section is present in the developer/contributing.rst section too. If you modify it here, ensure to update it there as well.
 
 See the initial extension in action
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Issue

When setting up the JupyterLab codebase on a Windows machine, I encountered a long list of errors after running pip install -e ".[dev,test]". The documentation did not provide a solution for this issue. After consulting with a contributor, I discovered that the errors were due to the need for symbolic links to be activated on Windows 10 or above for Python version 3.8 or higher by enabling ‘Developer Mode’.

This important detail was mentioned in the extension section of the documentation but not in the contributing section. As a result, new contributors using Windows may run into this issue without knowing how to resolve it.

## Solution

To help other contributors avoid this issue, I have added a notice to the contributing section of the documentation, instructing Windows users to activate ‘Developer Mode’ to enable symbolic links ( as mentioned in the extension section of the documentation ). This should provide a smoother setup experience for Windows users and prevent potential setup errors.

## Benefits:

1. Helps new contributors using Windows avoid setup issues.
2. Provides clear and necessary instructions for enabling symbolic links on Windows at the Project setup section itself.
2. Improves the overall documentation and setup process for the JupyterLab project.

## User-facing changes

The docs of Project Installation for at Contributing section has been updated

![Screenshot 2024-06-09 234242](https://github.com/jupyterlab/jupyterlab/assets/127468609/2fff5a11-ca17-4722-ba8f-9b86dce19f3b)

