### PR TITLE
[GSoC 2024] Use toolkit for the settings editor

### DIFF
--- a/packages/completer-extension/src/renderer.tsx
+++ b/packages/completer-extension/src/renderer.tsx
@@ -5,6 +5,7 @@
 
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
+import { NumberField } from '@jupyter/react-components';
 import type { FieldProps } from '@rjsf/utils';
 import React, { useState } from 'react';
 
@@ -61,12 +62,14 @@ export function renderAvailableProviders(props: FieldProps): JSX.Element {
               <div>
                 <h3> {key}</h3>
                 <div className="inputFieldWrapper">
-                  <input
+                  <NumberField
                     className="form-control"
-                    type="number"
                     value={settingValue[key]}
-                    onChange={e => {
-                      onSettingChange(key, e);
+                    onChange={(e: any) => {
+                      onSettingChange(
+                        key,
+                        e as React.ChangeEvent<HTMLInputElement>
+                      );
                     }}
                   />
                 </div>

--- a/packages/metadataform/test/metadataFormWidget.spec.ts
+++ b/packages/metadataform/test/metadataFormWidget.spec.ts
@@ -150,10 +150,8 @@ describe('metadataform/form simple', () => {
     metadataForm.form?.update();
     await sleep(100);
     expect(
-      node
-        .getElementsByClassName('jp-inputFieldWrapper')[0]
-        .children[0].getAttribute('type')
-    ).toBe('number');
+      node.getElementsByClassName('jp-inputFieldWrapper')[0].children[0].tagName
+    ).toBe('JP-NUMBER-FIELD');
   });
 
   it('should build the form', async () => {

--- a/packages/ui-components/src/components/form.tsx
+++ b/packages/ui-components/src/components/form.tsx
@@ -27,7 +27,13 @@ import {
   closeIcon,
   LabIcon
 } from '../icon';
-
+import { Button } from '@jupyter/react-components';
+import { BaseInputTemplate } from './widgets/textWidget';
+import { CheckboxesWidget } from './widgets/checkboxesWidget';
+import { CheckboxWidget } from './widgets/checkboxWidget';
+import { RadioWidget } from './widgets/radioWidget';
+import { SelectWidget } from './widgets/selectwidget';
+import { TextareaWidget } from './widgets/textareaWidget';
 /**
  * Default `ui:options` for the UiSchema.
  */
@@ -150,13 +156,13 @@ export const MoveButton = (
     props.direction === 'up' ? props.item.index - 1 : props.item.index + 1;
 
   return (
-    <button
-      className="jp-mod-styled jp-mod-reject jp-ArrayOperationsButton"
+    <Button
+      className="jp-ArrayOperationsButton"
       onClick={props.item.onReorderClick(props.item.index, moveTo)}
       disabled={disabled()}
     >
       {buttonContent}
-    </button>
+    </Button>
   );
 };
 
@@ -184,12 +190,13 @@ export const DropButton = (
   }
 
   return (
-    <button
-      className="jp-mod-styled jp-mod-warn jp-ArrayOperationsButton"
+    <Button
+      appearance="error"
+      className="jp-ArrayOperationsButton"
       onClick={props.item.onDropIndexClick(props.item.index)}
     >
       {buttonContent}
-    </button>
+    </Button>
   );
 };
 
@@ -213,12 +220,9 @@ export const AddButton = (
   }
 
   return (
-    <button
-      className="jp-mod-styled jp-mod-reject jp-ArrayOperationsButton"
-      onClick={props.onAddClick}
-    >
+    <Button className="jp-ArrayOperationsButton" onClick={props.onAddClick}>
       {buttonContent}
-    </button>
+    </Button>
   );
 };
 
@@ -624,6 +628,7 @@ export function FormComponent(props: IFormComponentProps): JSX.Element {
     showModifiedFromDefault,
     translator,
     formContext,
+    widgets,
     ...others
   } = props;
 
@@ -673,10 +678,23 @@ export function FormComponent(props: IFormComponentProps): JSX.Element {
   const templates: Record<string, React.FunctionComponent> = {
     FieldTemplate: fieldTemplate,
     ArrayFieldTemplate: arrayTemplate,
-    ObjectFieldTemplate: objectTemplate
+    ObjectFieldTemplate: objectTemplate,
+    BaseInputTemplate
   };
 
   return (
-    <Form templates={templates} formContext={formContext as any} {...others} />
+    <Form
+      templates={templates as any}
+      formContext={formContext as any}
+      widgets={{
+        CheckboxesWidget,
+        CheckboxWidget,
+        RadioWidget,
+        SelectWidget,
+        TextareaWidget,
+        ...widgets
+      }}
+      {...others}
+    />
   );
 }

--- a/packages/ui-components/src/components/widgets/checkboxWidget.tsx
+++ b/packages/ui-components/src/components/widgets/checkboxWidget.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import React from 'react';
+import {
+  ariaDescribedByIds,
+  FormContextType,
+  RJSFSchema,
+  schemaRequiresTrueValue,
+  StrictRJSFSchema,
+  WidgetProps
+} from '@rjsf/utils';
+import { Checkbox } from '@jupyter/react-components';
+
+export function CheckboxWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any
+>({
+  schema,
+  id,
+  value,
+  disabled,
+  readonly,
+  label,
+  onBlur,
+  onFocus,
+  onChange
+}: WidgetProps<T, S, F>) {
+  // Because an unchecked checkbox will cause html5 validation to fail, only add
+  // the "required" attribute if the field value must be "true", due to the
+  // "const" or "enum" keywords
+  const required = schemaRequiresTrueValue<S>(schema);
+  const _onChange = ({ target }: CustomEvent<HTMLInputElement>) => {
+    const inputTarget = target as HTMLInputElement;
+    if (inputTarget !== null) {
+      onChange(inputTarget.checked);
+    }
+  };
+  const _onBlur = ({
+    target
+  }: React.FocusEvent<HTMLElement & { value: string }>) =>
+    onBlur(id, target && target.value);
+  const _onFocus = ({
+    target
+  }: React.FocusEvent<HTMLElement & { value: string }>) =>
+    onFocus(id, target && target.value);
+
+  return (
+    <Checkbox
+      id={id}
+      name={id}
+      checked={typeof value === 'undefined' ? false : Boolean(value)}
+      required={required}
+      disabled={disabled || readonly}
+      onChange={_onChange}
+      onBlur={_onBlur}
+      onFocus={_onFocus}
+      aria-describedby={ariaDescribedByIds<T>(id)}
+    >
+      {label}
+    </Checkbox>
+  );
+}

--- a/packages/ui-components/src/components/widgets/checkboxesWidget.tsx
+++ b/packages/ui-components/src/components/widgets/checkboxesWidget.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import React, { FocusEvent } from 'react';
+import { Checkbox } from '@jupyter/react-components';
+import {
+  ariaDescribedByIds,
+  enumOptionsDeselectValue,
+  enumOptionsIsSelected,
+  enumOptionsSelectValue,
+  enumOptionsValueForIndex,
+  FormContextType,
+  optionId,
+  RJSFSchema,
+  StrictRJSFSchema,
+  WidgetProps
+} from '@rjsf/utils';
+
+/** The `CheckboxesWidget` is a widget for rendering checkbox groups.
+ *  It is typically used to represent an array of enums.
+ *
+ * @param props - The `WidgetProps` for this component
+ */
+export function CheckboxesWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any
+>({
+  id,
+  disabled,
+  options,
+  value,
+  readonly,
+  onChange,
+  onBlur,
+  onFocus
+}: WidgetProps<T, S, F>) {
+  const { enumOptions, enumDisabled, inline, emptyValue } = options;
+  const checkboxesValues = Array.isArray(value) ? value : [value];
+
+  const _onChange = (index: number) => (event: CustomEvent) => {
+    if (event.detail.checked) {
+      onChange(enumOptionsSelectValue<S>(index, checkboxesValues, enumOptions));
+    } else {
+      onChange(
+        enumOptionsDeselectValue<S>(index, checkboxesValues, enumOptions)
+      );
+    }
+  };
+
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
+    onBlur(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
+    onFocus(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
+
+  return (
+    <fieldset id={id} style={{ display: inline ? 'flex' : 'block' }}>
+      {(enumOptions ?? []).map((option, index) => {
+        const checked = enumOptionsIsSelected<S>(
+          option.value,
+          checkboxesValues
+        );
+        const itemDisabled = enumDisabled?.includes(option.value) || false;
+        return (
+          <Checkbox
+            id={optionId(id, index)}
+            key={optionId(id, index)}
+            name={id}
+            checked={checked}
+            disabled={disabled || itemDisabled || readonly}
+            onChange={_onChange(index)}
+            onBlur={_onBlur}
+            onFocus={_onFocus}
+            aria-describedby={ariaDescribedByIds<T>(id)}
+          >
+            {option.label}
+          </Checkbox>
+        );
+      })}
+    </fieldset>
+  );
+}

--- a/packages/ui-components/src/components/widgets/radioWidget.tsx
+++ b/packages/ui-components/src/components/widgets/radioWidget.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import React from 'react';
+import { FocusEvent } from 'react';
+import {
+  ariaDescribedByIds,
+  enumOptionsIsSelected,
+  enumOptionsValueForIndex,
+  FormContextType,
+  labelValue,
+  optionId,
+  RJSFSchema,
+  StrictRJSFSchema,
+  WidgetProps
+} from '@rjsf/utils';
+import { Radio, RadioGroup } from '@jupyter/react-components';
+
+/** The `RadioWidget` is a widget for rendering a radio group.
+ *  It is typically used with a string property constrained with enum options.
+ *
+ * @param props - The `WidgetProps` for this component
+ */
+export function RadioWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any
+>({
+  options,
+  value,
+  required,
+  disabled,
+  readonly,
+  autofocus = false,
+  label,
+  hideLabel,
+  onBlur,
+  onFocus,
+  onChange,
+  id,
+  ...others
+}: WidgetProps<T, S, F>) {
+  console.log(
+    'CustomRadioWidget',
+    options,
+    value,
+    required,
+    disabled,
+    readonly,
+    autofocus,
+    onBlur,
+    onFocus,
+    onChange,
+    id,
+    others
+  );
+
+  const { enumOptions, enumDisabled, inline, emptyValue } = options;
+
+  const _onChange = ({ target }: CustomEvent<HTMLInputElement>) => {
+    const inputTarget = target as HTMLInputElement;
+    if (inputTarget !== null) {
+      onChange(inputTarget.checked);
+    }
+  };
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
+    onBlur(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
+    onFocus(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
+
+  return (
+    <>
+      <RadioGroup
+        id={id}
+        name={id}
+        orientation={inline ? 'horizontal' : 'vertical'}
+      >
+        {labelValue(label || undefined, hideLabel)}
+        {Array.isArray(enumOptions) &&
+          enumOptions.map((option, index) => {
+            const checked = enumOptionsIsSelected<S>(option.value, value);
+            const itemDisabled =
+              Array.isArray(enumDisabled) &&
+              enumDisabled.indexOf(option.value) !== -1;
+
+            const radio = (
+              <Radio
+                id={optionId(id, index)}
+                checked={checked}
+                name={id}
+                value={String(index)}
+                disabled={disabled || itemDisabled || readonly}
+                readonly={readonly}
+                onChange={_onChange}
+                onBlur={_onBlur}
+                onFocus={_onFocus}
+                aria-describedby={ariaDescribedByIds<T>(id)}
+              >
+                {option.label}
+              </Radio>
+            );
+
+            return radio;
+          })}
+      </RadioGroup>
+    </>
+  );
+}

--- a/packages/ui-components/src/components/widgets/selectWidget.tsx
+++ b/packages/ui-components/src/components/widgets/selectWidget.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import React from 'react';
+import {
+  ariaDescribedByIds,
+  enumOptionsIndexForValue,
+  enumOptionsValueForIndex,
+  FormContextType,
+  RJSFSchema,
+  StrictRJSFSchema,
+  WidgetProps
+} from '@rjsf/utils';
+import { Option, Select } from '@jupyter/react-components';
+
+export function SelectWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any
+>({
+  id,
+  options,
+  value,
+  required,
+  disabled,
+  readonly,
+  multiple = false,
+  rawErrors = [],
+  onChange,
+  onBlur,
+  onFocus,
+  schema,
+  placeholder
+}: WidgetProps<T, S, F>) {
+  const { enumOptions, enumDisabled, emptyValue: optEmptyVal } = options;
+
+  const selectedIndexes = enumOptionsIndexForValue<S>(
+    value,
+    enumOptions,
+    multiple
+  );
+  let selectedIndexesAsArray: string[] = [];
+
+  if (typeof selectedIndexes === 'string') {
+    selectedIndexesAsArray = [selectedIndexes];
+  } else if (Array.isArray(selectedIndexes)) {
+    selectedIndexesAsArray = selectedIndexes.map(index => String(index));
+  }
+
+  const dropdownValue = selectedIndexesAsArray
+    .map(index => (enumOptions ? enumOptions[Number(index)].label : undefined))
+    .join(', ');
+
+  const _onBlur = () => onBlur(id, selectedIndexes);
+  const _onFocus = () => onFocus(id, selectedIndexes);
+  const _onChange = (event: CustomEvent) => {
+    const details = event.detail;
+    const newValue = multiple
+      ? Array.from(
+          details.selectedOptions as HTMLOptionElement[],
+          option => option.value
+        )
+      : (details.selectedOptions as HTMLOptionElement).value;
+    onChange(enumOptionsValueForIndex<S>(newValue, enumOptions, optEmptyVal));
+  };
+
+  const showPlaceholderOption = !multiple && schema.default === undefined;
+
+  return (
+    <Select
+      aria-invalid={rawErrors.length > 0}
+      id={id}
+      value={dropdownValue}
+      disabled={disabled || readonly}
+      onBlur={_onBlur}
+      onFocus={_onFocus}
+      onChange={_onChange}
+      aria-required={required}
+      aria-describedby={ariaDescribedByIds<T>(id)}
+    >
+      {showPlaceholderOption && <Option value="">{placeholder || ''}</Option>}
+      {Array.isArray(enumOptions) &&
+        enumOptions.map(({ value, label }, i) => {
+          const disabled = enumDisabled && enumDisabled.indexOf(value) !== -1;
+          return (
+            <Option key={i} value={String(i)} disabled={disabled}>
+              {label}
+            </Option>
+          );
+        })}
+    </Select>
+  );
+}

--- a/packages/ui-components/src/components/widgets/textWidget.tsx
+++ b/packages/ui-components/src/components/widgets/textWidget.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import React, { FocusEvent } from 'react';
+import { NumberField, TextField } from '@jupyter/react-components';
+import {
+  ariaDescribedByIds,
+  BaseInputTemplateProps,
+  examplesId,
+  FormContextType,
+  GenericObjectType,
+  getInputProps,
+  RJSFSchema,
+  StrictRJSFSchema
+} from '@rjsf/utils';
+
+const INPUT_STYLE = {
+  width: '100%'
+};
+
+/** The `BaseInputTemplate` is the template to use to render the basic `<input>` component for the `core` theme.
+ * It is used as the template for rendering many of the <input> based widgets that differ by `type` and callbacks only.
+ * It can be customized/overridden for other themes or individual implementations as needed.
+ *
+ * @param props - The `WidgetProps` for this template
+ */
+export function BaseInputTemplate<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any
+>(props: BaseInputTemplateProps<T, S, F>) {
+  const {
+    disabled,
+    formContext,
+    id,
+    onBlur,
+    onChange,
+    onChangeOverride,
+    onFocus,
+    options,
+    placeholder,
+    readonly,
+    schema,
+    value,
+    type
+  } = props;
+
+  const inputProps = getInputProps<T, S, F>(schema, type, options, false);
+  const { type: type_, step, ...otherProps } = inputProps;
+  const { readonlyAsDisabled = true } = formContext as GenericObjectType;
+
+  const handleNumberChange = (event: CustomEvent) => {
+    if (event.detail.valueAsNumber !== undefined) {
+      onChange(event.detail.valueAsNumber);
+    }
+  };
+
+  const handleTextChange = onChangeOverride
+    ? (onChangeOverride as any)
+    : (event: CustomEvent) => {
+        const textValue =
+          event.detail.value === '' ? options.emptyValue : event.detail.value;
+        onChange(textValue);
+      };
+
+  const handleBlur = ({ target }: FocusEvent<HTMLInputElement>) => {
+    onBlur(id, target?.value);
+  };
+
+  const handleFocus = ({ target }: FocusEvent<HTMLInputElement>) => {
+    onFocus(id, target?.value);
+  };
+
+  const input =
+    inputProps.type === 'number' || inputProps.type === 'integer' ? (
+      <NumberField
+        disabled={disabled || (readonlyAsDisabled && readonly)}
+        id={id}
+        name={id}
+        onBlur={!readonly ? handleBlur : undefined}
+        onChange={!readonly ? handleNumberChange : undefined}
+        onFocus={!readonly ? handleFocus : undefined}
+        placeholder={placeholder}
+        style={INPUT_STYLE}
+        list={schema.examples ? examplesId<T>(id) : undefined}
+        {...otherProps}
+        step={step as any}
+        value={value}
+        aria-describedby={ariaDescribedByIds<T>(id, !!schema.examples)}
+      />
+    ) : (
+      <TextField
+        disabled={disabled || (readonlyAsDisabled && readonly)}
+        id={id}
+        name={id}
+        onBlur={!readonly ? handleBlur : undefined}
+        onChange={!readonly ? handleTextChange : undefined}
+        onFocus={!readonly ? handleFocus : undefined}
+        placeholder={placeholder}
+        style={INPUT_STYLE}
+        list={schema.examples ? examplesId<T>(id) : undefined}
+        {...otherProps}
+        type={type_ as any}
+        value={value as string | undefined}
+        aria-describedby={ariaDescribedByIds<T>(id, !!schema.examples)}
+      />
+    );
+
+  return (
+    <>
+      {input}
+      {Array.isArray(schema.examples) && (
+        <datalist id={examplesId<T>(id)}>
+          {(schema.examples as string[])
+            .concat(
+              schema.default && !schema.examples.includes(schema.default)
+                ? ([schema.default] as string[])
+                : []
+            )
+            .map(example => (
+              <option key={example} value={example} />
+            ))}
+        </datalist>
+      )}
+    </>
+  );
+}

--- a/packages/ui-components/src/components/widgets/textareaWidget.tsx
+++ b/packages/ui-components/src/components/widgets/textareaWidget.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import React from 'react';
+import { FocusEvent, useCallback } from 'react';
+import {
+  ariaDescribedByIds,
+  FormContextType,
+  RJSFSchema,
+  StrictRJSFSchema,
+  WidgetProps
+} from '@rjsf/utils';
+import { TextArea } from '@jupyter/react-components';
+
+/** The `TextareaWidget` is a widget for rendering input fields as textarea.
+ *
+ * @param props - The `WidgetProps` for this component
+ */
+export function TextareaWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any
+>({
+  id,
+  options,
+  placeholder,
+  value,
+  required,
+  disabled,
+  readonly,
+  autofocus = false,
+  onChange,
+  onBlur,
+  onFocus
+}: WidgetProps<T, S, F>) {
+  const handleChange = useCallback(
+    ({ target }: CustomEvent) =>
+      onChange(
+        (target as any).value === ''
+          ? options.emptyValue
+          : (target as any).value
+      ),
+    [onChange, options.emptyValue]
+  );
+
+  const handleBlur = useCallback(
+    ({ target }: FocusEvent<HTMLTextAreaElement>) =>
+      onBlur(id, target && target.value),
+    [onBlur, id]
+  );
+
+  const handleFocus = useCallback(
+    ({ target }: FocusEvent<HTMLTextAreaElement>) =>
+      onFocus(id, target && target.value),
+    [id, onFocus]
+  );
+
+  return (
+    <TextArea
+      id={id}
+      name={id}
+      className="form-control"
+      value={value || ''}
+      placeholder={placeholder}
+      required={required}
+      disabled={disabled}
+      readOnly={readonly}
+      autofocus={autofocus}
+      onBlur={handleBlur}
+      onFocus={handleFocus}
+      onChange={handleChange}
+      aria-describedby={ariaDescribedByIds<T>(id)}
+    />
+  );
+}


### PR DESCRIPTION
**Issue:**
Inconsistencies have arisen in the user interface across various JupyterLab extensions, including the Table of Content, Debugger Variables, and Running tabs.

**Background:**
This update aims to introduce a variety of user interface components in the settings editor to enhance functionality and user interaction across JupyterLab.

**Description of New Features in Settings Editor:**
The settings editor will now include the following toolkit components to cater to different user needs:

**Input:** This component allows users to enter text or numeric values. It can be used to capture information such as names, email addresses, phone numbers, and more.
**Option:** This component presents users with a set of predefined choices. It can be used to select preferences, enable or disable features, or make other binary decisions.
**Button:** This component triggers an action when clicked. It can be used to save changes, submit forms, navigate to different pages, or perform other tasks.
**Select:** This component allows users to choose from a list of options. It can be used to select items from a menu, filter content, or perform other selection-based tasks.
**Search:** This component provides a search bar where users can enter keywords to find specific content or information. It can be used to search through a list of items, a database, or other resources.

**Goals:**
These components are designed to be flexible and customizable, allowing developers to easily integrate them into their applications and create intuitive and user-friendly interfaces. This enhancement aims to improve the consistency and accessibility of JupyterLab's user interface, making it more streamlined and efficient for all users.
