### PR TITLE
Bump required setuptools to `40.8.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "jupyterlab_server>=2.27.1,<3",
     "notebook_shim>=0.2",
     "packaging",
-    "setuptools>=40.1.0",
+    "setuptools>=40.8.0",
     "tomli>=1.2.2;python_version<\"3.11\"",
     "tornado>=6.2.0",
     "traitlets",


### PR DESCRIPTION
## References

Trying to fix https://github.com/jupyterlab/jupyterlab/issues/17003

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None
