### PR TITLE
Do not skip cells with hidden input when navigating with "k" "j" "<Up>" and "<Down>"

### DIFF
--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -921,7 +921,7 @@ export namespace NotebookActions {
     // find first non hidden cell above current cell
     while (possibleNextCellIndex >= 0) {
       const possibleNextCell = notebook.widgets[possibleNextCellIndex];
-      if (!possibleNextCell.inputHidden && !possibleNextCell.isHidden) {
+      if (!possibleNextCell.isHidden) {
         break;
       }
       possibleNextCellIndex -= 1;
@@ -969,7 +969,7 @@ export namespace NotebookActions {
     // find first non hidden cell below current cell
     while (possibleNextCellIndex < maxCellIndex) {
       let possibleNextCell = notebook.widgets[possibleNextCellIndex];
-      if (!possibleNextCell.inputHidden && !possibleNextCell.isHidden) {
+      if (!possibleNextCell.isHidden) {
         break;
       }
       possibleNextCellIndex += 1;


### PR DESCRIPTION
## References

Issue #11162

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Description

This fixes the issue where cells with hidden (i.e. "collapsed") code are not accessible from the cell navigation keyboard shortcuts "k" "j" "\<Up>" and "\<Down>".

This issue makes running or navigating to collapsed cells impossible without either 1) clicking the cell (which also automatically expands the cell) or 2) using the shift + enter shortcut (which requires running preceding cells). Sometimes the user may already know the contents of a collapsed cell by its output or any preceding markdown headers, but may wish to keep the cell collapsed for the sake of readability or to prevent large multi-line cells from dominating the screen.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## Code changes

This removes the `!possibleNextCell.inputHidden` condition used by the `selectAbove()` and `selectBelow()` functions to automatically skip cells with hidden input code.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Cells with hidden (i.e. "collapsed") input code are no longer skipped when navigating with the keyboard shortcuts "j" "k" "\<Up>" and "\<Down>" (or any other custom user shortcuts mapped to these actions).

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

See above (changes cell navigation behavior).

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
