### PR TITLE
Fix contrast for unselected search matches in Dark High Contrast theme

### DIFF
--- a/packages/theme-dark-high-contrast-extension/style/variables.css
+++ b/packages/theme-dark-high-contrast-extension/style/variables.css
@@ -393,7 +393,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-search-unselected-match-background-color: var(
     --jp-inverse-layout-color0
   );
-  --jp-search-unselected-match-color: var(--jp-ui-inverse-font-color0);
+  --jp-search-unselected-match-color: black;
 
   /* scrollbar related styles. Supports every browser except Edge. */
 


### PR DESCRIPTION
## References

Fixes https://github.com/jupyter/notebook/issues/7537

## Code changes

Aligns the color of the `--jp-search-unselected-match-color` to the color of `--jp-search-selected-match-color` which already is set to `black` to allow for the highlighted text to be readable.

## User-facing changes

| Before | After |
|--|--|
| ![Screenshot from 2024-12-09 18-12-12](https://github.com/user-attachments/assets/abb5b6f8-6aba-4955-933c-e8d34515f55d)  | ![Screenshot from 2024-12-09 18-11-31](https://github.com/user-attachments/assets/fe3e3f09-4b19-45de-b3ee-25358212f728) |

## Backwards-incompatible changes

None