### PR TITLE
Improve notebook output stream processing

### DIFF
--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -526,6 +526,9 @@ namespace Private {
     if (text === undefined) {
       text = '';
     }
+    if (!(newText.includes('\b') || newText.includes('\r'))) {
+      return text + newText;
+    }
     let idx0 = text.length;
     for (let idx1 = 0; idx1 < newText.length; idx1++) {
       const newChar = newText[idx1];


### PR DESCRIPTION
## References

See #16812.

## Code changes

Take a shortcut when notebook stream outputs don't have `\r` or `\b` characters.

## User-facing changes

Better performances when opening notebooks with lots of text outputs.

## Backwards-incompatible changes

None.