### PR TITLE
Replace link to accessiblity project with a link to accessiblity issues

### DIFF
--- a/docs/source/getting_started/accessibility.rst
+++ b/docs/source/getting_started/accessibility.rst
@@ -38,7 +38,7 @@ This section includes audits from different stakeholders on Jupyter products.
 * `JupyterLab v2.2.6 WCAG 2.1 <https://github.com/jupyterlab/jupyterlab/issues/9399>`_ - conducted in 2020
 * `Jupyter Notebook WCAG 2.0 <https://github.com/jupyter/accessibility/issues/7>`_ - conducted in 2019
 
-Many of the issues identified in these audits can be tracked in issues with the `tag:Accessibility <https://github.com/jupyterlab/jupyterlab/issues?q=is%3Aopen+is%3Aissue+label%3Atag%3AAccessibility>`_ label.
+Many of the issues identified in these audits can be tracked in issues with the `tag:Accessibility <https://github.com/jupyterlab/jupyterlab/issues?q=is%3Aopen+is%3Aissue+label%3Atag%3AAccessibility>`__ label.
 
 Accessibility Statement for JupyterLab
 --------------------------------------
@@ -142,7 +142,7 @@ Evaluation report
 """""""""""""""""
 
 * An evaluation for JupyterLab is available at: `jupyterlab/jupyterlab/issues/9399 <https://github.com/jupyterlab/jupyterlab/issues/9399>`_.
-* User reports on JupyterLab's accessibility are available at: `the jupyterlab/jupyterlab label tag:Accessibility <https://github.com/jupyterlab/jupyterlab/labels/tag%3AAccessibility>`_.
+* User reports on JupyterLab's accessibility are available at: `the jupyterlab/jupyterlab label tag:Accessibility <https://github.com/jupyterlab/jupyterlab/labels/tag%3AAccessibility>`__.
 
 What the community is doing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -166,7 +166,7 @@ We welcome your feedback and formal complaints on the accessibility status of Ju
 Please let us know if you encounter accessibility barriers on JupyterLab:
 
 * `Write an issue on jupyter/accessibility <https://github.com/jupyter/accessibility/issues/new>`_
-* `Write an issue on jupyterlab/jupyterlab <https://github.com/jupyterlab/jupyterlab/issues/new>`_ and request it be labeled `tag:Accessibility <https://github.com/jupyterlab/jupyterlab/labels/tag%3AAccessibility>`_
+* `Write an issue on jupyterlab/jupyterlab <https://github.com/jupyterlab/jupyterlab/issues/new>`_ and request it be labeled `tag:Accessibility <https://github.com/jupyterlab/jupyterlab/labels/tag%3AAccessibility>`__
 * If you are interested in being part of any potential research or organized feedback initiatives, please reach out via one of the many JupyterLab community channels. Gauging community interest in user research participation helps us gain the support to make it happen.
 
 Please note there is no private way to contact us for JupyterLab accessibility issues.

--- a/docs/source/getting_started/accessibility.rst
+++ b/docs/source/getting_started/accessibility.rst
@@ -38,7 +38,7 @@ This section includes audits from different stakeholders on Jupyter products.
 * `JupyterLab v2.2.6 WCAG 2.1 <https://github.com/jupyterlab/jupyterlab/issues/9399>`_ - conducted in 2020
 * `Jupyter Notebook WCAG 2.0 <https://github.com/jupyter/accessibility/issues/7>`_ - conducted in 2019
 
-Many of the issues identified in these audits can be tracked in this `GitHub project within the JupyterLab organization <https://github.com/orgs/jupyterlab/projects/1>`_
+Many of the issues identified in these audits can be tracked in issues with the `tag:Accessibility <https://github.com/jupyterlab/jupyterlab/issues?q=is%3Aopen+is%3Aissue+label%3Atag%3AAccessibility>`_ label.
 
 Accessibility Statement for JupyterLab
 --------------------------------------

--- a/docs/source/getting_started/accessibility.rst
+++ b/docs/source/getting_started/accessibility.rst
@@ -142,7 +142,7 @@ Evaluation report
 """""""""""""""""
 
 * An evaluation for JupyterLab is available at: `jupyterlab/jupyterlab/issues/9399 <https://github.com/jupyterlab/jupyterlab/issues/9399>`_.
-* User reports on JupyterLab's accessibility are available at:`the jupyterlab/jupyterlab label `tag:accessibility <https://github.com/jupyterlab/jupyterlab/labels/tag%3AAccessibility>`_.
+* User reports on JupyterLab's accessibility are available at: `the jupyterlab/jupyterlab label tag:Accessibility <https://github.com/jupyterlab/jupyterlab/labels/tag%3AAccessibility>`_.
 
 What the community is doing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/16785

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Fix link to non-existing accessibility project: https://github.com/orgs/jupyterlab/projects/1

<!-- Describe the code changes and how they address the issue. -->

Fix another malformed rst link.

## User-facing changes

Readers of the accessibility page in the docs are directed to issues labeled as `tag:Accessibility` instead.

![image](https://github.com/user-attachments/assets/86a20898-bad8-42d0-8749-f51407d271f8)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
