### PR TITLE
Provide `ISettingsConnector` via a separate plugin

### DIFF
--- a/galata/test/documentation/plugins.test.ts-snapshots/tokens-documentation-linux.json
+++ b/galata/test/documentation/plugins.test.ts-snapshots/tokens-documentation-linux.json
@@ -12,6 +12,7 @@
   "@jupyterlab/apputils:ICommandPalette": "A service for the application command palette\n  in the left panel. Use this to add commands to the palette.",
   "@jupyterlab/apputils:IWindowResolver": "A service for a window resolver for the\n  application. JupyterLab workspaces are given a name, which are determined using\n  the window resolver. Require this if you want to use the name of the current workspace.",
   "@jupyterlab/apputils:ISanitizer": "A service for sanitizing HTML strings.",
+  "@jupyterlab/coreutils:ISettingConnector": "A service to connect to the settings endpoint.",
   "@jupyterlab/coreutils:ISettingRegistry": "A service for the JupyterLab settings system.\n  Use this if you want to store settings for your application.\n  See \"schemaDir\" for more information.",
   "@jupyterlab/coreutils:IStateDB": "A service for the JupyterLab state database.\n  Use this if you want to store data that will persist across page loads.\n  See \"state database\" for more information.",
   "@jupyterlab/apputils:ISplashScreen": "A service for the splash screen for the application.\n  Use this if you want to show the splash screen for your own purposes.",

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -37,7 +37,7 @@ import { Debouncer, Throttler } from '@lumino/polling';
 import { announcements } from './announcements';
 import { notificationPlugin } from './notificationplugin';
 import { Palette } from './palette';
-import { settingsPlugin } from './settingsplugin';
+import { settingsConnector, settingsPlugin } from './settingsplugin';
 import { kernelStatus, runningSessionsStatus } from './statusbarplugin';
 import { themesPaletteMenuPlugin, themesPlugin } from './themesplugins';
 import { toolbarRegistry } from './toolbarregistryplugin';
@@ -739,6 +739,7 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   resolver,
   runningSessionsStatus,
   sanitizer,
+  settingsConnector,
   settingsPlugin,
   state,
   splash,

--- a/packages/apputils-extension/src/settingconnector.ts
+++ b/packages/apputils-extension/src/settingconnector.ts
@@ -5,8 +5,8 @@
 
 import { PageConfig } from '@jupyterlab/coreutils';
 import {
-  ISettingRegistry,
-  ISettingsConnector
+  ISettingConnector,
+  ISettingRegistry
 } from '@jupyterlab/settingregistry';
 import { DataConnector, IDataConnector } from '@jupyterlab/statedb';
 import { Throttler } from '@lumino/polling';
@@ -19,7 +19,7 @@ import { Throttler } from '@lumino/polling';
  */
 export class SettingConnector
   extends DataConnector<ISettingRegistry.IPlugin, string>
