### PR TITLE
Fix performance when resizing side panel when it contains > 100 files/folders

### DIFF
--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -268,6 +268,8 @@
   padding: 0;
   list-style-type: none;
   overflow: auto;
+  contain: layout style;
+  content-visibility: auto;
   background-color: var(--jp-layout-color1);
   overflow-x: hidden;
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
Fixes #16840
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Smooth resizing of side pannel
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
