### PR TITLE
Standardize Contextual Help placeholder according to TOC

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -21,6 +21,8 @@ anymore. The side effects for extensions are:
   prepend the class ``.jp-ThemedContainer`` to your rule; e.g.
   ``.jp-Inspector-content pre`` becomes ``.jp-ThemedContainer .jp-Inspector-content pre``
 
+The ``jp-Inspector-default-content`` class was renamed to ``jp-Inspector-placeholderContent``.
+The name of this contextual help class is now consistent with the equivalent table of contents and property inspector classes.
 
 JupyterLab 4.1 to 4.2
 ---------------------

--- a/packages/inspector/src/inspector.ts
+++ b/packages/inspector/src/inspector.ts
@@ -23,7 +23,7 @@ const CONTENT_CLASS = 'jp-Inspector-content';
 /**
  * The class name added to default inspector content.
  */
-const DEFAULT_CONTENT_CLASS = 'jp-Inspector-default-content';
+const DEFAULT_CONTENT_CLASS = 'jp-Inspector-placeholderContent';
 
 /**
  * A panel which contains a set of inspectors.

--- a/packages/inspector/src/inspector.ts
+++ b/packages/inspector/src/inspector.ts
@@ -51,7 +51,7 @@ export class InspectorPanel
         'No Documentation'
       )}</h3>`;
       const placeholderText = `<p>${this._trans.__(
-        'Select a code fragment (e.g. function or object) to request information about it from the kernel attached to the editor.'
+        'Move the cursor to a code fragment (e.g. function or object) to request information about it from the kernel attached to the editor.'
       )}</p>`;
 
       this._content = InspectorPanel._generateContentWidget(

--- a/packages/inspector/src/inspector.ts
+++ b/packages/inspector/src/inspector.ts
@@ -47,10 +47,15 @@ export class InspectorPanel
         `<p>${options.initialContent}</p>`
       );
     } else {
+      const placeholderHeadline = `<h3>${this._trans.__(
+        'No Documentation'
+      )}</h3>`;
+      const placeholderText = `<p>${this._trans.__(
+        'Select a code fragment (e.g. function or object) to request information about it from the kernel attached to the editor.'
+      )}</p>`;
+
       this._content = InspectorPanel._generateContentWidget(
-        '<p>' +
-          this._trans.__('Click on a function to see documentation.') +
-          '</p>'
+        `${placeholderHeadline}${placeholderText}`
       );
     }
 

--- a/packages/inspector/style/base.css
+++ b/packages/inspector/style/base.css
@@ -42,3 +42,7 @@
   text-align: center;
   color: var(--jp-content-font-color2);
 }
+
+.jp-Inspector-placeholderContent > h3 {
+  margin-bottom: var(--jp-content-heading-margin-bottom);
+}

--- a/packages/inspector/style/base.css
+++ b/packages/inspector/style/base.css
@@ -38,11 +38,7 @@
   white-space: pre-wrap;
 }
 
-.jp-Inspector-default-content {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: xx-large;
-  font-style: italic;
-  color: darkgray;
+.jp-Inspector-placeholderContent {
+  text-align: center;
+  color: var(--jp-content-font-color2);
 }


### PR DESCRIPTION
Hi! 👋 

## References

Closes #14234

## Code changes

The Contextual Help placeholder styles have been adjusted to match those of the Table of Contents and the Property Inspector. Additionally, the class name has been updated to include the "placeholder" keyword instead of "default" for consistency.

Let me know if I should update the placeholder string or not, please.

## User-facing changes

The Contextual Help placeholder is now visually similar to the Table of Contents and Property Inspector placeholders:

<img width="1582" alt="Screenshot 2024-07-10 at 19 24 02" src="https://github.com/jupyterlab/jupyterlab/assets/17132927/2ded7dfb-3bfa-4f8e-b7d3-08f78483b622">

## Backwards-incompatible changes

None.