### PR TITLE
Use correct hub restart URL

### DIFF
--- a/.github/workflows/linuxjs-tests.yml
+++ b/.github/workflows/linuxjs-tests.yml
@@ -35,6 +35,7 @@ jobs:
             js-documentsearch,
             js-filebrowser,
             js-fileeditor,
+            js-hub-extension,
             js-imageviewer,
             js-inspector,
             js-logconsole,

--- a/packages/hub-extension/babel.config.js
+++ b/packages/hub-extension/babel.config.js
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+module.exports = require('@jupyterlab/testing/lib/babel-config');

--- a/packages/hub-extension/jest.config.js
+++ b/packages/hub-extension/jest.config.js
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+const func = require('@jupyterlab/testing/lib/jest-config');
+module.exports = func(__dirname);

--- a/packages/hub-extension/package.json
+++ b/packages/hub-extension/package.json
@@ -30,7 +30,12 @@
   ],
   "scripts": {
     "build": "tsc",
+    "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
+    "test": "jest",
+    "test:cov": "jest --collect-coverage",
+    "test:debug": "node --inspect-brk ../../node_modules/.bin/jest --runInBand",
+    "test:debug:watch": "node --inspect-brk ../../node_modules/.bin/jest --runInBand --watch",
     "watch": "tsc -w --listEmittedFiles"
   },
   "dependencies": {
@@ -41,6 +46,8 @@
     "@jupyterlab/translation": "^4.3.0-alpha.0"
   },
   "devDependencies": {
+    "@types/jest": "^29.2.0",
+    "jest": "^29.2.0",
     "rimraf": "~5.0.5",
     "typescript": "~5.1.6"
   },

--- a/packages/hub-extension/src/index.ts
+++ b/packages/hub-extension/src/index.ts
@@ -58,7 +58,7 @@ function activateHubExtension(
 
   // If hubServerName is set, use JupyterHub 1.0 URL.
   const spawnBase = URLExt.join(hubPrefix, 'spawn');
-  let restartUrl: string;
+  let restartUrl = hubHost + spawnBase;
   if (hubServerName) {
     const suffix = URLExt.join(spawnBase, hubUser, hubServerName);
     if (!suffix.startsWith(spawnBase)) {
@@ -66,7 +66,6 @@ function activateHubExtension(
     }
     restartUrl = hubHost + suffix;
   }
-  restartUrl = hubHost + spawnBase;
 
   const { commands } = app;
 

--- a/packages/hub-extension/test/hub.spec.ts
+++ b/packages/hub-extension/test/hub.spec.ts
@@ -105,5 +105,29 @@ describe('@jupyterlab/hub-extension', () => {
       await commands.execute(CommandIDs.controlPanel);
       expect(windowOpenSpy).toHaveBeenCalledWith(`${hubPrefix}/home`, '_blank');
     });
+
+    it('should reject on invalid username', async () => {
+      let commands = new CommandRegistry();
+      const callback = async () => {
+        await activateHubExtension(commands, {
+          hubPrefix,
+          hubUser: '../',
+          hubServerName
+        });
+      };
+      await expect(callback).rejects.toThrow();
+    });
+
+    it('should reject on invalid server name', async () => {
+      let commands = new CommandRegistry();
+      const callback = async () => {
+        await activateHubExtension(commands, {
+          hubPrefix,
+          hubUser,
+          hubServerName: '../../'
+        });
+      };
+      await expect(callback).rejects.toThrow();
+    });
   });
 });

