### PR TITLE
Fix display of tooltip/title for terminal and kernel sessions statusbar item

### DIFF
--- a/packages/apputils/src/runningSessions.tsx
+++ b/packages/apputils/src/runningSessions.tsx
@@ -124,11 +124,18 @@ export class RunningSessions extends VDomRenderer<RunningSessions.Model> {
     }
     // TODO-TRANS: Should probably be handled differently.
     // This is more localizable friendly: "Terminals: %1 | Kernels: %2"
-    this.title.caption = this._trans.__(
+
+    // Generate a localized caption for the tooltip
+    const caption = this._trans.__(
       '%1 Terminals, %2 Kernel sessions',
       this.model.terminals,
-      this.model!.sessions
+      this.model.sessions
     );
+
+    // Explicitly synchronize the title attribute with the Lumino widget's DOM
+    // This ensures the tooltip displays correctly when hovering over the widget
+    this.node.title = caption;
+
     return (
       <RunningSessionsComponent
         sessions={this.model.sessions}


### PR DESCRIPTION
## References

Fixes #14082 

This PR addresses a tooltip display issue in the RunningSessions widget caused by an improper synchronization between React and Lumino. The key changes ensure the title attribute (used for the tooltip) is correctly applied to the Lumino DOM node
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

### Screenshot
<img width="399" alt="Screenshot 2025-01-26 at 3 16 18 PM" src="https://github.com/user-attachments/assets/1637516f-c9b2-4c9c-a974-88136d3faba0" />


<!-- Describe the code changes and how they address the issue. -->



<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->


