### PR TITLE
Update to TypeScript 5.5

### DIFF
--- a/builder/package.json
+++ b/builder/package.json
@@ -71,7 +71,7 @@
     "@types/node": "^20.11.27",
     "@types/supports-color": "^5.3.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/buildutils/package.json
+++ b/buildutils/package.json
@@ -57,7 +57,7 @@
     "process": "^0.11.10",
     "semver": "^7.3.2",
     "sort-package-json": "~1.53.1",
-    "typescript": "~5.4.5",
+    "typescript": "~5.5.4",
     "verdaccio": "^5.25.0"
   },
   "devDependencies": {

--- a/buildutils/template/package.json
+++ b/buildutils/template/package.json
@@ -40,7 +40,7 @@
     "@jupyterlab/testing": "^4.4.0-alpha.3",
     "@types/jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -46,7 +46,7 @@ The **icons in use** are in the ``ui-components/style/icons/debugger`` folder, w
 TypeScript update
 ^^^^^^^^^^^^^^^^^
 
-As a follow-up to the update to TypeScript 5.4, the ``tsconfig.json`` configuration of the ``@jupyterlab/buildutils`` package changed
+As a follow-up to the update to TypeScript 5.5, the ``tsconfig.json`` configuration of the ``@jupyterlab/buildutils`` package changed
 the ``module`` option from ``commonjs`` to ``Node16``:
 
 .. code:: diff

--- a/examples/cell/package.json
+++ b/examples/cell/package.json
@@ -28,7 +28,7 @@
     "mini-svg-data-uri": "^1.4.4",
     "rimraf": "~5.0.5",
     "style-loader": "~3.3.1",
-    "typescript": "~5.4.5",
+    "typescript": "~5.5.4",
     "webpack": "^5.76.1",
     "webpack-cli": "^5.0.1"
   }

--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -25,7 +25,7 @@
     "mini-css-extract-plugin": "^2.7.0",
     "rimraf": "~5.0.5",
     "style-loader": "~3.3.1",
-    "typescript": "~5.4.5",
+    "typescript": "~5.5.4",
     "webpack": "^5.76.1",
     "webpack-cli": "^5.0.1"
   }

--- a/examples/filebrowser/package.json
+++ b/examples/filebrowser/package.json
@@ -29,7 +29,7 @@
     "mini-svg-data-uri": "^1.4.4",
     "rimraf": "~5.0.5",
     "style-loader": "~3.3.1",
-    "typescript": "~5.4.5",
+    "typescript": "~5.5.4",
     "webpack": "^5.76.1",
     "webpack-cli": "^5.0.1"
   }

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -34,7 +34,7 @@
     "mini-svg-data-uri": "^1.4.4",
     "rimraf": "~5.0.5",
     "style-loader": "~3.3.1",
-    "typescript": "~5.4.5",
+    "typescript": "~5.5.4",
     "webpack": "^5.76.1",
     "webpack-cli": "^5.0.1"
   }

--- a/examples/terminal/package.json
+++ b/examples/terminal/package.json
@@ -21,7 +21,7 @@
     "mini-svg-data-uri": "^1.4.4",
     "rimraf": "~5.0.5",
     "style-loader": "~3.3.1",
-    "typescript": "~5.4.5",
+    "typescript": "~5.5.4",
     "webpack": "^5.76.1",
     "webpack-cli": "^5.0.1"
   }

--- a/galata/extension/package.json
+++ b/galata/extension/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@jupyterlab/builder": "^4.4.0-alpha.3",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "jupyterlab": {
     "extension": true,

--- a/galata/package.json
+++ b/galata/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -67,7 +67,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/apputils-extension/package.json
+++ b/packages/apputils-extension/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -72,7 +72,7 @@
     "@types/sanitize-html": "^2.11.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cell-toolbar-extension/package.json
+++ b/packages/cell-toolbar-extension/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cell-toolbar/package.json
+++ b/packages/cell-toolbar/package.json
@@ -58,7 +58,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -77,7 +77,7 @@
     "@types/react": "^18.0.26",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/celltags-extension/package.json
+++ b/packages/celltags-extension/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -63,7 +63,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@types/react": "^18.0.26",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -79,7 +79,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/completer-extension/package.json
+++ b/packages/completer-extension/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -71,7 +71,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/console-extension/package.json
+++ b/packages/console-extension/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -66,7 +66,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -57,7 +57,7 @@
     "jest-junit": "^15.0.0",
     "rimraf": "~5.0.5",
     "ts-jest": "^29.1.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/csvviewer-extension/package.json
