### PR TITLE
Bump jupyter-ydoc to 3.0.0a8

### DIFF
--- a/examples/cell/package.json
+++ b/examples/cell/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@jupyter/web-components": "^0.16.6",
-    "@jupyter/ydoc": "^3.0.0-a5",
+    "@jupyter/ydoc": "^3.0.0-a8",
     "@jupyterlab/application": "^4.3.0-beta.1",
     "@jupyterlab/apputils": "^4.4.0-beta.1",
     "@jupyterlab/cells": "^4.3.0-beta.1",

--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@jupyter/web-components": "^0.16.6",
-    "@jupyter/ydoc": "^3.0.0-a5",
+    "@jupyter/ydoc": "^3.0.0-a8",
     "@jupyterlab/application": "^4.3.0-beta.1",
     "@jupyterlab/codemirror": "^4.3.0-beta.1",
     "@jupyterlab/console": "^4.3.0-beta.1",

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@jupyter/web-components": "^0.16.6",
-    "@jupyter/ydoc": "^3.0.0-a5",
+    "@jupyter/ydoc": "^3.0.0-a8",
     "@jupyterlab/application": "^4.3.0-beta.1",
     "@jupyterlab/apputils": "^4.4.0-beta.1",
     "@jupyterlab/codemirror": "^4.3.0-beta.1",

--- a/packages/cell-toolbar/package.json
+++ b/packages/cell-toolbar/package.json
@@ -40,7 +40,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^3.0.0-a5",
+    "@jupyter/ydoc": "^3.0.0-a8",
     "@jupyterlab/apputils": "^4.4.0-beta.1",
     "@jupyterlab/cells": "^4.3.0-beta.1",
     "@jupyterlab/docregistry": "^4.3.0-beta.1",

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@codemirror/state": "^6.4.1",
     "@codemirror/view": "^6.26.3",
-    "@jupyter/ydoc": "^3.0.0-a5",
+    "@jupyter/ydoc": "^3.0.0-a8",
     "@jupyterlab/apputils": "^4.4.0-beta.1",
     "@jupyterlab/attachments": "^4.3.0-beta.1",
     "@jupyterlab/codeeditor": "^4.3.0-beta.1",

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@codemirror/state": "^6.4.1",
-    "@jupyter/ydoc": "^3.0.0-a5",
+    "@jupyter/ydoc": "^3.0.0-a8",
     "@jupyterlab/apputils": "^4.4.0-beta.1",
     "@jupyterlab/coreutils": "^6.3.0-beta.1",
     "@jupyterlab/nbformat": "^4.3.0-beta.1",

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -43,7 +43,7 @@
     "@codemirror/legacy-modes": "^6.4.0",
     "@codemirror/search": "^6.5.6",
     "@codemirror/view": "^6.26.3",
-    "@jupyter/ydoc": "^3.0.0-a5",
+    "@jupyter/ydoc": "^3.0.0-a8",
     "@jupyterlab/application": "^4.3.0-beta.1",
     "@jupyterlab/codeeditor": "^4.3.0-beta.1",
     "@jupyterlab/codemirror": "^4.3.0-beta.1",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -57,7 +57,7 @@
     "@codemirror/search": "^6.5.6",
     "@codemirror/state": "^6.4.1",
     "@codemirror/view": "^6.26.3",
-    "@jupyter/ydoc": "^3.0.0-a5",
+    "@jupyter/ydoc": "^3.0.0-a8",
     "@jupyterlab/codeeditor": "^4.3.0-beta.1",
     "@jupyterlab/coreutils": "^6.3.0-beta.1",
     "@jupyterlab/documentsearch": "^4.3.0-beta.1",

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@codemirror/state": "^6.4.1",
     "@codemirror/view": "^6.26.3",
-    "@jupyter/ydoc": "^3.0.0-a5",
+    "@jupyter/ydoc": "^3.0.0-a8",
     "@jupyterlab/apputils": "^4.4.0-beta.1",
     "@jupyterlab/codeeditor": "^4.3.0-beta.1",
     "@jupyterlab/codemirror": "^4.3.0-beta.1",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -42,7 +42,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^3.0.0-a5",
