### PR TITLE
 banner "Your extensions may break with new releases of JupyterLab" position changed

### DIFF
--- a/docs/source/extension/extension_dev.rst
+++ b/docs/source/extension/extension_dev.rst
@@ -12,13 +12,6 @@ A JupyterLab extension is a package that contains a number of JupyterLab plugins
 
 See the sections below for more detailed information, or browse the rest of this page for an overview.
 
-.. warning::
-    Your extensions may break with new releases of JupyterLab. As noted in :ref:`versioning_notes`,
-    JupyterLab development and release cycles follow semantic versioning, so we recommend planning
-    your development process to account for possible future breaking changes that may disrupt users
-    of your extensions. Consider documenting your maintenance plans to users in your project, or
-    setting an upper bound on the version of JupyterLab your extension is compatible with in your
-    project's package metadata.
 
 .. toctree::
    :maxdepth: 1
@@ -79,6 +72,14 @@ A JupyterLab plugin is the basic unit of extensibility in JupyterLab. An extensi
 An extension can be published both as a source extension on NPM and as a prebuilt extension (e.g., published as a Python package). In some cases, system administrators may even choose to install a prebuilt extension by directly copying the prebuilt bundle to an appropriate directory, circumventing the need to create a Python package. If a source extension and a prebuilt extension with the same name are installed in JupyterLab, the prebuilt extension takes precedence.
 
 Because prebuilt extensions do not require a JupyterLab rebuild, they have a distinct advantage in multi-user systems where JupyterLab is installed at the system level. On such systems, only the system administrator has permissions to rebuild JupyterLab and install source extensions. Since prebuilt extensions can be installed at the per-user level, the per-environment level, or the system level, each user can have their own separate set of prebuilt extensions that are loaded dynamically in their browser on top of the system-wide JupyterLab.
+
+.. warning::
+    Your extensions may break with new releases of JupyterLab. As noted in :ref:`versioning_notes`,
+    JupyterLab development and release cycles follow semantic versioning, so we recommend planning
+    your development process to account for possible future breaking changes that may disrupt users
+    of your extensions. Consider documenting your maintenance plans to users in your project, or
+    setting an upper bound on the version of JupyterLab your extension is compatible with in your
+    project's package metadata.
 
 .. tip::
 

--- a/packages/shortcuts-extension/style/base.css
+++ b/packages/shortcuts-extension/style/base.css
@@ -68,7 +68,7 @@
 }
 
 .jp-mod-selected-InputText {
-  background-color: var(--jp-brand-color2);
+  background-color: var(--jp-brand-color3);
   overflow: hidden;
 }
 
@@ -228,7 +228,7 @@
 
 .jp-Shortcuts-Plus {
   opacity: 0;
-  background: var(--jp-brand-color2);
+  background: var(--jp-brand-color3);
   border-color: var(--jp-layout-color0);
   border-radius: var(--jp-border-radius);
   border-width: var(--jp-border-width);
@@ -239,7 +239,7 @@
 }
 
 .jp-Shortcuts-Plus:hover {
-  background: var(--jp-brand-color1);
+  background-color: var(--jp-brand-color2);
 }
 
 .jp-Shortcuts-Plus:active {

--- a/packages/shortcuts-extension/style/base.css
+++ b/packages/shortcuts-extension/style/base.css
@@ -68,7 +68,7 @@
 }
 
 .jp-mod-selected-InputText {
-  background-color: var(--jp-brand-color3);
+  background-color: var(--jp-brand-color2);
   overflow: hidden;
 }
 
@@ -228,7 +228,7 @@
 
 .jp-Shortcuts-Plus {
   opacity: 0;
-  background: var(--jp-brand-color3);
+  background: var(--jp-brand-color2);
   border-color: var(--jp-layout-color0);
   border-radius: var(--jp-border-radius);
   border-width: var(--jp-border-width);
@@ -239,7 +239,7 @@
 }
 
 .jp-Shortcuts-Plus:hover {
-  background-color: var(--jp-brand-color2);
+  background: var(--jp-brand-color1);
 }
 
 .jp-Shortcuts-Plus:active {


### PR DESCRIPTION


## References
#15099 


## Code changes

updated the extension_dev.rst file : changed banner positioning to improve UI

## User-facing changes

Before 
![Screenshot 2025-01-11 000413](https://github.com/user-attachments/assets/3b419045-872b-4e06-ac95-f27d713df046)

After 
![Screenshot 2025-01-11 000119](https://github.com/user-attachments/assets/bfe45dd4-04c4-412e-8ad5-2ad88b3ae676)


## Backwards-incompatible changes

None
