### PR TITLE
Add feature to scroll to currently executing cell on progress circle click

### DIFF
--- a/packages/statusbar/src/components/progressCircle.tsx
+++ b/packages/statusbar/src/components/progressCircle.tsx
@@ -25,6 +25,10 @@ export namespace ProgressCircle {
      * Element height
      */
     height?: number;
+    /**
+     * Click handler
+     */
+    onClick?: () => void;
   }
 }
 
@@ -54,6 +58,7 @@ export function ProgressCircle(props: ProgressCircle.IProps): JSX.Element {
       aria-valuemin={0}
       aria-valuemax={100}
       aria-valuenow={props.progress}
+      onClick={props.onClick}
     >
       <svg viewBox="0 0 250 250">
         <circle


### PR DESCRIPTION
## References #16867 

### Description
This PR introduces a feature where clicking the progress circle in the status bar will automatically scroll to the currently executing cell if present. This feature improves usability when users are working on large notebook, making it easier to locate the cell that is currently running.

### Changes
- Added a click handler on the progress circle that checks if a cell is in the "running" state.
- If a running cell is detected, the notebook will scroll to that cell using the `scrollToCell` method.

### Additional Notes:
- This behavior only works when the notebook is in the "busy" execution state i.e when some cell is being executed. 

Please review and let me know if further improvements are needed or a test needs to be added.

