### PR TITLE
Maintain autosave timers while disconnected

### DIFF
--- a/packages/docmanager/src/savehandler.ts
+++ b/packages/docmanager/src/savehandler.ts
@@ -92,6 +92,8 @@ export class SaveHandler implements IDisposable {
     this._autosaveTimer = window.setTimeout(() => {
       if (this._isConnectedCallback()) {
         this._save();
+      } else {
+        this._setTimer();
       }
     }, this._interval);
   }

--- a/packages/docmanager/test/savehandler.spec.ts
+++ b/packages/docmanager/test/savehandler.spec.ts
@@ -49,6 +49,25 @@ describe('docregistry/savehandler', () => {
       });
     });
 
+    describe('#setTimer()', () => {
+      it('should reset autosave timer when disconnected', async () => {
+        jest.useFakeTimers();
+
+        jest
+          .spyOn(handler as any, '_isConnectedCallback')
+          .mockReturnValue(false);
+        jest.spyOn(handler as any, '_setTimer');
+        jest.spyOn(handler as any, '_save');
+
+        handler.saveInterval = 120;
+        handler.start();
+        jest.advanceTimersByTime(120000); // in ms
+        expect((handler as any)._setTimer).toHaveBeenCalledTimes(2);
+
+        jest.useRealTimers();
+      });
+    });
+
     describe('#saveInterval()', () => {
       it('should be the save interval of the handler', () => {
         expect(handler.saveInterval).toBe(120);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
 
Fixes #16798.
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

The autosave feature works by starting a timer.  When the timer expires, it clears itself; then, if the session is connected, it attempts a save (which then restarts the timer for the next save).  However, if the session is disconnected, the timer never gets restarted - this code just calls `_setTimer()` in that case.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
