### PR TITLE
Fix handling of a `null` banner in the code console

### DIFF
--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -815,12 +815,16 @@ export class CodeConsole extends Widget {
    */
   private _handleInfo(info: KernelMessage.IInfoReplyMsg['content']): void {
     if (info.status !== 'ok') {
-      this._banner!.model.sharedModel.setSource(
-        'Error in getting kernel banner'
-      );
+      if (this._banner) {
+        this._banner.model.sharedModel.setSource(
+          'Error in getting kernel banner'
+        );
+      }
       return;
     }
-    this._banner!.model.sharedModel.setSource(info.banner);
+    if (this._banner) {
+      this._banner.model.sharedModel.setSource(info.banner);
+    }
     const lang = info.language_info as nbformat.ILanguageInfoMetadata;
     this._mimetype = this._mimeTypeService.getMimeTypeByLanguage(lang);
     if (this.promptCell) {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/13837.

## Code changes

Fix the use of the non-null assertion operator in the code console widget, now that there is an option to hide the banner:

https://github.com/jupyterlab/jupyterlab/blob/e64f81f24594d72f0ad409a1daf2d85ac5778cb3/packages/console/src/widget.ts#L818-L823

This non-null assertion was causing the following error the be logged in the dev tools console:


https://github.com/user-attachments/assets/5d958c0e-ac84-4660-8d46-8602c42f8ff2



Noticed downstream in https://github.com/jupyterlite/jupyterlite/pull/1573.

## User-facing changes

Likely none.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
