### PR TITLE
Fix "running" prompt state with server-side execution

### DIFF
--- a/packages/cells/test/widget.spec.ts
+++ b/packages/cells/test/widget.spec.ts
@@ -978,6 +978,26 @@ describe('cells/widget', () => {
           `[${(msg as IExecuteReplyMsg).content.execution_count}]:`
         );
       });
+
+      it('should set the cell prompt properly on server-side execution', async () => {
+        const widget = new CodeCell({
+          model,
+          rendermime,
+          contentFactory,
+          placeholder: false
+        });
+        widget.initializeState();
+        const sharedModel = widget.model.sharedModel;
+        // Clearing execution count should not overwrite the execution state:
+        sharedModel.executionState = 'running';
+        sharedModel.execution_count = null;
+        expect(sharedModel.executionState).toEqual('running');
+        expect(widget.promptNode!.textContent).toEqual('[*]:');
+        // Setting execution count should also set execution state to idle:
+        sharedModel.execution_count = 1;
+        expect(sharedModel.executionState).toEqual('idle');
+        expect(widget.promptNode!.textContent).toEqual('[1]:');
+      });
     });
   });
 


### PR DESCRIPTION
## References

- Follow up to https://github.com/jupyterlab/jupyterlab/pull/16651

## Code changes

- [x] Adds a test demonstrating an issue where the `execution_count` being reset incorrectly overrode the execution state, resulting in no `[*]` prompt in the interface but instead only `[ ]`
- [ ] Fixes the issue by not changing `execution_count` when provided with the value of `null`

## User-facing changes

`[*]` shows up correctly when using server-side exeuction

## Backwards-incompatible changes

None
