### PR TITLE
Fix the identifier to download licenses in JSON format

### DIFF
--- a/galata/test/jupyterlab/help.test.ts
+++ b/galata/test/jupyterlab/help.test.ts
@@ -4,6 +4,23 @@
  */
 
 import { expect, test } from '@jupyterlab/galata';
+import { readFile } from 'fs/promises';
+
+import { isBlank, isValidJSON } from './utils';
+
+const licenseFormats = [
+  {
+    name: 'Markdown',
+    extension: 'md',
+    validation: (value: string) => !isBlank(value)
+  },
+  {
+    name: 'CSV',
+    extension: 'csv',
+    validation: (value: string) => !isBlank(value)
+  },
+  { name: 'JSON', extension: 'json', validation: isValidJSON }
+];
 
 test('Switch back and forth to reference page', async ({ page }) => {
   // The goal is to test switching back and forth with a tab containing an iframe
@@ -29,4 +46,30 @@ test('Switch back and forth to reference page', async ({ page }) => {
   await expect(
     page.locator('.jp-MarkdownCell .jp-InputArea-editor')
   ).toHaveText(cellContent);
+});
+
+test.describe('Licenses', () => {
+  licenseFormats.forEach(licenseFormat => {
+    test(`Exporting licenses as ${licenseFormat.name} must download a ${licenseFormat.name} file`, async ({
+      page
+    }) => {
+      await page.menu.clickMenuItem('Help>Licenses');
+
+      const downloadPromise = page.waitForEvent('download');
+      await page
+        .getByRole('button', {
+          name: `Download All Licenses as ${licenseFormat.name}`
+        })
+        .click();
+      const download = await downloadPromise;
+
+      const fileName = download.suggestedFilename();
+      const fileContent = await readFile(await download.path(), {
+        encoding: 'utf8'
+      });
+
+      expect(fileName).toBe(`jupyterlab-licenses.${licenseFormat.extension}`);
+      expect(licenseFormat.validation(fileContent)).toBeTruthy();
+    });
+  });
 });

--- a/galata/test/jupyterlab/utils.ts
+++ b/galata/test/jupyterlab/utils.ts
@@ -73,3 +73,22 @@ export async function dragCellTo(
   await page.waitForCondition(options.stopCondition);
   await page.mouse.up();
 }
+
+/**
+ * Check if a given string value is valid JSON.
+ */
+export function isValidJSON(value: string): boolean {
+  try {
+    JSON.parse(value);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
+ * Check if a given string value is empty (excluding spaces).
+ */
+export function isBlank(value: string): boolean {
+  return value.trim().length === 0;
+}

--- a/packages/help-extension/src/licenses.tsx
+++ b/packages/help-extension/src/licenses.tsx
@@ -183,7 +183,7 @@ export namespace Licenses {
       icon: spreadsheetIcon
     },
     json: {
-      id: 'csv',
+      id: 'json',
       title: 'JSON',
       icon: jsonIcon
     }


### PR DESCRIPTION
Hi! 👋 

## References

Closes #16583 

## Code changes

Updated the JSON format `id` from `csv` to `json`.

### Note

I had to manually copy the `third-party-licenses.json` file to the `~/jupyterlab/dev_mode/static/` folder in development mode in order to test the changes.

## User-facing changes

After pressing the `Download All Licenses as JSON` button (_Help_ > _Licenses_ > Toolbar), the user now gets a `jupyterlab-licenses.json` file:

<img width="1582" alt="Screenshot 2024-07-12 at 20 07 43" src="https://github.com/user-attachments/assets/52a9fb51-a2fa-4384-9abe-259a1ef59c74">

## Backwards-incompatible changes

None.