### PR TITLE
Fix read-only cells becoming editable on settings change

### DIFF
--- a/galata/test/jupyterlab/settings.test.ts
+++ b/galata/test/jupyterlab/settings.test.ts
@@ -410,3 +410,29 @@ test('Settings Import: Importing a JSON file applies the correct settings', asyn
 
   fs.unlinkSync(importFilePath);
 });
+
+test('Read-only cells should remain read-only after changing settings', async ({
+  page
+}) => {
+  await page.notebook.createNew();
+  await page.sidebar.close();
+  await page.notebook.setCell(0, 'code', '"test"');
+
+  // Set the cell to read-only using the Property Inspector
+  await page.menu.clickMenuItem('View>Property Inspector');
+  await page.locator('.jp-Collapse:has-text("Common Tools")').click();
+  await page
+    .locator('select:has-text("Editable")')
+    .selectOption({ label: 'Read-Only' });
+
+  // Change a notebook setting (kernel preference)
+  await page.notebook
+    .getToolbarItemLocator('kernelName')
+    .then(item => item?.click());
+  await page.locator('.jp-Dialog-checkbox').click();
+  await page.locator('.jp-Dialog-button:has-text("Select")').click();
+
+  // Assert the first cell is still read-only
+  const cell = page.locator('.jp-Notebook-cell').nth(0);
+  await expect(cell.locator('.jp-mod-readOnly')).toHaveCount(1);
+});

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -567,7 +567,7 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
   updateEditorConfig(v: Record<string, any>): void {
     this._editorConfig = { ...this._editorConfig, ...v };
     if (this.editor) {
-      this.editor.setOptions(this._editorConfig);
+      this.editor.setBaseOptions(this._editorConfig);
     }
   }
 

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -371,6 +371,11 @@ export namespace CodeEditor {
     setOptions(options: Record<string, any>): void;
 
     /**
+     * Set a base config options for the editor.
+     */
+    setBaseOptions(options: Record<string, any>): void;
+
+    /**
      * Inject an extension into the editor
      *
      * @alpha

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -221,6 +221,13 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
   }
 
   /**
+   * Set a base config options for the editor.
+   */
+  setBaseOptions(options: Record<string, any>): void {
+    this._configurator.setBaseOptions(options);
+  }
+
+  /**
    * Inject an extension into the editor
    *
    * @alpha

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -578,7 +578,16 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
     configurator: IExtensionsHandler,
     changes: Record<string, any>
   ): void {
-    configurator.reconfigureExtensions(this._editor, changes);
+    const definedChanges = Object.keys(changes).reduce<Record<string, any>>(
+      (agg, key) => {
+        if (changes[key] != undefined) {
+          agg[key] = changes[key];
+        }
+        return agg;
+      },
+      {}
+    );
+    configurator.reconfigureExtensions(this._editor, definedChanges);
     // when customStyles change and the editor is not initialized
     if (changes['customStyles'] && !changes['fontSize']) {
       // update the state to change the gutter height

--- a/packages/codemirror/src/extension.ts
+++ b/packages/codemirror/src/extension.ts
@@ -185,6 +185,7 @@ export class ExtensionsHandler
    * to `IExtensionsHandler.configChanged`.
    */
   setBaseOptions(options: Record<string, any>): void {
+    //Change values of baseConfig
     const changed = this._getChangedOptions(options, this._baseConfig);
     if (changed.length > 0) {
       this._baseConfig = options;
@@ -197,6 +198,12 @@ export class ExtensionsHandler
             return agg;
           }, {})
         );
+      }
+    }
+    //Chang values of config keys if present in options
+    for (const key of Object.keys(options)) {
+      if (key in this._config && this._config[key] != options[key]) {
+        this.setOption(key, options[key]);
       }
     }
   }

