### PR TITLE
Fix compatibility with `jupyterlab-unfold`

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1097,12 +1097,19 @@ export class DirListing extends Widget {
   }
 
   private _updateColumnSizes() {
-    // adjust column sizes so that they add up to the total width available, preserving ratios
+    // Adjust column sizes so that they add up to the total width available, preserving ratios
     // and removing width from the last column so that it fills the width available;
-    const visibleColumns = this._visibleColumns.map(column => ({
-      ...column,
-      element: DOMUtils.findElement(this.node, column.className)
-    }));
+    const visibleColumns = this._visibleColumns
+      .map(column => ({
+        ...column,
+        element: DOMUtils.findElement(this.node, column.className)
+      }))
+      .filter(column => {
+        // While all visible column will have an element, some extensions like jupyter-unfold
+        // do not render columns even if user requests them to be visible; this filter exists
+        // to ensure backward compatibility with such extensions and may be removed in the future.
+        return column.element;
+      });
 
     // read from DOM
     let total = 0;


### PR DESCRIPTION
## References

Fixes #16756

## Code changes

Prevents access to columns which are not rendered in unfold as of today. This is meant to ease the transition to JupyterLab 4.3 for users of current version of jupyterlab-unfold.

## User-facing changes

jupyterlab-unfold does not crash

## Backwards-incompatible changes

None