### PR TITLE
[GSoC 2024] PoC Async plugin providing a widget factory

### DIFF
--- a/dev_mode/index.js
+++ b/dev_mode/index.js
@@ -64,7 +64,7 @@ export async function main() {
   var deferred = [];
   var ignorePlugins = [];
   var register = [];
-  var entrypoints = []
+  var entrypoints = {}
 
 
   const federatedExtensionPromises = [];
@@ -179,19 +179,20 @@ export async function main() {
         const entryPointData = pkgJson['jupyterlab']['entrypoint'];
 
         if(entryPointData){
-          for(const widgetFactory of entryPointData.widgetFactory){
-            entrypoints.push({
-              extension: '{{@key}}',
-              data : {
-                name: widgetFactory.name,
-                fileTypes: widgetFactory.fileTypes,
-                defaultFor: widgetFactory.defaultFor
-              },
-              activate: async ()=>{
-                return pluginRegistry.activatePlugin(widgetFactory.pluginId)
-              }
+          Object.entries(entryPointData).forEach(([entryPoint, data]) => {
+            if (!entrypoints[entryPoint]) {
+              entrypoints[entryPoint] = []
+            }
+            data.forEach(pluginData=>{
+              entrypoints[entryPoint].push({
+                extension: '{{@key}}',
+                data : pluginData,
+                activate: () => {
+                  return pluginRegistry.activatePlugin(pluginData.pluginId)
+                }
+              })
             })
-          }
+          });
         }
         for(let plugin of processPlugins(pkgPlugins, '{{@key}}')) {
           register.push({...plugin, loader: async () => {

--- a/examples/filebrowser/src/index.ts
+++ b/examples/filebrowser/src/index.ts
@@ -151,9 +151,8 @@ function createApp(
           type: 'file',
           path: fbModel.path
         })
-        .then(model => {
-          docManager.open(model.path);
-        });
+        .then(model => docManager.open(model.path))
+        .catch(console.error);
     }
   });
   fbWidget.toolbar.insertItem(0, 'create', creator);
@@ -184,7 +183,7 @@ function createApp(
     mnemonic: 0,
     execute: () => {
       for (const item of fbWidget.selectedItems()) {
-        docManager.openOrReveal(item.path);
+        docManager.openOrReveal(item.path).catch(console.error);
       }
     }
   });

--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -61,7 +61,7 @@ function main(): void {
   });
 }
 
-function createApp(manager: ServiceManager.IManager): void {
+async function createApp(manager: ServiceManager.IManager): Promise<void> {
   // Initialize the command registry with the bindings.
   const commands = new CommandRegistry();
   const useCapture = true;
@@ -216,7 +216,7 @@ function createApp(manager: ServiceManager.IManager): void {
   docRegistry.addWidgetFactory(wFactory);
 
   const notebookPath = PageConfig.getOption('notebookPath');
-  const nbWidget = docManager.open(notebookPath) as NotebookPanel;
+  const nbWidget = (await docManager.open(notebookPath)) as NotebookPanel;
   const palette = new CommandPalette({ commands });
   palette.addClass('notebookCommandPalette');
 

--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -56,9 +56,7 @@ import { COMMAND_IDS, setupCommands } from './commands';
 
 function main(): void {
   const manager = new ServiceManager();
-  void manager.ready.then(() => {
-    createApp(manager);
-  });
+  void manager.ready.then(() => createApp(manager)).catch(console.error);
 }
 
 async function createApp(manager: ServiceManager.IManager): Promise<void> {

--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -2,6 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { CommandLinker } from '@jupyterlab/apputils';
+import { IEntrypoint } from '@jupyterlab/coreutils';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { ServiceManager } from '@jupyterlab/services';
 import { ContextMenuSvg } from '@jupyterlab/ui-components';
@@ -224,7 +225,7 @@ export namespace JupyterFrontEnd {
    */
   export interface IOptions<T extends IShell = IShell, U = any>
     extends Application.IOptions<T> {
-    entrypoints?: any;
+    entrypoints?: Record<string, IEntrypoint[]>;
     /**
      * The document registry instance used by the application.
      */

--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -66,7 +66,11 @@ export abstract class JupyterFrontEnd<
 
     this.commandLinker =
       options.commandLinker || new CommandLinker({ commands: this.commands });
-    this.docRegistry = options.docRegistry || new DocumentRegistry();
+    this.docRegistry =
+      options.docRegistry ||
+      new DocumentRegistry({
+        entrypoints: options.entrypoints
+      });
     this.restored =
       options.restored ||
       this.started.then(() => restored).catch(() => restored);
@@ -220,6 +224,7 @@ export namespace JupyterFrontEnd {
    */
   export interface IOptions<T extends IShell = IShell, U = any>
     extends Application.IOptions<T> {
+    entrypoints?: any;
     /**
      * The document registry instance used by the application.
      */

--- a/packages/coreutils/src/plugins.ts
+++ b/packages/coreutils/src/plugins.ts
@@ -31,6 +31,23 @@ export interface IPluginModule {
   default: IPlugin<any, any> | IPlugin<any, any>[];
 }
 
+export interface IEntrypoint {
+  /**
+   *  The name of the widget factory.
+   */
+  extension: string;
+
+  /**
+   * function tha will active the widget factory
+   */
+  activate: () => Promise<void>;
+
+  /**
+   * data from the package json
+   */
+  data: any;
+}
+
 export interface IPlugin2<T = any, U = any>
   extends Omit<
     IPlugin<T, U>,

--- a/packages/csvviewer-extension/package.json
+++ b/packages/csvviewer-extension/package.json
@@ -92,7 +92,31 @@
         ],
         "autoStart": false
       }
-    ]
+    ],
+    "entrypoint": {
+      "widgetFactory": [
+        {
+          "pluginId": "@jupyterlab/csvviewer-extension:csv",
+          "name": "CSVTable",
+          "fileTypes": [
+            "csv"
+          ],
+          "defaultFor": [
+            "csv"
+          ]
+        },
+        {
+          "pluginId": "@jupyterlab/csvviewer-extension:tsv",
+          "name": "TSVTable",
+          "fileTypes": [
+            "tsv"
+          ],
+          "defaultFor": [
+            "tsv"
+          ]
+        }
+      ]
+    }
   },
   "styleModule": "style/index.js"
 }

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -719,7 +719,8 @@ function addCommands(
         (args['options'] as DocumentRegistry.IOpenOptions) || void 0;
       return docManager.services.contents
         .get(path, { content: false })
-        .then(() => docManager.openOrReveal(path, factory, kernel, options));
+        .then(() => docManager.openOrReveal(path, factory, kernel, options))
+        .catch(console.error);
     },
     iconClass: args => (args['icon'] as string) || '',
     label: args =>
@@ -1132,11 +1133,14 @@ function addLabCommands(
         return;
       }
       // Clone the widget.
-      docManager.cloneWidget(widget).then(child => {
-        if (child) {
-          widgetOpener.open(child, options);
-        }
-      });
+      docManager
+        .cloneWidget(widget)
+        .then(child => {
+          if (child) {
+            widgetOpener.open(child, options);
+          }
+        })
+        .catch(console.error);
     }
   });
 

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -1132,10 +1132,11 @@ function addLabCommands(
         return;
       }
       // Clone the widget.
