### PR TITLE
Improve performance of rendering stdout/stderr

### DIFF
--- a/packages/rendermime/test/factories.spec.ts
+++ b/packages/rendermime/test/factories.spec.ts
@@ -679,7 +679,7 @@ describe('rendermime/factories', () => {
         // Local timings:
         // - fastPathTime: 1105
         // - slowPathTime: 1480
-        expect(fastPathTime).toBeLessThan(slowPathTime);
+        expect(fastPathTime * 1.1).toBeLessThan(slowPathTime);
       });
 
       it.each([


### PR DESCRIPTION
## References

- another fix for performance regression reported in #16957
- follow-up to https://github.com/jupyterlab/jupyterlab/pull/16975

## Code changes

- [x] Adds a test for a fast path discussed in https://github.com/jupyterlab/jupyterlab/issues/16957#issuecomment-2507653383
   - I initially tried to implement test timing the performance but in that case it does not work as jsdom does not use a complied implementation for sanitization of `textContent` (it's not using a real browse) and also the ANSI parsing has quite some overhead when a match is detected so the fast test case even on `main` was faster than the test case for slow path
- [x] Implements the fast path when logging without ASCII escapes

## User-facing changes

Rendering the stdout and stderr will be faster

| Browser | `4.3.0` | #16975 | #16975 + this PR |
|--|--|--|--|
| Chrome 131.0 | 67s | 25s | 19s |
| Firefox 133.0 | 136s | 35s | 21s |

<details>
<summary>Test case</summary>

```python
import logging

logger = logging.getLogger()

for i in range(4000):
    logger.error(f"{i} XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
```

</details>

## Backwards-incompatible changes

None
