### PR TITLE
Reuse serverSettings when reopen an existing terminal

### DIFF
--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -360,7 +360,7 @@ function addCommands(
 
       let session;
       if (name) {
-        const models = await TerminalAPI.listRunning();
+        const models = await TerminalAPI.listRunning(serviceManager.serverSettings);
         if (models.map(d => d.name).includes(name)) {
           // we are restoring a terminal widget and the corresponding terminal exists
           // let's connect to it

--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -360,7 +360,9 @@ function addCommands(
 
       let session;
       if (name) {
-        const models = await TerminalAPI.listRunning(serviceManager.serverSettings);
+        const models = await TerminalAPI.listRunning(
+          serviceManager.serverSettings
+        );
         if (models.map(d => d.name).includes(name)) {
           // we are restoring a terminal widget and the corresponding terminal exists
           // let's connect to it


### PR DESCRIPTION
Fixes #16920.

Single line change to reuse existing server settings when requesting the list of running terminals. There is no user-facing change here, it just avoids unnecessarily creating a new object.