### PR TITLE
Pin Python version for visual regression testing to 3.11

### DIFF
--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          python_version: "3.11"
 
       - name: Set up browser cache
         uses: actions/cache@v4


### PR DESCRIPTION
## References

Workarounds https://github.com/jupyterlab/jupyterlab/issues/16982 which was caused by a change in new `maintainer-tools` release.

Of note the test is failing in cleanup step, not in the actual test step so pinning the Python version for now seems warranted.

Tagging it for backporting two versions back as the change in `maintainer-tools` will affect all branches.

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None