### PR TITLE
Fix a test in `terminal.spec.ts`

### DIFF
--- a/packages/services/test/terminal/terminal.spec.ts
+++ b/packages/services/test/terminal/terminal.spec.ts
@@ -46,7 +46,7 @@ describe('terminal', () => {
         session = await manager.startNew();
         const emission = testEmission(session.messageReceived, {
           test: (sender, msg) => {
-            return msg.type === 'stdout';
+            expect(msg.type).toBe('stdout');
           }
         });
         session.send({ type: 'stdin', content: ['cd\r'] });


### PR DESCRIPTION
The msg.type was not actually getting checked, since test() resolves the promise regardless of its return value.

Went searching for other tests using testEmission that were silently passing instead of performing the test, but fortunately only found this one!

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
