### PR TITLE
Focus terminal after copy and paste operations

### DIFF
--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -452,6 +452,8 @@ function addCommands(
 
       if (text) {
         Clipboard.copyToSystem(text);
+        // Focus the widget to ensure user can continue typing
+        widget.activate();
       }
     },
     isEnabled: () => {
@@ -490,6 +492,8 @@ function addCommands(
       if (clipboardData) {
         // Paste data to the terminal
         widget.paste(clipboardData);
+        // Focus the widget to ensure user can continue typing
+        widget.activate();
       }
     },
     isEnabled: () => Boolean(isEnabled() && tracker.currentWidget?.content),


### PR DESCRIPTION
## References

Fixes #17095 

## Code changes

Calls `widget.activate()` after copy/paste. This is because opening the context menu blurs the terminal.

## User-facing changes

Less user distraction when using terminal as they can type after pasting (or copying)

## Backwards-incompatible changes

None