### PR TITLE
Fix `docmanager/savehandler` "continue to save" test

### DIFF
--- a/packages/docmanager/test/savehandler.spec.ts
+++ b/packages/docmanager/test/savehandler.spec.ts
@@ -111,12 +111,12 @@ describe('docregistry/savehandler', () => {
         // Lower the duration multiplier.
         (handler as any)._multiplier = 1;
         const promise = testEmission(context.fileChanged, {
-          test: () => {
-            if (called === 0) {
+          find: () => {
+            called++;
+            if (called === 1) {
               context.model.fromString('bar');
-              called++;
             }
-            return called === 1;
+            return called === 2;
           }
         });
         context.model.fromString('foo');


### PR DESCRIPTION
There were two problems with the previous test so that it didn't really test what was intended.

When the signal was triggered and the test() method was called, the promise was resolved regardless of test()'s return value. The subsequent change to the context.model inside test() then did not trigger anything.  We switch to find() which only resolves the promise when the return value is true.

Additionally, the initial call to the triggered function would always return true due to the ordering of the increment and check of the call counter; this has also been fixed.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
