### PR TITLE
Backport PR #16450 on branch 4.2.x (Align extension migration docs with the latest extension template)

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -189,7 +189,7 @@ Or with ``conda``:
 
 .. code:: bash
 
-   conda install -c conda-forge jupyterlab=4 "copier=8" jinja2-time tomli-w "pydantic<2" "pyyaml-include<2.0"
+   conda install -c conda-forge jupyterlab=4 "copier=9" jinja2-time
 
 
 Then at the root folder of the extension, run:

--- a/docs/source/extension/notebook.rst
+++ b/docs/source/extension/notebook.rst
@@ -248,10 +248,10 @@ Start from the extension template.
 
 .. code-block:: shell
 
-    pip install "copier~=8.0" jinja2-time
+    pip install "copier~=9" jinja2-time
     mkdir myextension
     cd myextension
-    copier copy --UNSAFE https://github.com/jupyterlab/extension-template .
+    copier copy --trust https://github.com/jupyterlab/extension-template .
 
 Install the dependencies. Note that extensions are built against the
 released npm packages, not the development versions.

--- a/jupyterlab/upgrade_extension.py
+++ b/jupyterlab/upgrade_extension.py
@@ -341,7 +341,7 @@ if __name__ == "__main__":
     if answer_file.exists():
         msg = "This script won't do anything for copier template, instead execute in your extension directory:\n\n    copier update"
         if tuple(copier.__version__.split(".")) >= ("8", "0", "0"):
-            msg += " --UNSAFE"
+            msg += " --trust"
         print(msg)
     else:
         update_extension(args.path, args.vcs_ref, args.no_input is False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ upgrade-extension = [
     "pyyaml-include<3.0",
     "copier>=9,<10",
     "jinja2-time<0.3",
-    "pydantic<2.0",
+    "pydantic<3.0",
     "tomli-w<2.0"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,8 +122,8 @@ dev = [
     "ruff==0.3.5",
 ]
 upgrade-extension = [
-    "pyyaml-include<2.0",
-    "copier>=8,<10",
+    "pyyaml-include<3.0",
+    "copier>=9,<10",
     "jinja2-time<0.3",
     "pydantic<2.0",
     "tomli-w<2.0"


### PR DESCRIPTION
Backport PR https://github.com/jupyterlab/jupyterlab/pull/16450 on branch 4.2.x (Align extension migration docs with the latest extension template)