### PR TITLE
Fix license table CSS selector to apply the selected row styles

### DIFF
--- a/packages/help-extension/style/base.css
+++ b/packages/help-extension/style/base.css
@@ -218,7 +218,7 @@
   background-color: transparent;
 }
 
-.jp-Licenses-Grid tr.jp-mod-selected {
+.jp-Licenses-Grid.jp-RenderedHTMLCommon tr.jp-mod-selected {
   background-color: var(--jp-brand-color1);
   color: #fff;
 }


### PR DESCRIPTION
Hi! 👋 

## References

Closes #16542 

## Code changes

Standardize the license table CSS selector to `.jp-Licenses-Grid.jp-RenderedHTMLCommon` instead of just `.jp-Licenses-Grid` so that selected row styles are applied as expected.

### Note

I had to manually copy the `third-party-licenses.json` files to the `~/jupyterlab/dev_mode/static/` folder in development mode in order to test the changes. This file is not generated in development mode as far as I noticed.

## User-facing changes

The text of the selected row is visible, similar to what happens in the file browser:

<img width="1582" alt="Screenshot 2024-07-02 at 19 23 32" src="https://github.com/jupyterlab/jupyterlab/assets/17132927/93b9718f-d1df-4017-858d-f17d05de7250">

## Backwards-incompatible changes

None, as far as I know.