### PR TITLE
Dialog box removed

### DIFF
--- a/packages/apputils/style/dialog.css
+++ b/packages/apputils/style/dialog.css
@@ -114,16 +114,17 @@ button.jp-Dialog-close-button {
 .jp-Dialog-footer {
   display: flex;
   flex-direction: row;
-  justify-content: flex-end;
+  justify-content: flex-start;
   align-items: center;
   flex: 0 0 auto;
-  margin-left: -12px;
-  margin-right: -12px;
+  margin-left: 0px;
+  margin-right: 51px;
   padding: 12px;
 }
 
 .jp-Dialog-checkbox {
   padding-right: 5px;
+  display: none;
 }
 
 .jp-Dialog-spacer {


### PR DESCRIPTION
## References
#16917 

## Code changes

Removed the "Rename Untitled on First Save" dialog entirely.

## User-facing changes
Before 
![image](https://github.com/user-attachments/assets/5be08313-83fd-4d4d-b2a7-77c5b0e5fd3b)

After 
![image](https://github.com/user-attachments/assets/e313354e-1073-4668-9ce8-8b8e0d7d4970)

Many popular IDEs and modern applications take a straightforward approach to saving, making it easier for users to focus on their work without getting interrupted by unnecessary dialog boxes which may be distracting and may affect UI
 If users don’t have to interpret unclear dialog
 options or make extra decisions, it simplifies their experience.

## Backwards-incompatible changes
None
