### PR TITLE
Stabilize cell height when scrolling

### DIFF
--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -831,6 +831,20 @@
       "enum": ["defer", "full", "none"],
       "default": "full"
     },
+    "cellHeightStabilization": {
+      "title": "Cell height stabilization",
+      "description": "Whether to pin height of the cells when scrolling to stabilize viewport (prevent jitter), and for how long since the last scroll event (in milliseconds).",
+      "type": "number",
+      "default": 750,
+      "minimum": 0
+    },
+    "assumeHeightStabilityAfter": {
+      "title": "Height stabilization sensitivity",
+      "description": "If cell height stabilization is enabled, how many milliseconds should pass since the last height measurement for the stabilization algorithm to be allowed to pin the cell height.",
+      "type": "number",
+      "default": 1000,
+      "minimum": 0
+    },
     "accessKernelHistory": {
       "title": "Kernel history access",
       "description": "Enable kernel history access from notebook cells. Enabling this allows you to scroll through kernel history from a given notebook cell.",

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1867,6 +1867,10 @@ function activateNotebookHandler(
 
     factory.editorConfig = { code, markdown, raw };
     factory.notebookConfig = {
+      assumeHeightStabilityAfter: settings.get('assumeHeightStabilityAfter')
+        .composite as number,
+      cellHeightStabilization: settings.get('cellHeightStabilization')
+        .composite as number,
       enableKernelInitNotification: settings.get('enableKernelInitNotification')
         .composite as boolean,
       autoRenderMarkdownCells: settings.get('autoRenderMarkdownCells')

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -211,14 +211,21 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
     const windowingActive =
       (options.notebookConfig?.windowingMode ??
         StaticNotebook.defaultNotebookConfig.windowingMode) === 'full';
+    const model = new NotebookViewModel(cells, {
+      overscanCount:
+        options.notebookConfig?.overscanCount ??
+        StaticNotebook.defaultNotebookConfig.overscanCount,
+      windowingActive
+    });
     super({
-      model: new NotebookViewModel(cells, {
-        overscanCount:
-          options.notebookConfig?.overscanCount ??
-          StaticNotebook.defaultNotebookConfig.overscanCount,
-        windowingActive
+      model,
+      layout: new NotebookWindowedLayout({
+        model,
+        cellHeightStabilization:
+          options.notebookConfig?.cellHeightStabilization,
+        assumeHeightStabilityAfter:
+          options.notebookConfig?.assumeHeightStabilityAfter
       }),
-      layout: new NotebookWindowedLayout(),
       renderer: options.renderer ?? WindowedList.defaultRenderer,
       scrollbar: false
     });
@@ -1138,6 +1145,18 @@ export namespace StaticNotebook {
    */
   export interface INotebookConfig {
     /**
+     * If cell height stabilization is enabled, how many milliseconds should pass since the
+     * last height measurement for the stabilization algorithm to be allowed to pin the cell height.
+     */
+    assumeHeightStabilityAfter?: number;
+
+    /**
+     * Whether to pin height of the cells when scrolling to stabilize viewport (prevent jitter),
+     * and for how long since the last scroll event (in milliseconds).
+     */
+    cellHeightStabilization?: number;
+
+    /**
      * The default type for new notebook cells.
      */
     defaultCell: nbformat.CellType;
@@ -1239,6 +1258,8 @@ export namespace StaticNotebook {
    * Default configuration options for notebooks.
    */
   export const defaultNotebookConfig: INotebookConfig = {
+    assumeHeightStabilityAfter: 1000,
+    cellHeightStabilization: 750,
     enableKernelInitNotification: false,
     showHiddenCellsButton: true,
     scrollPastEnd: true,


### PR DESCRIPTION
## References

- Fixes https://github.com/jupyterlab/jupyterlab/issues/16326
- Should also fix https://github.com/jupyter-book/jupyterlab-myst/issues/243

## Code changes

Adds `cellHeightStabilization` and `assumeHeightStabilityAfter` options:
- `cellHeightStabilization`: Whether to pin height of the cells when scrolling to stabilize viewport (prevent jitter), and for how long since the last scroll event (in milliseconds).
- `assumeHeightStabilityAfter`: If cell height stabilization is enabled, how many milliseconds should pass since the last height measurement for the stabilization algorithm to be allowed to pin the cell height

To be done:
- [ ] minimise public API additions (`widgetSizes` exposure/`_getCellIndex` method)
- [ ] confirm the default choices: 
   - [ ] should `assumeHeightStabilityAfter` be 5 seconds favouring some widgets rendering for up to seconds and less frequent output "unroll" animation, or should it be 1 second favouring more stability when scrolling but less frequent "unroll" animations?
  - [ ] what should `cellHeightStabilization` be? Ideally it is as large as to catch consecutive scroll events (i.e. >= interval between mouse scroll wheel steps, or mouse movements when using scrollbar), and as small as to minimise the time before the outputs are "unrolled" after the scroll stopped.

## User-facing changes

Scrolling is no longer jittery.

| Before | After |
|--|--|
| TBD | TBD |

## Backwards-incompatible changes

None
