### PR TITLE
Make `ILabShell` optional in the logconsole extension

### DIFF
--- a/packages/logconsole-extension/package.json
+++ b/packages/logconsole-extension/package.json
@@ -37,6 +37,7 @@
     "@jupyterlab/application": "^4.4.0-rc.0",
     "@jupyterlab/apputils": "^4.5.0-rc.0",
     "@jupyterlab/coreutils": "^6.4.0-rc.0",
+    "@jupyterlab/docregistry": "^4.4.0-rc.0",
     "@jupyterlab/logconsole": "^4.4.0-rc.0",
     "@jupyterlab/rendermime": "^4.4.0-rc.0",
     "@jupyterlab/settingregistry": "^4.4.0-rc.0",

--- a/packages/logconsole-extension/src/index.tsx
+++ b/packages/logconsole-extension/src/index.tsx
@@ -17,6 +17,7 @@ import {
   WidgetTracker
 } from '@jupyterlab/apputils';
 import { IChangedArgs } from '@jupyterlab/coreutils';
+import { DocumentWidget } from '@jupyterlab/docregistry';
 import {
   ILoggerRegistry,
   LogConsolePanel,
@@ -64,8 +65,14 @@ const logConsolePlugin: JupyterFrontEndPlugin<ILoggerRegistry> = {
   id: LOG_CONSOLE_PLUGIN_ID,
   description: 'Provides the logger registry.',
   provides: ILoggerRegistry,
-  requires: [ILabShell, IRenderMimeRegistry, ITranslator],
-  optional: [ICommandPalette, ILayoutRestorer, ISettingRegistry, IStatusBar],
+  requires: [IRenderMimeRegistry, ITranslator],
+  optional: [
+    ILabShell,
+    ICommandPalette,
+    ILayoutRestorer,
+    ISettingRegistry,
+    IStatusBar
+  ],
   autoStart: true
 };
 
@@ -74,9 +81,9 @@ const logConsolePlugin: JupyterFrontEndPlugin<ILoggerRegistry> = {
  */
 function activateLogConsole(
   app: JupyterFrontEnd,
-  labShell: ILabShell,
   rendermime: IRenderMimeRegistry,
   translator: ITranslator,
+  labShell: ILabShell | null,
   palette: ICommandPalette | null,
   restorer: ILayoutRestorer | null,
   settingRegistry: ISettingRegistry | null,
@@ -118,6 +125,18 @@ function activateLogConsole(
     translator
   });
 
+  const getCurrentWidgetPath = () => {
+    const currentWidget = app.shell.currentWidget;
+    if (labShell?.currentPath) {
+      return labShell.currentPath;
+    }
+    // For other shells, set the source to the current widget path
+    if (currentWidget && currentWidget instanceof DocumentWidget) {
+      return currentWidget.context.path;
+    }
+    return null;
+  };
+
   interface ILogConsoleOptions {
     source?: string;
     insertMode?: DockLayout.InsertMode;
@@ -127,7 +146,7 @@ function activateLogConsole(
   const createLogConsoleWidget = (options: ILogConsoleOptions = {}) => {
     logConsolePanel = new LogConsolePanel(loggerRegistry, translator);
 
-    logConsolePanel.source = options.source ?? labShell.currentPath ?? null;
+    logConsolePanel.source = options.source ?? getCurrentWidgetPath() ?? null;
 
     logConsoleWidget = new MainAreaWidget({ content: logConsolePanel });
     logConsoleWidget.addClass('jp-LogConsole');
@@ -264,10 +283,14 @@ function activateLogConsole(
   void app.restored.then(() => {
     // Set source only after app is restored in order to allow restorer to
     // restore previous source first, which may set the renderer
-    labShell.currentPathChanged.connect((_, { newValue }) =>
-      setSource(newValue)
-    );
-    setSource(labShell.currentPath ?? null);
+    if (labShell) {
+      labShell.currentPathChanged.connect((_, { newValue }) =>
+        setSource(newValue)
+      );
+      setSource(labShell.currentPath ?? null);
+    } else {
+      setSource(getCurrentWidgetPath());
+    }
   });
 
   if (settingRegistry) {

--- a/packages/logconsole-extension/style/index.css
+++ b/packages/logconsole-extension/style/index.css
@@ -9,6 +9,7 @@
 @import url('~@jupyterlab/statusbar/style/index.css');
 @import url('~@jupyterlab/apputils/style/index.css');
 @import url('~@jupyterlab/rendermime/style/index.css');
+@import url('~@jupyterlab/docregistry/style/index.css');
 @import url('~@jupyterlab/application/style/index.css');
 @import url('~@jupyterlab/logconsole/style/index.css');
 @import url('./base.css');

--- a/packages/logconsole-extension/style/index.js
+++ b/packages/logconsole-extension/style/index.js
@@ -9,6 +9,7 @@ import '@jupyterlab/ui-components/style/index.js';
 import '@jupyterlab/statusbar/style/index.js';
 import '@jupyterlab/apputils/style/index.js';
 import '@jupyterlab/rendermime/style/index.js';
+import '@jupyterlab/docregistry/style/index.js';
 import '@jupyterlab/application/style/index.js';
 import '@jupyterlab/logconsole/style/index.js';
 

--- a/packages/logconsole-extension/tsconfig.json
+++ b/packages/logconsole-extension/tsconfig.json
@@ -32,6 +32,9 @@
     },
     {
       "path": "../ui-components"
+    },
+    {
+      "path": "../docregistry"
     }
   ]
 }

--- a/packages/logconsole-extension/tsconfig.json
+++ b/packages/logconsole-extension/tsconfig.json
@@ -16,6 +16,9 @@
       "path": "../coreutils"
     },
     {
+      "path": "../docregistry"
+    },
+    {
       "path": "../logconsole"
     },
     {
@@ -32,9 +35,6 @@
     },
     {
       "path": "../ui-components"
-    },
-    {
-      "path": "../docregistry"
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3844,6 +3844,7 @@ __metadata:
     "@jupyterlab/application": ^4.4.0-rc.0
     "@jupyterlab/apputils": ^4.5.0-rc.0
     "@jupyterlab/coreutils": ^6.4.0-rc.0
+    "@jupyterlab/docregistry": ^4.4.0-rc.0
     "@jupyterlab/logconsole": ^4.4.0-rc.0
     "@jupyterlab/rendermime": ^4.4.0-rc.0
     "@jupyterlab/settingregistry": ^4.4.0-rc.0


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Noticed when trying to add support for the `down` area in Notebook 7.

Current the logconsole plugin has a hard requirement on `ILabShell`, which makes reusing the plugin downstream difficult.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Handle the case where `ILabShell` is missing.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None for JupyterLab users.

Chances to get the log console to work for Notebook users.

Using this patch downstream in Notebook:

![image](https://github.com/user-attachments/assets/a434b621-f3e6-4c43-86cf-6de4fd8ae47b)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