-      const child = docManager.cloneWidget(widget);
-      if (child) {
-        widgetOpener.open(child, options);
-      }
+      docManager.cloneWidget(widget).then(child => {
+        if (child) {
+          widgetOpener.open(child, options);
+        }
+      });
     }
   });
 

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -246,7 +246,7 @@ export class DocumentManager implements IDocumentManager {
    *  Uses the same widget factory and context as the source, or returns
    *  `undefined` if the source widget is not managed by this manager.
    */
-  cloneWidget(widget: Widget): IDocumentWidget | undefined {
+  async cloneWidget(widget: Widget): Promise<IDocumentWidget | undefined> {
     return this._widgetManager.cloneWidget(widget);
   }
 
@@ -315,11 +315,11 @@ export class DocumentManager implements IDocumentManager {
    * This function will return `undefined` if a valid widget factory
    * cannot be found.
    */
-  createNew(
+  async createNew(
     path: string,
     widgetName = 'default',
     kernel?: Partial<Kernel.IModel>
-  ): Widget | undefined {
+  ): Promise<Widget | undefined> {
     return this._createOrOpenDocument('create', path, widgetName, kernel);
   }
 
@@ -431,12 +431,12 @@ export class DocumentManager implements IDocumentManager {
    * This function will return `undefined` if a valid widget factory
    * cannot be found.
    */
-  open(
+  async open(
     path: string,
     widgetName = 'default',
     kernel?: Partial<Kernel.IModel>,
     options?: DocumentRegistry.IOpenOptions
-  ): IDocumentWidget | undefined {
+  ): Promise<IDocumentWidget | undefined> {
     return this._createOrOpenDocument(
       'open',
       path,
@@ -462,12 +462,12 @@ export class DocumentManager implements IDocumentManager {
    * This function will return `undefined` if a valid widget factory
    * cannot be found.
    */
-  openOrReveal(
+  async openOrReveal(
     path: string,
     widgetName = 'default',
     kernel?: Partial<Kernel.IModel>,
     options?: DocumentRegistry.IOpenOptions
-  ): IDocumentWidget | undefined {
+  ): Promise<IDocumentWidget | undefined> {
     const widget = this.findWidget(path, widgetName);
     if (widget) {
       this._opener.open(widget, {
@@ -627,13 +627,13 @@ export class DocumentManager implements IDocumentManager {
    * The two cases differ in how the document context is handled, but the creation
    * of the widget and launching of the kernel are identical.
    */
-  private _createOrOpenDocument(
+  private async _createOrOpenDocument(
     which: 'open' | 'create',
     path: string,
     widgetName = 'default',
     kernel?: Partial<Kernel.IModel>,
     options?: DocumentRegistry.IOpenOptions
-  ): IDocumentWidget | undefined {
+  ): Promise<IDocumentWidget | undefined> {
     const widgetFactory = this._widgetFactoryFor(path, widgetName);
     if (!widgetFactory) {
       return undefined;
@@ -672,7 +672,10 @@ export class DocumentManager implements IDocumentManager {
       throw new Error(`Invalid argument 'which': ${which}`);
     }
 
-    const widget = this._widgetManager.createWidget(widgetFactory, context);
+    const widget = await this._widgetManager.createWidget(
+      widgetFactory,
+      context
+    );
     this._opener.open(widget, { type: widgetFactory.name, ...options });
 
     // If the initial opening of the context fails, dispose of the widget.

--- a/packages/docmanager/src/tokens.ts
+++ b/packages/docmanager/src/tokens.ts
@@ -95,7 +95,7 @@ export interface IDocumentManager extends IDisposable {
    *  Uses the same widget factory and context as the source, or returns
    *  `undefined` if the source widget is not managed by this manager.
    */
-  cloneWidget(widget: Widget): IDocumentWidget | undefined;
+  cloneWidget(widget: Widget): Promise<IDocumentWidget | undefined>;
 
   /**
    * Close all of the open documents.
@@ -153,7 +153,7 @@ export interface IDocumentManager extends IDisposable {
     path: string,
     widgetName?: string,
     kernel?: Partial<Kernel.IModel>
-  ): Widget | undefined;
+  ): Promise<Widget | undefined>;
 
   /**
    * Delete a file.
@@ -223,7 +223,7 @@ export interface IDocumentManager extends IDisposable {
     widgetName?: string,
     kernel?: Partial<Kernel.IModel>,
     options?: DocumentRegistry.IOpenOptions
-  ): IDocumentWidget | undefined;
+  ): Promise<IDocumentWidget | undefined>;
 
   /**
    * Open a file and return the widget used to view it.
@@ -246,7 +246,7 @@ export interface IDocumentManager extends IDisposable {
     widgetName?: string,
     kernel?: Partial<Kernel.IModel>,
     options?: DocumentRegistry.IOpenOptions
-  ): IDocumentWidget | undefined;
+  ): Promise<IDocumentWidget | undefined>;
 
   /**
    * Overwrite a file.

--- a/packages/docmanager/src/widgetmanager.ts
+++ b/packages/docmanager/src/widgetmanager.ts
@@ -93,11 +93,11 @@ export class DocumentWidgetManager implements IDisposable {
    *
    * @throws If the factory is not registered.
    */
-  createWidget(
+  async createWidget(
     factory: DocumentRegistry.WidgetFactory,
     context: DocumentRegistry.Context
-  ): IDocumentWidget {
-    const widget = factory.createNew(context);
+  ): Promise<IDocumentWidget> {
+    const widget = await Promise.resolve(factory.createNew(context));
     this._initializeWidget(widget, factory, context);
     return widget;
   }
@@ -204,7 +204,7 @@ export class DocumentWidgetManager implements IDisposable {
    *  Uses the same widget factory and context as the source, or throws
    *  if the source widget is not managed by this manager.
    */
-  cloneWidget(widget: Widget): IDocumentWidget | undefined {
+  async cloneWidget(widget: Widget): Promise<IDocumentWidget | undefined> {
     const context = Private.contextProperty.get(widget);
     if (!context) {
       return undefined;
@@ -213,7 +213,9 @@ export class DocumentWidgetManager implements IDisposable {
     if (!factory) {
       return undefined;
     }
-    const newWidget = factory.createNew(context, widget as IDocumentWidget);
+    const newWidget = await Promise.resolve(
+      factory.createNew(context, widget as IDocumentWidget)
+    );
     this._initializeWidget(newWidget, factory, context);
     return newWidget;
   }

--- a/packages/docmanager/test/manager.spec.ts
+++ b/packages/docmanager/test/manager.spec.ts
@@ -137,7 +137,7 @@ describe('@jupyterlab/docmanager', () => {
           type: 'file',
           ext: '.txt'
         });
-        widget = manager.open(model.path)!;
+        widget = (await manager.open(model.path))!;
         expect(widget.hasClass('WidgetFactory')).toBe(true);
         await dismissDialog();
       });
@@ -153,7 +153,7 @@ describe('@jupyterlab/docmanager', () => {
           type: 'test'
         });
         const id = session.kernel!.id;
-        widget = manager.open(session.path, 'default', { id })!;
+        widget = (await manager.open(session.path, 'default', { id }))!;
         context = manager.contextForWidget(widget)!;
         await context.ready;
         await context.sessionContext.ready;
@@ -166,7 +166,7 @@ describe('@jupyterlab/docmanager', () => {
           type: 'file',
           ext: '.txt'
         });
-        widget = manager.open(model.path, 'default')!;
+        widget = (await manager.open(model.path, 'default'))!;
         context = manager.contextForWidget(widget)!;
         await dismissDialog();
         expect(context.sessionContext.session?.kernel).toBeFalsy();
@@ -177,7 +177,7 @@ describe('@jupyterlab/docmanager', () => {
           type: 'file',
           ext: '.txt'
         });
-        widget = manager.open(model.path, 'foo');
+        widget = await manager.open(model.path, 'foo');
         expect(widget).toBeUndefined();
       });
 
@@ -192,7 +192,7 @@ describe('@jupyterlab/docmanager', () => {
           type: 'file',
           ext: '.txt'
         });
-        widget = manager.open(model.path, 'foo');
+        widget = await manager.open(model.path, 'foo');
         expect(widget).toBeUndefined();
       });
     });
@@ -203,7 +203,7 @@ describe('@jupyterlab/docmanager', () => {
           type: 'file',
           ext: '.txt'
         });
-        widget = manager.createNew(model.path)!;
+        widget = (await manager.createNew(model.path))!;
         expect(widget.hasClass('WidgetFactory')).toBe(true);
         await dismissDialog();
       });
@@ -219,7 +219,7 @@ describe('@jupyterlab/docmanager', () => {
           type: 'test'
         });
         const id = session.kernel!.id;
-        widget = manager.createNew(session.path, 'default', { id })!;
+        widget = (await manager.createNew(session.path, 'default', { id }))!;
         context = manager.contextForWidget(widget)!;
         await context.ready;
         await context.sessionContext.ready;
@@ -232,7 +232,7 @@ describe('@jupyterlab/docmanager', () => {
           type: 'file',
           ext: '.txt'
         });
-        widget = manager.createNew(model.path, 'default')!;
+        widget = (await manager.createNew(model.path, 'default'))!;
         context = manager.contextForWidget(widget)!;
         await dismissDialog();
         expect(context.sessionContext.session?.kernel).toBeFalsy();
@@ -243,7 +243,7 @@ describe('@jupyterlab/docmanager', () => {
           type: 'file',
           ext: '.txt'
         });
-        widget = manager.createNew(model.path, 'foo');
+        widget = await manager.createNew(model.path, 'foo');
         expect(widget).toBeUndefined();
       });
 
@@ -258,7 +258,7 @@ describe('@jupyterlab/docmanager', () => {
           type: 'file',
           ext: '.txt'
         });
-        widget = manager.createNew(model.path, 'foo');
+        widget = await manager.createNew(model.path, 'foo');
         expect(widget).toBeUndefined();
       });
     });
@@ -269,7 +269,7 @@ describe('@jupyterlab/docmanager', () => {
           type: 'file',
           ext: '.txt'
         });
-        widget = manager.createNew(model.path);
+        widget = await manager.createNew(model.path);
         expect(manager.findWidget(model.path, 'test')).toBe(widget);
         await dismissDialog();
       });
@@ -279,7 +279,7 @@ describe('@jupyterlab/docmanager', () => {
           type: 'file',
           ext: '.txt'
         });
-        widget = manager.createNew(model.path);
+        widget = await manager.createNew(model.path);
         expect(manager.findWidget(model.path)).toBe(widget);
         await dismissDialog();
       });
@@ -298,7 +298,7 @@ describe('@jupyterlab/docmanager', () => {
           type: 'file',
           ext: '.txt'
         });
-        widget = manager.createNew(model.path, 'test2');
+        widget = await manager.createNew(model.path, 'test2');
         expect(manager.findWidget(model.path)).toBeUndefined();
       });
 
@@ -312,7 +312,7 @@ describe('@jupyterlab/docmanager', () => {
           type: 'file',
           ext: '.txt'
         });
-        widget = manager.createNew(model.path, 'test2');
+        widget = await manager.createNew(model.path, 'test2');
         expect(manager.findWidget(model.path, null)).toBe(widget);
         await dismissDialog();
       });
