### PR TITLE
Speed up output rendering: add a limit on max length of protocol to linkify

### DIFF
--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -531,11 +531,29 @@ interface ILinker {
 }
 
 namespace ILinker {
+  // Matching regular expressions is slow; we can fast-reject
+  // a string if it does not start with `data:`, `www.`, or
+  // a valid schema. We define a valid schema as an alphanumeric
+  // sequence of length at least two and followed by `://`,
+  // e.g.`https://`. To fast-reject in long sequence of characters
+  // we need to impose an additional restriction on the length.
+  // As of 2025 the longest registered URI schemes are:
+  // - machineProvisioningProgressReporter - 35
+  // - microsoft.windows.camera.multipicker - 36
+  // See https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
+  // While technically any length is allowed, it is unlikely that any scheme
+  // longer than 40 characters would be of a general benefit to most users,
+  // and if one finds themselves with a use case which requires it, they are
+  // welcome to open a PR which allows to customize this restriction.
+  const maxAcceptedProtocolLength = 40;
+
   // Taken from Visual Studio Code:
   // https://github.com/microsoft/vscode/blob/9f709d170b06e991502153f281ec3c012add2e42/src/vs/workbench/contrib/debug/browser/linkDetector.ts#L17-L18
   const controlCodes = '\\u0000-\\u0020\\u007f-\\u009f';
   export const webLinkRegex = new RegExp(
-    '(?<path>(?:[a-zA-Z][a-zA-Z0-9+.-]{2,}:\\/\\/|data:|www\\.)[^\\s' +
+    '(?<path>(?:[a-zA-Z][a-zA-Z0-9+.-]{2,' +
+      maxAcceptedProtocolLength +
+      '}:\\/\\/|data:|www\\.)[^\\s' +
       controlCodes +
       '"]{2,}[^\\s' +
       controlCodes +


### PR DESCRIPTION
## References

- Helps with https://github.com/jupyterlab/jupyterlab/issues/16957

## Code changes

Matching regular expressions is slow; we can fast-reject a string if it does not start with `data:`, `www.`, or a valid schema. 
We define a valid schema as an alphanumeric sequence of length at least two and followed by `://`, e.g.`https://`. To fast-reject in long sequence of characters  we need to impose an additional restriction on the length.

As of today the longest registered URI schemes are:
- `machineProvisioningProgressReporter` - 35
- `microsoft.windows.camera.multipicker` - 36

See https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml

While technically any length is allowed, it is unlikely that any scheme longer than 40 characters would be of a general benefit to most users, and if one finds themselves with a use case which requires it, they are welcome to open a PR which allows to customize or loosen this restriction.

## User-facing changes

- The UI will no longer freeze when rendering textual outputs which contain continuous strings of alphanumeric characters.
- URLs with schema of length greater than 40 will no longer be turned into HTML anchors
   > There is no known schema of such length registered with IANA as of February 2025

### >x42 speedup when streaming 46k characters in one line in 1000 steps

| Before | After |
|--|--|
| >10 minutes\* | 14 seconds |

*) I lost patience at ~11 minutes

```python
import sys

for i in range(1000):
    print(f"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", end='')
    sys.stdout.flush()
```

### >6x speedup when streaming ~9k characters in one line in 2000 steps

| Before | After |
|--|--|
| 27 seconds | 4 seconds |

```python
import sys

for i in range(2000):
    print(f"a{i}", end='')
    sys.stdout.flush()
```

**Before**

https://github.com/user-attachments/assets/bb9a2fea-9ecf-4ea7-a28f-2383546cb0c2

**After**

https://github.com/user-attachments/assets/64c79a7d-d5d7-4774-a486-5740cbfd6d37


## Backwards-incompatible changes

`renderError` and `renderText` will no longer linkify paths which include an URL schema of length greater than 40.
