### PR TITLE
Ensure context menu closes when clicking outside it in the minimap

### DIFF
--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -989,8 +989,6 @@ export class WindowedList<
   handleEvent(event: Event): void {
     switch (event.type) {
       case 'pointerdown':
-        event.preventDefault();
-        event.stopPropagation();
         this._evtPointerDown(event as PointerEvent);
         break;
       case 'scroll':

--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -990,6 +990,10 @@ export class WindowedList<
     switch (event.type) {
       case 'pointerdown':
         this._evtPointerDown(event as PointerEvent);
+        // Stop propagation of this event; a `mousedown` event will still
+        // be automatically dispatched and handled by the parent notebook
+        // (which will close any open context menu, etc.)
+        event.stopPropagation();
         break;
       case 'scroll':
         this.onScroll(event);

--- a/packages/ui-components/style/windowedlist.css
+++ b/packages/ui-components/style/windowedlist.css
@@ -23,6 +23,7 @@
 .jp-WindowedPanel-scrollbar {
   display: none;
   position: relative;
+  user-select: none;
 }
 
 .jp-WindowedPanel.jp-mod-virtual-scrollbar > .jp-WindowedPanel-scrollbar {


### PR DESCRIPTION
## References

Closes #16853.

## Code changes

This PR ensures the context menu closes if the user right-clicks somewhere, then left clicks in the minimap. Previously, the context menu would remain open.

Additionally, a css change now prevents users from selecting text in the minimap; see #16853 for a discussion.

Please let me know if a test is needed for this - I could add something that checks that the event correctly bubbles up, but in this case we are making the behavior of the context menu _more_ like the rest of jupyterlab, so should be covered by those tests.

## User-facing changes

This PR changes how the context menu behaves when clicking in the minimap; the behavior when clicking inside the minimap now matches the behavior when clicking anywhere outside the minimap.

[output.webm](https://github.com/user-attachments/assets/7464e17f-81c2-4fcd-90fc-4a855e592a66)

## Backwards-incompatible changes

None.
