### PR TITLE
Fix handling of carriage return in output streams

### DIFF
--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -366,7 +366,10 @@ export class OutputAreaModel implements IOutputAreaModel {
       if (typeof value.text !== 'string') {
         value.text = value.text.join('');
       }
-      const {text, index} = Private.processText(this._streamIndex, value.text);
+      const { text, index } = Private.processText(
+        this._streamIndex,
+        value.text
+      );
       this._streamIndex = index;
       value.text = text;
     }
@@ -533,13 +536,18 @@ namespace Private {
   /*
    * Handle backspaces in `newText` and concatenates to `text`, if any.
    */
-  export function processText(index: number, newText: string, text?: string): {text: string, index: number} {
+  export function processText(
+    index: number,
+    newText: string,
+    text?: string
+  ): { text: string; index: number } {
     if (text === undefined) {
       text = '';
     }
     if (!(newText.includes('\b') || newText.includes('\r'))) {
-      text = text.slice(0, index) + newText + text.slice(index + newText.length);
-      return {text, index: index + newText.length};
+      text =
+        text.slice(0, index) + newText + text.slice(index + newText.length);
+      return { text, index: index + newText.length };
     }
     let idx0 = index;
     let idx1: number = -1;
@@ -591,14 +599,18 @@ namespace Private {
         throw Error(`This should not happen`);
       }
     }
-    return {text, index: idx0};
+    return { text, index: idx0 };
   }
 
   /*
    * Concatenate a string to an observable string, handling backspaces.
    */
-  export function addText(prevIndex: number, curText: IObservableString, newText: string): number {
-    const {text, index} = processText(prevIndex, newText, curText.text);
+  export function addText(
+    prevIndex: number,
+    curText: IObservableString,
+    newText: string
+  ): number {
+    const { text, index } = processText(prevIndex, newText, curText.text);
     // Compute the difference between current text and new text.
     let done = false;
     let idx = 0;

--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -358,7 +358,7 @@ export class OutputAreaModel implements IOutputAreaModel {
       const curText = prev.streamText!;
       const newText =
         typeof value.text === 'string' ? value.text : value.text.join('');
-      Private.addText(curText, newText);
+      this._streamIndex = Private.addText(this._streamIndex, curText, newText);
       return this.length;
     }
 
@@ -366,7 +366,9 @@ export class OutputAreaModel implements IOutputAreaModel {
       if (typeof value.text !== 'string') {
         value.text = value.text.join('');
       }
-      value.text = Private.processText(value.text);
+      const {text, index} = Private.processText(this._streamIndex, value.text);
+      this._streamIndex = index;
+      value.text = text;
     }
 
     // Create the new item.
@@ -480,6 +482,7 @@ export class OutputAreaModel implements IOutputAreaModel {
   private _changed = new Signal<OutputAreaModel, IOutputAreaModel.ChangedArgs>(
     this
   );
+  private _streamIndex = 0;
 }
 
 /**
@@ -530,14 +533,15 @@ namespace Private {
   /*
    * Handle backspaces in `newText` and concatenates to `text`, if any.
    */
-  export function processText(newText: string, text?: string): string {
+  export function processText(index: number, newText: string, text?: string): {text: string, index: number} {
     if (text === undefined) {
       text = '';
     }
     if (!(newText.includes('\b') || newText.includes('\r'))) {
-      return text + newText;
+      text = text.slice(0, index) + newText + text.slice(index + newText.length);
+      return {text, index: index + newText.length};
     }
-    let idx0 = text.length;
+    let idx0 = index;
     let idx1: number = -1;
     let lastEnd: number = 0;
     const regex = /[\n\b\r]/;
@@ -587,14 +591,14 @@ namespace Private {
         throw Error(`This should not happen`);
       }
     }
-    return text;
+    return {text, index: idx0};
   }
 
   /*
    * Concatenate a string to an observable string, handling backspaces.
    */
-  export function addText(curText: IObservableString, newText: string): void {
-    const text = processText(newText, curText.text);
+  export function addText(prevIndex: number, curText: IObservableString, newText: string): number {
+    const {text, index} = processText(prevIndex, newText, curText.text);
     // Compute the difference between current text and new text.
     let done = false;
     let idx = 0;
@@ -619,5 +623,6 @@ namespace Private {
         idx++;
       }
     }
+    return index;
   }
 }


### PR DESCRIPTION
## References

Fixes #16995.

## Code changes

We need to keep track of the cursor position.

## User-facing changes

Carriage return is properly handled even for fast print statements.

## Backwards-incompatible changes

None.