### PR TITLE
Improving reliability of the the galata tests

### DIFF
--- a/galata/test/documentation/debugger.test.ts
+++ b/galata/test/documentation/debugger.test.ts
@@ -160,6 +160,8 @@ test.describe('Debugger', () => {
 
     // Wait to be stopped on the breakpoint
     await page.debugger.waitForCallStack();
+    // Wait for the red debug indicator box to appear
+    await page.waitForTimeout(50);
     expect(
       await page.screenshot({
         clip: { y: 110, x: 300, width: 300, height: 80 }
@@ -182,6 +184,8 @@ test.describe('Debugger', () => {
 
     // Wait to be stopped on the breakpoint
     await page.debugger.waitForCallStack();
+    // Wait for the red debug indicator box to appear
+    await page.waitForTimeout(50);
     expect(
       await page.screenshot({
         clip: { y: 110, x: 300, width: 300, height: 80 }

--- a/galata/test/documentation/debugger.test.ts
+++ b/galata/test/documentation/debugger.test.ts
@@ -161,7 +161,11 @@ test.describe('Debugger', () => {
     // Wait to be stopped on the breakpoint
     await page.debugger.waitForCallStack();
     // Wait for the red debug indicator box to appear
-    await page.waitForTimeout(50);
+    const firstCell = (await page.notebook.getCellLocator(0))!;
+    await firstCell.locator('.jp-DebuggerEditor-highlight').waitFor({
+      state: 'visible',
+      timeout: 1000
+    });
     expect(
       await page.screenshot({
         clip: { y: 110, x: 300, width: 300, height: 80 }
@@ -185,14 +189,21 @@ test.describe('Debugger', () => {
     // Wait to be stopped on the breakpoint
     await page.debugger.waitForCallStack();
     // Wait for the red debug indicator box to appear
-    await page.waitForTimeout(50);
+    await firstCell.locator('.jp-DebuggerEditor-highlight').waitFor({
+      state: 'visible',
+      timeout: 1000
+    });
     expect(
       await page.screenshot({
         clip: { y: 110, x: 300, width: 300, height: 80 }
       })
     ).toMatchSnapshot('debugger_stop_on_raised_exception.png');
     await page.click('jp-button[title^=Continue]');
+    await page.debugger.waitForCallStack();
     await page.click('jp-button[title^=Continue]');
+    await page.debugger.waitForCallStack();
+    await page.click('jp-button[title^=Continue]');
+    await page.notebook.waitForRun(0);
   });
 
   test('Debugger sidebar', async ({ page, tmpPath }) => {

--- a/galata/test/documentation/debugger.test.ts
+++ b/galata/test/documentation/debugger.test.ts
@@ -198,11 +198,11 @@ test.describe('Debugger', () => {
         clip: { y: 110, x: 300, width: 300, height: 80 }
       })
     ).toMatchSnapshot('debugger_stop_on_raised_exception.png');
-    await page.click('jp-button[title^=Continue]');
+    await page.click('jp-button[title^=Continue]'); // Pauses as the error is raised (try block)
     await page.debugger.waitForCallStack();
-    await page.click('jp-button[title^=Continue]');
+    await page.click('jp-button[title^=Continue]'); // Pauses as the error is raised (catch block)
     await page.debugger.waitForCallStack();
-    await page.click('jp-button[title^=Continue]');
+    await page.click('jp-button[title^=Continue]'); // Pauses again as the error is unhandled
     await page.notebook.waitForRun(0);
   });
 

--- a/galata/test/jupyterlab/windowed-notebook.test.ts
+++ b/galata/test/jupyterlab/windowed-notebook.test.ts
@@ -91,7 +91,7 @@ test('should not update height when hiding', async ({ page, tmpPath }) => {
   // Wait to ensure the rendering logic is stable.
   do {
     previousHeight = initialHeight;
-    await page.waitForTimeout(200);
+    await page.waitForTimeout(300);
 
     initialHeight = await getInnerHeight(notebook!);
   } while (previousHeight !== initialHeight && counter++ < 10);


### PR DESCRIPTION
## References #14947

The two tests `Debugger › Breakpoints on exception` and `windowed-notebook.test.ts› should not update height when hiding` aren't reliable keeps failing on CI. This PR aims to increase their reliability.

#### 1.  `Debugger › Breakpoints on exception`
This test verifies that the code execution pauses when some kind of exception is raised. The test compares a snapshot of the cell with the expected output. However, the red debug box that appears on breakpoints occasionally takes some time to load, causing the snapshots to mismatch and the CI to fail.

To resolve this, a small time delay has been added to ensure the red debug box is fully loaded before the snapshot is captured.

**Before:**
![Screenshot from 2025-01-26 15-02-50](https://github.com/user-attachments/assets/ebd801ca-0ec1-4966-b601-4e94c2653dee)


**After:**
![Screenshot from 2025-01-26 15-02-38](https://github.com/user-attachments/assets/7a8a209a-b29e-4e9d-84f0-c5729c3ff695)

#### 2.  `windowed-notebook.test.ts› should not update height when hiding`

This test is designed to verify that the height of a large notebook does not change when it is hidden (e.g., by opening a new tab). It compares the notebook's height before and after hiding it.

However, during local testing, I observed that the notebook's height continues to increase even after it is hidden. This suggests that the notebook's rendering process is still ongoing in the background. The test currently passes because the height comparison occurs immediately after switching tabs, before the rendering completes. If a delay were introduced before the height verification, the test would consistently fail due to the height continuing to increase.

I am still investigating this issue and working to identify a solution. Any insights or suggestions would be greatly appreciated!