+    "@jupyter/ydoc": "^3.0.0-a8",
     "@jupyterlab/apputils": "^4.4.0-beta.1",
     "@jupyterlab/cells": "^4.3.0-beta.1",
     "@jupyterlab/codeeditor": "^4.3.0-beta.1",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -51,7 +51,7 @@
     "@codemirror/state": "^6.4.1",
     "@codemirror/view": "^6.26.3",
     "@jupyter/react-components": "^0.16.6",
-    "@jupyter/ydoc": "^3.0.0-a5",
+    "@jupyter/ydoc": "^3.0.0-a8",
     "@jupyterlab/application": "^4.3.0-beta.1",
     "@jupyterlab/apputils": "^4.4.0-beta.1",
     "@jupyterlab/cells": "^4.3.0-beta.1",

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -41,7 +41,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^3.0.0-a5",
+    "@jupyter/ydoc": "^3.0.0-a8",
     "@jupyterlab/apputils": "^4.4.0-beta.1",
     "@jupyterlab/codeeditor": "^4.3.0-beta.1",
     "@jupyterlab/coreutils": "^6.3.0-beta.1",

--- a/packages/fileeditor/package.json
+++ b/packages/fileeditor/package.json
@@ -39,7 +39,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^3.0.0-a5",
+    "@jupyter/ydoc": "^3.0.0-a8",
     "@jupyterlab/apputils": "^4.4.0-beta.1",
     "@jupyterlab/codeeditor": "^4.3.0-beta.1",
     "@jupyterlab/codemirror": "^4.3.0-beta.1",

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -36,7 +36,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^3.0.0-a5",
+    "@jupyter/ydoc": "^3.0.0-a8",
     "@jupyterlab/application": "^4.3.0-beta.1",
     "@jupyterlab/apputils": "^4.4.0-beta.1",
     "@jupyterlab/cells": "^4.3.0-beta.1",

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -40,7 +40,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^3.0.0-a5",
+    "@jupyter/ydoc": "^3.0.0-a8",
     "@jupyterlab/apputils": "^4.4.0-beta.1",
     "@jupyterlab/cells": "^4.3.0-beta.1",
     "@jupyterlab/codeeditor": "^4.3.0-beta.1",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -45,7 +45,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^3.0.0-a5",
+    "@jupyter/ydoc": "^3.0.0-a8",
     "@jupyterlab/coreutils": "^6.3.0-beta.1",
     "@jupyterlab/nbformat": "^4.3.0-beta.1",
     "@jupyterlab/settingregistry": "^4.3.0-beta.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2074,9 +2074,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyter/ydoc@npm:^3.0.0-a5":
-  version: 3.0.0-a5
-  resolution: "@jupyter/ydoc@npm:3.0.0-a5"
+"@jupyter/ydoc@npm:^3.0.0-a8":
+  version: 3.0.0-a8
+  resolution: "@jupyter/ydoc@npm:3.0.0-a8"
   dependencies:
     "@jupyterlab/nbformat": ^3.0.0 || ^4.0.0-alpha.21 || ^4.0.0
     "@lumino/coreutils": ^1.11.0 || ^2.0.0
@@ -2084,7 +2084,7 @@ __metadata:
     "@lumino/signaling": ^1.10.0 || ^2.0.0
     y-protocols: ^1.0.5
     yjs: ^13.5.40
-  checksum: 226e9ac32bf5df0b41ac36290801eecb7ec5bcdb359558c82a5708d52e6d11a5c16c30b2463d5aa04c584839b0b45c8f697a53e84179b28e19473759aa5094a8
+  checksum: def37030b73d78a195b41da8d457960598745f2c6c261c3aedabd3bc985835226f022c31e9d340c99449956c3767c4bda3a7f02d0b51d22893a0718c50b31310
   languageName: node
   linkType: hard
 
