### PR TITLE
Fix background of the popup toolbar

### DIFF
--- a/packages/ui-components/style/toolbar.css
+++ b/packages/ui-components/style/toolbar.css
@@ -85,7 +85,7 @@ button.jp-ToolbarButtonComponent .jp-ToolbarButtonComponent-label {
   flex-shrink: 1;
 }
 
-.jp-Toolbar-responsive-popup {
+.jp-Toolbar-responsive-popup.jp-ThemedContainer {
   position: absolute;
   height: fit-content;
   border-bottom: var(--jp-border-width) solid var(--jp-toolbar-border-color);


### PR DESCRIPTION

## References

Fixes #17096 

## Code changes

Increases specificity of the toolbar rules.

## User-facing changes

Popup toolbar is in the right color again.

| Before | After |
|--|--|
| ![Screenshot from 2024-12-18 10-49-59](https://github.com/user-attachments/assets/b824cc58-c10a-4388-a81a-d15f8c949d4d) | ![Screenshot from 2024-12-18 10-49-33](https://github.com/user-attachments/assets/4344a1b7-4539-4c60-bd42-ee1e505472b9) |


## Backwards-incompatible changes

None
