### PR TITLE
Respect query argument in `settingeditor:open` when settings editor is already open

### DIFF
--- a/galata/test/jupyterlab/settings.test.ts
+++ b/galata/test/jupyterlab/settings.test.ts
@@ -5,7 +5,6 @@ import { IJupyterLabPageFixture, test } from '@jupyterlab/galata';
 import { expect, Locator } from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
-import { LogConsoleHelper } from '../../lib/helpers';
 
 test('Open the settings editor with a specific search query', async ({
   page

--- a/galata/test/jupyterlab/settings.test.ts
+++ b/galata/test/jupyterlab/settings.test.ts
@@ -34,7 +34,7 @@ test('Open the settings editor with a specific search query', async ({
   expect(await settingsPanel.screenshot()).toMatchSnapshot(
     'settings-panel.png'
   );
-  
+
   await page.evaluate(async () => {
     await window.jupyterapp.commands.execute('settingeditor:open', {
       query: 'CodeMirror'
@@ -42,7 +42,6 @@ test('Open the settings editor with a specific search query', async ({
   });
 
   await expect(page.locator('.jp-PluginList-entry')).toHaveCount(1);
-
 });
 
 test.describe('change font-size', () => {

--- a/galata/test/jupyterlab/settings.test.ts
+++ b/galata/test/jupyterlab/settings.test.ts
@@ -31,9 +31,11 @@ test('Open the settings editor with a specific search query', async ({
 
   const settingsPanel = page.locator('.jp-SettingsPanel');
 
-  expect(await settingsPanel.screenshot()).toMatchSnapshot(
+  expect.soft(await settingsPanel.screenshot()).toMatchSnapshot(
     'settings-panel.png'
   );
+  // Test that new query takes effect
+  await expect(page.locator('.jp-PluginList-entry')).toHaveCount(0);
 
   await page.evaluate(async () => {
     await window.jupyterapp.commands.execute('settingeditor:open', {

--- a/galata/test/jupyterlab/settings.test.ts
+++ b/galata/test/jupyterlab/settings.test.ts
@@ -31,9 +31,9 @@ test('Open the settings editor with a specific search query', async ({
 
   const settingsPanel = page.locator('.jp-SettingsPanel');
 
-  expect.soft(await settingsPanel.screenshot()).toMatchSnapshot(
-    'settings-panel.png'
-  );
+  expect
+    .soft(await settingsPanel.screenshot())
+    .toMatchSnapshot('settings-panel.png');
   // Test that new query takes effect
   await expect(page.locator('.jp-PluginList-entry')).toHaveCount(0);
 

--- a/galata/test/jupyterlab/settings.test.ts
+++ b/galata/test/jupyterlab/settings.test.ts
@@ -42,7 +42,7 @@ test('Open the settings editor with a specific search query', async ({
     });
   });
 
-  await expect(page.locator('.jp-SettingsForm')).toHaveCount(2);
+  await expect(page.locator('.jp-PluginList-entry')).toHaveCount(1);
 
 });
 

--- a/galata/test/jupyterlab/settings.test.ts
+++ b/galata/test/jupyterlab/settings.test.ts
@@ -5,6 +5,7 @@ import { IJupyterLabPageFixture, test } from '@jupyterlab/galata';
 import { expect, Locator } from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
+import { LogConsoleHelper } from '../../lib/helpers';
 
 test('Open the settings editor with a specific search query', async ({
   page
@@ -34,6 +35,15 @@ test('Open the settings editor with a specific search query', async ({
   expect(await settingsPanel.screenshot()).toMatchSnapshot(
     'settings-panel.png'
   );
+  
+  await page.evaluate(async () => {
+    await window.jupyterapp.commands.execute('settingeditor:open', {
+      query: 'CodeMirror'
+    });
+  });
+
+  await expect(page.locator('.jp-SettingsForm')).toHaveCount(2);
+
 });
 
 test.describe('change font-size', () => {

--- a/galata/test/jupyterlab/settings.test.ts
+++ b/galata/test/jupyterlab/settings.test.ts
@@ -35,15 +35,21 @@ test('Open the settings editor with a specific search query', async ({
     .soft(await settingsPanel.screenshot())
     .toMatchSnapshot('settings-panel.png');
   // Test that new query takes effect
-  await expect(page.locator('.jp-PluginList-entry')).toHaveCount(0);
+  await expect(page.locator('.jp-PluginList-entry')).toHaveCount(1);
 
   await page.evaluate(async () => {
     await window.jupyterapp.commands.execute('settingeditor:open', {
       query: 'CodeMirror'
     });
   });
+  // wait for command to be executed
+  await page.waitForTimeout(1000);
+  const listEntry = await page
+    .locator('.jp-PluginList-entry-label-text')
+    .first();
+  const textContent = await listEntry.textContent();
 
-  await expect(page.locator('.jp-PluginList-entry')).toHaveCount(1);
+  expect(textContent).toBe('CodeMirror');
 });
 
 test.describe('change font-size', () => {

--- a/galata/test/jupyterlab/settings.test.ts
+++ b/galata/test/jupyterlab/settings.test.ts
@@ -25,9 +25,9 @@ test('Open the settings editor with a specific search query', async ({
 
   const pluginList = page.locator('.jp-PluginList');
 
-  expect(await pluginList.screenshot()).toMatchSnapshot(
-    'settings-plugin-list.png'
-  );
+  expect
+    .soft(await pluginList.screenshot())
+    .toMatchSnapshot('settings-plugin-list.png');
 
   const settingsPanel = page.locator('.jp-SettingsPanel');
 
@@ -43,9 +43,7 @@ test('Open the settings editor with a specific search query', async ({
     });
   });
   // wait for command to be executed
-  const fistListEntry = page
-    .locator('.jp-PluginList-entry-label-text')
-    .first();
+  const fistListEntry = page.locator('.jp-PluginList-entry-label-text').first();
 
   await expect(fistListEntry).toHaveText('CodeMirror');
 });

--- a/galata/test/jupyterlab/settings.test.ts
+++ b/galata/test/jupyterlab/settings.test.ts
@@ -43,13 +43,11 @@ test('Open the settings editor with a specific search query', async ({
     });
   });
   // wait for command to be executed
-  await page.waitForTimeout(1000);
-  const listEntry = await page
+  const fistListEntry = page
     .locator('.jp-PluginList-entry-label-text')
     .first();
-  const textContent = await listEntry.textContent();
 
-  expect(textContent).toBe('CodeMirror');
+  await expect(fistListEntry).toHaveText('CodeMirror');
 });
 
 test.describe('change font-size', () => {

--- a/packages/settingeditor-extension/src/index.ts
+++ b/packages/settingeditor-extension/src/index.ts
@@ -27,7 +27,7 @@ import {
   IFormRendererRegistry,
   launchIcon,
   Toolbar,
-  ToolbarButton,
+  ToolbarButton
 } from '@jupyterlab/ui-components';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import {
@@ -131,7 +131,7 @@ function activate(
       if (!tracker.currentWidget.isAttached) {
         shell.add(tracker.currentWidget, 'main', { type: 'Settings' });
       }
-      console.log("attach to settings")
+      console.log('attach to settings');
       shell.activateById(tracker.currentWidget.id);
       const settingsWidget = tracker.currentWidget.content as SettingsEditor;
       settingsWidget.updateQuery(args.query ?? '');

--- a/packages/settingeditor-extension/src/index.ts
+++ b/packages/settingeditor-extension/src/index.ts
@@ -131,7 +131,6 @@ function activate(
       if (!tracker.currentWidget.isAttached) {
         shell.add(tracker.currentWidget, 'main', { type: 'Settings' });
       }
-      console.log('attach to settings');
       shell.activateById(tracker.currentWidget.id);
       const settingsWidget = tracker.currentWidget.content as SettingsEditor;
       settingsWidget.updateQuery(args.query ?? '');

--- a/packages/settingeditor-extension/src/index.ts
+++ b/packages/settingeditor-extension/src/index.ts
@@ -27,7 +27,7 @@ import {
   IFormRendererRegistry,
   launchIcon,
   Toolbar,
-  ToolbarButton
+  ToolbarButton,
 } from '@jupyterlab/ui-components';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import {
@@ -126,12 +126,15 @@ function activate(
     });
   }
 
-  const openUi = async (args: { query: string }) => {
+  const openUi = async (args: { query?: string }) => {
     if (tracker.currentWidget && !tracker.currentWidget.isDisposed) {
       if (!tracker.currentWidget.isAttached) {
         shell.add(tracker.currentWidget, 'main', { type: 'Settings' });
       }
+      console.log("attach to settings")
       shell.activateById(tracker.currentWidget.id);
+      const settingsWidget = tracker.currentWidget.content as SettingsEditor;
+      settingsWidget.updateQuery(args.query ?? '');
       return;
     }
 

--- a/packages/settingeditor-extension/src/index.ts
+++ b/packages/settingeditor-extension/src/index.ts
@@ -132,7 +132,7 @@ function activate(
         shell.add(tracker.currentWidget, 'main', { type: 'Settings' });
       }
       shell.activateById(tracker.currentWidget.id);
-      const settingsWidget = tracker.currentWidget.content as SettingsEditor;
+      const settingsWidget = tracker.currentWidget.content;
       settingsWidget.updateQuery(args.query ?? '');
       return;
     }

--- a/packages/settingeditor-extension/src/index.ts
+++ b/packages/settingeditor-extension/src/index.ts
@@ -132,8 +132,9 @@ function activate(
         shell.add(tracker.currentWidget, 'main', { type: 'Settings' });
       }
       shell.activateById(tracker.currentWidget.id);
-      const settingsWidget = tracker.currentWidget.content;
-      settingsWidget.updateQuery(args.query ?? '');
+      if (args.query) {
+        tracker.currentWidget.content.updateQuery(args.query);
+      }
       return;
     }
 

--- a/packages/settingeditor/src/settingseditor.tsx
+++ b/packages/settingeditor/src/settingseditor.tsx
@@ -109,6 +109,11 @@ export class SettingsEditor extends SplitPanel {
     this._saveStateChange.emit(dirty ? 'started' : 'completed');
   }
 
+  /**
+   * Updates the filter of the plugin list.
+   *
+   * @param query The query to filter the plugin list
+   */
   updateQuery(query: string): void {
     this._list.setFilter(
       query ? updateFilterFunction(query, false, false) : null,

--- a/packages/settingeditor/src/settingseditor.tsx
+++ b/packages/settingeditor/src/settingseditor.tsx
@@ -12,6 +12,7 @@ import {
   IFormRendererRegistry,
   ReactWidget,
   UseSignal,
+  updateFilterFunction
 } from '@jupyterlab/ui-components';
 import { CommandRegistry } from '@lumino/commands';
 import { IDisposable } from '@lumino/disposable';
@@ -110,9 +111,7 @@ export class SettingsEditor extends SplitPanel {
   }
 
   updateQuery(query: string): void {
-    console.log("setting query")
-    this._list.setQuery(query);
-    console.log("finished updating query")
+    this._list.setFilter(query ? updateFilterFunction(query, false, false) : null, query);
   }
 
   /**

--- a/packages/settingeditor/src/settingseditor.tsx
+++ b/packages/settingeditor/src/settingseditor.tsx
@@ -11,7 +11,7 @@ import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import {
   IFormRendererRegistry,
   ReactWidget,
-  UseSignal
+  UseSignal,
 } from '@jupyterlab/ui-components';
 import { CommandRegistry } from '@lumino/commands';
 import { IDisposable } from '@lumino/disposable';
@@ -38,6 +38,7 @@ export class SettingsEditor extends SplitPanel {
       registry: options.registry,
       // Filters out a couple of plugins that take too long to load in the new settings editor.
       toSkip: options.toSkip
+
     });
     this._list = new PluginList({
       registry: options.registry,
@@ -106,6 +107,12 @@ export class SettingsEditor extends SplitPanel {
       this.title.className = this.title.className.replace('jp-mod-dirty', '');
     }
     this._saveStateChange.emit(dirty ? 'started' : 'completed');
+  }
+
+  updateQuery(query: string): void {
+    console.log("setting query")
+    this._list.setQuery(query);
+    console.log("finished updating query")
   }
 
   /**

--- a/packages/settingeditor/src/settingseditor.tsx
+++ b/packages/settingeditor/src/settingseditor.tsx
@@ -11,8 +11,8 @@ import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import {
   IFormRendererRegistry,
   ReactWidget,
-  UseSignal,
-  updateFilterFunction
+  updateFilterFunction,
+  UseSignal
 } from '@jupyterlab/ui-components';
 import { CommandRegistry } from '@lumino/commands';
 import { IDisposable } from '@lumino/disposable';
@@ -39,7 +39,6 @@ export class SettingsEditor extends SplitPanel {
       registry: options.registry,
       // Filters out a couple of plugins that take too long to load in the new settings editor.
       toSkip: options.toSkip
-
     });
     this._list = new PluginList({
       registry: options.registry,
@@ -111,7 +110,10 @@ export class SettingsEditor extends SplitPanel {
   }
 
   updateQuery(query: string): void {
-    this._list.setFilter(query ? updateFilterFunction(query, false, false) : null, query);
+    this._list.setFilter(
+      query ? updateFilterFunction(query, false, false) : null,
+      query
+    );
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Closes #16479 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Adds the ability for the function editor to update the PluginList Filter and calls on that functionality when openUI is called.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

Now if the settings editor is already open, when the `settingeditor:open` command is used with a query argument, the query argument will be respected.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

This adds an `updateQuery` parameter to `SettingsEditor` for updated the filter.
