### PR TITLE
Fix inconsistency in `Contents.IChangedArgs` documentation

### DIFF
--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -228,12 +228,12 @@ export namespace Contents {
     type: 'new' | 'delete' | 'rename' | 'save';
 
     /**
-     * The new contents.
+     * The old contents.
      */
     oldValue: Partial<IModel> | null;
 
     /**
-     * The old contents.
+     * The new contents.
      */
     newValue: Partial<IModel> | null;
   }


### PR DESCRIPTION
This pull request fixes the inconsistency in the documentation of `services.Contents.IChangedArgs`

## References
Closes #16913
