### PR TITLE
Underscore visibility issue in filenames with 'Ubuntu' font

### DIFF
--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -316,6 +316,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   user-select: none;
+  line-height: 1.2;
 }
 
 .jp-DirListing-item:has(.jp-DirListing-itemText:focus-visible) {


### PR DESCRIPTION
## References

#16820 

### Problem:
When using the 'Ubuntu' font on the default 100% zoom level in JupyterLab, underscores in filenames were hidden. This issue was observed in the directory listing where filenames with underscores were not fully visible.

### Solution:
I explored two solutions to resolve this:
1. Adding padding to the `.jp-Dirlisting-itemtext` element.
2. Adjusting the line-height of the `.jp-Dirlisting-itemtext` class.

I chose to adjust the line-height to `1.2` because it solves the problem without affecting the external layout or adding unnecessary space between elements, as padding would. This keeps the fix more contained and focused on typography.

### Testing:
Tested at 100% zoom with the 'Ubuntu' font, and the underscores are now visible without layout issues.

### Before
![Screenshot from 2024-10-01 22-28-29](https://github.com/user-attachments/assets/99a19da9-b33e-4b56-a272-bfa2364cd506)

###After
![Screenshot from 2024-10-01 22-28-44](https://github.com/user-attachments/assets/25f86fb5-1867-4875-bee4-377f9a9de6dd)

