### PR TITLE
More specific selector for "Copy Output to Clipboard"

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1614,7 +1614,7 @@ function activateCopyOutput(
 
   app.contextMenu.addItem({
     command: CommandIDs.copyToClipboard,
-    selector: '.jp-OutputArea-child',
+    selector: '.jp-Notebook .jp-OutputArea-child',
     rank: 0
   });
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/17411

Since the related command (`notebook:copy-to-clipboard`) is added in `@jupyterlab/notebook-extension` and expects an `INotebookTracker` here:

https://github.com/jupyterlab/jupyterlab/blob/e1487fdb0444683193a2d9b078b37dca5bf80e51/packages/notebook-extension/src/index.ts#L1558

This has effect to disable the "Copy Output to Clipboard" context menu entry for the log console.

As noticed in https://github.com/jupyterlab/jupyterlab/issues/17411#issuecomment-2734323606, this context menu entry for the log console may not have been intentional.

## Code changes

More specific selector for "Copy Output to Clipboard".


## User-facing changes

https://github.com/user-attachments/assets/02a81687-4045-412c-9c71-b39749cf8f39

## Backwards-incompatible changes

None