### PR TITLE
Improve handling of shared output changes

### DIFF
--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -790,8 +790,23 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
   ): void {
     if (change.outputsChange) {
       globalModelDBMutex(() => {
-        this.outputs.clear();
-        slot.getOutputs().forEach(output => this._outputs.add(output));
+        let retain = 0;
+        for (const outputsChange of change.outputsChange!) {
+          if ('retain' in outputsChange) {
+            retain += outputsChange.retain!;
+          }
+          if ('delete' in outputsChange) {
+            for (let i = 0; i < outputsChange.delete!; i++) {
+              this._outputs.remove(retain);
+            }
+          }
+          if ('insert' in outputsChange) {
+            // Inserting an output always results in appending it.
+            for (const output of outputsChange.insert!) {
+              this._outputs.add(output.toJSON());
+            }
+          }
+        }
       });
     }
 

--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -57,6 +57,11 @@ export interface IOutputAreaModel extends IDisposable {
   add(output: nbformat.IOutput): number;
 
   /**
+   * Remove an output at a given index.
+   */
+  remove(index: number): void;
+
+  /**
    * Set the value at the specified index.
    */
   set(index: number, output: nbformat.IOutput): void;
@@ -253,6 +258,14 @@ export class OutputAreaModel implements IOutputAreaModel {
     }
 
     return this._add(output);
+  }
+
+  /**
+   * Remove an output at a given index.
+   */
+  remove(index: number): void {
+    this.list.get(index).dispose();
+    this.list.remove(index);
   }
 
   /**


### PR DESCRIPTION
## Code changes

The way shared output changes are handled currently is not optimal: any change in the Y will results in removing all previous outputs from the modelDB model and adding all new outputs. This is because we were only supporting the initialization from a file, but other cases are appearing, for instance in server-side execution an output can be added. In this case we don't want to clear all outputs, but just handle the added output.

## User-facing changes

None

## Backwards-incompatible changes

None.