### PR TITLE
Fix usage of `ITerminalAPIClient` in `TerminalConnection`

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,9 @@
     "marked": "^15.0.7",
     "react": "^18.2.0",
     "type-fest": "^4.30.0",
-    "yjs": "^13.5.40"
+    "yjs": "^13.5.40",
+    "@jupyterlab/logconsole-extension@^4.4.0-rc.0": "patch:@jupyterlab/logconsole-extension@workspace%3Apackages/logconsole-extension#./.yarn/patches/@jupyterlab-logconsole-extension-workspace-a661810673.patch",
+    "@jupyterlab/logconsole-extension@~4.4.0-rc.0": "patch:@jupyterlab/logconsole-extension@workspace%3Apackages/logconsole-extension#./.yarn/patches/@jupyterlab-logconsole-extension-workspace-a661810673.patch"
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "~6.13.2",

--- a/package.json
+++ b/package.json
@@ -109,9 +109,7 @@
     "marked": "^15.0.7",
     "react": "^18.2.0",
     "type-fest": "^4.30.0",
-    "yjs": "^13.5.40",
-    "@jupyterlab/logconsole-extension@^4.4.0-rc.0": "patch:@jupyterlab/logconsole-extension@workspace%3Apackages/logconsole-extension#./.yarn/patches/@jupyterlab-logconsole-extension-workspace-a661810673.patch",
-    "@jupyterlab/logconsole-extension@~4.4.0-rc.0": "patch:@jupyterlab/logconsole-extension@workspace%3Apackages/logconsole-extension#./.yarn/patches/@jupyterlab-logconsole-extension-workspace-a661810673.patch"
+    "yjs": "^13.5.40"
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "~6.13.2",

--- a/packages/services/src/terminal/manager.ts
+++ b/packages/services/src/terminal/manager.ts
@@ -122,7 +122,8 @@ export class TerminalManager extends BaseManager implements Terminal.IManager {
   ): Terminal.ITerminalConnection {
     const terminalConnection = new TerminalConnection({
       ...options,
-      serverSettings: this.serverSettings
+      serverSettings: this.serverSettings,
+      terminalAPIClient: this._terminalAPIClient
     });
     this._onStarted(terminalConnection);
     if (!this._names.includes(options.model.name)) {

--- a/packages/services/src/terminal/terminal.ts
+++ b/packages/services/src/terminal/terminal.ts
@@ -93,6 +93,11 @@ export namespace ITerminalConnection {
      * The server settings.
      */
     serverSettings?: ServerConnection.ISettings;
+
+    /**
+     * The Terminal API client.
+     */
+    terminalAPIClient?: ITerminalAPIClient;
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

As noticed in https://github.com/jupyterlite/terminal/pull/49#issuecomment-2758684746 thanks to @ianthomas23.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Fix usage of `ITerminalAPIClient` in `TerminalConnection`

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
