### PR TITLE
Fix checkbox alignment in dialog using `display: flex`

### DIFF
--- a/packages/apputils/style/dialog.css
+++ b/packages/apputils/style/dialog.css
@@ -124,6 +124,8 @@ button.jp-Dialog-close-button {
 
 .jp-Dialog-checkbox {
   padding-right: 5px;
+  display: flex;
+  align-items: center;
 }
 
 .jp-Dialog-spacer {


### PR DESCRIPTION

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes the checkbox alignment issue in dialogs.

## Code changes

<!-- Describe the code changes and how they address the issue. -->
- Updated `dialog.css` to improve checkbox alignment.
- Applied `display: flex; align-items: center;` to `.jp-Dialog-checkbox` to ensure proper vertical alignment.
- Removed unnecessary spacing inconsistencies.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
- **Before:** Checkboxes in the dialog were misaligned.
- **After:** Checkboxes are now correctly aligned with their labels.

<!-- For visual changes, include before and after screenshots here. -->
### **Before**
<img width="1470" alt="415621977-e139f7ca-cac2-428c-be78-867f5eeae590" src="https://github.com/user-attachments/assets/6d76aa2e-1a77-41e7-a3ef-f055043ebcda" />

### **After**
![Screenshot 2025-02-26 143037](https://github.com/user-attachments/assets/b0fcfc82-89df-4d01-b17d-adbf3e58d7dd)

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None.
