### PR TITLE
Add option to disable input placeholder text

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -809,6 +809,11 @@ export namespace Cell {
     maxNumberOutputs?: number;
 
     /**
+     * Show placeholder text for standard input
+     */
+    showInputPlaceholder?: boolean;
+
+    /**
      * Whether to split stdin line history by kernel session or keep globally accessible.
      */
     inputHistoryScope?: 'global' | 'session';
@@ -1094,7 +1099,8 @@ export class CodeCell extends Cell<ICodeCellModel> {
       maxNumberOutputs: this.maxNumberOutputs,
       translator: this.translator,
       promptOverlay: true,
-      inputHistoryScope: options.inputHistoryScope
+      inputHistoryScope: options.inputHistoryScope,
+      showInputPlaceholder: options.showInputPlaceholder
     }));
     output.node.addEventListener('keydown', this._detectCaretMovementInOuput);
 

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -701,7 +701,7 @@
     },
     "showInputPlaceholder": {
       "title": "Show input placeholder",
-      "description": "Show placeholder text for standard input fields.",
+      "description": "Show placeholder text for standard input fields. (Needs reload)",
       "type": "boolean",
       "default": true
     },

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -701,7 +701,7 @@
     },
     "showInputPlaceholder": {
       "title": "Show input placeholder",
-      "description": "Show placeholder text for standard input fields. (Needs reload)",
+      "description": "Show placeholder text for standard input fields (requires reload)",
       "type": "boolean",
       "default": true
     },

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -699,6 +699,12 @@
       "type": "boolean",
       "default": false
     },
+    "showInputPlaceholder": {
+      "title": "Show input placeholder",
+      "description": "Show placeholder text for standard input fields.",
+      "type": "boolean",
+      "default": true
+    },
     "inputHistoryScope": {
       "type": "string",
       "default": "global",

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1875,6 +1875,8 @@ function activateNotebookHandler(
       defaultCell: settings.get('defaultCell').composite as nbformat.CellType,
       recordTiming: settings.get('recordTiming').composite as boolean,
       overscanCount: settings.get('overscanCount').composite as number,
+      showInputPlaceholder: settings.get('showInputPlaceholder')
+        .composite as boolean,
       inputHistoryScope: settings.get('inputHistoryScope').composite as
         | 'global'
         | 'session',

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -705,6 +705,7 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
       contentFactory,
       editorConfig,
       inputHistoryScope: this.notebookConfig.inputHistoryScope,
+      showInputPlaceholder: this.notebookConfig.showInputPlaceholder,
       maxNumberOutputs: this.notebookConfig.maxNumberOutputs,
       model,
       placeholder: this._notebookConfig.windowingMode !== 'none',
@@ -1157,6 +1158,11 @@ export namespace StaticNotebook {
     maxNumberOutputs: number;
 
     /**
+     * Show placeholder text for standard input
+     */
+    showInputPlaceholder: boolean;
+
+    /**
      * Whether to split stdin line history by kernel session or keep globally accessible.
      */
     inputHistoryScope: 'global' | 'session';
@@ -1243,7 +1249,8 @@ export namespace StaticNotebook {
     sideBySideOutputRatio: 1,
     overscanCount: 1,
     windowingMode: 'full',
-    accessKernelHistory: false
+    accessKernelHistory: false,
+    showInputPlaceholder: true
   };
 
   /**

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -109,6 +109,7 @@ export class OutputArea extends Widget {
     this._maxNumberOutputs = options.maxNumberOutputs ?? Infinity;
     this._translator = options.translator ?? nullTranslator;
     this._inputHistoryScope = options.inputHistoryScope ?? 'global';
+    this._showInputPlaceholder = options.showInputPlaceholder ?? true;
 
     const model = (this.model = options.model);
     for (
@@ -482,7 +483,8 @@ export class OutputArea extends Widget {
       password,
       future,
       translator: this._translator,
-      inputHistoryScope: this._inputHistoryScope
+      inputHistoryScope: this._inputHistoryScope,
+      showInputPlaceholder: this._showInputPlaceholder
     });
     input.addClass(OUTPUT_AREA_OUTPUT_CLASS);
     panel.addWidget(input);
@@ -809,6 +811,7 @@ export class OutputArea extends Widget {
   private _translator: ITranslator;
   private _inputHistoryScope: 'global' | 'session' = 'global';
   private _pendingInput: boolean = false;
+  private _showInputPlaceholder: boolean = true;
 }
 
 export class SimplifiedOutputArea extends OutputArea {
@@ -883,6 +886,11 @@ export namespace OutputArea {
      * Whether to split stdin line history by kernel session or keep globally accessible.
      */
     inputHistoryScope?: 'global' | 'session';
+
+    /**
+     * Whether to show placeholder text in standard input
+     */
+    showInputPlaceholder?: boolean;
   }
 
   /**
@@ -1137,7 +1145,7 @@ export class Stdin extends Widget implements IStdin {
 
     this._input = this.node.getElementsByTagName('input')[0];
     // make users aware of the line history feature
-    if (!this._password) {
+    if (options.showInputPlaceholder && !this._password) {
       this._input.placeholder = this._trans.__(
         '↑↓ for history. Search history with c-↑/c-↓'
       );
@@ -1346,6 +1354,11 @@ export namespace Stdin {
      * Whether to split stdin line history by kernel session or keep globally accessible.
      */
     inputHistoryScope?: 'global' | 'session';
+
+    /**
+     * Show placeholder text
+     */
+    showInputPlaceholder?: boolean;
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

Fixes: https://github.com/jupyterlab/jupyterlab/issues/15138

This pull request is a follow up on https://github.com/jupyterlab/jupyterlab/pull/15321. 

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Adds `showInputPlaceholder` setting to notebook defaulted to `True`. Initialize this option in OutputArea, StdIn.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

Adds new `Show input placeholder` option in Settings.

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
