### PR TITLE
Normalize translator plugin ids

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -97,6 +97,12 @@ the updated rendering logic.
 This change improves both the rendering performance and the maintainability of extensions
 using the ``GroupItem`` component.
 
+Plugins
+-------
+
+- ``@jupyterlab/translation-extension`` from 4.3 to 4.4
+   * The ``@jupyterlab/translation:translator`` plugin id has been renamed to ``@jupyterlab/translation-extension:translator``
+
 JupyterLab 4.2 to 4.3
 ---------------------
 

--- a/packages/translation-extension/src/index.ts
+++ b/packages/translation-extension/src/index.ts
@@ -34,7 +34,7 @@ const PLUGIN_ID = '@jupyterlab/translation-extension:plugin';
  * source or endpoint.
  */
 const translatorConnector: JupyterFrontEndPlugin<ITranslatorConnector> = {
-  id: '@jupyterlab/translation:translator-connector',
+  id: '@jupyterlab/translation-extension:translator-connector',
   description: 'Provides the application translation connector.',
   autoStart: true,
   requires: [JupyterFrontEnd.IPaths],
@@ -50,7 +50,7 @@ const translatorConnector: JupyterFrontEndPlugin<ITranslatorConnector> = {
  * The main translator plugin.
  */
 const translator: JupyterFrontEndPlugin<ITranslator> = {
-  id: '@jupyterlab/translation:translator',
+  id: '@jupyterlab/translation-extension:translator',
   description: 'Provides the application translation object.',
   autoStart: true,
   requires: [JupyterFrontEnd.IPaths, ISettingRegistry],


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Rename the `@jupyterlab/translation-extension` plugins to they follow the same naming convention as other JupyterLab plugins.

## Code changes

- Rename `@jupyterlab/translation:translator` to `@jupyterlab/translation-extension:translator`
- Rename `@jupyterlab/translation:translator-connector` to `@jupyterlab/translation-extension:translator-connector`


## User-facing changes

None

## Backwards-incompatible changes

None

Mention the change in the extension migration just in case folks were relying on that plugin or replacing it.