+++ b/packages/csvviewer-extension/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/csvviewer/package.json
+++ b/packages/csvviewer/package.json
@@ -59,7 +59,7 @@
     "jest": "^29.2.0",
     "jest-canvas-mock": "^2.5.2",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/debugger-extension/package.json
+++ b/packages/debugger-extension/package.json
@@ -65,7 +65,7 @@
     "@types/jest": "^29.2.0",
     "@types/react-dom": "^18.0.9",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -84,7 +84,7 @@
     "jest": "^29.2.0",
     "jest-canvas-mock": "^2.5.2",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/docmanager/package.json
+++ b/packages/docmanager/package.json
@@ -64,7 +64,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -65,7 +65,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/docregistry/src/testutils.ts
+++ b/packages/docregistry/src/testutils.ts
@@ -4,7 +4,7 @@
 // We explicitly reference the jest typings since the jest.d.ts file shipped
 // with jest 26 masks the @types/jest typings
 
-/// <reference types="jest" />
+/// <reference types="jest" preserve="true"/>
 
 import { ISessionContext, SessionContext } from '@jupyterlab/apputils';
 import {

--- a/packages/documentsearch-extension/package.json
+++ b/packages/documentsearch-extension/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/documentsearch/package.json
+++ b/packages/documentsearch/package.json
@@ -55,7 +55,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/extensionmanager-extension/package.json
+++ b/packages/extensionmanager-extension/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/extensionmanager/package.json
+++ b/packages/extensionmanager/package.json
@@ -54,7 +54,7 @@
     "@types/semver": "^7.3.3",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/filebrowser-extension/package.json
+++ b/packages/filebrowser-extension/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -67,7 +67,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/fileeditor-extension/package.json
+++ b/packages/fileeditor-extension/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/fileeditor/package.json
+++ b/packages/fileeditor/package.json
@@ -63,7 +63,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/help-extension/package.json
+++ b/packages/help-extension/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/htmlviewer-extension/package.json
+++ b/packages/htmlviewer-extension/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/htmlviewer/package.json
+++ b/packages/htmlviewer/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/hub-extension/package.json
+++ b/packages/hub-extension/package.json
@@ -49,7 +49,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/imageviewer-extension/package.json
+++ b/packages/imageviewer-extension/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/imageviewer/package.json
+++ b/packages/imageviewer/package.json
@@ -53,7 +53,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/inspector-extension/package.json
+++ b/packages/inspector-extension/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -59,7 +59,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/javascript-extension/package.json
+++ b/packages/javascript-extension/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/json-extension/package.json
+++ b/packages/json-extension/package.json
@@ -52,7 +52,7 @@
     "@types/react-dom": "^18.0.9",
     "@types/react-highlight-words": "^0.16.4",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/launcher-extension/package.json
+++ b/packages/launcher-extension/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@types/react": "^18.0.26",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/logconsole-extension/package.json
+++ b/packages/logconsole-extension/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/logconsole/package.json
+++ b/packages/logconsole/package.json
@@ -55,7 +55,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/lsp-extension/package.json
+++ b/packages/lsp-extension/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/lsp/package.json
+++ b/packages/lsp/package.json
@@ -64,7 +64,7 @@
     "jest": "^29.2.0",
     "json-schema-to-typescript": "^8.0.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mainmenu-extension/package.json
+++ b/packages/mainmenu-extension/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mainmenu/package.json
+++ b/packages/mainmenu/package.json
@@ -54,7 +54,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/markdownviewer-extension/package.json
+++ b/packages/markdownviewer-extension/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/markdownviewer/package.json
+++ b/packages/markdownviewer/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/markedparser-extension/package.json
+++ b/packages/markedparser-extension/package.json
@@ -49,7 +49,7 @@
     "@types/d3": "^7.4.0",
     "@types/dompurify": "^2.4.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mathjax-extension/package.json
+++ b/packages/mathjax-extension/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mermaid-extension/package.json
+++ b/packages/mermaid-extension/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -53,7 +53,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/metadataform-extension/package.json
+++ b/packages/metadataform-extension/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/metadataform/package.json
+++ b/packages/metadataform/package.json
@@ -65,7 +65,7 @@
     "@types/react": "^18.0.26",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -141,7 +141,7 @@
     "jest": "^29.2.0",
     "json-to-html": "~0.1.2",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/nbformat/package.json
+++ b/packages/nbformat/package.json
@@ -44,7 +44,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -78,7 +78,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -76,7 +76,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/observables/package.json
+++ b/packages/observables/package.json
@@ -47,7 +47,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/outputarea/package.json
+++ b/packages/outputarea/package.json
@@ -61,7 +61,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/pdf-extension/package.json
+++ b/packages/pdf-extension/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/pluginmanager-extension/package.json
+++ b/packages/pluginmanager-extension/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/pluginmanager/package.json
+++ b/packages/pluginmanager/package.json
@@ -55,7 +55,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/property-inspector/package.json
+++ b/packages/property-inspector/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/rendermime-extension/package.json
+++ b/packages/rendermime-extension/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/rendermime-interfaces/package.json
+++ b/packages/rendermime-interfaces/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -61,7 +61,7 @@
     "fs-extra": "^10.1.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/running-extension/package.json
+++ b/packages/running-extension/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/running/package.json
+++ b/packages/running/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/services/examples/browser/package.json
+++ b/packages/services/examples/browser/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5",
+    "typescript": "~5.5.4",
     "webpack": "^5.76.1",
     "webpack-cli": "^5.0.1"
   }

