### PR TITLE
Fix jupyverse installation instructions

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -108,7 +108,7 @@ You can install ``jupyverse`` with ``pip``:
 
 .. code:: bash
 
-    pip install jupyverse[auth,jupyterlab]
+    pip install "jupyverse[auth,jupyterlab]"
 
 or with ``conda``:
 

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -108,7 +108,7 @@ You can install ``jupyverse`` with ``pip``:
 
 .. code:: bash
 
-    pip install jupyverse[auth, jupyterlab]
+    pip install jupyverse[auth,jupyterlab]
 
 or with ``conda``:
 


### PR DESCRIPTION
```
$ python -m pip install -U jupyverse[auth, jupyterlab]
ERROR: Invalid requirement: 'jupyverse[auth,': Expected extra name after comma
    jupyverse[auth,
                   ^
```

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Docs
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
