### PR TITLE
Drop Python 3.8

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,7 +31,6 @@ from collections import ChainMap
 from functools import partial
 from pathlib import Path
 from subprocess import check_call
-from typing import List
 
 HERE = Path(__file__).parent.resolve()
 
@@ -165,7 +164,7 @@ IMAGES_FOLDER = "images"
 AUTOMATED_SCREENSHOTS_FOLDER = "galata/test/documentation"
 
 
-def copy_automated_screenshots(temp_folder: Path) -> List[Path]:
+def copy_automated_screenshots(temp_folder: Path) -> list[Path]:
     """Copy PlayWright automated screenshots in documentation folder.
 
     Args:

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -23,7 +23,7 @@ from glob import glob
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from threading import Event
-from typing import FrozenSet, Optional
+from typing import Optional
 from urllib.error import URLError
 from urllib.request import Request, quote, urljoin, urlopen
 
@@ -2403,7 +2403,7 @@ def _is_disabled(name, disabled=None):
 class LockStatus:
     entire_extension_locked: bool
     # locked plugins are only given if extension is not locked as a whole
-    locked_plugins: Optional[FrozenSet[str]] = None
+    locked_plugins: Optional[frozenset[str]] = None
 
 
 def _is_locked(name, locked=None) -> LockStatus:

--- a/jupyterlab/extensions/manager.py
+++ b/jupyterlab/extensions/manager.py
@@ -7,7 +7,7 @@ import json
 import re
 from dataclasses import dataclass, field, fields, replace
 from pathlib import Path
-from typing import Dict, FrozenSet, List, Optional, Set, Tuple, Union
+from typing import Optional, Union
 
 import tornado
 from jupyterlab_server.translation_utils import translator
@@ -115,7 +115,7 @@ class ActionResult:
     #       keeping str for simplicity
     status: str
     message: Optional[str] = None
-    needs_restart: List[str] = field(default_factory=list)
+    needs_restart: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -129,7 +129,7 @@ class PluginManagerOptions:
             The plugin names need to follow colon-separated format of `extension:plugin`.
     """
 
-    lock_rules: FrozenSet[str] = field(default_factory=frozenset)
+    lock_rules: frozenset[str] = field(default_factory=frozenset)
     lock_all: bool = False
 
 
@@ -144,8 +144,8 @@ class ExtensionManagerOptions(PluginManagerOptions):
         listings_tornado_options: The optional kwargs to use for the listings HTTP requests as described on https://www.tornadoweb.org/en/stable/httpclient.html#tornado.httpclient.HTTPRequest
     """
 
-    allowed_extensions_uris: Set[str] = field(default_factory=set)
-    blocked_extensions_uris: Set[str] = field(default_factory=set)
+    allowed_extensions_uris: set[str] = field(default_factory=set)
+    blocked_extensions_uris: set[str] = field(default_factory=set)
     listings_refresh_seconds: int = 60 * 60
     listings_tornado_options: dict = field(default_factory=dict)
 
@@ -174,7 +174,7 @@ class ExtensionsCache:
         last_page: Last available page result
     """
 
-    cache: Dict[int, Optional[Dict[str, ExtensionPackage]]] = field(default_factory=dict)
+    cache: dict[int, Optional[dict[str, ExtensionPackage]]] = field(default_factory=dict)
     last_page: int = 1
 
 
@@ -225,7 +225,7 @@ class PluginManager(LoggingConfigurable):
             "allLocked": self.options.lock_all,
         }
 
-    def _find_locked(self, plugins_or_extensions: List[str]) -> FrozenSet[str]:
+    def _find_locked(self, plugins_or_extensions: list[str]) -> frozenset[str]:
         """Find a subset of plugins (or extensions) which are locked"""
         if self.options.lock_all:
             return set(plugins_or_extensions)
@@ -244,7 +244,7 @@ class PluginManager(LoggingConfigurable):
                 locked_subset.add(plugin)
         return locked_subset
 
-    async def disable(self, plugins: Union[str, List[str]]) -> ActionResult:
+    async def disable(self, plugins: Union[str, list[str]]) -> ActionResult:
         """Disable a set of plugins (or an extension).
 
         Args:
@@ -270,7 +270,7 @@ class PluginManager(LoggingConfigurable):
         except Exception as err:
             return ActionResult(status="error", message=repr(err))
 
-    async def enable(self, plugins: Union[str, List[str]]) -> ActionResult:
+    async def enable(self, plugins: Union[str, list[str]]) -> ActionResult:
         """Enable a set of plugins (or an extension).
 
         Args:
@@ -336,7 +336,7 @@ class ExtensionManager(PluginManager):
         self.app_dir = Path(self.app_options.app_dir)
         self.core_config = self.app_options.core_config
         self.options = ExtensionManagerOptions(**(ext_options or {}))
-        self._extensions_cache: Dict[Optional[str], ExtensionsCache] = {}
+        self._extensions_cache: dict[Optional[str], ExtensionsCache] = {}
         self._listings_cache: Optional[dict] = None
         self._listings_block_mode = True
         self._listing_fetch: Optional[tornado.ioloop.PeriodicCallback] = None
@@ -376,7 +376,7 @@ class ExtensionManager(PluginManager):
 
     async def list_packages(
         self, query: str, page: int, per_page: int
-    ) -> Tuple[Dict[str, ExtensionPackage], Optional[int]]:
+    ) -> tuple[dict[str, ExtensionPackage], Optional[int]]:
         """List the available extensions.
 
         Args:
@@ -457,7 +457,7 @@ class ExtensionManager(PluginManager):
 
     async def list_extensions(
         self, query: Optional[str] = None, page: int = 1, per_page: int = 30
-    ) -> Tuple[List[ExtensionPackage], Optional[int]]:
+    ) -> tuple[list[ExtensionPackage], Optional[int]]:
         """List extensions for a given ``query`` search term.
 
         This will return the extensions installed (if ``query`` is None) or
