### PR TITLE
Add clarification about FileFormat in `Services.Contents`

### DIFF
--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -140,7 +140,12 @@ export namespace Contents {
   export type ContentType = string;
 
   /**
-   * A contents file format.
+   * A contents file format. Always `json` for `notebook` and
+   * `directory` types. It should be set to either `text` or
+   * `base64` for `file` type.
+   * See the
+   * [jupyter server data model for filesystem entities](https://jupyter-server.readthedocs.io/en/latest/developers/contents.html#filesystem-entities)
+   * for more details.
    */
   export type FileFormat = 'json' | 'text' | 'base64' | null;
 


### PR DESCRIPTION
This pull request adds more details about `FileFormat` in `Services.Contents`.
## References
Closes #16924 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Improve documentation adding:
- a basic reminder of `FileFormat` possible values
- a link to the Jupyter Server documentation.
<!-- Describe the code changes and how they address the issue. -->