### PR TITLE
Add pip as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "jupyterlab_server>=2.27.1,<3",
     "notebook_shim>=0.2",
     "packaging",
+    "pip",
     "setuptools>=41.1.0",
     "tomli>=1.2.2;python_version<\"3.11\"",
     "tornado>=6.2.0",


### PR DESCRIPTION
## References

- #17375

## Code changes

I added `"pip"` to the list of dependencies in `pyproject.toml`.

## User-facing changes

This will fix a bug where `%pip install X` doesn't work in Jupyter Lab installations that were created using `uv tool install`.

## Backwards-incompatible changes

None.
