### PR TITLE
Adopt theme CSS variables for generic input fields

### DIFF
--- a/packages/ui-components/style/rjsfTemplates.css
+++ b/packages/ui-components/style/rjsfTemplates.css
@@ -57,9 +57,9 @@
 .jp-FormGroup-content fieldset input:focus,
 .jp-FormGroup-content fieldset select:focus {
   -moz-outline-radius: unset;
-  outline: var(--jp-border-width) solid var(--md-blue-500, #2196f3);
+  outline: var(--jp-border-width) solid var(--jp-input-active-border-color);
   outline-offset: -1px;
-  box-shadow: inset 0 0 4px var(--md-blue-300, #64b5f6);
+  box-shadow: var(--jp-input-box-shadow);
 }
 
 .jp-FormGroup-content fieldset input:hover:not(:focus),

--- a/packages/ui-components/style/styling.css
+++ b/packages/ui-components/style/styling.css
@@ -42,8 +42,8 @@ input[type='checkbox'].jp-mod-styled {
 }
 
 input.jp-mod-styled:focus {
-  border: var(--jp-border-width) solid var(--md-blue-500, #2196f3);
-  box-shadow: inset 0 0 4px var(--md-blue-300, #64b5f6);
+  border: var(--jp-border-width) solid var(--jp-input-active-border-color);
+  box-shadow: var(--jp-input-box-shadow);
 }
 
 input[type='checkbox'].jp-mod-styled:focus-visible {


### PR DESCRIPTION
Hi 👋 

## References

Closes #16544 

## Code changes

Instead of _hard coded_ property values ​​to style focused input fields (like those on the Licenses page and the Property Inspector), CSS variables defined in themes are used.

## User-facing changes

Visually, the focused input fields are slightly different because the themes' property values ​​are different from the original values, standardizing them with the themes.

For theme creators, these input fields can now also be customized via CSS variables.

### Before

<img width="1582" alt="Screenshot 2024-07-02 at 20 37 09" src="https://github.com/jupyterlab/jupyterlab/assets/17132927/1d2d2a93-e836-42f4-ae12-e2236dae1d8c">

<img width="1582" alt="Screenshot 2024-07-02 at 20 40 46" src="https://github.com/jupyterlab/jupyterlab/assets/17132927/f8b5b2ac-907f-4dcc-a5e4-e9dc82bcbe72">

### After
<img width="1582" alt="Screenshot 2024-07-02 at 20 44 55" src="https://github.com/jupyterlab/jupyterlab/assets/17132927/407d3044-e0a9-44f7-8842-6e65469bc978">

<img width="1582" alt="Screenshot 2024-07-02 at 20 48 46" src="https://github.com/jupyterlab/jupyterlab/assets/17132927/461bc773-83a2-464d-a179-8930a0c47223">

## Backwards-incompatible changes

None, as far as I know.