### PR TITLE
Export user preference settings to a json file

### DIFF
--- a/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
+++ b/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
@@ -2274,6 +2274,12 @@
     ]
   },
   {
+    "id": "settingeditor:export",
+    "label": "Export User Settings",
+    "caption": "",
+    "shortcuts": []
+  },
+  {
     "id": "settingsmenu:open",
     "label": "Open Settings Menu",
     "caption": "",

--- a/galata/test/jupyterlab/settings.test.ts
+++ b/galata/test/jupyterlab/settings.test.ts
@@ -315,3 +315,17 @@ test('Keyboard Shortcuts: validate "Or" button behavior when editing shortcuts',
     'settings-shortcuts-edit.png'
   );
 });
+
+test('Settings Export: Clicking the export button triggers a download', async ({
+  page
+}) => {
+  await page.evaluate(async () => {
+    await window.jupyterapp.commands.execute('settingeditor:open');
+  });
+  const downloadPromise = page.waitForEvent('download', { timeout: 5000 });
+
+  await page.getByText('Export Settings').click();
+  const download = await downloadPromise;
+
+  expect(download).toBeDefined();
+});

--- a/packages/settingeditor-extension/src/index.ts
+++ b/packages/settingeditor-extension/src/index.ts
@@ -39,7 +39,12 @@ import { IPluginManager } from '@jupyterlab/pluginmanager';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IStateDB } from '@jupyterlab/statedb';
 import { ITranslator } from '@jupyterlab/translation';
-import { saveIcon, settingsIcon, undoIcon, downloadIcon } from '@jupyterlab/ui-components';
+import {
+  downloadIcon,
+  saveIcon,
+  settingsIcon,
+  undoIcon
+} from '@jupyterlab/ui-components';
 import { IDisposable } from '@lumino/disposable';
 
 /**

--- a/packages/settingeditor-extension/src/index.ts
+++ b/packages/settingeditor-extension/src/index.ts
@@ -53,6 +53,8 @@ namespace CommandIDs {
   export const revert = 'settingeditor:revert';
 
   export const save = 'settingeditor:save';
+
+  export const exportSettings = 'settingeditor:export';
 }
 
 type SettingEditorType = 'ui' | 'json';
@@ -141,6 +143,16 @@ function activate(
         query: args.query as string
       })
     });
+
+    editor.toolbar.addItem(
+      'export-settings',
+      new CommandToolbarButton({
+        commands,
+        id: CommandIDs.exportSettings,
+        icon: saveIcon,
+        label: trans.__('Export Settings')
+      })
+    );
 
     editor.toolbar.addItem('spacer', Toolbar.createSpacerItem());
     if (pluginManager) {
@@ -356,6 +368,67 @@ function activateJSON(
     label: trans.__('Save User Settings'),
     isEnabled: () => tracker.currentWidget?.content.canSaveRaw ?? false
   });
+
+  commands.addCommand(CommandIDs.exportSettings, {
+    execute: () => {
+      const userSettings = collectUserSettings(registry);
+      const jsonContent = JSON.stringify(userSettings, null, 2);
+      downloadSettings(jsonContent, 'overrides.json');
+    },
+    label: trans.__('Export Settings'),
+    icon: saveIcon
+  });
+
+  /**
+   * Collect user settings from the registry.
+   */
+  function collectUserSettings(
+    registry: ISettingRegistry
+  ): Record<string, any> {
+    const userSettings: Record<string, any> = {};
+    for (const [pluginId, plugin] of Object.entries(registry.plugins)) {
+      if (plugin) {
+        try {
+          if (plugin.raw) {
+            const withoutSingleLineComments = plugin.raw.replace(
+              /\/\/.*$/gm,
+              ''
+            );
+            const withoutComments = withoutSingleLineComments.replace(
+              /\/\*[\s\S]*?\*\//g,
+              ''
+            );
+            const preferredSettings = JSON.parse(withoutComments);
+            if (Object.keys(preferredSettings).length > 0) {
+              userSettings[pluginId] = preferredSettings;
+            }
+          }
+        } catch (error) {
+          console.error(
+            `Error loading settings for plugin ${pluginId}:`,
+            error
+          );
+        }
+      }
+    }
+    return userSettings;
+  }
+
+  /**
+   * Trigger a download of the settings as a JSON file.
+   */
+  function downloadSettings(jsonContent: string, filename: string): void {
+    const blob = new Blob([jsonContent], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
 
   return tracker;
 }

--- a/packages/settingeditor-extension/src/index.ts
+++ b/packages/settingeditor-extension/src/index.ts
@@ -39,7 +39,7 @@ import { IPluginManager } from '@jupyterlab/pluginmanager';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IStateDB } from '@jupyterlab/statedb';
 import { ITranslator } from '@jupyterlab/translation';
-import { saveIcon, settingsIcon, undoIcon } from '@jupyterlab/ui-components';
+import { saveIcon, settingsIcon, undoIcon, downloadIcon } from '@jupyterlab/ui-components';
 import { IDisposable } from '@lumino/disposable';
 
 /**
@@ -149,7 +149,7 @@ function activate(
       new CommandToolbarButton({
         commands,
         id: CommandIDs.exportSettings,
-        icon: saveIcon,
+        icon: downloadIcon,
         label: trans.__('Export Settings')
       })
     );
@@ -376,7 +376,7 @@ function activateJSON(
       downloadSettings(jsonContent, 'overrides.json');
     },
     label: trans.__('Export Settings'),
-    icon: saveIcon
+    icon: downloadIcon
   });
 
   /**


### PR DESCRIPTION
## References #16895 

## Overview

This pull request implements the functionality to export user preference settings from the JupyterLab Settings Editor to an `overrides.json` file. 

## Changes Made

- Introduced a new command `settingeditor:export` to handle the export action.
- Added a toolbar button labeled "Export Settings" with an appropriate icon.
- Implemented the logic to compile user-modified settings and write them to the `overrides.json` file.

## Notes

This is not a complete PR. I want to discuss some things:
- I wasn't clear on what we should exactly do with the file. Currently, I have implemented logic to download it. If the file needs to be saved in the **Application Settings Directory**, we might need to write server-side logic as well.
- Can I get some guidance on this?

## Snapshot

![Screenshot from 2024-10-28 23-38-01](https://github.com/user-attachments/assets/52ecdee3-f60f-48e1-bf82-cacfa58eae3e)


I'm also open to writing tests and updating docs after the feature is finalized.
