### PR TITLE
Rename "Delete" to "Move to Trash"

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -736,6 +736,8 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
         page_config["exposeAppInBrowser"] = self.expose_app_in_browser
         page_config["quitButton"] = self.serverapp.quit_button
         page_config["allow_hidden_files"] = self.serverapp.contents_manager.allow_hidden
+        if hasattr(self.serverapp.contents_manager, "delete_to_trash"):
+            page_config["delete_to_trash"] = self.serverapp.contents_manager.delete_to_trash
 
         # Client-side code assumes notebookVersion is a JSON-encoded string
         page_config["notebookVersion"] = json.dumps(jpserver_version_info)

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -917,6 +917,7 @@ function addCommands(
   const trans = translator.load('jupyterlab');
   const { docRegistry: registry, commands } = app;
   const { tracker } = factory;
+  const deleteToTrash = PageConfig.getOption('delete_to_trash') === 'true';
 
   commands.addCommand(CommandIDs.del, {
     execute: () => {
@@ -927,7 +928,7 @@ function addCommands(
       }
     },
     icon: closeIcon.bindprops({ stylesheet: 'menuItem' }),
-    label: trans.__('Delete'),
+    label: deleteToTrash ? trans.__('Move to Trash') : trans.__('Delete'),
     mnemonic: 0
   });
 


### PR DESCRIPTION
## References

This is a fix for https://github.com/jupyterlab/jupyterlab/issues/13116

## Code changes

* Exposed the configuration using the `PageConfig` object
* Read the config `delete_to_trash` from PageConfig when constructing the context menu
* Change the menu label accordingly

## User-facing changes

Users will see the menu `Move to Trash` instead of `Delete` when the configuration `delete_to_trash` is true (Which is the default value)

![image](https://github.com/user-attachments/assets/cd23e478-a3b7-4ee0-856f-3d5e4632bd04)


## Backwards-incompatible changes

No changes to APIs.


----

Please let me know if I should change anything else. Thanks!
