### PR TITLE
restore bottom httpx version window

### DIFF
--- a/jupyterlab/extensions/pypi.py
+++ b/jupyterlab/extensions/pypi.py
@@ -21,6 +21,7 @@ from subprocess import CalledProcessError, run
 from tarfile import TarFile
 from typing import Any, Callable, Optional
 from urllib.parse import urlparse
+from packaging.version import Version
 from zipfile import ZipFile
 
 import httpx
@@ -49,8 +50,6 @@ class ProxiedTransport(xmlrpc.client.Transport):
         return connection
 
 
-xmlrpc_transport_override = None
-
 all_proxy_url = environ.get("ALL_PROXY")
 # For historical reasons, we also support the lowercase environment variables.
 # Info: https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/
@@ -58,7 +57,13 @@ http_proxy_url = environ.get("http_proxy") or environ.get("HTTP_PROXY") or all_p
 https_proxy_url = (
     environ.get("https_proxy") or environ.get("HTTPS_PROXY") or http_proxy_url or all_proxy_url
 )
+
+# sniff ``httpx`` version for version-sensitive API
+_httpx_version = Version(httpx.__version__)
+_httpx_client_args = {}
+
 proxies = None
+xmlrpc_transport_override = None
 
 if http_proxy_url:
     http_proxy = urlparse(http_proxy_url)
@@ -66,7 +71,11 @@ if http_proxy_url:
 
     proxies = {
         "http://": httpx.HTTPTransport(proxy=http_proxy_url),
-        "https://": httpx.HTTPTransport(proxy=https_proxy_url),
+        "https://": httpx.HTTPTransport(proxy=http_proxy_url),
+    }
+
+    _httpx_client_args = {
+        ("mounts" if _httpx_version >= Version("0.28.0") else "proxies"): proxies,
     }
 
     xmlrpc_transport_override = ProxiedTransport()
@@ -131,7 +140,7 @@ class PyPIExtensionManager(ExtensionManager):
         parent: Optional[config.Configurable] = None,
     ) -> None:
         super().__init__(app_options, ext_options, parent)
-        self._httpx_client = httpx.AsyncClient(mounts=proxies)
+        self._httpx_client = httpx.AsyncClient(**_httpx_client_args)
         # Set configurable cache size to fetch function
         self._fetch_package_metadata = partial(_fetch_package_metadata, self._httpx_client)
         self._observe_package_metadata_cache_size({"new": self.package_metadata_cache_size})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 ]
 dependencies = [
     "async_lru>=1.0.0",
-    "httpx~=0.28.0",
+    "httpx>=0.25.0",
     "importlib-metadata>=4.8.3;python_version<\"3.10\"",
     "importlib-resources>=1.4;python_version<\"3.9\"",
     "ipykernel>=6.5.0",


### PR DESCRIPTION
## References

- put back `httpx >=0.25.0`
- fixes https://github.com/jupyterlab/jupyterlab/issues/17035

## Code changes

- sniff `httpx.__version__`, use appropriate arguments

## User-facing changes

- users will be easier able to install `jupyterlab 4.3.3` while the libraries they are interested in adjust to the `httpx` API breakage

## Backwards-incompatible changes

- n/a

## Future Work

- looks like `https_proxy_url` isn't used. 
  - seems bad.
- the proxy feature has no tests
  - this could be done with `proxy-py` (BSD-3-Clause, no deps, pure python), but its probably more important to get this out so that people (that probably dont' even care about proxies) can actually _install_ the software next to their other code
- as raised when this was _originally_ added, the `fetch` should be isolated within a configurable
  - `jupyterlab_server` already hauls in `requests` which can handle proxies, but is blocking, but could be wrapped in a `run_in_executor`
- going forward, we should likely never use `pkg ~x.y.z` in `[project.dependencies]` (test deps are what they are)