### PR TITLE
Require `JupyterLab.IInfo` for the plugin manager plugin

### DIFF
--- a/packages/application/src/lab.ts
+++ b/packages/application/src/lab.ts
@@ -325,7 +325,7 @@ export namespace JupyterLab {
   }
 
   /**
-   * The layout restorer token.
+   * The application info token.
    */
   export const IInfo = new Token<IInfo>(
     '@jupyterlab/application:IInfo',

--- a/packages/pluginmanager-extension/src/index.ts
+++ b/packages/pluginmanager-extension/src/index.ts
@@ -8,6 +8,7 @@
  */
 import {
   ILayoutRestorer,
+  JupyterFrontEnd,
   JupyterFrontEndPlugin,
   JupyterLab
 } from '@jupyterlab/application';
@@ -47,11 +48,12 @@ const pluginmanager: JupyterFrontEndPlugin<IPluginManager> = {
   id: PLUGIN_ID,
   description: 'Enable or disable individual plugins.',
   autoStart: true,
-  requires: [],
+  requires: [JupyterLab.IInfo],
   optional: [ITranslator, ICommandPalette, ILayoutRestorer],
   provides: IPluginManager,
   activate: (
-    app: JupyterLab,
+    app: JupyterFrontEnd,
+    appInfo: JupyterLab.IInfo,
     translator: ITranslator | null,
     palette: ICommandPalette | null,
     restorer: ILayoutRestorer | null
@@ -77,7 +79,7 @@ const pluginmanager: JupyterFrontEndPlugin<IPluginManager> = {
       const model = new PluginListModel({
         ...args,
         pluginData: {
-          availablePlugins: app.info.availablePlugins
+          availablePlugins: appInfo.availablePlugins
         },
         serverSettings: app.serviceManager.serverSettings,
         extraLockedPlugins: [


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Currentl `@jupyterlab/pluginmanager-extension:plugin` was expecting the `app` it gets in the `activate` function to be a `JupyterLab` instance:

https://github.com/jupyterlab/jupyterlab/blob/d470c501f50ad7075413cd89967a1a8a332b9a2f/packages/pluginmanager-extension/src/index.ts#L54

This may not always be the case, for example if the plugin is used in another lab-based application.

Instead we can require `JupyterLab.IInfo`, which provides the information needed for the plugin. That way another lab-based application could provide `JupyterLab.IInfo` via a plugin, instead of being itself a `JupyterLab`.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- Require `JupyterLab.IInfo`

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
