### PR TITLE
Add `IKernelAPIClient` and `ISessionAPIClient` as options for `Kernel.IManager` and `Session.IManager`

### DIFF
--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -495,7 +495,7 @@ export class KernelConnection implements Kernel.IKernelConnection {
     if (this.status === 'dead') {
       throw new Error('Kernel is dead');
     }
-    return this._kernelAPIClient.interruptKernel(this.id);
+    return this._kernelAPIClient.interrupt(this.id);
   }
 
   /**
@@ -523,7 +523,7 @@ export class KernelConnection implements Kernel.IKernelConnection {
     this._updateStatus('restarting');
     this._clearKernelState();
     this._kernelSession = RESTARTING_KERNEL_SESSION;
-    await this._kernelAPIClient.restartKernel(this.id);
+    await this._kernelAPIClient.restart(this.id);
     // Reconnect to the kernel to address cases where kernel ports
     // have changed during the restart.
     await this.reconnect();
@@ -581,7 +581,7 @@ export class KernelConnection implements Kernel.IKernelConnection {
    */
   async shutdown(): Promise<void> {
     if (this.status !== 'dead') {
-      await this._kernelAPIClient.shutdownKernel(this.id);
+      await this._kernelAPIClient.shutdown(this.id);
     }
     this.handleShutdown();
   }
