### PR TITLE
Fix contrast issues for keyboard shortcut 'Add' button 

### DIFF
--- a/packages/shortcuts-extension/style/base.css
+++ b/packages/shortcuts-extension/style/base.css
@@ -68,7 +68,7 @@
 }
 
 .jp-mod-selected-InputText {
-  background-color: var(--jp-brand-color3);
+  background-color: #004080;
   overflow: hidden;
 }
 
@@ -228,8 +228,8 @@
 
 .jp-Shortcuts-Plus {
   opacity: 0;
-  background: var(--jp-brand-color3);
-  border-color: var(--jp-layout-color0);
+  background: #004080;
+  border-color: #002850;
   border-radius: var(--jp-border-radius);
   border-width: var(--jp-border-width);
   margin: 3px 0;
@@ -239,11 +239,11 @@
 }
 
 .jp-Shortcuts-Plus:hover {
-  background-color: var(--jp-brand-color2);
+  background-color: #0059b3;
 }
 
 .jp-Shortcuts-Plus:active {
-  background-color: var(--jp-brand-color2);
+  background-color: #0059b3;
 }
 
 .jp-Shortcuts-Reset {


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
[#16801 ](https://github.com/jupyterlab/jupyterlab/issues/16801)

## Code changes

The following changes were made in packages/shortcuts-extension/style/base.css to improve the accessibility and contrast of elements in the dark theme:

- Updated .jp-Shortcuts-Plus background and border-color.
- Adjusted hover and active states background of .jp-Shortcuts-Plus.
- Modified the .jp-mod-selected-InputText background color.

These updates ensure better visibility and compliance with WCAG AA contrast standards.

## User-facing changes

Users will notice:

- Improved visibility for the "Add" button in the keyboard shortcuts UI and selected shortcuts that already exist while in dark theme.

### Before
![image](https://github.com/user-attachments/assets/2c0eb783-4fc3-425d-b16e-7799de0e0c98)
![image](https://github.com/user-attachments/assets/37dda196-80ca-4968-b8e7-9d147249ca93)


### After
Normal
![image](https://github.com/user-attachments/assets/b1d9d621-71a2-41c8-a490-1cacd570ce0f)
Hover
![image](https://github.com/user-attachments/assets/acd2089e-581e-4b5f-af45-24d4ad6ef59a)
![image](https://github.com/user-attachments/assets/bf28f63c-dc1f-41ce-90c0-768d9ea52d4c)




## Backwards-incompatible changes

None
