### PR TITLE
Fix missing checks for author comment association for docs

### DIFF
--- a/.github/workflows/galata-update.yml
+++ b/.github/workflows/galata-update.yml
@@ -106,7 +106,10 @@ jobs:
       (
         github.event.issue.author_association == 'OWNER' ||
         github.event.issue.author_association == 'COLLABORATOR' ||
-        github.event.issue.author_association == 'MEMBER'
+        github.event.issue.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR' ||
+        github.event.comment.author_association == 'MEMBER'
       ) && github.event.issue.pull_request && (
         contains(github.event.comment.body, 'please update documentation snapshots') ||
         contains(github.event.comment.body, 'please update snapshots')


### PR DESCRIPTION
## References

- Noticed in https://github.com/jupyterlab/jupyterlab/pull/17244#issuecomment-2656172713
- Follow-up to https://github.com/jupyterlab/jupyterlab/pull/16872

## Code changes

Fixes unitended difference in conditions between:

https://github.com/jupyterlab/jupyterlab/blob/362e9570ecc44a02ff0b3d75f371610438b3052b/.github/workflows/galata-update.yml#L12-L25

and

https://github.com/jupyterlab/jupyterlab/blob/362e9570ecc44a02ff0b3d75f371610438b3052b/.github/workflows/galata-update.yml#L103-L113

## User-facing changes

None

## Backwards-incompatible changes

None