### PR TITLE
Fix for issue preventing cell metadata removal

### DIFF
--- a/packages/notebook-extension/src/tool-widgets/metadataEditorFields.tsx
+++ b/packages/notebook-extension/src/tool-widgets/metadataEditorFields.tsx
@@ -61,6 +61,12 @@ export class CellMetadataField extends NotebookTools.MetadataEditorTool {
 
   private _onSourceChanged() {
     if (this.editor.source) {
+      const metadataKeys = Object.keys(
+        this._tracker.activeCell?.model.sharedModel.metadata ?? {}
+      );
+      for (const key of metadataKeys) {
+        this._tracker.activeCell?.model.sharedModel.deleteMetadata(key);
+      }
       this._tracker.activeCell?.model.sharedModel.setMetadata(
         this.editor.source.toJSON()
       );

--- a/packages/notebook-extension/src/tool-widgets/metadataEditorFields.tsx
+++ b/packages/notebook-extension/src/tool-widgets/metadataEditorFields.tsx
@@ -60,16 +60,17 @@ export class CellMetadataField extends NotebookTools.MetadataEditorTool {
   }
 
   private _onSourceChanged() {
-    if (this.editor.source) {
-      const metadataKeys = Object.keys(
-        this._tracker.activeCell?.model.sharedModel.metadata ?? {}
-      );
-      for (const key of metadataKeys) {
-        this._tracker.activeCell?.model.sharedModel.deleteMetadata(key);
-      }
-      this._tracker.activeCell?.model.sharedModel.setMetadata(
-        this.editor.source.toJSON()
-      );
+    const activeCell = this._tracker.activeCell?.model.sharedModel;
+    if (activeCell && this.editor.source) {
+      const metadataKeys = Object.keys(activeCell.metadata ?? {});
+      const source = this.editor.source.toJSON() ?? {};
+
+      activeCell.transact(() => {
+        // Iterate over all existing metadata keys and delete each one.
+        // This ensures that any keys not present in the new metadata are removed.
+        metadataKeys.forEach(key => activeCell.deleteMetadata(key));
+        activeCell.setMetadata(source);
+      });
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/17164

The root cause was that `setMetadata` method of the `ISharedBaseCell` only overrides the partial metadata (existing keys), rather than replacing the entire metadata.

I have just provided a workaround to ensure the complete removal and replacement of all metadata. However, a more prominent solution would be overriding the `setMetadata` method to ensure it completely replaces the metadata.
