### PR TITLE
Fix exposing `ISignal` instead of `Signal`

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -2397,11 +2397,19 @@ namespace Private {
   }
 
   export class RestorableSplitPanel extends SplitPanel {
-    updated: Signal<RestorableSplitPanel, void>;
-
+    /**
+     * Construct a new RestorableSplitPanel.
+     */
     constructor(options: SplitPanel.IOptions = {}) {
       super(options);
-      this.updated = new Signal(this);
+      this._updated = new Signal(this);
+    }
+
+    /**
+     * A signal emitted when the split panel is updated.
+     */
+    get updated(): ISignal<RestorableSplitPanel, void> {
+      return this._updated;
     }
 
     /**
@@ -2409,7 +2417,9 @@ namespace Private {
      */
     protected onUpdateRequest(msg: Message): void {
       super.onUpdateRequest(msg);
-      this.updated.emit();
+      this._updated.emit();
     }
+
+    private _updated: Signal<RestorableSplitPanel, void>;
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Looks like `RestorableSplitPanel` was exposing a `Signal` instead of `ISignal`.

Not a big deal since it's privately defined withing the shell. But we can likely still update it so it exposes an `ISignal` instead, to follow the rest of the code base.

## Code changes

Expose an `ISignal` instead of `Signal` from `RestorableSplitPanel`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None, since it's private.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