@@ -324,7 +324,7 @@ describe('@jupyterlab/docmanager', () => {
           type: 'file',
           ext: '.txt'
         });
-        widget = manager.createNew(model.path)!;
+        widget = (await manager.createNew(model.path))!;
         context = manager.contextForWidget(widget)!;
         expect(context.path).toBe(model.path);
         await dismissDialog();
@@ -342,33 +342,35 @@ describe('@jupyterlab/docmanager', () => {
           type: 'file',
           ext: '.txt'
         });
-        widget = manager.createNew(model.path)!;
-        const clone = manager.cloneWidget(widget)!;
+        widget = (await manager.createNew(model.path))!;
+        const clone = (await manager.cloneWidget(widget))!;
         expect(manager.contextForWidget(widget)).toBe(
           manager.contextForWidget(clone)
         );
         await dismissDialog();
       });
 
-      it('should return undefined if the source widget is not managed', () => {
+      it('should return undefined if the source widget is not managed', async () => {
         widget = new Widget();
-        expect(manager.cloneWidget(widget)).toBeUndefined();
+        const clonedWidget = await manager.cloneWidget(widget);
+        expect(clonedWidget).toBeUndefined();
       });
 
-      it('should allow widget factories to have custom clone behavior', () => {
-        widget = manager.createNew('foo', 'CloneTestWidget')!;
-        const clonedWidget: CloneTestWidget = manager.cloneWidget(
+      it('should allow widget factories to have custom clone behavior', async () => {
+        widget = (await manager.createNew('foo', 'CloneTestWidget'))!;
+        const clonedWidget: CloneTestWidget = (await manager.cloneWidget(
           widget
-        ) as CloneTestWidget;
+        )) as CloneTestWidget;
         expect(clonedWidget.counter).toBe(1);
-        const newWidget: CloneTestWidget = manager.createNew(
+        const newWidget: CloneTestWidget = (await manager.createNew(
           'bar',
           'CloneTestWidget'
-        ) as CloneTestWidget;
+        )) as CloneTestWidget;
         expect(newWidget.counter).toBe(0);
-        expect(
-          (manager.cloneWidget(clonedWidget) as CloneTestWidget).counter
-        ).toBe(2);
+        const newClonedWidget = (await manager.cloneWidget(
+          clonedWidget
+        )) as CloneTestWidget;
+        expect(newClonedWidget.counter).toBe(2);
       });
     });
 
@@ -381,8 +383,8 @@ describe('@jupyterlab/docmanager', () => {
           ext: '.txt'
         });
         path = model.path;
-        widget = manager.createNew(path)!;
-        const clone = manager.cloneWidget(widget)!;
+        widget = (await manager.createNew(path))!;
+        const clone = (await manager.cloneWidget(widget))!;
 
         widget.disposed.connect(() => {
           called++;
@@ -409,12 +411,12 @@ describe('@jupyterlab/docmanager', () => {
           ext: '.txt'
         });
         path = model.path;
-        const widget0 = manager.createNew(path)!;
+        const widget0 = (await manager.createNew(path))!;
         widget0.disposed.connect(() => {
           called++;
         });
         await dismissDialog();
-        const widget1 = manager.createNew(path)!;
+        const widget1 = (await manager.createNew(path))!;
         widget1.disposed.connect(() => {
           called++;
         });

--- a/packages/docmanager/test/widgetmanager.spec.ts
+++ b/packages/docmanager/test/widgetmanager.spec.ts
@@ -114,13 +114,13 @@ describe('@jupyterlab/docmanager', () => {
         expect(widget).toBeInstanceOf(Widget);
       });
 
-      it('should emit the widgetCreated signal', () => {
+      it('should emit the widgetCreated signal', async () => {
         let called = false;
 
         widgetFactory.widgetCreated.connect(() => {
           called = true;
         });
-        manager.createWidget(widgetFactory, context);
+        await manager.createWidget(widgetFactory, context);
         expect(called).toBe(true);
       });
     });

--- a/packages/docmanager/test/widgetmanager.spec.ts
+++ b/packages/docmanager/test/widgetmanager.spec.ts
@@ -108,8 +108,8 @@ describe('@jupyterlab/docmanager', () => {
     });
 
     describe('#createWidget()', () => {
-      it('should create a widget', () => {
-        const widget = manager.createWidget(widgetFactory, context);
+      it('should create a widget', async () => {
+        const widget = await manager.createWidget(widgetFactory, context);
 
         expect(widget).toBeInstanceOf(Widget);
       });
@@ -155,9 +155,8 @@ describe('@jupyterlab/docmanager', () => {
     });
 
     describe('#findWidget()', () => {
-      it('should find a registered widget', () => {
-        const widget = manager.createWidget(widgetFactory, context);
-
+      it('should find a registered widget', async () => {
+        const widget = await manager.createWidget(widgetFactory, context);
         expect(manager.findWidget(context, 'test')).toBe(widget);
       });
 
@@ -167,8 +166,8 @@ describe('@jupyterlab/docmanager', () => {
     });
 
     describe('#contextForWidget()', () => {
-      it('should return the context for a widget', () => {
-        const widget = manager.createWidget(widgetFactory, context);
+      it('should return the context for a widget', async () => {
+        const widget = await manager.createWidget(widgetFactory, context);
 
         expect(manager.contextForWidget(widget)).toBe(context);
       });
@@ -179,24 +178,25 @@ describe('@jupyterlab/docmanager', () => {
     });
 
     describe('#cloneWidget()', () => {
-      it('should create a new widget with the same context using the same factory', () => {
-        const widget = manager.createWidget(widgetFactory, context);
-        const clone = manager.cloneWidget(widget)!;
+      it('should create a new widget with the same context using the same factory', async () => {
+        const widget = await manager.createWidget(widgetFactory, context);
+        const clone = (await manager.cloneWidget(widget))!;
 
         expect(clone.hasClass('WidgetFactory')).toBe(true);
         expect(clone.hasClass('jp-Document')).toBe(true);
         expect(manager.contextForWidget(clone)).toBe(context);
       });
 
-      it('should return undefined if the source widget is not managed', () => {
-        expect(manager.cloneWidget(new Widget())).toBeUndefined();
+      it('should return undefined if the source widget is not managed', async () => {
+        const clonedWidget = await manager.cloneWidget(new Widget());
+        expect(clonedWidget).toBeUndefined();
       });
     });
 
     describe('#closeWidgets()', () => {
       it('should close all of the widgets associated with a context', async () => {
-        const widget = manager.createWidget(widgetFactory, context);
-        const clone = manager.cloneWidget(widget)!;
+        const widget = await manager.createWidget(widgetFactory, context);
+        const clone = (await manager.cloneWidget(widget))!;
 
         await manager.closeWidgets(context);
         expect(widget.isDisposed).toBe(true);
@@ -216,15 +216,15 @@ describe('@jupyterlab/docmanager', () => {
         );
       });
 
-      it('should return false for close-request messages', () => {
-        const widget = manager.createWidget(widgetFactory, context);
+      it('should return false for close-request messages', async () => {
+        const widget = await manager.createWidget(widgetFactory, context);
         const msg = new Message('close-request');
 
         expect(manager.messageHook(widget, msg)).toBe(false);
       });
 
-      it('should return true for other messages', () => {
-        const widget = manager.createWidget(widgetFactory, context);
+      it('should return true for other messages', async () => {
+        const widget = await manager.createWidget(widgetFactory, context);
         const msg = new Message('foo');
 
         expect(manager.messageHook(widget, msg)).toBe(true);
@@ -235,7 +235,7 @@ describe('@jupyterlab/docmanager', () => {
       it('should set the title of the widget', async () => {
         await context.initialize(true);
 
-        const widget = manager.createWidget(widgetFactory, context);
+        const widget = await manager.createWidget(widgetFactory, context);
         const delegate = new PromiseDelegate();
 
         widget.title.changed.connect(async () => {
@@ -252,7 +252,7 @@ describe('@jupyterlab/docmanager', () => {
 
     describe('#onClose()', () => {
       it('should be called when a widget is closed', async () => {
-        const widget = manager.createWidget(widgetFactory, context);
+        const widget = await manager.createWidget(widgetFactory, context);
         const delegate = new PromiseDelegate();
 
         widget.disposed.connect(async () => {
@@ -266,7 +266,7 @@ describe('@jupyterlab/docmanager', () => {
 
       it('should ask confirmation when a widget is closing', async () => {
         manager.confirmClosingDocument = true;
-        const widget = manager.createWidget(widgetFactory, context);
+        const widget = await manager.createWidget(widgetFactory, context);
 
         widget.close();
         await dismissDialog();
@@ -277,7 +277,7 @@ describe('@jupyterlab/docmanager', () => {
 
       it('should confirm widget close action', async () => {
         manager.confirmClosingDocument = true;
-        const widget = manager.createWidget(widgetFactory, context);
+        const widget = await manager.createWidget(widgetFactory, context);
         const delegate = new PromiseDelegate();
 
         widget.close();
@@ -294,7 +294,7 @@ describe('@jupyterlab/docmanager', () => {
         // Populate the model with content.
         context.model.fromString('foo');
 
-        const widget = manager.createWidget(widgetFactory, context);
+        const widget = await manager.createWidget(widgetFactory, context);
         const closed = manager.onClose(widget);
 
         await Promise.all([dangerDialog(), closed]);
@@ -306,7 +306,7 @@ describe('@jupyterlab/docmanager', () => {
         manager.confirmClosingDocument = true;
         context.model.fromString('foo');
 
-        const widget = manager.createWidget(widgetFactory, context);
+        const widget = await manager.createWidget(widgetFactory, context);
         const closed = manager.onClose(widget);
 
         await Promise.all([dangerDialog(), closed]);
@@ -315,7 +315,7 @@ describe('@jupyterlab/docmanager', () => {
       });
 
       it('should not prompt if the factory is readonly', async () => {
-        const readonly = manager.createWidget(readOnlyFactory, context);
+        const readonly = await manager.createWidget(readOnlyFactory, context);
 
         await manager.onClose(readonly);
 
@@ -326,8 +326,8 @@ describe('@jupyterlab/docmanager', () => {
         // Populate the model with content.
         context.model.fromString('foo');
 
-        const one = manager.createWidget(widgetFactory, context);
-        const two = manager.createWidget(widgetFactory, context);
+        const one = await manager.createWidget(widgetFactory, context);
+        const two = await manager.createWidget(widgetFactory, context);
 
         await manager.onClose(one);
 
@@ -340,8 +340,8 @@ describe('@jupyterlab/docmanager', () => {
         // Populate the model with content.
         context.model.fromString('foo');
 
-        const writable = manager.createWidget(widgetFactory, context);
-        const readonly = manager.createWidget(readOnlyFactory, context);
+        const writable = await manager.createWidget(widgetFactory, context);
+        const readonly = await manager.createWidget(readOnlyFactory, context);
         const closed = manager.onClose(writable);
 
         await dangerDialog();
@@ -354,7 +354,7 @@ describe('@jupyterlab/docmanager', () => {
 
       it('should close the widget', async () => {
         context.model.fromString('foo');
-        const widget = manager.createWidget(widgetFactory, context);
+        const widget = await manager.createWidget(widgetFactory, context);
         const promise = manager.onClose(widget);
         await dismissDialog();
         await promise;

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -5,6 +5,7 @@ import { ISessionContext, ToolbarRegistry } from '@jupyterlab/apputils';
 import { CodeEditor } from '@jupyterlab/codeeditor';
 import {
   IChangedArgs as IChangedArgsGeneric,
+  IEntrypoint,
   PathExt
 } from '@jupyterlab/coreutils';
 import { IObservableList } from '@jupyterlab/observables';
@@ -64,7 +65,7 @@ export class DocumentRegistry implements IDisposable {
 
     const entrypoints = options.entrypoints;
     if (entrypoints) {
-      for (const entrypoint of entrypoints) {
+      for (const entrypoint of entrypoints.widgetFactory) {
         const factory = new DummyWidgetFactory({
           ...entrypoint,
           documentRegistry: this
@@ -376,6 +377,7 @@ export class DocumentRegistry implements IDisposable {
    */
   preferredWidgetFactories(path: string): DocumentRegistry.WidgetFactory[] {
     const factories = new Set<string>();
+
     // Get the ordered matching file types.
     const fts = this.getFileTypesForPath(PathExt.basename(path));
     // Start with any user overrides for the defaults.
@@ -536,7 +538,6 @@ export class DocumentRegistry implements IDisposable {
     ) {
       throw Error(`Factory ${factory} cannot view file type ${fileType}`);
     }
-    console.log(fileType, factory);
     this._defaultWidgetFactoryOverrides[fileType] = factory;
   }
 
@@ -772,23 +773,6 @@ export class DocumentRegistry implements IDisposable {
   private _isDisposed = false;
 }
 
-interface IEntrypoint {
-  /**
-   *  The name of the widget factory.
-   */
-  extension: string;
-
-  /**
-   * function tha will active the widget factory
-   */
-  activate: () => void;
-
-  /**
-   * data from the package json
-   */
-  data: any;
-}
-
 /**
  * The namespace for the `DocumentRegistry` class statics.
  */
@@ -820,9 +804,9 @@ export namespace DocumentRegistry {
     translator?: ITranslator;
 
     /**
-     * The entrypoints for the widgets.
+     * Document registry entry points.
      */
-    entrypoints?: IEntrypoint[];
+    entrypoints?: Record<string, IEntrypoint[]>;
   }
 
   /**

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1212,7 +1212,7 @@ export class DirListing extends Widget {
         );
     } else {
       const path = item.path;
-      this._manager.openOrReveal(path);
+      this._manager.openOrReveal(path).catch(console.error);
     }
   }
 
@@ -1730,7 +1730,7 @@ export class DirListing extends Widget {
                 void 0,
                 options
               );
-              this._manager.openOrReveal(item!.path);
+              this._manager.openOrReveal(item!.path).catch(console.error);
             });
           });
           firstWidgetPlaced.resolve(void 0);

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1706,25 +1706,25 @@ export class DirListing extends Widget {
 
     if (item && item.type !== 'directory') {
       const otherPaths = selectedPaths.slice(1).reverse();
-      this._drag.mimeData.setData(FACTORY_MIME, () => {
+      this._drag.mimeData.setData(FACTORY_MIME, async () => {
         if (!item) {
           return;
         }
         const path = item.path;
         let widget = this._manager.findWidget(path);
         if (!widget) {
-          widget = this._manager.open(item.path);
+          widget = await this._manager.open(item.path);
         }
         if (otherPaths.length) {
           const firstWidgetPlaced = new PromiseDelegate<void>();
           void firstWidgetPlaced.promise.then(() => {
             let prevWidget = widget;
-            otherPaths.forEach(path => {
+            otherPaths.forEach(async path => {
               const options: DocumentRegistry.IOpenOptions = {
                 ref: prevWidget?.id,
                 mode: 'tab-after'
               };
-              prevWidget = this._manager.openOrReveal(
+              prevWidget = await this._manager.openOrReveal(
                 path,
                 void 0,
                 void 0,

--- a/packages/rendermime-extension/src/index.ts
+++ b/packages/rendermime-extension/src/index.ts
@@ -93,13 +93,14 @@ function activate(
             // if applicable.
             const factory =
               docManager.registry.defaultRenderedWidgetFactory(path);
-            docManager.openOrReveal(path, factory.name).then(widget => {
+            return docManager.openOrReveal(path, factory.name).then(widget => {
               // Handle the hash if one has been provided.
               if (widget && id) {
                 widget.setFragment(id);
               }
             });
-          });
+          })
+          .catch(console.error);
       }
     });
   }

--- a/packages/rendermime-extension/src/index.ts
+++ b/packages/rendermime-extension/src/index.ts
@@ -93,12 +93,12 @@ function activate(
             // if applicable.
             const factory =
               docManager.registry.defaultRenderedWidgetFactory(path);
-            const widget = docManager.openOrReveal(path, factory.name);
-
-            // Handle the hash if one has been provided.
-            if (widget && id) {
-              widget.setFragment(id);
-            }
+            docManager.openOrReveal(path, factory.name).then(widget => {
+              // Handle the hash if one has been provided.
+              if (widget && id) {
+                widget.setFragment(id);
+              }
+            });
           });
       }
     });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Part of https://github.com/jupyterlab/lumino/issues/601 for [GSoC 2024 project](https://github.com/jupyterlab/frontends-team-compass/wiki/GSoC-2024#idea-2----make-the-plugin-system-data-based)

https://github.com/jupyterlab/jupyterlab/pull/16537

## Code changes

Will load plugin data from entrypoint.
Change return type of activate function will be a promise now.
Wil use Dummy Widget factory as a placeholder until actual code is required.

## User-facing changes

Loading of the jupyterlab will be a bit fast. (Not measured but theoretically it should)

## Backwards-incompatible changes

~~Yes the changes are backward compatible.~~

> Actually it is not as we needed to change a couple method to be asynchronous. Those methods are related to the generation of a widget when opening a document.
