### PR TITLE
Bump httpx v0.28.0

### DIFF
--- a/jupyterlab/extensions/pypi.py
+++ b/jupyterlab/extensions/pypi.py
@@ -65,8 +65,8 @@ if http_proxy_url:
     proxy_host, _, proxy_port = http_proxy.netloc.partition(":")
 
     proxies = {
-        "http://": http_proxy_url,
-        "https://": https_proxy_url,
+        "http://": httpx.HTTPTransport(proxy=http_proxy_url),
+        "https://": httpx.HTTPTransport(proxy=https_proxy_url),
     }
 
     xmlrpc_transport_override = ProxiedTransport()
@@ -131,7 +131,7 @@ class PyPIExtensionManager(ExtensionManager):
         parent: Optional[config.Configurable] = None,
     ) -> None:
         super().__init__(app_options, ext_options, parent)
-        self._httpx_client = httpx.AsyncClient(proxies=proxies)
+        self._httpx_client = httpx.AsyncClient(mounts=proxies)
         # Set configurable cache size to fetch function
         self._fetch_package_metadata = partial(_fetch_package_metadata, self._httpx_client)
         self._observe_package_metadata_cache_size({"new": self.package_metadata_cache_size})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 ]
 dependencies = [
     "async_lru>=1.0.0",
-    "httpx>=0.25.0",
+    "httpx>=0.28.0",
     "importlib-metadata>=4.8.3;python_version<\"3.10\"",
     "importlib-resources>=1.4;python_version<\"3.9\"",
     "ipykernel>=6.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 ]
 dependencies = [
     "async_lru>=1.0.0",
-    "httpx>=0.28.0",
+    "httpx~=0.28.0",
     "importlib-metadata>=4.8.3;python_version<\"3.10\"",
     "importlib-resources>=1.4;python_version<\"3.9\"",
     "ipykernel>=6.5.0",


### PR DESCRIPTION
With [httpx v0.28.0](https://github.com/encode/httpx/pull/3419), the deprecated `proxies` argument has been removed. But we still use it in the `pypi` extension manager:
```
[W 2024-11-29 09:22:50.941 LabApp] Failed to instantiate the extension manager pypi. Falling back to read-only manager.
    Traceback (most recent call last):
      File "/home/david/.local/share/mamba/envs/tmp-jupyter-collaboration/lib/python3.13/site-packages/jupyterlab/labapp.py", line 837, in initialize_handlers
        ext_manager = manager_factory(app_options, listings_config, self)
      File "/home/david/.local/share/mamba/envs/tmp-jupyter-collaboration/lib/python3.13/site-packages/jupyterlab/extensions/__init__.py", line 46, in get_pypi_manager
        return PyPIExtensionManager(app_options, ext_options, parent)
      File "/home/david/.local/share/mamba/envs/tmp-jupyter-collaboration/lib/python3.13/site-packages/jupyterlab/extensions/pypi.py", line 134, in __init__
        self._httpx_client = httpx.AsyncClient(proxies=proxies)
                             ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
    TypeError: AsyncClient.__init__() got an unexpected keyword argument 'proxies'
```

## References

See https://github.com/encode/httpx/pull/2879.

## Code changes

Use `mounts` instead of `proxies`.

## User-facing changes

The `pypi` extension manager works fine.

## Backwards-incompatible changes

None.