### PR TITLE
Fix setter for `contentProviderId`

### DIFF
--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -498,7 +498,7 @@ export abstract class ABCWidgetFactory<
   get contentProviderId(): string | undefined {
     return this._contentProviderId;
   }
-  set contentProviderId(value: string) {
+  set contentProviderId(value: string | undefined) {
     if (this._contentProviderId && value !== this._contentProviderId) {
       throw Error(
         `Cannot change content provider on factory with an existing provider: ${this._contentProviderId}`


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

This should help fix the TypeScript build issue noticed in https://github.com/jupyter/notebook/pull/7559#issuecomment-2573550718

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/17092

## Code changes

Update setter for the docregistry `contentProviderId`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
