### PR TITLE
Disable new `ctrl` + `m` toggle focus binding, enable configuring it via Keyboard Shortcuts

### DIFF
--- a/packages/codemirror-extension/src/commands.ts
+++ b/packages/codemirror-extension/src/commands.ts
@@ -108,7 +108,7 @@ export const commandsPlugin: JupyterFrontEndPlugin<void> = {
     app.commands.addCommand(CommandIDs.toggleTabFocusMode, {
       label: trans.__('Toggle Tab Focus Mode'),
       caption: trans.__(
-        'Toggles behaviour of Tab key between inserting indentation and moving to next focusable element'
+        'Toggles behavior of Tab key between inserting indentation and moving to next focusable element'
       ),
       execute: () => {
         const view = findEditorView();

--- a/packages/codemirror-extension/src/commands.ts
+++ b/packages/codemirror-extension/src/commands.ts
@@ -6,7 +6,8 @@
 import {
   deleteLine,
   toggleBlockComment,
-  toggleComment
+  toggleComment,
+  toggleTabFocusMode
 } from '@codemirror/commands';
 import { EditorView } from '@codemirror/view';
 import { selectNextOccurrence } from '@codemirror/search';
@@ -24,6 +25,7 @@ namespace CommandIDs {
   export const toggleBlockComment = 'codemirror:toggle-block-comment';
   export const toggleComment = 'codemirror:toggle-comment';
   export const selectNextOccurrence = 'codemirror:select-next-occurrence';
+  export const toggleTabFocusMode = 'codemirror:toggle-tab-focus-mode';
 }
 
 /**
@@ -99,6 +101,21 @@ export const commandsPlugin: JupyterFrontEndPlugin<void> = {
           return;
         }
         toggleComment(view);
+      },
+      isEnabled
+    });
+
+    app.commands.addCommand(CommandIDs.toggleTabFocusMode, {
+      label: trans.__('Toggle Tab Focus Mode'),
+      caption: trans.__(
+        'Toggles behaviour of Tab key between inserting indentation and moving to next focusable element'
+      ),
+      execute: () => {
+        const view = findEditorView();
+        if (!view) {
+          return;
+        }
+        toggleTabFocusMode(view);
       },
       isEnabled
     });

--- a/packages/codemirror/src/extension.ts
+++ b/packages/codemirror/src/extension.ts
@@ -735,7 +735,7 @@ export namespace EditorExtensionRegistry {
             // - Disable default Enter handler because it prevents us from
             //   accepting a completer suggestion with Enter.
             // - Disable Ctrl-m (Shift-Alt-m on Mac) which toggles tab focus mode;
-            //   JupyterLab binds `Esc` to an equivalent behaviour (switching
+            //   JupyterLab binds `Esc` to an equivalent behavior (switching
             //   between command end edit mode) in notebooks, but has no equivalent
             //   in the File Editor; instead, a `codemirror:toggle-tab-focus-mode`
             //   command can be bound to invoke this behaviour.

--- a/packages/codemirror/src/extension.ts
+++ b/packages/codemirror/src/extension.ts
@@ -734,7 +734,13 @@ export namespace EditorExtensionRegistry {
             //   want to run a cell action (switch to command mode) on Esc
             // - Disable default Enter handler because it prevents us from
             //   accepting a completer suggestion with Enter.
+            // - Disable Ctrl-m (Shift-Alt-m on Mac) which toggles tab focus mode;
+            //   JupyterLab binds `Esc` to an equivalent behaviour (switching
+            //   between command end edit mode) in notebooks, but has no equivalent
+            //   in the File Editor; instead, a `codemirror:toggle-tab-focus-mode`
+            //   command can be bound to invoke this behaviour.
             return ![
+              'Ctrl-m',
               'Mod-Enter',
               'Shift-Mod-k',
               'Mod-/',


### PR DESCRIPTION
## References

Addresses first point in #17080. I found this Ctrl + M can lead to user confusion as this is not documented anywhere and has no visual indicator; in notebook switching between edit/command mode has equivalent effect. Instead, this PR allows user to opt-in and choose a suitable key-binding by binding a new `codemirror:toggle-tab-focus-mode` command.

## Code changes

Adds new `codemirror:toggle-tab-focus-mode` command.

## User-facing changes

- Ctrl + M no longer switches tab focus mode in CodeMirror (this was never released, it was added in 4.4.0a as inherited change from upstream CodeMirror)
- Users are able to set a preferred shortcut for toggling tab focus mode (no shortcut is set by default yet as we do not know what would be a good one)

## Backwards-incompatible changes

None