### PR TITLE
Use the same `isPalette` arg as for other commands

### DIFF
--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -724,14 +724,14 @@ async function activateConsole(
       },
       isEnabled: isEnabled,
       label: trans.__(`Prompt to ${position}`),
-      icon: args => (args.palette ? undefined : iconMap[position])
+      icon: args => (args['isPalette'] ? undefined : iconMap[position])
     });
 
     if (palette) {
       palette.addItem({
         command,
         category,
-        args: { palette: true }
+        args: { isPalette: true }
       });
     }
   });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Minor follow-up to https://github.com/jupyterlab/jupyterlab/pull/17253

Other commands use the `isPalette` arg, for example here:

https://github.com/jupyterlab/jupyterlab/blob/68075b17a11258481f5aba68f473788aeaa88650/packages/console-extension/src/index.ts#L685

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Make the use of commands in the palette consistent with other commands.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
