### PR TITLE
Fixed the search functionality for Cell outputs

### DIFF
--- a/packages/notebook/src/searchprovider.ts
+++ b/packages/notebook/src/searchprovider.ts
@@ -236,7 +236,7 @@ export class NotebookSearchProvider extends SearchProvider<NotebookPanel> {
         disabledDescription: trans.__(
           'Search in the cell outputs (not available when replace options are shown).'
         ),
-        default: false,
+        default: true,
         supportReplace: false
       },
       selection: {


### PR DESCRIPTION
## References
#15445 

## Code changes
Updated the search functionality to include outputs in JupyterLab cells.
## User-facing changes

Users can now search for text within cell outputs directly (This is now the default behavior)

## Backwards-incompatible changes
None