-  implements ISettingsConnector
+  implements ISettingConnector
 {
   constructor(connector: IDataConnector<ISettingRegistry.IPlugin, string>) {
     super();

--- a/packages/apputils-extension/src/settingconnector.ts
+++ b/packages/apputils-extension/src/settingconnector.ts
@@ -4,7 +4,10 @@
  */
 
 import { PageConfig } from '@jupyterlab/coreutils';
-import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import {
+  ISettingRegistry,
+  ISettingsConnector
+} from '@jupyterlab/settingregistry';
 import { DataConnector, IDataConnector } from '@jupyterlab/statedb';
 import { Throttler } from '@lumino/polling';
 
@@ -14,10 +17,10 @@ import { Throttler } from '@lumino/polling';
  * #### Notes
  * This connector adds a query parameter to the base services setting manager.
  */
-export class SettingConnector extends DataConnector<
-  ISettingRegistry.IPlugin,
-  string
-> {
+export class SettingConnector
+  extends DataConnector<ISettingRegistry.IPlugin, string>
+  implements ISettingsConnector
+{
   constructor(connector: IDataConnector<ISettingRegistry.IPlugin, string>) {
     super();
     this._connector = connector;

--- a/packages/apputils-extension/src/settingsplugin.ts
+++ b/packages/apputils-extension/src/settingsplugin.ts
@@ -8,18 +8,40 @@ import {
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 import { PageConfig } from '@jupyterlab/coreutils';
-import { ISettingRegistry, SettingRegistry } from '@jupyterlab/settingregistry';
+import {
+  ISettingRegistry,
+  ISettingsConnector,
+  SettingRegistry
+} from '@jupyterlab/settingregistry';
 import { SettingConnector } from './settingconnector';
+
+/**
+ * The default settings connector.
+ */
+export const settingsConnector: JupyterFrontEndPlugin<ISettingsConnector> = {
+  id: '@jupyterlab/apputils-extension:settings-connector',
+  autoStart: true,
+  provides: ISettingsConnector,
+  activate: (app: JupyterFrontEnd) =>
+    new SettingConnector(app.serviceManager.settings)
+};
 
 /**
  * The default setting registry provider.
  */
 export const settingsPlugin: JupyterFrontEndPlugin<ISettingRegistry> = {
   id: '@jupyterlab/apputils-extension:settings',
+  autoStart: true,
+  provides: ISettingRegistry,
+  optional: [ISettingsConnector],
   description: 'Provides the setting registry.',
-  activate: async (app: JupyterFrontEnd): Promise<ISettingRegistry> => {
+  activate: async (
+    app: JupyterFrontEnd,
+    settingsConnector: ISettingsConnector | null
+  ): Promise<ISettingRegistry> => {
     const { isDisabled } = PageConfig.Extension;
-    const connector = new SettingConnector(app.serviceManager.settings);
+    const connector =
+      settingsConnector ?? new SettingConnector(app.serviceManager.settings);
 
     // On startup, check if a plugin is available in the application.
     // This helps avoid loading plugin files from other lab-based applications
@@ -61,7 +83,5 @@ export const settingsPlugin: JupyterFrontEndPlugin<ISettingRegistry> = {
     });
 
     return registry;
-  },
-  autoStart: true,
-  provides: ISettingRegistry
+  }
 };

--- a/packages/apputils-extension/src/settingsplugin.ts
+++ b/packages/apputils-extension/src/settingsplugin.ts
@@ -16,7 +16,7 @@ import {
 import { SettingConnector } from './settingconnector';
 
 /**
- * Provide the settings connector as a separate plugin to allow for alternative
+ * Provides the settings connector as a separate plugin to allow for alternative
  * implementations that may want to fetch settings from a different source or
  * endpoint.
  */

--- a/packages/apputils-extension/src/settingsplugin.ts
+++ b/packages/apputils-extension/src/settingsplugin.ts
@@ -9,8 +9,8 @@ import {
 } from '@jupyterlab/application';
 import { PageConfig } from '@jupyterlab/coreutils';
 import {
+  ISettingConnector,
   ISettingRegistry,
-  ISettingsConnector,
   SettingRegistry
 } from '@jupyterlab/settingregistry';
 import { SettingConnector } from './settingconnector';
@@ -20,11 +20,11 @@ import { SettingConnector } from './settingconnector';
  * implementations that may want to fetch settings from a different source or
  * endpoint.
  */
-export const settingsConnector: JupyterFrontEndPlugin<ISettingsConnector> = {
+export const settingsConnector: JupyterFrontEndPlugin<ISettingConnector> = {
   id: '@jupyterlab/apputils-extension:settings-connector',
   description: 'Provides the settings connector.',
   autoStart: true,
-  provides: ISettingsConnector,
+  provides: ISettingConnector,
   activate: (app: JupyterFrontEnd) =>
     new SettingConnector(app.serviceManager.settings)
 };
@@ -36,11 +36,11 @@ export const settingsPlugin: JupyterFrontEndPlugin<ISettingRegistry> = {
   id: '@jupyterlab/apputils-extension:settings',
   autoStart: true,
   provides: ISettingRegistry,
-  optional: [ISettingsConnector],
+  optional: [ISettingConnector],
   description: 'Provides the setting registry.',
   activate: async (
     app: JupyterFrontEnd,
-    settingsConnector: ISettingsConnector | null
+    settingsConnector: ISettingConnector | null
   ): Promise<ISettingRegistry> => {
     const { isDisabled } = PageConfig.Extension;
     const connector =

--- a/packages/apputils-extension/src/settingsplugin.ts
+++ b/packages/apputils-extension/src/settingsplugin.ts
@@ -16,7 +16,9 @@ import {
 import { SettingConnector } from './settingconnector';
 
 /**
- * The default settings connector.
+ * Provide the settings connector as a separate plugin to allow for alternative
+ * implementations that may want to fetch settings from a different source or
+ * endpoint.
  */
 export const settingsConnector: JupyterFrontEndPlugin<ISettingsConnector> = {
   id: '@jupyterlab/apputils-extension:settings-connector',

--- a/packages/apputils-extension/src/settingsplugin.ts
+++ b/packages/apputils-extension/src/settingsplugin.ts
@@ -22,6 +22,7 @@ import { SettingConnector } from './settingconnector';
  */
 export const settingsConnector: JupyterFrontEndPlugin<ISettingsConnector> = {
   id: '@jupyterlab/apputils-extension:settings-connector',
+  description: 'Provides the settings connector.',
   autoStart: true,
   provides: ISettingsConnector,
   activate: (app: JupyterFrontEnd) =>

--- a/packages/settingregistry/src/tokens.ts
+++ b/packages/settingregistry/src/tokens.ts
@@ -18,7 +18,7 @@ import { ISchemaValidator } from './settingregistry';
 import type { RJSFSchema, UiSchema } from '@rjsf/utils';
 
 /**
- * A service to connect to the server endpoint.
+ * A service to connect to the settings endpoint.
  */
 export const ISettingConnector = new Token<ISettingConnector>(
   '@jupyterlab/coreutils:ISettingConnector',

--- a/packages/settingregistry/src/tokens.ts
+++ b/packages/settingregistry/src/tokens.ts
@@ -20,8 +20,8 @@ import type { RJSFSchema, UiSchema } from '@rjsf/utils';
 /**
  * A service to connect to the server endpoint.
  */
-export const ISettingsConnector = new Token<ISettingsConnector>(
-  '@jupyterlab/coreutils:ISettingsConnector',
+export const ISettingConnector = new Token<ISettingConnector>(
+  '@jupyterlab/coreutils:ISettingConnector',
   'A service to connect to the settings endpoint.'
 );
 
@@ -38,7 +38,7 @@ export const ISettingRegistry = new Token<ISettingRegistry>(
 /**
  * The settings connector interface.
  */
-export interface ISettingsConnector
+export interface ISettingConnector
   extends IDataConnector<ISettingRegistry.IPlugin, string> {}
 
 /**

--- a/packages/settingregistry/src/tokens.ts
+++ b/packages/settingregistry/src/tokens.ts
@@ -18,12 +18,6 @@ import { ISchemaValidator } from './settingregistry';
 import type { RJSFSchema, UiSchema } from '@rjsf/utils';
 
 /**
- * The settings connector interface.
- */
-export interface ISettingsConnector
-  extends IDataConnector<ISettingRegistry.IPlugin, string> {}
-
-/**
  * A service to connect to the server endpoint.
  */
 export const ISettingsConnector = new Token<ISettingsConnector>(
@@ -40,6 +34,12 @@ export const ISettingRegistry = new Token<ISettingRegistry>(
   Use this if you want to store settings for your application.
   See "schemaDir" for more information.`
 );
+
+/**
+ * The settings connector interface.
+ */
+export interface ISettingsConnector
+  extends IDataConnector<ISettingRegistry.IPlugin, string> {}
 
 /**
  * The settings registry interface.

--- a/packages/settingregistry/src/tokens.ts
+++ b/packages/settingregistry/src/tokens.ts
@@ -18,6 +18,20 @@ import { ISchemaValidator } from './settingregistry';
 import type { RJSFSchema, UiSchema } from '@rjsf/utils';
 
 /**
+ * The settings connector interface.
+ */
+export interface ISettingsConnector
+  extends IDataConnector<ISettingRegistry.IPlugin, string> {}
+
+/**
+ * A service to connect to the server endpoint.
+ */
+export const ISettingsConnector = new Token<ISettingsConnector>(
+  '@jupyterlab/coreutils:ISettingsConnector',
+  'A service to connect to the settings endpoint.'
+);
+
+/**
  * The setting registry token.
  */
 export const ISettingRegistry = new Token<ISettingRegistry>(


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Similar to https://github.com/jupyterlab/jupyterlab/pull/17325 but for the settings.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Provide `ISettingsConnector` via a separate plugin, so it can more easily be swapped from an extension.

One use case is to allow for extension to store settings in the browser instead of the server.

Although this should also now be possible after #16794 by providing a custom `Setting.IManager` and replace the following plugin:

https://github.com/jupyterlab/jupyterlab/blob/ad4e2d979d37e90ef91530a8fe4e147078668ccf/packages/services-extension/src/index.ts#L192-L207

This PR enables a similar possibility, except that downstream extensions could then provide a regular `JupyterFrontendPlugin` instead of a `ServiceManagerPlugin` (considered more advanced).

As a follow-up, we could also consider deprecating the use `app.serviceManager.settings`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
