### PR TITLE
Add a command and instructions to serve documentation files locally

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,7 +15,7 @@ BUILDDIR      = build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: help Makefile serve
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
@@ -26,3 +26,10 @@ clean:
 	# clean api build as well
 	-rm -rf "$(SOURCEDIR)/api"
 	@$(SPHINXBUILD) -M clean "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+serve:
+	@if [ -d "$(BUILDDIR)/html" ]; then \
+        python -m http.server --directory "$(BUILDDIR)/html"; \
+    else \
+        echo "$(BUILDDIR)/html" does not exist. Run make html first.; \
+    fi

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -38,6 +38,14 @@ if errorlevel 9009 (
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
 goto end
 
+:serve
+if exist %BUILDDIR%\html (
+    python -m http.server --directory %BUILDDIR%\html
+) else (
+    echo %BUILDDIR%\html does not exist. Run make html first.
+)
+goto end
+
 :help
 %SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
 

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -16,6 +16,7 @@ set BUILDDIR=build
 set SPHINXPROJ=JupyterLab
 
 if "%1" == "" goto help
+if "%1" == "serve" goto serve
 
 if not exist "%APIDIR%" (
     echo Creating api directory...

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -670,7 +670,7 @@ provided in the report. You can use these information to debug failing tests. Ga
 report can be downloaded from GitHub Actions page for a UI test run. Test artifact is
 named ``galata-report`` and once you extract it, you can access the report by launching
 a server to serve the files ``python -m http.server -d <path-to-extracted-report>``.
-Then open *http://localhost:8000* with your web browser.
+Then open http://localhost:8000/ with your web browser.
 
 Main reasons for UI test failures are:
 
@@ -899,7 +899,16 @@ The Read the Docs pages can be built using ``make``:
    cd docs
    make html
 
-Or with ``jlpm``:
+The JupyterLab API reference documentation is also included in the previous step.
+To access the documentation, first launch a server to serve the generated files:
+
+.. code:: bash
+
+   make serve
+
+And then go to http://localhost:8000/ in your browser.
+
+The JupyterLab API reference documentation can be built separately using ``jlpm``:
 
 .. code:: bash
 


### PR DESCRIPTION
Hi! 👋 

## References

Closes #16573

## Code changes

The Sphinx documentation `Makefile` and `make.bat` have been updated with a new command to launch a server to serve the locally generated files. The corresponding contributor documentation has also been updated.

## User-facing changes

https://jupyterlab.readthedocs.io/en/stable/developer/contributing.html#writing-documentation will have a new command and updated information.

## Backwards-incompatible changes

None.

## References

- https://github.com/canonical/sphinx-docs-guide/blob/206fbb2cd80ca0a978d24fa0116eddd73b644615/Makefile by Canonical
- https://github.com/linlsOS/linls.summary.github.io/blob/a4ff865e0367c5bcfdc5aef544b95dc3d36c05f4/make.bat by linls