### PR TITLE
Fix: Add scrollbar to File menu section in JupyterLab 4.3.x

### DIFF
--- a/packages/application/style/menus.css
+++ b/packages/application/style/menus.css
@@ -29,8 +29,6 @@
 
 .lm-MenuBar-menu.jp-ThemedContainer {
   top: calc(-2 * var(--jp-border-width));
-  scrollbar-width: none;
-  -ms-overflow-style: none;
   overflow: auto;
   background:
     linear-gradient(var(--jp-layout-color0) 30%, rgba(0, 0, 0, 0)) center top,
@@ -63,10 +61,6 @@
     100% 14px,
     100% 14px;
   background-attachment: local, local, scroll, scroll;
-}
-
-.lm-MenuBar-menu.jp-ThemedContainer::-webkit-scrollbar {
-  display: none;
 }
 
 .lm-MenuBar-item {


### PR DESCRIPTION

## References

- Fixes #17083 

## Code changes

- Adjusted the CSS to ensure the scrollbar is visible and functional, providing a smoother user experience in JupyterLab 4.3.x

## User-facing changes

- The File menu now includes a scrollbar when its content exceeds the visible area, allowing users to scroll through all available options.
- This resolves the issue where the menu was truncated without a scrollbar, forcing users to rely on touchpad gestures or mouse wheel scroll.

Before - 
<img width="1044" alt="before" src="https://github.com/user-attachments/assets/9ec329f4-65d5-47ca-9c86-02b3f9c692c0" />

After - 
<img width="950" alt="after" src="https://github.com/user-attachments/assets/999bc8ea-9eae-4009-a831-ae6f8519a2a8" />


## Backwards-incompatible changes

None