@@ -539,7 +539,7 @@ class ExtensionManager(PluginManager):
 
     async def _get_installed_extensions(
         self, get_latest_version=True
-    ) -> Dict[str, ExtensionPackage]:
+    ) -> dict[str, ExtensionPackage]:
         """Get the installed extensions.
 
         Args:

--- a/jupyterlab/extensions/pypi.py
+++ b/jupyterlab/extensions/pypi.py
@@ -19,7 +19,7 @@ from os import environ
 from pathlib import Path
 from subprocess import CalledProcessError, run
 from tarfile import TarFile
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Optional
 from urllib.parse import urlparse
 from zipfile import ZipFile
 
@@ -239,7 +239,7 @@ class PyPIExtensionManager(ExtensionManager):
 
     async def list_packages(
         self, query: str, page: int, per_page: int
-    ) -> Tuple[Dict[str, ExtensionPackage], Optional[int]]:
+    ) -> tuple[dict[str, ExtensionPackage], Optional[int]]:
         """List the available extensions.
 
         Note:
@@ -307,7 +307,7 @@ class PyPIExtensionManager(ExtensionManager):
 
         return extensions, math.ceil((counter + 1) / per_page)
 
-    async def __get_all_extensions(self) -> List[Tuple[str, str]]:
+    async def __get_all_extensions(self) -> list[tuple[str, str]]:
         if self.__all_packages_cache is None or datetime.now(
             tz=timezone.utc
         ) > self.__last_all_packages_request_time + timedelta(seconds=self.cache_timeout):
@@ -336,9 +336,10 @@ class PyPIExtensionManager(ExtensionManager):
             The action result
         """
         current_loop = tornado.ioloop.IOLoop.current()
-        with tempfile.TemporaryDirectory() as ve_dir, tempfile.NamedTemporaryFile(
-            mode="w+", dir=ve_dir, delete=False
-        ) as fconstraint:
+        with (
+            tempfile.TemporaryDirectory() as ve_dir,
+            tempfile.NamedTemporaryFile(mode="w+", dir=ve_dir, delete=False) as fconstraint,
+        ):
             fconstraint.write(f"jupyterlab=={__version__}")
             fconstraint.flush()
 

--- a/jupyterlab/extensions/readonly.py
+++ b/jupyterlab/extensions/readonly.py
@@ -4,7 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import sys
-from typing import Dict, Optional, Tuple
+from typing import Optional
 
 from jupyterlab_server.translation_utils import translator
 
@@ -31,7 +31,7 @@ class ReadOnlyExtensionManager(ExtensionManager):
 
     async def list_packages(
         self, query: str, page: int, per_page: int
-    ) -> Tuple[Dict[str, ExtensionPackage], Optional[int]]:
+    ) -> tuple[dict[str, ExtensionPackage], Optional[int]]:
         """List the available extensions.
 
         Args:

--- a/jupyterlab/handlers/announcements.py
+++ b/jupyterlab/handlers/announcements.py
@@ -7,9 +7,10 @@ import abc
 import hashlib
 import json
 import xml.etree.ElementTree as ET
+from collections.abc import Awaitable
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
-from typing import Awaitable, Optional, Tuple, Union
+from typing import Optional, Union
 
 from jupyter_server.base.handlers import APIHandler
 from jupyterlab_server.translation_utils import translator
@@ -44,7 +45,7 @@ class Notification:
     message: str
     modifiedAt: float  # noqa
     type: str = "default"
-    link: Tuple[str, str] = field(default_factory=tuple)
+    link: tuple[str, str] = field(default_factory=tuple)
     options: dict = field(default_factory=dict)
 
 
@@ -63,7 +64,7 @@ class CheckForUpdateABC(abc.ABC):
         self.version = version
 
     @abc.abstractmethod
-    async def __call__(self) -> Awaitable[Union[None, str, Tuple[str, Tuple[str, str]]]]:
+    async def __call__(self) -> Awaitable[Union[None, str, tuple[str, tuple[str, str]]]]:
         """Get the notification message if a new version is available.
 
         Returns:
@@ -86,7 +87,7 @@ class CheckForUpdate(CheckForUpdateABC):
         logger - logging.Logger: Server logger
     """
 
-    async def __call__(self) -> Awaitable[Tuple[str, Tuple[str, str]]]:
+    async def __call__(self) -> Awaitable[tuple[str, tuple[str, str]]]:
         """Get the notification message if a new version is available.
 
         Returns:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,7 +249,7 @@ after-publish-assets = "npm run after:publish:assets"
 
 [tool.ruff]
 exclude = ["*.ipynb"]
-target-version = "py38"
+target-version = "py39"
 line-length = 100
 lint.select = [
   "A", "B", "C", "DTZ", "E", "EM", "F", "FBT", "I", "ICN", "N",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "jupyterlab"
 description = "JupyterLab computational environment"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "Jupyter Development Team", email = "jupyter@googlegroups.com" },
 ]
@@ -28,11 +28,11 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "async_lru>=1.0.0",


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Python 3.8 is now EOL: https://devguide.python.org/versions/#unsupported-versions

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/16852

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes



<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

- [x] Require Python 3.9 or above to run JupyterLab.
- [x] Add the 3.13 trove classifier

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
