### PR TITLE
reduced the time for the autosaveInterval from 120sec to 5sec

### DIFF
--- a/packages/docmanager-extension/schema/plugin.json
+++ b/packages/docmanager-extension/schema/plugin.json
@@ -120,7 +120,7 @@
       "type": "number",
       "title": "Autosave Interval",
       "description": "Length of save interval in seconds",
-      "default": 120
+      "default": 5
     },
     "confirmClosingDocument": {
       "type": "boolean",

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -262,7 +262,7 @@ const docManagerPlugin: JupyterFrontEndPlugin<void> = {
       const autosaveInterval = settings.get('autosaveInterval').composite as
         | number
         | null;
-      docManager.autosaveInterval = autosaveInterval || 120;
+      docManager.autosaveInterval = autosaveInterval || 5;
 
       // Handle last modified timestamp check margin
       const lastModifiedCheckMargin = settings.get('lastModifiedCheckMargin')

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -128,7 +128,7 @@ export class DocumentManager implements IDocumentManager {
         if (!handler) {
           return;
         }
-        handler.saveInterval = value || 120;
+        handler.saveInterval = value || 5;
       });
       this._stateChanged.emit({
         name: 'autosaveInterval',
@@ -713,7 +713,7 @@ export class DocumentManager implements IDocumentManager {
   private _widgetManager: DocumentWidgetManager;
   private _isDisposed = false;
   private _autosave = true;
-  private _autosaveInterval = 120;
+  private _autosaveInterval = 5;
   private _lastModifiedCheckMargin = 500;
   private _renameUntitledFileOnSave = true;
   private _when: Promise<void>;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

## issue number 
#16892 

## Code changes
changed the autosaveInterval default time  from 120secs to 5ecs and updated all defaults to match the new default.
