### PR TITLE
Fix job updating snapshots when triggered by comment on first-time contributor PR

### DIFF
--- a/.github/workflows/galata-update.yml
+++ b/.github/workflows/galata-update.yml
@@ -15,7 +15,10 @@ jobs:
       (
         github.event.issue.author_association == 'OWNER' ||
         github.event.issue.author_association == 'COLLABORATOR' ||
-        github.event.issue.author_association == 'MEMBER'
+        github.event.issue.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR' ||
+        github.event.comment.author_association == 'MEMBER'
       ) && github.event.issue.pull_request && (
         contains(github.event.comment.body, 'please update galata snapshots') ||
         contains(github.event.comment.body, 'please update snapshots')


### PR DESCRIPTION

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/16730

This should help with updating snapshots in https://github.com/jupyterlab/jupyterlab/pull/16866

## Code changes

Allows the galata snapshot update job to run if the comment author is owner/member/collaborator (in addition to allowing to update snapshots if the PR author is owner/member/collaborator).

## User-facing changes

None

## Backwards-incompatible changes

None
