### PR TITLE
Fix emission of `lastCell` from notebook run actions

### DIFF
--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2396,7 +2396,7 @@ namespace Private {
     sessionDialogs?: ISessionContextDialogs,
     translator?: ITranslator
   ): Promise<boolean> {
-    const lastCell = cells[-1];
+    const lastCell = cells[cells.length - 1];
     notebook.mode = 'command';
 
     let initializingDialogShown = false;

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -1118,7 +1118,8 @@ describe('@jupyterlab/notebook', () => {
         let notebook: Notebook | null = null;
         let lastCell: Cell | null = null;
         NotebookActions.selectionExecuted.connect(async (_, args) => {
-          notebook, (lastCell = args);
+          notebook = args[0];
+          lastCell = args[1];
           emitted += 1;
         });
         const result = await NotebookActions.runCells(

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -1111,6 +1111,24 @@ describe('@jupyterlab/notebook', () => {
         expect(result).toBe(true);
         expect(widget.isSelected(widget.widgets[2])).toBe(true);
       });
+
+      it('should run the selected cells', async () => {
+        let emitted = 0;
+        const next = widget.widgets[2];
+        NotebookActions.selectionExecuted.connect(async (_, args) => {
+          const { notebook, lastCell } = args;
+          expect(notebook).not.toBe(null);
+          expect(lastCell).not.toBe(null);
+          emitted += 1;
+        });
+        const result = await NotebookActions.runCells(
+          widget,
+          [widget.widgets[1], widget.widgets[2]],
+          sessionContext
+        );
+        expect(result).toBe(true);
+        expect(emitted).toBe(2);
+      });
     });
 
     describe('#runAll()', () => {

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -1129,8 +1129,8 @@ describe('@jupyterlab/notebook', () => {
         );
         expect(result).toBe(true);
         expect(emitted).toBe(1);
-        expect(notebook).not.toBe(null);
-        expect(lastCell).not.toBe(null);
+        expect(notebook).toBeInstanceOf(Notebook);
+        expect(lastCell).toBeInstanceOf(Cell);
       });
     });
 

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -4,6 +4,7 @@
 import { ISessionContext, SessionContext } from '@jupyterlab/apputils';
 import { createSessionContext } from '@jupyterlab/apputils/lib/testutils';
 import {
+  Cell,
   CodeCell,
   ICodeCellModel,
   MarkdownCell,
@@ -1114,11 +1115,10 @@ describe('@jupyterlab/notebook', () => {
 
       it('should run the selected cells', async () => {
         let emitted = 0;
-        const next = widget.widgets[2];
+        let notebook: Notebook | null = null;
+        let lastCell: Cell | null = null;
         NotebookActions.selectionExecuted.connect(async (_, args) => {
-          const { notebook, lastCell } = args;
-          expect(notebook).not.toBe(null);
-          expect(lastCell).not.toBe(null);
+          notebook, (lastCell = args);
           emitted += 1;
         });
         const result = await NotebookActions.runCells(
@@ -1128,6 +1128,8 @@ describe('@jupyterlab/notebook', () => {
         );
         expect(result).toBe(true);
         expect(emitted).toBe(2);
+        expect(notebook).not.toBe(null);
+        expect(lastCell).not.toBe(null);
       });
     });
 

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -1128,7 +1128,7 @@ describe('@jupyterlab/notebook', () => {
           sessionContext
         );
         expect(result).toBe(true);
-        expect(emitted).toBe(2);
+        expect(emitted).toBe(1);
         expect(notebook).not.toBe(null);
         expect(lastCell).not.toBe(null);
       });

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -1118,8 +1118,8 @@ describe('@jupyterlab/notebook', () => {
         let notebook: Notebook | null = null;
         let lastCell: Cell | null = null;
         NotebookActions.selectionExecuted.connect(async (_, args) => {
-          notebook = args[0];
-          lastCell = args[1];
+          notebook = args.notebook;
+          lastCell = args.lastCell;
           emitted += 1;
         });
         const result = await NotebookActions.runCells(


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->
None

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Minor bugfix resolving issue in actions with accessing last notebook's cell. This PR e.g. enables NotebookActions.selectionExecuted to properly return the information about last cell.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->
None

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
