### PR TITLE
Fix lack of color contrast for the project version and license selected on the Licenses page

### DIFF
--- a/packages/help-extension/style/base.css
+++ b/packages/help-extension/style/base.css
@@ -223,10 +223,6 @@
   color: #fff;
 }
 
-.jp-Licenses-Grid.jp-RenderedHTMLCommon .jp-mod-selected code {
-  color: #fff;
-}
-
 /* license text */
 .jp-Licenses-Text {
   min-width: calc(10 * var(--jp-ui-font-size1));

--- a/packages/help-extension/style/base.css
+++ b/packages/help-extension/style/base.css
@@ -214,12 +214,17 @@
   width: 100%;
 }
 
-.jp-Licenses-Grid.jp-RenderedHTMLCommon code {
+.jp-Licenses .jp-Licenses-Grid.jp-RenderedHTMLCommon code {
   background-color: transparent;
+  padding: 0;
 }
 
 .jp-Licenses-Grid.jp-RenderedHTMLCommon tr.jp-mod-selected {
   background-color: var(--jp-brand-color1);
+  color: #fff;
+}
+
+.jp-Licenses-Grid.jp-RenderedHTMLCommon .jp-mod-selected code {
   color: #fff;
 }
 


### PR DESCRIPTION
Hi! 👋 

## References

Closes #16580 

## Code changes

The style for the project version and license when the respective row is selected was removed, thus keeping the text and background color of these columns the same as those of the unselected rows. I chose this option because it seemed more in line with the content under _DISTRIBUTIONS_.

Another alternative would have been to specify the background color the same as the background color of the selected row. Let me know what you prefer, please!

### Note

I had to manually copy the `third-party-licenses.json` file to the `~/jupyterlab/dev_mode/static/` folder in development mode in order to test the changes.

## User-facing changes

Project version and license text are now visible:

<img width="1582" alt="Screenshot 2024-07-12 at 19 38 14" src="https://github.com/user-attachments/assets/e04a0e9b-014e-488c-8b06-bfd47e549568">

<img width="1582" alt="Screenshot 2024-07-12 at 20 03 51" src="https://github.com/user-attachments/assets/a5fc9b1c-2eea-446e-8e5b-ae4ae396cf44">

## Backwards-incompatible changes

None.