### PR TITLE
Add `crossorigin="anonymous"` to GitHub images

### DIFF
--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -62,6 +62,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
         {githubUser ? (
           <img
             src={`https://github.com/${githubUser}.png?size=${BADGE_QUERY_SIZE}`}
+            crossOrigin="anonymous"
             style={{ width: '32px', height: '32px' }}
           />
         ) : (

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -61,8 +61,10 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
       <div style={{ marginRight: '8px' }}>
         {githubUser ? (
           <img
-            src={`https://github.com/${githubUser}.png?size=${BADGE_QUERY_SIZE}`}
+            // cross-origin needs to be before src, see
+            // https://github.com/facebook/react/issues/14035
             crossOrigin="anonymous"
+            src={`https://github.com/${githubUser}.png?size=${BADGE_QUERY_SIZE}`}
             style={{ width: '32px', height: '32px' }}
           />
         ) : (


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/16388

Similar to #16535 but changed the order

## Code changes

```diff
+ crossOrigin="anonymous"
```

## User-facing changes

Images in the extension manager display properly when using restricted cross origin policy (e.g. to allow extensions to use `SharedArrayBuffer`).

## Backwards-incompatible changes

None