### PR TITLE
Avoid changing type of read-only cells

### DIFF
--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2615,6 +2615,19 @@ namespace Private {
         });
         return;
       }
+      if (child.model.getMetadata('editable') == false) {
+        translator = translator || nullTranslator;
+        const trans = translator.load('jupyterlab');
+        // Do not permit changing cell type when the cell is readonly
+        void showDialog({
+          title: trans.__('Cell type not editable'),
+          body: trans.__(
+            'The cell type is not editable, its type cannot be changed!'
+          ),
+          buttons: [Dialog.okButton()]
+        });
+        return;
+      }
       if (child.model.type !== value) {
         const raw = child.model.toJSON();
         notebookSharedModel.transact(() => {

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2620,9 +2620,9 @@ namespace Private {
         const trans = translator.load('jupyterlab');
         // Do not permit changing cell type when the cell is readonly
         void showDialog({
-          title: trans.__('Cell type not editable'),
+          title: trans.__('Cell is not editable'),
           body: trans.__(
-            'The cell type is not editable, its type cannot be changed!'
+            'The cell is not editable, its type cannot be changed!'
           ),
           buttons: [Dialog.okButton()]
         });

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2620,9 +2620,9 @@ namespace Private {
         const trans = translator.load('jupyterlab');
         // Do not permit changing cell type when the cell is readonly
         void showDialog({
-          title: trans.__('Cell is not editable'),
+          title: trans.__('Cell is read-only'),
           body: trans.__(
-            'The cell is not editable, its type cannot be changed!'
+            'The cell is read-only, its type cannot be changed!'
           ),
           buttons: [Dialog.okButton()]
         });

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2621,9 +2621,7 @@ namespace Private {
         // Do not permit changing cell type when the cell is readonly
         void showDialog({
           title: trans.__('Cell is read-only'),
-          body: trans.__(
-            'The cell is read-only, its type cannot be changed!'
-          ),
+          body: trans.__('The cell is read-only, its type cannot be changed!'),
           buttons: [Dialog.okButton()]
         });
         return;

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -698,6 +698,22 @@ describe('@jupyterlab/notebook', () => {
         NotebookActions.changeCellType(widget, 'raw');
         expect(widget.activeCell).toBeInstanceOf(RawCell);
       });
+
+      it('should not change cell type when the cell is not editable', async () => {
+        NotebookActions.changeCellType(widget, 'markdown');
+        let cell = widget.activeCell as MarkdownCell;
+        expect(widget.activeCell).toBeInstanceOf(MarkdownCell);
+        cell.model.setMetadata('editable', false);
+
+        // Try to change cell type
+        NotebookActions.changeCellType(widget, 'raw');
+        // Cell type should stay unchanged.
+        expect(widget.activeCell).toBeInstanceOf(MarkdownCell);
+
+        // Should show a dialog informing user why cell type could not be changed
+        await waitForDialog();
+        await acceptDialog();
+      });
     });
 
     describe('#run()', () => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
This pull request closes  #11165: thanks for considering it.
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
This pull request adds a check for read-only status of the cell, as described [here](https://github.com/jupyterlab/jupyterlab/issues/11165#issuecomment-2016493224).

The related spec has been added.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
