### PR TITLE
Fix disappearing cells (heal offsets after updating estimated sizes)

### DIFF
--- a/galata/test/jupyterlab/windowed-notebook.test.ts
+++ b/galata/test/jupyterlab/windowed-notebook.test.ts
@@ -406,12 +406,12 @@ test('should display cells below on scrolling after inserting a cell on top', as
   // https://github.com/jupyterlab/jupyterlab/issues/16978
   await page.notebook.openByPath(`${tmpPath}/${fileName}`);
 
-  const h = await page.notebook.getNotebookInPanelLocator();
-  const firstCell = h!.locator('.jp-Cell[data-windowed-list-index="1"]');
-  const lastCell = h!.locator('.jp-Cell[data-windowed-list-index="18"]');
+  const notebook = await page.notebook.getNotebookInPanelLocator()!;
+  const firstCell = notebook.locator('.jp-Cell[data-windowed-list-index="1"]');
+  const lastCell = notebook.locator('.jp-Cell[data-windowed-list-index="18"]');
   await firstCell.waitFor();
 
-  const bbox = await h!.boundingBox();
+  const bbox = await notebook.boundingBox();
   await page.mouse.move(bbox!.x, bbox!.y);
 
   // Needs to be two separate mouse wheel events.

--- a/galata/test/jupyterlab/windowed-notebook.test.ts
+++ b/galata/test/jupyterlab/windowed-notebook.test.ts
@@ -398,6 +398,55 @@ test('should remove all cells including hidden outputs artifacts', async ({
   expect(found).toEqual(false);
 });
 
+test('should display cells below on scrolling after inserting a cell on top', async ({
+  page,
+  tmpPath
+}) => {
+  // Regression test against "disappearing cells" issue:
+  // https://github.com/jupyterlab/jupyterlab/issues/16978
+  await page.notebook.openByPath(`${tmpPath}/${fileName}`);
+
+  const h = await page.notebook.getNotebookInPanelLocator();
+  const firstCell = h!.locator('.jp-Cell[data-windowed-list-index="1"]');
+  const lastCell = h!.locator('.jp-Cell[data-windowed-list-index="18"]');
+  await firstCell.waitFor();
+
+  const bbox = await h!.boundingBox();
+  await page.mouse.move(bbox!.x, bbox!.y);
+
+  // Needs to be two separate mouse wheel events.
+  await page.mouse.wheel(0, 3000);
+  await page.mouse.wheel(0, 3000);
+
+  // Scroll down to reveal last cell to ensure these all items have been measured...
+  await Promise.all([
+    firstCell.waitFor({ state: 'hidden' }),
+    lastCell.waitFor()
+  ]);
+
+  await page.mouse.wheel(0, -3000);
+  await page.mouse.wheel(0, -3000);
+
+  // ...then scroll back up and select first cell.
+  await Promise.all([
+    lastCell.waitFor({ state: 'hidden' }),
+    firstCell.waitFor()
+  ]);
+  await page.notebook.selectCells(0);
+
+  // Insert cell below.
+  await page.keyboard.press('b');
+  await page.mouse.wheel(0, 3000);
+  await page.mouse.wheel(0, 3000);
+
+  // Scroll down again.
+  await Promise.all([
+    firstCell.waitFor({ state: 'hidden' }),
+    lastCell.waitFor()
+  ]);
+  await expect(lastCell).toBeVisible();
+});
+
 test('should center on next cell after rendering markdown cell and advancing', async ({
   page,
   tmpPath

--- a/packages/notebook/src/windowing.ts
+++ b/packages/notebook/src/windowing.ts
@@ -58,7 +58,7 @@ export class NotebookViewModel extends WindowedListModel {
 
     const nLines = model.sharedModel.getSource().split('\n').length;
     let outputsLines = 0;
-    if (model instanceof CodeCellModel) {
+    if (model instanceof CodeCellModel && !model.isDisposed) {
       for (let outputIdx = 0; outputIdx < model.outputs.length; outputIdx++) {
         const output = model.outputs.get(outputIdx);
         const data = output.data['text/plain'];

--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -663,8 +663,13 @@ export abstract class WindowedListModel implements WindowedList.IModel {
 
         offset += size;
       }
-
-      this._measuredAllUntilIndex = index;
+      // Because the loop above updates estimated sizes,
+      // we need to fix (heal) offsets of the remaining items.
+      for (let i = index + 1; i < this._widgetSizers.length; i++) {
+        const sizer = this._widgetSizers[i];
+        const previous = this._widgetSizers[i - 1];
+        sizer.offset = previous.offset + previous.size;
+      }
     }
 
     for (let i = 0; i <= this._measuredAllUntilIndex; i++) {


### PR DESCRIPTION
## References

Fixes #16978

## Code changes

- Do not set `_measuredAllUntilIndex` as a side effect in `_getItemMetadata` - this is wrong as we are not actually measuring sizes there, just estimating
- Update offsets in `_getItemMetadata` after changing values in `_widgetSizers` by populating estimates sizes (this is a side effect which I think should not in this getter, but this PR is a hotfix and it is not feasible to write unit tests for these scenarios)

## User-facing changes

Cells no longer disappear after copy-paste/dragging.

## Backwards-incompatible changes

None
