### PR TITLE
Create "Kernels" section, split statusbar settings

### DIFF
--- a/packages/apputils-extension/schema/kernels-settings.json
+++ b/packages/apputils-extension/schema/kernels-settings.json
@@ -1,12 +1,14 @@
 {
-  "title": "Terminals and Kernels sessions settings",
-  "description": "Terminals and Kernels sessions settings",
+  "title": "Kernels settings",
+  "description": "Kernels and kernel sessions settings",
+  "jupyter.lab.setting-icon": "ui-components:kernel",
+  "jupyter.lab.setting-icon-label": "Kernel",
   "additionalProperties": false,
   "properties": {
     "showStatusBarItem": {
       "type": "boolean",
       "title": "Show the status bar item",
-      "description": "Whether to show the running terminals and kernels item in the status bar",
+      "description": "Whether to show the running kernels item in the status bar",
       "default": true
     },
     "commsOverSubshells": {

--- a/packages/apputils-extension/schema/kernels-settings.json
+++ b/packages/apputils-extension/schema/kernels-settings.json
@@ -1,5 +1,5 @@
 {
-  "title": "Kernels settings",
+  "title": "Kernels",
   "description": "Kernels and kernel sessions settings",
   "jupyter.lab.setting-icon": "ui-components:kernel",
   "jupyter.lab.setting-icon-label": "Kernel",

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -728,10 +728,24 @@ const sanitizer: JupyterFrontEndPlugin<IRenderMime.ISanitizer> = {
   }
 };
 
+/*
+ * A plugin owning the kernel settings
+ */
+export const kernelSettings: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlab/apputils-extension:kernels-settings',
+  description: 'Reserves the name for kernel settings.',
+  autoStart: true,
+  requires: [ISettingRegistry],
+  activate: (_app: JupyterFrontEnd, settingRegistry: ISettingRegistry) => {
+    void settingRegistry.load(kernelSettings.id);
+  }
+};
+
 /**
  * Export the plugins as default.
  */
 const plugins: JupyterFrontEndPlugin<any>[] = [
+  kernelSettings,
   announcements,
   kernelStatus,
   licensesClient,

--- a/packages/apputils-extension/src/statusbarplugin.ts
+++ b/packages/apputils-extension/src/statusbarplugin.ts
@@ -217,7 +217,7 @@ export const runningSessionsStatus: JupyterFrontEndPlugin<void> = {
           ];
 
         disposable?.dispose();
-        if (showKernels || showTerminals) {
+        if (showKernels || showTerminals !== false) {
           disposable = registerItem({
             showKernels,
             showTerminals

--- a/packages/apputils-extension/src/statusbarplugin.ts
+++ b/packages/apputils-extension/src/statusbarplugin.ts
@@ -225,14 +225,17 @@ export const runningSessionsStatus: JupyterFrontEndPlugin<void> = {
         }
       };
 
+      const kernelsPluginId = '@jupyterlab/apputils-extension:kernels-settings';
+      const terminalPluginId = '@jupyterlab/terminal-extension:plugin';
+
       void Promise.all([
-        // terminal settings may be missing if terminal plugin is not included
-        settingRegistry
-          .load('@jupyterlab/apputils-extension:kernels-settings')
-          .catch(() => undefined),
-        settingRegistry
-          .load('@jupyterlab/terminal-extension:plugin')
-          .catch(() => undefined)
+        // Settings may be missing if the respective plugins are not enabled/included.
+        kernelsPluginId in settingRegistry.plugins
+          ? settingRegistry.load(kernelsPluginId).catch(() => undefined)
+          : Promise.resolve(undefined),
+        terminalPluginId in settingRegistry.plugins
+          ? settingRegistry.load(terminalPluginId).catch(() => undefined)
+          : Promise.resolve(undefined)
       ]).then(([kernelSettings, terminalSettings]) => {
         onSettingsUpdated(kernelSettings, terminalSettings);
         if (kernelSettings) {

--- a/packages/apputils-extension/src/statusbarplugin.ts
+++ b/packages/apputils-extension/src/statusbarplugin.ts
@@ -148,7 +148,10 @@ export const runningSessionsStatus: JupyterFrontEndPlugin<void> = {
     translator: ITranslator,
     settingRegistry: ISettingRegistry | null
   ) => {
-    const createStatusItem = () => {
+    const createStatusItem = (options: {
+      showKernels: boolean;
+      showTerminals?: boolean;
+    }) => {
       const item = new RunningSessions({
         onClick: () => app.shell.activateById('jp-running-sessions'),
         onKeyDown: (event: KeyboardEvent<HTMLImageElement>) => {
@@ -163,7 +166,8 @@ export const runningSessionsStatus: JupyterFrontEndPlugin<void> = {
           }
         },
         serviceManager: app.serviceManager,
-        translator
+        translator,
+        ...options
       });
 
       item.model.sessions = Array.from(
@@ -176,8 +180,11 @@ export const runningSessionsStatus: JupyterFrontEndPlugin<void> = {
       return item;
     };
 
-    const registerItem = () => {
-      const item = createStatusItem();
+    const registerItem = (options: {
+      showKernels: boolean;
+      showTerminals?: boolean;
+    }) => {
+      const item = createStatusItem(options);
       return statusBar.registerStatusItem(runningSessionsStatus.id, {
         item,
         align: 'left',
@@ -188,25 +195,63 @@ export const runningSessionsStatus: JupyterFrontEndPlugin<void> = {
     if (settingRegistry) {
       let disposable: IDisposable;
       const onSettingsUpdated = (
-        settings: ISettingRegistry.ISettings
+        kernelSettings?: ISettingRegistry.ISettings,
+        terminalsSettings?: ISettingRegistry.ISettings
       ): void => {
-        const showStatusBarItem = settings.get('showStatusBarItem')
-          .composite as boolean;
+        const showTerminalsMap = {
+          'if-any': undefined,
+          never: false,
+          always: true
+        };
+        const showKernels =
+          (kernelSettings?.get('showStatusBarItem').composite as
+            | boolean
+            | undefined) ?? true;
+        const showTerminals =
+          showTerminalsMap[
+            (terminalsSettings?.get('showStatusBarItem').composite as
+              | 'if-any'
+              | 'never'
+              | 'always'
+              | undefined) ?? 'if-any'
+          ];
 
         disposable?.dispose();
-        if (showStatusBarItem) {
-          disposable = registerItem();
+        if (showKernels || showTerminals) {
+          disposable = registerItem({
+            showKernels,
+            showTerminals
+          });
         }
       };
 
-      void settingRegistry
-        .load('@jupyterlab/apputils-extension:sessions-settings')
-        .then(settings => {
-          onSettingsUpdated(settings);
-          settings.changed.connect(onSettingsUpdated);
-        });
+      void Promise.all([
+        // terminal settings may be missing if terminal plugin is not included
+        settingRegistry
+          .load('@jupyterlab/apputils-extension:kernels-settings')
+          .catch(() => undefined),
+        settingRegistry
+          .load('@jupyterlab/terminal-extension:plugin')
+          .catch(() => undefined)
+      ]).then(([kernelSettings, terminalSettings]) => {
+        onSettingsUpdated(kernelSettings, terminalSettings);
+        if (kernelSettings) {
+          kernelSettings.changed.connect(settings => {
+            kernelSettings = settings;
+            onSettingsUpdated(kernelSettings, terminalSettings);
+          });
+        }
+        if (terminalSettings) {
+          terminalSettings.changed.connect(settings => {
+            terminalSettings = settings;
+            onSettingsUpdated(kernelSettings, terminalSettings);
+          });
+        }
+      });
     } else {
-      registerItem();
+      registerItem({
+        showKernels: true
+      });
     }
   }
 };

--- a/packages/apputils-extension/src/subshell-settings.ts
+++ b/packages/apputils-extension/src/subshell-settings.ts
@@ -27,7 +27,7 @@ export const subshellsSettings: JupyterFrontEndPlugin<void> = {
       app.started
         .then(async () => {
           const subshellsSettings = await settingRegistry.load(
-            '@jupyterlab/apputils-extension:sessions-settings'
+            '@jupyterlab/apputils-extension:kernels-settings'
           );
 
           const commsOverSubshells = subshellsSettings.get('commsOverSubshells')

--- a/packages/apputils/src/runningSessions.tsx
+++ b/packages/apputils/src/runningSessions.tsx
@@ -37,6 +37,8 @@ const HALF_SPACING = 4;
 function RunningSessionsComponent(
   props: RunningSessionsComponent.IProps
 ): React.ReactElement<RunningSessionsComponent.IProps> {
+  const showKernels = props.showKernels ?? true;
+  const showTerminals = props.showTerminals ?? props.terminals > 0;
   return (
     <GroupItem
       tabIndex={0}
@@ -45,16 +47,18 @@ function RunningSessionsComponent(
       onKeyDown={props.handleKeyDown}
       style={{ cursor: 'pointer' }}
     >
-      {props.terminals > 0 ? (
+      {showTerminals ? (
         <GroupItem spacing={HALF_SPACING}>
           <TextItem source={props.terminals} />
           <terminalIcon.react verticalAlign="middle" stylesheet="statusBar" />
         </GroupItem>
       ) : null}
-      <GroupItem spacing={HALF_SPACING}>
-        <TextItem source={props.sessions} />
-        <kernelIcon.react verticalAlign="middle" stylesheet="statusBar" />
-      </GroupItem>
+      {showKernels ? (
+        <GroupItem spacing={HALF_SPACING}>
+          <TextItem source={props.sessions} />
+          <kernelIcon.react verticalAlign="middle" stylesheet="statusBar" />
+        </GroupItem>
+      ) : null}
     </GroupItem>
   );
 }
@@ -87,6 +91,18 @@ namespace RunningSessionsComponent {
      * The number of active terminal sessions.
      */
     terminals: number;
+
+    /**
+     * Whether to show kernels, true by default.
+     */
+    showKernels?: boolean;
+
+    /**
+     * Whether to show terminals.
+     *
+     * The default is true if one or more terminals are open, false otherwise.
+     */
+    showTerminals?: boolean;
   }
 }
 
@@ -103,6 +119,8 @@ export class RunningSessions extends VDomRenderer<RunningSessions.Model> {
     this._handleClick = opts.onClick;
     this._handleKeyDown = opts.onKeyDown;
     this.translator = opts.translator || nullTranslator;
+    this._showKernels = opts.showKernels;
+    this._showTerminals = opts.showTerminals;
     this._trans = this.translator.load('jupyterlab');
 
     this._serviceManager.sessions.runningChanged.connect(
@@ -144,6 +162,8 @@ export class RunningSessions extends VDomRenderer<RunningSessions.Model> {
         terminals={this.model.terminals}
         handleClick={this._handleClick}
         handleKeyDown={this._handleKeyDown}
+        showKernels={this._showKernels}
+        showTerminals={this._showTerminals}
       />
     );
   }
@@ -189,6 +209,8 @@ export class RunningSessions extends VDomRenderer<RunningSessions.Model> {
   private _handleClick: () => void;
   private _handleKeyDown: (event: KeyboardEvent<HTMLImageElement>) => void;
   private _serviceManager: ServiceManager.IManager;
+  private _showKernels?: boolean;
+  private _showTerminals?: boolean;
 }
 
 /**
@@ -258,5 +280,17 @@ export namespace RunningSessions {
      * The application language translator.
      */
     translator?: ITranslator;
+
+    /**
+     * Whether to show kernels, true by default.
+     */
+    showKernels?: boolean;
+
+    /**
+     * Whether to show terminals.
+     *
+     * The default is true if one or more terminals are open, false otherwise.
+     */
+    showTerminals?: boolean;
   }
 }

--- a/packages/terminal-extension/schema/plugin.json
+++ b/packages/terminal-extension/schema/plugin.json
@@ -114,6 +114,26 @@
       "description": "Whether to blink the cursor. Changes require reopening the terminal.",
       "type": "boolean",
       "default": true
+    },
+    "showStatusBarItem": {
+      "type": "string",
+      "title": "Show the status bar item",
+      "description": "Whether to show the running terminals item in the status bar",
+      "default": "if-any",
+      "oneOf": [
+        {
+          "const": "if-any",
+          "title": "Show if one or more"
+        },
+        {
+          "const": "always",
+          "title": "Always show"
+        },
+        {
+          "const": "never",
+          "title": "Don't show"
+        }
+      ]
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
## References

Fixes #17406

## Code changes

- renames `session-settings` created in #17363 (merged yesterday, not released) to `kernel-settings`
- add setting for showing status bar item in terminal settings

## User-facing changes

### Unified Kernels section in Settings

![kernels](https://github.com/user-attachments/assets/59c442ff-f06f-4f1a-ae13-114ea05c916c)

### New setting in terminals

![image](https://github.com/user-attachments/assets/a0ceab79-306b-4a4e-a5a4-4f9a410a0b28)

## Follow-up work:

- move "kernel dialogs" into "Kernels settings" (this would go into 5.0 unless we can migrate user settings)
- maybe invert the relation: make `@jupyterlab/apputils-extension:running-sessions-status` provide a token and then the terminals plugin register its preference for showing or not showing terminal count.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
