### PR TITLE
Update pending input message for clarification

### DIFF
--- a/packages/notebook/src/cellexecutor.ts
+++ b/packages/notebook/src/cellexecutor.ts
@@ -56,7 +56,7 @@ export async function runCell({
           await showDialog({
             title: trans.__('Cell not executed due to pending input'),
             body: trans.__(
-              'The cell has not been executed to avoid kernel deadlock as there is another pending input! Submit your pending input and try again.'
+              'The cell has not been executed to avoid kernel deadlock as there is another pending input! Type your input in the input box, press Enter and try again.'
             ),
             buttons: [Dialog.okButton()]
           });


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/16320

## Code changes

N/A

## User-facing changes

Users will see a new message indicating they must type something and press enter when there is pending input.

## Backwards-incompatible changes

N/A