@@ -2408,7 +2408,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/cell-toolbar@workspace:packages/cell-toolbar"
   dependencies:
-    "@jupyter/ydoc": ^3.0.0-a5
+    "@jupyter/ydoc": ^3.0.0-a8
     "@jupyterlab/apputils": ^4.4.0-beta.1
     "@jupyterlab/cells": ^4.3.0-beta.1
     "@jupyterlab/docregistry": ^4.3.0-beta.1
@@ -2434,7 +2434,7 @@ __metadata:
   dependencies:
     "@codemirror/state": ^6.4.1
     "@codemirror/view": ^6.26.3
-    "@jupyter/ydoc": ^3.0.0-a5
+    "@jupyter/ydoc": ^3.0.0-a8
     "@jupyterlab/apputils": ^4.4.0-beta.1
     "@jupyterlab/attachments": ^4.3.0-beta.1
     "@jupyterlab/codeeditor": ^4.3.0-beta.1
@@ -2490,7 +2490,7 @@ __metadata:
   resolution: "@jupyterlab/codeeditor@workspace:packages/codeeditor"
   dependencies:
     "@codemirror/state": ^6.4.1
-    "@jupyter/ydoc": ^3.0.0-a5
+    "@jupyter/ydoc": ^3.0.0-a8
     "@jupyterlab/apputils": ^4.4.0-beta.1
     "@jupyterlab/coreutils": ^6.3.0-beta.1
     "@jupyterlab/nbformat": ^4.3.0-beta.1
@@ -2523,7 +2523,7 @@ __metadata:
     "@codemirror/legacy-modes": ^6.4.0
     "@codemirror/search": ^6.5.6
     "@codemirror/view": ^6.26.3
-    "@jupyter/ydoc": ^3.0.0-a5
+    "@jupyter/ydoc": ^3.0.0-a8
     "@jupyterlab/application": ^4.3.0-beta.1
     "@jupyterlab/codeeditor": ^4.3.0-beta.1
     "@jupyterlab/codemirror": ^4.3.0-beta.1
@@ -2566,7 +2566,7 @@ __metadata:
     "@codemirror/search": ^6.5.6
     "@codemirror/state": ^6.4.1
     "@codemirror/view": ^6.26.3
-    "@jupyter/ydoc": ^3.0.0-a5
+    "@jupyter/ydoc": ^3.0.0-a8
     "@jupyterlab/codeeditor": ^4.3.0-beta.1
     "@jupyterlab/coreutils": ^6.3.0-beta.1
     "@jupyterlab/documentsearch": ^4.3.0-beta.1
@@ -2614,7 +2614,7 @@ __metadata:
   dependencies:
     "@codemirror/state": ^6.4.1
     "@codemirror/view": ^6.26.3
-    "@jupyter/ydoc": ^3.0.0-a5
+    "@jupyter/ydoc": ^3.0.0-a8
     "@jupyterlab/apputils": ^4.4.0-beta.1
     "@jupyterlab/codeeditor": ^4.3.0-beta.1
     "@jupyterlab/codemirror": ^4.3.0-beta.1
@@ -2670,7 +2670,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/console@workspace:packages/console"
   dependencies:
-    "@jupyter/ydoc": ^3.0.0-a5
+    "@jupyter/ydoc": ^3.0.0-a8
     "@jupyterlab/apputils": ^4.4.0-beta.1
     "@jupyterlab/cells": ^4.3.0-beta.1
     "@jupyterlab/codeeditor": ^4.3.0-beta.1
@@ -2799,7 +2799,7 @@ __metadata:
     "@codemirror/state": ^6.4.1
     "@codemirror/view": ^6.26.3
     "@jupyter/react-components": ^0.16.6
-    "@jupyter/ydoc": ^3.0.0-a5
+    "@jupyter/ydoc": ^3.0.0-a8
     "@jupyterlab/application": ^4.3.0-beta.1
     "@jupyterlab/apputils": ^4.4.0-beta.1
     "@jupyterlab/cells": ^4.3.0-beta.1
