### PR TITLE
Cache item state to improve filebrowser's performance 

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -2864,7 +2864,6 @@ export namespace DirListing {
    * The default implementation of an `IRenderer`.
    */
   export class Renderer implements IRenderer {
-    private lastRenderedState = new WeakMap<HTMLElement, string>();
     /**
      * Create the DOM node for a dir listing.
      */
@@ -3160,11 +3159,14 @@ export namespace DirListing {
       translator = translator || nullTranslator;
       const trans = translator.load('jupyterlab');
 
-      const prevState = this.lastRenderedState.get(node);
+      const prevState = this._lastRenderedState.get(node);
       const newState = JSON.stringify({
         name: model.name,
         selected,
         lastModified: model.last_modified,
+        modifiedStyle,
+        hiddenColumns,
+        columnsSizes,
         fileSize: model.size
       });
 
@@ -3179,7 +3181,7 @@ export namespace DirListing {
       if (checkbox) checkbox.checked = selected ?? false;
 
       if (prevState === newState) return;
-      this.lastRenderedState.set(node, newState);
+      this._lastRenderedState.set(node, newState);
 
       const iconContainer = DOMUtils.findElement(node, ITEM_ICON_CLASS);
       const text = DOMUtils.findElement(node, ITEM_TEXT_CLASS);
@@ -3484,6 +3486,8 @@ export namespace DirListing {
       HTMLElement,
       { date: string; style: Time.HumanStyle }
     >();
+
+    private _lastRenderedState = new WeakMap<HTMLElement, string>();
   }
 
   /**

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -41,7 +41,6 @@ import { ISignal, Signal } from '@lumino/signaling';
 import { h, VirtualDOM } from '@lumino/virtualdom';
 import { Widget } from '@lumino/widgets';
 import { FilterFileBrowserModel } from './model';
-import { Debouncer } from '@lumino/polling';
 
 /**
  * The class name added to DirListing widget.
@@ -971,19 +970,16 @@ export class DirListing extends Widget {
         );
       }
       const ft = this._manager.registry.getFileTypeForModel(item);
-      const debounceUpdateItemNodes = new Debouncer(() => {
-        this.renderer.updateItemNode(
-          node,
-          item,
-          ft,
-          this.translator,
-          this._hiddenColumns,
-          this.selection[item.path],
-          this._modifiedStyle,
-          this._columnSizes
-        );
-      }, 200);
-      debounceUpdateItemNodes.invoke();
+      this.renderer.updateItemNode(
+        node,
+        item,
+        ft,
+        this.translator,
+        this._hiddenColumns,
+        this.selection[item.path],
+        this._modifiedStyle,
+        this._columnSizes
+      );
       if (
         this.selection[item.path] &&
         this._isCut &&

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -41,6 +41,7 @@ import { ISignal, Signal } from '@lumino/signaling';
 import { h, VirtualDOM } from '@lumino/virtualdom';
 import { Widget } from '@lumino/widgets';
 import { FilterFileBrowserModel } from './model';
+import { Debouncer } from '@lumino/polling';
 
 /**
  * The class name added to DirListing widget.
@@ -970,17 +971,19 @@ export class DirListing extends Widget {
         );
       }
       const ft = this._manager.registry.getFileTypeForModel(item);
-
-      this.renderer.updateItemNode(
-        node,
-        item,
-        ft,
-        this.translator,
-        this._hiddenColumns,
-        this.selection[item.path],
-        this._modifiedStyle,
-        this._columnSizes
-      );
+      const debounceUpdateItemNodes = new Debouncer(() => {
+        this.renderer.updateItemNode(
+          node,
+          item,
+          ft,
+          this.translator,
+          this._hiddenColumns,
+          this.selection[item.path],
+          this._modifiedStyle,
+          this._columnSizes
+        );
+      }, 200);
+      debounceUpdateItemNodes.invoke();
       if (
         this.selection[item.path] &&
         this._isCut &&

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -3151,6 +3151,9 @@ export namespace DirListing {
       modifiedStyle?: Time.HumanStyle,
       columnsSizes?: Record<DirListing.IColumn['id'], number | null>
     ): void {
+      if (selected) {
+        node.classList.add(SELECTED_CLASS);
+      }
       fileType =
         fileType || DocumentRegistry.getDefaultTextFileType(translator);
       const { icon, iconClass, name } = fileType;
@@ -3165,14 +3168,18 @@ export namespace DirListing {
         fileSize: model.size
       });
 
+      const checkboxWrapper = DOMUtils.findElement(
+        node,
+        CHECKBOX_WRAPPER_CLASS
+      );
+      const checkbox = checkboxWrapper?.querySelector(
+        'input[type="checkbox"]'
+      ) as HTMLInputElement | undefined;
+
+      if (checkbox) checkbox.checked = selected ?? false;
+
       if (prevState === newState) return;
       this.lastRenderedState.set(node, newState);
-
-      if (selected) {
-        node.classList.add(SELECTED_CLASS);
-      } else {
-        node.classList.remove(SELECTED_CLASS);
-      }
 
       const iconContainer = DOMUtils.findElement(node, ITEM_ICON_CLASS);
       const text = DOMUtils.findElement(node, ITEM_TEXT_CLASS);
@@ -3183,10 +3190,6 @@ export namespace DirListing {
       let fileSize = DOMUtils.findElement(node, ITEM_FILE_SIZE_CLASS) as
         | HTMLElement
         | undefined;
-      const checkboxWrapper = DOMUtils.findElement(
-        node,
-        CHECKBOX_WRAPPER_CLASS
-      );
 
       const showFileCheckboxes = !hiddenColumns?.has('is_selected');
       if (checkboxWrapper && !showFileCheckboxes) {
@@ -3276,9 +3279,6 @@ export namespace DirListing {
       }
 
       // Adds an aria-label to the checkbox element.
-      const checkbox = checkboxWrapper?.querySelector(
-        'input[type="checkbox"]'
-      ) as HTMLInputElement | undefined;
 
       if (checkbox) {
         let ariaLabel: string;

--- a/packages/filebrowser/test/listing.spec.ts
+++ b/packages/filebrowser/test/listing.spec.ts
@@ -139,11 +139,9 @@ describe('filebrowser/listing', () => {
         Widget.attach(dirListing, document.body);
         dirListing.handleEvent(event);
         await signalToPromise(dirListing.allUploaded);
-        await new Promise(resolve => setTimeout(resolve, 200));
         const topLevel = getItemTitles(dirListing);
         expect(topLevel).toStrictEqual(['test-dir']);
         await dirListing.model.cd('test-dir');
-        await new Promise(resolve => setTimeout(resolve, 200));
         const testDir = getItemTitles(dirListing);
         expect(testDir).toEqual(
           expect.arrayContaining(['empty-dir', 'file.txt', 'code.py'])
@@ -576,7 +574,6 @@ describe('filebrowser/listing', () => {
           const checkbox = dirListing.renderer.getCheckboxNode!(
             itemNode
           ) as HTMLInputElement;
-          await new Promise(resolve => setTimeout(resolve, 200));
           expect(checkbox.checked).toBe(false);
           const nameNode = dirListing.renderer.getNameNode!(
             itemNode
@@ -586,7 +583,6 @@ describe('filebrowser/listing', () => {
           );
           dirListing.selectNext();
           await signalToPromise(dirListing.updated);
-          await new Promise(resolve => setTimeout(resolve, 200));
           expect(checkbox.checked).toBe(true);
           expect(checkbox.getAttribute('aria-label')).toBe(
             ariaDeselectFile(nameNode.textContent)
@@ -603,7 +599,6 @@ describe('filebrowser/listing', () => {
           ) as HTMLElement;
           dirListing.selectNext();
           await signalToPromise(dirListing.updated);
-          await new Promise(resolve => setTimeout(resolve, 200));
           expect(checkbox.checked).toBe(true);
           expect(checkbox.getAttribute('aria-label')).toBe(
             ariaDeselectFile(nameNode.textContent)
@@ -611,7 +606,6 @@ describe('filebrowser/listing', () => {
           // Selecting the next item unselects the first.
           dirListing.selectNext();
           await signalToPromise(dirListing.updated);
-          await new Promise(resolve => setTimeout(resolve, 200));
           expect(checkbox.checked).toBe(false);
           expect(checkbox.getAttribute('aria-label')).toBe(
             ariaSelectFile(nameNode.textContent)
@@ -666,7 +660,6 @@ describe('filebrowser/listing', () => {
           const nameNodes = itemNodes.map(node =>
             dirListing.renderer.getNameNode!(node)
           ) as HTMLElement[];
-          await new Promise(resolve => setTimeout(resolve, 200));
           expect(checkboxes[0].checked).toBe(false);
           expect(checkboxes[1].checked).toBe(false);
           expect(checkboxes[0].getAttribute('aria-label')).toBe(
@@ -678,7 +671,6 @@ describe('filebrowser/listing', () => {
           dirListing.selectNext();
           dirListing.selectNext(true); // true = keep existing selection
           await signalToPromise(dirListing.updated);
-          await new Promise(resolve => setTimeout(resolve, 200));
           expect(checkboxes[0].checked).toBe(true);
           expect(checkboxes[1].checked).toBe(true);
           expect(checkboxes[0].getAttribute('aria-label')).toBe(
@@ -718,7 +710,6 @@ describe('filebrowser/listing', () => {
           const waitForUpdate = signalToPromise(dirListing.updated);
           await dirListing.selectItemByName(item.value.name);
           await waitForUpdate;
-          await new Promise(resolve => setTimeout(resolve, 200));
           expect(checkbox.checked).toBe(true);
           expect(dirListing.isSelected(item.value.name)).toBe(true);
           const waitForUpdate2 = signalToPromise(dirListing.updated);
@@ -728,7 +719,6 @@ describe('filebrowser/listing', () => {
             button: 2
           });
           await waitForUpdate2;
-          await new Promise(resolve => setTimeout(resolve, 200));
           // Item is still selected and checkbox is still checked after
           // right-click.
           expect(dirListing.isSelected(item.value.name)).toBe(true);
@@ -897,7 +887,6 @@ describe('filebrowser/listing', () => {
             key: 'name'
           });
           await signalToPromise(dirListing.updated);
-          await new Promise(resolve => setTimeout(resolve, 200));
           expect(getItemTitles(dirListing)).toEqual([
             '2',
             '5',
@@ -913,7 +902,6 @@ describe('filebrowser/listing', () => {
             key: 'name'
           });
           await signalToPromise(dirListing.updated);
-          await new Promise(resolve => setTimeout(resolve, 200));
           expect(getItemTitles(dirListing)).toEqual([
             '5',
             '2',
@@ -932,10 +920,8 @@ describe('filebrowser/listing', () => {
             key: 'name'
           });
           await signalToPromise(dirListing.updated);
-          await new Promise(resolve => setTimeout(resolve, 200));
           dirListing.setNotebooksFirstSorting(true);
           await signalToPromise(dirListing.updated);
-          await new Promise(resolve => setTimeout(resolve, 200));
           expect(getItemTitles(dirListing)).toEqual([
             '2',
             '5',
@@ -953,7 +939,6 @@ describe('filebrowser/listing', () => {
             key: 'name'
           });
           await signalToPromise(dirListing.updated);
-          await new Promise(resolve => setTimeout(resolve, 200));
           expect(getItemTitles(dirListing)).toEqual([
             '5',
             '2',
@@ -972,7 +957,6 @@ describe('filebrowser/listing', () => {
             key: 'last_modified'
           });
           await signalToPromise(dirListing.updated);
-          await new Promise(resolve => setTimeout(resolve, 200));
           expect(getItemTitles(dirListing)).toEqual([
             '2',
             '5',
@@ -984,7 +968,6 @@ describe('filebrowser/listing', () => {
 
           dirListing.setNotebooksFirstSorting(true);
           await signalToPromise(dirListing.updated);
-          await new Promise(resolve => setTimeout(resolve, 200));
           expect(getItemTitles(dirListing)).toEqual([
             '2',
             '5',
@@ -996,7 +979,6 @@ describe('filebrowser/listing', () => {
 
           dirListing.setNotebooksFirstSorting(false);
           await signalToPromise(dirListing.updated);
-          await new Promise(resolve => setTimeout(resolve, 200));
           expect(getItemTitles(dirListing)).toEqual([
             '2',
             '5',

--- a/packages/filebrowser/test/listing.spec.ts
+++ b/packages/filebrowser/test/listing.spec.ts
@@ -139,9 +139,11 @@ describe('filebrowser/listing', () => {
         Widget.attach(dirListing, document.body);
         dirListing.handleEvent(event);
         await signalToPromise(dirListing.allUploaded);
+        await new Promise(resolve => setTimeout(resolve, 200));
         const topLevel = getItemTitles(dirListing);
         expect(topLevel).toStrictEqual(['test-dir']);
         await dirListing.model.cd('test-dir');
+        await new Promise(resolve => setTimeout(resolve, 200));
         const testDir = getItemTitles(dirListing);
         expect(testDir).toEqual(
           expect.arrayContaining(['empty-dir', 'file.txt', 'code.py'])
@@ -574,6 +576,7 @@ describe('filebrowser/listing', () => {
           const checkbox = dirListing.renderer.getCheckboxNode!(
             itemNode
           ) as HTMLInputElement;
+          await new Promise(resolve => setTimeout(resolve, 200));
           expect(checkbox.checked).toBe(false);
           const nameNode = dirListing.renderer.getNameNode!(
             itemNode
@@ -583,6 +586,7 @@ describe('filebrowser/listing', () => {
           );
           dirListing.selectNext();
           await signalToPromise(dirListing.updated);
+          await new Promise(resolve => setTimeout(resolve, 200));
           expect(checkbox.checked).toBe(true);
           expect(checkbox.getAttribute('aria-label')).toBe(
             ariaDeselectFile(nameNode.textContent)
@@ -599,6 +603,7 @@ describe('filebrowser/listing', () => {
           ) as HTMLElement;
           dirListing.selectNext();
           await signalToPromise(dirListing.updated);
+          await new Promise(resolve => setTimeout(resolve, 200));
           expect(checkbox.checked).toBe(true);
           expect(checkbox.getAttribute('aria-label')).toBe(
             ariaDeselectFile(nameNode.textContent)
@@ -606,6 +611,7 @@ describe('filebrowser/listing', () => {
           // Selecting the next item unselects the first.
           dirListing.selectNext();
           await signalToPromise(dirListing.updated);
+          await new Promise(resolve => setTimeout(resolve, 200));
           expect(checkbox.checked).toBe(false);
           expect(checkbox.getAttribute('aria-label')).toBe(
             ariaSelectFile(nameNode.textContent)
@@ -660,6 +666,7 @@ describe('filebrowser/listing', () => {
           const nameNodes = itemNodes.map(node =>
             dirListing.renderer.getNameNode!(node)
           ) as HTMLElement[];
+          await new Promise(resolve => setTimeout(resolve, 200));
           expect(checkboxes[0].checked).toBe(false);
           expect(checkboxes[1].checked).toBe(false);
           expect(checkboxes[0].getAttribute('aria-label')).toBe(
@@ -671,6 +678,7 @@ describe('filebrowser/listing', () => {
           dirListing.selectNext();
           dirListing.selectNext(true); // true = keep existing selection
           await signalToPromise(dirListing.updated);
+          await new Promise(resolve => setTimeout(resolve, 200));
           expect(checkboxes[0].checked).toBe(true);
           expect(checkboxes[1].checked).toBe(true);
           expect(checkboxes[0].getAttribute('aria-label')).toBe(
@@ -710,6 +718,7 @@ describe('filebrowser/listing', () => {
           const waitForUpdate = signalToPromise(dirListing.updated);
           await dirListing.selectItemByName(item.value.name);
           await waitForUpdate;
+          await new Promise(resolve => setTimeout(resolve, 200));
           expect(checkbox.checked).toBe(true);
           expect(dirListing.isSelected(item.value.name)).toBe(true);
           const waitForUpdate2 = signalToPromise(dirListing.updated);
@@ -719,6 +728,7 @@ describe('filebrowser/listing', () => {
             button: 2
           });
           await waitForUpdate2;
+          await new Promise(resolve => setTimeout(resolve, 200));
           // Item is still selected and checkbox is still checked after
           // right-click.
           expect(dirListing.isSelected(item.value.name)).toBe(true);
@@ -887,7 +897,7 @@ describe('filebrowser/listing', () => {
             key: 'name'
           });
           await signalToPromise(dirListing.updated);
-
+          await new Promise(resolve => setTimeout(resolve, 200));
           expect(getItemTitles(dirListing)).toEqual([
             '2',
             '5',
@@ -903,7 +913,7 @@ describe('filebrowser/listing', () => {
             key: 'name'
           });
           await signalToPromise(dirListing.updated);
-
+          await new Promise(resolve => setTimeout(resolve, 200));
           expect(getItemTitles(dirListing)).toEqual([
             '5',
             '2',
@@ -922,9 +932,10 @@ describe('filebrowser/listing', () => {
             key: 'name'
           });
           await signalToPromise(dirListing.updated);
+          await new Promise(resolve => setTimeout(resolve, 200));
           dirListing.setNotebooksFirstSorting(true);
           await signalToPromise(dirListing.updated);
-
+          await new Promise(resolve => setTimeout(resolve, 200));
           expect(getItemTitles(dirListing)).toEqual([
             '2',
             '5',
@@ -942,7 +953,7 @@ describe('filebrowser/listing', () => {
             key: 'name'
           });
           await signalToPromise(dirListing.updated);
-
+          await new Promise(resolve => setTimeout(resolve, 200));
           expect(getItemTitles(dirListing)).toEqual([
             '5',
             '2',
@@ -961,6 +972,7 @@ describe('filebrowser/listing', () => {
             key: 'last_modified'
           });
           await signalToPromise(dirListing.updated);
+          await new Promise(resolve => setTimeout(resolve, 200));
           expect(getItemTitles(dirListing)).toEqual([
             '2',
             '5',
@@ -972,6 +984,7 @@ describe('filebrowser/listing', () => {
 
           dirListing.setNotebooksFirstSorting(true);
           await signalToPromise(dirListing.updated);
+          await new Promise(resolve => setTimeout(resolve, 200));
           expect(getItemTitles(dirListing)).toEqual([
             '2',
             '5',
@@ -983,6 +996,7 @@ describe('filebrowser/listing', () => {
 
           dirListing.setNotebooksFirstSorting(false);
           await signalToPromise(dirListing.updated);
+          await new Promise(resolve => setTimeout(resolve, 200));
           expect(getItemTitles(dirListing)).toEqual([
             '2',
             '5',

--- a/packages/filebrowser/test/openfiledialog.spec.ts
+++ b/packages/filebrowser/test/openfiledialog.spec.ts
@@ -184,7 +184,6 @@ describe('@jupyterlab/filebrowser', () => {
 
       await waitForDialog();
       await framePromise();
-      await new Promise(resolve => setTimeout(resolve, 200));
 
       let counter = 0;
       const listing = node.getElementsByClassName('jp-DirListing-content')[0];
@@ -247,7 +246,6 @@ describe('@jupyterlab/filebrowser', () => {
 
       await waitForDialog();
       await framePromise();
-      await new Promise(resolve => setTimeout(resolve, 200));
 
       let counter = 0;
       const listing = node.getElementsByClassName('jp-DirListing-content')[0];
@@ -331,7 +329,6 @@ describe('@jupyterlab/filebrowser', () => {
 
       await waitForDialog();
       await framePromise();
-      await new Promise(resolve => setTimeout(resolve, 200));
 
       let counter = 0;
       const listing = node.getElementsByClassName('jp-DirListing-content')[0];

--- a/packages/filebrowser/test/openfiledialog.spec.ts
+++ b/packages/filebrowser/test/openfiledialog.spec.ts
@@ -184,6 +184,7 @@ describe('@jupyterlab/filebrowser', () => {
 
       await waitForDialog();
       await framePromise();
+      await new Promise(resolve => setTimeout(resolve, 200));
 
       let counter = 0;
       const listing = node.getElementsByClassName('jp-DirListing-content')[0];
@@ -246,6 +247,7 @@ describe('@jupyterlab/filebrowser', () => {
 
       await waitForDialog();
       await framePromise();
+      await new Promise(resolve => setTimeout(resolve, 200));
 
       let counter = 0;
       const listing = node.getElementsByClassName('jp-DirListing-content')[0];
@@ -329,6 +331,7 @@ describe('@jupyterlab/filebrowser', () => {
 
       await waitForDialog();
       await framePromise();
+      await new Promise(resolve => setTimeout(resolve, 200));
 
       let counter = 0;
       const listing = node.getElementsByClassName('jp-DirListing-content')[0];


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
Fixes #16767 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
I've added a cache to check for last state of the node if their are no changes it doesn't rerender, used weakmap so its collected by garbage collector when references of particular node is removed
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Smooth UI of filebrowser

https://github.com/user-attachments/assets/fe5e9198-43ae-411e-87b5-707274bbc8f8


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
