### PR TITLE
Use locale name instead of display/native name to toggle language

### DIFF
--- a/packages/translation-extension/src/index.ts
+++ b/packages/translation-extension/src/index.ts
@@ -133,8 +133,7 @@ const langMenu: JupyterFrontEndPlugin<void> = {
               const displayName = value.displayName;
               const nativeName = value.nativeName;
               const toggled =
-                (currentLocale === 'default' ? 'en-US' : currentLocale) ===
-                locale;
+                (currentLocale === 'default' ? 'en' : currentLocale) === locale;
               const label = toggled
                 ? `${displayName}`
                 : `${displayName} - ${nativeName}`;

--- a/packages/translation-extension/src/index.ts
+++ b/packages/translation-extension/src/index.ts
@@ -132,7 +132,9 @@ const langMenu: JupyterFrontEndPlugin<void> = {
               const value = data['data'][locale];
               const displayName = value.displayName;
               const nativeName = value.nativeName;
-              const toggled = displayName === nativeName;
+              const toggled =
+                (currentLocale === 'default' ? 'en-US' : currentLocale) ===
+                locale;
               const label = toggled
                 ? `${displayName}`
                 : `${displayName} - ${nativeName}`;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes #16620 

## Code changes

The fix uses locale name to decide which language to toggle instead of looking for menu string being identical for the language name in the current language and the target language.

## User-facing changes
NA

## Backwards-incompatible changes

NA
