### PR TITLE
Adopt the `--jp-border-radius` CSS variable in missing input fields

### DIFF
--- a/packages/ui-components/style/base.css
+++ b/packages/ui-components/style/base.css
@@ -110,7 +110,7 @@
 .jp-InputGroup input {
   box-sizing: border-box;
   border: none;
-  border-radius: 0;
+  border-radius: var(--jp-border-radius);
   background-color: transparent;
   color: var(--jp-ui-font-color0);
   box-shadow: inset 0 0 0 var(--jp-border-width) var(--jp-input-border-color);

--- a/packages/ui-components/style/styling.css
+++ b/packages/ui-components/style/styling.css
@@ -24,6 +24,7 @@ input.jp-mod-styled {
   height: 28px;
   box-sizing: border-box;
   border: var(--jp-border-width) solid var(--jp-border-color1);
+  border-radius: var(--jp-border-radius);
   padding-left: 7px;
   padding-right: 7px;
   font-size: var(--jp-ui-font-size2);
@@ -86,7 +87,7 @@ select.jp-mod-styled {
   color: var(--jp-ui-font-color0);
   padding: 0 25px 0 8px;
   border: var(--jp-border-width) solid var(--jp-input-border-color);
-  border-radius: 0;
+  border-radius: var(--jp-border-radius);
   outline: none;
   appearance: none;
   -webkit-appearance: none;


### PR DESCRIPTION
Hi! 👋 

## References

Closes #16562

## Code changes

The border radius for input fields in modals/dialogs, the Licenses page, and the JSON editor, for example, is now set to the `--jp-border-radius` CSS variable, defined in JupyterLab themes.

## User-facing changes

The input fields mentioned above now have a border radius other than 0 ([`2px`](https://github.com/jupyterlab/jupyterlab/blob/c4490110093280be3a2859749fb6b5675df3c0f2/packages/theme-light-extension/style/variables.css#L95)):

<img width="1582" alt="Screenshot 2024-07-09 at 19 02 41" src="https://github.com/jupyterlab/jupyterlab/assets/17132927/2ae1e018-cab2-4d9d-8c2e-7436138f6b37">

<img width="1582" alt="Screenshot 2024-07-09 at 19 04 33" src="https://github.com/jupyterlab/jupyterlab/assets/17132927/bb735c28-05d7-4e21-91c4-028bf7e013c9">

<img width="1582" alt="Screenshot 2024-07-09 at 19 05 55" src="https://github.com/jupyterlab/jupyterlab/assets/17132927/19d44dc8-0f65-45ac-9156-aee8e2e3f64a">

Additionally, because the border radius is now defined by the `--jp-border-radius` CSS variable, these input fields are now customized consistently with the others when creating new themes.

## Backwards-incompatible changes

None.