### PR TITLE
Fix total size estimation in full windowing mode to reduce scrollbar jitter

### DIFF
--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -504,7 +504,10 @@ export abstract class WindowedListModel implements WindowedList.IModel {
   resetAfterIndex(index: number): void {
     const oldValue = this._measuredAllUntilIndex;
     this._measuredAllUntilIndex = Math.min(index, this._measuredAllUntilIndex);
-    // Heal the offsets
+    // Because `resetAfterIndex` is always called after an operation modifying
+    // the list of widget sizers, we need to ensure that offsets are correct;
+    // e.g. removing a cell would make the offsets of all following cells too high.
+    // The simplest way to "heal" the offsets is to recompute them all.
     for (const [i, sizer] of this._widgetSizers.entries()) {
       if (i === 0) {
         continue;
@@ -583,7 +586,7 @@ export abstract class WindowedListModel implements WindowedList.IModel {
             allPreviousMeasured = false;
           }
         }
-        if (hadSizer && offsetDelta != 0) {
+        if (hadSizer && offsetDelta !== 0) {
           // Adjust offsets for all items where it is needed
           sizer.offset += offsetDelta;
         }

--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -504,7 +504,7 @@ export abstract class WindowedListModel implements WindowedList.IModel {
   resetAfterIndex(index: number): void {
     const oldValue = this._measuredAllUntilIndex;
     this._measuredAllUntilIndex = Math.min(index, this._measuredAllUntilIndex);
-    // heal the offsets
+    // Heal the offsets
     for (const [i, sizer] of this._widgetSizers.entries()) {
       if (i === 0) {
         continue;
@@ -576,7 +576,7 @@ export abstract class WindowedListModel implements WindowedList.IModel {
         // If all items so far have actual size measurements...
         if (allPreviousMeasured) {
           if (sizer.measured) {
-            // and this item has a size measurement, we the can say that
+            // and this item has a size measurement, we can say that
             // all items until now have measurements:
             measuredAllItemsUntil = index;
           } else {

--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -488,8 +488,8 @@ export abstract class WindowedListModel implements WindowedList.IModel {
   getSpan(startIndex: number, stopIndex: number): [number, number] {
     const startSizer = this._getItemMetadata(startIndex);
     const top = startSizer.offset;
-    const stopSize = this._getItemMetadata(stopIndex);
-    const height = stopSize.offset - startSizer.offset + stopSize.size;
+    const stopSizer = this._getItemMetadata(stopIndex);
+    const height = stopSizer.offset - startSizer.offset + stopSizer.size;
     return [top, height];
   }
 

--- a/packages/ui-components/test/windowedlist.spec.ts
+++ b/packages/ui-components/test/windowedlist.spec.ts
@@ -1,0 +1,103 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { WindowedListModel } from '@jupyterlab/ui-components';
+import { Widget } from '@lumino/widgets';
+import { ObservableList } from '@jupyterlab/observables';
+
+const FIXED_ESTIMATED_SIZE = 100;
+
+class TestModel extends WindowedListModel {
+  estimateWidgetSize = (_index: number): number => {
+    return 100;
+  };
+  widgetRenderer = (_index: number): Widget => {
+    return new Widget();
+  };
+}
+
+describe('@jupyterlab/ui-components', () => {
+  describe('WindowedListModel', () => {
+    describe('#setWidgetSize()', () => {
+      it('should update sizes', () => {
+        const model = new TestModel({
+          itemsList: new ObservableList({
+            values: [1, 2, 3]
+          })
+        });
+        model.windowingActive = true;
+        const getTotalSize = () => {
+          return model.getEstimatedTotalSize();
+        };
+        expect(getTotalSize()).toBe(3 * FIXED_ESTIMATED_SIZE);
+        model.setWidgetSize([
+          {
+            index: 0,
+            size: 10
+          }
+        ]);
+        expect(getTotalSize()).toBe(2 * FIXED_ESTIMATED_SIZE + 10);
+        model.setWidgetSize([
+          {
+            index: 1,
+            size: 20
+          }
+        ]);
+        expect(getTotalSize()).toBe(1 * FIXED_ESTIMATED_SIZE + 10 + 20);
+        model.setWidgetSize([
+          {
+            index: 1,
+            size: 15
+          },
+          {
+            index: 2,
+            size: 25
+          }
+        ]);
+        expect(getTotalSize()).toBe(10 + 15 + 25);
+      });
+    });
+    it('should update offsets', () => {
+      const model = new TestModel({
+        itemsList: new ObservableList({
+          values: [1, 2, 3]
+        })
+      });
+      model.windowingActive = true;
+      const getOffset = (index: number) => {
+        return model.getSpan(index, index)[0];
+      };
+      expect(getOffset(0)).toBe(0);
+      expect(getOffset(1)).toBe(100);
+      model.setWidgetSize([
+        {
+          index: 0,
+          size: 10
+        }
+      ]);
+      expect(getOffset(0)).toBe(0);
+      expect(getOffset(1)).toBe(10);
+
+      model.setWidgetSize([
+        {
+          index: 1,
+          size: 20
+        }
+      ]);
+
+      expect(getOffset(0)).toBe(0);
+      expect(getOffset(1)).toBe(10);
+      expect(getOffset(2)).toBe(10 + 20);
+
+      model.setWidgetSize([
+        {
+          index: 0,
+          size: 50
+        }
+      ]);
+      expect(getOffset(0)).toBe(0);
+      expect(getOffset(1)).toBe(50);
+      expect(getOffset(2)).toBe(50 + 20);
+    });
+  });
+});

--- a/packages/ui-components/test/windowedlist.spec.ts
+++ b/packages/ui-components/test/windowedlist.spec.ts
@@ -18,6 +18,69 @@ class TestModel extends WindowedListModel {
 
 describe('@jupyterlab/ui-components', () => {
   describe('WindowedListModel', () => {
+    describe('#onListChanged()', () => {
+      it('should increase size when new item gets added', () => {
+        const itemsList = new ObservableList({
+          values: [1]
+        });
+        const model = new TestModel({ itemsList });
+        model.windowingActive = true;
+        expect(model.getEstimatedTotalSize()).toBe(FIXED_ESTIMATED_SIZE);
+        itemsList.pushAll([2]);
+        expect(model.getEstimatedTotalSize()).toBe(2 * FIXED_ESTIMATED_SIZE);
+      });
+      it('should keep measured size when new item gets added at the back', () => {
+        const itemsList = new ObservableList({
+          values: ['a']
+        });
+        const model = new TestModel({ itemsList });
+        model.windowingActive = true;
+        model.setWidgetSize([
+          {
+            index: 0,
+            size: 10
+          }
+        ]);
+        expect(model.getEstimatedTotalSize()).toBe(10);
+        itemsList.pushAll(['b']);
+        expect(model.getEstimatedTotalSize()).toBe(FIXED_ESTIMATED_SIZE + 10);
+      });
+      it('should keep measured size when new item gets added in front', () => {
+        const itemsList = new ObservableList({
+          values: ['b']
+        });
+        const model = new TestModel({ itemsList });
+        model.windowingActive = true;
+        model.setWidgetSize([
+          {
+            index: 0,
+            size: 10
+          }
+        ]);
+        expect(model.getEstimatedTotalSize()).toBe(10);
+        itemsList.insert(0, 'a');
+        expect(model.getEstimatedTotalSize()).toBe(FIXED_ESTIMATED_SIZE + 10);
+      });
+      it('should regenerate offsets when new item gets added', () => {
+        const itemsList = new ObservableList({
+          values: ['a', 'b']
+        });
+        const model = new TestModel({ itemsList });
+        const getOffset = (index: number) => {
+          return model.getSpan(index, index)[0];
+        };
+        model.windowingActive = true;
+        model.setWidgetSize([
+          {
+            index: 0,
+            size: 10
+          }
+        ]);
+        expect(getOffset(1)).toBe(10);
+        itemsList.insert(0, 'c');
+        expect(getOffset(2)).toBe(FIXED_ESTIMATED_SIZE + 10);
+      });
+    });
     describe('#setWidgetSize()', () => {
       it('should update sizes', () => {
         const model = new TestModel({
@@ -56,48 +119,130 @@ describe('@jupyterlab/ui-components', () => {
         ]);
         expect(getTotalSize()).toBe(10 + 15 + 25);
       });
-    });
-    it('should update offsets', () => {
-      const model = new TestModel({
-        itemsList: new ObservableList({
-          values: [1, 2, 3]
-        })
+      it('should update offsets', () => {
+        const model = new TestModel({
+          itemsList: new ObservableList({
+            values: [1, 2, 3]
+          })
+        });
+        model.windowingActive = true;
+        const getOffset = (index: number) => {
+          return model.getSpan(index, index)[0];
+        };
+        expect(getOffset(0)).toBe(0);
+        expect(getOffset(1)).toBe(100);
+        model.setWidgetSize([
+          {
+            index: 0,
+            size: 10
+          }
+        ]);
+        expect(getOffset(0)).toBe(0);
+        expect(getOffset(1)).toBe(10);
+
+        model.setWidgetSize([
+          {
+            index: 1,
+            size: 20
+          }
+        ]);
+
+        expect(getOffset(0)).toBe(0);
+        expect(getOffset(1)).toBe(10);
+        expect(getOffset(2)).toBe(10 + 20);
+
+        model.setWidgetSize([
+          {
+            index: 0,
+            size: 50
+          }
+        ]);
+        expect(getOffset(0)).toBe(0);
+        expect(getOffset(1)).toBe(50);
+        expect(getOffset(2)).toBe(50 + 20);
       });
-      model.windowingActive = true;
-      const getOffset = (index: number) => {
-        return model.getSpan(index, index)[0];
-      };
-      expect(getOffset(0)).toBe(0);
-      expect(getOffset(1)).toBe(100);
-      model.setWidgetSize([
-        {
-          index: 0,
-          size: 10
-        }
-      ]);
-      expect(getOffset(0)).toBe(0);
-      expect(getOffset(1)).toBe(10);
-
-      model.setWidgetSize([
-        {
-          index: 1,
-          size: 20
-        }
-      ]);
-
-      expect(getOffset(0)).toBe(0);
-      expect(getOffset(1)).toBe(10);
-      expect(getOffset(2)).toBe(10 + 20);
-
-      model.setWidgetSize([
-        {
-          index: 0,
-          size: 50
-        }
-      ]);
-      expect(getOffset(0)).toBe(0);
-      expect(getOffset(1)).toBe(50);
-      expect(getOffset(2)).toBe(50 + 20);
+      it('should correctly update offsets if only few cells change size', () => {
+        const model = new TestModel({
+          itemsList: new ObservableList({
+            values: [0, 1, 2, 3, 4]
+          })
+        });
+        model.windowingActive = true;
+        const getOffset = (index: number) => {
+          return model.getSpan(index, index)[0];
+        };
+        model.setWidgetSize([
+          {
+            index: 0,
+            size: 10
+          },
+          {
+            index: 1,
+            size: 10
+          },
+          {
+            index: 2,
+            size: 10
+          },
+          {
+            index: 3,
+            size: 10
+          },
+          {
+            index: 4,
+            size: 10
+          }
+        ]);
+        expect(getOffset(3)).toBe(30);
+        expect(getOffset(4)).toBe(40);
+        expect(getOffset(5)).toBe(50);
+        model.setWidgetSize([
+          {
+            index: 0,
+            size: 13
+          },
+          {
+            index: 2,
+            size: 13
+          }
+        ]);
+        expect(getOffset(3)).toBe(36);
+        expect(getOffset(4)).toBe(46);
+        expect(getOffset(5)).toBe(56);
+      });
+      it('should keep offset the same if cell height changes balance out', () => {
+        const model = new TestModel({
+          itemsList: new ObservableList({
+            values: [1, 2, 3]
+          })
+        });
+        model.windowingActive = true;
+        const getOffset = (index: number) => {
+          return model.getSpan(index, index)[0];
+        };
+        model.setWidgetSize([
+          {
+            index: 0,
+            size: 20
+          },
+          {
+            index: 1,
+            size: 10
+          }
+        ]);
+        expect(getOffset(2)).toBe(30);
+        model.setWidgetSize([
+          {
+            index: 0,
+            size: 10
+          },
+          {
+            index: 1,
+            size: 20
+          }
+        ]);
+        expect(getOffset(2)).toBe(30);
+      });
     });
   });
 });

--- a/packages/ui-components/test/windowedlist.spec.ts
+++ b/packages/ui-components/test/windowedlist.spec.ts
@@ -9,7 +9,7 @@ const FIXED_ESTIMATED_SIZE = 100;
 
 class TestModel extends WindowedListModel {
   estimateWidgetSize = (_index: number): number => {
-    return 100;
+    return FIXED_ESTIMATED_SIZE;
   };
   widgetRenderer = (_index: number): Widget => {
     return new Widget();


### PR DESCRIPTION
## References

Alleviates issues caused by the rendered outputs or cells changing height:
- https://github.com/jupyterlab/jupyterlab/issues/16326
- https://github.com/jupyter-book/jupyterlab-myst/issues/243

## Code changes

1) Previously if height of a cell in the middle of the notebook changed then the sizes and offsets of all subsequent cells were discarded. After change the offset delta is instead computed and subsequent sizes and offsets are adjusted rather than being discarded.

2) Previously the size estimates were only stored after the viewport window was moved away from initial null position; this constraint was now reduced to also store sizes when windowing is active but window size has not been computed yet.

3) Previously if new cell was added  (or a cell was removed/type of a cell was changed) the height estimates were discarded for the purpose of scrollbar size calculation; with this PR this is no longer the case (3341517)

## User-facing changes

| Before (4.3.0) | After (this PR) |
|--|--|
| ![before](https://github.com/user-attachments/assets/2ea3ee46-9930-4d4a-8f87-28c21e2c44a3) | ![after](https://github.com/user-attachments/assets/468cfe63-d3da-4350-9d9e-6612e9010872) |

Before this change the total scrollbar length was reset after changing height of any cell other than the last. This was causing very jittrery scroll as the scrollbar height was changing as the notebook was scrolled.

| Before (4.3.0) | After (this PR) |
|--|--|
| ![before](https://github.com/user-attachments/assets/ef7480dc-8485-4c44-8b15-2cc95238258e) | ![after](https://github.com/user-attachments/assets/979dfa0c-1755-4f90-9ce0-be4a145a466b) |


## Backwards-incompatible changes

None