### PR TITLE
Fix title for overscan count option

### DIFF
--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -755,7 +755,7 @@
       "default": false
     },
     "overscanCount": {
-      "title": "Number of cells to render outside de the viewport",
+      "title": "Number of cells to render outside the viewport",
       "description": "In 'full' windowing mode, this is the number of cells above and below the viewport.",
       "type": "number",
       "default": 1,


### PR DESCRIPTION
## References

It looks like the French preposition "de" found it's way into the codebase in https://github.com/jupyterlab/jupyterlab/pull/12554 and no one noticed for three years ;)

## Code changes

```diff
-      "title": "Number of cells to render outside de the viewport",
+      "title": "Number of cells to render outside the viewport",
```

## User-facing changes

As above

## Backwards-incompatible changes

None
