### PR TITLE
Fix sanitizer call in ToC if html data is array of strings

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1312,9 +1312,13 @@ export class CodeCell extends Cell<ICodeCellModel> {
 
         // Parse HTML output
         if (htmlType) {
+          let htmlData = m.data[htmlType] as string | string[];
+          if (typeof htmlData !== 'string') {
+            htmlData = htmlData.join('');
+          }
           headings.push(
             ...TableOfContentsUtils.getHTMLHeadings(
-              this._rendermime.sanitizer.sanitize(m.data[htmlType] as string)
+              this._rendermime.sanitizer.sanitize(htmlData)
             ).map(heading => {
               return {
                 ...heading,

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1314,7 +1314,7 @@ export class CodeCell extends Cell<ICodeCellModel> {
         if (htmlType) {
           let htmlData = m.data[htmlType] as string | string[];
           if (typeof htmlData !== 'string') {
-            htmlData = htmlData.join('');
+            htmlData = htmlData.join('\n');
           }
           headings.push(
             ...TableOfContentsUtils.getHTMLHeadings(

--- a/packages/cells/test/widget.spec.ts
+++ b/packages/cells/test/widget.spec.ts
@@ -546,6 +546,27 @@ describe('cells/widget', () => {
       });
     });
 
+    describe('#headings', () => {
+      it('get headings with string[]', () => {
+        const modelheadings = new CodeCellModel();
+        const widget = new CodeCell({
+          contentFactory: NBTestUtils.createCodeCellFactory(),
+          model: modelheadings,
+          rendermime
+        });
+        widget.initializeState();
+        widget.model.outputs.add({
+          output_type: 'display_data',
+          data: {
+            'text/html': ['Some ', ' thing']
+          },
+          metadata: {}
+        });
+        // try if headings got a problem with multi line html
+        expect(widget.headings).toEqual([]);
+      });
+    });
+
     describe('#outputArea', () => {
       it('should be the output area used by the cell', () => {
         const widget = new CodeCell({

--- a/packages/cells/test/widget.spec.ts
+++ b/packages/cells/test/widget.spec.ts
@@ -547,7 +547,7 @@ describe('cells/widget', () => {
     });
 
     describe('#headings', () => {
-      it('get headings with string[]', () => {
+      it('should not throw when outputs contain an array of strings', () => {
         const modelheadings = new CodeCellModel();
         const widget = new CodeCell({
           contentFactory: NBTestUtils.createCodeCellFactory(),


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes https://github.com/jupyterlab/jupyterlab/issues/16856

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
If the HTML data is an array of strings (e.g. as plotly generates it), the data is joined).

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->
No.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
No.
