### PR TITLE
Improve stream output handling

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -22,7 +22,7 @@
     "@codemirror/view": "^6.9.6",
     "@jupyter/react-components": "^0.16.6",
     "@jupyter/web-components": "^0.16.6",
-    "@jupyter/ydoc": "^2.0.1",
+    "@jupyter/ydoc": "^3.0.0-a2",
     "@jupyterlab/application": "~4.3.0-alpha.2",
     "@jupyterlab/application-extension": "~4.3.0-alpha.2",
     "@jupyterlab/apputils": "~4.4.0-alpha.2",

--- a/examples/cell/package.json
+++ b/examples/cell/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@jupyter/web-components": "^0.16.6",
-    "@jupyter/ydoc": "^2.0.1",
+    "@jupyter/ydoc": "^3.0.0-a2",
     "@jupyterlab/application": "^4.3.0-alpha.2",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/cells": "^4.3.0-alpha.2",

--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@jupyter/web-components": "^0.16.6",
-    "@jupyter/ydoc": "^2.0.1",
+    "@jupyter/ydoc": "^3.0.0-a2",
     "@jupyterlab/application": "^4.3.0-alpha.2",
     "@jupyterlab/codemirror": "^4.3.0-alpha.2",
     "@jupyterlab/console": "^4.3.0-alpha.2",

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@jupyter/web-components": "^0.16.6",
-    "@jupyter/ydoc": "^2.0.1",
+    "@jupyter/ydoc": "^3.0.0-a2",
     "@jupyterlab/application": "^4.3.0-alpha.2",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/codemirror": "^4.3.0-alpha.2",

--- a/packages/cell-toolbar/package.json
+++ b/packages/cell-toolbar/package.json
@@ -40,7 +40,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^2.0.1",
+    "@jupyter/ydoc": "^3.0.0-a2",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/cells": "^4.3.0-alpha.2",
     "@jupyterlab/docregistry": "^4.3.0-alpha.2",

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@codemirror/state": "^6.4.1",
     "@codemirror/view": "^6.26.3",
-    "@jupyter/ydoc": "^2.0.1",
+    "@jupyter/ydoc": "^3.0.0-a2",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/attachments": "^4.3.0-alpha.2",
     "@jupyterlab/codeeditor": "^4.3.0-alpha.2",

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -13,11 +13,7 @@ import { IChangedArgs } from '@jupyterlab/coreutils';
 
 import * as nbformat from '@jupyterlab/nbformat';
 
-import {
-  IObservableString,
-  ObservableString,
-  ObservableValue
-} from '@jupyterlab/observables';
+import { IObservableString, ObservableValue } from '@jupyterlab/observables';
 
 import { IOutputAreaModel, OutputAreaModel } from '@jupyterlab/outputarea';
 
