### PR TITLE
Ensure api Directory is Present to Build Documentation

### DIFF
--- a/docs/make.bat
+++ b/docs/make.bat
@@ -11,10 +11,16 @@ if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=python -msphinx
 )
 set SOURCEDIR=source
+set APIDIR=%SOURCEDIR%\api
 set BUILDDIR=build
 set SPHINXPROJ=JupyterLab
 
 if "%1" == "" goto help
+
+if not exist "%APIDIR%" (
+    echo Creating api directory...
+    mkdir "%APIDIR%"
+)
 
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (


### PR DESCRIPTION
## References

This PR addresses the issue #16466 

## Issue

When running make html, the build process fails with the following error:
`FileNotFoundError: [WinError 3] The system cannot find the path specified: '...\\jupyterlab\\docs\\source\\api'`

## Code changes

This PR addresses an issue where the documentation build process fails if the api directory is not present. Specifically, running make html results in a FileNotFoundError because Sphinx expects the docs/source/api directory to exist.

Since the api directory is under .gitignore, it is not present in a newly cloned repo. To solve this, I added a few lines of code to create the api directory if it is not present during the documentation build process. This ensures that the api directory is always present, so Sphinx doesn't raise any errors.

### After modifying the make.bat file, docs build successfully in windows:

![Screenshot 2024-06-10 074142](https://github.com/jupyterlab/jupyterlab/assets/127468609/c2579ce3-ae1a-4959-9f73-3738475a85e3)


## Additional Context:

1. This change ensures that new contributors or users can build the documentation without encountering this error.
2. This PR helps improve the developer experience by preventing a common pitfall during the setup process.
