### PR TITLE
Convert `@jupyterlab/completer` type colors to theme CSS variables

### DIFF
--- a/packages/completer/style/base.css
+++ b/packages/completer/style/base.css
@@ -137,47 +137,47 @@
 }
 
 .jp-Completer-type[data-color-index='0'] {
-  background: var(--jp-completer-type-background0);
+  background: var(--jp-completer-type-background0, transparent);
 }
 
 .jp-Completer-type[data-color-index='1'] {
-  background: var(--jp-completer-type-background1);
+  background: var(--jp-completer-type-background1, #1f77b4);
 }
 
 .jp-Completer-type[data-color-index='2'] {
-  background: var(--jp-completer-type-background2);
+  background: var(--jp-completer-type-background2, #ff7f0e);
 }
 
 .jp-Completer-type[data-color-index='3'] {
-  background: var(--jp-completer-type-background3);
+  background: var(--jp-completer-type-background3, #2ca02c);
 }
 
 .jp-Completer-type[data-color-index='4'] {
-  background: var(--jp-completer-type-background4);
+  background: var(--jp-completer-type-background4, #d62728);
 }
 
 .jp-Completer-type[data-color-index='5'] {
-  background: var(--jp-completer-type-background5);
+  background: var(--jp-completer-type-background5, #9467bd);
 }
 
 .jp-Completer-type[data-color-index='6'] {
-  background: var(--jp-completer-type-background6);
+  background: var(--jp-completer-type-background6, #8c564b);
 }
 
 .jp-Completer-type[data-color-index='7'] {
-  background: var(--jp-completer-type-background7);
+  background: var(--jp-completer-type-background7, #e377c2);
 }
 
 .jp-Completer-type[data-color-index='8'] {
-  background: var(--jp-completer-type-background8);
+  background: var(--jp-completer-type-background8, #7f7f7f);
 }
 
 .jp-Completer-type[data-color-index='9'] {
-  background: var(--jp-completer-type-background9);
+  background: var(--jp-completer-type-background9, #bcbd22);
 }
 
 .jp-Completer-type[data-color-index='10'] {
-  background: var(--jp-completer-type-background10);
+  background: var(--jp-completer-type-background10, #17becf);
 }
 
 .jp-Completer-loading-bar-container {

--- a/packages/completer/style/base.css
+++ b/packages/completer/style/base.css
@@ -137,47 +137,47 @@
 }
 
 .jp-Completer-type[data-color-index='0'] {
-  background: transparent;
+  background: var(--jp-completer-type-background0);
 }
 
 .jp-Completer-type[data-color-index='1'] {
-  background: #1f77b4;
+  background: var(--jp-completer-type-background1);
 }
 
 .jp-Completer-type[data-color-index='2'] {
-  background: #ff7f0e;
+  background: var(--jp-completer-type-background2);
 }
 
 .jp-Completer-type[data-color-index='3'] {
-  background: #2ca02c;
+  background: var(--jp-completer-type-background3);
 }
 
 .jp-Completer-type[data-color-index='4'] {
-  background: #d62728;
+  background: var(--jp-completer-type-background4);
 }
 
 .jp-Completer-type[data-color-index='5'] {
-  background: #9467bd;
+  background: var(--jp-completer-type-background5);
 }
 
 .jp-Completer-type[data-color-index='6'] {
-  background: #8c564b;
+  background: var(--jp-completer-type-background6);
 }
 
 .jp-Completer-type[data-color-index='7'] {
-  background: #e377c2;
+  background: var(--jp-completer-type-background7);
 }
 
 .jp-Completer-type[data-color-index='8'] {
-  background: #7f7f7f;
+  background: var(--jp-completer-type-background8);
 }
 
 .jp-Completer-type[data-color-index='9'] {
-  background: #bcbd22;
+  background: var(--jp-completer-type-background9);
 }
 
 .jp-Completer-type[data-color-index='10'] {
-  background: #17becf;
+  background: var(--jp-completer-type-background10);
 }
 
 .jp-Completer-loading-bar-container {

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -437,9 +437,11 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-inspector-icon-color: var(--md-grey-200, #eee);
   --jp-switch-color: var(--md-grey-400, #bdbdbd);
   --jp-switch-true-position-color: var(--md-orange-700, #f57c00);
+}
 
-  /* Completer specific styles */
+/* Completer specific styles */
 
+.jp-Completer {
   --jp-completer-type-background0: transparent;
   --jp-completer-type-background1: #1f77b4;
   --jp-completer-type-background2: #ff7f0e;

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -437,4 +437,18 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-inspector-icon-color: var(--md-grey-200, #eee);
   --jp-switch-color: var(--md-grey-400, #bdbdbd);
   --jp-switch-true-position-color: var(--md-orange-700, #f57c00);
+
+  /* Completer specific styles */
+
+  --jp-completer-type-background0: transparent;
+  --jp-completer-type-background1: #1f77b4;
+  --jp-completer-type-background2: #ff7f0e;
+  --jp-completer-type-background3: #2ca02c;
+  --jp-completer-type-background4: #d62728;
+  --jp-completer-type-background5: #9467bd;
+  --jp-completer-type-background6: #8c564b;
+  --jp-completer-type-background7: #e377c2;
+  --jp-completer-type-background8: #7f7f7f;
+  --jp-completer-type-background9: #bcbd22;
+  --jp-completer-type-background10: #17becf;
 }

--- a/packages/theme-dark-high-contrast-extension/style/variables.css
+++ b/packages/theme-dark-high-contrast-extension/style/variables.css
@@ -437,4 +437,18 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-inspector-icon-color: var(--md-grey-200);
   --jp-switch-color: var(--md-grey-400);
   --jp-switch-true-position-color: var(--md-orange-700);
+
+  /* Completer specific styles */
+
+  --jp-completer-type-background0: transparent;
+  --jp-completer-type-background1: #1f77b4;
+  --jp-completer-type-background2: #ff7f0e;
+  --jp-completer-type-background3: #2ca02c;
+  --jp-completer-type-background4: #d62728;
+  --jp-completer-type-background5: #9467bd;
+  --jp-completer-type-background6: #8c564b;
+  --jp-completer-type-background7: #e377c2;
+  --jp-completer-type-background8: #7f7f7f;
+  --jp-completer-type-background9: #bcbd22;
+  --jp-completer-type-background10: #17becf;
 }

--- a/packages/theme-dark-high-contrast-extension/style/variables.css
+++ b/packages/theme-dark-high-contrast-extension/style/variables.css
@@ -437,9 +437,11 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-inspector-icon-color: var(--md-grey-200);
   --jp-switch-color: var(--md-grey-400);
   --jp-switch-true-position-color: var(--md-orange-700);
+}
 
-  /* Completer specific styles */
+/* Completer specific styles */
 
+.jp-Completer {
   --jp-completer-type-background0: transparent;
   --jp-completer-type-background1: #1f77b4;
   --jp-completer-type-background2: #ff7f0e;

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -421,9 +421,11 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-inspector-icon-color: var(--md-grey-700, #616161);
   --jp-switch-color: var(--md-grey-400, #bdbdbd);
   --jp-switch-true-position-color: var(--md-orange-900, #e65100);
+}
 
-  /* Completer specific styles */
+/* Completer specific styles */
 
+.jp-Completer {
   --jp-completer-type-background0: transparent;
   --jp-completer-type-background1: #1f77b4;
   --jp-completer-type-background2: #ff7f0e;

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -421,4 +421,18 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-inspector-icon-color: var(--md-grey-700, #616161);
   --jp-switch-color: var(--md-grey-400, #bdbdbd);
   --jp-switch-true-position-color: var(--md-orange-900, #e65100);
+
+  /* Completer specific styles */
+
+  --jp-completer-type-background0: transparent;
+  --jp-completer-type-background1: #1f77b4;
+  --jp-completer-type-background2: #ff7f0e;
+  --jp-completer-type-background3: #2ca02c;
+  --jp-completer-type-background4: #d62728;
+  --jp-completer-type-background5: #9467bd;
+  --jp-completer-type-background6: #8c564b;
+  --jp-completer-type-background7: #e377c2;
+  --jp-completer-type-background8: #7f7f7f;
+  --jp-completer-type-background9: #bcbd22;
+  --jp-completer-type-background10: #17becf;
 }


### PR DESCRIPTION
Hi! 👋 

## References

Closes #16589

## Code changes

The `@jupyterlab/completer` type background colors are now set by theme CSS variables.

## User-facing changes

Visually, none. For theme creators, it is now possible to customize the `@jupyterlab/completer` color palette along with other theme CSS variables.

## Backwards-incompatible changes

None.