### PR TITLE
Update docs to include export and import functionality for overrides.json

### DIFF
--- a/docs/source/user/directories.rst
+++ b/docs/source/user/directories.rst
@@ -234,6 +234,12 @@ example, if the :ref:`application_directory` is
     }
   }
 
+JupyterLab also allows you to **export** and **import** an ``overrides.json`` file
+directly through the interface. You can generate an ``overrides.json`` file based
+on your current customized settings by clicking the **Export** button in the **Settings Editor**
+Similarly, you can use the **Import** button to apply an existing ``overrides.json`` file.
+This makes it easier to back up, share, or reuse your configuration.
+
 .. _build_configjson:
 
 build_config.json


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
#17084 

## Description

This PR updates the documentation to highlight the newly added feature that allows users to export and import the overrides.json file through the JupyterLab interface.

Please let me know if further improvements are needed or if the information should be placed in different section with greater details.