### PR TITLE
Fix galata docs on overriding `tmpPath`

### DIFF
--- a/galata/README.md
+++ b/galata/README.md
@@ -536,16 +536,16 @@ Example:
 test.use({ tmpPath: 'test-toc' });
 
 test.describe.serial('Table of Contents', () => {
-  test.beforeAll(async ({ baseURL, tmpPath }) => {
-    const contents = galata.newContentsHelper(baseURL);
+  test.beforeAll(async ({ request, tmpPath }) => {
+    const contents = galata.newContentsHelper(request);
     await contents.uploadFile(
       path.resolve(__dirname, `./notebooks/${fileName}`),
       `${tmpPath}/${fileName}`
     );
   });
 
-  test.afterAll(async ({ baseURL, tmpPath }) => {
-    const contents = galata.newContentsHelper(baseURL);
+  test.afterAll(async ({ request, tmpPath }) => {
+    const contents = galata.newContentsHelper(request);
     await contents.deleteDirectory(tmpPath);
   });
 });


### PR DESCRIPTION
## References

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/13029

## Code changes

None

`galata.newContentsHelper(baseURL)` → `galata.newContentsHelper(request)`

## User-facing changes

None

## Backwards-incompatible changes

None