### PR TITLE
Do not block shift-click mouse up handler on active cell

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -2672,14 +2672,10 @@ export class Notebook extends StaticNotebook {
       // We don't want to prevent the default selection behavior
       // if there is currently text selected in an output.
       const hasSelection = (window.getSelection() ?? '').toString() !== '';
-      // We don't want to block the shift-click mouse up handler
-      // when the current cell is the active cell.
-      const isActiveCell = index == this.activeCellIndex;
       if (
         button === 0 &&
         shiftKey &&
         !hasSelection &&
-        !isActiveCell &&
         !['INPUT', 'OPTION'].includes(target.tagName)
       ) {
         // Prevent browser selecting text in prompt or output
@@ -2695,6 +2691,13 @@ export class Notebook extends StaticNotebook {
         }
         // Enter selecting mode
         this._mouseMode = 'select';
+
+        // We don't want to block the shift-click mouse up handler
+        // when the current cell is (and remains) the active cell.
+        this._selectData = {
+          startedOnActiveCell: index == this.activeCellIndex,
+          startingCellIndex: this.activeCellIndex
+        };
         document.addEventListener('mouseup', this, true);
         document.addEventListener('mousemove', this, true);
       } else if (button === 0 && !shiftKey) {
@@ -2740,8 +2743,21 @@ export class Notebook extends StaticNotebook {
    * Handle the `'mouseup'` event on the document.
    */
   private _evtDocumentMouseup(event: MouseEvent): void {
-    event.preventDefault();
-    event.stopPropagation();
+    const [, index] = this._findEventTargetAndCell(event);
+
+    let shouldPreventDefault = true;
+    if (this._mouseMode === 'select' && this._selectData) {
+      // User did not move the mouse over to a difference cell, so there was no selection
+      const { startedOnActiveCell, startingCellIndex } = this._selectData;
+      if (startedOnActiveCell && index === startingCellIndex) {
+        shouldPreventDefault = false;
+      }
+      this._selectData = null;
+    }
+    if (shouldPreventDefault) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
 
     // Remove the event listeners we put on the document
     document.removeEventListener('mousemove', this, true);
@@ -2749,8 +2765,6 @@ export class Notebook extends StaticNotebook {
 
     if (this._mouseMode === 'couldDrag') {
       // We didn't end up dragging if we are here, so treat it as a click event.
-
-      const [, index] = this._findEventTargetAndCell(event);
 
       this.deselectAll();
       this.activeCellIndex = index;
@@ -3162,6 +3176,10 @@ export class Notebook extends StaticNotebook {
     pressX: number;
     pressY: number;
     index: number;
+  } | null = null;
+  private _selectData: {
+    startedOnActiveCell: boolean;
+    startingCellIndex: number;
   } | null = null;
   private _mouseMode: 'select' | 'couldDrag' | null = null;
   private _activeCellChanged = new Signal<this, Cell | null>(this);

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -2672,8 +2672,8 @@ export class Notebook extends StaticNotebook {
       // We don't want to prevent the default selection behavior
       // if there is currently text selected in an output.
       const hasSelection = (window.getSelection() ?? '').toString() !== '';
-      // We don't want to prevent the default behavior
-      // if the current cell is the active cell.
+      // We don't want to block the shift-click mouse up handler
+      // when the current cell is the active cell.
       const isActiveCell = index == this.activeCellIndex;
       if (
         button === 0 &&

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -2672,10 +2672,14 @@ export class Notebook extends StaticNotebook {
       // We don't want to prevent the default selection behavior
       // if there is currently text selected in an output.
       const hasSelection = (window.getSelection() ?? '').toString() !== '';
+      // We don't want to prevent the default behavior
+      // if the current cell is the active cell.
+      const isActiveCell = index == this.activeCellIndex;
       if (
         button === 0 &&
         shiftKey &&
         !hasSelection &&
+        !isActiveCell &&
         !['INPUT', 'OPTION'].includes(target.tagName)
       ) {
         // Prevent browser selecting text in prompt or output

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -1240,7 +1240,10 @@ describe('@jupyter/notebook', () => {
           // test that selecting mode was NOT entered; in selecting mode we listen
           // to the `mouseup` event to stop selecting when the mouse button gets
           // released; this event gets default prevented as handled by the notebook.
-          const mouseUpEvent = new MouseEvent('mouseup', { shiftKey: true });
+          const mouseUpEvent = new MouseEvent('mouseup', {
+            bubbles: true,
+            cancelable: true
+          });
           widget.widgets[3].node.dispatchEvent(mouseUpEvent);
           expect(mouseUpEvent.defaultPrevented).toBe(false);
 
@@ -1268,11 +1271,21 @@ describe('@jupyter/notebook', () => {
           simulate(widget.widgets[3].node, 'mousedown', { shiftKey: true });
           expect(widget.activeCellIndex).toBe(3);
           expect(selected(widget)).toEqual([]);
-          // test that selecting mode was entered; in selecting mode we listen
-          // to the `mouseup` event to stop selecting when the mouse button gets
-          // released; this event gets default prevented as handled by the notebook.
-          const blockedMouseUpEvent = new MouseEvent('mouseup');
-          widget.widgets[3].node.dispatchEvent(blockedMouseUpEvent);
+
+          // shift click select by dragging from active cell
+          expect(widget.activeCellIndex).toBe(3);
+          simulate(widget.widgets[3].node, 'mousedown', { shiftKey: true });
+          expect(widget.activeCellIndex).toBe(3);
+          simulate(widget.widgets[4].node, 'mousemove', { shiftKey: true });
+          expect(selected(widget)).toEqual([3, 4]);
+          // test that selecting mode mouse up handler prevents default;
+          // in selecting mode we listen to the `mouseup` event to stop
+          // selecting when the mouse button gets released
+          const blockedMouseUpEvent = new MouseEvent('mouseup', {
+            bubbles: true,
+            cancelable: true
+          });
+          widget.widgets[4].node.dispatchEvent(blockedMouseUpEvent);
           expect(blockedMouseUpEvent.defaultPrevented).toBe(true);
         });
 

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -1237,7 +1237,8 @@ describe('@jupyter/notebook', () => {
           simulate(widget.widgets[3].node, 'mousedown', { shiftKey: true });
           expect(widget.activeCellIndex).toBe(3);
           expect(selected(widget)).toEqual([]);
-          // test that selecting mode was NOT entered; in selecting mode we listen
+          // test that selecting mode handler does not prevent default
+          // if no cells were selected; in the selecting mode we listen
           // to the `mouseup` event to stop selecting when the mouse button gets
           // released; this event gets default prevented as handled by the notebook.
           const mouseUpEvent = new MouseEvent('mouseup', {

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -1252,6 +1252,11 @@ describe('@jupyter/notebook', () => {
           simulate(widget.widgets[2].node, 'mousedown', { shiftKey: true });
           expect(widget.activeCellIndex).toBe(2);
           expect(selected(widget)).toEqual([2, 3]);
+
+          // shift click no-op
+          simulate(widget.widgets[3].node, 'mousedown', { shiftKey: true });
+          expect(widget.activeCellIndex).toBe(3);
+          expect(selected(widget)).toEqual([]);
         });
 
         it('should not extend a selection if there is text selected in the output', () => {

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -1271,9 +1271,9 @@ describe('@jupyter/notebook', () => {
           // test that selecting mode was entered; in selecting mode we listen
           // to the `mouseup` event to stop selecting when the mouse button gets
           // released; this event gets default prevented as handled by the notebook.
-          const mouseUpEvent = new MouseEvent('mouseup');
-          widget.widgets[3].node.dispatchEvent(mouseUpEvent);
-          expect(mouseUpEvent.defaultPrevented).toBe(true);
+          const blockedMouseUpEvent = new MouseEvent('mouseup');
+          widget.widgets[3].node.dispatchEvent(blockedMouseUpEvent);
+          expect(blockedMouseUpEvent.defaultPrevented).toBe(true);
         });
 
         it('should not extend a selection if there is text selected in the output', () => {

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -1237,7 +1237,7 @@ describe('@jupyter/notebook', () => {
           simulate(widget.widgets[3].node, 'mousedown', { shiftKey: true });
           expect(widget.activeCellIndex).toBe(3);
           expect(selected(widget)).toEqual([]);
-          expect(widget._mouseMode.toBe(null));
+          expect(widget._mouseMode).toBe(null);
 
           // shift click below
           simulate(widget.widgets[4].node, 'mousedown', { shiftKey: true });
@@ -1263,7 +1263,7 @@ describe('@jupyter/notebook', () => {
           simulate(widget.widgets[3].node, 'mousedown', { shiftKey: true });
           expect(widget.activeCellIndex).toBe(3);
           expect(selected(widget)).toEqual([]);
-          expect(widget._mouseMode.toBe('select'));
+          expect(widget._mouseMode).toBe('select');
         });
 
         it('should not extend a selection if there is text selected in the output', () => {

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -1233,6 +1233,12 @@ describe('@jupyter/notebook', () => {
         it('should extend selection if invoked with shift', () => {
           widget.activeCellIndex = 3;
 
+          // shift click no-op
+          simulate(widget.widgets[3].node, 'mousedown', { shiftKey: true });
+          expect(widget.activeCellIndex).toBe(3);
+          expect(selected(widget)).toEqual([]);
+          expect(widget._mouseMode.toBe(null));
+
           // shift click below
           simulate(widget.widgets[4].node, 'mousedown', { shiftKey: true });
           expect(widget.activeCellIndex).toBe(4);
@@ -1253,10 +1259,11 @@ describe('@jupyter/notebook', () => {
           expect(widget.activeCellIndex).toBe(2);
           expect(selected(widget)).toEqual([2, 3]);
 
-          // shift click no-op
+          // shift click deselect
           simulate(widget.widgets[3].node, 'mousedown', { shiftKey: true });
           expect(widget.activeCellIndex).toBe(3);
           expect(selected(widget)).toEqual([]);
+          expect(widget._mouseMode.toBe('select'));
         });
 
         it('should not extend a selection if there is text selected in the output', () => {

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -1237,7 +1237,12 @@ describe('@jupyter/notebook', () => {
           simulate(widget.widgets[3].node, 'mousedown', { shiftKey: true });
           expect(widget.activeCellIndex).toBe(3);
           expect(selected(widget)).toEqual([]);
-          expect(widget._mouseMode).toBe(null);
+          // test that selecting mode was NOT entered; in selecting mode we listen
+          // to the `mouseup` event to stop selecting when the mouse button gets
+          // released; this event gets default prevented as handled by the notebook.
+          const mouseUpEvent = new MouseEvent('mouseup', { shiftKey: true });
+          widget.widgets[3].node.dispatchEvent(mouseUpEvent);
+          expect(mouseUpEvent.defaultPrevented).toBe(false);
 
           // shift click below
           simulate(widget.widgets[4].node, 'mousedown', { shiftKey: true });
@@ -1263,7 +1268,12 @@ describe('@jupyter/notebook', () => {
           simulate(widget.widgets[3].node, 'mousedown', { shiftKey: true });
           expect(widget.activeCellIndex).toBe(3);
           expect(selected(widget)).toEqual([]);
-          expect(widget._mouseMode).toBe('select');
+          // test that selecting mode was entered; in selecting mode we listen
+          // to the `mouseup` event to stop selecting when the mouse button gets
+          // released; this event gets default prevented as handled by the notebook.
+          const mouseUpEvent = new MouseEvent('mouseup');
+          widget.widgets[3].node.dispatchEvent(mouseUpEvent);
+          expect(mouseUpEvent.defaultPrevented).toBe(true);
         });
 
         it('should not extend a selection if there is text selected in the output', () => {


### PR DESCRIPTION
## References

Fixes #16633

## Code changes

Don't prevent default behavior when the current cell is the active cell.

## User-facing changes

`shift+click` in the same cell no longer swallows the `mouseup` event.

## Backwards-incompatible changes

N/A
