### PR TITLE
Remove spurious regex to slightly improve performance of streaming large outputs

### DIFF
--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -809,6 +809,8 @@ function nativeSanitize(source: string): string {
   return el.innerHTML;
 }
 
+const ansiPrefix = '\x1b';
+
 /**
  * Render the textual representation into a host node.
  *
@@ -821,8 +823,7 @@ function renderTextual(
   // Unpack the options.
   const { host, sanitizer, source } = options;
 
-  const ansiPrefixRe = /\x1b/; // eslint-disable-line no-control-regex
-  const hasAnsiPrefix = ansiPrefixRe.test(source);
+  const hasAnsiPrefix = source.includes(ansiPrefix);
 
   // Create the HTML content:
   // If no ANSI codes are present use a fast path for escaping.


### PR DESCRIPTION
## References

- Extracted from https://github.com/jupyterlab/jupyterlab/pull/17197
- Step towards https://github.com/jupyterlab/jupyterlab/issues/16957
- Follow-up to https://github.com/jupyterlab/jupyterlab/pull/17022

## Code changes

Use `String.includes` method for checking if ANSI prefix is present over constructing and testing regular expression.

## User-facing changes

Small speedup (by 0.1s when streaming 5000 lines) from https://github.com/jupyterlab/jupyterlab/issues/16957 reproducer.

I verified across browsers using microbenchmarks https://jsben.ch/dg8ao and within JupyterLab by extracting the check to a function locally so that Chrome performance profiler was able to log time for that logic separately. The difference will be more noticeable with even longer streams.

## Backwards-incompatible changes

None