### PR TITLE
Adopt a theme CSS variable for the "expand a collapsed cell" button shadow

### DIFF
--- a/packages/cells/style/placeholder.css
+++ b/packages/cells/style/placeholder.css
@@ -46,7 +46,7 @@
 
 .jp-Placeholder-content .jp-MoreHorizIcon:hover {
   border: 1px solid var(--jp-border-color1);
-  box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.25);
+  box-shadow: var(--jp-toolbar-box-shadow);
   background-color: var(--jp-layout-color0);
 }
 


### PR DESCRIPTION
Hi! 👋 

## References

Closes #16631

## Code changes

The "expand a collapsed cell" button's `box-shadow` property is now set by a theme CSS variable (`--jp-toolbar-box-shadow`).

### Before

<img width="1582" alt="Screenshot 2024-08-07 at 18 34 01" src="https://github.com/user-attachments/assets/4ec89c3f-6984-47ad-a7ee-a9e88923d492">

### After

<img width="1582" alt="Screenshot 2024-08-07 at 18 37 27" src="https://github.com/user-attachments/assets/f4e7f104-4eb1-4469-a989-d22fc35bff2d">

## User-facing changes

Visually, the differences are not very noticeable. For theme creators, this change allows one of the variables to be applied more consistently.

## Backwards-incompatible changes

None.