### PR TITLE
Expose `ConfigSectionManager` via a plugin

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -97,6 +97,26 @@ the updated rendering logic.
 This change improves both the rendering performance and the maintainability of extensions
 using the ``GroupItem`` component.
 
+API updates
+^^^^^^^^^^^
+
+- The ``ConfigSection.create(options: ConfigSection.IOptions)`` function has been deprecated.
+   This was previously exposed as a helper function to create config sections on the Jupyter Server.
+   Instead, require the ``IConfigSectionManager`` token in a plugin, and use then ``create`` method to create a config section:
+
+.. code-block:: ts
+
+   const plugin: JupyterFrontEndPlugin<void> = {
+     id: 'example',
+     requires: [IConfigSectionManager],
+     activate: (
+       app: JupyterFrontEnd,
+       configSectionManager: ConfigSection.IManager
+     ): void => {
+        const section = configSectionManager.create({ name: 'notebook' });
+     }
+   };
+
 Plugins
 ^^^^^^^
 

--- a/galata/test/documentation/plugins.test.ts-snapshots/plugins-documentation-linux.json
+++ b/galata/test/documentation/plugins.test.ts-snapshots/plugins-documentation-linux.json
@@ -163,6 +163,8 @@
   "@jupyterlab/running-extension:recently-closed": "Adds recently closed documents list.",
   "@jupyterlab/running-extension:search-tabs": "Adds a widget to search open and closed tabs.",
   "@jupyterlab/running-extension:sidebar": "Provides the running session sidebar.",
+  "@jupyterlab/services-extension:config-section-manager": "Provides the config section manager.",
+  "@jupyterlab/services-extension:connection-status": "Provides the default connection status.",
   "@jupyterlab/services-extension:contents-manager": "The default contents manager plugin.",
   "@jupyterlab/services-extension:default-drive": "The default drive for the contents manager.",
   "@jupyterlab/services-extension:event-manager": "The event manager plugin.",

