### PR TITLE
Fix definition of the `ILicensesClient` interface

### DIFF
--- a/packages/apputils/src/licenses.tsx
+++ b/packages/apputils/src/licenses.tsx
@@ -324,7 +324,7 @@ export namespace Licenses {
     }
 
     /**
-     * fetch the license bundles from the server.
+     * Fetch the license bundles from the server.
      */
     async getBundles(): Promise<ILicenseResponse> {
       const response = await ServerConnection.makeRequest(

--- a/packages/apputils/src/licenses.tsx
+++ b/packages/apputils/src/licenses.tsx
@@ -309,14 +309,22 @@ export namespace Licenses {
     }
 
     /**
-     * Get the link to download the licenses in a given format.
+     * Download the licenses in the requested format.
      */
-    async getDownloadLink(options: IDownloadOptions): Promise<string> {
-      return `${this._licensesUrl}?format=${options.format}&download=1`;
+    async download(options: IDownloadOptions): Promise<void> {
+      const url = `${this._licensesUrl}?format=${options.format}&download=1`;
+      const element = document.createElement('a');
+      element.href = url;
+      element.download = '';
+      document.body.appendChild(element);
+      element.click();
+      document.body.removeChild(element);
+      URL.revokeObjectURL(url);
+      return void 0;
     }
 
     /**
-     * Fetch the license bundles from the server.
+     * fetch the license bundles from the server.
      */
     async getBundles(): Promise<ILicenseResponse> {
       const response = await ServerConnection.makeRequest(
@@ -364,19 +372,10 @@ export namespace Licenses {
     }
 
     /**
-     * Create a temporary download link, and emulate clicking it to trigger a named
-     * file download.
+     * Download the licenses in the requested format.
      */
     async download(options: IDownloadOptions): Promise<void> {
-      const url = await this._client.getDownloadLink(options);
-      const element = document.createElement('a');
-      element.href = url;
-      element.download = '';
-      document.body.appendChild(element);
-      element.click();
-      document.body.removeChild(element);
-      URL.revokeObjectURL(url);
-      return void 0;
+      return this._client.download(options);
     }
 
     /**

--- a/packages/apputils/src/tokens.ts
+++ b/packages/apputils/src/tokens.ts
@@ -90,9 +90,9 @@ export interface ILicensesClient {
   getBundles(): Promise<Licenses.ILicenseResponse>;
 
   /**
-   * Get the link to download the licenses in a given format.
+   * Download the licenses in the requested format.
    */
-  getDownloadLink(options: Licenses.IDownloadOptions): Promise<string>;
+  download(options: Licenses.IDownloadOptions): Promise<void>;
 }
 
 /**

--- a/packages/apputils/src/tokens.ts
+++ b/packages/apputils/src/tokens.ts
@@ -83,7 +83,17 @@ export const ILicensesClient = new Token<ILicensesClient>(
 /**
  * An interface for the license client.
  */
-export interface ILicensesClient extends Licenses.LicensesClient {}
+export interface ILicensesClient {
+  /**
+   * fetch the license bundles from the server.
+   */
+  getBundles(): Promise<Licenses.ILicenseResponse>;
+
+  /**
+   * Get the link to download the licenses in a given format.
+   */
+  getDownloadLink(options: Licenses.IDownloadOptions): Promise<string>;
+}
 
 /**
  * An interface for the session context dialogs.

--- a/packages/apputils/src/tokens.ts
+++ b/packages/apputils/src/tokens.ts
@@ -85,7 +85,7 @@ export const ILicensesClient = new Token<ILicensesClient>(
  */
 export interface ILicensesClient {
   /**
-   * fetch the license bundles from the server.
+   * Fetch the license bundles from the server.
    */
   getBundles(): Promise<Licenses.ILicenseResponse>;
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/17361.

## Code changes

Properly define `ILicensesClient`.

Otherwise, downstreams have to also implement `private` properties, which defeats the purpose of defining the interface in the first place.

Mentioned in https://learn.microsoft.com/en-us/archive/msdn-magazine/2015/january/typescript-understanding-typescript#typescript-inherits-differently:

> TypeScript requires that you include private members in the interface to be inherited from the class that the interface extends, instead of being reimplemented in the derived class.

## User-facing changes

None

## Backwards-incompatible changes

None.

This PR updates a public interface which was added in the previous beta (`4.4.0b1`), so not part of the API surface yet.