### PR TITLE
Add commands to change the console prompt position to the palette

### DIFF
--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -726,6 +726,13 @@ async function activateConsole(
       label: trans.__(`Prompt to ${position}`),
       icon: iconMap[position]
     });
+
+    if (palette) {
+      palette.addItem({
+        command,
+        category
+      });
+    }
   });
 
   /**

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -724,13 +724,14 @@ async function activateConsole(
       },
       isEnabled: isEnabled,
       label: trans.__(`Prompt to ${position}`),
-      icon: iconMap[position]
+      icon: args => (args.palette ? undefined : iconMap[position])
     });
 
     if (palette) {
       palette.addItem({
         command,
-        category
+        category,
+        args: { palette: true }
       });
     }
   });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/13837

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Add the commands to change the prompt cell position to the command palette.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

![image](https://github.com/user-attachments/assets/9993a693-85d9-4aa8-889c-c7c3e4e36119)




<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
