### PR TITLE
Fix cell output stream if previous chunk did not end in new line

### DIFF
--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -569,11 +569,11 @@ namespace Private {
       );
       text = text.slice(0, idx0) + prefix + text.slice(idx0 + prefix.length);
       lastEnd = idx1 + 1;
+      idx0 += prefix.length;
 
       if (idx1 === -1) {
         break;
       }
-      idx0 += prefix.length;
 
       const newChar = newText[idx1];
       if (newChar === '\b') {

--- a/packages/outputarea/test/model.spec.ts
+++ b/packages/outputarea/test/model.spec.ts
@@ -183,6 +183,22 @@ describe('outputarea/model', () => {
         expect(model.get(0).toJSON().text).toBe('abc\n-');
       });
 
+      it('should correctly merge lines if the first line does not end with new line', () => {
+        model.add({
+          name: 'stdout',
+          output_type: 'stream',
+          text: ['The meaning of life is....\nSome people... ']
+        });
+        model.add({
+          name: 'stdout',
+          output_type: 'stream',
+          text: ['More text.']
+        });
+        expect(model.get(0).toJSON().text).toBe(
+          'The meaning of life is....\nSome people... More text.'
+        );
+      });
+
       it('should be fast in sparse presence of returns and backspaces', () => {
         // locally this test run in 36 ms; setting it to 10 times
         // more to allow for slower runs on CI


### PR DESCRIPTION
## References

Fixes #17358.

## Code changes

Update current position to end of text.

## User-facing changes

Better handling of cell output streams.

## Backwards-incompatible changes

None.