### PR TITLE
Update the form schema if it changed

### DIFF
--- a/packages/settingeditor/src/SettingsFormEditor.tsx
+++ b/packages/settingeditor/src/SettingsFormEditor.tsx
@@ -117,7 +117,8 @@ export class SettingsFormEditor extends React.Component<
       filteredSchema: this.props.settings.schema,
       formContext: {
         defaultFormData: this.props.settings.default(),
-        settings: this.props.settings
+        settings: this.props.settings,
+        schema: JSONExt.deepCopy(this.props.settings.schema)
       }
     };
     this.handleChange = this.handleChange.bind(this);
@@ -136,6 +137,7 @@ export class SettingsFormEditor extends React.Component<
     if (prevProps.settings !== this.props.settings) {
       this.setState({
         formContext: {
+          ...this.state.formContext,
           settings: this.props.settings,
           defaultFormData: this.props.settings.default()
         }
@@ -265,9 +267,14 @@ export class SettingsFormEditor extends React.Component<
   }
 
   private _setFilteredSchema(prevFilteredValues?: string[] | null) {
+    // Update the filtered value if the filter or the schema has changed.
     if (
       prevFilteredValues === undefined ||
-      !JSONExt.deepEqual(prevFilteredValues, this.props.filteredValues)
+      !JSONExt.deepEqual(prevFilteredValues, this.props.filteredValues) ||
+      !JSONExt.deepEqual(
+        this.state.formContext.schema,
+        this.props.settings.schema
+      )
     ) {
       /**
        * Only show fields that match search value.
@@ -284,8 +291,13 @@ export class SettingsFormEditor extends React.Component<
           }
         }
       }
-
-      this.setState({ filteredSchema });
+      this.setState({
+        filteredSchema,
+        formContext: {
+          ...this.state.formContext,
+          schema: JSONExt.deepCopy(this.props.settings.schema)
+        }
+      });
     }
   }
 

--- a/packages/settingeditor/src/SettingsFormEditor.tsx
+++ b/packages/settingeditor/src/SettingsFormEditor.tsx
@@ -135,13 +135,13 @@ export class SettingsFormEditor extends React.Component<
     this._setFilteredSchema(prevProps.filteredValues);
 
     if (prevProps.settings !== this.props.settings) {
-      this.setState({
+      this.setState(previousState => ({
         formContext: {
-          ...this.state.formContext,
+          ...previousState.formContext,
           settings: this.props.settings,
           defaultFormData: this.props.settings.default()
         }
-      });
+      }));
     }
   }
 
@@ -291,13 +291,13 @@ export class SettingsFormEditor extends React.Component<
           }
         }
       }
-      this.setState({
+      this.setState(previousState => ({
         filteredSchema,
         formContext: {
-          ...this.state.formContext,
+          ...previousState.formContext,
           schema: JSONExt.deepCopy(this.props.settings.schema)
         }
-      });
+      }));
     }
   }
 


### PR DESCRIPTION
This PR allows updating the settings form when the schema has been programmatically updated.

![Peek 2024-10-31 12-00](https://github.com/user-attachments/assets/d10751d6-e09a-4a66-9151-947b0fbc8a50)

## Code changes

Save the schema in the context of the form, and update the displayed item if it changes.

## User-facing changes

Update the form in live.

## Backwards-incompatible changes

Should not be.
