### PR TITLE
Standardize the button role and label for single, dismissal buttons in dialogs

### DIFF
--- a/docs/source/developer/patterns.rst
+++ b/docs/source/developer/patterns.rst
@@ -181,5 +181,5 @@ Dialogs
 Buttons in dialogs with a single, dismissal button (e.g., *About JupyterLab*)
 should have the following attributes:
 
--  Button role: Cancel (``Dialog.cancelButton()``)
+-  Button variant: Cancel (``Dialog.cancelButton()``)
 -  Label: ``Close``

--- a/docs/source/developer/patterns.rst
+++ b/docs/source/developer/patterns.rst
@@ -174,3 +174,12 @@ Command Names
 Commands used in the application command registry should be formatted as
 follows: ``package-name:verb-noun``. They are typically grouped into a
 ``CommandIDs`` namespace in the extension that is not exported.
+
+Dialogs
+-------
+
+Buttons in dialogs with a single, dismissal button (e.g., *About JupyterLab*)
+should have the following attributes:
+
+-  Button role: Cancel (``Dialog.cancelButton()``)
+-  Label: ``Close``

--- a/packages/application/src/connectionlost.ts
+++ b/packages/application/src/connectionlost.ts
@@ -42,7 +42,7 @@ export const ConnectionLost: IConnectionLost = async function (
         'If checked, you will not see a dialog informing you about an issue with server connection in this session.'
       )
     },
-    buttons: [Dialog.okButton({ label: trans.__('Dismiss') })]
+    buttons: [Dialog.cancelButton({ label: trans.__('Close') })]
   })
     .then(result => {
       if (result.isChecked) {

--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -44,7 +44,7 @@ export function showErrorMessage(
   buttons?: ReadonlyArray<Dialog.IButton>
 ): Promise<void> {
   const trans = Dialog.translator.load('jupyterlab');
-  buttons = buttons ?? [Dialog.okButton({ label: trans.__('Dismiss') })];
+  buttons = buttons ?? [Dialog.cancelButton({ label: trans.__('Close') })];
   console.warn('Showing error:', error);
 
   // Cache promises to prevent multiple copies of identical dialogs showing

--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -149,9 +149,8 @@ const about: JupyterFrontEndPlugin<void> = {
           title,
           body,
           buttons: [
-            Dialog.createButton({
-              label: trans.__('Dismiss'),
-              className: 'jp-About-button jp-mod-reject jp-mod-styled'
+            Dialog.cancelButton({
+              label: trans.__('Close')
             })
           ]
         });
@@ -422,9 +421,8 @@ const resources: JupyterFrontEndPlugin<void> = {
                 title,
                 body,
                 buttons: [
-                  Dialog.createButton({
-                    label: trans.__('Dismiss'),
-                    className: 'jp-About-button jp-mod-reject jp-mod-styled'
+                  Dialog.cancelButton({
+                    label: trans.__('Close')
                   })
                 ]
               });


### PR DESCRIPTION
Hi! 👋 

## References

Closes #16578

## Code changes

The button type/role and the respective label have been adapted where necessary to standardize single, dismissal buttons in dialogs. Documentation about this pattern has also been added.

## User-facing changes

<img width="1582" alt="Screenshot 2024-07-29 at 15 28 32" src="https://github.com/user-attachments/assets/6a214404-57ee-48f0-9895-bc8ee689ed60">

<img width="1582" alt="Screenshot 2024-07-29 at 16 08 22" src="https://github.com/user-attachments/assets/ec9bc120-8267-4a72-a493-b05744cdd55d">

<img width="1582" alt="Screenshot 2024-07-29 at 16 08 37" src="https://github.com/user-attachments/assets/cffce034-bd2f-46c2-915b-60ecb6216bbf">

<img width="1582" alt="Screenshot 2024-07-29 at 16 15 09" src="https://github.com/user-attachments/assets/58664456-3be3-431b-82d2-295e3976230e">

<img width="1582" alt="Screenshot 2024-07-29 at 16 25 57" src="https://github.com/user-attachments/assets/57314125-bdd9-4d21-b359-f621a6e70007">

## Backwards-incompatible changes

None.