### PR TITLE
Replace proxied PyPI extension manager client httpx with tornado

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ classifiers = [
 ]
 dependencies = [
     "async_lru>=1.0.0",
-    "httpx~=0.28.0",
     "importlib-metadata>=4.8.3;python_version<\"3.10\"",
     "importlib-resources>=1.4;python_version<\"3.9\"",
     "ipykernel>=6.5.0",
@@ -97,6 +96,9 @@ docs-screenshots = [
     "pandas==2.2.3",
     "scipy==1.14.1",
     "vega_datasets==0.9.0",
+]
+proxy = [
+    "pycurl>=7.18.2"
 ]
 test = [
     "coverage",


### PR DESCRIPTION
## References

* fixes #17035 

## Code changes

* Replaces `httpx` with `tornado.httpclient`, as originally implemented, removing issue with `httpx` API break
* Adds test for the presence of optional `pycurl` with appropriate error message
* Removes `httpx` dependency and adds optional dependency group `proxy` with appropriate `pycurl` version spec
* Fixes https downgrade issue with XML-RPC client 

## User-facing changes

* Removes issue with `httpx` versioning due to API break
* Adds a potential optional dependency
* Restores functionality in common proxy configurations

## Backwards-incompatible changes
 
* None

## Remaining issues

* This is still not integrated with testing
* This could be done without adding any dependencies if we ran a sync client in an async executor. Alternatively, if a full-featured async http client like `httpx` or `aiohttp` was used universally, replacing `requests` + executor in other contexts, it could be used here.

## Notes

In addition to replacing httpx with the already-present Tornado HTTP client (although requiring pycurl as an optional dependency) this also fixes an issue with the _other_ HTTP client accessing the XML-RPC PyPI endpoint. Ideally this would go away at some point because the entire API service is not long for this world, this is necessary both to keep communication going over HTTPS and to work with some of the most common proxy setups.