### PR TITLE
Fix typo in LSP console message on kernel change

### DIFF
--- a/packages/notebook/src/notebooklspadapter.ts
+++ b/packages/notebook/src/notebooklspadapter.ts
@@ -201,7 +201,7 @@ export class NotebookAdapter extends WidgetLSPAdapter<NotebookPanel> {
         this.reloadConnection();
       } else {
         console.log(
-          'Keeping old LSP connection as the new kernel uses the same langauge'
+          'Keeping old LSP connection as the new kernel uses the same language'
         );
       }
     } catch (err) {


### PR DESCRIPTION
Fixes a typo in a console message sent when changing kernel