### PR TITLE
Use bare string `proxies` parameter for `httpx`<0.28

### DIFF
--- a/jupyterlab/extensions/pypi.py
+++ b/jupyterlab/extensions/pypi.py
@@ -62,21 +62,26 @@ https_proxy_url = (
 _httpx_version = Version(httpx.__version__)
 _httpx_client_args = {}
 
-proxies = None
 xmlrpc_transport_override = None
 
 if http_proxy_url:
     http_proxy = urlparse(http_proxy_url)
     proxy_host, _, proxy_port = http_proxy.netloc.partition(":")
 
-    proxies = {
-        "http://": httpx.AsyncHTTPTransport(proxy=http_proxy_url),
-        "https://": httpx.AsyncHTTPTransport(proxy=https_proxy_url),
-    }
-
-    _httpx_client_args = {
-        ("mounts" if _httpx_version >= Version("0.28.0") else "proxies"): proxies,
-    }
+    if _httpx_version >= Version("0.28.0"):
+        _httpx_client_args = {
+            "mounts": {
+                "http://": httpx.AsyncHTTPTransport(proxy=http_proxy_url),
+                "https://": httpx.AsyncHTTPTransport(proxy=https_proxy_url),
+            }
+        }
+    else:
+        _httpx_client_args = {
+            "proxies": {
+                "http://": http_proxy_url,
+                "https://": https_proxy_url,
+            }
+        }
 
     xmlrpc_transport_override = ProxiedTransport()
     xmlrpc_transport_override.set_proxy(proxy_host, proxy_port)


### PR DESCRIPTION
## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->
- fix #17110
- follow-up to #17041
- follow-up to #17058

## Code changes

Use bare string `proxies` parameter for `httpx`<0.28
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Proxy should work
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
