### PR TITLE
Bump `nanoid` from 3.3.6 to to 3.3.8

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -16040,11 +16040,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.6":
-  version: 3.3.6
-  resolution: "nanoid@npm:3.3.6"
+  version: 3.3.8
+  resolution: "nanoid@npm:3.3.8"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 7d0eda657002738aa5206107bd0580aead6c95c460ef1bdd0b1a87a9c7ae6277ac2e9b945306aaa5b32c6dcb7feaf462d0f552e7f8b5718abfc6ead5c94a71b3
+  checksum: dfe0adbc0c77e9655b550c333075f51bb28cfc7568afbf3237249904f9c86c9aaaed1f113f0fddddba75673ee31c758c30c43d4414f014a52a7a626efc5958c9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

## References

Closes #17056 

- https://github.com/ai/nanoid/compare/3.3.6...3.3.8
- no provenance, code for review: https://www.npmjs.com/package/nanoid/v/3.3.8?activeTab=code

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None