### PR TITLE
Add untitled files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,9 @@ packages/lsp/src/_*
 # generated reports
 webpack-bundle-analyzer.html
 examples/**/test-results/
+
+# untitled (default name) files
+Untitled*.ipynb
+untitled*.md
+untitled*.py
+untitled*.txt


### PR DESCRIPTION
Hi! 👋 

## References

Closes #16579

## Code changes

New entries have been added to the root `.gitignore` file to ignore files created from JupyterLab with the default name.

## User-facing changes

### Before

<img width="1582" alt="Screenshot 2024-07-16 at 19 27 42" src="https://github.com/user-attachments/assets/6ce54011-9659-4b02-97de-f0b89add1ccb">

### After

<img width="1582" alt="Screenshot 2024-07-16 at 19 30 59" src="https://github.com/user-attachments/assets/5c141e51-a5b0-43a0-a6ff-fd6117221a7e">

## Backwards-incompatible changes

None.