### PR TITLE
Fix for inconsistent tab closure in "Close All Tabs" operation

### DIFF
--- a/packages/notebook-extension/src/tool-widgets/metadataEditorFields.tsx
+++ b/packages/notebook-extension/src/tool-widgets/metadataEditorFields.tsx
@@ -61,12 +61,6 @@ export class CellMetadataField extends NotebookTools.MetadataEditorTool {
 
   private _onSourceChanged() {
     if (this.editor.source) {
-      const metadataKeys = Object.keys(
-        this._tracker.activeCell?.model.sharedModel.metadata ?? {}
-      );
-      for (const key of metadataKeys) {
-        this._tracker.activeCell?.model.sharedModel.deleteMetadata(key);
-      }
       this._tracker.activeCell?.model.sharedModel.setMetadata(
         this.editor.source.toJSON()
       );

--- a/packages/notebook-extension/src/tool-widgets/metadataEditorFields.tsx
+++ b/packages/notebook-extension/src/tool-widgets/metadataEditorFields.tsx
@@ -61,6 +61,12 @@ export class CellMetadataField extends NotebookTools.MetadataEditorTool {
 
   private _onSourceChanged() {
     if (this.editor.source) {
+      const metadataKeys = Object.keys(
+        this._tracker.activeCell?.model.sharedModel.metadata ?? {}
+      );
+      for (const key of metadataKeys) {
+        this._tracker.activeCell?.model.sharedModel.deleteMetadata(key);
+      }
       this._tracker.activeCell?.model.sharedModel.setMetadata(
         this.editor.source.toJSON()
       );

--- a/packages/running-extension/src/opentabs.ts
+++ b/packages/running-extension/src/opentabs.ts
@@ -76,7 +76,8 @@ export function addOpenTabsSessionManager(
       });
     },
     shutdownAll: () => {
-      for (const widget of labShell.widgets('main')) {
+      const widgets = Array.from(labShell.widgets('main'));
+      for (const widget of widgets) {
         widget.close();
       }
     },


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/17140

The issue occurred because the `for..of` loop directly consumed the iterator returned by `labShell.widgets('main')`. As widgets were closed during iteration, the iterator's state was modified, causing it to skip widgets.

More specifically, when the `launcher tab` is closed, it is immediately removed from `labShell.widgets('main')`. This modification to the iterator’s state causes the next widget (the first opened notebook) to be skipped, leaving it unclosed.

The solution is to convert the iterator into an array before iterating over it to avoid this problem.