### PR TITLE
Add a guard on uninitialized nodes when resizing, remove log

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -921,6 +921,10 @@ export class DirListing extends Widget {
     items.forEach((item, i) => {
       const node = nodes[i];
       if (sizeOnly && this.renderer.updateItemSize) {
+        if (!node) {
+          // short-circuit in case if node is not yet ready
+          return;
+        }
         return this.renderer.updateItemSize(
           node,
           item,
@@ -2864,7 +2868,6 @@ export namespace DirListing {
       const target = event.target as HTMLElement;
 
       const sortableColumns = DirListing.columns.filter(Private.isSortable);
-      console.log(sortableColumns);
 
       for (const column of sortableColumns) {
         const header = node.querySelector(`.${column.className}`);


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/16669

## Code changes

- Adds a guard against undefined node in case if array length changes when the resize request if fired.
- Removes spurious `console.log` which slipped through review

## User-facing changes

None

## Backwards-incompatible changes

None
