### PR TITLE
Add option to render markdown cells upon exit

### DIFF
--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -727,8 +727,8 @@
         "matchBrackets": false
       }
     },
-    "renderMarkdownOnExit": {
-      "title": "Render markdown cells upon exit",
+    "renderMarkdownOnCursorLeave": {
+      "title": "Render markdown when cursor leaves markdown cells",
       "description": "Whether to render markdown cells when the cursor moves out of them.",
       "type": "boolean",
       "default": false

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -368,284 +368,397 @@
   "jupyter.lab.shortcuts": [
     {
       "command": "notebook:change-cell-to-code",
-      "keys": ["Y"],
+      "keys": [
+        "Y"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-1",
-      "keys": ["1"],
+      "keys": [
+        "1"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-2",
-      "keys": ["2"],
+      "keys": [
+        "2"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-3",
-      "keys": ["3"],
+      "keys": [
+        "3"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-4",
-      "keys": ["4"],
+      "keys": [
+        "4"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-5",
-      "keys": ["5"],
+      "keys": [
+        "5"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-6",
-      "keys": ["6"],
+      "keys": [
+        "6"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-markdown",
-      "keys": ["M"],
+      "keys": [
+        "M"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-raw",
-      "keys": ["R"],
+      "keys": [
+        "R"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:copy-cell",
-      "keys": ["C"],
+      "keys": [
+        "C"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:cut-cell",
-      "keys": ["X"],
+      "keys": [
+        "X"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:delete-cell",
-      "keys": ["D", "D"],
+      "keys": [
+        "D",
+        "D"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:enter-command-mode",
-      "keys": ["Escape"],
+      "keys": [
+        "Escape"
+      ],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {
       "command": "notebook:enter-command-mode",
-      "keys": ["Ctrl M"],
+      "keys": [
+        "Ctrl M"
+      ],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {
       "command": "notebook:access-previous-history-entry",
-      "keys": ["Alt ArrowUp"],
+      "keys": [
+        "Alt ArrowUp"
+      ],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {
       "command": "notebook:access-next-history-entry",
-      "keys": ["Alt ArrowDown"],
+      "keys": [
+        "Alt ArrowDown"
+      ],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {
       "command": "notebook:enter-edit-mode",
-      "keys": ["Enter"],
+      "keys": [
+        "Enter"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode .jp-Cell:focus"
     },
     {
       "command": "notebook:extend-marked-cells-above",
-      "keys": ["Shift ArrowUp"],
+      "keys": [
+        "Shift ArrowUp"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:extend-marked-cells-above",
-      "keys": ["Shift K"],
+      "keys": [
+        "Shift K"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:extend-marked-cells-top",
-      "keys": ["Shift Home"],
+      "keys": [
+        "Shift Home"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:extend-marked-cells-below",
-      "keys": ["Shift ArrowDown"],
+      "keys": [
+        "Shift ArrowDown"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:extend-marked-cells-bottom",
-      "keys": ["Shift End"],
+      "keys": [
+        "Shift End"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:extend-marked-cells-below",
-      "keys": ["Shift J"],
+      "keys": [
+        "Shift J"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:insert-cell-above",
-      "keys": ["A"],
+      "keys": [
+        "A"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:insert-cell-below",
-      "keys": ["B"],
+      "keys": [
+        "B"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:merge-cells",
-      "keys": ["Shift M"],
+      "keys": [
+        "Shift M"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:merge-cell-above",
-      "keys": ["Ctrl Backspace"],
+      "keys": [
+        "Ctrl Backspace"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:merge-cell-below",
-      "keys": ["Ctrl Shift M"],
+      "keys": [
+        "Ctrl Shift M"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cursor-down",
-      "keys": ["ArrowDown"],
+      "keys": [
+        "ArrowDown"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cursor-down",
-      "keys": ["J"],
+      "keys": [
+        "J"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cursor-up",
-      "keys": ["ArrowUp"],
+      "keys": [
+        "ArrowUp"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cursor-up",
-      "keys": ["K"],
+      "keys": [
+        "K"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cursor-heading-above-or-collapse",
-      "keys": ["ArrowLeft"],
+      "keys": [
+        "ArrowLeft"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cursor-heading-below-or-expand",
-      "keys": ["ArrowRight"],
+      "keys": [
+        "ArrowRight"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:insert-heading-above",
-      "keys": ["Shift A"],
+      "keys": [
+        "Shift A"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:insert-heading-below",
-      "keys": ["Shift B"],
+      "keys": [
+        "Shift B"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:collapse-all-headings",
-      "keys": ["Ctrl Shift ArrowLeft"],
+      "keys": [
+        "Ctrl Shift ArrowLeft"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:expand-all-headings",
-      "keys": ["Ctrl Shift ArrowRight"],
+      "keys": [
+        "Ctrl Shift ArrowRight"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:paste-cell-below",
-      "keys": ["V"],
+      "keys": [
+        "V"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:redo-cell-action",
-      "keys": ["Shift Z"],
+      "keys": [
+        "Shift Z"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:run-cell",
-      "macKeys": ["Ctrl Enter"],
+      "macKeys": [
+        "Ctrl Enter"
+      ],
       "keys": [],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:run-cell",
-      "macKeys": ["Ctrl Enter"],
+      "macKeys": [
+        "Ctrl Enter"
+      ],
       "keys": [],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {
       "command": "notebook:run-cell",
-      "keys": ["Accel Enter"],
+      "keys": [
+        "Accel Enter"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:run-cell",
-      "keys": ["Accel Enter"],
+      "keys": [
+        "Accel Enter"
+      ],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {
       "command": "notebook:run-cell-and-insert-below",
-      "keys": ["Alt Enter"],
+      "keys": [
+        "Alt Enter"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:run-cell-and-insert-below",
-      "keys": ["Alt Enter"],
+      "keys": [
+        "Alt Enter"
+      ],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {
       "command": "notebook:run-in-console",
-      "keys": [""],
+      "keys": [
+        ""
+      ],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {
       "command": "notebook:run-cell-and-select-next",
-      "keys": ["Shift Enter"],
+      "keys": [
+        "Shift Enter"
+      ],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {
       "command": "viewmenu:line-numbering",
-      "keys": ["Shift L"],
+      "keys": [
+        "Shift L"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "viewmenu:match-brackets",
-      "keys": [""],
+      "keys": [
+        ""
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode"
     },
     {
       "command": "notebook:select-all",
-      "keys": ["Accel A"],
+      "keys": [
+        "Accel A"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:split-cell-at-cursor",
-      "keys": ["Ctrl Shift -"],
+      "keys": [
+        "Ctrl Shift -"
+      ],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {
       "command": "notebook:undo-cell-action",
-      "keys": ["Z"],
+      "keys": [
+        "Z"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:toggle-render-side-by-side-current",
-      "keys": ["Shift R"],
+      "keys": [
+        "Shift R"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cell-up",
-      "keys": ["Ctrl Shift ArrowUp"],
+      "keys": [
+        "Ctrl Shift ArrowUp"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cell-down",
-      "keys": ["Ctrl Shift ArrowDown"],
+      "keys": [
+        "Ctrl Shift ArrowDown"
+      ],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     }
   ],
@@ -690,7 +803,11 @@
       "title": "Default cell type",
       "description": "The default type (markdown, code, or raw) for new cells",
       "type": "string",
-      "enum": ["code", "markdown", "raw"],
+      "enum": [
+        "code",
+        "markdown",
+        "raw"
+      ],
       "default": "code"
     },
     "autoStartDefaultKernel": {
@@ -708,7 +825,10 @@
     "inputHistoryScope": {
       "type": "string",
       "default": "global",
-      "enum": ["global", "session"],
+      "enum": [
+        "global",
+        "session"
+      ],
       "title": "Input History Scope",
       "description": "Whether the line history for standard input (e.g. the ipdb prompt) should kept separately for different kernel sessions (`session`) or combined (`global`)."
     },
@@ -727,8 +847,8 @@
         "matchBrackets": false
       }
     },
-    "renderMarkdownOnCursorLeave": {
-      "title": "Render markdown when cursor leaves markdown cells",
+    "autoRenderMarkdownCells": {
+      "title": "Automatically render markdown when cursor leaves markdown cells",
       "description": "Whether to render markdown cells when the cursor moves out of them.",
       "type": "boolean",
       "default": false
@@ -803,7 +923,10 @@
     "renderingLayout": {
       "title": "Rendering Layout",
       "description": "Global setting to define the rendering layout in notebooks. 'default' or 'side-by-side' are supported.",
-      "enum": ["default", "side-by-side"],
+      "enum": [
+        "default",
+        "side-by-side"
+      ],
       "default": "default"
     },
     "sideBySideLeftMarginOverride": {
@@ -828,7 +951,11 @@
     "windowingMode": {
       "title": "Windowing mode",
       "description": "'defer': Improve loading time - Wait for idle CPU cycles to attach out of viewport cells - 'full': Best performance with side effects - Attach to the DOM only cells in viewport - 'none': Worst performance without side effects - Attach all cells to the viewport",
-      "enum": ["defer", "full", "none"],
+      "enum": [
+        "defer",
+        "full",
+        "none"
+      ],
       "default": "full"
     },
     "accessKernelHistory": {

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -727,6 +727,12 @@
         "matchBrackets": false
       }
     },
+    "renderMarkdownOnExit": {
+      "title": "Render markdown cells upon exit",
+      "description": "Whether to render markdown cells when the cursor moves out of them.",
+      "type": "boolean",
+      "default": false
+    },
     "rawCellConfig": {
       "title": "Raw Cell Configuration",
       "description": "The configuration for all raw cells; it will override the CodeMirror default configuration.",

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -368,397 +368,284 @@
   "jupyter.lab.shortcuts": [
     {
       "command": "notebook:change-cell-to-code",
-      "keys": [
-        "Y"
-      ],
+      "keys": ["Y"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-1",
-      "keys": [
-        "1"
-      ],
+      "keys": ["1"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-2",
-      "keys": [
-        "2"
-      ],
+      "keys": ["2"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-3",
-      "keys": [
-        "3"
-      ],
+      "keys": ["3"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-4",
-      "keys": [
-        "4"
-      ],
+      "keys": ["4"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-5",
-      "keys": [
-        "5"
-      ],
+      "keys": ["5"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-6",
-      "keys": [
-        "6"
-      ],
+      "keys": ["6"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-markdown",
-      "keys": [
-        "M"
-      ],
+      "keys": ["M"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-raw",
-      "keys": [
-        "R"
-      ],
+      "keys": ["R"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:copy-cell",
-      "keys": [
-        "C"
-      ],
+      "keys": ["C"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:cut-cell",
-      "keys": [
-        "X"
-      ],
+      "keys": ["X"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:delete-cell",
-      "keys": [
-        "D",
-        "D"
-      ],
+      "keys": ["D", "D"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:enter-command-mode",
-      "keys": [
-        "Escape"
-      ],
+      "keys": ["Escape"],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {
       "command": "notebook:enter-command-mode",
-      "keys": [
-        "Ctrl M"
-      ],
+      "keys": ["Ctrl M"],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {
       "command": "notebook:access-previous-history-entry",
-      "keys": [
-        "Alt ArrowUp"
-      ],
+      "keys": ["Alt ArrowUp"],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {
       "command": "notebook:access-next-history-entry",
-      "keys": [
-        "Alt ArrowDown"
-      ],
+      "keys": ["Alt ArrowDown"],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {
       "command": "notebook:enter-edit-mode",
-      "keys": [
-        "Enter"
-      ],
+      "keys": ["Enter"],
       "selector": ".jp-Notebook.jp-mod-commandMode .jp-Cell:focus"
     },
     {
       "command": "notebook:extend-marked-cells-above",
-      "keys": [
-        "Shift ArrowUp"
-      ],
+      "keys": ["Shift ArrowUp"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:extend-marked-cells-above",
-      "keys": [
-        "Shift K"
-      ],
+      "keys": ["Shift K"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:extend-marked-cells-top",
-      "keys": [
-        "Shift Home"
-      ],
+      "keys": ["Shift Home"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:extend-marked-cells-below",
-      "keys": [
-        "Shift ArrowDown"
-      ],
+      "keys": ["Shift ArrowDown"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:extend-marked-cells-bottom",
-      "keys": [
-        "Shift End"
-      ],
+      "keys": ["Shift End"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:extend-marked-cells-below",
-      "keys": [
-        "Shift J"
-      ],
+      "keys": ["Shift J"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:insert-cell-above",
-      "keys": [
-        "A"
-      ],
+      "keys": ["A"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:insert-cell-below",
-      "keys": [
-        "B"
-      ],
+      "keys": ["B"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:merge-cells",
-      "keys": [
-        "Shift M"
-      ],
+      "keys": ["Shift M"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:merge-cell-above",
-      "keys": [
-        "Ctrl Backspace"
-      ],
+      "keys": ["Ctrl Backspace"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:merge-cell-below",
-      "keys": [
-        "Ctrl Shift M"
-      ],
+      "keys": ["Ctrl Shift M"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cursor-down",
-      "keys": [
-        "ArrowDown"
-      ],
+      "keys": ["ArrowDown"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cursor-down",
-      "keys": [
-        "J"
-      ],
+      "keys": ["J"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cursor-up",
-      "keys": [
-        "ArrowUp"
-      ],
+      "keys": ["ArrowUp"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cursor-up",
-      "keys": [
-        "K"
-      ],
+      "keys": ["K"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cursor-heading-above-or-collapse",
-      "keys": [
-        "ArrowLeft"
-      ],
+      "keys": ["ArrowLeft"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cursor-heading-below-or-expand",
-      "keys": [
-        "ArrowRight"
-      ],
+      "keys": ["ArrowRight"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:insert-heading-above",
-      "keys": [
-        "Shift A"
-      ],
+      "keys": ["Shift A"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:insert-heading-below",
-      "keys": [
-        "Shift B"
-      ],
+      "keys": ["Shift B"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:collapse-all-headings",
-      "keys": [
-        "Ctrl Shift ArrowLeft"
-      ],
+      "keys": ["Ctrl Shift ArrowLeft"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:expand-all-headings",
-      "keys": [
-        "Ctrl Shift ArrowRight"
-      ],
+      "keys": ["Ctrl Shift ArrowRight"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:paste-cell-below",
-      "keys": [
-        "V"
-      ],
+      "keys": ["V"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:redo-cell-action",
-      "keys": [
-        "Shift Z"
-      ],
+      "keys": ["Shift Z"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:run-cell",
-      "macKeys": [
-        "Ctrl Enter"
-      ],
+      "macKeys": ["Ctrl Enter"],
       "keys": [],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:run-cell",
-      "macKeys": [
-        "Ctrl Enter"
-      ],
+      "macKeys": ["Ctrl Enter"],
       "keys": [],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {
       "command": "notebook:run-cell",
-      "keys": [
-        "Accel Enter"
-      ],
+      "keys": ["Accel Enter"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:run-cell",
-      "keys": [
-        "Accel Enter"
-      ],
+      "keys": ["Accel Enter"],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {
       "command": "notebook:run-cell-and-insert-below",
-      "keys": [
-        "Alt Enter"
-      ],
+      "keys": ["Alt Enter"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:run-cell-and-insert-below",
-      "keys": [
-        "Alt Enter"
-      ],
+      "keys": ["Alt Enter"],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {
       "command": "notebook:run-in-console",
-      "keys": [
-        ""
-      ],
+      "keys": [""],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {
       "command": "notebook:run-cell-and-select-next",
-      "keys": [
-        "Shift Enter"
-      ],
+      "keys": ["Shift Enter"],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {
       "command": "viewmenu:line-numbering",
-      "keys": [
-        "Shift L"
-      ],
+      "keys": ["Shift L"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "viewmenu:match-brackets",
-      "keys": [
-        ""
-      ],
+      "keys": [""],
       "selector": ".jp-Notebook.jp-mod-commandMode"
     },
     {
       "command": "notebook:select-all",
-      "keys": [
-        "Accel A"
-      ],
+      "keys": ["Accel A"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:split-cell-at-cursor",
-      "keys": [
-        "Ctrl Shift -"
-      ],
+      "keys": ["Ctrl Shift -"],
       "selector": ".jp-Notebook.jp-mod-editMode"
     },
     {
       "command": "notebook:undo-cell-action",
-      "keys": [
-        "Z"
-      ],
+      "keys": ["Z"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:toggle-render-side-by-side-current",
-      "keys": [
-        "Shift R"
-      ],
+      "keys": ["Shift R"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cell-up",
-      "keys": [
-        "Ctrl Shift ArrowUp"
-      ],
+      "keys": ["Ctrl Shift ArrowUp"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:move-cell-down",
-      "keys": [
-        "Ctrl Shift ArrowDown"
-      ],
+      "keys": ["Ctrl Shift ArrowDown"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     }
   ],
@@ -803,11 +690,7 @@
       "title": "Default cell type",
       "description": "The default type (markdown, code, or raw) for new cells",
       "type": "string",
-      "enum": [
-        "code",
-        "markdown",
-        "raw"
-      ],
+      "enum": ["code", "markdown", "raw"],
       "default": "code"
     },
     "autoStartDefaultKernel": {
@@ -825,10 +708,7 @@
     "inputHistoryScope": {
       "type": "string",
       "default": "global",
-      "enum": [
-        "global",
-        "session"
-      ],
+      "enum": ["global", "session"],
       "title": "Input History Scope",
       "description": "Whether the line history for standard input (e.g. the ipdb prompt) should kept separately for different kernel sessions (`session`) or combined (`global`)."
     },
@@ -923,10 +803,7 @@
     "renderingLayout": {
       "title": "Rendering Layout",
       "description": "Global setting to define the rendering layout in notebooks. 'default' or 'side-by-side' are supported.",
-      "enum": [
-        "default",
-        "side-by-side"
-      ],
+      "enum": ["default", "side-by-side"],
       "default": "default"
     },
     "sideBySideLeftMarginOverride": {
@@ -951,11 +828,7 @@
     "windowingMode": {
       "title": "Windowing mode",
       "description": "'defer': Improve loading time - Wait for idle CPU cycles to attach out of viewport cells - 'full': Best performance with side effects - Attach to the DOM only cells in viewport - 'none': Worst performance without side effects - Attach all cells to the viewport",
-      "enum": [
-        "defer",
-        "full",
-        "none"
-      ],
+      "enum": ["defer", "full", "none"],
       "default": "full"
     },
     "accessKernelHistory": {

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1869,6 +1869,8 @@ function activateNotebookHandler(
     factory.notebookConfig = {
       enableKernelInitNotification: settings.get('enableKernelInitNotification')
         .composite as boolean,
+      renderMarkdownOnExit: settings.get('renderMarkdownOnExit')
+        .composite as boolean,
       showHiddenCellsButton: settings.get('showHiddenCellsButton')
         .composite as boolean,
       scrollPastEnd: settings.get('scrollPastEnd').composite as boolean,

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1869,7 +1869,7 @@ function activateNotebookHandler(
     factory.notebookConfig = {
       enableKernelInitNotification: settings.get('enableKernelInitNotification')
         .composite as boolean,
-      renderMarkdownOnExit: settings.get('renderMarkdownOnExit')
+      renderMarkdownOnCursorLeave: settings.get('renderMarkdownOnCursorLeave')
         .composite as boolean,
       showHiddenCellsButton: settings.get('showHiddenCellsButton')
         .composite as boolean,

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1869,7 +1869,7 @@ function activateNotebookHandler(
     factory.notebookConfig = {
       enableKernelInitNotification: settings.get('enableKernelInitNotification')
         .composite as boolean,
-      renderMarkdownOnCursorLeave: settings.get('renderMarkdownOnCursorLeave')
+      autoRenderMarkdownCells: settings.get('autoRenderMarkdownCells')
         .composite as boolean,
       showHiddenCellsButton: settings.get('showHiddenCellsButton')
         .composite as boolean,

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1190,9 +1190,9 @@ export namespace StaticNotebook {
     renderingLayout: RenderingLayout;
 
     /**
-     * Render markdown when the cursor leaves a markdown cell
+     * Automatically render markdown when the cursor leaves a markdown cell
      */
-    renderMarkdownOnCursorLeave: boolean;
+    autoRenderMarkdownCells: boolean;
 
     /**
      * Enable scrolling past the last cell
@@ -1248,7 +1248,7 @@ export namespace StaticNotebook {
     maxNumberOutputs: 50,
     showEditorForReadOnlyMarkdown: true,
     disableDocumentWideUndoRedo: true,
-    renderMarkdownOnCursorLeave: false,
+    autoRenderMarkdownCells: false,
     renderingLayout: 'default',
     sideBySideLeftMarginOverride: '10px',
     sideBySideRightMarginOverride: '10px',
@@ -1729,7 +1729,7 @@ export class Notebook extends StaticNotebook {
         cell.rendered = false;
       }
       if (
-        this.notebookConfig.renderMarkdownOnCursorLeave &&
+        this.notebookConfig.autoRenderMarkdownCells &&
         cellChanged &&
         oldCell instanceof MarkdownCell
       ) {

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1190,9 +1190,9 @@ export namespace StaticNotebook {
     renderingLayout: RenderingLayout;
 
     /**
-     * Render markdown cells when the cursor exits them
+     * Render markdown when the cursor leaves a markdown cell
      */
-    renderMarkdownOnExit: boolean;
+    renderMarkdownOnCursorLeave: boolean;
 
     /**
      * Enable scrolling past the last cell
@@ -1248,7 +1248,7 @@ export namespace StaticNotebook {
     maxNumberOutputs: 50,
     showEditorForReadOnlyMarkdown: true,
     disableDocumentWideUndoRedo: true,
-    renderMarkdownOnExit: false,
+    renderMarkdownOnCursorLeave: false,
     renderingLayout: 'default',
     sideBySideLeftMarginOverride: '10px',
     sideBySideRightMarginOverride: '10px',
@@ -1729,7 +1729,7 @@ export class Notebook extends StaticNotebook {
         cell.rendered = false;
       }
       if (
-        this.notebookConfig.renderMarkdownOnExit &&
+        this.notebookConfig.renderMarkdownOnCursorLeave &&
         cellChanged &&
         oldCell instanceof MarkdownCell
       ) {

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1190,6 +1190,11 @@ export namespace StaticNotebook {
     renderingLayout: RenderingLayout;
 
     /**
+     * Render markdown cells when the cursor exits them
+     */
+    renderMarkdownOnExit: boolean;
+
+    /**
      * Enable scrolling past the last cell
      */
     scrollPastEnd: boolean;
@@ -1243,6 +1248,7 @@ export namespace StaticNotebook {
     maxNumberOutputs: 50,
     showEditorForReadOnlyMarkdown: true,
     disableDocumentWideUndoRedo: true,
+    renderMarkdownOnExit: false,
     renderingLayout: 'default',
     sideBySideLeftMarginOverride: '10px',
     sideBySideRightMarginOverride: '10px',
@@ -1704,6 +1710,7 @@ export class Notebook extends StaticNotebook {
     }
 
     this._activeCellIndex = newValue;
+    const oldCell = this.widgets[oldValue] ?? null;
     const cell = this.widgets[newValue] ?? null;
     (this.layout as NotebookWindowedLayout).activeCell = cell;
     const cellChanged = cell !== this._activeCell;
@@ -1717,9 +1724,19 @@ export class Notebook extends StaticNotebook {
       this._activeCellChanged.emit(cell);
     }
 
-    if (this.mode === 'edit' && cell instanceof MarkdownCell) {
-      cell.rendered = false;
+    if (this.mode === 'edit') {
+      if (cell instanceof MarkdownCell) {
+        cell.rendered = false;
+      }
+      if (
+        this.notebookConfig.renderMarkdownOnExit &&
+        cellChanged &&
+        oldCell instanceof MarkdownCell
+      ) {
+        oldCell.rendered = true;
+      }
     }
+
     this._ensureFocus();
     if (newValue === oldValue) {
       return;

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -808,7 +808,7 @@ describe('@jupyter/notebook', () => {
         expect(widget.activeCell).toBe(widget.widgets[1]);
       });
 
-      it('should render a markdown cell when moving active cells if renderMarkdownOnCursorLeave is true', () => {
+      it('should render a markdown cell when moving active cells if autoRenderMarkdownCells is true', () => {
         const widget = createActiveWidget();
         Widget.attach(widget, document.body);
         MessageLoop.sendMessage(widget, Widget.Msg.ActivateRequest);
@@ -825,7 +825,7 @@ describe('@jupyter/notebook', () => {
         // Turn on rendering of markdown cells when exiting
         widget.notebookConfig = {
           ...widget.notebookConfig,
-          renderMarkdownOnCursorLeave: true
+          autoRenderMarkdownCells: true
         };
 
         // Exiting should trigger rendering of the old cell

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -807,6 +807,31 @@ describe('@jupyter/notebook', () => {
         widget.activeCellIndex = 1;
         expect(widget.activeCell).toBe(widget.widgets[1]);
       });
+
+      it('should render a markdown cell when moving active cells if renderMarkdownOnExit is true', () => {
+        const widget = createActiveWidget();
+        Widget.attach(widget, document.body);
+        MessageLoop.sendMessage(widget, Widget.Msg.ActivateRequest);
+        widget.model!.sharedModel.insertCell(0, {
+          cell_type: 'markdown',
+          source: '# Hello'
+        }); // Should be rendered with content.
+        const child = widget.widgets[0] as MarkdownCell;
+        expect(child.rendered).toBe(true);
+        widget.activeCellIndex = 0;
+        widget.mode = 'edit';
+        expect(child.rendered).toBe(false);
+
+        // Turn on rendering of markdown cells when exiting
+        widget.notebookConfig = {
+          ...widget.notebookConfig,
+          renderMarkdownOnExit: true
+        };
+
+        // Exiting should trigger rendering of the old cell
+        widget.activeCellIndex = 1;
+        expect(child.rendered).toBe(true);
+      });
     });
 
     describe('#activeCell', () => {

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -808,7 +808,7 @@ describe('@jupyter/notebook', () => {
         expect(widget.activeCell).toBe(widget.widgets[1]);
       });
 
-      it('should render a markdown cell when moving active cells if renderMarkdownOnExit is true', () => {
+      it('should render a markdown cell when moving active cells if renderMarkdownOnCursorLeave is true', () => {
         const widget = createActiveWidget();
         Widget.attach(widget, document.body);
         MessageLoop.sendMessage(widget, Widget.Msg.ActivateRequest);
@@ -825,7 +825,7 @@ describe('@jupyter/notebook', () => {
         // Turn on rendering of markdown cells when exiting
         widget.notebookConfig = {
           ...widget.notebookConfig,
-          renderMarkdownOnExit: true
+          renderMarkdownOnCursorLeave: true
         };
 
         // Exiting should trigger rendering of the old cell


### PR DESCRIPTION
## References

Closes #16980.

## Code changes

This PR adds a configuration setting to render markdown cells when the cursor exits the cell. This is turned off by default, preserving present behavior.

When enabled, a user who enters a markdown cell with their cursor will see it become editable, showing codemirror. Exiting the cell with the cursor will trigger rendering of the cell. A test was added to ensure this behavior works as described.

## User-facing changes

[output.webm](https://github.com/user-attachments/assets/5b5f4f7e-9270-4b71-a82b-7a6ae217a0da)

## Backwards-incompatible changes

None. This PR preserves current behavior unless the user enables it.
