### PR TITLE
Update `Show Virtual Scrollbar` -> `Show Minimap`

### DIFF
--- a/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
+++ b/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
@@ -2097,8 +2097,8 @@
   },
   {
     "id": "notebook:toggle-virtual-scrollbar",
-    "label": "Show Virtual Scrollbar",
-    "caption": "Show virtual scrollbar (enabled with windowing mode: full)",
+    "label": "Show Minimap",
+    "caption": "Show Minimap (enabled with windowing mode: full)",
     "shortcuts": []
   },
   {

--- a/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
+++ b/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
@@ -2098,7 +2098,7 @@
   {
     "id": "notebook:toggle-virtual-scrollbar",
     "label": "Show Minimap",
-    "caption": "Show Minimap (enabled with windowing mode: full)",
+    "caption": "Show Minimap (virtual scrollbar, enabled with windowing mode: full)",
     "shortcuts": []
   },
   {

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -3536,10 +3536,8 @@ function addCommands(
   });
 
   commands.addCommand(CommandIDs.virtualScrollbar, {
-    label: trans.__('Show Virtual Scrollbar'),
-    caption: trans.__(
-      'Show virtual scrollbar (enabled with windowing mode: full)'
-    ),
+    label: trans.__('Show Minimap'),
+    caption: trans.__('Show Minimap (enabled with windowing mode: full)'),
     execute: args => {
       const current = getCurrent(tracker, shell, args);
 

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -3537,7 +3537,9 @@ function addCommands(
 
   commands.addCommand(CommandIDs.virtualScrollbar, {
     label: trans.__('Show Minimap'),
-    caption: trans.__('Show Minimap (enabled with windowing mode: full)'),
+    caption: trans.__(
+      'Show Minimap (virtual scrollbar, enabled with windowing mode: full)'
+    ),
     execute: args => {
       const current = getCurrent(tracker, shell, args);
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

The user facing changelog for `4.3.0` mentions the word minimap:

https://jupyterlab.readthedocs.io/en/latest/getting_started/changelog.html#minimap

However this feature is still reference as "Virtual Scrollbar" in the UI. For someone looking at the changelog and for this feature it could be confusing. Also the work "Minimap" might be more user-friendly than "Virtual Scrollbar"?

## Code changes

Update the user facing "Virtual Scrollbar" to "Minimap".

## User-facing changes

![image](https://github.com/user-attachments/assets/c2ba5148-3bb3-406d-9cac-b4384836fa98)

![image](https://github.com/user-attachments/assets/6f292bdb-7a00-4a11-8732-76980f55e8b4)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
