### PR TITLE
Standardize Property Inspector placeholder according to TOC

### DIFF
--- a/packages/property-inspector/src/index.ts
+++ b/packages/property-inspector/src/index.ts
@@ -186,8 +186,10 @@ export class SideBarPropertyInspectorProvider extends PropertyInspectorProvider 
     } else {
       const node = document.createElement('div');
       const content = document.createElement('div');
-      content.textContent = this._trans.__('No properties to inspect.');
+      const placeholderText = document.createElement('p');
+      placeholderText.textContent = this._trans.__('No properties to inspect.');
       content.className = 'jp-PropertyInspector-placeholderContent';
+      content.appendChild(placeholderText);
       node.appendChild(content);
       this._placeholder = new Widget({ node });
       this._placeholder.addClass('jp-PropertyInspector-placeholder');

--- a/packages/property-inspector/style/base.css
+++ b/packages/property-inspector/style/base.css
@@ -14,11 +14,10 @@
 }
 
 .jp-PropertyInspector-placeholder {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  text-align: center;
 }
 
 .jp-PropertyInspector-placeholderContent {
+  color: var(--jp-content-font-color2);
   padding: 8px;
 }


### PR DESCRIPTION
Hi! 👋 

## References

Closes #14235 

## Code changes

The Property Inspector placeholder styling was adapted based on the [Table of Contents placeholder](https://github.com/jupyterlab/jupyterlab/blob/c4490110093280be3a2859749fb6b5675df3c0f2/packages/toc/style/base.css#L23-L30) as well as the [HTML elements](https://github.com/jupyterlab/jupyterlab/blob/c4490110093280be3a2859749fb6b5675df3c0f2/packages/toc/src/treeview.tsx#L30-L40) that make up it to take advantage of `<p>` styles and for consistency. 

Let me know your feedback, please!

## User-facing changes

The Property Inspector placeholder is now visually and element-wise similar to the Table of Contents placeholder:

<img width="1582" alt="Screenshot 2024-07-09 at 18 25 33" src="https://github.com/jupyterlab/jupyterlab/assets/17132927/698465c6-f7a6-4b07-ab0b-c25d222e9eee">

## Backwards-incompatible changes

None.