@@ -1439,7 +1439,7 @@ export class KernelConnection implements Kernel.IKernelConnection {
       this._reason = '';
       this._model = undefined;
       try {
-        const model = await this._kernelAPIClient.getKernelModel(this._id);
+        const model = await this._kernelAPIClient.getModel(this._id);
         this._model = model;
         if (model?.execution_state === 'dead') {
           this._updateStatus('dead');

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -14,7 +14,7 @@ import * as KernelMessage from './messages';
 import { KernelSpec } from '../kernelspec';
 import { IManager as IBaseManager } from '../basemanager';
 
-import { IKernelOptions, IModel } from './restapi';
+import { IKernelOptions, IModel, KernelAPIClient } from './restapi';
 
 export { Status } from './messages';
 export { IModel, IKernelOptions };
@@ -625,6 +625,11 @@ export namespace IKernelConnection {
     serverSettings?: ServerConnection.ISettings;
 
     /**
+     * The kernel API client.
+     */
+    kernelAPIClient?: IKernelAPIClient;
+
+    /**
      * The username of the kernel client.
      */
     username?: string;
@@ -998,3 +1003,8 @@ export interface IAnyMessageArgs {
    */
   direction: 'send' | 'recv';
 }
+
+/**
+ * Interface for making requests to the Kernel API.
+ */
+export interface IKernelAPIClient extends KernelAPIClient {}

--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -6,12 +6,7 @@ import { ISignal, Signal } from '@lumino/signaling';
 import { ServerConnection } from '..';
 import * as Kernel from './kernel';
 import { BaseManager } from '../basemanager';
-import {
-  IKernelOptions,
-  listRunning,
-  shutdownKernel,
-  startNew
-} from './restapi';
+import { IKernelOptions, KernelAPIClient } from './restapi';
 import { KernelConnection } from './default';
 
 /**
@@ -25,6 +20,10 @@ export class KernelManager extends BaseManager implements Kernel.IManager {
    */
   constructor(options: KernelManager.IOptions = {}) {
     super(options);
+
+    this._kernelAPIClient =
+      options.kernelAPIClient ??
+      new KernelAPIClient({ serverSettings: this.serverSettings });
 
     // Start model and specs polling with exponential backoff.
     this._pollModels = new Poll({
@@ -120,7 +119,8 @@ export class KernelManager extends BaseManager implements Kernel.IManager {
     const kernelConnection = new KernelConnection({
       handleComms,
       ...options,
-      serverSettings: this.serverSettings
+      serverSettings: this.serverSettings,
+      kernelAPIClient: this._kernelAPIClient
     });
     this._onStarted(kernelConnection);
     if (!this._models.has(id)) {
@@ -182,7 +182,7 @@ export class KernelManager extends BaseManager implements Kernel.IManager {
       'model' | 'serverSettings'
     > = {}
   ): Promise<Kernel.IKernelConnection> {
-    const model = await startNew(createOptions, this.serverSettings);
+    const model = await this._kernelAPIClient.startNew(createOptions);
     return this.connectTo({
       ...connectOptions,
       model
@@ -197,7 +197,7 @@ export class KernelManager extends BaseManager implements Kernel.IManager {
    * @returns A promise that resolves when the operation is complete.
    */
   async shutdown(id: string): Promise<void> {
-    await shutdownKernel(id, this.serverSettings);
+    await this._kernelAPIClient.shutdownKernel(id);
     await this.refreshRunning();
   }
 
@@ -213,7 +213,7 @@ export class KernelManager extends BaseManager implements Kernel.IManager {
     // Shut down all models.
     await Promise.all(
       [...this._models.keys()].map(id =>
-        shutdownKernel(id, this.serverSettings)
+        this._kernelAPIClient.shutdownKernel(id)
       )
     );
 
@@ -242,7 +242,7 @@ export class KernelManager extends BaseManager implements Kernel.IManager {
   protected async requestRunning(): Promise<void> {
     let models: Kernel.IModel[];
     try {
-      models = await listRunning(this.serverSettings);
+      models = await this._kernelAPIClient.listRunning();
     } catch (err) {
       // Handle network errors, as well as cases where we are on a
       // JupyterHub and the server is not running. JupyterHub returns a
@@ -338,6 +338,7 @@ export class KernelManager extends BaseManager implements Kernel.IManager {
   private _pollModels: Poll;
   private _runningChanged = new Signal<this, Kernel.IModel[]>(this);
   private _connectionFailure = new Signal<this, Error>(this);
+  private _kernelAPIClient: Kernel.IKernelAPIClient;
 }
 
 /**
@@ -352,6 +353,11 @@ export namespace KernelManager {
      * When the manager stops polling the API. Defaults to `when-hidden`.
      */
     standby?: Poll.Standby | (() => boolean | Poll.Standby);
+
+    /**
+     * The kernel API client.
+     */
+    kernelAPIClient?: Kernel.IKernelAPIClient;
   }
 
   /**

--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -197,7 +197,7 @@ export class KernelManager extends BaseManager implements Kernel.IManager {
    * @returns A promise that resolves when the operation is complete.
    */
   async shutdown(id: string): Promise<void> {
-    await this._kernelAPIClient.shutdownKernel(id);
+    await this._kernelAPIClient.shutdown(id);
     await this.refreshRunning();
   }
 
@@ -212,9 +212,7 @@ export class KernelManager extends BaseManager implements Kernel.IManager {
 
     // Shut down all models.
     await Promise.all(
-      [...this._models.keys()].map(id =>
-        this._kernelAPIClient.shutdownKernel(id)
-      )
+      [...this._models.keys()].map(id => this._kernelAPIClient.shutdown(id))
     );
 
     // Update the list of models to clear out our state.

--- a/packages/services/src/kernel/restapi.ts
+++ b/packages/services/src/kernel/restapi.ts
@@ -250,9 +250,14 @@ export class KernelAPIClient {
    * @param options - The options used to create the client.
    */
   constructor(options: { serverSettings?: ServerConnection.ISettings } = {}) {
-    this._serverSettings =
+    this.serverSettings =
       options.serverSettings ?? ServerConnection.makeSettings();
   }
+
+  /**
+   * The server settings for the client.
+   */
+  readonly serverSettings: ServerConnection.ISettings;
 
   /**
    * List the running kernels.
@@ -265,7 +270,7 @@ export class KernelAPIClient {
    * The promise is fulfilled on a valid response and rejected otherwise.
    */
   async listRunning(): Promise<IModel[]> {
-    return listRunning(this._serverSettings);
+    return listRunning(this.serverSettings);
   }
 
   /**
@@ -282,7 +287,7 @@ export class KernelAPIClient {
    * If the kernel does not exist on the server, the promise is resolved with `undefined`.
    */
   async getKernelModel(id: string): Promise<IModel | undefined> {
-    return getKernelModel(id, this._serverSettings);
+    return getKernelModel(id, this.serverSettings);
   }
 
   /**
@@ -298,7 +303,7 @@ export class KernelAPIClient {
    * The promise is fulfilled on a valid response and rejected otherwise.
    */
   async startNew(options: IKernelOptions = {}): Promise<IModel> {
-    return startNew(options, this._serverSettings);
+    return startNew(options, this.serverSettings);
   }
 
   /**
@@ -314,7 +319,7 @@ export class KernelAPIClient {
    * The promise is fulfilled on a valid response and rejected otherwise.
    */
   async restartKernel(id: string): Promise<void> {
-    return restartKernel(id, this._serverSettings);
+    return restartKernel(id, this.serverSettings);
   }
 
   /**
@@ -330,7 +335,7 @@ export class KernelAPIClient {
    * The promise is fulfilled on a valid response and rejected otherwise.
    */
   async interruptKernel(id: string): Promise<void> {
-    return interruptKernel(id, this._serverSettings);
+    return interruptKernel(id, this.serverSettings);
   }
 
   /**
@@ -346,8 +351,6 @@ export class KernelAPIClient {
    * The promise is fulfilled on a valid response and rejected otherwise.
    */
   async shutdownKernel(id: string): Promise<void> {
-    return shutdownKernel(id, this._serverSettings);
+    return shutdownKernel(id, this.serverSettings);
   }
-
-  private _serverSettings: ServerConnection.ISettings;
 }

--- a/packages/services/src/kernel/restapi.ts
+++ b/packages/services/src/kernel/restapi.ts
@@ -286,7 +286,7 @@ export class KernelAPIClient {
    * The promise is fulfilled on a valid response and rejected otherwise.
    * If the kernel does not exist on the server, the promise is resolved with `undefined`.
    */
-  async getKernelModel(id: string): Promise<IModel | undefined> {
+  async getModel(id: string): Promise<IModel | undefined> {
     return getKernelModel(id, this.serverSettings);
   }
 
@@ -318,7 +318,7 @@ export class KernelAPIClient {
    *
    * The promise is fulfilled on a valid response and rejected otherwise.
    */
-  async restartKernel(id: string): Promise<void> {
+  async restart(id: string): Promise<void> {
     return restartKernel(id, this.serverSettings);
   }
 
@@ -334,7 +334,7 @@ export class KernelAPIClient {
    *
    * The promise is fulfilled on a valid response and rejected otherwise.
    */
-  async interruptKernel(id: string): Promise<void> {
+  async interrupt(id: string): Promise<void> {
     return interruptKernel(id, this.serverSettings);
   }
 
@@ -350,7 +350,7 @@ export class KernelAPIClient {
    *
    * The promise is fulfilled on a valid response and rejected otherwise.
    */
-  async shutdownKernel(id: string): Promise<void> {
+  async shutdown(id: string): Promise<void> {
     return shutdownKernel(id, this.serverSettings);
   }
 }

--- a/packages/services/src/kernel/restapi.ts
+++ b/packages/services/src/kernel/restapi.ts
@@ -235,3 +235,119 @@ export async function getKernelModel(
   validateModel(data);
   return data;
 }
+
+/**
+ * The kernel API client.
+ *
+ * #### Notes
+ * Use this class to interact with the Jupyter Server Kernel API.
+ * This class adheres to the Jupyter Server API endpoints.
+ */
+export class KernelAPIClient {
+  /**
+   * Create a new kernel API client.
+   *
+   * @param options - The options used to create the client.
+   */
+  constructor(options: { serverSettings?: ServerConnection.ISettings } = {}) {
+    this._serverSettings =
+      options.serverSettings ?? ServerConnection.makeSettings();
+  }
+
+  /**
+   * List the running kernels.
+   *
+   * @returns A promise that resolves with the list of running kernel models.
+   *
+   * #### Notes
+   * Uses the [Jupyter Server API](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter-server/jupyter_server/main/jupyter_server/services/api/api.yaml#!/kernels) and validates the response model.
+   *
+   * The promise is fulfilled on a valid response and rejected otherwise.
+   */
+  async listRunning(): Promise<IModel[]> {
+    return listRunning(this._serverSettings);
+  }
+
+  /**
+   * Get a kernel model.
+   *
+   * @param id - The id of the kernel of interest.
+   *
+   * @returns A promise that resolves with the kernel model.
+   *
+   * #### Notes
+   * Uses the [Jupyter Server API](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter-server/jupyter_server/main/jupyter_server/services/api/api.yaml#!/kernels) and validates the response model.
+   *
+   * The promise is fulfilled on a valid response and rejected otherwise.
+   * If the kernel does not exist on the server, the promise is resolved with `undefined`.
+   */
+  async getKernelModel(id: string): Promise<IModel | undefined> {
+    return getKernelModel(id, this._serverSettings);
+  }
+
+  /**
+   * Start a new kernel.
+   *
+   * @param options - The options used to create the kernel.
+   *
+   * @returns A promise that resolves with the kernel model.
+   *
+   * #### Notes
+   * Uses the [Jupyter Server API](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter-server/jupyter_server/main/jupyter_server/services/api/api.yaml#!/kernels) and validates the response model.
+   *
+   * The promise is fulfilled on a valid response and rejected otherwise.
+   */
+  async startNew(options: IKernelOptions = {}): Promise<IModel> {
+    return startNew(options, this._serverSettings);
+  }
+
+  /**
+   * Restart a kernel.
+   *
+   * @param id - The id of the kernel to restart.
+   *
+   * @returns A promise that resolves when the kernel is restarted.
+   *
+   * #### Notes
+   * Uses the [Jupyter Server API](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter-server/jupyter_server/main/jupyter_server/services/api/api.yaml#!/kernels) and validates the response model.
+   *
+   * The promise is fulfilled on a valid response and rejected otherwise.
+   */
+  async restartKernel(id: string): Promise<void> {
+    return restartKernel(id, this._serverSettings);
+  }
+
+  /**
+   * Interrupt a kernel.
+   *
+   * @param id - The id of the kernel to interrupt.
+   *
+   * @returns A promise that resolves when the kernel is interrupted.
+   *
+   * #### Notes
+   * Uses the [Jupyter Server API](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter-server/jupyter_server/main/jupyter_server/services/api/api.yaml#!/kernels) and validates the response model.
+   *
+   * The promise is fulfilled on a valid response and rejected otherwise.
+   */
+  async interruptKernel(id: string): Promise<void> {
+    return interruptKernel(id, this._serverSettings);
+  }
+
+  /**
+   * Shut down a kernel by id.
+   *
+   * @param id - The id of the kernel to shut down.
+   *
+   * @returns A promise that resolves when the kernel is shut down.
+   *
+   * #### Notes
+   * Uses the [Jupyter Server API](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter-server/jupyter_server/main/jupyter_server/services/api/api.yaml#!/kernels) and validates the response model.
+   *
+   * The promise is fulfilled on a valid response and rejected otherwise.
+   */
+  async shutdownKernel(id: string): Promise<void> {
+    return shutdownKernel(id, this._serverSettings);
+  }
+
+  private _serverSettings: ServerConnection.ISettings;
+}

--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -9,8 +9,8 @@ import { ServerConnection } from '..';
 
 import * as Session from './session';
 
-import { shutdownSession, updateSession } from './restapi';
 import { UUID } from '@lumino/coreutils';
+import { SessionAPIClient } from './restapi';
 
 type DeepPartial<T> = {
   [P in keyof T]?: DeepPartial<T[P]>;
@@ -36,6 +36,9 @@ export class SessionConnection implements Session.ISessionConnection {
     this._kernelConnectionOptions = options.kernelConnectionOptions ?? {};
     this.serverSettings =
       options.serverSettings ?? ServerConnection.makeSettings();
+    this._sessionAPIClient =
+      options.sessionAPIClient ??
+      new SessionAPIClient({ serverSettings: this.serverSettings });
     this.setupKernel(options.model.kernel);
   }
 
@@ -297,7 +300,7 @@ export class SessionConnection implements Session.ISessionConnection {
     if (this.isDisposed) {
       throw new Error('Session is disposed');
     }
-    await shutdownSession(this.id, this.serverSettings);
+    await this._sessionAPIClient.shutdownSession(this.id);
     this.dispose();
   }
 
@@ -391,10 +394,10 @@ export class SessionConnection implements Session.ISessionConnection {
   private async _patch(
     body: DeepPartial<Session.IModel>
   ): Promise<Session.IModel> {
-    const model = await updateSession(
-      { ...body, id: this._id },
-      this.serverSettings
-    );
+    const model = await this._sessionAPIClient.updateSession({
+      ...body,
+      id: this._id
+    });
     this.update(model);
     return model;
   }
@@ -443,4 +446,5 @@ export class SessionConnection implements Session.ISessionConnection {
     Kernel.IKernelConnection.IOptions,
     'model' | 'username' | 'clientId' | 'serverSettings'
   >;
+  private _sessionAPIClient: Session.ISessionAPIClient;
 }

--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -300,7 +300,7 @@ export class SessionConnection implements Session.ISessionConnection {
     if (this.isDisposed) {
       throw new Error('Session is disposed');
     }
-    await this._sessionAPIClient.shutdownSession(this.id);
+    await this._sessionAPIClient.shutdown(this.id);
     this.dispose();
   }
 
@@ -394,7 +394,7 @@ export class SessionConnection implements Session.ISessionConnection {
   private async _patch(
     body: DeepPartial<Session.IModel>
   ): Promise<Session.IModel> {
-    const model = await this._sessionAPIClient.updateSession({
+    const model = await this._sessionAPIClient.update({
       ...body,
       id: this._id
     });

--- a/packages/services/src/session/manager.ts
+++ b/packages/services/src/session/manager.ts
@@ -109,7 +109,8 @@ export class SessionManager extends BaseManager implements Session.IManager {
     const sessionConnection = new SessionConnection({
       ...options,
       connectToKernel: this._connectToKernel,
-      serverSettings: this.serverSettings
+      serverSettings: this.serverSettings,
+      sessionAPIClient: this._sessionAPIClient
     });
     this._onStarted(sessionConnection);
     if (!this._models.has(options.model.id)) {

--- a/packages/services/src/session/manager.ts
+++ b/packages/services/src/session/manager.ts
@@ -161,7 +161,7 @@ export class SessionManager extends BaseManager implements Session.IManager {
       'model' | 'connectToKernel' | 'serverSettings'
     > = {}
   ): Promise<Session.ISessionConnection> {
-    const model = await this._sessionAPIClient.startSession(createOptions);
+    const model = await this._sessionAPIClient.startNew(createOptions);
     await this.refreshRunning();
     return this.connectTo({ ...connectOptions, model });
   }
@@ -170,7 +170,7 @@ export class SessionManager extends BaseManager implements Session.IManager {
    * Shut down a session by id.
    */
   async shutdown(id: string): Promise<void> {
-    await this._sessionAPIClient.shutdownSession(id);
+    await this._sessionAPIClient.shutdown(id);
     await this.refreshRunning();
   }
 
@@ -185,9 +185,7 @@ export class SessionManager extends BaseManager implements Session.IManager {
 
     // Shut down all models.
     await Promise.all(
-      [...this._models.keys()].map(id =>
-        this._sessionAPIClient.shutdownSession(id)
-      )
+      [...this._models.keys()].map(id => this._sessionAPIClient.shutdown(id))
     );
 
     // Update the list of models to clear out our state.

--- a/packages/services/src/session/restapi.ts
+++ b/packages/services/src/session/restapi.ts
@@ -157,9 +157,14 @@ export class SessionAPIClient {
    * @param options - The options used to create the client.
    */
   constructor(options: { serverSettings?: ServerConnection.ISettings }) {
-    this._serverSettings =
+    this.serverSettings =
       options.serverSettings ?? ServerConnection.makeSettings();
   }
+
+  /**
+   * The server settings used by the client.
+   */
+  readonly serverSettings: ServerConnection.ISettings;
 
   /**
    * List the running sessions.
@@ -172,7 +177,7 @@ export class SessionAPIClient {
    * The promise is fulfilled on a valid response and rejected otherwise.
    */
   async listRunning(): Promise<Session.IModel[]> {
-    return listRunning(this._serverSettings);
+    return listRunning(this.serverSettings);
   }
 
   /**
@@ -188,7 +193,7 @@ export class SessionAPIClient {
    * The promise is fulfilled on a valid response and rejected otherwise.
    */
   async getSessionModel(id: string): Promise<Session.IModel> {
-    return getSessionModel(id, this._serverSettings);
+    return getSessionModel(id, this.serverSettings);
   }
 
   /**
@@ -206,7 +211,7 @@ export class SessionAPIClient {
   async startSession(
     options: Session.ISessionOptions
   ): Promise<Session.IModel> {
-    return startSession(options, this._serverSettings);
+    return startSession(options, this.serverSettings);
   }
 
   /**
@@ -222,7 +227,7 @@ export class SessionAPIClient {
    * The promise is fulfilled on a valid response and rejected otherwise.
    */
   async shutdownSession(id: string): Promise<void> {
-    return shutdownSession(id, this._serverSettings);
+    return shutdownSession(id, this.serverSettings);
   }
 
   /**
@@ -240,8 +245,6 @@ export class SessionAPIClient {
   async updateSession(
     model: Pick<Session.IModel, 'id'> & DeepPartial<Omit<Session.IModel, 'id'>>
   ): Promise<Session.IModel> {
-    return updateSession(model, this._serverSettings);
+    return updateSession(model, this.serverSettings);
   }
-
-  private _serverSettings: ServerConnection.ISettings;
 }

--- a/packages/services/src/session/restapi.ts
+++ b/packages/services/src/session/restapi.ts
@@ -192,7 +192,7 @@ export class SessionAPIClient {
    *
    * The promise is fulfilled on a valid response and rejected otherwise.
    */
-  async getSessionModel(id: string): Promise<Session.IModel> {
+  async getModel(id: string): Promise<Session.IModel> {
     return getSessionModel(id, this.serverSettings);
   }
 
@@ -208,9 +208,7 @@ export class SessionAPIClient {
    *
    * The promise is fulfilled on a valid response and rejected otherwise.
    */
-  async startSession(
-    options: Session.ISessionOptions
-  ): Promise<Session.IModel> {
+  async startNew(options: Session.ISessionOptions): Promise<Session.IModel> {
     return startSession(options, this.serverSettings);
   }
 
@@ -226,7 +224,7 @@ export class SessionAPIClient {
    *
    * The promise is fulfilled on a valid response and rejected otherwise.
    */
-  async shutdownSession(id: string): Promise<void> {
+  async shutdown(id: string): Promise<void> {
     return shutdownSession(id, this.serverSettings);
   }
 
@@ -242,7 +240,7 @@ export class SessionAPIClient {
    *
    * The promise is fulfilled on a valid response and rejected otherwise.
    */
-  async updateSession(
+  async update(
     model: Pick<Session.IModel, 'id'> & DeepPartial<Omit<Session.IModel, 'id'>>
   ): Promise<Session.IModel> {
     return updateSession(model, this.serverSettings);

--- a/packages/services/src/session/restapi.ts
+++ b/packages/services/src/session/restapi.ts
@@ -145,10 +145,16 @@ export async function updateSession(
 
 /**
  * The session API client.
+ *
+ * #### Notes
+ * Use this class to interact with the Jupyter Server Session API.
+ * This class adheres to the Jupyter Server API endpoints.
  */
 export class SessionAPIClient {
   /**
    * Create a new session API client.
+   *
+   * @param options - The options used to create the client.
    */
   constructor(options: { serverSettings?: ServerConnection.ISettings }) {
     this._serverSettings =
@@ -157,6 +163,13 @@ export class SessionAPIClient {
 
   /**
    * List the running sessions.
+   *
+   * @returns A promise that resolves with the list of running session models.
+   *
+   * #### Notes
+   * Uses the [Jupyter Server API](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter-server/jupyter_server/main/jupyter_server/services/api/api.yaml#!/sessions) and validates the response model.
+   *
+   * The promise is fulfilled on a valid response and rejected otherwise.
    */
   async listRunning(): Promise<Session.IModel[]> {
     return listRunning(this._serverSettings);
@@ -164,6 +177,15 @@ export class SessionAPIClient {
 
   /**
    * Get a session model.
+   *
+   * @param id - The id of the session of interest.
+   *
+   * @returns A promise that resolves with the session model.
+   *
+   * #### Notes
+   * Uses the [Jupyter Server API](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter-server/jupyter_server/main/jupyter_server/services/api/api.yaml#!/sessions) and validates the response model.
+   *
+   * The promise is fulfilled on a valid response and rejected otherwise.
    */
   async getSessionModel(id: string): Promise<Session.IModel> {
     return getSessionModel(id, this._serverSettings);
@@ -171,6 +193,15 @@ export class SessionAPIClient {
 
   /**
    * Create a new session.
+   *
+   * @param options - The options used to create the session.
+   *
+   * @returns A promise that resolves with the session model.
+   *
+   * #### Notes
+   * Uses the [Jupyter Server API](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter-server/jupyter_server/main/jupyter_server/services/api/api.yaml#!/sessions) and validates the response model.
+   *
+   * The promise is fulfilled on a valid response and rejected otherwise.
    */
   async startSession(
     options: Session.ISessionOptions
@@ -180,6 +211,15 @@ export class SessionAPIClient {
 
   /**
    * Shut down a session by id.
+   *
+   * @param id - The id of the session to shut down.
+   *
+   * @returns A promise that resolves when the session is shut down.
+   *
+   * #### Notes
+   * Uses the [Jupyter Server API](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter-server/jupyter_server/main/jupyter_server/services/api/api.yaml#!/sessions) and validates the response model.
+   *
+   * The promise is fulfilled on a valid response and rejected otherwise.
    */
   async shutdownSession(id: string): Promise<void> {
     return shutdownSession(id, this._serverSettings);
@@ -187,6 +227,15 @@ export class SessionAPIClient {
 
   /**
    * Update a session by id.
+   *
+   * @param model - The session model to update.
+   *
+   * @returns A promise that resolves with the updated session model.
+   *
+   * #### Notes
+   * Uses the [Jupyter Server API](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter-server/jupyter_server/main/jupyter_server/services/api/api.yaml#!/sessions) and validates the response model.
+   *
+   * The promise is fulfilled on a valid response and rejected otherwise.
    */
   async updateSession(
     model: Pick<Session.IModel, 'id'> & DeepPartial<Omit<Session.IModel, 'id'>>

--- a/packages/services/src/session/restapi.ts
+++ b/packages/services/src/session/restapi.ts
@@ -142,3 +142,57 @@ export async function updateSession(
   validateModel(data);
   return data;
 }
+
+/**
+ * The session API client.
+ */
+export class SessionAPIClient {
+  /**
+   * Create a new session API client.
+   */
+  constructor(options: { serverSettings?: ServerConnection.ISettings }) {
+    this._serverSettings =
+      options.serverSettings ?? ServerConnection.makeSettings();
+  }
+
+  /**
+   * List the running sessions.
+   */
+  async listRunning(): Promise<Session.IModel[]> {
+    return listRunning(this._serverSettings);
+  }
+
+  /**
+   * Get a session model.
+   */
+  async getSessionModel(id: string): Promise<Session.IModel> {
+    return getSessionModel(id, this._serverSettings);
+  }
+
+  /**
+   * Create a new session.
+   */
+  async startSession(
+    options: Session.ISessionOptions
+  ): Promise<Session.IModel> {
+    return startSession(options, this._serverSettings);
+  }
+
+  /**
+   * Shut down a session by id.
+   */
+  async shutdownSession(id: string): Promise<void> {
+    return shutdownSession(id, this._serverSettings);
+  }
+
+  /**
+   * Update a session by id.
+   */
+  async updateSession(
+    model: Pick<Session.IModel, 'id'> & DeepPartial<Omit<Session.IModel, 'id'>>
+  ): Promise<Session.IModel> {
+    return updateSession(model, this._serverSettings);
+  }
+
+  private _serverSettings: ServerConnection.ISettings;
+}

--- a/packages/services/src/session/session.ts
+++ b/packages/services/src/session/session.ts
@@ -183,11 +183,6 @@ export interface ISessionConnection extends IObservableDisposable {
 }
 
 /**
- * Interface for making requests to the session API.
- */
-export interface ISessionAPIClient extends SessionAPIClient {}
-
-/**
  * A namespace for ISessionConnection statics.
  */
 export namespace ISessionConnection {
@@ -408,3 +403,8 @@ export interface IModel {
 export type ISessionOptions = Pick<IModel, 'path' | 'type' | 'name'> & {
   kernel?: Partial<Pick<Kernel.IModel, 'name'>>;
 };
+
+/**
+ * Interface for making requests to the Session API.
+ */
+export interface ISessionAPIClient extends SessionAPIClient {}

--- a/packages/services/src/session/session.ts
+++ b/packages/services/src/session/session.ts
@@ -9,6 +9,8 @@ import { Kernel, KernelMessage } from '../kernel';
 
 import { ServerConnection } from '..';
 
+import { SessionAPIClient } from './restapi';
+
 import { IChangedArgs } from '@jupyterlab/coreutils';
 
 /**
@@ -180,6 +182,14 @@ export interface ISessionConnection extends IObservableDisposable {
   shutdown(): Promise<void>;
 }
 
+/**
+ * Interface for making requests to the session API.
+ */
+export interface ISessionAPIClient extends SessionAPIClient {}
+
+/**
+ * A namespace for ISessionConnection statics.
+ */
 export namespace ISessionConnection {
   /**
    * The session initialization options.
@@ -201,6 +211,11 @@ export namespace ISessionConnection {
      * The server settings.
      */
     serverSettings?: ServerConnection.ISettings;
+
+    /**
+     * The session API client.
+     */
+    sessionAPIClient?: ISessionAPIClient;
 
     /**
      * The username of the session client.

--- a/packages/services/test/session/isession.spec.ts
+++ b/packages/services/test/session/isession.spec.ts
@@ -9,7 +9,9 @@ import {
   KernelAPI,
   KernelManager,
   KernelMessage,
+  ServerConnection,
   Session,
+  SessionAPI,
   SessionManager
 } from '../../src';
 import { handleRequest, SessionTester } from '../utils';
@@ -31,6 +33,7 @@ async function startNew(): Promise<Session.ISessionConnection> {
 
 describe('session', () => {
   let session: Session.ISessionConnection;
+  let sessionAPIClient: Session.ISessionAPIClient;
   let defaultSession: Session.ISessionConnection;
   let server: JupyterServer;
 
@@ -40,7 +43,9 @@ describe('session', () => {
     server = new JupyterServer();
     await server.start();
     kernelManager = new KernelManager();
-    sessionManager = new SessionManager({ kernelManager });
+    const serverSettings = ServerConnection.makeSettings();
+    sessionAPIClient = new SessionAPI.SessionAPIClient({ serverSettings });
+    sessionManager = new SessionManager({ kernelManager, sessionAPIClient });
     defaultSession = await startNew();
   }, 30000);
 
@@ -267,17 +272,17 @@ describe('session', () => {
       });
 
       it('should fail for improper response status', async () => {
-        handleRequest(defaultSession, 201, {});
+        handleRequest(sessionAPIClient, 201, {});
         await expect(defaultSession.setPath(UUID.uuid4())).rejects.toThrow();
       });
 
       it('should fail for error response status', async () => {
-        handleRequest(defaultSession, 500, {});
+        handleRequest(sessionAPIClient, 500, {});
         await expect(defaultSession.setPath(UUID.uuid4())).rejects.toThrow();
       });
 
       it('should fail for improper model', async () => {
-        handleRequest(defaultSession, 200, {});
+        handleRequest(sessionAPIClient, 200, {});
         await expect(defaultSession.setPath(UUID.uuid4())).rejects.toThrow();
       });
 
@@ -301,17 +306,17 @@ describe('session', () => {
       });
 
       it('should fail for improper response status', async () => {
-        handleRequest(defaultSession, 201, {});
+        handleRequest(sessionAPIClient, 201, {});
         await expect(defaultSession.setType(UUID.uuid4())).rejects.toThrow();
       });
 
       it('should fail for error response status', async () => {
-        handleRequest(defaultSession, 500, {});
+        handleRequest(sessionAPIClient, 500, {});
         await expect(defaultSession.setType(UUID.uuid4())).rejects.toThrow();
       });
 
       it('should fail for improper model', async () => {
-        handleRequest(defaultSession, 200, {});
+        handleRequest(sessionAPIClient, 200, {});
         await expect(defaultSession.setType(UUID.uuid4())).rejects.toThrow();
       });
 
@@ -333,17 +338,17 @@ describe('session', () => {
       });
 
       it('should fail for improper response status', async () => {
-        handleRequest(defaultSession, 201, {});
+        handleRequest(sessionAPIClient, 201, {});
         await expect(defaultSession.setName(UUID.uuid4())).rejects.toThrow();
       });
 
       it('should fail for error response status', async () => {
-        handleRequest(defaultSession, 500, {});
+        handleRequest(sessionAPIClient, 500, {});
         await expect(defaultSession.setName(UUID.uuid4())).rejects.toThrow();
       });
 
       it('should fail for improper model', async () => {
-        handleRequest(defaultSession, 200, {});
+        handleRequest(sessionAPIClient, 200, {});
         await expect(defaultSession.setName(UUID.uuid4())).rejects.toThrow();
       });
 
@@ -412,18 +417,18 @@ describe('session', () => {
       });
 
       it('should fail for an incorrect response status', async () => {
-        handleRequest(defaultSession, 200, {});
+        handleRequest(sessionAPIClient, 200, {});
         await expect(defaultSession.shutdown()).rejects.toThrow();
       });
 
       it('should handle a 404 status', async () => {
         session = await startNew();
-        handleRequest(session, 404, {});
+        handleRequest(sessionAPIClient, 404, {});
         await expect(session.shutdown()).resolves.not.toThrow();
       });
 
       it('should handle a specific error status', async () => {
-        handleRequest(defaultSession, 410, {});
+        handleRequest(sessionAPIClient, 410, {});
         const promise = defaultSession.shutdown();
         await expect(promise).rejects.toThrow(
           'The kernel was deleted but the session was not'
@@ -431,7 +436,7 @@ describe('session', () => {
       });
 
       it('should fail for an error response status', async () => {
-        handleRequest(defaultSession, 500, {});
+        handleRequest(sessionAPIClient, 500, {});
         await expect(defaultSession.shutdown()).rejects.toThrow();
       });
 

--- a/packages/services/test/session/isession.spec.ts
+++ b/packages/services/test/session/isession.spec.ts
@@ -392,7 +392,7 @@ describe('session', () => {
         await previous.info;
         const path = UUID.uuid4() + '.ipynb';
         const model = { ...session.model, path };
-        handleRequest(session, 200, model);
+        handleRequest(sessionAPIClient, 200, model);
         await session.changeKernel({ name: previous.name });
         expect(session.kernel!.name).toBe(previous.name);
         expect(session.path).toBe(model.path);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

As a follow-up to https://github.com/jupyterlab/jupyterlab/pull/16794, extensions can now provide a different `Kernel.IManager` or `Session.IManager` via a plugin. This is great, as it allows experimenting with different custom implementations, including the use case of in-browser kernels.

Although extensions can implement and provide their own `Kernel.IManager`, `Session.IManager`, `Kernel.IKernelConnection`, `Session.ISessionConnection`, it is still a lot of logic to implement, such as handling kernel messages or message hooks. Some of the logic from the concrete `KernelManager` and `SessionManager` implementations often needs to be duplicated since it is currently privately defined. 

The current implementations of `KernelManager`, `SessionManager`, `KernelConnection` and `SessionConnection` talk to the respective Jupyter Sever API endpoints, as illustrated on this diagram: https://github.com/jupyterlab/jupyterlab/blob/main/packages/services/README.md#session-context. Because of this, extensions may need to provide implementations for these 4 concrete classes.

In the case of in-browser kernels, the custom kernel and session managers don't necessarely need to rewrite a `KernelManager` and `SessionManager` from scratch. They mostly need to be able to swap the part that makes requests to the Jupyter Server API. 

In the current state of https://github.com/jupyterlite/jupyterlite/pull/1590, the custom `KernelManager`, `SessionManager`, `KernelConnection` and `SessionConnection` are derived from the concrete implementations from `@jupyterlab/services`, with a few methods overridden, to avoid duplicating too much code from the base implementations. However this also requires accessing private attributes and methods to be able to reuse the rest of the upstream implementation.

With this PR, the proposal is to add more granularity to what can be configured when instantiating a `KernelManager` or `SessionManager`. In this case, it extracts the functions that make requests to the Jupyter Server REST API, so a different implementation could be provided when instantiating a new `KernelManager` and `SessionManager`.

This should make the use case of downstream extensions like JupyterLite easier to handle, as they could then define their plugin in a much more minimal way, for example:

```ts
const kernelManagerPlugin: ServiceManagerPlugin<Kernel.IManager> = {
  id: 'example:kernel-manager',
  description: 'Custom kernel manager plugin.',
  autoStart: true,
  provides: IKernelManager,
  optional: [IServerSettings],
  activate: (_: null, serverSettings?: ServerConnection.ISettings): Kernel.IManager => {
    class CustomKernelAPIClient implements Kernel.IKernelAPIClient {
      // implement the functions
    }
    const kernelAPIClient = new CustomKernelAPIClient();
    return new KernelManager({ kernelAPIClient, serverSettings });
  },
};
```

## Code changes

- [x] Add `Kernel.IKernelAPIClient` and `Session.ISessionAPIClient`
- [x] Allow `Kernel.IManager` and `Kernel.IKernelConnection` to take an optional `Kernel.IKernelClient`
- [x] Allow `Session.IManager` and `Session.ISessionConnection` to take an optional `Session.IKernelClient`

The names are currently set to `KernelAPIClient` / `SessionAPIClient` to not conflict with the already publicly exposed `KernelAPI` / `SessionAPI`.

## User-facing changes

None

## Backwards-incompatible changes

None.

The current `KernelAPI` and `SessionAPI` are preserved.

If we want to be cautious, we could also mark the new options as experimental for now.
