### PR TITLE
Standardize dialogs to shut down all kernels

### DIFF
--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -535,13 +535,15 @@ function createKernelMenu(
   commands.addCommand(CommandIDs.shutdownAllKernels, {
     label: trans.__('Shut Down All Kernels…'),
     isEnabled: () => {
-      return !app.serviceManager.sessions.running().next().done;
+      return !app.serviceManager.kernels.running().next().done;
     },
     execute: () => {
       return showDialog({
         title: trans.__('Shut Down All?'),
-        body: trans.__(
-          'Are you sure you want to permanently shut down all running kernels?'
+        body: trans._n(
+          'Are you sure you want to permanently shut down the running kernel?',
+          'Are you sure you want to permanently shut down the %1 running kernels?',
+          app.serviceManager.kernels.runningCount()
         ),
         buttons: [
           Dialog.cancelButton(),
@@ -549,7 +551,7 @@ function createKernelMenu(
         ]
       }).then(result => {
         if (result.button.accept) {
-          return app.serviceManager.sessions.shutdownAll();
+          return app.serviceManager.kernels.shutdownAll();
         }
       });
     }

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -540,9 +540,11 @@ function createKernelMenu(
     execute: () => {
       return showDialog({
         title: trans.__('Shut Down All?'),
-        body: trans.__('Shut down all kernels?'),
+        body: trans.__(
+          'Are you sure you want to permanently shut down all running kernels?'
+        ),
         buttons: [
-          Dialog.cancelButton({ label: trans.__('Dismiss') }),
+          Dialog.cancelButton({ label: trans.__('Cancel') }),
           Dialog.warnButton({ label: trans.__('Shut Down All') })
         ]
       }).then(result => {

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -535,7 +535,7 @@ function createKernelMenu(
   commands.addCommand(CommandIDs.shutdownAllKernels, {
     label: trans.__('Shut Down All Kernels…'),
     isEnabled: () => {
-      return !app.serviceManager.kernels.running().next().done;
+      return !app.serviceManager.sessions.running().next().done;
     },
     execute: () => {
       return showDialog({
@@ -551,7 +551,7 @@ function createKernelMenu(
         ]
       }).then(result => {
         if (result.button.accept) {
-          return app.serviceManager.kernels.shutdownAll();
+          return app.serviceManager.sessions.shutdownAll();
         }
       });
     }

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -544,7 +544,7 @@ function createKernelMenu(
           'Are you sure you want to permanently shut down all running kernels?'
         ),
         buttons: [
-          Dialog.cancelButton({ label: trans.__('Cancel') }),
+          Dialog.cancelButton(),
           Dialog.warnButton({ label: trans.__('Shut Down All') })
         ]
       }).then(result => {

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -543,7 +543,7 @@ function createKernelMenu(
         body: trans._n(
           'Are you sure you want to permanently shut down the running kernel?',
           'Are you sure you want to permanently shut down the %1 running kernels?',
-          app.serviceManager.kernels.runningCount()
+          app.serviceManager.kernels.runningCount
         ),
         buttons: [
           Dialog.cancelButton(),

--- a/packages/running-extension/src/kernels.tsx
+++ b/packages/running-extension/src/kernels.tsx
@@ -95,7 +95,7 @@ export async function addKernelRunningSessionManager(
       trans._n(
         'Are you sure you want to permanently shut down the running kernel?',
         'Are you sure you want to permanently shut down the %1 running kernels?',
-        kernels.runningCount()
+        kernels.runningCount
       )
   });
 

--- a/packages/running-extension/src/kernels.tsx
+++ b/packages/running-extension/src/kernels.tsx
@@ -91,9 +91,12 @@ export async function addKernelRunningSessionManager(
     runningChanged,
     shutdownLabel: trans.__('Shut Down Kernel'),
     shutdownAllLabel: trans.__('Shut Down All'),
-    shutdownAllConfirmationText: trans.__(
-      'Are you sure you want to permanently shut down all running kernels?'
-    )
+    shutdownAllConfirmationText: () =>
+      trans._n(
+        'Are you sure you want to permanently shut down the running kernel?',
+        'Are you sure you want to permanently shut down the %1 running kernels?',
+        kernels.runningCount()
+      )
   });
 
   // Add running kernels commands to the registry.

--- a/packages/running/src/index.tsx
+++ b/packages/running/src/index.tsx
@@ -601,11 +601,14 @@ class Section extends PanelWithToolbar {
 
     const shutdownAllLabel = this._shutdownAllLabel;
     const shutdownTitle = `${shutdownAllLabel}?`;
-    const shutdownAllConfirmationText =
-      this._manager.shutdownAllConfirmationText ||
-      `${shutdownAllLabel} ${this._manager.name}`;
 
     const onShutdown = () => {
+      const shutdownAllConfirmationText =
+        (typeof this._manager.shutdownAllConfirmationText === 'function'
+          ? this._manager.shutdownAllConfirmationText()
+          : this._manager.shutdownAllConfirmationText) ??
+        `${shutdownAllLabel} ${this._manager.name}`;
+
       void showDialog({
         title: shutdownTitle,
         body: shutdownAllConfirmationText,
@@ -1189,7 +1192,7 @@ export namespace IRunningSessions {
     /**
      * A string used as the body text in the shutdown all confirmation dialog.
      */
-    shutdownAllConfirmationText?: string;
+    shutdownAllConfirmationText?: string | (() => string);
 
     /**
      * The icon to show for shutting down an individual item in this section.

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -618,6 +618,13 @@ export interface IManager extends IBaseManager {
   running(): IterableIterator<IModel>;
 
   /**
+   * Count the number of running kernels.
+   *
+   * @returns The number of running kernels.
+   */
+  runningCount(): number;
+
+  /**
    * Force a refresh of the running kernels.
    *
    * @returns A promise that resolves when the models are refreshed.

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -618,11 +618,9 @@ export interface IManager extends IBaseManager {
   running(): IterableIterator<IModel>;
 
   /**
-   * Count the number of running kernels.
-   *
-   * @returns The number of running kernels.
+   * The number of running kernels.
    */
-  runningCount(): number;
+  readonly runningCount: number;
 
   /**
    * Force a refresh of the running kernels.

--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -143,11 +143,9 @@ export class KernelManager extends BaseManager implements Kernel.IManager {
   }
 
   /**
-   * Count the number of running kernels.
-   *
-   * @returns The number of running kernels.
+   * The number of running kernels.
    */
-  runningCount(): number {
+  get runningCount(): number {
     return this._models.size;
   }
 

--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -143,6 +143,15 @@ export class KernelManager extends BaseManager implements Kernel.IManager {
   }
 
   /**
+   * Count the number of running kernels.
+   *
+   * @returns The number of running kernels.
+   */
+  runningCount(): number {
+    return this._models.size;
+  }
+
+  /**
    * Force a refresh of the running kernels.
    *
    * @returns A promise that resolves when the running list has been refreshed.


### PR DESCRIPTION
Hi! 👋 

## References

Closes #16624

## Code changes

The content of the command palette dialog was standardized according to the sidebar. Additionally, a new method was introduced in the kernel manager to obtain the number of running kernels and the `shutdownAllConfirmationText` prop was updated to also receive a _dynamic_ function.

## User-facing changes

The dialog content is now consistent regardless of whether the user triggers the shut-down of all kernels from the sidebar or the command palette. Additionally, the number of kernels that will be shut down is now included in the body text.

https://github.com/user-attachments/assets/428f20ba-14b3-4fd4-a9ed-cbc7d01e4fab

## Backwards-incompatible changes

Yes, given that some translatable strings have changed.