--- a/galata/test/documentation/plugins.test.ts-snapshots/tokens-documentation-linux.json
+++ b/galata/test/documentation/plugins.test.ts-snapshots/tokens-documentation-linux.json
@@ -1,5 +1,6 @@
 {
   "@jupyterlab/application:IConnectionLost": "A service for invoking the dialog shown\n  when JupyterLab has lost its connection to the server. Use this if, for some reason,\n  you want to bring up the \"connection lost\" dialog under new circumstances.",
+  "@jupyterlab/application:IConnectionStatus": "A service providing the application connection status.",
   "@jupyterlab/application:IInfo": "A service providing metadata about the current application, including disabled extensions and whether dev mode is enabled.",
   "@jupyterlab/application:ILabShell": "A service for interacting with the JupyterLab shell. The top-level ``application`` object also has a reference to the shell, but it has a restricted interface in order to be agnostic to different shell implementations on the application. Use this to get more detailed information about currently active widgets and layout state.",
   "@jupyterlab/application:ILabStatus": "A service for interacting with the application busy/dirty\n  status. Use this if you want to set the application \"busy\" favicon, or to set\n  the application \"dirty\" status, which asks the user for confirmation before leaving the application page.",
@@ -71,6 +72,7 @@
   "@jupyterlab/rendermime:IRenderMimeRegistry": "A service for the rendermime registry for the application. Use this to create renderers for various mime-types in your extension. Many times it will be easier to create a \"mime renderer extension\" rather than using this service directly.",
   "@jupyterlab/running:IRunningSessionManagers": "A service to add running session managers.",
   "@jupyterlab/running:IRunningSessionsSidebar": "A token allowing to modify the running sessions sidebar.",
+  "@jupyterlab/services:IConfigSectionManager": "A service providing the config section manager.",
   "@jupyterlab/services:IContentsManager": "The contents manager token.",
   "@jupyterlab/services:IDefaultDrive": "The default drive for the contents manager.",
   "@jupyterlab/services:IEventManager": "The event manager token.",

--- a/packages/apputils-extension/src/announcements.ts
+++ b/packages/apputils-extension/src/announcements.ts
@@ -9,7 +9,11 @@ import {
 } from '@jupyterlab/application';
 import { Notification } from '@jupyterlab/apputils';
 import { URLExt } from '@jupyterlab/coreutils';
-import { ConfigSection, ServerConnection } from '@jupyterlab/services';
+import {
+  ConfigSection,
+  IConfigSectionManager,
+  ServerConnection
+} from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 
@@ -55,9 +59,10 @@ export const announcements: JupyterFrontEndPlugin<void> = {
   description:
     'Add the announcement feature. It will fetch news on the internet and check for application updates.',
   autoStart: true,
-  optional: [ISettingRegistry, ITranslator],
+  optional: [IConfigSectionManager, ISettingRegistry, ITranslator],
   activate: (
     app: JupyterFrontEnd,
+    configSectionManager: ConfigSection.IManager | null,
     settingRegistry: ISettingRegistry | null,
     translator: ITranslator | null
   ): void => {
@@ -69,9 +74,9 @@ export const announcements: JupyterFrontEndPlugin<void> = {
         Promise.resolve(null),
       // Use config instead of state to store independently of the workspace
       // if a news has been displayed or not.
-      ConfigSection.create({
+      configSectionManager?.create({
         name: CONFIG_SECTION_NAME
-      })
+      }) ?? Promise.resolve(null)
     ]).then(async ([_, settings, config]) => {
       const trans = (translator ?? nullTranslator).load('jupyterlab');
 
@@ -85,7 +90,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
         if ((tags ?? []).some(tag => ['news', 'update'].includes(tag)) && id) {
           const update: { [k: string]: INewsState } = {};
           update[id] = { seen: true, dismissed: true };
-          config.update(update as any).catch(reason => {
+          config?.update(update as any).catch(reason => {
             console.error(
               `Failed to update the announcements config:\n${reason}`
             );
@@ -127,7 +132,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
                 callback: () => {
                   Notification.dismiss(notificationId);
                   config
-                    .update({})
+                    ?.update({})
                     .then(() => fetchNews())
                     .catch(reason => {
                       console.error(`Failed to get the news:\n${reason}`);
@@ -170,7 +175,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
               // @ts-expect-error data has no index
               const id = options.data!['id'] as string;
               // Filter those notifications
-              const state = (config.data[id] as INewsState) ?? {
+              const state = (config?.data[id] as INewsState) ?? {
                 seen: false,
                 dismissed: false
               };
@@ -182,7 +187,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
                     callback: () => {
                       const update: { [k: string]: INewsState } = {};
                       update[id] = { seen: true, dismissed: true };
-                      config.update(update as any).catch(reason => {
+                      config?.update(update as any).catch(reason => {
                         console.error(
                           `Failed to update the announcements config:\n${reason}`
                         );
@@ -204,7 +209,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
                   options.autoClose = 5000;
                   const update: { [k: string]: INewsState } = {};
                   update[id] = { seen: true };
-                  config.update(update as any).catch(reason => {
+                  config?.update(update as any).catch(reason => {
                     console.error(
                       `Failed to update the announcements config:\n${reason}`
                     );
@@ -232,7 +237,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
             const { link, message, type, options } = response.notification;
             // @ts-expect-error data has no index
             const id = options.data!['id'] as string;
-            const state = (config.data[id] as INewsState) ?? {
+            const state = (config?.data[id] as INewsState) ?? {
               seen: false,
               dismissed: false
             };
@@ -275,7 +280,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
                 options.autoClose = 5000;
                 const update: { [k: string]: INewsState } = {};
                 update[id] = { seen: true };
-                config.update(update as any).catch(reason => {
+                config?.update(update as any).catch(reason => {
                   console.error(
                     `Failed to update the announcements config:\n${reason}`
                   );

--- a/packages/apputils-extension/src/announcements.ts
+++ b/packages/apputils-extension/src/announcements.ts
@@ -59,11 +59,10 @@ export const announcements: JupyterFrontEndPlugin<void> = {
   description:
     'Add the announcement feature. It will fetch news on the internet and check for application updates.',
   autoStart: true,
-  requires: [IConfigSectionManager],
-  optional: [ISettingRegistry, ITranslator],
+  optional: [IConfigSectionManager, ISettingRegistry, ITranslator],
   activate: (
     app: JupyterFrontEnd,
-    configSectionManager: ConfigSection.IManager,
+    configSectionManager: ConfigSection.IManager | null,
     settingRegistry: ISettingRegistry | null,
     translator: ITranslator | null
   ): void => {
@@ -75,9 +74,9 @@ export const announcements: JupyterFrontEndPlugin<void> = {
         Promise.resolve(null),
       // Use config instead of state to store independently of the workspace
       // if a news has been displayed or not.
-      configSectionManager.create({
+      configSectionManager?.create({
         name: CONFIG_SECTION_NAME
-      })
+      }) ?? Promise.resolve(null)
     ]).then(async ([_, settings, config]) => {
       const trans = (translator ?? nullTranslator).load('jupyterlab');
 
@@ -91,7 +90,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
         if ((tags ?? []).some(tag => ['news', 'update'].includes(tag)) && id) {
           const update: { [k: string]: INewsState } = {};
           update[id] = { seen: true, dismissed: true };
-          config.update(update as any).catch(reason => {
+          config?.update(update as any).catch(reason => {
             console.error(
               `Failed to update the announcements config:\n${reason}`
             );
@@ -133,7 +132,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
                 callback: () => {
                   Notification.dismiss(notificationId);
                   config
-                    .update({})
+                    ?.update({})
                     .then(() => fetchNews())
                     .catch(reason => {
                       console.error(`Failed to get the news:\n${reason}`);
@@ -176,7 +175,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
               // @ts-expect-error data has no index
               const id = options.data!['id'] as string;
               // Filter those notifications
-              const state = (config.data[id] as INewsState) ?? {
+              const state = (config?.data[id] as INewsState) ?? {
                 seen: false,
                 dismissed: false
               };
@@ -188,7 +187,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
                     callback: () => {
                       const update: { [k: string]: INewsState } = {};
                       update[id] = { seen: true, dismissed: true };
-                      config.update(update as any).catch(reason => {
+                      config?.update(update as any).catch(reason => {
                         console.error(
                           `Failed to update the announcements config:\n${reason}`
                         );
@@ -210,7 +209,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
                   options.autoClose = 5000;
                   const update: { [k: string]: INewsState } = {};
                   update[id] = { seen: true };
-                  config.update(update as any).catch(reason => {
+                  config?.update(update as any).catch(reason => {
                     console.error(
                       `Failed to update the announcements config:\n${reason}`
                     );
@@ -238,7 +237,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
             const { link, message, type, options } = response.notification;
             // @ts-expect-error data has no index
             const id = options.data!['id'] as string;
-            const state = (config.data[id] as INewsState) ?? {
+            const state = (config?.data[id] as INewsState) ?? {
               seen: false,
               dismissed: false
             };
@@ -281,7 +280,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
                 options.autoClose = 5000;
                 const update: { [k: string]: INewsState } = {};
                 update[id] = { seen: true };
-                config.update(update as any).catch(reason => {
+                config?.update(update as any).catch(reason => {
                   console.error(
                     `Failed to update the announcements config:\n${reason}`
                   );

--- a/packages/apputils-extension/src/announcements.ts
+++ b/packages/apputils-extension/src/announcements.ts
@@ -59,10 +59,11 @@ export const announcements: JupyterFrontEndPlugin<void> = {
   description:
     'Add the announcement feature. It will fetch news on the internet and check for application updates.',
   autoStart: true,
-  optional: [IConfigSectionManager, ISettingRegistry, ITranslator],
+  requires: [IConfigSectionManager],
+  optional: [ISettingRegistry, ITranslator],
   activate: (
     app: JupyterFrontEnd,
-    configSectionManager: ConfigSection.IManager | null,
+    configSectionManager: ConfigSection.IManager,
     settingRegistry: ISettingRegistry | null,
     translator: ITranslator | null
   ): void => {
@@ -74,9 +75,9 @@ export const announcements: JupyterFrontEndPlugin<void> = {
         Promise.resolve(null),
       // Use config instead of state to store independently of the workspace
       // if a news has been displayed or not.
-      configSectionManager?.create({
+      configSectionManager.create({
         name: CONFIG_SECTION_NAME
-      }) ?? Promise.resolve(null)
+      })
     ]).then(async ([_, settings, config]) => {
       const trans = (translator ?? nullTranslator).load('jupyterlab');
 
@@ -90,7 +91,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
         if ((tags ?? []).some(tag => ['news', 'update'].includes(tag)) && id) {
           const update: { [k: string]: INewsState } = {};
           update[id] = { seen: true, dismissed: true };
-          config?.update(update as any).catch(reason => {
+          config.update(update as any).catch(reason => {
             console.error(
               `Failed to update the announcements config:\n${reason}`
             );
@@ -132,7 +133,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
                 callback: () => {
                   Notification.dismiss(notificationId);
                   config
-                    ?.update({})
+                    .update({})
                     .then(() => fetchNews())
                     .catch(reason => {
                       console.error(`Failed to get the news:\n${reason}`);
@@ -175,7 +176,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
               // @ts-expect-error data has no index
               const id = options.data!['id'] as string;
               // Filter those notifications
-              const state = (config?.data[id] as INewsState) ?? {
+              const state = (config.data[id] as INewsState) ?? {
                 seen: false,
                 dismissed: false
               };
@@ -187,7 +188,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
                     callback: () => {
                       const update: { [k: string]: INewsState } = {};
                       update[id] = { seen: true, dismissed: true };
-                      config?.update(update as any).catch(reason => {
+                      config.update(update as any).catch(reason => {
                         console.error(
                           `Failed to update the announcements config:\n${reason}`
                         );
@@ -209,7 +210,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
                   options.autoClose = 5000;
                   const update: { [k: string]: INewsState } = {};
                   update[id] = { seen: true };
-                  config?.update(update as any).catch(reason => {
+                  config.update(update as any).catch(reason => {
                     console.error(
                       `Failed to update the announcements config:\n${reason}`
                     );
@@ -237,7 +238,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
             const { link, message, type, options } = response.notification;
             // @ts-expect-error data has no index
             const id = options.data!['id'] as string;
-            const state = (config?.data[id] as INewsState) ?? {
+            const state = (config.data[id] as INewsState) ?? {
               seen: false,
               dismissed: false
             };
@@ -280,7 +281,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
                 options.autoClose = 5000;
                 const update: { [k: string]: INewsState } = {};
                 update[id] = { seen: true };
-                config?.update(update as any).catch(reason => {
+                config.update(update as any).catch(reason => {
                   console.error(
                     `Failed to update the announcements config:\n${reason}`
                   );

--- a/packages/services-extension/src/index.ts
+++ b/packages/services-extension/src/index.ts
@@ -57,7 +57,7 @@ import type { IPlugin } from '@lumino/coreutils';
 /**
  * Config section manager plugin.
  */
-export const configSectionManager: IPlugin<null, ConfigSection.IManager> = {
+const configSectionManager: IPlugin<null, ConfigSection.IManager> = {
   id: '@jupyterlab/services-extension:config-section-manager',
   autoStart: true,
   provides: IConfigSectionManager,
@@ -74,7 +74,7 @@ export const configSectionManager: IPlugin<null, ConfigSection.IManager> = {
 /**
  * The default connection status provider.
  */
-export const connectionStatus: IPlugin<null, IConnectionStatus> = {
+const connectionStatusPlugin: IPlugin<null, IConnectionStatus> = {
   id: '@jupyterlab/services-extension:connection-status',
   autoStart: true,
   provides: IConnectionStatus,
@@ -352,6 +352,7 @@ const serviceManagerPlugin: ServiceManagerPlugin<ServiceManager.IManager> = {
 
 export default [
   configSectionManager,
+  connectionStatusPlugin,
   contentsManagerPlugin,
   defaultDrivePlugin,
   eventManagerPlugin,

--- a/packages/services-extension/src/index.ts
+++ b/packages/services-extension/src/index.ts
@@ -8,12 +8,15 @@
  */
 
 import {
+  ConfigSection,
+  ConfigSectionManager,
   ConnectionStatus,
   Contents,
   ContentsManager,
   Drive,
   Event,
   EventManager,
+  IConfigSectionManager,
   IConnectionStatus,
   IContentsManager,
   IDefaultDrive,
@@ -50,6 +53,23 @@ import {
 } from '@jupyterlab/services';
 
 import type { IPlugin } from '@lumino/coreutils';
+
+/**
+ * Config section manager plugin.
+ */
+export const configSectionManager: IPlugin<null, ConfigSection.IManager> = {
+  id: '@jupyterlab/services-extension:config-section-manager',
+  autoStart: true,
+  provides: IConfigSectionManager,
+  optional: [IServerSettings],
+  description: 'Provides the config section manager.',
+  activate: (
+    _: null,
+    serverSettings: ServerConnection.ISettings | undefined
+  ) => {
+    return new ConfigSectionManager({ serverSettings });
+  }
+};
 
 /**
  * The default connection status provider.
@@ -331,6 +351,7 @@ const serviceManagerPlugin: ServiceManagerPlugin<ServiceManager.IManager> = {
 };
 
 export default [
+  configSectionManager,
   contentsManagerPlugin,
   defaultDrivePlugin,
   eventManagerPlugin,

--- a/packages/services-extension/src/index.ts
+++ b/packages/services-extension/src/index.ts
@@ -67,7 +67,10 @@ const configSectionManager: IPlugin<null, ConfigSection.IManager> = {
     _: null,
     serverSettings: ServerConnection.ISettings | undefined
   ) => {
-    return new ConfigSectionManager({ serverSettings });
+    const manager = new ConfigSectionManager({ serverSettings });
+    // Set the config section manager for the global ConfigSection.
+    ConfigSection._setConfigSectionManager(manager);
+    return manager;
   }
 };
 

--- a/packages/services/examples/browser/src/config.ts
+++ b/packages/services/examples/browser/src/config.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { ConfigSection, ConfigWithDefaults } from '@jupyterlab/services';
+import {
+  ConfigSectionManager,
+  ConfigWithDefaults,
+  ServerConnection
+} from '@jupyterlab/services';
 
 import { log } from './log';
 
@@ -9,7 +13,9 @@ export async function main(): Promise<void> {
   log('Config');
   // The base url of the Jupyter server.
 
-  const section = await ConfigSection.create({ name: 'notebook' });
+  const serverSettings = ServerConnection.makeSettings();
+  const configSectionManager = new ConfigSectionManager({ serverSettings });
+  const section = await configSectionManager.create({ name: 'notebook' });
   const config = new ConfigWithDefaults({
     section,
     defaults: { default_cell_type: 'code' },

--- a/packages/services/src/config/index.ts
+++ b/packages/services/src/config/index.ts
@@ -263,7 +263,10 @@ export class ConfigSectionManager implements ConfigSection.IManager {
   async create(
     options: ConfigSectionManager.ICreateOptions
   ): Promise<IConfigSection> {
-    const section = new DefaultConfigSection(options);
+    const section = new DefaultConfigSection({
+      ...options,
+      serverSettings: this.serverSettings
+    });
     await section.load();
     return section;
   }

--- a/packages/services/src/config/index.ts
+++ b/packages/services/src/config/index.ts
@@ -46,7 +46,8 @@ export namespace ConfigSection {
    *
    * @returns A Promise that is fulfilled with the config section is loaded.
    *
-   * @deprecated Require `IConfigSectionManager` in a plugin instead.
+   * @deprecated Creating a config section via the `ConfigSection.create()` global has been deprecated and may be removed in a future version.
+   * Instead, require the config section manager service via the `IConfigSectionManager` token in a plugin.
    */
   export async function create(
     options: ConfigSection.IOptions

--- a/packages/services/src/config/index.ts
+++ b/packages/services/src/config/index.ts
@@ -46,7 +46,7 @@ export namespace ConfigSection {
    *
    * @returns A Promise that is fulfilled with the config section is loaded.
    *
-   * @deprecated Use `IConfigSectionManager` in a plugin instead
+   * @deprecated Require `IConfigSectionManager` in a plugin instead.
    */
   export async function create(
     options: ConfigSection.IOptions

--- a/packages/services/src/config/index.ts
+++ b/packages/services/src/config/index.ts
@@ -69,6 +69,11 @@ export namespace ConfigSection {
      */
     serverSettings?: ServerConnection.ISettings;
   }
+
+  /**
+   * The interface for the build manager.
+   */
+  export interface IManager extends ConfigSectionManager {}
 }
 
 /**
@@ -241,5 +246,48 @@ export namespace ConfigWithDefaults {
      * The optional classname namespace.
      */
     className?: string;
+  }
+}
+
+/**
+ * A manager for config sections.
+ */
+export class ConfigSectionManager implements ConfigSection.IManager {
+  /**
+   * Create a config section manager.
+   */
+  constructor(options: ConfigSectionManager.IOptions) {
+    this.serverSettings =
+      options.serverSettings ?? ServerConnection.makeSettings();
+  }
+
+  /**
+   * Create a config section.
+   */
+  async create(options: ConfigSection.IOptions): Promise<IConfigSection> {
+    return ConfigSection.create({
+      ...options,
+      serverSettings: this.serverSettings
+    });
+  }
+
+  /**
+   * The server settings used to make API requests.
+   */
+  readonly serverSettings: ServerConnection.ISettings;
+}
+
+/**
+ * A namespace for config section API interfaces.
+ */
+export namespace ConfigSectionManager {
+  /**
+   * The instantiation options for a config section manager.
+   */
+  export interface IOptions {
+    /**
+     * The server settings used to make API requests.
+     */
+    serverSettings?: ServerConnection.ISettings;
   }
 }

--- a/packages/services/src/config/index.ts
+++ b/packages/services/src/config/index.ts
@@ -45,25 +45,21 @@ export namespace ConfigSection {
    * Create a config section.
    *
    * @returns A Promise that is fulfilled with the config section is loaded.
+   *
+   * @deprecated Use `IConfigSectionManager` in a plugin instead
    */
-  export function create(
+  export async function create(
     options: ConfigSection.IOptions
   ): Promise<IConfigSection> {
     const section = new DefaultConfigSection(options);
-    return section.load().then(() => {
-      return section;
-    });
+    await section.load();
+    return section;
   }
 
   /**
    * The options used to create a config section.
    */
-  export interface IOptions {
-    /**
-     * The section name.
-     */
-    name: string;
-
+  export interface IOptions extends ConfigSectionManager.ICreateOptions {
     /**
      * The optional server settings.
      */
@@ -264,11 +260,12 @@ export class ConfigSectionManager implements ConfigSection.IManager {
   /**
    * Create a config section.
    */
-  async create(options: ConfigSection.IOptions): Promise<IConfigSection> {
-    return ConfigSection.create({
-      ...options,
-      serverSettings: this.serverSettings
-    });
+  async create(
+    options: ConfigSectionManager.ICreateOptions
+  ): Promise<IConfigSection> {
+    const section = new DefaultConfigSection(options);
+    await section.load();
+    return section;
   }
 
   /**
@@ -289,5 +286,15 @@ export namespace ConfigSectionManager {
      * The server settings used to make API requests.
      */
     serverSettings?: ServerConnection.ISettings;
+  }
+
+  /**
+   * The config section create options
+   */
+  export interface ICreateOptions {
+    /**
+     * The section name.
+     */
+    name: string;
   }
 }

--- a/packages/services/src/config/index.ts
+++ b/packages/services/src/config/index.ts
@@ -47,7 +47,7 @@ export namespace ConfigSection {
    * @returns A Promise that is fulfilled with the config section is loaded.
    *
    * @deprecated Creating a config section via the `ConfigSection.create()` global has been deprecated and may be removed in a future version.
-   * Instead, require the config section manager service via the `IConfigSectionManager` token in a plugin.
+   * Instead, require the config section manager via the `IConfigSectionManager` token in a plugin.
    */
   export async function create(
     options: ConfigSection.IOptions

--- a/packages/services/src/tokens.ts
+++ b/packages/services/src/tokens.ts
@@ -2,6 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
+  ConfigSection,
   Contents,
   Event,
   Kernel,
@@ -56,6 +57,14 @@ export interface IConnectionStatus {
 export const IConnectionStatus = new Token<IConnectionStatus>(
   '@jupyterlab/application:IConnectionStatus',
   'A service providing the application connection status.'
+);
+
+/**
+ * Token providing the config section manager.
+ */
+export const IConfigSectionManager = new Token<ConfigSection.IManager>(
+  '@jupyterlab/services:IConfigSectionManager',
+  'A service providing the config section manager.'
 );
 
 /**

--- a/packages/services/test/config/config.spec.ts
+++ b/packages/services/test/config/config.spec.ts
@@ -3,8 +3,8 @@
 
 import { expectFailure, JupyterServer } from '@jupyterlab/testing';
 import { JSONObject, UUID } from '@lumino/coreutils';
-import { ConfigSection, ConfigWithDefaults } from '../../src';
-import { getRequestHandler, handleRequest, makeSettings } from '../utils';
+import { ConfigSectionManager, ConfigWithDefaults } from '../../src';
+import { handleRequest, makeSettings } from '../utils';
 
 /**
  * Generate a random config section name.
@@ -19,6 +19,8 @@ function randomName() {
 }
 
 const server = new JupyterServer();
+const serverSettings = makeSettings();
+const configSectionManager = new ConfigSectionManager({ serverSettings });
 
 beforeAll(async () => {
   await server.start();
@@ -29,26 +31,22 @@ afterAll(async () => {
 });
 
 describe('config', () => {
-  describe('ConfigSection.create()', () => {
+  describe('ConfigSectionManager', () => {
     it('should load a config', async () => {
-      const config = await ConfigSection.create({ name: randomName() });
+      const config = await configSectionManager.create({ name: randomName() });
       expect(Object.keys(config.data).length).toBe(0);
     });
 
     it('should accept server settings', async () => {
-      const serverSettings = makeSettings();
-      const config = await ConfigSection.create({
-        name: randomName(),
-        serverSettings
+      const config = await configSectionManager.create({
+        name: randomName()
       });
       expect(Object.keys(config.data).length).toBe(0);
     });
 
     it('should fail for an incorrect response', async () => {
-      const serverSettings = getRequestHandler(201, {});
-      const configPromise = ConfigSection.create({
-        name: randomName(),
-        serverSettings
+      const configPromise = configSectionManager.create({
+        name: randomName()
       });
       await expect(configPromise).rejects.toThrow(/Invalid response: 201/);
     });
@@ -56,7 +54,7 @@ describe('config', () => {
 
   describe('#update()', () => {
     it('should update a config', async () => {
-      const config = await ConfigSection.create({ name: randomName() });
+      const config = await configSectionManager.create({ name: randomName() });
       const data: any = await config.update({ foo: 'baz', spam: 'eggs' });
       expect(data.foo).toBe('baz');
       expect(config.data['foo']).toBe('baz');
@@ -65,10 +63,8 @@ describe('config', () => {
     });
 
     it('should accept server settings', async () => {
-      const serverSettings = makeSettings();
-      const config = await ConfigSection.create({
-        name: randomName(),
-        serverSettings
+      const config = await configSectionManager.create({
+        name: randomName()
       });
       const data: any = await config.update({ foo: 'baz', spam: 'eggs' });
       expect(data.foo).toBe('baz');
@@ -78,7 +74,7 @@ describe('config', () => {
     });
 
     it('should fail for an incorrect response', async () => {
-      const config = await ConfigSection.create({ name: randomName() });
+      const config = await configSectionManager.create({ name: randomName() });
       handleRequest(config, 201, {});
       const update = config.update({ foo: 'baz' });
       await expect(update).rejects.toThrow(/Invalid response: 201/);
@@ -91,7 +87,7 @@ describe('jupyter.services - ConfigWithDefaults', () => {
     it('should complete properly', async () => {
       const defaults: JSONObject = { spam: 'eggs' };
       const className = 'testclass';
-      const section = await ConfigSection.create({
+      const section = await configSectionManager.create({
         name: randomName()
       });
       const config = new ConfigWithDefaults({
@@ -107,7 +103,7 @@ describe('jupyter.services - ConfigWithDefaults', () => {
     it('should get a new config value', async () => {
       const defaults: JSONObject = { foo: 'bar' };
       const className = 'testclass';
-      const section = await ConfigSection.create({
+      const section = await configSectionManager.create({
         name: randomName()
       });
       const config = new ConfigWithDefaults({
@@ -122,7 +118,7 @@ describe('jupyter.services - ConfigWithDefaults', () => {
     it('should get a default config value', async () => {
       const defaults: JSONObject = { spam: 'eggs' };
       const className = 'testclass';
-      const section = await ConfigSection.create({
+      const section = await configSectionManager.create({
         name: randomName()
       });
       const config = new ConfigWithDefaults({
@@ -137,7 +133,7 @@ describe('jupyter.services - ConfigWithDefaults', () => {
     it('should get a default config value with no class', async () => {
       const defaults: JSONObject = { spam: 'eggs' };
       const className = 'testclass';
-      const section = await ConfigSection.create({
+      const section = await configSectionManager.create({
         name: randomName()
       });
       const config = new ConfigWithDefaults({
@@ -152,10 +148,8 @@ describe('jupyter.services - ConfigWithDefaults', () => {
     it('should get a falsey value', async () => {
       const defaults: JSONObject = { foo: true };
       const className = 'testclass';
-      const serverSettings = getRequestHandler(200, { foo: false });
-      const section = await ConfigSection.create({
-        name: randomName(),
-        serverSettings
+      const section = await configSectionManager.create({
+        name: randomName()
       });
       const config = new ConfigWithDefaults({
         section,
@@ -170,7 +164,7 @@ describe('jupyter.services - ConfigWithDefaults', () => {
   describe('#set()', () => {
     it('should set a value in a class immediately', async () => {
       const className = 'testclass';
-      const section = await ConfigSection.create({ name: randomName() });
+      const section = await configSectionManager.create({ name: randomName() });
       const config = new ConfigWithDefaults({ section, className });
       let data: any = await config.set('foo', 'bar');
       data = section.data['testclass'] as JSONObject;
@@ -178,7 +172,7 @@ describe('jupyter.services - ConfigWithDefaults', () => {
     });
 
     it('should set a top level value', async () => {
-      const section = await ConfigSection.create({ name: randomName() });
+      const section = await configSectionManager.create({ name: randomName() });
       const config = new ConfigWithDefaults({ section });
       const set = config.set('foo', 'bar');
       expect(section.data['foo']).toBe('bar');
@@ -187,10 +181,8 @@ describe('jupyter.services - ConfigWithDefaults', () => {
     });
 
     it('should fail for an invalid response', async () => {
-      const serverSettings = getRequestHandler(200, {});
-      const section = await ConfigSection.create({
-        name: randomName(),
-        serverSettings
+      const section = await configSectionManager.create({
+        name: randomName()
       });
       handleRequest(section, 201, { foo: 'bar' });
       const config = new ConfigWithDefaults({ section });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/17344

## Code changes

- [x] Deprecate `ConfigManager.create`
- [x] Provide `IConfigSectionManager` via a plugin
- [x] Mention in the extension migration guide

## User-facing changes

None

## Backwards-incompatible changes

None. But mark `ConfigManager.create` as `@deprecated`.