### PR TITLE
Update the copyright year in About JupyterLab and LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2022 Project Jupyter Contributors
+Copyright (c) 2015-2024 Project Jupyter Contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -135,11 +135,7 @@ const about: JupyterFrontEndPlugin<void> = {
         );
         const copyright = (
           <span className="jp-About-copyright">
-            {trans.__(
-              '© %1-%2 Project Jupyter Contributors',
-              2015,
-              new Date().getUTCFullYear()
-            )}
+            {trans.__('© %1-%2 Project Jupyter Contributors', 2015, 2024)}
           </span>
         );
         const body = (

--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -135,7 +135,7 @@ const about: JupyterFrontEndPlugin<void> = {
         );
         const copyright = (
           <span className="jp-About-copyright">
-            {trans.__('© 2015-2023 Project Jupyter Contributors')}
+            {trans.__('© 2015-2024 Project Jupyter Contributors')}
           </span>
         );
         const body = (

--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -135,7 +135,11 @@ const about: JupyterFrontEndPlugin<void> = {
         );
         const copyright = (
           <span className="jp-About-copyright">
-            {trans.__('© 2015-2024 Project Jupyter Contributors')}
+            {trans.__(
+              '© %1-%2 Project Jupyter Contributors',
+              2015,
+              new Date().getUTCFullYear()
+            )}
           </span>
         );
         const body = (


### PR DESCRIPTION
Hi! 👋 

## References

Closes #16642 

## Code changes

Change `2023` to `2024`, as well as the format of the translatable string.

## User-facing changes

The current year (2024) is now shown in the _About JupyterLab_ dialog:

<img width="1582" alt="Screenshot 2024-08-05 at 11 54 43" src="https://github.com/user-attachments/assets/a534846a-9362-43ef-b005-8850a005a006">

## Backwards-incompatible changes

Yes, given that a translatable string has changed.