@@ -2895,7 +2895,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/docregistry@workspace:packages/docregistry"
   dependencies:
-    "@jupyter/ydoc": ^3.0.0-a5
+    "@jupyter/ydoc": ^3.0.0-a8
     "@jupyterlab/apputils": ^4.4.0-beta.1
     "@jupyterlab/codeeditor": ^4.3.0-beta.1
     "@jupyterlab/coreutils": ^6.3.0-beta.1
@@ -3016,7 +3016,7 @@ __metadata:
   resolution: "@jupyterlab/example-cell@workspace:examples/cell"
   dependencies:
     "@jupyter/web-components": ^0.16.6
-    "@jupyter/ydoc": ^3.0.0-a5
+    "@jupyter/ydoc": ^3.0.0-a8
     "@jupyterlab/application": ^4.3.0-beta.1
     "@jupyterlab/apputils": ^4.4.0-beta.1
     "@jupyterlab/cells": ^4.3.0-beta.1
@@ -3045,7 +3045,7 @@ __metadata:
   resolution: "@jupyterlab/example-console@workspace:examples/console"
   dependencies:
     "@jupyter/web-components": ^0.16.6
-    "@jupyter/ydoc": ^3.0.0-a5
+    "@jupyter/ydoc": ^3.0.0-a8
     "@jupyterlab/application": ^4.3.0-beta.1
     "@jupyterlab/codemirror": ^4.3.0-beta.1
     "@jupyterlab/console": ^4.3.0-beta.1
@@ -3191,7 +3191,7 @@ __metadata:
   resolution: "@jupyterlab/example-notebook@workspace:examples/notebook"
   dependencies:
     "@jupyter/web-components": ^0.16.6
-    "@jupyter/ydoc": ^3.0.0-a5
+    "@jupyter/ydoc": ^3.0.0-a8
     "@jupyterlab/application": ^4.3.0-beta.1
     "@jupyterlab/apputils": ^4.4.0-beta.1
     "@jupyterlab/codemirror": ^4.3.0-beta.1
@@ -3432,7 +3432,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/fileeditor@workspace:packages/fileeditor"
   dependencies:
-    "@jupyter/ydoc": ^3.0.0-a5
+    "@jupyter/ydoc": ^3.0.0-a8
     "@jupyterlab/apputils": ^4.4.0-beta.1
     "@jupyterlab/codeeditor": ^4.3.0-beta.1
     "@jupyterlab/codemirror": ^4.3.0-beta.1
@@ -4200,7 +4200,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/notebook-extension@workspace:packages/notebook-extension"
   dependencies:
-    "@jupyter/ydoc": ^3.0.0-a5
+    "@jupyter/ydoc": ^3.0.0-a8
     "@jupyterlab/application": ^4.3.0-beta.1
     "@jupyterlab/apputils": ^4.4.0-beta.1
     "@jupyterlab/cells": ^4.3.0-beta.1
@@ -4248,7 +4248,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/notebook@workspace:packages/notebook"
   dependencies:
-    "@jupyter/ydoc": ^3.0.0-a5
+    "@jupyter/ydoc": ^3.0.0-a8
     "@jupyterlab/apputils": ^4.4.0-beta.1
     "@jupyterlab/cells": ^4.3.0-beta.1
     "@jupyterlab/codeeditor": ^4.3.0-beta.1
@@ -4522,7 +4522,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/services@workspace:packages/services"
   dependencies:
-    "@jupyter/ydoc": ^3.0.0-a5
+    "@jupyter/ydoc": ^3.0.0-a8
     "@jupyterlab/coreutils": ^6.3.0-beta.1
     "@jupyterlab/nbformat": ^4.3.0-beta.1
     "@jupyterlab/settingregistry": ^4.3.0-beta.1


### PR DESCRIPTION
## References

Closes https://github.com/jupyter-server/jupyter_ydoc/pull/275

## Code changes

None

## User-facing changes

Notebooks open faster

## Backwards-incompatible changes

None