@@ -765,9 +761,7 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
         case 'add': {
           for (const output of event.newValues) {
             if (output.type === 'stream') {
-              (
-                output.observableData.get('text') as unknown as ObservableString
-              ).changed.connect(
+              output.observableText!.changed.connect(
                 (
                   sender: IObservableString,
                   textEvent: IObservableString.IChangedArgs

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -761,7 +761,7 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
         case 'add': {
           for (const output of event.newValues) {
             if (output.type === 'stream') {
-              output.observableText!.changed.connect(
+              output.streamText!.changed.connect(
                 (
                   sender: IObservableString,
                   textEvent: IObservableString.IChangedArgs

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -794,7 +794,7 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
             event.newIndex,
             event.newIndex,
             outputs,
-            'modeldb'
+            'silent-change'
           );
           break;
         }
@@ -804,7 +804,7 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
             event.oldIndex,
             event.oldIndex + newValues.length,
             newValues,
-            'modeldb'
+            'silent-change'
           );
           break;
         }
@@ -813,7 +813,7 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
             event.oldIndex,
             event.oldValues.length,
             [],
-            'modeldb'
+            'silent-change'
           );
           break;
         default:

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1412,7 +1412,7 @@ export class CodeCell extends Cell<ICodeCellModel> {
         }
       },
       false,
-      'modeldb'
+      'silent-change'
     );
   }
 
@@ -1731,7 +1731,7 @@ export namespace CodeCell {
           model.clearExecution();
         },
         false,
-        'modeldb'
+        'silent-change'
       );
       return;
     }
@@ -1748,7 +1748,7 @@ export namespace CodeCell {
         cell.outputHidden = false;
       },
       false,
-      'modeldb'
+      'silent-change'
     );
     // note: in future we would like to distinguish running from scheduled
     model.executionState = 'running';

--- a/packages/cells/test/model.spec.ts
+++ b/packages/cells/test/model.spec.ts
@@ -614,7 +614,9 @@ describe('cells/model', () => {
         } as any;
         model['onOutputsChange'](null as any, newEvent0);
         expect(sharedModel.ymodel.get('outputs').length).toBe(1);
-        expect(sharedModel.ymodel.get('outputs').get(0)).toEqual(output0);
+        expect(sharedModel.ymodel.get('outputs').get(0).toJSON()).toEqual(
+          output0
+        );
 
         const newEvent1 = {
           type: 'add',
@@ -625,7 +627,9 @@ describe('cells/model', () => {
         } as any;
         model['onOutputsChange'](null as any, newEvent1);
         expect(sharedModel.ymodel.get('outputs').length).toBe(2);
-        expect(sharedModel.ymodel.get('outputs').get(1)).toEqual(output1);
+        expect(sharedModel.ymodel.get('outputs').get(1).toJSON()).toEqual(
+          output1
+        );
       });
 
       it('should set new items correctly', () => {
@@ -644,7 +648,9 @@ describe('cells/model', () => {
         } as any;
         model['onOutputsChange'](null as any, newEvent0);
         expect(sharedModel.ymodel.get('outputs').length).toBe(2);
-        expect(sharedModel.ymodel.get('outputs').get(0)).toEqual(output2);
+        expect(sharedModel.ymodel.get('outputs').get(0).toJSON()).toEqual(
+          output2
+        );
         const newEvent1 = {
           type: 'set',
           newValues: [{ toJSON: () => output2 }],
@@ -654,7 +660,9 @@ describe('cells/model', () => {
         } as any;
         model['onOutputsChange'](null as any, newEvent1);
         expect(sharedModel.ymodel.get('outputs').length).toBe(2);
-        expect(sharedModel.ymodel.get('outputs').get(1)).toEqual(output2);
+        expect(sharedModel.ymodel.get('outputs').get(1).toJSON()).toEqual(
+          output2
+        );
       });
 
       it('should remove items correctly', () => {

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@codemirror/state": "^6.4.1",
-    "@jupyter/ydoc": "^2.0.1",
+    "@jupyter/ydoc": "^3.0.0-a2",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/coreutils": "^6.3.0-alpha.2",
     "@jupyterlab/nbformat": "^4.3.0-alpha.2",

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -43,7 +43,7 @@
     "@codemirror/legacy-modes": "^6.4.0",
     "@codemirror/search": "^6.5.6",
     "@codemirror/view": "^6.26.3",
-    "@jupyter/ydoc": "^2.0.1",
+    "@jupyter/ydoc": "^3.0.0-a2",
     "@jupyterlab/application": "^4.3.0-alpha.2",
     "@jupyterlab/codeeditor": "^4.3.0-alpha.2",
     "@jupyterlab/codemirror": "^4.3.0-alpha.2",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -57,7 +57,7 @@
     "@codemirror/search": "^6.5.6",
     "@codemirror/state": "^6.4.1",
     "@codemirror/view": "^6.26.3",
-    "@jupyter/ydoc": "^2.0.1",
+    "@jupyter/ydoc": "^3.0.0-a2",
     "@jupyterlab/codeeditor": "^4.3.0-alpha.2",
     "@jupyterlab/coreutils": "^6.3.0-alpha.2",
     "@jupyterlab/documentsearch": "^4.3.0-alpha.2",

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@codemirror/state": "^6.4.1",
     "@codemirror/view": "^6.26.3",
-    "@jupyter/ydoc": "^2.0.1",
+    "@jupyter/ydoc": "^3.0.0-a2",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/codeeditor": "^4.3.0-alpha.2",
     "@jupyterlab/codemirror": "^4.3.0-alpha.2",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -42,7 +42,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^2.0.1",
+    "@jupyter/ydoc": "^3.0.0-a2",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/cells": "^4.3.0-alpha.2",
     "@jupyterlab/codeeditor": "^4.3.0-alpha.2",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -51,7 +51,7 @@
     "@codemirror/state": "^6.4.1",
     "@codemirror/view": "^6.26.3",
     "@jupyter/react-components": "^0.16.6",
-    "@jupyter/ydoc": "^2.0.1",
+    "@jupyter/ydoc": "^3.0.0-a2",
     "@jupyterlab/application": "^4.3.0-alpha.2",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/cells": "^4.3.0-alpha.2",

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -41,7 +41,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^2.0.1",
+    "@jupyter/ydoc": "^3.0.0-a2",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/codeeditor": "^4.3.0-alpha.2",
     "@jupyterlab/coreutils": "^6.3.0-alpha.2",

--- a/packages/fileeditor/package.json
+++ b/packages/fileeditor/package.json
@@ -39,7 +39,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^2.0.1",
+    "@jupyter/ydoc": "^3.0.0-a2",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/codeeditor": "^4.3.0-alpha.2",
     "@jupyterlab/codemirror": "^4.3.0-alpha.2",

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -36,7 +36,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^2.0.1",
+    "@jupyter/ydoc": "^3.0.0-a2",
     "@jupyterlab/application": "^4.3.0-alpha.2",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/cells": "^4.3.0-alpha.2",

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -40,7 +40,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^2.0.1",
+    "@jupyter/ydoc": "^3.0.0-a2",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/cells": "^4.3.0-alpha.2",
     "@jupyterlab/codeeditor": "^4.3.0-alpha.2",

--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -335,18 +335,16 @@ export class OutputAreaModel implements IOutputAreaModel {
       // This creates a text change event.
       const prev = this.list.get(this.length - 1) as IOutputModel;
       const curText = prev.streamText!;
-      const newText = value.text as string;
+      const newText =
+        typeof value.text === 'string' ? value.text : value.text.join('');
       Private.addText(curText, newText);
       return this.length;
     }
 
     let newText = '';
     if (nbformat.isStream(value)) {
-      if (typeof value.text === 'string') {
-        newText = value.text as string;
-      } else {
-        newText = (value.text as string[]).join();
-      }
+      newText =
+        typeof value.text === 'string' ? value.text : value.text.join('');
       value.text = '';
     }
 

--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -61,6 +61,11 @@ export interface IOutputAreaModel extends IDisposable {
   add(output: nbformat.IOutput): number;
 
   /**
+   * Remove an output at a given index.
+   */
+  remove(index: number): void;
+
+  /**
    * Set the value at the specified index.
    */
   set(index: number, output: nbformat.IOutput): void;
@@ -260,6 +265,14 @@ export class OutputAreaModel implements IOutputAreaModel {
   }
 
   /**
+   * Remove an output at a given index.
+   */
+  remove(index: number): void {
+    this.list.get(index).dispose();
+    this.list.remove(index);
+  }
+
+  /**
    * Clear all of the output.
    *
    * @param wait Delay clearing the output until the next message is added.
@@ -339,6 +352,9 @@ export class OutputAreaModel implements IOutputAreaModel {
     // Create the new item.
     const item = this._createItem({ value, trusted });
 
+    // Add the item to our list and return the new length.
+    const length = this.list.push(item);
+
     // Update the stream information.
     if (nbformat.isStream(value)) {
       this._lastStreamName = value.name;
@@ -350,8 +366,7 @@ export class OutputAreaModel implements IOutputAreaModel {
       this._lastStreamName = '';
     }
 
-    // Add the item to our list and return the new length.
-    return this.list.push(item);
+    return length;
   }
 
   /**

--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -334,7 +334,7 @@ export class OutputAreaModel implements IOutputAreaModel {
       // We append the new text to the current text.
       // This creates a text change event.
       const prev = this.list.get(this.length - 1) as IOutputModel;
-      const curText = prev.observableText!;
+      const curText = prev.streamText!;
       const newText = value.text as string;
       Private.addText(curText, newText);
       return this.length;
@@ -342,7 +342,11 @@ export class OutputAreaModel implements IOutputAreaModel {
 
     let newText = '';
     if (nbformat.isStream(value)) {
-      newText = value.text as string;
+      if (typeof value.text === 'string') {
+        newText = value.text as string;
+      } else {
+        newText = (value.text as string[]).join();
+      }
       value.text = '';
     }
 
@@ -355,7 +359,7 @@ export class OutputAreaModel implements IOutputAreaModel {
     // Update the stream information.
     if (nbformat.isStream(value)) {
       this._lastStreamName = value.name;
-      const curText = item.observableText!;
+      const curText = item.streamText!;
       Private.addText(curText, newText);
     } else {
       this._lastStreamName = '';

--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -334,9 +334,7 @@ export class OutputAreaModel implements IOutputAreaModel {
       // We append the new text to the current text.
       // This creates a text change event.
       const prev = this.list.get(this.length - 1) as IOutputModel;
-      const curText = prev.observableData.get(
-        'text'
-      ) as unknown as IObservableString;
+      const curText = prev.observableText!;
       const newText = value.text as string;
       Private.addText(curText, newText);
       return this.length;
@@ -357,9 +355,7 @@ export class OutputAreaModel implements IOutputAreaModel {
     // Update the stream information.
     if (nbformat.isStream(value)) {
       this._lastStreamName = value.name;
-      const curText = item.observableData.get(
-        'text'
-      ) as unknown as IObservableString;
+      const curText = item.observableText!;
       Private.addText(curText, newText);
     } else {
       this._lastStreamName = '';

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -288,10 +288,7 @@ export class OutputArea extends Widget {
         this._insertOutput(args.newIndex, output);
         if (output.type === 'stream') {
           // A stream ouput has been added, follow changes to the text.
-          const obsText = output.observableData.get(
-            'text'
-          ) as unknown as IObservableString;
-          obsText.changed.connect(
+          output.observableText!.changed.connect(
             (
               sender: IObservableString,
               event: IObservableString.IChangedArgs

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -288,7 +288,7 @@ export class OutputArea extends Widget {
         this._insertOutput(args.newIndex, output);
         if (output.type === 'stream') {
           // A stream ouput has been added, follow changes to the text.
-          output.observableText!.changed.connect(
+          output.streamText!.changed.connect(
             (
               sender: IObservableString,
               event: IObservableString.IChangedArgs

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -288,37 +288,15 @@ export class OutputArea extends Widget {
         this._insertOutput(args.newIndex, output);
         if (output.type === 'stream') {
           // A stream ouput has been added, follow changes to the text.
-          const text = output.observableData.get(
+          const obsText = output.observableData.get(
             'text'
           ) as unknown as IObservableString;
-          text.changed.connect(
+          obsText.changed.connect(
             (
               sender: IObservableString,
               event: IObservableString.IChangedArgs
             ) => {
-              const node = (
-                this.widgets[this.widgets.length - 1].layout as PanelLayout
-              ).widgets[1].node;
-              if (event.type === 'remove') {
-                // Remove the text.
-                const children = node.children;
-                const text = (children[children.length - 1] as HTMLElement)
-                  .innerText;
-                const newText = text.slice(0, event.start);
-                children[children.length - 1].remove();
-                const pre = document.createElement('pre');
-                pre.innerText = newText;
-                node.appendChild(pre);
-              } else {
-                // Append the text.
-                const pre = document.createElement('pre');
-                let newText = event.value;
-                if (newText.endsWith('\n')) {
-                  newText = newText.slice(0, newText.length - 1);
-                }
-                pre.innerText = newText;
-                node.appendChild(pre);
-              }
+              this._setOutput(args.newIndex, output);
             }
           );
         }

--- a/packages/outputarea/test/widget.spec.ts
+++ b/packages/outputarea/test/widget.spec.ts
@@ -323,15 +323,28 @@ describe('outputarea/widget', () => {
         expect(widget.widgets.length).toBe(0);
       });
 
-      it('should handle a set', () => {
+      it('should handle stream outputs of same name', () => {
         widget.model.clear();
-        widget.model.add(DEFAULT_OUTPUTS[0]);
-        widget.methods = [];
+        // An initial stdout stream creates an output.
         widget.model.add(DEFAULT_OUTPUTS[0]);
         expect(widget.methods).toEqual(
           expect.arrayContaining(['onModelChanged'])
         );
-        expect(widget.widgets.length).toBe(1);
+        // Another stdout stream only changes the "text" of the last output.
+        widget.methods = [];
+        widget.model.add(DEFAULT_OUTPUTS[0]);
+        expect(widget.methods).toEqual([]);
+        // A stderr stream creates a new output.
+        widget.methods = [];
+        widget.model.add(DEFAULT_OUTPUTS[1]);
+        expect(widget.methods).toEqual(
+          expect.arrayContaining(['onModelChanged'])
+        );
+        // Another stderr stream only changes the "text" of the last output.
+        widget.methods = [];
+        widget.model.add(DEFAULT_OUTPUTS[1]);
+        expect(widget.methods).toEqual([]);
+        expect(widget.widgets.length).toBe(2);
       });
 
       it('should rerender when preferred mimetype changes', () => {

--- a/packages/rendermime/src/outputmodel.ts
+++ b/packages/rendermime/src/outputmodel.ts
@@ -88,7 +88,8 @@ export class OutputModel implements IOutputModel {
    * Construct a new output model.
    */
   constructor(options: IOutputModel.IOptions) {
-    const { metadata, trusted } = Private.getBundleOptions(options);
+    const { data, metadata, trusted } = Private.getBundleOptions(options);
+    this._rawData = data;
     const newData: { [key: string]: any } = {};
     if (options.value !== undefined) {
       for (const key in options.value) {
@@ -181,6 +182,7 @@ export class OutputModel implements IOutputModel {
   setData(options: IRenderMime.IMimeModel.ISetDataOptions): void {
     if (options.data) {
       this._updateObservable(this._data, options.data);
+      this._rawData = options.data;
     }
     if (options.metadata) {
       this._updateObservable(this._metadata, options.metadata!);
@@ -197,21 +199,17 @@ export class OutputModel implements IOutputModel {
     for (const key in this._raw) {
       output[key] = Private.extract(this._raw, key);
     }
-    const data: { [key: string]: any } = {};
     for (const key of this._data.keys()) {
       if (key === 'text') {
         const text = (this._data.get(key) as unknown as ObservableString).text;
-        data[key] = text;
         output['text'] = text;
-      } else {
-        data[key] = this._data.get(key);
       }
     }
     switch (this.type) {
       case 'display_data':
       case 'execute_result':
       case 'update_display_data':
-        output['data'] = data.data as PartialJSONObject;
+        output['data'] = this._rawData as PartialJSONObject;
         output['metadata'] = this.metadata as PartialJSONObject;
         break;
       default:
@@ -252,6 +250,7 @@ export class OutputModel implements IOutputModel {
   private _changed = new Signal<this, void>(this);
   private _raw: PartialJSONObject = {};
   private _rawMetadata: ReadonlyPartialJSONObject;
+  private _rawData: ReadonlyPartialJSONObject;
   private _data: IObservableJSON;
   private _metadata: IObservableJSON;
 }

--- a/packages/rendermime/src/outputmodel.ts
+++ b/packages/rendermime/src/outputmodel.ts
@@ -41,9 +41,9 @@ export interface IOutputModel extends IRenderMime.IMimeModel {
   readonly executionCount: nbformat.ExecutionCount;
 
   /**
-   * The observable data.
+   * The observable text, present when the output `type` is set to `"stream"`.
    */
-  readonly observableText?: IObservableString;
+  readonly streamText?: IObservableString;
 
   /**
    * Whether the output is trusted.
@@ -155,7 +155,7 @@ export class OutputModel implements IOutputModel {
     return Private.getData(this.toJSON());
   }
 
-  get observableText(): IObservableString | undefined {
+  get streamText(): IObservableString | undefined {
     return this._text;
   }
 

--- a/packages/rendermime/src/outputmodel.ts
+++ b/packages/rendermime/src/outputmodel.ts
@@ -211,7 +211,7 @@ export class OutputModel implements IOutputModel {
       case 'display_data':
       case 'execute_result':
       case 'update_display_data':
-        output['data'] = data as PartialJSONObject;
+        output['data'] = data.data as PartialJSONObject;
         output['metadata'] = this.metadata as PartialJSONObject;
         break;
       default:

--- a/packages/rendermime/src/outputmodel.ts
+++ b/packages/rendermime/src/outputmodel.ts
@@ -92,7 +92,11 @@ export class OutputModel implements IOutputModel {
     const { data, metadata, trusted } = Private.getBundleOptions(options);
     this._rawData = data;
     if (options.value !== undefined && nbformat.isStream(options.value)) {
-      this._text = new ObservableString(options.value['text'] as string);
+      this._text = new ObservableString(
+        typeof options.value.text === 'string'
+          ? options.value.text
+          : options.value.text.join('')
+      );
     }
     this._metadata = new ObservableJSON({ values: metadata as JSONObject });
     this._rawMetadata = metadata;

--- a/packages/rendermime/src/outputmodel.ts
+++ b/packages/rendermime/src/outputmodel.ts
@@ -157,8 +157,7 @@ export class OutputModel implements IOutputModel {
    * The data associated with the model.
    */
   get data(): ReadonlyPartialJSONObject {
-    const data = Private.getData(this.toJSON());
-    return data;
+    return Private.getData(this.toJSON());
   }
 
   get observableData(): IObservableJSON {
@@ -195,22 +194,24 @@ export class OutputModel implements IOutputModel {
    */
   toJSON(): nbformat.IOutput {
     const output: PartialJSONValue = {};
+    for (const key in this._raw) {
+      output[key] = Private.extract(this._raw, key);
+    }
     const data: { [key: string]: any } = {};
     for (const key of this._data.keys()) {
       if (key === 'text') {
-        data[key] = (this._data.get(key) as unknown as ObservableString).text;
+        const text = (this._data.get(key) as unknown as ObservableString).text;
+        data[key] = text;
+        output['text'] = text;
       } else {
         data[key] = this._data.get(key);
       }
-    }
-    for (const key in data) {
-      output[key] = Private.extract(data, key);
     }
     switch (this.type) {
       case 'display_data':
       case 'execute_result':
       case 'update_display_data':
-        output['data'] = this.data as PartialJSONObject;
+        output['data'] = data as PartialJSONObject;
         output['metadata'] = this.metadata as PartialJSONObject;
         break;
       default:

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -45,7 +45,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^2.0.1",
+    "@jupyter/ydoc": "^3.0.0-a2",
     "@jupyterlab/coreutils": "^6.3.0-alpha.2",
     "@jupyterlab/nbformat": "^4.3.0-alpha.2",
     "@jupyterlab/settingregistry": "^4.3.0-alpha.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2408,11 +2408,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/cell-toolbar@workspace:packages/cell-toolbar"
   dependencies:
-<<<<<<< HEAD
-    "@jupyter/ydoc": ^3.0.0-a1
-=======
     "@jupyter/ydoc": ^3.0.0-a2
->>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
     "@jupyterlab/docregistry": ^4.3.0-alpha.2
@@ -2438,11 +2434,7 @@ __metadata:
   dependencies:
     "@codemirror/state": ^6.4.1
     "@codemirror/view": ^6.26.3
-<<<<<<< HEAD
-    "@jupyter/ydoc": ^3.0.0-a1
-=======
     "@jupyter/ydoc": ^3.0.0-a2
->>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/attachments": ^4.3.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
@@ -2498,11 +2490,7 @@ __metadata:
   resolution: "@jupyterlab/codeeditor@workspace:packages/codeeditor"
   dependencies:
     "@codemirror/state": ^6.4.1
-<<<<<<< HEAD
-    "@jupyter/ydoc": ^3.0.0-a1
-=======
     "@jupyter/ydoc": ^3.0.0-a2
->>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/coreutils": ^6.3.0-alpha.2
     "@jupyterlab/nbformat": ^4.3.0-alpha.2
@@ -2535,11 +2523,7 @@ __metadata:
     "@codemirror/legacy-modes": ^6.4.0
     "@codemirror/search": ^6.5.6
     "@codemirror/view": ^6.26.3
-<<<<<<< HEAD
-    "@jupyter/ydoc": ^3.0.0-a1
-=======
     "@jupyter/ydoc": ^3.0.0-a2
->>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
     "@jupyterlab/codemirror": ^4.3.0-alpha.2
@@ -2582,11 +2566,7 @@ __metadata:
     "@codemirror/search": ^6.5.6
     "@codemirror/state": ^6.4.1
     "@codemirror/view": ^6.26.3
-<<<<<<< HEAD
-    "@jupyter/ydoc": ^3.0.0-a1
-=======
     "@jupyter/ydoc": ^3.0.0-a2
->>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
     "@jupyterlab/coreutils": ^6.3.0-alpha.2
     "@jupyterlab/documentsearch": ^4.3.0-alpha.2
@@ -2633,11 +2613,7 @@ __metadata:
   dependencies:
     "@codemirror/state": ^6.4.1
     "@codemirror/view": ^6.26.3
-<<<<<<< HEAD
-    "@jupyter/ydoc": ^3.0.0-a1
-=======
     "@jupyter/ydoc": ^3.0.0-a2
->>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
     "@jupyterlab/codemirror": ^4.3.0-alpha.2
@@ -2693,11 +2669,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/console@workspace:packages/console"
   dependencies:
-<<<<<<< HEAD
-    "@jupyter/ydoc": ^3.0.0-a1
-=======
     "@jupyter/ydoc": ^3.0.0-a2
->>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
@@ -2824,13 +2796,8 @@ __metadata:
   dependencies:
     "@codemirror/state": ^6.4.1
     "@codemirror/view": ^6.26.3
-<<<<<<< HEAD
     "@jupyter/react-components": ^0.16.6
-    "@jupyter/ydoc": ^3.0.0-a1
-=======
-    "@jupyter/react-components": ^0.16.3
     "@jupyter/ydoc": ^3.0.0-a2
->>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
@@ -2926,11 +2893,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/docregistry@workspace:packages/docregistry"
   dependencies:
-<<<<<<< HEAD
-    "@jupyter/ydoc": ^3.0.0-a1
-=======
     "@jupyter/ydoc": ^3.0.0-a2
->>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
     "@jupyterlab/coreutils": ^6.3.0-alpha.2
@@ -3050,13 +3013,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/example-cell@workspace:examples/cell"
   dependencies:
-<<<<<<< HEAD
     "@jupyter/web-components": ^0.16.6
-    "@jupyter/ydoc": ^3.0.0-a1
-=======
-    "@jupyter/web-components": ^0.16.3
     "@jupyter/ydoc": ^3.0.0-a2
->>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
@@ -3084,13 +3042,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/example-console@workspace:examples/console"
   dependencies:
-<<<<<<< HEAD
     "@jupyter/web-components": ^0.16.6
-    "@jupyter/ydoc": ^3.0.0-a1
-=======
-    "@jupyter/web-components": ^0.16.3
     "@jupyter/ydoc": ^3.0.0-a2
->>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/codemirror": ^4.3.0-alpha.2
     "@jupyterlab/console": ^4.3.0-alpha.2
@@ -3235,13 +3188,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/example-notebook@workspace:examples/notebook"
   dependencies:
-<<<<<<< HEAD
     "@jupyter/web-components": ^0.16.6
-    "@jupyter/ydoc": ^3.0.0-a1
-=======
-    "@jupyter/web-components": ^0.16.3
     "@jupyter/ydoc": ^3.0.0-a2
->>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/codemirror": ^4.3.0-alpha.2
@@ -3482,11 +3430,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/fileeditor@workspace:packages/fileeditor"
   dependencies:
-<<<<<<< HEAD
-    "@jupyter/ydoc": ^3.0.0-a1
-=======
     "@jupyter/ydoc": ^3.0.0-a2
->>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
     "@jupyterlab/codemirror": ^4.3.0-alpha.2
@@ -4254,11 +4198,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/notebook-extension@workspace:packages/notebook-extension"
   dependencies:
-<<<<<<< HEAD
-    "@jupyter/ydoc": ^3.0.0-a1
-=======
     "@jupyter/ydoc": ^3.0.0-a2
->>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
@@ -4306,11 +4246,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/notebook@workspace:packages/notebook"
   dependencies:
-<<<<<<< HEAD
-    "@jupyter/ydoc": ^3.0.0-a1
-=======
     "@jupyter/ydoc": ^3.0.0-a2
->>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
@@ -4584,11 +4520,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/services@workspace:packages/services"
   dependencies:
-<<<<<<< HEAD
-    "@jupyter/ydoc": ^3.0.0-a1
-=======
     "@jupyter/ydoc": ^3.0.0-a2
->>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/coreutils": ^6.3.0-alpha.2
     "@jupyterlab/nbformat": ^4.3.0-alpha.2
     "@jupyterlab/settingregistry": ^4.3.0-alpha.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -2074,9 +2074,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyter/ydoc@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@jupyter/ydoc@npm:2.0.1"
+"@jupyter/ydoc@npm:^3.0.0-a1":
+  version: 3.0.0-a1
+  resolution: "@jupyter/ydoc@npm:3.0.0-a1"
   dependencies:
     "@jupyterlab/nbformat": ^3.0.0 || ^4.0.0-alpha.21 || ^4.0.0
     "@lumino/coreutils": ^1.11.0 || ^2.0.0
@@ -2084,7 +2084,7 @@ __metadata:
     "@lumino/signaling": ^1.10.0 || ^2.0.0
     y-protocols: ^1.0.5
     yjs: ^13.5.40
-  checksum: f5f29e1ff3327ebc1cf326f53634e03c4c7bf7733d235087fe26975c16eebd404f23c2f3ba88b6e04b1927846be7162b09b8b8719a4b29e51d0299c745018cbb
+  checksum: 6cb6d5bd0ffd037030739c00045851a270ec359da6938f81d036c1dc64fcd336537868df5c412fb99779032d595486428530ed93aeb041f0b52fe36851443796
   languageName: node
   linkType: hard
 
@@ -2408,7 +2408,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/cell-toolbar@workspace:packages/cell-toolbar"
   dependencies:
-    "@jupyter/ydoc": ^2.0.1
+    "@jupyter/ydoc": ^3.0.0-a1
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
     "@jupyterlab/docregistry": ^4.3.0-alpha.2
@@ -2434,7 +2434,7 @@ __metadata:
   dependencies:
     "@codemirror/state": ^6.4.1
     "@codemirror/view": ^6.26.3
-    "@jupyter/ydoc": ^2.0.1
+    "@jupyter/ydoc": ^3.0.0-a1
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/attachments": ^4.3.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
@@ -2490,7 +2490,7 @@ __metadata:
   resolution: "@jupyterlab/codeeditor@workspace:packages/codeeditor"
   dependencies:
     "@codemirror/state": ^6.4.1
-    "@jupyter/ydoc": ^2.0.1
+    "@jupyter/ydoc": ^3.0.0-a1
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/coreutils": ^6.3.0-alpha.2
     "@jupyterlab/nbformat": ^4.3.0-alpha.2
@@ -2523,7 +2523,7 @@ __metadata:
     "@codemirror/legacy-modes": ^6.4.0
     "@codemirror/search": ^6.5.6
     "@codemirror/view": ^6.26.3
-    "@jupyter/ydoc": ^2.0.1
+    "@jupyter/ydoc": ^3.0.0-a1
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
     "@jupyterlab/codemirror": ^4.3.0-alpha.2
@@ -2566,7 +2566,7 @@ __metadata:
     "@codemirror/search": ^6.5.6
     "@codemirror/state": ^6.4.1
     "@codemirror/view": ^6.26.3
-    "@jupyter/ydoc": ^2.0.1
+    "@jupyter/ydoc": ^3.0.0-a1
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
     "@jupyterlab/coreutils": ^6.3.0-alpha.2
     "@jupyterlab/documentsearch": ^4.3.0-alpha.2
@@ -2613,7 +2613,7 @@ __metadata:
   dependencies:
     "@codemirror/state": ^6.4.1
     "@codemirror/view": ^6.26.3
-    "@jupyter/ydoc": ^2.0.1
+    "@jupyter/ydoc": ^3.0.0-a1
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
     "@jupyterlab/codemirror": ^4.3.0-alpha.2
@@ -2669,7 +2669,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/console@workspace:packages/console"
   dependencies:
-    "@jupyter/ydoc": ^2.0.1
+    "@jupyter/ydoc": ^3.0.0-a1
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
@@ -2797,7 +2797,7 @@ __metadata:
     "@codemirror/state": ^6.4.1
     "@codemirror/view": ^6.26.3
     "@jupyter/react-components": ^0.16.6
-    "@jupyter/ydoc": ^2.0.1
+    "@jupyter/ydoc": ^3.0.0-a1
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
@@ -2893,7 +2893,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/docregistry@workspace:packages/docregistry"
   dependencies:
-    "@jupyter/ydoc": ^2.0.1
+    "@jupyter/ydoc": ^3.0.0-a1
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
     "@jupyterlab/coreutils": ^6.3.0-alpha.2
@@ -3014,7 +3014,7 @@ __metadata:
   resolution: "@jupyterlab/example-cell@workspace:examples/cell"
   dependencies:
     "@jupyter/web-components": ^0.16.6
-    "@jupyter/ydoc": ^2.0.1
+    "@jupyter/ydoc": ^3.0.0-a1
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
@@ -3043,7 +3043,7 @@ __metadata:
   resolution: "@jupyterlab/example-console@workspace:examples/console"
   dependencies:
     "@jupyter/web-components": ^0.16.6
-    "@jupyter/ydoc": ^2.0.1
+    "@jupyter/ydoc": ^3.0.0-a1
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/codemirror": ^4.3.0-alpha.2
     "@jupyterlab/console": ^4.3.0-alpha.2
@@ -3189,7 +3189,7 @@ __metadata:
   resolution: "@jupyterlab/example-notebook@workspace:examples/notebook"
   dependencies:
     "@jupyter/web-components": ^0.16.6
-    "@jupyter/ydoc": ^2.0.1
+    "@jupyter/ydoc": ^3.0.0-a1
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/codemirror": ^4.3.0-alpha.2
@@ -3430,7 +3430,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/fileeditor@workspace:packages/fileeditor"
   dependencies:
-    "@jupyter/ydoc": ^2.0.1
+    "@jupyter/ydoc": ^3.0.0-a1
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
     "@jupyterlab/codemirror": ^4.3.0-alpha.2
@@ -4198,7 +4198,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/notebook-extension@workspace:packages/notebook-extension"
   dependencies:
-    "@jupyter/ydoc": ^2.0.1
+    "@jupyter/ydoc": ^3.0.0-a1
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
@@ -4246,7 +4246,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/notebook@workspace:packages/notebook"
   dependencies:
-    "@jupyter/ydoc": ^2.0.1
+    "@jupyter/ydoc": ^3.0.0-a1
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
@@ -4520,7 +4520,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/services@workspace:packages/services"
   dependencies:
-    "@jupyter/ydoc": ^2.0.1
+    "@jupyter/ydoc": ^3.0.0-a1
     "@jupyterlab/coreutils": ^6.3.0-alpha.2
     "@jupyterlab/nbformat": ^4.3.0-alpha.2
     "@jupyterlab/settingregistry": ^4.3.0-alpha.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -2074,9 +2074,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyter/ydoc@npm:^3.0.0-a1":
-  version: 3.0.0-a1
-  resolution: "@jupyter/ydoc@npm:3.0.0-a1"
+"@jupyter/ydoc@npm:^3.0.0-a2":
+  version: 3.0.0-a2
+  resolution: "@jupyter/ydoc@npm:3.0.0-a2"
   dependencies:
     "@jupyterlab/nbformat": ^3.0.0 || ^4.0.0-alpha.21 || ^4.0.0
     "@lumino/coreutils": ^1.11.0 || ^2.0.0
@@ -2084,7 +2084,7 @@ __metadata:
     "@lumino/signaling": ^1.10.0 || ^2.0.0
     y-protocols: ^1.0.5
     yjs: ^13.5.40
-  checksum: 6cb6d5bd0ffd037030739c00045851a270ec359da6938f81d036c1dc64fcd336537868df5c412fb99779032d595486428530ed93aeb041f0b52fe36851443796
+  checksum: 4d4e48ce604544f90ee584f7c9bae4efaa8e2b7dd01ab1f6d2a97f8f9d221be7055a60bd128eb1010f8ff4a478c53827f47eb60875e8fc67bfba5298a068b2a0
   languageName: node
   linkType: hard
 
@@ -2408,7 +2408,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/cell-toolbar@workspace:packages/cell-toolbar"
   dependencies:
+<<<<<<< HEAD
     "@jupyter/ydoc": ^3.0.0-a1
+=======
+    "@jupyter/ydoc": ^3.0.0-a2
+>>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
     "@jupyterlab/docregistry": ^4.3.0-alpha.2
@@ -2434,7 +2438,11 @@ __metadata:
   dependencies:
     "@codemirror/state": ^6.4.1
     "@codemirror/view": ^6.26.3
+<<<<<<< HEAD
     "@jupyter/ydoc": ^3.0.0-a1
+=======
+    "@jupyter/ydoc": ^3.0.0-a2
+>>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/attachments": ^4.3.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
@@ -2490,7 +2498,11 @@ __metadata:
   resolution: "@jupyterlab/codeeditor@workspace:packages/codeeditor"
   dependencies:
     "@codemirror/state": ^6.4.1
+<<<<<<< HEAD
     "@jupyter/ydoc": ^3.0.0-a1
+=======
+    "@jupyter/ydoc": ^3.0.0-a2
+>>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/coreutils": ^6.3.0-alpha.2
     "@jupyterlab/nbformat": ^4.3.0-alpha.2
@@ -2523,7 +2535,11 @@ __metadata:
     "@codemirror/legacy-modes": ^6.4.0
     "@codemirror/search": ^6.5.6
     "@codemirror/view": ^6.26.3
+<<<<<<< HEAD
     "@jupyter/ydoc": ^3.0.0-a1
+=======
+    "@jupyter/ydoc": ^3.0.0-a2
+>>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
     "@jupyterlab/codemirror": ^4.3.0-alpha.2
@@ -2566,7 +2582,11 @@ __metadata:
     "@codemirror/search": ^6.5.6
     "@codemirror/state": ^6.4.1
     "@codemirror/view": ^6.26.3
+<<<<<<< HEAD
     "@jupyter/ydoc": ^3.0.0-a1
+=======
+    "@jupyter/ydoc": ^3.0.0-a2
+>>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
     "@jupyterlab/coreutils": ^6.3.0-alpha.2
     "@jupyterlab/documentsearch": ^4.3.0-alpha.2
@@ -2613,7 +2633,11 @@ __metadata:
   dependencies:
     "@codemirror/state": ^6.4.1
     "@codemirror/view": ^6.26.3
+<<<<<<< HEAD
     "@jupyter/ydoc": ^3.0.0-a1
+=======
+    "@jupyter/ydoc": ^3.0.0-a2
+>>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
     "@jupyterlab/codemirror": ^4.3.0-alpha.2
@@ -2669,7 +2693,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/console@workspace:packages/console"
   dependencies:
+<<<<<<< HEAD
     "@jupyter/ydoc": ^3.0.0-a1
+=======
+    "@jupyter/ydoc": ^3.0.0-a2
+>>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
@@ -2796,8 +2824,13 @@ __metadata:
   dependencies:
     "@codemirror/state": ^6.4.1
     "@codemirror/view": ^6.26.3
+<<<<<<< HEAD
     "@jupyter/react-components": ^0.16.6
     "@jupyter/ydoc": ^3.0.0-a1
+=======
+    "@jupyter/react-components": ^0.16.3
+    "@jupyter/ydoc": ^3.0.0-a2
+>>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
@@ -2893,7 +2926,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/docregistry@workspace:packages/docregistry"
   dependencies:
+<<<<<<< HEAD
     "@jupyter/ydoc": ^3.0.0-a1
+=======
+    "@jupyter/ydoc": ^3.0.0-a2
+>>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
     "@jupyterlab/coreutils": ^6.3.0-alpha.2
@@ -3013,8 +3050,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/example-cell@workspace:examples/cell"
   dependencies:
+<<<<<<< HEAD
     "@jupyter/web-components": ^0.16.6
     "@jupyter/ydoc": ^3.0.0-a1
+=======
+    "@jupyter/web-components": ^0.16.3
+    "@jupyter/ydoc": ^3.0.0-a2
+>>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
@@ -3042,8 +3084,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/example-console@workspace:examples/console"
   dependencies:
+<<<<<<< HEAD
     "@jupyter/web-components": ^0.16.6
     "@jupyter/ydoc": ^3.0.0-a1
+=======
+    "@jupyter/web-components": ^0.16.3
+    "@jupyter/ydoc": ^3.0.0-a2
+>>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/codemirror": ^4.3.0-alpha.2
     "@jupyterlab/console": ^4.3.0-alpha.2
@@ -3188,8 +3235,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/example-notebook@workspace:examples/notebook"
   dependencies:
+<<<<<<< HEAD
     "@jupyter/web-components": ^0.16.6
     "@jupyter/ydoc": ^3.0.0-a1
+=======
+    "@jupyter/web-components": ^0.16.3
+    "@jupyter/ydoc": ^3.0.0-a2
+>>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/codemirror": ^4.3.0-alpha.2
@@ -3430,7 +3482,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/fileeditor@workspace:packages/fileeditor"
   dependencies:
+<<<<<<< HEAD
     "@jupyter/ydoc": ^3.0.0-a1
+=======
+    "@jupyter/ydoc": ^3.0.0-a2
+>>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
     "@jupyterlab/codemirror": ^4.3.0-alpha.2
@@ -4198,7 +4254,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/notebook-extension@workspace:packages/notebook-extension"
   dependencies:
+<<<<<<< HEAD
     "@jupyter/ydoc": ^3.0.0-a1
+=======
+    "@jupyter/ydoc": ^3.0.0-a2
+>>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
@@ -4246,7 +4306,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/notebook@workspace:packages/notebook"
   dependencies:
+<<<<<<< HEAD
     "@jupyter/ydoc": ^3.0.0-a1
+=======
+    "@jupyter/ydoc": ^3.0.0-a2
+>>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
@@ -4520,7 +4584,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/services@workspace:packages/services"
   dependencies:
+<<<<<<< HEAD
     "@jupyter/ydoc": ^3.0.0-a1
+=======
+    "@jupyter/ydoc": ^3.0.0-a2
+>>>>>>> 76593e90c2 (Update with jupyter-ydoc v3.0.0a2)
     "@jupyterlab/coreutils": ^6.3.0-alpha.2
     "@jupyterlab/nbformat": ^4.3.0-alpha.2
     "@jupyterlab/settingregistry": ^4.3.0-alpha.2


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/16515.
Needs https://github.com/jupyter-server/jupyter_ydoc/pull/241.

In https://github.com/jupyter-server/jupyter_ydoc/pull/201, code cell outputs changed from an untyped `Y.Array` to a `Y.Array` where each item is a `Y.Map`. For stream outputs, the `text` entry of this `Y.Map` becomes a `Y.Text`. This is to handle incoming stream data in an incremental and efficient way, by just modifying the `text`. Previously, the whole output was discarded and a new one was created, identical to the previous one except for the `text` that had the new data, leading to catastrophic memory consumption.

## Code changes

This PR takes advantage of this new schema, by doing the equivalent change in the `OutputModel`, where stream outputs have a `text` entry of type `ObservableString`.

## User-facing changes

Better performances, especially in collaborative mode.

## Backwards-incompatible changes

None.