### PR TITLE
CSS: Remove unnecessary left-alignment of LaTeX outputs

### DIFF
--- a/packages/rendermime/style/base.css
+++ b/packages/rendermime/style/base.css
@@ -223,10 +223,8 @@
   line-height: var(--jp-content-line-height);
 }
 
-/* Left-justify outputs.*/
 .jp-OutputArea-output.jp-RenderedLatex {
   padding: var(--jp-code-padding);
-  text-align: left;
 }
 
 /*-----------------------------------------------------------------------------


### PR DESCRIPTION

## References

This partially reverts #5115.

The underlying problem has been fixed in https://github.com/ipython/ipython/pull/11357 and https://github.com/sympy/sympy/pull/15625.

## Code changes

Remove a line of CSS.

## User-facing changes

None. Except when using versions of IPython and SymPy that are more than 5 years old.

## Backwards-incompatible changes

None.