### PR TITLE
Fix moving files when `Last Modified` column is hidden

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -3358,9 +3358,23 @@ export namespace DirListing {
       fileType?: DocumentRegistry.IFileType
     ): HTMLElement {
       const dragImage = node.cloneNode(true) as HTMLElement;
-      const modified = DOMUtils.findElement(dragImage, ITEM_MODIFIED_CLASS);
       const icon = DOMUtils.findElement(dragImage, ITEM_ICON_CLASS);
-      dragImage.removeChild(modified as HTMLElement);
+
+      // Hide additional columns from the drag image to keep it unobtrusive.
+      const extraColumns = DirListing.columns.filter(
+        column => column.id !== 'name'
+      );
+      for (const extraColumn of extraColumns) {
+        const columnElement = DOMUtils.findElement(
+          dragImage,
+          extraColumn.itemClassName
+        );
+        if (!columnElement) {
+          // We can only remove columns which are rendered.
+          continue;
+        }
+        dragImage.removeChild(columnElement);
+      }
 
       if (!fileType) {
         icon.textContent = '';


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/16958

## Code changes

1. Check if the `Last Modified` column is present in drag image before attempting to remove it
2. Remove the other columns as well (when new columns like checkbox and file size were added no one remembered to add the code for their removal here so we ended up with ugly drag images)

## User-facing changes

1. Users are able to drag-and-drop files in the file browser listing when "Last Modified" column is hidden
2. The drag image is less obtrusive for cases where "File Size" and/or "Checkbox" column are visible

| Before | After |
|--|--|
| ![image](https://github.com/user-attachments/assets/a7a616b6-423d-45c3-bbc5-81d7c71c8747) | ![image](https://github.com/user-attachments/assets/24c79cef-fc72-4a5a-ae07-8a42e2129909) |

Note: there is no change in padding due to this PR. It is purely due to not including the checkbox in the drag image. This can be confirmed by looking at Before/After when the other columns are hidden:

<details>

| Before | After |
|--|--|
| ![image](https://github.com/user-attachments/assets/1327a1cf-6223-489b-aaee-3a968c952216) | ![image](https://github.com/user-attachments/assets/6adc0eae-36d4-4660-be81-b4aa8bffd7cd) |

</details>

Adjustments to padding of the drag image are outside of the scope of this PR as I would like to fix a regression in 4.3.0.

## Backwards-incompatible changes

None