### PR TITLE
Use `ITranslationConnector` to fetch the translations

### DIFF
--- a/packages/translation-extension/src/index.ts
+++ b/packages/translation-extension/src/index.ts
@@ -152,6 +152,7 @@ const langMenu: JupyterFrontEndPlugin<void> = {
         // Get list of available locales
         translatorConnector
           .fetch({ language: '' })
+          // TODO: fix usage of any
           .then((data: any) => {
             for (const locale in data['data']) {
               const value = data['data'][locale];

--- a/packages/translation-extension/src/index.ts
+++ b/packages/translation-extension/src/index.ts
@@ -18,7 +18,6 @@ import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import {
   ITranslator,
   ITranslatorConnector,
-  requestTranslationsAPI,
   TranslationManager,
   TranslatorConnector
 } from '@jupyterlab/translation';
@@ -96,13 +95,14 @@ const translator: JupyterFrontEndPlugin<ITranslator> = {
 const langMenu: JupyterFrontEndPlugin<void> = {
   id: PLUGIN_ID,
   description: 'Adds translation commands and settings.',
-  requires: [ISettingRegistry, ITranslator],
+  requires: [ISettingRegistry, ITranslator, ITranslatorConnector],
   optional: [IMainMenu, ICommandPalette],
   autoStart: true,
   activate: (
     app: JupyterFrontEnd,
     settings: ISettingRegistry,
     translator: ITranslator,
+    translatorConnector: ITranslatorConnector,
     mainMenu: IMainMenu | null,
     palette: ICommandPalette | null
   ) => {
@@ -149,10 +149,10 @@ const langMenu: JupyterFrontEndPlugin<void> = {
 
         let command: string;
 
-        const serverSettings = app.serviceManager.serverSettings;
         // Get list of available locales
-        requestTranslationsAPI<any>('', '', {}, serverSettings)
-          .then(data => {
+        translatorConnector
+          .fetch({ language: '' })
+          .then((data: any) => {
             for (const locale in data['data']) {
               const value = data['data'][locale];
               const displayName = value.displayName;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/17325

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Fix the use of a raw API request to fetch the translation.

Instead, use the translator connector exposed via a plugin in https://github.com/jupyterlab/jupyterlab/pull/17325.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
