### PR TITLE
Disable paste for read-only markdown cells & fix replace all for markdown cells

### DIFF
--- a/packages/cells/src/searchprovider.ts
+++ b/packages/cells/src/searchprovider.ts
@@ -429,11 +429,14 @@ class MarkdownCellSearchProvider extends CellSearchProvider {
    * @param newText The replacement text.
    * @returns Whether a replace occurred.
    */
-  async replaceAllMatches(newText: string): Promise<boolean> {
+  async replaceAllMatches(
+    newText: string,
+    options?: IReplaceOptions
+  ): Promise<boolean> {
     if (this.model.getMetadata('editable') === false)
       return Promise.resolve(false);
 
-    const result = await super.replaceAllMatches(newText);
+    const result = await super.replaceAllMatches(newText, options);
     // if the cell is rendered force update
     if ((this.cell as MarkdownCell).rendered) {
       this.cell.update();

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1948,7 +1948,8 @@ export abstract class AttachmentsCell<
    * Handle the `paste` event for the widget
    */
   private _evtPaste(event: ClipboardEvent): void {
-    if (event.clipboardData) {
+    const isEditable = this.model.getMetadata('editable');
+    if (event.clipboardData && isEditable) {
       const items = event.clipboardData.items;
       for (let i = 0; i < items.length; i++) {
         if (items[i].type === 'text/plain') {

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1948,7 +1948,7 @@ export abstract class AttachmentsCell<
    * Handle the `paste` event for the widget
    */
   private _evtPaste(event: ClipboardEvent): void {
-    const isEditable = this.model.getMetadata('editable');
+    const isEditable = this.model.getMetadata('editable') ?? true;
     if (event.clipboardData && isEditable) {
       const items = event.clipboardData.items;
       for (let i = 0; i < items.length; i++) {

--- a/packages/notebook/test/searchprovider.spec.ts
+++ b/packages/notebook/test/searchprovider.spec.ts
@@ -419,7 +419,7 @@ describe('@jupyterlab/notebook', () => {
       it('should replace all matches using regex', async () => {
         panel.model!.sharedModel.insertCells(0, [
           {
-            cell_type: 'code',
+            cell_type: 'markdown',
             source: 'a=123',
             metadata: { editable: true }
           },


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/11124

And for the issue https://github.com/jupyterlab/jupyterlab/issues/16925, the PR - https://github.com/jupyterlab/jupyterlab/pull/16940 did not address the issue for markdown cells; so, I have addressed those changes too in this PR.