### PR TITLE
Update the CSS variable used for notebook cell shadows

### DIFF
--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -152,7 +152,7 @@
 
 .jp-Notebook.jp-mod-editMode .jp-Cell.jp-mod-active .jp-InputArea-editor {
   border: var(--jp-border-width) solid var(--jp-cell-editor-active-border-color);
-  box-shadow: var(--jp-input-box-shadow);
+  box-shadow: var(--jp-cell-editor-box-shadow);
   background-color: var(--jp-cell-editor-active-background);
 }
 


### PR DESCRIPTION
Hi! 👋 

## References

Closes #16543 

## Code changes

The `--jp-cell-editor-box-shadow` CSS variable for themes is used instead of the _generic_ `--jp-input-box-shadow` variable to customize the shadow of notebook cells.

## User-facing changes

For JupyterLab users, none, given that both variables have the same value in the built-in themes. For theme creators, this update allows them to customize notebook cells separately from _generic_ input fields (in terms of `box-shadow` as well).

### Before

<img width="1582" alt="Screenshot 2024-07-02 at 18 10 03" src="https://github.com/jupyterlab/jupyterlab/assets/17132927/58ec8a5e-b2a0-41cc-8e4b-4bdf289dfbe3">

### After

<img width="1582" alt="Screenshot 2024-07-02 at 18 12 24" src="https://github.com/jupyterlab/jupyterlab/assets/17132927/53390884-606c-4a66-8fa1-f95707a231c0">

## Backwards-incompatible changes

None, as far as I know.