### PR TITLE
Clarify documentation on bot privileges for updating snapshots

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -692,7 +692,8 @@ Main reasons for UI test failures are:
    - ``please update snapshots``: Combine the two previous comments effects.
 
     The bot will react with +1 emoji to indicate that the run started and then comment
-    back once it concluded.
+    back once it concluded. This feature is restricted to a subset of users with higher
+    privileges due to security concerns.
 
 For more information on UI Testing, please read the `UI Testing developer documentation <https://github.com/jupyterlab/jupyterlab/blob/main/galata/README.md>`__
 and `Playwright documentation <https://playwright.dev/docs/intro>`__.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

This PR updates the documentation to explicitly state that the bot's ability to update snapshots is restricted to a subset of users with higher privileges due to security concerns. This change addresses confusion where users might assume the bot can handle snapshot updates for all users.

## References

Closes #17174 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

No code changes, only documentation updates.

### Documentation changes

Updated the relevant documentation section to clarify that only users with elevated privileges can use the bot to update snapshots.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Clearer documentation to prevent misunderstandings regarding bot permissions.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