--- a/packages/codemirror/src/extension.ts
+++ b/packages/codemirror/src/extension.ts
@@ -185,7 +185,6 @@ export class ExtensionsHandler
    * to `IExtensionsHandler.configChanged`.
    */
   setBaseOptions(options: Record<string, any>): void {
-    console.log("In setBase Options!");
     const changed = this._getChangedOptions(options, this._baseConfig);
     if (changed.length > 0) {
       this._baseConfig = options;
@@ -810,7 +809,7 @@ export namespace EditorExtensionRegistry {
         default: [],
         factory: () =>
           createConfigurableExtension((value: number[]) =>
-            value.length > 0 ? rulers(value) : []
+            value?.length > 0 ? rulers(value) : []
           ),
         schema: {
           type: 'array',

--- a/packages/codemirror/src/extension.ts
+++ b/packages/codemirror/src/extension.ts
@@ -185,6 +185,7 @@ export class ExtensionsHandler
    * to `IExtensionsHandler.configChanged`.
    */
   setBaseOptions(options: Record<string, any>): void {
+    console.log("In setBase Options!");
     const changed = this._getChangedOptions(options, this._baseConfig);
     if (changed.length > 0) {
       this._baseConfig = options;
@@ -215,21 +216,7 @@ export class ExtensionsHandler
   setOptions(options: Record<string, any>): void {
     const changed = this._getChangedOptions(options, this._config);
     if (changed.length > 0) {
-      // Filter keys that are undefined in options and have been customized from the base configuration
-      const customizedKeys = changed.filter(
-        key =>
-          options[key] === undefined &&
-          this._config[key] !== this._baseConfig[key]
-      );
-      const customizedOptions = customizedKeys.reduce<Record<string, any>>(
-        (aggregated, key) => {
-          aggregated[key] = this._config[key];
-          return aggregated;
-        },
-        {}
-      );
-
-      this._config = { ...options, ...customizedOptions };
+      this._config = { ...options };
       this._configChanged.emit(
         changed.reduce<Record<string, any>>((agg, key) => {
           agg[key] = this._config[key] ?? this._baseConfig[key];

--- a/packages/codemirror/src/extension.ts
+++ b/packages/codemirror/src/extension.ts
@@ -185,7 +185,7 @@ export class ExtensionsHandler
    * to `IExtensionsHandler.configChanged`.
    */
   setBaseOptions(options: Record<string, any>): void {
-    //Change values of baseConfig
+    // Change values of baseConfig
     const changed = this._getChangedOptions(options, this._baseConfig);
     if (changed.length > 0) {
       this._baseConfig = options;
@@ -200,7 +200,7 @@ export class ExtensionsHandler
         );
       }
     }
-    //Chang values of config keys if present in options
+    // Change values of config keys if present in options
     for (const key of Object.keys(options)) {
       if (key in this._config && this._config[key] != options[key]) {
         this.setOption(key, options[key]);
@@ -816,7 +816,7 @@ export namespace EditorExtensionRegistry {
         default: [],
         factory: () =>
           createConfigurableExtension((value: number[]) =>
-            value?.length > 0 ? rulers(value) : []
+            value.length > 0 ? rulers(value) : []
           ),
         schema: {
           type: 'array',

--- a/packages/codemirror/src/extension.ts
+++ b/packages/codemirror/src/extension.ts
@@ -215,8 +215,21 @@ export class ExtensionsHandler
   setOptions(options: Record<string, any>): void {
     const changed = this._getChangedOptions(options, this._config);
     if (changed.length > 0) {
-      this._config = { ...options };
+      // Filter keys that are undefined in options and have been customized from the base configuration
+      const customizedKeys = changed.filter(
+        key =>
+          options[key] === undefined &&
+          this._config[key] !== this._baseConfig[key]
+      );
+      const customizedOptions = customizedKeys.reduce<Record<string, any>>(
+        (aggregated, key) => {
+          aggregated[key] = this._config[key];
+          return aggregated;
+        },
+        {}
+      );
 
+      this._config = { ...options, ...customizedOptions };
       this._configChanged.emit(
         changed.reduce<Record<string, any>>((agg, key) => {
           agg[key] = this._config[key] ?? this._baseConfig[key];

--- a/packages/codemirror/src/token.ts
+++ b/packages/codemirror/src/token.ts
@@ -92,6 +92,14 @@ export interface IExtensionsHandler extends IDisposable {
   setOptions(options: Record<string, any>): void;
 
   /**
+   * Set a base config options for the editor.
+   *
+   * You will need to reconfigure the editor extensions by listening
+   * to `IExtensionsHandler.configChanged`.
+   */
+  setBaseOptions(options: Record<string, any>): void;
+
+  /**
    * Returns the list of initial extensions of an editor.
    *
    * @returns The initial editor extensions


### PR DESCRIPTION
## References

Fixes #15514 

### Problem
Read-only cells became editable when modifying notebook settings. This occurred because keys like `readOnly` are only stored in the `config` but not in the cell's `editorConfig`. During config updates, these keys were returned by `getChanged` (as it returns modified keys and keys not present in new config but present in old config) and subsequently removed from the config (when new config is assigned to config), causing the `readOnly` property to be lost.

### Solution
Modified the implementation of `setOptions` to ensure that customized keys present in the config but missing from the cell's `editorConfig` are preserved in the config, preventing the loss of the `readOnly` property.