### PR TITLE
Backport PR #16508 on branch 4.2.x (Fix inline completer configure calls not being propagated correctly)

### DIFF
--- a/packages/completer/src/manager.ts
+++ b/packages/completer/src/manager.ts
@@ -251,15 +251,12 @@ export class CompletionProviderManager implements ICompletionProviderManager {
       },
       configure: (settings: IInlineCompleterSettings) => {
         this._inlineCompleterSettings = settings;
-        this._panelHandlers.forEach((handler, handlerId) => {
-          for (const [
-            providerId,
-            provider
-          ] of this._inlineProviders.entries()) {
-            if (provider.configure) {
-              provider.configure(settings.providers[providerId]);
-            }
+        for (const [providerId, provider] of this._inlineProviders.entries()) {
+          if (provider.configure) {
+            provider.configure(settings.providers[providerId]);
           }
+        }
+        this._panelHandlers.forEach((handler, handlerId) => {
           if (handler.inlineCompleter) {
             handler.inlineCompleter.configure(settings);
           }

--- a/packages/metapackage/test/completer/manager.spec.ts
+++ b/packages/metapackage/test/completer/manager.spec.ts
@@ -247,33 +247,6 @@ describe('completer/manager', () => {
       });
     });
 
-    describe('#selected', () => {
-      let completerContext: ICompletionContext;
-      let widget: NotebookPanel;
-
-      beforeEach(() => {
-        const context = contextFactory();
-        widget = NBTestUtils.createNotebookPanel(context);
-        completerContext = { widget };
-      });
-
-      it('should emit `selected` signal', async () => {
-        const callback = jest.fn();
-        await manager.updateCompleter(completerContext);
-        const handler = manager['_panelHandlers'].get(
-          widget.id
-        ) as CompletionHandler;
-        handler.completer.model!.setCompletionItems([{ label: 'foo' }]);
-        MessageLoop.sendMessage(handler.completer, Widget.Msg.UpdateRequest);
-
-        manager.selected.connect(callback);
-        expect(callback).toHaveBeenCalledTimes(0);
-        manager.select(widget.id);
-        expect(callback).toHaveBeenCalledTimes(1);
-        manager.selected.disconnect(callback);
-      });
-    });
-
     describe('#inline', () => {
       let inline: IInlineCompleterActions;
       beforeEach(() => {


### PR DESCRIPTION
Backport PR https://github.com/jupyterlab/jupyterlab/pull/16508 on branch 4.2.x (Fix inline completer configure calls not being propagated correctly)