### PR TITLE
Store/retrieve execution state from the shared model

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -22,7 +22,7 @@
     "@codemirror/view": "^6.9.6",
     "@jupyter/react-components": "^0.16.6",
     "@jupyter/web-components": "^0.16.6",
-    "@jupyter/ydoc": "^3.0.0-a2",
+    "@jupyter/ydoc": "^3.0.0-a3",
     "@jupyterlab/application": "~4.3.0-alpha.2",
     "@jupyterlab/application-extension": "~4.3.0-alpha.2",
     "@jupyterlab/apputils": "~4.4.0-alpha.2",

--- a/examples/cell/package.json
+++ b/examples/cell/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@jupyter/web-components": "^0.16.6",
-    "@jupyter/ydoc": "^3.0.0-a2",
+    "@jupyter/ydoc": "^3.0.0-a3",
     "@jupyterlab/application": "^4.3.0-alpha.2",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/cells": "^4.3.0-alpha.2",

--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@jupyter/web-components": "^0.16.6",
-    "@jupyter/ydoc": "^3.0.0-a2",
+    "@jupyter/ydoc": "^3.0.0-a3",
     "@jupyterlab/application": "^4.3.0-alpha.2",
     "@jupyterlab/codemirror": "^4.3.0-alpha.2",
     "@jupyterlab/console": "^4.3.0-alpha.2",

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@jupyter/web-components": "^0.16.6",
-    "@jupyter/ydoc": "^3.0.0-a2",
+    "@jupyter/ydoc": "^3.0.0-a3",
     "@jupyterlab/application": "^4.3.0-alpha.2",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/codemirror": "^4.3.0-alpha.2",

--- a/packages/cell-toolbar/package.json
+++ b/packages/cell-toolbar/package.json
@@ -40,7 +40,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^3.0.0-a2",
+    "@jupyter/ydoc": "^3.0.0-a3",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/cells": "^4.3.0-alpha.2",
     "@jupyterlab/docregistry": "^4.3.0-alpha.2",

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@codemirror/state": "^6.4.1",
     "@codemirror/view": "^6.26.3",
