### PR TITLE
Fix invalid JSON syntax and indentation in the documentation

### DIFF
--- a/docs/source/extension/extension_points.rst
+++ b/docs/source/extension/extension_points.rst
@@ -153,13 +153,14 @@ menu using the settings.
 
     {
       "jupyter.lab.menus": {
-      "context": [
-        {
-          "command": "my-command",
-          "selector": ".jp-Notebook",
-          "rank": 500
-        }
-      ]
+        "context": [
+          {
+            "command": "my-command",
+            "selector": ".jp-Notebook",
+            "rank": 500
+          }
+        ]
+      }
     }
 
 In this example, the command with id ``my-command`` is shown whenever the user
@@ -342,15 +343,15 @@ This requires you to define a keyboard shortcut for ``apputils:run-all-enabled``
       "command": "apputils:run-all-enabled",
       "keys": ["Accel T"],
       "args": {
-          "commands": [
-              "my-command-1",
-              "my-command-2"
-          ],
-          "args": [
-              {},
-              {}
-            ]
-        },
+        "commands": [
+          "my-command-1",
+          "my-command-2"
+        ],
+        "args": [
+          {},
+          {}
+        ]
+      },
       "selector": "body"
     }
 
@@ -469,19 +470,20 @@ To add a new menu with your extension command:
 
     {
       "jupyter.lab.menus": {
-      "main": [
-        {
-          "id": "jp-mainmenu-myextension",
-          "label": "My Menu",
-          "items": [
-            {
-              "command": "my-command",
-              "rank": 500
-            }
-          ],
-          "rank": 100
-        }
-      ]
+        "main": [
+          {
+            "id": "jp-mainmenu-myextension",
+            "label": "My Menu",
+            "items": [
+              {
+                "command": "my-command",
+                "rank": 500
+              }
+            ],
+            "rank": 100
+          }
+        ]
+      }
     }
 
 The menu item label will be set with the command label. For menus (and
@@ -497,17 +499,18 @@ To add a new entry in an existing menu:
 
     {
       "jupyter.lab.menus": {
-      "main": [
-        {
-          "id": "jp-mainmenu-file",
-          "items": [
-            {
-              "command": "my-command",
-              "rank": 500
-            }
-          ]
-        }
-      ]
+        "main": [
+          {
+            "id": "jp-mainmenu-file",
+            "items": [
+              {
+                "command": "my-command",
+                "rank": 500
+              }
+            ]
+          }
+        ]
+      }
     }
 
 Here is the list of default menu ids:


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

For production documentation in live, this link: https://jupyterlab.readthedocs.io/en/stable/extension/extension_points.html#keyboard-shortcuts with this link: https://jupyterlab.readthedocs.io/en/stable/extension/extension_points.html#settings-defined-menu consists invalid JSON body or incorrect indentation.

## Code changes

- When following the extensions guidelines to develope and customize the menus, encountered several JSON indentation issues, caused the invalid configuration applied.

## User-facing changes

Before:

<img width="749" alt="image" src="https://github.com/user-attachments/assets/e0faac6d-c14b-4cd1-8036-42b72646b7ad">

After:

(will upload later when setup on local dev env)

## Backwards-incompatible changes

No.
