### PR TITLE
Restore viewport `min-height` when not windowing

### DIFF
--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -1315,6 +1315,7 @@ export class WindowedList<
   private _applyNoWindowingStyles() {
     this._viewport.style.position = 'relative';
     this._viewport.style.top = '0px';
+    this._viewport.style.minHeight = '';
     this._innerElement.style.height = '';
   }
   /**


### PR DESCRIPTION
This PR restore the `min-height` property of the windowed viewport DOM element when not windowing.

The `min-height` is null if jupyterlab starts without windowing.
When the windowing is set to `full`, this property is set to ensure the minimal size of the viewport.

But this property is not restored to null when switching back to 'no windowing'. This can lead to wrong display with extensions that reorganize the cells, like [jupyterlab-deck](https://github.com/deathbeds/jupyterlab-deck).

## User-facing changes

Should not in lab

## Backwards-incompatible changes

None
