### PR TITLE
Fixes debugger UI-test with python>=3.12

### DIFF
--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-        with:
-          python_version: "3.11"
 
       - name: Set up browser cache
         uses: actions/cache@v4

--- a/galata/test/jupyterlab/debugger.test.ts
+++ b/galata/test/jupyterlab/debugger.test.ts
@@ -247,6 +247,9 @@ test.describe('Debugger Variables', () => {
     await expect(
       page.getByRole('menuitem', { name: 'Copy Variable to Globals' })
     ).toHaveCount(0);
+
+    await page.getByRole('menu').press('Escape');
+    await page.click('jp-button[title^=Continue]');
   });
 
   test('Copy to globals not available from kernel', async ({
@@ -284,6 +287,8 @@ test.describe('Debugger Variables', () => {
     await expect(
       page.getByRole('menuitem', { name: 'Copy to Clipboard' })
     ).toHaveCount(0);
+
+    await page.click('jp-button[title^=Continue]');
   });
 
   test('Copy to clipboard', async ({ page, tmpPath }) => {
@@ -317,6 +322,8 @@ test.describe('Debugger Variables', () => {
     await expect(
       page.getByRole('menuitem', { name: 'Copy to Clipboard' })
     ).toHaveCount(0);
+
+    await page.click('jp-button[title^=Continue]');
   });
 });
 


### PR DESCRIPTION
## References

Should fix https://github.com/jupyterlab/jupyterlab/issues/16982

Reverts https://github.com/jupyterlab/jupyterlab/pull/16989

## Code changes

Ends the execution of the cell during debugger tests.

I don't know why it used to pass and why it was falling with python 3.12, it must be a race condition.

## User-facing changes

None

## Backwards-incompatible changes

None
