### PR TITLE
Bump `@codemirror/lang-python` to provide match-case indentation

### DIFF
--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -47,7 +47,7 @@
     "@codemirror/lang-json": "^6.0.1",
     "@codemirror/lang-markdown": "^6.3.1",
     "@codemirror/lang-php": "^6.0.1",
-    "@codemirror/lang-python": "^6.1.6",
+    "@codemirror/lang-python": "^6.1.7",
     "@codemirror/lang-rust": "^6.0.1",
     "@codemirror/lang-sql": "^6.8.0",
     "@codemirror/lang-wast": "^6.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1529,16 +1529,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemirror/lang-python@npm:^6.1.6":
-  version: 6.1.6
-  resolution: "@codemirror/lang-python@npm:6.1.6"
+"@codemirror/lang-python@npm:^6.1.7":
+  version: 6.1.7
+  resolution: "@codemirror/lang-python@npm:6.1.7"
   dependencies:
     "@codemirror/autocomplete": ^6.3.2
     "@codemirror/language": ^6.8.0
     "@codemirror/state": ^6.0.0
     "@lezer/common": ^1.2.1
     "@lezer/python": ^1.1.4
-  checksum: eb1faabd332bb95d0f3e227eb19ac5a31140cf238905bbe73e061040999f5680a012f9145fb3688bc2fcbb1908c957511edc8eeb8a9aa88d27d4fa55ad451e95
+  checksum: a3015abf8035b0c30e5bfc1e8b1bd43c5d9d4ec908b9c3f1e293e755256b41f6e48ad19b2e39c9f91c67264b9061235d9dc293acfe39175d4c2edaab951ceae2
   languageName: node
   linkType: hard
 
@@ -2651,7 +2651,7 @@ __metadata:
     "@codemirror/lang-json": ^6.0.1
     "@codemirror/lang-markdown": ^6.3.1
     "@codemirror/lang-php": ^6.0.1
-    "@codemirror/lang-python": ^6.1.6
+    "@codemirror/lang-python": ^6.1.7
     "@codemirror/lang-rust": ^6.0.1
     "@codemirror/lang-sql": ^6.8.0
     "@codemirror/lang-wast": ^6.0.2


### PR DESCRIPTION
## References

Solved #17177

## Code changes

Only bumping codemirror/lang-python dependency.

## User-facing changes

Magically users' match-case codes get indentation automatically.

## Backwards-incompatible changes

Nope.

## Notes on testing
I've done local build and launched dev Jupyterlab to make sure this works as expected. Steps are:
1. `pip install -e ".[dev,test]"`
2. `jlpm install && jlpm run build`
3. `jlpm run update:dependency @codemirror/lang-python ^6.1.7`
4. `jlpm run integrity && jlpm run build`
5. `jupyter lab --dev-mode --watch`.



