### PR TITLE
Fix prefix removal when reconciling completions from multiple sources

### DIFF
--- a/packages/completer/src/reconciliator.ts
+++ b/packages/completer/src/reconciliator.ts
@@ -220,13 +220,16 @@ export class ProviderReconciliator implements IProviderReconciliator {
       if (!line) {
         return replies;
       }
+      const lineOffset = editor.getOffsetAt({ line: cursor.line, column: 0 });
 
       return replies.map(reply => {
+        const prefixStart = Math.max(reply.start - lineOffset, 0);
+        const prefixEnd = Math.max(maxStart - lineOffset, 0);
         // No prefix to strip, return as-is.
-        if (reply.start == maxStart) {
+        if (prefixStart == prefixEnd) {
           return reply;
         }
-        let prefix = line.substring(reply.start, maxStart);
+        const prefix = line.substring(prefixStart, prefixEnd);
         return {
           ...reply,
           items: reply.items.map(item => {


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/16951

## Code changes

Accounts for the offset of the line for which completion was requested (where the cursor is).

## User-facing changes

| Before | After |
|--|--|
| ![before](https://github.com/user-attachments/assets/dc53f510-19f9-46db-9eb7-e436c4ae1aa0) | ![after](https://github.com/user-attachments/assets/8bee2a31-6e91-47d6-ba2e-4701d3a7b32a) |


## Backwards-incompatible changes


None