### PR TITLE
Fix/17011-ai-completion-skip-completion

### DIFF
--- a/packages/completer/test/inline.spec.ts
+++ b/packages/completer/test/inline.spec.ts
@@ -5,7 +5,7 @@ import {
   IInlineCompletionProvider,
   InlineCompleter
 } from '@jupyterlab/completer';
-import { CodeEditorWrapper } from '@jupyterlab/codeeditor';
+import { type CodeEditor, CodeEditorWrapper } from '@jupyterlab/codeeditor';
 import { nullTranslator } from '@jupyterlab/translation';
 import { framePromise, simulate } from '@jupyterlab/testing';
 import { Signal } from '@lumino/signaling';
@@ -13,6 +13,12 @@ import { createEditorWidget } from '@jupyterlab/completer/lib/testutils';
 import { Widget } from '@lumino/widgets';
 import { MessageLoop } from '@lumino/messaging';
 import { Doc, Text } from 'yjs';
+import type {
+  CellChange,
+  FileChange,
+  ISharedText,
+  SourceChange
+} from '@jupyter/ydoc';
 
 const GHOST_TEXT_CLASS = 'jp-GhostText';
 const STREAMING_INDICATOR_CLASS = 'jp-GhostText-streamingIndicator';
@@ -85,6 +91,33 @@ describe('completer/inline', () => {
         expect(editorWidget.editor.model.sharedModel.source).toBe(
           'suggestion a'
         );
+      });
+
+      it('should set the cursor position at the same time as the completion suggestion', () => {
+        model.setCompletions({
+          items: suggestionsAbc
+        });
+        let editorPosition: CodeEditor.IPosition = { line: 0, column: 0 };
+        const onContentChange = (
+          str: ISharedText,
+          changed: SourceChange | CellChange | FileChange
+        ) => {
+          if (changed.sourceChange) {
+            editorPosition = editorWidget.editor.getCursorPosition();
+          }
+        };
+        editorWidget.editor.model.sharedModel.changed.connect(onContentChange);
+        try {
+          completer.accept();
+        } finally {
+          editorWidget.editor.model.sharedModel.changed.disconnect(
+            onContentChange
+          );
+        }
+        expect(editorPosition).toEqual({
+          line: 0,
+          column: 12
+        });
       });
     });
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #17011
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Apply inline completion suggestion and cursor position update in the same codemirror transaction to avoid document change listener react with a wrong editor position.

This is therefore done using codemirror mechanism and not the shared model.

> I checked that the changes are still applied as single change for the undo manager.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Continuous inline completion works as expected.
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None