### PR TITLE
Fix settings editor missing plugins with transform step or registered late

### DIFF
--- a/packages/settingeditor/src/pluginlist.tsx
+++ b/packages/settingeditor/src/pluginlist.tsx
@@ -55,9 +55,13 @@ export class PluginList extends ReactWidget {
     this.addClass('jp-PluginList');
     this._confirm = options.confirm;
     this._model = options.model ?? new PluginList.Model(options);
-    this._model.ready.then(() => {
-      this.update();
-    });
+    this._model.ready
+      .then(() => {
+        this.update();
+      })
+      .catch(reason => {
+        console.error(`Failed to load the plugin list model:\n${reason}`);
+      });
     this._model.changed.connect(() => {
       this.update();
     });
@@ -561,9 +565,13 @@ export namespace PluginList {
         }
       }, this);
       this._plugins = this._loadPlugins();
-      this._loadSettings(this._plugins).then(() => {
-        this._ready.resolve(undefined);
-      });
+      this._loadSettings(this._plugins)
+        .then(() => {
+          this._ready.resolve(undefined);
+        })
+        .catch(reason => {
+          console.error(`Failed to load the settings:\n${reason}`);
+        });
     }
 
     /**

--- a/packages/settingeditor/src/pluginlist.tsx
+++ b/packages/settingeditor/src/pluginlist.tsx
@@ -58,13 +58,13 @@ export class PluginList extends ReactWidget {
     this._model.ready
       .then(() => {
         this.update();
+        this._model.changed.connect(() => {
+          this.update();
+        });
       })
       .catch(reason => {
         console.error(`Failed to load the plugin list model:\n${reason}`);
       });
-    this._model.changed.connect(() => {
-      this.update();
-    });
     this.mapPlugins = this.mapPlugins.bind(this);
     this.setFilter = this.setFilter.bind(this);
     this.setFilter(

--- a/packages/settingeditor/src/settingseditor.tsx
+++ b/packages/settingeditor/src/settingseditor.tsx
@@ -69,9 +69,13 @@ export class SettingsEditor extends SplitPanel {
       </UseSignal>
     );
     // Initializes the settings panel after loading the schema for all plugins.
-    this._listModel.ready.then(() => {
-      this.addWidget(settingsPanel);
-    });
+    this._listModel.ready
+      .then(() => {
+        this.addWidget(settingsPanel);
+      })
+      .catch(reason => {
+        console.error(`Failed to load the setting plugins:\n${reason}`);
+      });
   }
 
   /**

--- a/packages/settingeditor/test/pluginlist.spec.tsx
+++ b/packages/settingeditor/test/pluginlist.spec.tsx
@@ -107,12 +107,16 @@ describe('@jupyterlab/settingeditor', () => {
         await model.ready;
 
         // Change to a non-default value
-        settings.set('testSetting', 'test');
-        await expect(signalToPromise(model.changed)).resolves.not.toThrow();
+        await Promise.all([
+          settings.set('testSetting', 'test'),
+          expect(signalToPromise(model.changed)).resolves.not.toThrow()
+        ]);
 
         // Change back to the default
-        settings.set('testSetting', 'example');
-        await expect(signalToPromise(model.changed)).resolves.not.toThrow();
+        await Promise.all([
+          settings.set('testSetting', 'example'),
+          expect(signalToPromise(model.changed)).resolves.not.toThrow()
+        ]);
       });
     });
 

--- a/packages/settingeditor/test/pluginlist.spec.tsx
+++ b/packages/settingeditor/test/pluginlist.spec.tsx
@@ -1,0 +1,215 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+import { PluginList } from '../src/pluginlist';
+import { signalToPromise } from '@jupyterlab/coreutils';
+import { StateDB } from '@jupyterlab/statedb';
+import { ISettingRegistry, SettingRegistry } from '@jupyterlab/settingregistry';
+
+class TestConnector extends StateDB {
+  schemas: { [key: string]: ISettingRegistry.ISchema } = {};
+
+  async fetch(id: string): Promise<ISettingRegistry.IPlugin | undefined> {
+    const fetched = await super.fetch(id);
+    if (!fetched && !this.schemas[id]) {
+      return undefined;
+    }
+
+    const schema: ISettingRegistry.ISchema = this.schemas[id] || {
+      type: 'object'
+    };
+    const composite = {};
+    const user = {};
+    const raw = (fetched as string) || '{ }';
+    const version = 'test';
+    return { id, data: { composite, user }, raw, schema, version };
+  }
+
+  async list(): Promise<any> {
+    return Promise.reject('list method not implemented');
+  }
+}
+
+class TestRegistry extends SettingRegistry {
+  get preloaded() {
+    return this.ready;
+  }
+}
+
+describe('@jupyterlab/settingeditor', () => {
+  describe('PluginList.Model', () => {
+    let connector: TestConnector;
+    let registry: TestRegistry;
+
+    const id = 'test-id';
+    const schema: ISettingRegistry.ISchema = {
+      type: 'object',
+      properties: {
+        testSetting: {
+          type: 'string',
+          default: 'example'
+        }
+      }
+    };
+    const transformSchema = {
+      'jupyter.lab.transform': true,
+      ...schema
+    };
+
+    beforeAll(() => {
+      connector = new TestConnector();
+    });
+
+    beforeEach(() => {
+      registry = new TestRegistry({ connector });
+    });
+
+    afterEach(async () => {
+      connector.schemas = {};
+      await connector.clear();
+    });
+
+    describe('#changed', () => {
+      it('should emit when a new plugin is loaded', async () => {
+        connector.schemas[id] = schema;
+
+        const model = new PluginList.Model({ registry });
+        await model.ready;
+
+        await registry.load(id);
+
+        await signalToPromise(model.changed);
+      });
+
+      it('should emit when the transform of a plugin resolves', async () => {
+        connector.schemas[id] = transformSchema;
+        const plugin = await connector.fetch(id);
+
+        // Preload the plugin
+        registry = new TestRegistry({ connector, plugins: [plugin!] });
+        const model = new PluginList.Model({ registry });
+        await model.ready;
+
+        // Register transforms
+        registry.transform(id, {
+          fetch: p => p
+        });
+        // Load with transformer
+        await registry.load(id);
+
+        await signalToPromise(model.changed);
+      });
+    });
+
+    describe('#plugins', () => {
+      it('should load plugins loaded after the model has initialised', async () => {
+        connector.schemas[id] = schema;
+
+        const model = new PluginList.Model({ registry });
+        await model.ready;
+        expect(model.plugins).toHaveLength(0);
+
+        await registry.load(id);
+
+        await signalToPromise(model.changed);
+        expect(model.plugins).toHaveLength(1);
+        expect(model.plugins[0].id).toBe(id);
+      });
+
+      it('should include pre-loaded plugins', async () => {
+        connector.schemas[id] = schema;
+        const plugin = await connector.fetch(id);
+
+        // Passing a plugin without transform will lead to pre-loading
+        registry = new TestRegistry({ connector, plugins: [plugin!] });
+        await registry.preloaded;
+
+        const model = new PluginList.Model({ registry });
+        await model.ready;
+
+        expect(model.plugins).toHaveLength(1);
+        expect(model.plugins[0].id).toBe(id);
+      });
+
+      it('should include pre-fetched plugins once their transform is applied', async () => {
+        connector.schemas[id] = transformSchema;
+        const plugin = await connector.fetch(id);
+
+        // Passing a plugin with transform will cache it (but not load yet!)
+        registry = new TestRegistry({ connector, plugins: [plugin!] });
+        const model = new PluginList.Model({ registry });
+        await model.ready;
+
+        expect(model.plugins).toHaveLength(0);
+
+        // Register transforms
+        registry.transform(id, {
+          fetch: p => p
+        });
+        // Load with transformer
+        await registry.load(id);
+
+        await signalToPromise(model.changed);
+        expect(model.plugins).toHaveLength(1);
+      });
+    });
+
+    describe('#settings', () => {
+      it('should load settings for plugins loaded after the model has initialised', async () => {
+        connector.schemas[id] = schema;
+
+        const model = new PluginList.Model({ registry });
+        await model.ready;
+        expect(Object.keys(model.settings)).toHaveLength(0);
+
+        await registry.load(id);
+
+        await signalToPromise(model.changed);
+        expect(Object.keys(model.settings)).toHaveLength(1);
+        expect(model.settings[id].id).toBe(id);
+      });
+
+      it('should include settings for pre-loaded plugins', async () => {
+        connector.schemas[id] = schema;
+        const plugin = await connector.fetch(id);
+
+        // Passing a plugin without transform will lead to pre-loading
+        registry = new TestRegistry({ connector, plugins: [plugin!] });
+        await registry.preloaded;
+
+        const model = new PluginList.Model({ registry });
+        await model.ready;
+
+        expect(Object.keys(model.settings)).toHaveLength(1);
+        expect(model.settings[id].id).toBe(id);
+      });
+
+      it('includes settings for pre-fetched plugins once their transform is applied', async () => {
+        connector.schemas[id] = transformSchema;
+        const plugin = await connector.fetch(id);
+
+        // Passing a plugin with transform will cache it (but not load yet!)
+        registry = new TestRegistry({ connector, plugins: [plugin!] });
+        await registry.preloaded;
+
+        const model = new PluginList.Model({ registry });
+        await model.ready;
+
+        expect(Object.keys(model.settings)).toHaveLength(0);
+
+        // Register transforms
+        registry.transform(id, {
+          fetch: p => {
+            p.schema['transformed'] = true;
+            return p;
+          }
+        });
+        // Load with transformer
+        await registry.load(id);
+
+        await signalToPromise(model.changed);
+        expect(Object.keys(model.settings)).toHaveLength(1);
+        expect(model.settings[id].schema.transformed).toBe(true);
+      });
+    });
+  });
+});

--- a/packages/settingeditor/test/pluginlist.spec.tsx
+++ b/packages/settingeditor/test/pluginlist.spec.tsx
@@ -77,7 +77,7 @@ describe('@jupyterlab/settingeditor', () => {
 
         await registry.load(id);
 
-        await signalToPromise(model.changed);
+        await expect(signalToPromise(model.changed)).resolves.not.toThrow();
       });
 
       it('should emit when the transform of a plugin resolves', async () => {
@@ -96,7 +96,23 @@ describe('@jupyterlab/settingeditor', () => {
         // Load with transformer
         await registry.load(id);
 
-        await signalToPromise(model.changed);
+        await expect(signalToPromise(model.changed)).resolves.not.toThrow();
+      });
+
+      it('should emit when settings change', async () => {
+        connector.schemas[id] = schema;
+
+        const settings = await registry.load(id);
+        const model = new PluginList.Model({ registry });
+        await model.ready;
+
+        // Change to a non-default value
+        settings.set('testSetting', 'test');
+        await expect(signalToPromise(model.changed)).resolves.not.toThrow();
+
+        // Change back to the default
+        settings.set('testSetting', 'example');
+        await expect(signalToPromise(model.changed)).resolves.not.toThrow();
       });
     });
 

--- a/packages/settingregistry/src/settingregistry.ts
+++ b/packages/settingregistry/src/settingregistry.ts
@@ -560,6 +560,13 @@ export class SettingRegistry implements ISettingRegistry {
   }
 
   /**
+   * A promise which resolves when the pre-fetched plugins passed to the registry finished pre-loading.
+   */
+  protected get ready() {
+    return this._ready;
+  }
+
+  /**
    * Load a plugin into the registry.
    */
   private async _load(data: ISettingRegistry.IPlugin): Promise<void> {


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/15871

## Code changes

- removes bad code duplication between `PluginList` and `SettingsEditor` which lead to loading the settings for each plugin twice (this leads to a minimal performance improvement because the fetched plugins were already cached before)
- adds a dedicated `PluginList.Model` model class which is used by both `PluginList` and `SettingsEditor`
- deprecates `PluginList.sortPlugins()` - this function was only used to implement the aforementioned duplicated logic; an equivalent function is now one of the private model methods
- deprecates `toSkip` option previously passed to the `PluginList` constructor which should now be supplied to the `PluginList.Model` instead
- deprecates `PluginList.registry` attribute - the plugin list should not provide the settings registry as it is not its responsibility; private `_registry` name is to be used going forward

## User-facing changes

- When the plugin gets added after the Settings Editor was opened this plugin is now visible on the list
- When settings schema gets populated after the Settings Editor was opened (due to the use of `transform`), the settings are now correctly shown in the editor

## Backwards-incompatible changes

None