### PR TITLE
Update contents model on file change due to save from RTC

### DIFF
--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -413,6 +413,17 @@ export class Context<
     sender: Contents.IManager,
     change: Contents.IChangedArgs
   ): void {
+    if (change.type === 'save' && this._model.collaborative) {
+      // Update the contents model with the new values provided on save.
+      // This is needed for save operations performed on the server-side
+      // by the collaborative drive which needs to update the `hash`
+      // of the content when it changes on the backend.
+      this._updateContentsModel({
+        ...this._contentsModel,
+        ...change.newValue
+      } as Contents.IModel);
+      return;
+    }
     if (change.type !== 'rename') {
       return;
     }


### PR DESCRIPTION

## References

- Needed for https://github.com/jupyterlab/jupyter-collaboration/pull/337

## Code changes

When collaborative drive emits `fileChanged` signal of `save` type, update the contents model.

It is limited to collaborative drives so that we do not update contents model twice on save in non-collaborative context (which would likely be harmless, just confusing when following the logic in future debugging efforts).

I considered an alternative of introducing a new event type called `server-side-save` but I think using `save` type will actually help extensions like RTC which expect to see `save` events (which prior to https://github.com/jupyterlab/jupyter-collaboration/pull/337 were not emitted from RTC drive).

## User-facing changes

With https://github.com/jupyterlab/jupyter-collaboration/pull/337 the spurious "File Changed" will be gone.

## Backwards-incompatible changes

None
