### PR TITLE
Document mandatory steps before running JupyterLab in dev mode

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -443,16 +443,12 @@ Then use the following steps:
    cd jupyterlab
    pip install -e ".[dev,test]"
    jlpm install
-   jlpm run build  # Build the dev mode assets (optional)
+   jlpm run build  # Build the dev mode assets
 
-Additionally, you might want to execute the following optional commands:
-
-.. code:: bash
-
-   # Build the core mode assets (optional)
+   # Build the core mode assets
    jlpm run build:core
 
-   # Build the app dir assets (optional)
+   # Build the app dir assets
    jupyter lab build
 
 Frequent issues

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -266,7 +266,8 @@ def ensure_app(app_dir):
 
     msgs = [
         f'JupyterLab application assets not found in "{app_dir}"',
-        "Please run `jupyter lab build` or use a different app directory",
+        "Please run `jlpm run build:core` then `jupyter lab build` ",
+        "or use a different app directory",
     ]
     return msgs
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
This pull request fixes #16313.
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
- The documentation now lists all the steps as mandatory, as suggested in https://github.com/jupyterlab/jupyterlab/issues/16313#issuecomment-2104205250
- The necessity to run `jlpm run build:core` is mentioned in the error message.
<!-- Describe the code changes and how they address the issue. -->

Note that I couldn't reproduce the error reported in #16313: in my case it was a 
```
JupyterLab Error
JupyterLab application assets not found in "/.../share/jupyter/lab"
Please run `jupyter lab build` or use a different app directory
```
I would have preferred to add a specific message for the missing `jlpm run build:core`, but it wasn't clear to me how should I manage the `ensure_core` [function](https://github.com/jupyterlab/jupyterlab/blob/06c5b357b59ffdd272b3ec71b8444c0a51f5146b/jupyterlab/commands.py#L246).

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