--- a/packages/hub-extension/test/hub.spec.ts
+++ b/packages/hub-extension/test/hub.spec.ts
@@ -11,7 +11,6 @@ describe('@jupyterlab/hub-extension', () => {
   const hubPrefix = '/hub';
   const hubUser = 'test_user';
   const hubServerName = 'test_server';
-  let dummyPaths = {} as JupyterFrontEnd.IPaths;
 
   // Extension in test
   const hubExtension = extensions[0];
@@ -34,19 +33,21 @@ describe('@jupyterlab/hub-extension', () => {
   });
 
   describe('hub commands', () => {
-    it('should add hub commands to registry', async () => {
-      // Override readonly props on the interface
-      (dummyPaths as any)['urls'] = {
-        hubPrefix: hubPrefix
-      };
-      let commands = new CommandRegistry();
-      void hubExtension.activate(
-        {
-          commands: commands
-        } as any,
-        dummyPaths,
+    const activateHubExtension = (
+      commands: CommandRegistry,
+      urls: Partial<JupyterFrontEnd.IPaths['urls']>
+    ) => {
+      return hubExtension.activate(
+        { commands } as JupyterFrontEnd,
+        { urls },
         nullTranslator
       );
+    };
+    it('should add hub commands to registry', async () => {
+      let commands = new CommandRegistry();
+      void activateHubExtension(commands, {
+        hubPrefix
+      });
 
       expect(commands.hasCommand(CommandIDs.controlPanel)).toBeTruthy();
       expect(commands.hasCommand(CommandIDs.restart)).toBeTruthy();
@@ -54,18 +55,10 @@ describe('@jupyterlab/hub-extension', () => {
     });
 
     it('should not add hub commands when hubPrefix is empty', async () => {
-      // Override readonly props on the interface
-      (dummyPaths as any)['urls'] = {
-        hubPrefix: ''
-      };
       let commands = new CommandRegistry();
-      void hubExtension.activate(
-        {
-          commands: commands
-        } as any,
-        dummyPaths,
-        nullTranslator
-      );
+      void activateHubExtension(commands, {
+        hubPrefix: ''
+      });
 
       expect(commands.hasCommand(CommandIDs.controlPanel)).toBeFalsy();
       expect(commands.hasCommand(CommandIDs.restart)).toBeFalsy();
@@ -73,20 +66,12 @@ describe('@jupyterlab/hub-extension', () => {
     });
 
     it('should include hubServerName in restartUrl when it is non empty', async () => {
-      // Override readonly props on the interface
-      (dummyPaths as any)['urls'] = {
-        hubPrefix: hubPrefix,
-        hubUser: hubUser,
-        hubServerName: hubServerName
-      };
       let commands = new CommandRegistry();
-      void hubExtension.activate(
-        {
-          commands: commands
-        } as any,
-        dummyPaths,
-        nullTranslator
-      );
+      void activateHubExtension(commands, {
+        hubPrefix,
+        hubUser,
+        hubServerName
+      });
 
       await commands.execute(CommandIDs.restart);
       expect(windowOpenSpy).toHaveBeenCalledWith(
@@ -95,20 +80,12 @@ describe('@jupyterlab/hub-extension', () => {
       );
     });
 
-    it('should set spawn Url for default server when hubServerName is empty', async () => {
-      // Override readonly props on the interface
-      (dummyPaths as any)['urls'] = {
-        hubPrefix: hubPrefix,
-        hubUser: hubUser
-      };
+    it('should set spawn URL for default server when hubServerName is empty', async () => {
       let commands = new CommandRegistry();
-      void hubExtension.activate(
-        {
-          commands: commands
-        } as any,
-        dummyPaths,
-        nullTranslator
-      );
+      void activateHubExtension(commands, {
+        hubPrefix,
+        hubUser
+      });
 
       await commands.execute(CommandIDs.restart);
       expect(windowOpenSpy).toHaveBeenCalledWith(
@@ -117,21 +94,13 @@ describe('@jupyterlab/hub-extension', () => {
       );
     });
 
-    it('should set correct hub home Url', async () => {
-      // Override readonly props on the interface
-      (dummyPaths as any)['urls'] = {
-        hubPrefix: hubPrefix,
-        hubUser: hubUser,
-        hubServerName: hubServerName
-      };
+    it('should set correct hub home URL', async () => {
       let commands = new CommandRegistry();
-      void hubExtension.activate(
-        {
-          commands: commands
-        } as any,
-        dummyPaths,
-        nullTranslator
-      );
+      void activateHubExtension(commands, {
+        hubPrefix,
+        hubUser,
+        hubServerName
+      });
 
       await commands.execute(CommandIDs.controlPanel);
       expect(windowOpenSpy).toHaveBeenCalledWith(`${hubPrefix}/home`, '_blank');

--- a/packages/hub-extension/test/hub.spec.ts
+++ b/packages/hub-extension/test/hub.spec.ts
@@ -1,0 +1,140 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { JupyterFrontEnd } from '@jupyterlab/application';
+import { nullTranslator } from '@jupyterlab/translation';
+import { CommandRegistry } from '@lumino/commands';
+import extensions, { CommandIDs } from '@jupyterlab/hub-extension';
+
+describe('@jupyterlab/hub-extension', () => {
+  // Mock path parameters
+  const hubPrefix = '/hub';
+  const hubUser = 'test_user';
+  const hubServerName = 'test_server';
+  let dummyPaths = {} as JupyterFrontEnd.IPaths;
+
+  // Extension in test
+  const hubExtension = extensions[0];
+
+  // Spy on window open
+  let windowOpenSpy: jest.SpyInstance;
+
+  // To restore original open after each test
+  const { open } = window;
+
+  beforeEach(() => {
+    // Replace with the custom value
+    window.open = jest.fn();
+    windowOpenSpy = jest.spyOn(window, 'open');
+  });
+
+  afterAll(() => {
+    // Restore original
+    window.open = open;
+  });
+
+  describe('hub commands', () => {
+    it('should add hub commands to registry', async () => {
+      // Override readonly props on the interface
+      (dummyPaths as any)['urls'] = {
+        hubPrefix: hubPrefix
+      };
+      let commands = new CommandRegistry();
+      void hubExtension.activate(
+        {
+          commands: commands
+        } as any,
+        dummyPaths,
+        nullTranslator
+      );
+
+      expect(commands.hasCommand(CommandIDs.controlPanel)).toBeTruthy();
+      expect(commands.hasCommand(CommandIDs.restart)).toBeTruthy();
+      expect(commands.hasCommand(CommandIDs.logout)).toBeTruthy();
+    });
+
+    it('should not add hub commands when hubPrefix is empty', async () => {
+      // Override readonly props on the interface
+      (dummyPaths as any)['urls'] = {
+        hubPrefix: ''
+      };
+      let commands = new CommandRegistry();
+      void hubExtension.activate(
+        {
+          commands: commands
+        } as any,
+        dummyPaths,
+        nullTranslator
+      );
+
+      expect(commands.hasCommand(CommandIDs.controlPanel)).toBeFalsy();
+      expect(commands.hasCommand(CommandIDs.restart)).toBeFalsy();
+      expect(commands.hasCommand(CommandIDs.logout)).toBeFalsy();
+    });
+
+    it('should include hubServerName in restartUrl when it is non empty', async () => {
+      // Override readonly props on the interface
+      (dummyPaths as any)['urls'] = {
+        hubPrefix: hubPrefix,
+        hubUser: hubUser,
+        hubServerName: hubServerName
+      };
+      let commands = new CommandRegistry();
+      void hubExtension.activate(
+        {
+          commands: commands
+        } as any,
+        dummyPaths,
+        nullTranslator
+      );
+
+      await commands.execute(CommandIDs.restart);
+      expect(windowOpenSpy).toHaveBeenCalledWith(
+        `${hubPrefix}/spawn/${hubUser}/${hubServerName}`,
+        '_blank'
+      );
+    });
+
+    it('should set spawn Url for default server when hubServerName is empty', async () => {
+      // Override readonly props on the interface
+      (dummyPaths as any)['urls'] = {
+        hubPrefix: hubPrefix,
+        hubUser: hubUser
+      };
+      let commands = new CommandRegistry();
+      void hubExtension.activate(
+        {
+          commands: commands
+        } as any,
+        dummyPaths,
+        nullTranslator
+      );
+
+      await commands.execute(CommandIDs.restart);
+      expect(windowOpenSpy).toHaveBeenCalledWith(
+        `${hubPrefix}/spawn`,
+        '_blank'
+      );
+    });
+
+    it('should set correct hub home Url', async () => {
+      // Override readonly props on the interface
+      (dummyPaths as any)['urls'] = {
+        hubPrefix: hubPrefix,
+        hubUser: hubUser,
+        hubServerName: hubServerName
+      };
+      let commands = new CommandRegistry();
+      void hubExtension.activate(
+        {
+          commands: commands
+        } as any,
+        dummyPaths,
+        nullTranslator
+      );
+
+      await commands.execute(CommandIDs.controlPanel);
+      expect(windowOpenSpy).toHaveBeenCalledWith(`${hubPrefix}/home`, '_blank');
+    });
+  });
+});

--- a/packages/hub-extension/tsconfig.test.json
+++ b/packages/hub-extension/tsconfig.test.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../tsconfigbase.test",
+  "include": ["src/*", "test/*"],
+  "references": [
+    {
+      "path": "../application"
+    },
+    {
+      "path": "../apputils"
+    },
+    {
+      "path": "../coreutils"
+    },
+    {
+      "path": "../services"
+    },
+    {
+      "path": "../translation"
+    },
+    {
+      "path": "."
+    }
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3571,6 +3571,8 @@ __metadata:
     "@jupyterlab/coreutils": ^6.3.0-alpha.0
     "@jupyterlab/services": ^7.3.0-alpha.0
     "@jupyterlab/translation": ^4.3.0-alpha.0
+    "@types/jest": ^29.2.0
+    jest: ^29.2.0
     rimraf: ~5.0.5
     typescript: ~5.1.6
   languageName: unknown


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## Code changes

Seems like `hub` extension is never taking the `restartUrl` for the current single user server. This PR corrects it by using the `restartUrl` of current single user server when config parameters are found. If not, `restartUrl` will be set to spawn page.

## User-facing changes

Users will be able to restart their servers instead of redirecting to spawn page

## Backwards-incompatible changes

NA

@krassowski Does it make sense? I think it was a regression introduced in [this PR](https://github.com/advisories/GHSA-44cc-43rp-5947).
