### PR TITLE
Fix typo in the `IPropertyInspectorProvider` plugin description

### DIFF
--- a/galata/test/documentation/plugins.test.ts-snapshots/tokens-documentation-linux.json
+++ b/galata/test/documentation/plugins.test.ts-snapshots/tokens-documentation-linux.json
@@ -8,7 +8,7 @@
   "@jupyterlab/application:ILabStatus": "A service for interacting with the application busy/dirty\n  status. Use this if you want to set the application \"busy\" favicon, or to set\n  the application \"dirty\" status, which asks the user for confirmation before leaving the application page.",
   "@jupyterlab/application:IInfo": "A service providing metadata about the current application, including disabled extensions and whether dev mode is enabled.",
   "@jupyterlab/application:IPaths": "A service providing information about various\n  URLs and server paths for the current application. Use this service if you want to\n  assemble URLs to use the JupyterLab REST API.",
-  "@jupyterlab/property-inspector:IPropertyInspectorProvider": "A service to registry new widget in the property inspector side panel.",
+  "@jupyterlab/property-inspector:IPropertyInspectorProvider": "A service to register new widgets in the property inspector side panel.",
   "@jupyterlab/apputils:IKernelStatusModel": "A service to register kernel session provider to the kernel status indicator.",
   "@jupyterlab/apputils:ICommandPalette": "A service for the application command palette\n  in the left panel. Use this to add commands to the palette.",
   "@jupyterlab/apputils:IWindowResolver": "A service for a window resolver for the\n  application. JupyterLab workspaces are given a name, which are determined using\n  the window resolver. Require this if you want to use the name of the current workspace.",

--- a/packages/property-inspector/src/token.ts
+++ b/packages/property-inspector/src/token.ts
@@ -56,5 +56,5 @@ export interface IPropertyInspectorProvider {
  */
 export const IPropertyInspectorProvider = new Token<IPropertyInspectorProvider>(
   '@jupyterlab/property-inspector:IPropertyInspectorProvider',
-  'A service to registry new widget in the property inspector side panel.'
+  'A service to register new widgets in the property inspector side panel.'
 );


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Noticed while browsing the docs:

![image](https://github.com/user-attachments/assets/6c6220b8-7c20-4f09-b60c-fb806f626f10)


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Fix typo in a plugin description, which is reflected in the docs

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
