### PR TITLE
Fix FileBrowserModel.onFileChanged

### DIFF
--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -606,7 +606,7 @@ export class FileBrowserModel implements IDisposable {
     sender: Contents.IManager,
     change: Contents.IChangedArgs
   ): void {
-    const path = this._model.path;
+    const path = this._model.path.slice(this.driveName.length + 1);
     const { sessions } = this.manager.services;
     const { oldValue, newValue } = change;
     const value =


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyter-collaboration/issues/406.

## Code changes

When an operation is made on a file, we emit a signal if the file is in the current directory, which may trigger a refresh of the directory content. For instance, if a file is created, it immediately appears in the file browser, instead of after the next poll.
To check if the file is in the current directory, we compare the current file browser path with the path of the file. Both may have a drive prefix (e.g. `RTC:`). To get the directory of the file, we use `PathExt.dirname()` which seems to strip the drive prefix. But the current file browser path has the drive prefix, so the outcome is that we always think that the file is not in the current directory.
This PR removes the drive prefix of the current file browser path when making this comparison.

## User-facing changes

Operations such as creating a file or uploading a file look immediate in the file browser.

## Backwards-incompatible changes

None.