### PR TITLE
Fix newline handling in stream outputs

### DIFF
--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -366,10 +366,7 @@ export class OutputAreaModel implements IOutputAreaModel {
       if (typeof value.text !== 'string') {
         value.text = value.text.join('');
       }
-      const { text, index } = Private.processText(
-        this._streamIndex,
-        value.text
-      );
+      const { text, index } = Private.processText(0, value.text);
       this._streamIndex = index;
       value.text = text;
     }
@@ -544,7 +541,13 @@ namespace Private {
     if (text === undefined) {
       text = '';
     }
-    if (!(newText.includes('\b') || newText.includes('\r'))) {
+    if (
+      !(
+        newText.includes('\b') ||
+        newText.includes('\r') ||
+        newText.includes('\n')
+      )
+    ) {
       text =
         text.slice(0, index) + newText + text.slice(index + newText.length);
       return { text, index: index + newText.length };

--- a/packages/outputarea/test/model.spec.ts
+++ b/packages/outputarea/test/model.spec.ts
@@ -169,6 +169,20 @@ describe('outputarea/model', () => {
         expect(model.get(0).toJSON().text).toBe('jupyter\njupyter\njupyter');
       });
 
+      it('should reconcile stream with new lines after carriage returns', () => {
+        model.add({
+          name: 'stdout',
+          output_type: 'stream',
+          text: ['abc\r']
+        });
+        model.add({
+          name: 'stdout',
+          output_type: 'stream',
+          text: ['\n-']
+        });
+        expect(model.get(0).toJSON().text).toBe('abc\n-');
+      });
+
       it('should be fast in sparse presence of returns and backspaces', () => {
         // locally this test run in 36 ms; setting it to 10 times
         // more to allow for slower runs on CI


### PR DESCRIPTION
## References

Fixes #17039.

## Code changes

Don't shortcut logic when stream has a newline character.

## User-facing changes

Streams are correctly handled, especially progress bars.

## Backwards-incompatible changes

None.