### PR TITLE
Prevent text cursor on clickable items in settings

### DIFF
--- a/packages/settingeditor/style/base.css
+++ b/packages/settingeditor/style/base.css
@@ -129,6 +129,7 @@
   overflow: hidden;
   padding: 4px 0 4px 4px;
   white-space: nowrap;
+  cursor: pointer;
 }
 
 .jp-PluginList-entry:hover {

--- a/packages/shortcuts-extension/style/base.css
+++ b/packages/shortcuts-extension/style/base.css
@@ -263,6 +263,7 @@
 .jp-Shortcuts-Reset {
   color: var(--jp-brand-color2);
   padding-left: 10px;
+  cursor: pointer;
 }
 
 .jp-Shortcuts-Reset:hover {


### PR DESCRIPTION

## Fixes #16802 

### This PR addresses the issue where certain clickable items in the settings panel were showing a text cursor (indicating editable text), which could cause confusion for users. The fix ensures that the cursor behaves as expected (pointer) over all clickable elements.

### Code changes

- Added `cursor: pointer` to the following JupyterLab classes:
  - `.jp-Shortcuts-Reset`
  - `.jp-PluginList-entry`
  - This updated the cursor style for clickable items to ensure it reflects a pointer rather than text when hovered.
  
### Screenshots (After)

![Screenshot from 2024-09-24 21-02-47](https://github.com/user-attachments/assets/59599cc2-94d1-4261-8b22-2fe3fd57e259)

![Screenshot from 2024-09-24 21-03-23](https://github.com/user-attachments/assets/1f8a50c4-108d-4eef-9e72-79c4e95156c7)
