### PR TITLE
Fix visual indication for drag and drop in editor

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -25,6 +25,7 @@ import {
   IEditorLanguageRegistry,
   IExtensionsHandler
 } from './token';
+import { dropCursor } from '@codemirror/view';
 
 /**
  * The class name added to CodeMirrorWidget instances.
@@ -786,6 +787,10 @@ namespace Private {
     doc?: string
   ): EditorView {
     const extensions = editorConfig.getInitialExtensions();
+    // Check if dropCursor is enabled in the config (defaulting to true)
+    if (editorConfig.getOption('dropCursor') !== false) {
+      extensions.push(dropCursor());
+    }
     extensions.push(...additionalExtensions);
     const view = new EditorView({
       state: EditorState.create({

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -88,6 +88,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
         // We need to set the order to high, otherwise the keybinding for ArrowUp/ArrowDown
         // will process the event shunting our edge detection code.
         Prec.high(onKeyDown),
+        dropCursor(),
         updateListener,
         // Initialize with empty extension
         this._language.of([]),
@@ -787,10 +788,6 @@ namespace Private {
     doc?: string
   ): EditorView {
     const extensions = editorConfig.getInitialExtensions();
-    // Check if dropCursor is enabled in the config (defaulting to true)
-    if (editorConfig.getOption('dropCursor') !== false) {
-      extensions.push(dropCursor());
-    }
     extensions.push(...additionalExtensions);
     const view = new EditorView({
       state: EditorState.create({

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -25,7 +25,6 @@ import {
   IEditorLanguageRegistry,
   IExtensionsHandler
 } from './token';
-import { dropCursor } from '@codemirror/view';
 
 /**
  * The class name added to CodeMirrorWidget instances.
@@ -88,7 +87,6 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
         // We need to set the order to high, otherwise the keybinding for ArrowUp/ArrowDown
         // will process the event shunting our edge detection code.
         Prec.high(onKeyDown),
-        dropCursor(),
         updateListener,
         // Initialize with empty extension
         this._language.of([]),

--- a/packages/codemirror/src/extension.ts
+++ b/packages/codemirror/src/extension.ts
@@ -19,6 +19,7 @@ import {
 import {
   crosshairCursor,
   drawSelection,
+  dropCursor,
   EditorView,
   highlightActiveLine,
   highlightSpecialChars,
@@ -774,6 +775,15 @@ export namespace EditorExtensionRegistry {
         schema: {
           type: 'boolean',
           title: trans.__('Line Wrap')
+        }
+      }),
+      Object.freeze({
+        name: 'dropCursor',
+        default: true,
+        factory: () => createConditionalExtension(dropCursor()),
+        schema: {
+          type: 'boolean',
+          title: trans.__('Drop Cursor')
         }
       }),
       Object.freeze({


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
Fixes - #17427 

After changes 
The cursor moves as the selection is being moved as expected.

https://github.com/user-attachments/assets/a45dd26d-9084-474e-979f-1cb98e11fad9