--- a/packages/services/examples/typescript-browser-with-output/package.json
+++ b/packages/services/examples/typescript-browser-with-output/package.json
@@ -25,7 +25,7 @@
     "css-loader": "^6.7.1",
     "rimraf": "~5.0.5",
     "style-loader": "~3.3.1",
-    "typescript": "~5.4.5",
+    "typescript": "~5.5.4",
     "webpack": "^5.76.1",
     "webpack-cli": "^5.0.1"
   },

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -63,7 +63,7 @@
     "@types/ws": "^8.5.3",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5",
+    "typescript": "~5.5.4",
     "webpack": "^5.76.1",
     "webpack-cli": "^5.0.1"
   },

--- a/packages/services/src/testutils.ts
+++ b/packages/services/src/testutils.ts
@@ -1,11 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-// We explicitly reference the jest typings since the jest.d.ts file shipped
-// with jest 26 masks the @types/jest typings
-
-/// <reference types="jest" />
-
 import { PathExt } from '@jupyterlab/coreutils';
 import { PartialJSONObject, ReadonlyJSONObject, UUID } from '@lumino/coreutils';
 import { AttachedProperty } from '@lumino/properties';

--- a/packages/services/src/testutils.ts
+++ b/packages/services/src/testutils.ts
@@ -1,6 +1,11 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+// We explicitly reference the jest typings since the jest.d.ts file shipped
+// with jest 26 masks the @types/jest typings
+
+/// <reference types="jest" preserve="true"/>
+
 import { PathExt } from '@jupyterlab/coreutils';
 import { PartialJSONObject, ReadonlyJSONObject, UUID } from '@lumino/coreutils';
 import { AttachedProperty } from '@lumino/properties';

