### PR TITLE
Support for keyboard layouts.

### DIFF
--- a/packages/settingregistry/src/settingregistry.ts
+++ b/packages/settingregistry/src/settingregistry.ts
@@ -738,13 +738,15 @@ export class BaseSettings<
       const defaultValue = this.default(key);
       if (
         value === undefined ||
-        defaultValue === undefined ||
         JSONExt.deepEqual(value, JSONExt.emptyObject) ||
         JSONExt.deepEqual(value, JSONExt.emptyArray)
       ) {
         continue;
       }
-      if (!JSONExt.deepEqual(value, defaultValue)) {
+      if (
+        defaultValue === undefined ||
+        !JSONExt.deepEqual(value, defaultValue)
+      ) {
         return false;
       }
     }

--- a/packages/shortcuts-extension/package.json
+++ b/packages/shortcuts-extension/package.json
@@ -51,6 +51,8 @@
     "@lumino/domutils": "^2.0.2",
     "@lumino/keyboard": "^2.0.2",
     "@lumino/signaling": "^2.1.3",
+    "@rjsf/core": "^5.13.4",
+    "@rjsf/utils": "^5.13.4",
     "react": "^18.2.0"
   },
   "devDependencies": {

--- a/packages/shortcuts-extension/schema/keyboard-layout.json
+++ b/packages/shortcuts-extension/schema/keyboard-layout.json
@@ -1,0 +1,47 @@
+{
+  "jupyter.lab.setting-icon": "ui-components:keyboard",
+  "jupyter.lab.setting-icon-label": "Keyboard Layout",
+  "title": "Keyboard Layout",
+  "description": "Keyboard layout settings.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "useBrowserLayout": {
+      "title": "Browser layout",
+      "description": "Whether to use the browser's keyboard layout, if the browser supports it. If this is set, and the browser supports it, it will override the selected layout.",
+      "type": "boolean",
+      "default": true
+    },
+    "layout": {
+      "title": "Keyboard Layout",
+      "description": "The keyboard layout to use for shortcuts etc",
+      "type": "string"
+    },
+    "customLayouts": {
+      "title": "Custom Layouts",
+      "description": "User specified keyboard layouts",
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "keyMap": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "modifiers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/shortcuts-extension/src/components/KeyboardCapture.tsx
+++ b/packages/shortcuts-extension/src/components/KeyboardCapture.tsx
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import * as React from 'react';
+import { KeycodeLayout } from '@lumino/keyboard';
+import { IKeyboardLayoutSettings } from '../types';
+
+type CaptureData = { key: string; code?: string; type: 'modifier' | 'code' };
+
+function LayoutCaptureArea({
+  onCapture
+}: {
+  onCapture: (data: CaptureData) => void;
+}): React.ReactElement {
+  return (
+    <div
+      tabIndex={0}
+      className="jp-Keyboard-captureArea"
+      style={{
+        minWidth: '200px',
+        border: '3px dashed',
+        borderRadius: '5px',
+        padding: '6px',
+        margin: '6px',
+        maxWidth: '500px',
+        minHeight: '2lh',
+        display: 'flex',
+        alignItems: 'center',
+        textAlign: 'center'
+      }}
+      onKeyDown={event => {
+        event.stopPropagation();
+        event.preventDefault();
+        if (event.getModifierState(event.key as any)) {
+          onCapture({ key: event.key, type: 'modifier' });
+        }
+      }}
+      onKeyUp={event => {
+        event.stopPropagation();
+        event.preventDefault();
+        if (event.getModifierState(event.key as any)) {
+          onCapture({ key: event.key, type: 'modifier' });
+          return;
+        }
+        let { key, code } = event;
+        if (key === 'Dead') {
+          console.log('Dead key', event);
+        } else if (!code || code === 'Unidentified') {
+          console.log('Unidentified code', event);
+        } else {
+          onCapture({ key, code, type: 'code' });
+        }
+      }}
+    >
+      Focus me and hit each key on your keyboard without any modifiers <br />
+      (click the modifiers separately)
+    </div>
+  );
+}
+
+function renderCaptureData({
+  type,
+  code,
+  key
+}: CaptureData): React.ReactElement {
+  return (
+    <div className="jp-Keyboard-captureAreaOutput">
+      Added {type}: {code ? `${code} →` : ''}{' '}
+      <kbd>{key.charAt(0).toUpperCase() + key.slice(1)}</kbd>
+    </div>
+  );
+}
+
+function exportData({
+  name,
+  codeMap,
+  modifiers
+}: IKeyboardLayoutSettings): IKeyboardLayoutSettings {
+  return {
+    name,
+    modifiers: modifiers.sort(),
+    codeMap: Object.keys(codeMap)
+      .sort()
+      .reduce<{ [code: string]: string }>((acc, k) => {
+        acc[k] = codeMap[k].charAt(0).toUpperCase() + codeMap[k].slice(1);
+        return acc;
+      }, {})
+  };
+}
+
+export function KeyboardCapture({
+  onAdd
+}: {
+  onAdd: (data: IKeyboardLayoutSettings) => void;
+}): React.ReactElement {
+  const [codeMap, setCodeMap] = React.useState<KeycodeLayout.ModernCodeMap>({});
+  const [modifiers, setModifiers] = React.useState([] as string[]);
+  const [name, setName] = React.useState('');
+  const [latestAction, setLatestAction] = React.useState<CaptureData | null>(
+    null
+  );
+
+  const canAdd = name && Object.keys(codeMap).length > 0;
+
+  return (
+    <div className="jp-Keyboard-captureContainer">
+      <b>Build your own map:</b>
+      <LayoutCaptureArea
+        onCapture={({ key, code, type }) => {
+          if (type === 'modifier') {
+            if (!modifiers.includes(key)) {
+              setModifiers([...modifiers, key]);
+            }
+          } else {
+            setCodeMap({ ...codeMap, [code!]: key });
+          }
+          setLatestAction({ key, code, type });
+        }}
+      />
+      {latestAction ? (
+        renderCaptureData(latestAction)
+      ) : (
+        <div className="jp-Keyboard-captureAreaOutput">No keys added</div>
+      )}
+      <div className="jp-Keyboard-captureActions">
+        <label>
+          Name:
+          <input
+            title="The name to use for the new keyboard layout"
+            value={name}
+            onChange={event => {
+              setName(event.target.value);
+            }}
+          />
+        </label>
+        <button
+          disabled={!canAdd}
+          title={
+            canAdd
+              ? 'Add the captured map as the specified name'
+              : 'Enter a name and capture some keys to add the captured map'
+          }
+          onClick={() => {
+            onAdd(exportData({ codeMap, modifiers, name }));
+            setModifiers([]);
+            setCodeMap({});
+            setName('');
+          }}
+        >
+          Add
+        </button>
+        <button
+          title="Clear the in-progress captured keyboard data"
+          onClick={() => {
+            setModifiers([]);
+            setCodeMap({});
+            setName('');
+          }}
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/shortcuts-extension/src/components/KeyboardLayoutUI.tsx
+++ b/packages/shortcuts-extension/src/components/KeyboardLayoutUI.tsx
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import * as React from 'react';
+import { map } from '@lumino/algorithm';
+import { JSONArray, JSONExt } from '@lumino/coreutils';
+import { getDefaultRegistry } from '@rjsf/core';
+import type { FieldProps, WidgetProps } from '@rjsf/utils';
+import { KeyboardCapture } from './KeyboardCapture';
+import { IKeyboardLayoutRegistry, IKeyboardLayoutSettings } from '../types';
+
+const SelectWidget = getDefaultRegistry().widgets['SelectWidget'];
+
+/**
+ * Renderer for a manually captured keyboard layout.
+ */
+function Layout({
+  layout,
+  onRemove
+}: {
+  layout: IKeyboardLayoutSettings;
+  onRemove: (name: string) => void;
+}): React.ReactElement {
+  return (
+    <details className="jp-Keyboard-layoutDetails">
+      <summary>
+        {layout.name}
+        <button onClick={() => onRemove(layout.name)}>Delete</button>
+      </summary>
+      <h4>Keys:</h4>
+      <ul className="jp-Keyboard-List">
+        {Object.keys(layout.codeMap).some(a => a)
+          ? [
+              ...Object.entries(layout.codeMap).map(([code, key]) => (
+                <li key={code} className="jp-Keyboard-Entry">
+                  <span key="key">
+                    <kbd>{key === ' ' ? 'Space' : key}</kbd>
+                  </span>
+                  <span key="code">{code}</span>
+                </li>
+              ))
+            ]
+          : 'No keys registered'}
+      </ul>
+      <h4>Modifiers:</h4>
+      <ul className="jp-Keyboard-ModifierList">
+        {layout.modifiers.length > 0
+          ? [
+              ...map(layout.modifiers, modifier => (
+                <li key={modifier} className="jp-Keyboard-Entry">
+                  <span>
+                    <kbd>{modifier}</kbd>
+                  </span>
+                </li>
+              ))
+            ]
+          : 'No modifiers registered'}
+      </ul>
+    </details>
+  );
+}
+
+/**
+ * Snapshot of the available layouts in the registry.
+ */
+type RegistrySnapshot = {
+  custom: [string, IKeyboardLayoutSettings][];
+  fixed: string[];
+};
+
+/**
+ * Hook for using the layouts in the registry in react.
+ */
+function useRegistry(registry: IKeyboardLayoutRegistry): RegistrySnapshot {
+  const cache = React.useRef<{ fixed: string[]; custom: JSONArray }>({
+    custom: [],
+    fixed: []
+  });
+
+  const subscribe = React.useCallback(
+    (callback: () => void) => {
+      registry.changed.connect(callback);
+      return () => registry.changed.disconnect(callback);
+    },
+    [registry]
+  );
+
+  const getSnapshot = React.useCallback(() => {
+    const withRaw = registry.names.map(
+      name =>
+        [name, registry.getRaw(name)] as [
+          string,
+          IKeyboardLayoutSettings | undefined
+        ]
+    );
+    const custom = withRaw.filter(([name, raw]) => raw) as JSONArray;
+    const fixed = withRaw.filter(([name, raw]) => !raw).map(([name]) => name);
+    if (
+      !JSONExt.deepEqual(
+        [fixed, custom],
+        [cache.current.fixed, cache.current.custom]
+      )
+    ) {
+      const value = { custom, fixed };
+      cache.current = value;
+    }
+    return cache.current as RegistrySnapshot;
+  }, [registry]);
+
+  return React.useSyncExternalStore(subscribe, getSnapshot);
+}
+
+/** Props for ShortcutUI component */
+export type KeyboardLayoutUIProps = FieldProps & {
+  layoutRegistry: IKeyboardLayoutRegistry;
+};
+
+/**
+ * Render the layout settings UI.
+ * @param param0
+ * @returns
+ */
+export function KeyboardLayoutUI({
+  layoutRegistry
+}: KeyboardLayoutUIProps): React.ReactElement {
+  const { custom, fixed } = useRegistry(layoutRegistry);
+  return (
+    <>
+      {fixed.length > 0 && (
+        <div className="jp-FormGroup-contentNormal">
+          <h3 className="jp-FormGroup-contentItem jp-FormGroup-fieldLabel">
+            Built-in maps
+          </h3>
+          <div className="jp-FormGroup-contentItem">{fixed.join(', ')}</div>
+          <div className="jp-FormGroup-description">
+            The keyboard layouts included in the build. Informational only.
+          </div>
+        </div>
+      )}
+      <div className="jp-FormGroup-contentNormal">
+        <h3 className="jp-FormGroup-contentItem jp-FormGroup-fieldLabel">
+          Custom maps
+        </h3>
+        {custom.length > 0 && (
+          <>
+            <div className="jp-FormGroup-description">
+              Maps added by the user:
+            </div>
+            <ul
+              style={{
+                listStyleType: 'none',
+                paddingInlineStart: '20px',
+                width: '100%'
+              }}
+            >
+              {custom.map(([name, raw]) => (
+                <li key={name}>
+                  <Layout
+                    layout={raw}
+                    onRemove={name => layoutRegistry.remove(name)}
+                  />
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+        <KeyboardCapture
+          onAdd={data => {
+            layoutRegistry.add(data);
+          }}
+        />
+      </div>
+    </>
+  );
+}
+
+/**
+ * Custom render for dropdown to inject our options as enum options.
+ */
+export function LayoutDropdownWidget(
+  props: WidgetProps & { layoutRegistry: IKeyboardLayoutRegistry }
+): React.ReactElement {
+  const { layoutRegistry, options, ...rest } = props;
+  const { custom, fixed } = useRegistry(layoutRegistry);
+
+  const newOptions = React.useMemo(() => {
+    const values = Array.from(
+      new Set([...fixed, ...custom.map(b => b[0])])
+    ).sort();
+    return {
+      ...options,
+      enumOptions: values.map(v => ({ label: v, value: v }))
+    };
+  }, [custom, fixed]);
+
+  return <SelectWidget {...rest} options={newOptions} />;
+}

--- a/packages/shortcuts-extension/src/components/index.ts
+++ b/packages/shortcuts-extension/src/components/index.ts
@@ -3,4 +3,5 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+export * from './KeyboardLayoutUI';
 export * from './ShortcutUI';

--- a/packages/shortcuts-extension/src/layoutregistry.ts
+++ b/packages/shortcuts-extension/src/layoutregistry.ts
@@ -1,0 +1,66 @@
+import { JSONArray } from '@lumino/coreutils';
+import { IKeyboardLayout, KeycodeLayout } from '@lumino/keyboard';
+import { ISignal, Signal } from '@lumino/signaling';
+import { IKeyboardLayoutRegistry, IKeyboardLayoutSettings } from './types';
+
+export class KeyboardLayoutRegistry implements IKeyboardLayoutRegistry {
+  /**
+   *
+   */
+  constructor(fixed: IKeyboardLayout[]) {
+    for (const layout of fixed) {
+      this._fixedData.set(layout.name, layout);
+    }
+  }
+
+  get(name: string): IKeyboardLayout | undefined {
+    if (this._data.has(name)) {
+      if (this._cache.has(name)) {
+        return this._cache.get(name);
+      }
+      const { codeMap, modifiers } = this._data.get(name)!;
+      const layout = new KeycodeLayout(name, {}, [...modifiers], codeMap);
+      this._cache.set(name, layout);
+      return layout;
+    }
+    return this._fixedData.get(name);
+  }
+
+  getRaw(name: string): IKeyboardLayoutSettings | undefined {
+    return this._data.get(name);
+  }
+
+  add(layout: IKeyboardLayoutSettings): void {
+    this._data.set(layout.name, layout);
+    this._cache.delete(layout.name);
+    this._changed.emit(undefined);
+  }
+
+  remove(name: string): void {
+    this._data.delete(name);
+    this._cache.delete(name);
+    this._changed.emit(undefined);
+  }
+
+  serialize(): JSONArray {
+    return [...this._data.values()].map(layout => ({ ...layout }));
+  }
+
+  set customLayouts(layouts: IKeyboardLayoutSettings[]) {
+    this._data = new Map(layouts.map(layout => [layout.name, layout]));
+    this._cache = new Map();
+  }
+
+  get names(): string[] {
+    return [...new Set([...this._fixedData.keys(), ...this._data.keys()])];
+  }
+
+  get changed(): ISignal<unknown, unknown> {
+    return this._changed;
+  }
+
+  private _changed = new Signal({});
+  private _fixedData = new Map<string, IKeyboardLayout>();
+  private _data = new Map<string, IKeyboardLayoutSettings>();
+  private _cache = new Map<string, IKeyboardLayout>();
+}

--- a/packages/shortcuts-extension/src/layoutregistry.ts
+++ b/packages/shortcuts-extension/src/layoutregistry.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
 import { JSONArray } from '@lumino/coreutils';
 import { IKeyboardLayout, KeycodeLayout } from '@lumino/keyboard';
 import { ISignal, Signal } from '@lumino/signaling';

--- a/packages/shortcuts-extension/src/renderer.tsx
+++ b/packages/shortcuts-extension/src/renderer.tsx
@@ -4,11 +4,32 @@
  */
 
 import React from 'react';
-import { ShortcutUI } from './components';
-import { IShortcutUI } from './types';
+import type { FieldProps, WidgetProps } from '@rjsf/utils';
+import {
+  KeyboardLayoutUI,
+  LayoutDropdownWidget,
+  ShortcutUI
+} from './components';
+import { IKeyboardLayoutRegistry, IShortcutUI } from './types';
 
-export const renderShortCut = (props: {
-  external: IShortcutUI.IExternalBundle;
-}): JSX.Element => {
+export const renderShortCut = (
+  props: FieldProps & {
+    external: IShortcutUI.IExternalBundle;
+  }
+): JSX.Element => {
   return <ShortcutUI external={props.external} height={1000} width={1000} />;
+};
+
+export const renderKeyboardLayout = (
+  props: FieldProps & {
+    layoutRegistry: IKeyboardLayoutRegistry;
+  }
+): JSX.Element => {
+  return <KeyboardLayoutUI {...props} />;
+};
+
+export const renderLayoutDropdown = (
+  props: WidgetProps & { layoutRegistry: IKeyboardLayoutRegistry }
+): JSX.Element => {
+  return <LayoutDropdownWidget {...props} />;
 };

--- a/packages/shortcuts-extension/src/types.ts
+++ b/packages/shortcuts-extension/src/types.ts
@@ -8,6 +8,7 @@ import type { CommandRegistry } from '@lumino/commands';
 import type { ISignal } from '@lumino/signaling';
 import type { ISettingRegistry } from '@jupyterlab/settingregistry';
 import type { ITranslator } from '@jupyterlab/translation';
+import type { IKeyboardLayout, KeycodeLayout } from '@lumino/keyboard';
 
 /**
  * Identifiers of commands registered by shortcuts UI.
@@ -221,4 +222,30 @@ export interface IShortcutRegistry
    * Find targets that would conflict with given keys chord under given sequence.
    */
   findConflictsFor(keys: string[], selector: string): IShortcutTarget[];
+}
+
+/**
+ * Registry of keyboard layouts.
+ */
+export interface IKeyboardLayoutRegistry {
+  get(name: string): IKeyboardLayout | undefined;
+
+  getRaw(name: string): IKeyboardLayoutSettings | undefined;
+
+  add(layout: IKeyboardLayoutSettings): void;
+
+  remove(name: string): void;
+
+  get names(): string[];
+
+  get changed(): ISignal<unknown, unknown>;
+}
+
+/**
+ * Structure of settings of individual stored keyboard layouts.
+ */
+export interface IKeyboardLayoutSettings {
+  name: string;
+  codeMap: KeycodeLayout.ModernCodeMap;
+  modifiers: string[];
 }

--- a/packages/shortcuts-extension/style/base.css
+++ b/packages/shortcuts-extension/style/base.css
@@ -372,3 +372,98 @@
   margin-left: 8px;
   margin-right: 16px;
 }
+
+.jp-Keyboard-layoutDetails {
+  padding-block-end: 0.5lh;
+}
+
+.jp-Keyboard-layoutDetails > summary {
+  font-weight: bold;
+}
+
+.jp-Keyboard-layoutDetails > h4 {
+  padding-inline-start: 20px;
+}
+
+.jp-ThemedContainer .jp-Keyboard-layoutDetails kbd,
+.jp-ThemedContainer .jp-Keyboard-captureAreaOutput kbd {
+  border: 2px solid var(--jp-ui-font-color2);
+  display: inline-block;
+  font-size: calc(0.85 * var(--jp-code-font-size));
+  font-weight: 700;
+  padding: 2px 6px;
+  white-space: nowrap;
+}
+
+.jp-Keyboard-ModifierList {
+  display: flex;
+  list-style-type: none;
+}
+
+.jp-Keyboard-List {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 7em 10em);
+}
+
+.jp-Keyboard-List .jp-Keyboard-Entry {
+  display: grid;
+  grid-column: span 2;
+  grid-template-columns: subgrid;
+}
+
+.jp-Keyboard-Entry {
+  padding: 6px 12px;
+}
+
+.jp-Keyboard-layoutDetails button {
+  background: var(--jp-shortcuts-button-background);
+  border-color: var(--jp-layout-color0);
+  border-radius: var(--jp-border-radius);
+  border-width: var(--jp-border-width);
+  padding: 5px 6px;
+  color: var(--jp-ui-inverse-font-color1);
+  margin-inline-start: 20px;
+  cursor: pointer;
+}
+
+.jp-Keyboard-layoutDetails button:hover {
+  background: var(--jp-shortcuts-button-hover-background);
+}
+
+.jp-Keyboard-captureContainer {
+  padding: 4px 7px;
+  border: 1px solid var(--jp-border-color2);
+  border-radius: 4px;
+  margin: 4px;
+  flex-basis: 100%;
+}
+
+.jp-Keyboard-captureActions {
+  margin-inline-start: 6px;
+  padding-inline-start: 6px;
+}
+
+.jp-Keyboard-captureActions input,
+.jp-Keyboard-captureActions button {
+  margin-inline: 6px;
+}
+
+.jp-Keyboard-captureActions button {
+  background: var(--jp-shortcuts-button-background);
+  border-color: var(--jp-layout-color0);
+  border-radius: var(--jp-border-radius);
+  border-width: var(--jp-border-width);
+  padding: 5px 6px;
+  color: var(--jp-ui-inverse-font-color1);
+  cursor: pointer;
+}
+
+.jp-Keyboard-captureActions button[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.jp-Keyboard-captureAreaOutput {
+  margin: 6px;
+  padding: 6px;
+}

--- a/packages/ui-components/style/rjsfTemplates.css
+++ b/packages/ui-components/style/rjsfTemplates.css
@@ -3,6 +3,10 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
+.jp-FormGroup-content {
+  width: 100%;
+}
+
 .jp-FormGroup-content fieldset {
   border: none;
   padding: 0;
@@ -43,6 +47,10 @@
 .jp-FormGroup-content .checkbox label {
   cursor: pointer;
   font-size: var(--jp-content-font-size1);
+}
+
+.jp-FormGroup-content .jp-root {
+  width: 100%;
 }
 
 .jp-FormGroup-content .jp-root > fieldset > legend {
@@ -95,6 +103,10 @@
 }
 
 /* RJSF ARRAY style */
+
+.jp-arrayFieldWrapper {
+  width: 100%;
+}
 
 .jp-arrayFieldWrapper legend {
   font-size: var(--jp-content-font-size2);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4788,6 +4788,8 @@ __metadata:
     "@lumino/domutils": ^2.0.2
     "@lumino/keyboard": ^2.0.2
     "@lumino/signaling": ^2.1.3
+    "@rjsf/core": ^5.13.4
+    "@rjsf/utils": ^5.13.4
     "@types/jest": ^29.2.0
     jest: ^29.2.0
     react: ^18.2.0


### PR DESCRIPTION
## References

Fixes #17355.

Resolves #7579.

## Code changes

Adds a new plugin in the shortcuts-extension package. Relies on the WIP lumino branch in this PR https://github.com/jupyterlab/lumino/pull/291/ .

## User-facing changes

- A new section is available in the settings editor for picking the keyboard layout.
- Users can pick from pre-defined keymaps in the settings editor.
- Users can capture their own keyboard mapping by a separate input widget in the settings dialog.
- Users can now define shortcuts based on non-US keyboards. I.e. if I add a shortcut for my `æ` key, it will only trigger if I push a button that produces that character (e.g. I have a Norwegian keyboard and press the `code=Quote` button, or if I have a Danish keyboard and press the `code=Semicolon` button). Non-QWERTY can also be configured (AZERTY, Dvorak, etc).

## Backwards-incompatible changes

Not sure if it qualifies as backwards-incompatible, but the shortcut-extension package will require a dependency on an as-yet unreleased feature in the Lumino "keyboard" package.
