### PR TITLE
Set the background color for the hover state of the New Launcher button

### DIFF
--- a/packages/launcher-extension/style/base.css
+++ b/packages/launcher-extension/style/base.css
@@ -6,7 +6,12 @@
 .jp-FileBrowser-toolbar
   .jp-ToolbarButtonComponent[data-command='launcher:create'] {
   width: 72px;
-  background: var(--jp-brand-color1);
+  background: var(--jp-accept-color-normal, var(--jp-brand-color1));
+}
+
+.jp-FileBrowser-toolbar
+  .jp-ToolbarButtonComponent[data-command='launcher:create']:hover {
+  background-color: var(--jp-accept-color-hover);
 }
 
 .jp-FileBrowser-toolbar


### PR DESCRIPTION
Hi! 👋 

## References

Closes #16549 

## Code changes

The background color for the hover state of the New Launcher button has been set according to the references in #16549. Additionally, the _default_ button background has also been updated to the `var(--jp-accept-color-normal, var(--jp-brand-color1))` variable for consistency.

## User-facing changes

When a user hovers over the New Launcher button, the background color will change:

https://github.com/jupyterlab/jupyterlab/assets/17132927/e9352210-51b9-42d1-838c-b449c1522b76

## Backwards-incompatible changes

None.