### PR TITLE
Update `aria-pressed` state for `ToolbarButton` when pressed

### DIFF
--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -983,13 +983,13 @@ export class ToolbarButton extends ReactWidget {
   /**
    * Returns the click handler for the button
    */
-  get onClick(): () => void {
-    return () => {
+  get onClick(): (event?: React.SyntheticEvent) => void {
+    return (event?: React.SyntheticEvent) => {
       // Toggle the `pressed` state of the button when clicked
       this.pressed = !this.pressed;
 
       // Call the original click handler, if defined
-      this._onClick();
+      this._onClick(event);
     };
   }
 
@@ -1007,7 +1007,7 @@ export class ToolbarButton extends ReactWidget {
 
   private _pressed: boolean;
   private _enabled: boolean;
-  private _onClick: () => void;
+  private _onClick: (event?: React.SyntheticEvent) => void;
 }
 
 /**


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
This PR fixes #14464 where the "More commands" button in the toolbar overflow menu did not reflect its pressed state. The aria-pressed attribute is now correctly toggled when the button is clicked.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
- Updated onClick logic to toggle the pressed state.
- Ensured aria-pressed updates dynamically based on the button’s pressed state.

## After necessary changes

https://github.com/user-attachments/assets/a2dc9476-30ca-4408-9ff2-aefd320acdb8


