### PR TITLE
Standardize the "go-to-line" input field using theme CSS variables

### DIFF
--- a/packages/codeeditor/style/linecol.css
+++ b/packages/codeeditor/style/linecol.css
@@ -20,7 +20,8 @@
 
 .jp-baseLineForm {
   border: none;
-  border-radius: 0;
+  border-top-right-radius: var(--jp-border-radius);
+  border-bottom-right-radius: var(--jp-border-radius);
   position: absolute;
   background-size: 16px;
   background-repeat: no-repeat;
@@ -59,13 +60,15 @@
   overflow: hidden;
   padding: 0 8px;
   border: 1px solid var(--jp-border-color0);
+  border-top-left-radius: var(--jp-border-radius);
+  border-bottom-left-radius: var(--jp-border-radius);
   background-color: var(--jp-input-active-background);
   height: 22px;
 }
 
 .jp-lineFormWrapperFocusWithin {
-  border: var(--jp-border-width) solid var(--md-blue-500, #2196f3);
-  box-shadow: inset 0 0 4px var(--md-blue-300, #64b5f6);
+  border: var(--jp-border-width) solid var(--jp-input-active-border-color);
+  box-shadow: var(--jp-input-box-shadow);
 }
 
 .jp-lineFormInput {
@@ -75,5 +78,5 @@
   border: none;
   outline: none;
   color: var(--jp-ui-font-color0);
-  line-height: 28px;
+  padding: 0;
 }


### PR DESCRIPTION
Hi! 👋 

## References

Closes #16577

## Code changes

The "go-to-line" input field styling has been updated. Theme CSS variables are now used for the border (border radius, color, etc.) and the input value is now centered.

## User-facing changes

### Before

<img width="1582" alt="Screenshot 2024-07-22 at 07 24 00" src="https://github.com/user-attachments/assets/ddd81ea8-f89d-4184-adeb-8d31f2b3106d">

<img width="1582" alt="Screenshot 2024-07-22 at 07 24 14" src="https://github.com/user-attachments/assets/27b02c5b-cbea-462b-bb78-c572a2378de2">

<img width="1582" alt="Screenshot 2024-07-22 at 07 42 00" src="https://github.com/user-attachments/assets/a49381da-d97a-4a99-a3f2-16cea11f253f">

### After

<img width="1582" alt="Screenshot 2024-07-22 at 07 39 05" src="https://github.com/user-attachments/assets/8eb48a9e-bdcf-452d-8abf-3cf4bf67c9c8">

<img width="1582" alt="Screenshot 2024-07-22 at 07 39 18" src="https://github.com/user-attachments/assets/ded031d3-528a-405b-b382-71da0efeeb68">

<img width="1582" alt="Screenshot 2024-07-22 at 07 42 34" src="https://github.com/user-attachments/assets/5a739f34-3262-439e-9c25-ba9996757834">

## Backwards-incompatible changes

None.