### PR TITLE
Remove `--subshell-console` flag

### DIFF
--- a/galata/jupyter_server_test_config.py
+++ b/galata/jupyter_server_test_config.py
@@ -5,7 +5,6 @@ from jupyterlab.galata import configure_jupyter_server
 
 configure_jupyter_server(c)
 c.LabApp.dev_mode = True
-c.LabApp.subshell_console = True
 
 # Uncomment to set server log level to debug level
 # c.ServerApp.log_level = "DEBUG"

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -497,10 +497,6 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
         {"LabApp": {"custom_css": True}},
         "Load custom CSS in template html files. Default is False",
     )
-    flags["subshell-console"] = (
-        {"LabApp": {"subshell_console": True}},
-        "Enable subshell console for kernels that support subshells.",
-    )
 
     subcommands = {
         "build": (LabBuildApp, LabBuildApp.description.splitlines()[0]),
@@ -625,14 +621,6 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
         help="""A callable class that receives the current version at instantiation and calling it must return asynchronously a string indicating which version is available and how to install or None if no update is available. The string supports Markdown format.""",
     )
 
-    subshell_console = Bool(
-        False,
-        config=True,
-        help="""Enable subshell console for kernels that support subshells.
-        See https://github.com/jupyter/enhancement-proposals/pull/91
-        """,
-    )
-
     @default("app_dir")
     def _default_app_dir(self):
         app_dir = get_app_dir()
@@ -748,7 +736,6 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
         page_config["exposeAppInBrowser"] = self.expose_app_in_browser
         page_config["quitButton"] = self.serverapp.quit_button
         page_config["allow_hidden_files"] = self.serverapp.contents_manager.allow_hidden
-        page_config["subshellConsole"] = self.subshell_console
 
         # Client-side code assumes notebookVersion is a JSON-encoded string
         page_config["notebookVersion"] = json.dumps(jpserver_version_info)

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1418,10 +1418,7 @@ function activateCodeConsole(
     isVisible: () => {
       const kernel =
         tracker.currentWidget?.context.sessionContext.session?.kernel;
-      return (
-        (kernel?.supportsSubshells ?? false) &&
-        PageConfig.getOption('subshellConsole').toLowerCase() === 'true'
-      );
+      return kernel?.supportsSubshells ?? false;
     }
   });
 


### PR DESCRIPTION
This PR removes the `--subshell-console` config flag added in #16963.

Closes #17146, which is still open to debate.