### PR TITLE
Allow running the `browser_check` in headed mode

### DIFF
--- a/jupyterlab/browser-test.js
+++ b/jupyterlab/browser-test.js
@@ -11,6 +11,8 @@ const fs = require('fs');
 const URL = process.argv[2];
 const BROWSER_VAR = 'JLAB_BROWSER_TYPE';
 const BROWSER = process.env[BROWSER_VAR] || 'chromium';
+const HEADLESS_VAR = 'JLAB_BROWSER_HEADLESS';
+const HEADLESS = process.env[HEADLESS_VAR] === 'false' ? false : true;
 const OUTPUT_VAR = 'JLAB_BROWSER_CHECK_OUTPUT';
 const OUTPUT = process.env[OUTPUT_VAR];
 
@@ -32,6 +34,7 @@ async function main() {
 
   const pwBrowser = playwright[BROWSER];
   const browser = await pwBrowser.launch({
+    headless: HEADLESS,
     logger: {
       isEnabled: () => !!OUTPUT,
       log: (name, severity, message, args) => console.log(name, message)


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Add a new `JLAB_BROWSER_HEADLESS` environment variable to be able to run the `browser_check` in headed mode.

This makes it easier to debug the `browser_check` when it fails.

Usage:

```bash
JLAB_BROWSER_HEADLESS=false python -m jupyterlab.browser_check
```

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Add a `JLAB_BROWSER_HEADLESS` environment variable to the `browser-test.js` script to allow toggling the Playwright `headless` value

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
