### PR TITLE
Reset resizeData after column adjustment to allow file dragging

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1477,6 +1477,7 @@ export class DirListing extends Widget {
     // Remove the resize listeners if necessary.
     if (this._resizeData) {
       this._resizeData.overrides.dispose();
+      this._resizeData = null;
       document.removeEventListener('mousemove', this, true);
       document.removeEventListener('mouseup', this, true);
       return;


### PR DESCRIPTION
## References
Fixes #17042 

## Description
This PR resolves a bug where the side browser in the UI fails to allow file dragging after adjusting the column split between name/size. Once the split was adjusted, subsequent drag events incorrectly adjusted the column split instead of enabling file drag-and-drop.

## Root Cause
The `resizeData` object was not set to `null` after the `mouseUp` event. As a result, the drag logic interpreted any further drag actions as column resizing since `resizeData` had a non-null value.

## Fix
- Added a reset step to set `resizeData = null` after the `mouseUp` event if `resizeData` was set during the resize operation.

## Behavior After Fix
- Column adjustment now only occurs when the column header is dragged.
- File dragging and dropping functionality works as intended after resizing columns.

