### PR TITLE
Fix incorrect access to uninitialised `serverRequests`

### DIFF
--- a/packages/lsp/src/connection.ts
+++ b/packages/lsp/src/connection.ts
@@ -268,7 +268,8 @@ export class LSPConnection extends LspWsConnection implements ILSPConnection {
     if (this.isDisposed) {
       return;
     }
-    if (this.serverRequests) {    // `serverRequests` may be undefined if dispose is called during initialization sequence
+    if (this.serverRequests) {
+      // `serverRequests` may be undefined if dispose is called during initialization sequence
       Object.values(this.serverRequests).forEach(request =>
         request.clearHandler()
       );

--- a/packages/lsp/src/connection.ts
+++ b/packages/lsp/src/connection.ts
@@ -268,7 +268,7 @@ export class LSPConnection extends LspWsConnection implements ILSPConnection {
     if (this.isDisposed) {
       return;
     }
-    if (this.serverRequests) { /*if statement to check if serverrequest is empty*/
+    if (this.serverRequests) {    // `serverRequests` may be undefined if dispose is called during initialization sequence
       Object.values(this.serverRequests).forEach(request =>
         request.clearHandler()
       );

--- a/packages/lsp/src/connection.ts
+++ b/packages/lsp/src/connection.ts
@@ -268,9 +268,11 @@ export class LSPConnection extends LspWsConnection implements ILSPConnection {
     if (this.isDisposed) {
       return;
     }
-    Object.values(this.serverRequests).forEach(request =>
-      request.clearHandler()
-    );
+    if (this.serverRequests) { /*if statement to check if serverrequest is empty*/ 
+      Object.values(this.serverRequests).forEach(request =>
+        request.clearHandler()
+      );
+    }
     this.close();
     super.dispose();
   }

--- a/packages/lsp/src/connection.ts
+++ b/packages/lsp/src/connection.ts
@@ -268,7 +268,7 @@ export class LSPConnection extends LspWsConnection implements ILSPConnection {
     if (this.isDisposed) {
       return;
     }
-    if (this.serverRequests) { /*if statement to check if serverrequest is empty*/ 
+    if (this.serverRequests) { /*if statement to check if serverrequest is empty*/
       Object.values(this.serverRequests).forEach(request =>
         request.clearHandler()
       );

--- a/packages/lsp/test/connection_manager.spec.ts
+++ b/packages/lsp/test/connection_manager.spec.ts
@@ -100,7 +100,7 @@ describe('@jupyterlab/lsp', () => {
         expect(manager.disconnectDocumentSignals).toHaveBeenCalled();
       });
     });
-    describe('#onUninitializedLSPConnectionDisposed', () => {
+    describe('#dispose()', () => {
       it('should dispose of an uninitialized connection without errors', () => {
         const connection = new LSPConnection();
         connection.dispose();

--- a/packages/lsp/test/connection_manager.spec.ts
+++ b/packages/lsp/test/connection_manager.spec.ts
@@ -103,7 +103,7 @@ describe('@jupyterlab/lsp', () => {
     describe('#dispose()', () => {
       it('should dispose of an uninitialized connection without errors', () => {
         const connection = new LSPConnection({
-          capabilities: [],
+          capabilities: {},
           languageId: '',
           rootUri: '',
           serverUri: ''

--- a/packages/lsp/test/connection_manager.spec.ts
+++ b/packages/lsp/test/connection_manager.spec.ts
@@ -11,6 +11,7 @@ import {
 } from '@jupyterlab/lsp';
 import { LabShell } from '@jupyterlab/application';
 import { ServerConnection } from '@jupyterlab/services';
+import { LSPConnection } from '../src/connection';
 
 jest.mock('@jupyterlab/notebook');
 
@@ -97,6 +98,13 @@ describe('@jupyterlab/lsp', () => {
         });
         expect(manager.unregisterDocument).toHaveBeenCalled();
         expect(manager.disconnectDocumentSignals).toHaveBeenCalled();
+      });
+    });
+    describe('#onUninitializedLSPConnectionDisposed', () => {
+      it('should dispose of an uninitialized connection without errors', () => {
+        const connection = new LSPConnection();
+        connection.dispose();        
+        expect(connection.isDisposed).toBe(true);
       });
     });
   });

--- a/packages/lsp/test/connection_manager.spec.ts
+++ b/packages/lsp/test/connection_manager.spec.ts
@@ -103,7 +103,7 @@ describe('@jupyterlab/lsp', () => {
     describe('#onUninitializedLSPConnectionDisposed', () => {
       it('should dispose of an uninitialized connection without errors', () => {
         const connection = new LSPConnection();
-        connection.dispose();        
+        connection.dispose();
         expect(connection.isDisposed).toBe(true);
       });
     });

--- a/packages/lsp/test/connection_manager.spec.ts
+++ b/packages/lsp/test/connection_manager.spec.ts
@@ -102,7 +102,12 @@ describe('@jupyterlab/lsp', () => {
     });
     describe('#dispose()', () => {
       it('should dispose of an uninitialized connection without errors', () => {
-        const connection = new LSPConnection();
+        const connection = new LSPConnection({
+          capabilities: [],
+          languageId: '',
+          rootUri: '',
+          serverUri: ''
+        });
         connection.dispose();
         expect(connection.isDisposed).toBe(true);
       });


### PR DESCRIPTION


# References

This is a potential solution to issue #16185. It modifies the connection.ts to check whether the LSP connection is initialized before disposal and it creates a test case to examine this case.
There was one other pull request from hanlaman that implemented the same solution for checking whether the LSP connection was initialized before running the dispose. The difference between mine and the other user's changes is that I included a unit test as well, as requested in the description.

# Code Changes:
Added an if statement to the problematic code that checks if the serverrequest has been initialized before trying to dispose it.

For the test case, I added an import statement for LSPConnections and a describe test case that creates a new LSPconnection and tries to dispose it before it is properly initialized. It then checks isDisposed to see if it worked out