### PR TITLE
Fix compatibility with server-side execution extensions

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -37,10 +37,11 @@ Shared model
 ~~~~~~~~~~~~
 
 The outputs set on the shared cell model are now expected to be wrapped
-in the pycrdt ``Map`` objects rather than provided as plain dictionaries.
-Further, the ``"text"`` entry can now be specified as an ``Array<string>``
+in the ``Y.Map`` objects rather than provided as plain objects
+(or pycrdt ``Map`` objects rather than dictionaries when set on the backend).
+Further, the ``"text"`` entry must now be specified as an ``Array<string>``
 object for outputs of ``"stream"`` type, allowing for better performance.
-The use of dictionaries is deprecated and will stop working in a future version.
+The use of plain objects is deprecated and will stop working in a future version.
 For reference, see PRs:
 
 - https://github.com/jupyterlab/jupyterlab/pull/16498

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -38,6 +38,8 @@ Shared model
 
 The outputs set on the shared cell model are now expected to be wrapped
 in the pycrdt ``Map`` objects rather than provided as plain dictionaries.
+Further, the ``"text"`` entry can now be specified as an ``Array<string>``
+object for outputs of ``"stream"`` type, allowing for better performance.
 The use of dictionaries is deprecated and will stop working in a future version.
 For reference, see PRs:
 

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -32,6 +32,19 @@ breaking change when defining fixture values that are array of objects.
 
 See the `Playwright 1.46.0 release notes <https://github.com/microsoft/playwright/releases/tag/v1.46.0>`_ for more information.
 
+
+Shared model
+~~~~~~~~~~~~
+
+The outputs set on the shared cell model are now expected to be wrapped
+in the pycrdt ``Map`` objects rather than provided as plain dictionaries.
+The use of dictionaries is deprecated and will stop working in a future version.
+For reference, see PRs:
+
+- https://github.com/jupyterlab/jupyterlab/pull/16498
+- https://github.com/jupyter-server/jupyter_ydoc/pull/241
+
+
 JupyterLab 4.1 to 4.2
 ---------------------
 

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -854,7 +854,10 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
           if ('insert' in outputsChange) {
             // Inserting an output always results in appending it.
             for (const output of outputsChange.insert!) {
-              this._outputs.add(output.toJSON());
+              // For compatibility with older ydoc where a dictionary,
+              // (rather than a Map instance) could be provided.
+              // In a future major release the use of Map will be required.
+              this._outputs.add('toJSON' in output ? output.toJSON() : output);
             }
           }
         }

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -854,7 +854,7 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
           if ('insert' in outputsChange) {
             // Inserting an output always results in appending it.
             for (const output of outputsChange.insert!) {
-              // For compatibility with older ydoc where a dictionary,
+              // For compatibility with older ydoc where a plain object,
               // (rather than a Map instance) could be provided.
               // In a future major release the use of Map will be required.
               this._outputs.add('toJSON' in output ? output.toJSON() : output);


### PR DESCRIPTION
## References

- Fixes https://github.com/jupyterlab/jupyter-collaboration/issues/347
- and probably https://github.com/datalayer/jupyter-server-nbmodel/issues/26 but ideally it would also make a change as in https://github.com/jupyter-server/jupyverse/pull/435.

CC @davidbrochart

## Code changes

The data type assumed by the implementation changed from an plain dictionary to Map in:
- https://github.com/jupyterlab/jupyterlab/pull/16498

However, this already was a public API so I we should keep this compatible.

```diff
- this._outputs.add(output.toJSON());
+ this._outputs.add('toJSON' in output ? output.toJSON() : output);
```

## User-facing changes

Serve-side execution and related features work again.

## Backwards-incompatible changes

None
