### PR TITLE
Add kernel selection to Galata notebook creation

### DIFF
--- a/galata/src/helpers/notebook.ts
+++ b/galata/src/helpers/notebook.ts
@@ -1430,7 +1430,7 @@ export class NotebookHelper {
     const page = this.page;
     await page.locator('.jp-Dialog').waitFor();
 
-    if (options && option.kernel !== undefined) {
+    if (options && options.kernel !== undefined) {
       if (options.kernel === null) {
         await page
           .getByRole('dialog')

--- a/galata/src/helpers/notebook.ts
+++ b/galata/src/helpers/notebook.ts
@@ -1414,16 +1414,36 @@ export class NotebookHelper {
   }
 
   /**
-   * Create a new notebook
+   * Creates a new notebook.
    *
-   * @param name Name of the notebook
-   * @returns Name of the created notebook or null if it failed
+   * @param name - The name of the notebook. If provided, the notebook will be renamed to this name.
+   * @param options - Parameters for creating the notebook.
+   * @param options.kernel - The kernel to use for the notebook.
+   * @returns A Promise that resolves to the name of the created notebook, or `null` if the notebook creation failed.
    */
-  async createNew(name?: string): Promise<string | null> {
+  async createNew(
+    name?: string,
+    options?: { kernel?: string }
+  ): Promise<string | null> {
     await this.menu.clickMenuItem('File>New>Notebook');
 
     const page = this.page;
     await page.locator('.jp-Dialog').waitFor();
+
+    if (options?.kernel) {
+      if (options.kernel === 'null') {
+        await page
+          .getByRole('dialog')
+          .getByRole('combobox')
+          .selectOption('null');
+      } else {
+        await page
+          .getByRole('dialog')
+          .getByRole('combobox')
+          .selectOption(`{"name":"${options.kernel}"}`);
+      }
+    }
+
     await page.click('.jp-Dialog .jp-mod-accept');
 
     const activeTab = this.activity.getTabLocator();

--- a/galata/src/helpers/notebook.ts
+++ b/galata/src/helpers/notebook.ts
@@ -1430,7 +1430,7 @@ export class NotebookHelper {
     const page = this.page;
     await page.locator('.jp-Dialog').waitFor();
 
-    if (options?.kernel) {
+    if (options && option.kernel !== undefined) {
       if (options.kernel === null) {
         await page
           .getByRole('dialog')

--- a/galata/src/helpers/notebook.ts
+++ b/galata/src/helpers/notebook.ts
@@ -1423,7 +1423,7 @@ export class NotebookHelper {
    */
   async createNew(
     name?: string,
-    options?: { kernel?: string }
+    options?: { kernel?: string | null }
   ): Promise<string | null> {
     await this.menu.clickMenuItem('File>New>Notebook');
 
@@ -1431,7 +1431,7 @@ export class NotebookHelper {
     await page.locator('.jp-Dialog').waitFor();
 
     if (options?.kernel) {
-      if (options.kernel === 'null') {
+      if (options.kernel === null) {
         await page
           .getByRole('dialog')
           .getByRole('combobox')

--- a/galata/test/galata/notebook.spec.ts
+++ b/galata/test/galata/notebook.spec.ts
@@ -35,7 +35,7 @@ test.describe('Notebook Tests', () => {
     tmpPath
   }) => {
     const fileName = 'create_no_kernel_test.ipynb';
-    await page.notebook.createNew(fileName, { kernel: 'null' });
+    await page.notebook.createNew(fileName, { kernel: null });
     await page.getByRole('main').getByText(fileName).waitFor();
 
     expect(await page.contents.fileExists(`${tmpPath}/${fileName}`)).toEqual(

--- a/galata/test/galata/notebook.spec.ts
+++ b/galata/test/galata/notebook.spec.ts
@@ -18,6 +18,32 @@ test.describe('Notebook Tests', () => {
       true
     );
   });
+  test('Create New Notebook with kernel', async ({ page, tmpPath }) => {
+    const fileName = 'create_kernel_test.ipynb';
+    await page.notebook.createNew(fileName, { kernel: 'python3' });
+    await page.getByRole('main').getByText(fileName).waitFor();
+
+    expect(await page.contents.fileExists(`${tmpPath}/${fileName}`)).toEqual(
+      true
+    );
+    const toolbar = page.getByRole('toolbar', { name: 'notebook actions' });
+    await expect(toolbar.getByText('Python 3 (ipykernel)')).toBeVisible();
+  });
+
+  test('Create New Notebook with kernel - no kernel', async ({
+    page,
+    tmpPath
+  }) => {
+    const fileName = 'create_no_kernel_test.ipynb';
+    await page.notebook.createNew(fileName, { kernel: 'null' });
+    await page.getByRole('main').getByText(fileName).waitFor();
+
+    expect(await page.contents.fileExists(`${tmpPath}/${fileName}`)).toEqual(
+      true
+    );
+    const toolbar = page.getByRole('toolbar', { name: 'notebook actions' });
+    await expect(toolbar.getByText('No Kernel')).toBeVisible();
+  });
 
   test('Create Markdown cell', async ({ page }) => {
     await page.notebook.createNew();


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Change to address #16553 
Summary of the issue is that the Galata test tools can only open notebooks that use the Python 3 kernel. To make this test tool useful for the author of other kernels, I propose we support the ability to select which kernel to use. 
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
The proposed change is to add an optional second parameter to the method createNew in the Galata notebook fixture. 
This parameter is a json structure with an optional field called 'kernel' which is the to choose which kernel the notebook should use. 

I should note that the value you have to pass as the "kernel" field is the kernel.id, not the user visible name. This is due to how the Playwright selectOption function works. This value is easily found either via the HTML or via the kernel definition. 

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->
Should be no user facing changes - test tool change only. 

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
Should be backwards compatible - new arguments are optional. No existing tests needed updating. 