### PR TITLE
Provide `ITranslatorConnector` via a separate plugin

### DIFF
--- a/packages/translation-extension/src/index.ts
+++ b/packages/translation-extension/src/index.ts
@@ -31,7 +31,7 @@ const PLUGIN_ID = '@jupyterlab/translation-extension:plugin';
 /**
  * Provide the translator connector as a separate plugin to allow for alternative
  * implementations that may want to fetch translation bundles from a different
- * source.
+ * source or endpoint.
  */
 const translatorConnector: JupyterFrontEndPlugin<ITranslatorConnector> = {
   id: '@jupyterlab/translation:translator-connector',

--- a/packages/translation/src/manager.ts
+++ b/packages/translation/src/manager.ts
@@ -20,7 +20,7 @@ export class TranslationManager implements ITranslator {
    *
    * @param translationsUrl The URL of the translation server.
    * @param stringsPrefix (optional) The prefix for translation strings.
-   * @param serverSettings (optional) The settings for the translation server.
+   * @param serverSettings (optional) The server settings.
    * @param connector (optional) The translation connector. If provided, the `translationsUrl` and `serverSettings` parameters will be ignored.
    */
   constructor(

--- a/packages/translation/src/manager.ts
+++ b/packages/translation/src/manager.ts
@@ -3,23 +3,41 @@
 
 import { ServerConnection } from '@jupyterlab/services';
 import { Gettext } from './gettext';
-import { ITranslator, TranslationBundle, TranslatorConnector } from './tokens';
+import {
+  ITranslator,
+  ITranslatorConnector,
+  TranslationBundle,
+  TranslatorConnector
+} from './tokens';
 import { normalizeDomain } from './utils';
 
 /**
- * Translation Manager
+ * Translation Manager.
  */
 export class TranslationManager implements ITranslator {
+  /**
+   * Construct a new TranslationManager.
+   *
+   * @param translationsUrl The URL of the translation server.
+   * @param stringsPrefix (optional) The prefix for translation strings.
+   * @param serverSettings (optional) The settings for the translation server.
+   * @param connector (optional) The translation connector. If provided, the `translationsUrl` and `serverSettings` parameters will be ignored.
+   */
   constructor(
     translationsUrl: string = '',
     stringsPrefix?: string,
-    serverSettings?: ServerConnection.ISettings
+    serverSettings?: ServerConnection.ISettings,
+    connector?: ITranslatorConnector
   ) {
-    this._connector = new TranslatorConnector(translationsUrl, serverSettings);
+    this._connector =
+      connector ?? new TranslatorConnector(translationsUrl, serverSettings);
     this._stringsPrefix = stringsPrefix || '';
     this._englishBundle = new Gettext({ stringsPrefix: this._stringsPrefix });
   }
 
+  /**
+   * Get the language code of the current locale.
+   */
   get languageCode(): string {
     return this._currentLocale;
   }
@@ -90,7 +108,7 @@ export class TranslationManager implements ITranslator {
     }
   }
 
-  private _connector: TranslatorConnector;
+  private _connector: ITranslatorConnector;
   private _currentLocale: string;
   private _domainData: any = {};
   private _englishBundle: Gettext;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

It turns out that a `ITranslatorConnector` token was already defined as part of the `@jupyterlab/translation` tokens here: 

https://github.com/jupyterlab/jupyterlab/blob/c0bb677556bb7fffab501df43188271c2a7cdd72/packages/translation/src/tokens.ts#L23-L29

However until now it was not exposed as a service via a plugin, since the `TranslationManager` currently instantiates its own connector here: 

https://github.com/jupyterlab/jupyterlab/blob/c0bb677556bb7fffab501df43188271c2a7cdd72/packages/translation/src/manager.ts#L18

This PR extracts the translation connector so it can be provided via its own plugin. It looks like it was meant to be exposed via a plugin but never ended up being the case?

This will allow downstream extensions and applications to more easily provide a different way for fetching the different bundles if they want to, for example if they are served from a different source or via a different endpoint. With this PR, they can simply replace the connector by providing a plugin exposing a `ITranslatorConnector`, instead of having to replace the `@jupyterlab/translation:translator` plugin entirely to provide a custom `TranslationManager`.

## Code changes

To stay backwards compatible, the `connector` is passed as an optional parameter when instantiating the `TranslationManager`.

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