--- a/packages/services/tsconfig.json
+++ b/packages/services/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "module": "commonjs",
-    "types": ["node"]
+    "types": ["jest", "node"]
   },
   "include": ["src/**/*"],
   "references": [

--- a/packages/services/tsconfig.json
+++ b/packages/services/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "references": [

--- a/packages/settingeditor-extension/package.json
+++ b/packages/settingeditor-extension/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/settingeditor/package.json
+++ b/packages/settingeditor/package.json
@@ -73,7 +73,7 @@
     "react-test-renderer": "^18.2.0",
     "rimraf": "~5.0.5",
     "ts-jest": "^29.1.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/settingregistry/package.json
+++ b/packages/settingregistry/package.json
@@ -51,7 +51,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "peerDependencies": {
     "react": ">=16"

--- a/packages/shortcuts-extension/package.json
+++ b/packages/shortcuts-extension/package.json
@@ -58,7 +58,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/statedb/package.json
+++ b/packages/statedb/package.json
@@ -46,7 +46,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/statusbar-extension/package.json
+++ b/packages/statusbar-extension/package.json
@@ -46,7 +46,7 @@
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/statusbar/package.json
+++ b/packages/statusbar/package.json
@@ -50,7 +50,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/terminal-extension/package.json
+++ b/packages/terminal-extension/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@types/webpack-env": "^1.18.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -60,7 +60,7 @@
     "jest": "^29.2.0",
     "jest-canvas-mock": "^2.5.2",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -51,7 +51,7 @@
     "@types/jest": "^29.2.0",
     "@types/node": "^20.11.27",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "peerDependencies": {
     "typescript": ">=4.3"

--- a/packages/theme-dark-extension/package.json
+++ b/packages/theme-dark-extension/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/theme-dark-high-contrast-extension/package.json
+++ b/packages/theme-dark-high-contrast-extension/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/theme-light-extension/package.json
+++ b/packages/theme-light-extension/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/toc-extension/package.json
+++ b/packages/toc-extension/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/toc/package.json
+++ b/packages/toc/package.json
@@ -62,7 +62,7 @@
     "@types/react": "^18.0.26",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tooltip-extension/package.json
+++ b/packages/tooltip-extension/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/translation-extension/package.json
+++ b/packages/translation-extension/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/translation/package.json
+++ b/packages/translation/package.json
@@ -48,7 +48,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-components-extension/package.json
+++ b/packages/ui-components-extension/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-components/examples/simple-windowed-list/package.json
+++ b/packages/ui-components/examples/simple-windowed-list/package.json
@@ -23,7 +23,7 @@
     "mini-svg-data-uri": "^1.4.4",
     "rimraf": "~5.0.5",
     "style-loader": "~3.3.1",
-    "typescript": "~5.4.5",
+    "typescript": "~5.5.4",
     "webpack": "^5.76.1",
     "webpack-cli": "^5.0.1"
   },

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -69,7 +69,7 @@
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
     "svgo": "^3.3.2",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "peerDependencies": {
     "react": "^18.2.0"

--- a/packages/vega5-extension/package.json
+++ b/packages/vega5-extension/package.json
@@ -51,7 +51,7 @@
     "jest": "^29.2.0",
     "jest-canvas-mock": "^2.5.2",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/workspaces-extension/package.json
+++ b/packages/workspaces-extension/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@types/jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/workspaces/package.json
+++ b/packages/workspaces/package.json
@@ -49,7 +49,7 @@
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/testutils/package.json
+++ b/testutils/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "rimraf": "~5.0.5",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20149,17 +20149,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:>=3 < 6":
-  version: 5.4.5
-  resolution: "typescript@npm:5.4.5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 53c879c6fa1e3bcb194b274d4501ba1985894b2c2692fa079db03c5a5a7140587a1e04e1ba03184605d35f439b40192d9e138eb3279ca8eee313c081c8bcd9b0
-  languageName: node
-  linkType: hard
-
-"typescript@npm:~5.5.4":
+"typescript@npm:>=3 < 6, typescript@npm:~5.5.4":
   version: 5.5.4
   resolution: "typescript@npm:5.5.4"
   bin:
@@ -20169,17 +20159,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@>=3 < 6#~builtin<compat/typescript>":
-  version: 5.4.5
-  resolution: "typescript@patch:typescript@npm%3A5.4.5#~builtin<compat/typescript>::version=5.4.5&hash=85af82"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 2373c693f3b328f3b2387c3efafe6d257b057a142f9a79291854b14ff4d5367d3d730810aee981726b677ae0fd8329b23309da3b6aaab8263dbdccf1da07a3ba
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@~5.5.4#~builtin<compat/typescript>":
+"typescript@patch:typescript@>=3 < 6#~builtin<compat/typescript>, typescript@patch:typescript@~5.5.4#~builtin<compat/typescript>":
   version: 5.5.4
   resolution: "typescript@patch:typescript@npm%3A5.5.4#~builtin<compat/typescript>::version=5.5.4&hash=85af82"
   bin:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2203,7 +2203,7 @@ __metadata:
     "@lumino/widgets": ^2.5.0
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -2315,7 +2315,7 @@ __metadata:
     "@types/jest": ^29.2.0
     jest: ^29.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -2347,7 +2347,7 @@ __metadata:
     react-dom: ^18.2.0
     react-toastify: ^9.0.8
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -2381,7 +2381,7 @@ __metadata:
     react: ^18.2.0
     rimraf: ~5.0.5
     sanitize-html: ~2.12.1
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -2396,7 +2396,7 @@ __metadata:
     "@lumino/disposable": ^2.1.3
     "@lumino/signaling": ^2.1.3
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -2436,7 +2436,7 @@ __metadata:
     style-loader: ~3.3.1
     supports-color: ^7.2.0
     terser-webpack-plugin: ^5.3.7
-    typescript: ~5.4.5
+    typescript: ~5.5.4
     webpack: ^5.76.1
     webpack-cli: ^5.0.1
     webpack-merge: ^5.8.0
@@ -2473,7 +2473,7 @@ __metadata:
     rimraf: ~5.0.5
     semver: ^7.3.2
     sort-package-json: ~1.53.1
-    typescript: ~5.4.5
+    typescript: ~5.5.4
     verdaccio: ^5.25.0
   bin:
     get-dependency: ./lib/get-dependency.js
@@ -2495,7 +2495,7 @@ __metadata:
     "@jupyterlab/settingregistry": ^4.4.0-alpha.3
     "@jupyterlab/translation": ^4.4.0-alpha.3
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -2519,7 +2519,7 @@ __metadata:
     "@types/jest": ^29.2.0
     jest: ^29.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -2560,7 +2560,7 @@ __metadata:
     jest: ^29.2.0
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -2576,7 +2576,7 @@ __metadata:
     "@rjsf/utils": ^5.13.4
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -2604,7 +2604,7 @@ __metadata:
     jest: ^29.2.0
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -2633,7 +2633,7 @@ __metadata:
     "@types/react": ^18.0.26
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -2679,7 +2679,7 @@ __metadata:
     "@types/jest": ^29.2.0
     jest: ^29.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
     yjs: ^13.5.40
   languageName: unknown
   linkType: soft
@@ -2699,7 +2699,7 @@ __metadata:
     "@rjsf/utils": ^5.13.4
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -2731,7 +2731,7 @@ __metadata:
     "@types/jest": ^29.2.0
     jest: ^29.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -2757,7 +2757,7 @@ __metadata:
     "@lumino/properties": ^2.0.2
     "@lumino/widgets": ^2.5.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -2787,7 +2787,7 @@ __metadata:
     "@types/jest": ^29.2.0
     jest: ^29.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -2810,7 +2810,7 @@ __metadata:
     path-browserify: ^1.0.0
     rimraf: ~5.0.5
     ts-jest: ^29.1.0
-    typescript: ~5.4.5
+    typescript: ~5.5.4
     url-parse: ~1.5.4
   languageName: unknown
   linkType: soft
@@ -2831,7 +2831,7 @@ __metadata:
     "@lumino/datagrid": ^2.4.1
     "@lumino/widgets": ^2.5.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -2855,7 +2855,7 @@ __metadata:
     jest: ^29.2.0
     jest-canvas-mock: ^2.5.2
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -2883,7 +2883,7 @@ __metadata:
     "@types/jest": ^29.2.0
     "@types/react-dom": ^18.0.9
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -2926,7 +2926,7 @@ __metadata:
     jest-canvas-mock: ^2.5.2
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -2953,7 +2953,7 @@ __metadata:
     "@lumino/widgets": ^2.5.0
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -2982,7 +2982,7 @@ __metadata:
     jest: ^29.2.0
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3012,7 +3012,7 @@ __metadata:
     jest: ^29.2.0
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3028,7 +3028,7 @@ __metadata:
     "@lumino/commands": ^2.3.1
     "@lumino/widgets": ^2.5.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3051,7 +3051,7 @@ __metadata:
     jest: ^29.2.0
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3129,7 +3129,7 @@ __metadata:
     mini-svg-data-uri: ^1.4.4
     rimraf: ~5.0.5
     style-loader: ~3.3.1
-    typescript: ~5.4.5
+    typescript: ~5.5.4
     webpack: ^5.76.1
     webpack-cli: ^5.0.1
   languageName: unknown
@@ -3155,7 +3155,7 @@ __metadata:
     mini-css-extract-plugin: ^2.7.0
     rimraf: ~5.0.5
     style-loader: ~3.3.1
-    typescript: ~5.4.5
+    typescript: ~5.5.4
     webpack: ^5.76.1
     webpack-cli: ^5.0.1
   languageName: unknown
@@ -3275,7 +3275,7 @@ __metadata:
     mini-svg-data-uri: ^1.4.4
     rimraf: ~5.0.5
     style-loader: ~3.3.1
-    typescript: ~5.4.5
+    typescript: ~5.5.4
     webpack: ^5.76.1
     webpack-cli: ^5.0.1
   languageName: unknown
@@ -3310,7 +3310,7 @@ __metadata:
     mini-svg-data-uri: ^1.4.4
     rimraf: ~5.0.5
     style-loader: ~3.3.1
-    typescript: ~5.4.5
+    typescript: ~5.5.4
     webpack: ^5.76.1
     webpack-cli: ^5.0.1
   languageName: unknown
@@ -3324,7 +3324,7 @@ __metadata:
     "@jupyterlab/services": ^7.4.0-alpha.3
     "@lumino/coreutils": ^2.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
     webpack: ^5.76.1
     webpack-cli: ^5.0.1
   languageName: unknown
@@ -3341,7 +3341,7 @@ __metadata:
     css-loader: ^6.7.1
     rimraf: ~5.0.5
     style-loader: ~3.3.1
-    typescript: ~5.4.5
+    typescript: ~5.5.4
     webpack: ^5.76.1
     webpack-cli: ^5.0.1
   languageName: unknown
@@ -3363,7 +3363,7 @@ __metadata:
     mini-svg-data-uri: ^1.4.4
     rimraf: ~5.0.5
     style-loader: ~3.3.1
-    typescript: ~5.4.5
+    typescript: ~5.5.4
     webpack: ^5.76.1
     webpack-cli: ^5.0.1
   languageName: unknown
@@ -3385,7 +3385,7 @@ __metadata:
     mini-svg-data-uri: ^1.4.4
     rimraf: ~5.0.5
     style-loader: ~3.3.1
-    typescript: ~5.4.5
+    typescript: ~5.5.4
     webpack: ^5.76.1
     webpack-cli: ^5.0.1
   languageName: unknown
@@ -3402,7 +3402,7 @@ __metadata:
     "@jupyterlab/translation": ^4.4.0-alpha.3
     "@jupyterlab/ui-components": ^4.4.0-alpha.3
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3426,7 +3426,7 @@ __metadata:
     react-paginate: ^6.3.2
     rimraf: ~5.0.5
     semver: ^7.3.2
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3450,7 +3450,7 @@ __metadata:
     "@lumino/commands": ^2.3.1
     "@lumino/widgets": ^2.5.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3482,7 +3482,7 @@ __metadata:
     jest: ^29.2.0
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3519,7 +3519,7 @@ __metadata:
     "@lumino/coreutils": ^2.2.0
     "@lumino/widgets": ^2.5.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3549,7 +3549,7 @@ __metadata:
     react: ^18.2.0
     regexp-match-indices: ^1.0.2
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3570,7 +3570,7 @@ __metadata:
     "@lumino/coreutils": ^2.2.0
     "@lumino/signaling": ^2.1.3
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3595,7 +3595,7 @@ __metadata:
     path: ~0.12.7
     rimraf: ~5.0.5
     systeminformation: ^5.8.6
-    typescript: ~5.4.5
+    typescript: ~5.5.4
     vega: ^5.20.0
     vega-lite: ^5.6.1
     vega-statistics: ^1.7.9
@@ -3619,7 +3619,7 @@ __metadata:
     "@lumino/widgets": ^2.5.0
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3636,7 +3636,7 @@ __metadata:
     "@jupyterlab/translation": ^4.4.0-alpha.3
     "@jupyterlab/ui-components": ^4.4.0-alpha.3
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3654,7 +3654,7 @@ __metadata:
     "@lumino/widgets": ^2.5.0
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3670,7 +3670,7 @@ __metadata:
     "@types/jest": ^29.2.0
     jest: ^29.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3684,7 +3684,7 @@ __metadata:
     "@jupyterlab/imageviewer": ^4.4.0-alpha.3
     "@jupyterlab/translation": ^4.4.0-alpha.3
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3702,7 +3702,7 @@ __metadata:
     "@types/jest": ^29.2.0
     jest: ^29.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3720,7 +3720,7 @@ __metadata:
     "@jupyterlab/ui-components": ^4.4.0-alpha.3
     "@lumino/widgets": ^2.5.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3744,7 +3744,7 @@ __metadata:
     "@types/jest": ^29.2.0
     jest: ^29.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3755,7 +3755,7 @@ __metadata:
     "@jupyterlab/rendermime": ^4.4.0-alpha.3
     "@jupyterlab/rendermime-interfaces": ^3.12.0-alpha.3
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3781,7 +3781,7 @@ __metadata:
     react-json-tree: ^0.18.0
     rimraf: ~5.0.5
     style-mod: ^4.0.0
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3799,7 +3799,7 @@ __metadata:
     "@lumino/coreutils": ^2.2.0
     "@lumino/widgets": ^2.5.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3819,7 +3819,7 @@ __metadata:
     "@types/react": ^18.0.26
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3841,7 +3841,7 @@ __metadata:
     "@lumino/widgets": ^2.5.0
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3864,7 +3864,7 @@ __metadata:
     "@types/jest": ^29.2.0
     jest: ^29.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3885,7 +3885,7 @@ __metadata:
     "@rjsf/utils": ^5.13.4
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3911,7 +3911,7 @@ __metadata:
     json-schema-to-typescript: ^8.0.0
     lodash.mergewith: ^4.6.1
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
     vscode-jsonrpc: ^6.0.0
     vscode-languageserver-protocol: ^3.17.0
     vscode-ws-jsonrpc: ~1.0.2
@@ -3938,7 +3938,7 @@ __metadata:
     "@lumino/messaging": ^2.0.2
     "@lumino/widgets": ^2.5.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3957,7 +3957,7 @@ __metadata:
     "@types/jest": ^29.2.0
     jest: ^29.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3974,7 +3974,7 @@ __metadata:
     "@jupyterlab/toc": ^6.4.0-alpha.3
     "@jupyterlab/translation": ^4.4.0-alpha.3
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -3993,7 +3993,7 @@ __metadata:
     "@lumino/signaling": ^2.1.3
     "@lumino/widgets": ^2.5.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4013,7 +4013,7 @@ __metadata:
     marked-gfm-heading-id: ^4.1.1
     marked-mangle: ^1.1.10
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4026,7 +4026,7 @@ __metadata:
     "@lumino/coreutils": ^2.2.0
     mathjax-full: ^3.2.2
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4040,7 +4040,7 @@ __metadata:
     "@jupyterlab/rendermime-interfaces": ^3.12.0-alpha.3
     "@jupyterlab/translation": ^4.4.0-alpha.3
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4058,7 +4058,7 @@ __metadata:
     jest: ^29.2.0
     mermaid: ^11.4.1
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4074,7 +4074,7 @@ __metadata:
     "@jupyterlab/ui-components": ^4.4.0-alpha.3
     "@lumino/coreutils": ^2.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4100,7 +4100,7 @@ __metadata:
     json-schema: ^0.4.0
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4211,7 +4211,7 @@ __metadata:
     jest: ^29.2.0
     json-to-html: ~0.1.2
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4279,7 +4279,7 @@ __metadata:
     "@types/jest": ^29.2.0
     jest: ^29.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4336,7 +4336,7 @@ __metadata:
     "@rjsf/utils": ^5.13.4
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4378,7 +4378,7 @@ __metadata:
     jest: ^29.2.0
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4395,7 +4395,7 @@ __metadata:
     "@types/jest": ^29.2.0
     jest: ^29.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4421,7 +4421,7 @@ __metadata:
     "@types/jest": ^29.2.0
     jest: ^29.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4434,7 +4434,7 @@ __metadata:
     "@lumino/disposable": ^2.1.3
     "@lumino/widgets": ^2.5.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4449,7 +4449,7 @@ __metadata:
     "@jupyterlab/ui-components": ^4.4.0-alpha.3
     "@lumino/coreutils": ^2.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4471,7 +4471,7 @@ __metadata:
     jest: ^29.2.0
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4489,7 +4489,7 @@ __metadata:
     jest: ^29.2.0
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4503,7 +4503,7 @@ __metadata:
     "@jupyterlab/rendermime": ^4.4.0-alpha.3
     "@jupyterlab/translation": ^4.4.0-alpha.3
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4514,7 +4514,7 @@ __metadata:
     "@lumino/coreutils": ^1.11.0 || ^2.2.0
     "@lumino/widgets": ^1.37.2 || ^2.5.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4540,7 +4540,7 @@ __metadata:
     jest: ^29.2.0
     lodash.escape: ^4.0.1
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4589,7 +4589,7 @@ __metadata:
     "@lumino/widgets": ^2.5.0
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4610,7 +4610,7 @@ __metadata:
     "@lumino/widgets": ^2.5.0
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4633,7 +4633,7 @@ __metadata:
     "@types/ws": ^8.5.3
     jest: ^29.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
     webpack: ^5.76.1
     webpack-cli: ^5.0.1
     ws: ^8.11.0
@@ -4657,7 +4657,7 @@ __metadata:
     "@lumino/disposable": ^2.1.3
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4695,7 +4695,7 @@ __metadata:
     react-test-renderer: ^18.2.0
     rimraf: ~5.0.5
     ts-jest: ^29.1.0
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4716,7 +4716,7 @@ __metadata:
     jest: ^29.2.0
     json5: ^2.2.3
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   peerDependencies:
     react: ">=16"
   languageName: unknown
@@ -4742,7 +4742,7 @@ __metadata:
     jest: ^29.2.0
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4759,7 +4759,7 @@ __metadata:
     "@types/jest": ^29.2.0
     jest: ^29.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4775,7 +4775,7 @@ __metadata:
     "@types/react": ^18.0.26
     "@types/react-dom": ^18.0.9
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4795,7 +4795,7 @@ __metadata:
     jest: ^29.2.0
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4806,7 +4806,7 @@ __metadata:
     "@jupyterlab/testing": ^4.4.0-alpha.3
     "@types/jest": ^29.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4827,7 +4827,7 @@ __metadata:
     "@lumino/widgets": ^2.5.0
     "@types/webpack-env": ^1.18.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4852,7 +4852,7 @@ __metadata:
     jest: ^29.2.0
     jest-canvas-mock: ^2.5.2
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4876,7 +4876,7 @@ __metadata:
     rimraf: ~5.0.5
     simulate-event: ~1.4.0
     ts-jest: ^29.1.0
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   peerDependencies:
     typescript: ">=4.3"
   languageName: unknown
@@ -4892,7 +4892,7 @@ __metadata:
     "@jupyterlab/rendermime": ^4.4.0-alpha.3
     "@jupyterlab/testing": ^4.4.0-alpha.3
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4904,7 +4904,7 @@ __metadata:
     "@jupyterlab/apputils": ^4.5.0-alpha.3
     "@jupyterlab/translation": ^4.4.0-alpha.3
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4916,7 +4916,7 @@ __metadata:
     "@jupyterlab/apputils": ^4.5.0-alpha.3
     "@jupyterlab/translation": ^4.4.0-alpha.3
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4928,7 +4928,7 @@ __metadata:
     "@jupyterlab/apputils": ^4.5.0-alpha.3
     "@jupyterlab/translation": ^4.4.0-alpha.3
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4942,7 +4942,7 @@ __metadata:
     "@jupyterlab/translation": ^4.4.0-alpha.3
     "@jupyterlab/ui-components": ^4.4.0-alpha.3
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4970,7 +4970,7 @@ __metadata:
     jest: ^29.2.0
     react: ^18.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -4992,7 +4992,7 @@ __metadata:
     "@lumino/coreutils": ^2.2.0
     "@lumino/widgets": ^2.5.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -5008,7 +5008,7 @@ __metadata:
     "@lumino/messaging": ^2.0.2
     "@lumino/widgets": ^2.5.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -5022,7 +5022,7 @@ __metadata:
     "@jupyterlab/settingregistry": ^4.4.0-alpha.3
     "@jupyterlab/translation": ^4.4.0-alpha.3
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -5039,7 +5039,7 @@ __metadata:
     "@types/jest": ^29.2.0
     jest: ^29.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -5050,7 +5050,7 @@ __metadata:
     "@jupyterlab/application": ^4.4.0-alpha.3
     "@jupyterlab/ui-components": ^4.4.0-alpha.3
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -5084,7 +5084,7 @@ __metadata:
     react-dom: ^18.2.0
     rimraf: ~5.0.5
     svgo: ^3.3.2
-    typescript: ~5.4.5
+    typescript: ~5.5.4
     typestyle: ^2.0.4
   peerDependencies:
     react: ^18.2.0
@@ -5104,7 +5104,7 @@ __metadata:
     jest: ^29.2.0
     jest-canvas-mock: ^2.5.2
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
     vega: ^5.20.0
     vega-embed: ^6.2.1
     vega-lite: ^5.6.1-next.1
@@ -5127,7 +5127,7 @@ __metadata:
     "@jupyterlab/workspaces": ^4.4.0-alpha.3
     "@types/jest": ^29.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -5144,7 +5144,7 @@ __metadata:
     "@types/jest": ^29.2.0
     jest: ^29.2.0
     rimraf: ~5.0.5
-    typescript: ~5.4.5
+    typescript: ~5.5.4
   languageName: unknown
   linkType: soft
 
@@ -20149,7 +20149,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:>=3 < 6, typescript@npm:~5.4.5":
+"typescript@npm:>=3 < 6":
   version: 5.4.5
   resolution: "typescript@npm:5.4.5"
   bin:
@@ -20159,13 +20159,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@>=3 < 6#~builtin<compat/typescript>, typescript@patch:typescript@~5.4.5#~builtin<compat/typescript>":
+"typescript@npm:~5.5.4":
+  version: 5.5.4
+  resolution: "typescript@npm:5.5.4"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: b309040f3a1cd91c68a5a58af6b9fdd4e849b8c42d837b2c2e73f9a4f96a98c4f1ed398a9aab576ee0a4748f5690cf594e6b99dbe61de7839da748c41e6d6ca8
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@>=3 < 6#~builtin<compat/typescript>":
   version: 5.4.5
   resolution: "typescript@patch:typescript@npm%3A5.4.5#~builtin<compat/typescript>::version=5.4.5&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 2373c693f3b328f3b2387c3efafe6d257b057a142f9a79291854b14ff4d5367d3d730810aee981726b677ae0fd8329b23309da3b6aaab8263dbdccf1da07a3ba
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@~5.5.4#~builtin<compat/typescript>":
+  version: 5.5.4
+  resolution: "typescript@patch:typescript@npm%3A5.5.4#~builtin<compat/typescript>::version=5.5.4&hash=85af82"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: fc52962f31a5bcb716d4213bef516885e4f01f30cea797a831205fc9ef12b405a40561c40eae3127ab85ba1548e7df49df2bcdee6b84a94bfbe3a0d7eff16b14
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Continuing the TypeScript update journey towards https://github.com/jupyterlab/jupyterlab/issues/16174

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Update to `typescript~=5.5.4`
- [x] Add `preserve="true"` to the existing `/// <reference types="jest" />`, according to https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#simplified-reference-directive-declaration-emit

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
