### PR TITLE
Fix shutdown kernel button in running panel

### DIFF
--- a/packages/running/src/index.tsx
+++ b/packages/running/src/index.tsx
@@ -195,9 +195,9 @@ function Item(props: {
   collapseToggled: ISignal<Section, boolean>;
 }) {
   const { runningItem } = props;
+  const [collapsed, setCollapsed] = React.useState(false);
   // Use a ref instead of a state because the state does not have the time
   // to update in the callbacks
-  const [collapsed, collapse] = React.useState(false);
   const shuttingDown = useRef(false);
   const classList = [ITEM_CLASS];
   const detail = runningItem.detail?.();
@@ -236,7 +236,7 @@ function Item(props: {
         return;
       }
       if (collapsible) {
-        collapse(!collapsed);
+        setCollapsed(!collapsed);
       }
     },
     [collapsible, collapsed, shuttingDown]
@@ -244,7 +244,7 @@ function Item(props: {
 
   // Listen to signal to collapse from outside
   props.collapseToggled.connect((_emitter, newCollapseState) =>
-    collapse(newCollapseState)
+    setCollapsed(newCollapseState)
   );
 
   if (runningItem.className) {

--- a/packages/running/style/base.css
+++ b/packages/running/style/base.css
@@ -120,8 +120,13 @@ span.jp-RunningSessions-icon > svg {
   white-space: nowrap;
 }
 
-.jp-RunningSessions-item:not(:hover) .jp-RunningSessions-itemShutdown {
+.jp-RunningSessions-itemShutdown {
   visibility: hidden;
+}
+
+.jp-RunningSessions-item:focus-visible > .jp-RunningSessions-itemShutdown,
+.jp-RunningSessions-item:hover > .jp-RunningSessions-itemShutdown {
+  visibility: visible;
 }
 
 .jp-RunningSessions-shutdownAll.jp-ToolbarButtonComponent {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #16645
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Shutdown unconditionnally of the event status
Don't un-/collapse when clicking on the shutdown button
Show the shutdown button when the item gains focus

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Shutdown kernel button works
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None