### PR TITLE
added name and changed and reimplemented label

### DIFF
--- a/packages/running-extension/src/kernels.tsx
+++ b/packages/running-extension/src/kernels.tsx
@@ -239,7 +239,7 @@ namespace Private {
   type DocumentWidgetWithKernelItem = Omit<
     IRunningSessions.IRunningItem,
     'label'
-  > & { label(): string };
+  > & { label(): ReactNode; name(): string };
 
   export class RunningKernel implements IRunningSessions.IRunningItem {
     constructor(options: RunningKernel.IOptions) {
@@ -283,7 +283,16 @@ namespace Private {
                 : type === 'notebook'
                 ? notebookIcon
                 : jupyterIcon,
-            label: () => name,
+            name: () => name,
+            label: () => {
+              const kernelIdPrefix = this.kernel.id.split('-')[0];
+              return (
+                <>
+                  {name}{' '}
+                  <span className={KERNEL_LABEL_ID}>({kernelIdPrefix})</span>
+                </>
+              );
+            },
             labelTitle: () => path
           });
         }
@@ -328,11 +337,11 @@ namespace Private {
       if (children.length === 0) {
         return this.trans.__('No sessions connected');
       } else if (children.length == 1) {
-        return children[0].label();
+        return children[0].name();
       } else {
         return this.trans.__(
           '%1 and %2 more',
-          children[0].label(),
+          children[0].name(),
           children.length - 1
         );
       }

--- a/packages/running/style/base.css
+++ b/packages/running/style/base.css
@@ -269,3 +269,13 @@ span.jp-RunningSessions-icon > svg {
   ~ .jp-SearchableSessions-emptyIndicator {
   display: none;
 }
+
+.jp-mod-kernel-widget .jp-RunningSessions-item-label-kernel-id {
+  display: none;
+}
+
+.jp-mod-running-list-view
+  .jp-mod-kernel-widget
+  .jp-RunningSessions-item-label-kernel-id {
+  display: inline;
+}


### PR DESCRIPTION
## References

Fixes #15991

## Code changes

Reimplemented the way name and kernel-id shows to section and list view by changing return type for label and added new var name which return the name.
Implemented label to show kernel-id and name through ReactNode

## User-facing changes
section view
![hello](https://github.com/jupyterlab/jupyterlab/assets/54989885/f6e085d7-aec5-42ac-b5bc-29e7da5a4ee8)

list view
![hello](https://github.com/jupyterlab/jupyterlab/assets/54989885/83482f91-dec6-44fc-971f-9e47feb12f11)
