### PR TITLE
Enable Scroll for Overflowing Menus on Small Screens

### DIFF
--- a/packages/application/style/menus.css
+++ b/packages/application/style/menus.css
@@ -29,6 +29,13 @@
 
 .lm-MenuBar-menu.jp-ThemedContainer {
   top: calc(-2 * var(--jp-border-width));
+  overflow: scroll;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.lm-MenuBar-menu.jp-ThemedContainer::-webkit-scrollbar {
+  display: none;
 }
 
 .lm-MenuBar-item {

--- a/packages/application/style/menus.css
+++ b/packages/application/style/menus.css
@@ -39,8 +39,8 @@
         farthest-side at 50% 0,
         color-mix(
           in hsl,
-          var(--jp-layout-color0) 30%,
-          var(--jp-inverse-layout-color1) 50%
+          var(--jp-layout-color0) 50%,
+          var(--jp-inverse-layout-color0) 30%
         ),
         rgba(0, 0, 0, 0)
       )
@@ -49,8 +49,8 @@
         farthest-side at 50% 100%,
         color-mix(
           in hsl,
-          var(--jp-layout-color0) 30%,
-          var(--jp-inverse-layout-color1) 50%
+          var(--jp-layout-color0) 50%,
+          var(--jp-inverse-layout-color0) 30%
         ),
         rgba(0, 0, 0, 0)
       )
@@ -195,6 +195,7 @@
   position: relative;
   top: 4px;
   border-top: var(--jp-border-width) solid var(--jp-layout-color2);
+  mix-blend-mode: multiply;
 }
 
 /* gray out icon/caret for disabled menu items */

--- a/packages/application/style/menus.css
+++ b/packages/application/style/menus.css
@@ -29,9 +29,40 @@
 
 .lm-MenuBar-menu.jp-ThemedContainer {
   top: calc(-2 * var(--jp-border-width));
-  overflow: scroll;
   scrollbar-width: none;
   -ms-overflow-style: none;
+  overflow: auto;
+  background:
+    linear-gradient(var(--jp-layout-color0) 30%, rgba(0, 0, 0, 0)) center top,
+    linear-gradient(rgba(0, 0, 0, 0), var(--jp-layout-color0) 70%) center bottom,
+    radial-gradient(
+        farthest-side at 50% 0,
+        color-mix(
+          in hsl,
+          var(--jp-layout-color0) 30%,
+          var(--jp-inverse-layout-color1) 50%
+        ),
+        rgba(0, 0, 0, 0)
+      )
+      center top,
+    radial-gradient(
+        farthest-side at 50% 100%,
+        color-mix(
+          in hsl,
+          var(--jp-layout-color0) 30%,
+          var(--jp-inverse-layout-color1) 50%
+        ),
+        rgba(0, 0, 0, 0)
+      )
+      center bottom;
+  background-color: var(--jp-layout-color0);
+  background-repeat: no-repeat;
+  background-size:
+    100% 40px,
+    100% 40px,
+    100% 14px,
+    100% 14px;
+  background-attachment: local, local, scroll, scroll;
 }
 
 .lm-MenuBar-menu.jp-ThemedContainer::-webkit-scrollbar {


### PR DESCRIPTION
## References
Closes #16944

### Code Changes
Added scroll behavior to menus to handle overflow.

### User-Facing Changes
Users on small screens can now scroll within menus to access options and buttons at the bottom.


https://github.com/user-attachments/assets/7c9e9f1b-f30a-4ec9-8be5-ce53271687e6
