### PR TITLE
Fix inline completer `configure` calls not being propagated correctly

### DIFF
--- a/packages/completer/src/manager.ts
+++ b/packages/completer/src/manager.ts
@@ -266,15 +266,12 @@ export class CompletionProviderManager implements ICompletionProviderManager {
       },
       configure: (settings: IInlineCompleterSettings) => {
         this._inlineCompleterSettings = settings;
-        this._panelHandlers.forEach((handler, handlerId) => {
-          for (const [
-            providerId,
-            provider
-          ] of this._inlineProviders.entries()) {
-            if (provider.configure) {
-              provider.configure(settings.providers[providerId]);
-            }
+        for (const [providerId, provider] of this._inlineProviders.entries()) {
+          if (provider.configure) {
+            provider.configure(settings.providers[providerId]);
           }
+        }
+        this._panelHandlers.forEach((handler, handlerId) => {
           if (handler.inlineCompleter) {
             handler.inlineCompleter.configure(settings);
           }

--- a/packages/metapackage/test/completer/manager.spec.ts
+++ b/packages/metapackage/test/completer/manager.spec.ts
@@ -11,6 +11,10 @@ import {
   ContextCompleterProvider,
   ICompletionContext,
   ICompletionProvider,
+  IInlineCompleterActions,
+  IInlineCompleterSettings,
+  IInlineCompletionProvider,
+  InlineCompleter,
   ProviderReconciliator
 } from '@jupyterlab/completer';
 import { Context } from '@jupyterlab/docregistry';
@@ -21,6 +25,7 @@ import {
 } from '@jupyterlab/notebook';
 import { ServiceManager } from '@jupyterlab/services';
 import { createStandaloneCell } from '@jupyter/ydoc';
+import { nullTranslator } from '@jupyterlab/translation';
 
 import { createSessionContext } from '@jupyterlab/apputils/lib/testutils';
 import { NBTestUtils } from '@jupyterlab/notebook/lib/testutils';
@@ -268,6 +273,73 @@ describe('completer/manager', () => {
         manager.select(widget.id);
         expect(callback).toHaveBeenCalledTimes(1);
         manager.selected.disconnect(callback);
+      });
+    });
+
+    describe('#inline', () => {
+      let inline: IInlineCompleterActions;
+      beforeEach(() => {
+        manager.setInlineCompleterFactory({
+          factory: options =>
+            new InlineCompleter({
+              ...options,
+              trans: nullTranslator.load('jupyterlab')
+            })
+        });
+        inline = manager.inline!;
+      });
+
+      describe('#configure', () => {
+        it('should call `configure()` method of each provider', () => {
+          const provider1: IInlineCompletionProvider = {
+            fetch: async () => {
+              return { items: [] };
+            },
+            name: 'an inline provider',
+            identifier: 'test-provider-1',
+            configure: jest.fn()
+          };
+          const provider2: IInlineCompletionProvider = {
+            fetch: async () => {
+              return { items: [] };
+            },
+            name: 'a second inline provider',
+            identifier: 'test-provider-2',
+            configure: jest.fn()
+          };
+          manager.registerInlineProvider(provider1);
+          manager.registerInlineProvider(provider2);
+          expect(provider1.configure).toHaveBeenCalledTimes(0);
+
+          const sharedConfig = {
+            debouncerDelay: 0,
+            timeout: 10000
+          };
+          inline.configure({
+            providers: {
+              'test-provider-1': {
+                ...sharedConfig,
+                enabled: true
+              },
+              'test-provider-2': {
+                ...sharedConfig,
+                enabled: false
+              }
+            } as IInlineCompleterSettings['providers']
+          } as IInlineCompleterSettings);
+          expect(provider1.configure).toHaveBeenCalledTimes(1);
+          expect(provider1.configure).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              enabled: true
+            })
+          );
+          expect(provider2.configure).toHaveBeenCalledTimes(1);
+          expect(provider2.configure).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              enabled: false
+            })
+          );
+        });
       });
     });
   });


### PR DESCRIPTION
## References

- Fixes https://github.com/jupyterlab/jupyterlab/issues/16500

## Code changes

- [x] Adds a test case for the `IInlineCompleterActions.configure()` invoking the `configure()` of `IInlineCompletionProvider`s
- [x] Fixes the issue by moving the logic up one level

## User-facing changes

Inline completer works more reliably, especially if JupyterLab is loaded with empty workspace

## Backwards-incompatible changes

None
