### PR TITLE
Improve performance of concatenating stream strings

### DIFF
--- a/packages/outputarea/test/model.spec.ts
+++ b/packages/outputarea/test/model.spec.ts
@@ -168,6 +168,25 @@ describe('outputarea/model', () => {
         });
         expect(model.get(0).toJSON().text).toBe('jupyter\njupyter\njupyter');
       });
+
+      it('should be fast in sparse presence of returns and backspaces', () => {
+        // locally this test run in 36 ms; setting it to 10 times
+        // more to allow for slower runs on CI
+        const timeout = 360;
+        const size = 10 ** 7;
+        const output = {
+          name: 'stdout',
+          output_type: 'stream',
+          text: ['a'.repeat(size) + 'a\b' + 'a'.repeat(size)]
+        };
+
+        const start = performance.now();
+        model.add(output);
+        const end = performance.now();
+
+        expect(end - start).toBeLessThan(timeout);
+        expect(model.get(0).toJSON().text).toHaveLength(2 * size);
+      });
     });
 
     describe('#clear()', () => {


### PR DESCRIPTION
## References

- A part of the fixes for https://github.com/jupyterlab/jupyterlab/issues/16812
- Follow-up to https://github.com/jupyterlab/jupyterlab/pull/16814

## Code changes

- [x] Adds a performance unit test ensuring that the logic is not using quadratic or worse complexity
  - should fail on CI in the first commit
- [ ] Changes the logic to iterate over the text in chunks rather than character-by-character

## User-facing changes

Opening notebooks with streams which include `\n` is faster

## Backwards-incompatible changes

None