### PR TITLE
Click to Add cell expands to full width now on smaller screens

### DIFF
--- a/packages/notebook/style/notebookfooter.css
+++ b/packages/notebook/style/notebookfooter.css
@@ -37,3 +37,17 @@
     opacity: 1;
   }
 }
+
+@media (max-width: 760px) {
+  .jp-Notebook-footer {
+    margin-left: 28px;
+    width: calc(
+      100% -
+        (
+          var(--jp-cell-prompt-width) + var(--jp-cell-collapser-width) + 2 *
+            var(--jp-cell-padding) + 2 * var(--jp-notebook-padding) - 57.38px
+        )
+    );
+  }
+}
+

--- a/packages/notebook/style/notebookfooter.css
+++ b/packages/notebook/style/notebookfooter.css
@@ -45,9 +45,8 @@
       100% -
         (
           var(--jp-cell-prompt-width) + var(--jp-cell-collapser-width) + 2 *
-            var(--jp-cell-padding) + 2 * var(--jp-notebook-padding) - 57.38px
+            var(--jp-cell-padding) + 2 * var(--jp-notebook-padding) - 57.9px
         )
     );
   }
 }
-


### PR DESCRIPTION

## References
#16491 
## Code changes
added media query which will align the.jp-Notebook-footer to the correct place for screens with a size smaller than 760px. Margin-left is explicitly set to 28px to override the 87px Margin-left from the border-box styling of the.lm-widget. For maintaining the same width alignment with the cells above, the calculated width is subtracted by 57.38px. At the smaller screen sizes, this ensures that the footer perfectly matches the cell width.

## User-facing changes
**Before :**
![image](https://github.com/user-attachments/assets/0514fdb1-6ce6-49c3-9061-d250b41b00d8)

**After :** 
![image](https://github.com/user-attachments/assets/1047a5ed-0bee-4f6c-944e-0caece960038)


## Backwards-incompatible changes

NONE