-    "@jupyter/ydoc": "^3.0.0-a2",
+    "@jupyter/ydoc": "^3.0.0-a3",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/attachments": "^4.3.0-alpha.2",
     "@jupyterlab/codeeditor": "^4.3.0-alpha.2",

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -21,6 +21,7 @@ import {
   CellChange,
   createMutex,
   createStandaloneCell,
+  IExecutionState,
   IMapChange,
   ISharedAttachmentsCell,
   ISharedCell,
@@ -156,7 +157,7 @@ export interface ICodeCellModel extends ICellModel {
   /**
    * The code cell's state.
    */
-  executionState: 'running' | 'idle';
+  executionState: IExecutionState;
 
   /**
    * The cell outputs.
@@ -649,19 +650,11 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
   /**
    * The execution state of the cell.
    */
-  get executionState(): 'idle' | 'running' {
-    return this._executionState;
+  get executionState(): IExecutionState {
+    return this.sharedModel.executionState;
   }
-  set executionState(newValue: 'idle' | 'running') {
-    const oldValue = this._executionState;
-    if (oldValue != newValue) {
-      this._executionState = newValue;
-      this.stateChanged.emit({
-        name: 'executionState',
-        oldValue,
-        newValue
-      });
-    }
+  set executionState(newValue: IExecutionState) {
+    this.sharedModel.executionState = newValue;
   }
 
   /**
@@ -859,6 +852,14 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
       });
     }
 
+    if (change.executionStateChange) {
+      this.stateChanged.emit({
+        name: 'executionState',
+        oldValue: change.executionStateChange.oldValue,
+        newValue: change.executionStateChange.newValue
+      });
+    }
+
     if (change.sourceChange && this.executionCount !== null) {
       this._setDirty(
         this._executedCode !== this.sharedModel.getSource().trim()
@@ -883,7 +884,6 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
     }
   }
 
-  private _executionState: 'idle' | 'running' = 'idle';
   private _executedCode = '';
   private _isDirty = false;
   private _outputs: IOutputAreaModel;

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@codemirror/state": "^6.4.1",
-    "@jupyter/ydoc": "^3.0.0-a2",
+    "@jupyter/ydoc": "^3.0.0-a3",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/coreutils": "^6.3.0-alpha.2",
     "@jupyterlab/nbformat": "^4.3.0-alpha.2",

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -43,7 +43,7 @@
     "@codemirror/legacy-modes": "^6.4.0",
     "@codemirror/search": "^6.5.6",
     "@codemirror/view": "^6.26.3",
-    "@jupyter/ydoc": "^3.0.0-a2",
+    "@jupyter/ydoc": "^3.0.0-a3",
     "@jupyterlab/application": "^4.3.0-alpha.2",
     "@jupyterlab/codeeditor": "^4.3.0-alpha.2",
     "@jupyterlab/codemirror": "^4.3.0-alpha.2",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -57,7 +57,7 @@
     "@codemirror/search": "^6.5.6",
     "@codemirror/state": "^6.4.1",
     "@codemirror/view": "^6.26.3",
-    "@jupyter/ydoc": "^3.0.0-a2",
+    "@jupyter/ydoc": "^3.0.0-a3",
     "@jupyterlab/codeeditor": "^4.3.0-alpha.2",
     "@jupyterlab/coreutils": "^6.3.0-alpha.2",
     "@jupyterlab/documentsearch": "^4.3.0-alpha.2",

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@codemirror/state": "^6.4.1",
     "@codemirror/view": "^6.26.3",
-    "@jupyter/ydoc": "^3.0.0-a2",
+    "@jupyter/ydoc": "^3.0.0-a3",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/codeeditor": "^4.3.0-alpha.2",
     "@jupyterlab/codemirror": "^4.3.0-alpha.2",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -42,7 +42,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^3.0.0-a2",
+    "@jupyter/ydoc": "^3.0.0-a3",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/cells": "^4.3.0-alpha.2",
     "@jupyterlab/codeeditor": "^4.3.0-alpha.2",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -51,7 +51,7 @@
     "@codemirror/state": "^6.4.1",
     "@codemirror/view": "^6.26.3",
     "@jupyter/react-components": "^0.16.6",
-    "@jupyter/ydoc": "^3.0.0-a2",
+    "@jupyter/ydoc": "^3.0.0-a3",
     "@jupyterlab/application": "^4.3.0-alpha.2",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/cells": "^4.3.0-alpha.2",

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -41,7 +41,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^3.0.0-a2",
+    "@jupyter/ydoc": "^3.0.0-a3",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/codeeditor": "^4.3.0-alpha.2",
     "@jupyterlab/coreutils": "^6.3.0-alpha.2",

--- a/packages/fileeditor/package.json
+++ b/packages/fileeditor/package.json
@@ -39,7 +39,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^3.0.0-a2",
+    "@jupyter/ydoc": "^3.0.0-a3",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/codeeditor": "^4.3.0-alpha.2",
     "@jupyterlab/codemirror": "^4.3.0-alpha.2",

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -36,7 +36,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^3.0.0-a2",
+    "@jupyter/ydoc": "^3.0.0-a3",
     "@jupyterlab/application": "^4.3.0-alpha.2",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/cells": "^4.3.0-alpha.2",

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -40,7 +40,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^3.0.0-a2",
+    "@jupyter/ydoc": "^3.0.0-a3",
     "@jupyterlab/apputils": "^4.4.0-alpha.2",
     "@jupyterlab/cells": "^4.3.0-alpha.2",
     "@jupyterlab/codeeditor": "^4.3.0-alpha.2",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -45,7 +45,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^3.0.0-a2",
+    "@jupyter/ydoc": "^3.0.0-a3",
     "@jupyterlab/coreutils": "^6.3.0-alpha.2",
     "@jupyterlab/nbformat": "^4.3.0-alpha.2",
     "@jupyterlab/settingregistry": "^4.3.0-alpha.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2074,9 +2074,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyter/ydoc@npm:^3.0.0-a2":
-  version: 3.0.0-a2
-  resolution: "@jupyter/ydoc@npm:3.0.0-a2"
+"@jupyter/ydoc@npm:^3.0.0-a3":
+  version: 3.0.0-a3
+  resolution: "@jupyter/ydoc@npm:3.0.0-a3"
   dependencies:
     "@jupyterlab/nbformat": ^3.0.0 || ^4.0.0-alpha.21 || ^4.0.0
     "@lumino/coreutils": ^1.11.0 || ^2.0.0
@@ -2084,7 +2084,7 @@ __metadata:
     "@lumino/signaling": ^1.10.0 || ^2.0.0
     y-protocols: ^1.0.5
     yjs: ^13.5.40
-  checksum: 4d4e48ce604544f90ee584f7c9bae4efaa8e2b7dd01ab1f6d2a97f8f9d221be7055a60bd128eb1010f8ff4a478c53827f47eb60875e8fc67bfba5298a068b2a0
+  checksum: 6651b7433c73312f6caf24bcd066b999a55be695ec6850a48442fbe9f739343893b181532398bf5e0b6c10f3fe874c832c075c865f1adb902d859b306cc1d333
   languageName: node
   linkType: hard
 
@@ -2408,7 +2408,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/cell-toolbar@workspace:packages/cell-toolbar"
   dependencies:
-    "@jupyter/ydoc": ^3.0.0-a2
+    "@jupyter/ydoc": ^3.0.0-a3
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
     "@jupyterlab/docregistry": ^4.3.0-alpha.2
@@ -2434,7 +2434,7 @@ __metadata:
   dependencies:
     "@codemirror/state": ^6.4.1
     "@codemirror/view": ^6.26.3
-    "@jupyter/ydoc": ^3.0.0-a2
+    "@jupyter/ydoc": ^3.0.0-a3
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/attachments": ^4.3.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
@@ -2490,7 +2490,7 @@ __metadata:
   resolution: "@jupyterlab/codeeditor@workspace:packages/codeeditor"
   dependencies:
     "@codemirror/state": ^6.4.1
-    "@jupyter/ydoc": ^3.0.0-a2
+    "@jupyter/ydoc": ^3.0.0-a3
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/coreutils": ^6.3.0-alpha.2
     "@jupyterlab/nbformat": ^4.3.0-alpha.2
@@ -2523,7 +2523,7 @@ __metadata:
     "@codemirror/legacy-modes": ^6.4.0
     "@codemirror/search": ^6.5.6
     "@codemirror/view": ^6.26.3
-    "@jupyter/ydoc": ^3.0.0-a2
+    "@jupyter/ydoc": ^3.0.0-a3
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
     "@jupyterlab/codemirror": ^4.3.0-alpha.2
@@ -2566,7 +2566,7 @@ __metadata:
     "@codemirror/search": ^6.5.6
     "@codemirror/state": ^6.4.1
     "@codemirror/view": ^6.26.3
-    "@jupyter/ydoc": ^3.0.0-a2
+    "@jupyter/ydoc": ^3.0.0-a3
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
     "@jupyterlab/coreutils": ^6.3.0-alpha.2
     "@jupyterlab/documentsearch": ^4.3.0-alpha.2
@@ -2614,7 +2614,7 @@ __metadata:
   dependencies:
     "@codemirror/state": ^6.4.1
     "@codemirror/view": ^6.26.3
-    "@jupyter/ydoc": ^3.0.0-a2
+    "@jupyter/ydoc": ^3.0.0-a3
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
     "@jupyterlab/codemirror": ^4.3.0-alpha.2
@@ -2670,7 +2670,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/console@workspace:packages/console"
   dependencies:
-    "@jupyter/ydoc": ^3.0.0-a2
+    "@jupyter/ydoc": ^3.0.0-a3
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
@@ -2798,7 +2798,7 @@ __metadata:
     "@codemirror/state": ^6.4.1
     "@codemirror/view": ^6.26.3
     "@jupyter/react-components": ^0.16.6
-    "@jupyter/ydoc": ^3.0.0-a2
+    "@jupyter/ydoc": ^3.0.0-a3
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
@@ -2894,7 +2894,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/docregistry@workspace:packages/docregistry"
   dependencies:
-    "@jupyter/ydoc": ^3.0.0-a2
+    "@jupyter/ydoc": ^3.0.0-a3
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
     "@jupyterlab/coreutils": ^6.3.0-alpha.2
@@ -3015,7 +3015,7 @@ __metadata:
   resolution: "@jupyterlab/example-cell@workspace:examples/cell"
   dependencies:
     "@jupyter/web-components": ^0.16.6
-    "@jupyter/ydoc": ^3.0.0-a2
+    "@jupyter/ydoc": ^3.0.0-a3
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
@@ -3044,7 +3044,7 @@ __metadata:
   resolution: "@jupyterlab/example-console@workspace:examples/console"
   dependencies:
     "@jupyter/web-components": ^0.16.6
-    "@jupyter/ydoc": ^3.0.0-a2
+    "@jupyter/ydoc": ^3.0.0-a3
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/codemirror": ^4.3.0-alpha.2
     "@jupyterlab/console": ^4.3.0-alpha.2
@@ -3190,7 +3190,7 @@ __metadata:
   resolution: "@jupyterlab/example-notebook@workspace:examples/notebook"
   dependencies:
     "@jupyter/web-components": ^0.16.6
-    "@jupyter/ydoc": ^3.0.0-a2
+    "@jupyter/ydoc": ^3.0.0-a3
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/codemirror": ^4.3.0-alpha.2
@@ -3431,7 +3431,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/fileeditor@workspace:packages/fileeditor"
   dependencies:
-    "@jupyter/ydoc": ^3.0.0-a2
+    "@jupyter/ydoc": ^3.0.0-a3
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
     "@jupyterlab/codemirror": ^4.3.0-alpha.2
@@ -4199,7 +4199,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/notebook-extension@workspace:packages/notebook-extension"
   dependencies:
-    "@jupyter/ydoc": ^3.0.0-a2
+    "@jupyter/ydoc": ^3.0.0-a3
     "@jupyterlab/application": ^4.3.0-alpha.2
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
@@ -4247,7 +4247,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/notebook@workspace:packages/notebook"
   dependencies:
-    "@jupyter/ydoc": ^3.0.0-a2
+    "@jupyter/ydoc": ^3.0.0-a3
     "@jupyterlab/apputils": ^4.4.0-alpha.2
     "@jupyterlab/cells": ^4.3.0-alpha.2
     "@jupyterlab/codeeditor": ^4.3.0-alpha.2
@@ -4521,7 +4521,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/services@workspace:packages/services"
   dependencies:
-    "@jupyter/ydoc": ^3.0.0-a2
+    "@jupyter/ydoc": ^3.0.0-a3
     "@jupyterlab/coreutils": ^6.3.0-alpha.2
     "@jupyterlab/nbformat": ^4.3.0-alpha.2
     "@jupyterlab/settingregistry": ^4.3.0-alpha.2


### PR DESCRIPTION
## References

- Follow-up to https://github.com/jupyterlab/jupyterlab/pull/16431
- Fixes a number of issues around cell running indicator `[*]`; before this PR
   - it was not shown to collaborators when RTC extension was installed as reported in https://github.com/jupyterlab/jupyterlab/issues/11551
   - it was not shown at all when using server-side execution; sibling PR:
       - https://github.com/datalayer/jupyter-server-nbmodel/pull/25
    - it was lost when refreshing the page even with server-side execution

In principle fixes https://github.com/jupyterlab/jupyterlab/issues/16059 but does not solve the issue of input boxes on refresh yet.

Depends on:
- https://github.com/jupyter-server/jupyter_ydoc/pull/259
- https://github.com/jupyter-server/jupyter_ydoc/pull/197

## Code changes

Stores/retrieves `executionState` from the shared model instead of storing it locally.

## User-facing changes

Execution state indicator is shown:
- for collaborators in RTC setup
- when using server-side execution, including after refresh

## Backwards-incompatible changes

None