### PR TITLE
Fix filebrowser name order

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -3603,7 +3603,7 @@ namespace Private {
       // Sort by name
       copy.sort(
         compare((a: Contents.IModel, b: Contents.IModel) => {
-          return b.name.localeCompare(a.name);
+          return b.name.localeCompare(a.name, navigator.language || navigator.userLanguage, {numeric: true, sensitivity: 'base'});
         })
       );
     }

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -3568,7 +3568,7 @@ namespace Private {
      * Compare two items by their name using `translator.languageCode`, with fallback to `navigator.language`.
      */
     function compareByName(a: Contents.IModel, b: Contents.IModel) {
-      const languageCode = translator.languageCode.replace('_', '-');
+      const languageCode = (translator.languageCode ?? navigator.language).replace('_', '-');
       try {
         return a.name.localeCompare(b.name, languageCode, {
           numeric: true,

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -3533,10 +3533,16 @@ namespace Private {
   export function sort(
     items: Iterable<Contents.IModel>,
     state: DirListing.ISortState,
-    sortNotebooksFirst: boolean = false
+    sortNotebooksFirst: boolean = false,
+    translator?: ITranslator
   ): Contents.IModel[] {
     const copy = Array.from(items);
     const reverse = state.direction === 'descending' ? 1 : -1;
+    // Determine language code from the translator or fallback to navigator.language
+    translator = translator || nullTranslator;
+    const languageCode = translator
+      ? translator.languageCode
+      : navigator.language;
 
     /**
      * Compares two items and returns whether they should have a fixed priority.
@@ -3578,7 +3584,10 @@ namespace Private {
         }
 
         // Default sorting is alphabetical ascending
-        return a.name.localeCompare(b.name);
+        return a.name.localeCompare(b.name, languageCode, {
+          numeric: true,
+          sensitivity: 'base'
+        });
       };
     }
 
@@ -3603,7 +3612,10 @@ namespace Private {
       // Sort by name
       copy.sort(
         compare((a: Contents.IModel, b: Contents.IModel) => {
-          return b.name.localeCompare(a.name, navigator.language || navigator.userLanguage, {numeric: true, sensitivity: 'base'});
+          return b.name.localeCompare(a.name, languageCode, {
+            numeric: true,
+            sensitivity: 'base'
+          });
         })
       );
     }

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -3568,7 +3568,9 @@ namespace Private {
      * Compare two items by their name using `translator.languageCode`, with fallback to `navigator.language`.
      */
     function compareByName(a: Contents.IModel, b: Contents.IModel) {
-      const languageCode = (translator.languageCode ?? navigator.language).replace('_', '-');
+      const languageCode = (
+        translator.languageCode ?? navigator.language
+      ).replace('_', '-');
       try {
         return a.name.localeCompare(b.name, languageCode, {
           numeric: true,


### PR DESCRIPTION
## References

#17037

## Code changes

Fix wrong usage of `localeCompare` function. 

## User-facing changes

Before:
![ksnip_20241204-164821](https://github.com/user-attachments/assets/fbf930be-6f34-4667-9473-68770ef6d5e7)


After:
![ksnip_20241204-164745](https://github.com/user-attachments/assets/ba00c7ef-e128-41ac-98d4-d300613194f6)


## Backwards-incompatible changes

No
