### PR TITLE
Fix read-only indicator not showing in RTC docprovider

### DIFF
--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -888,10 +888,7 @@ function addCommands(
           if (saveInProgress.has(context)) {
             return;
           }
-          if (
-            !context.contentsModel?.writable &&
-            !context.model.collaborative
-          ) {
+          if (!context.contentsModel?.writable) {
             let type = (args._luminoEvent as ReadonlyPartialJSONObject)?.type;
             if (args._luminoEvent && type === 'keybinding') {
               readonlyNotification(context.path);

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -481,12 +481,11 @@ export class Context<
   private _updateContentsModel(
     model: Contents.IModel | Omit<Contents.IModel, 'content'>
   ): void {
-    const writable = model.writable && !this._model.collaborative;
     const newModel: Omit<Contents.IModel, 'content'> = {
       path: model.path,
       name: model.name,
       type: model.type,
-      writable,
+      writable: model.writable,
       created: model.created,
       last_modified: model.last_modified,
       mimetype: model.mimetype,

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -639,17 +639,15 @@ export class DocumentWidget<
       this._handleDirtyState();
     }
     if (!this.context.model.dirty) {
-      if (!this.context.model.collaborative) {
-        if (!this.context.contentsModel?.writable) {
-          const readOnlyIndicator = createReadonlyLabel(this);
-          let roi = this.toolbar.insertBefore(
-            'kernelName',
-            'read-only-indicator',
-            readOnlyIndicator
-          );
-          if (!roi) {
-            this.toolbar.addItem('read-only-indicator', readOnlyIndicator);
-          }
+      if (this.context.contentsModel?.writable === false) {
+        const readOnlyIndicator = createReadonlyLabel(this);
+        let roi = this.toolbar.insertBefore(
+          'kernelName',
+          'read-only-indicator',
+          readOnlyIndicator
+        );
+        if (!roi) {
+          this.toolbar.addItem('read-only-indicator', readOnlyIndicator);
         }
       }
     }


### PR DESCRIPTION
### References https://github.com/jupyterlab/jupyterlab/issues/17419 https://github.com/jupyterlab/jupyterlab/issues/15040 https://github.com/jupyterlab/jupyter-collaboration/issues/324

### Description:
This PR fixes the issue where the read-only indicator was not displayed in the toolbar when opening read-only files in collaborative mode. Additionally, attempting to save such files did not trigger a warning popup but instead resulted in an error in the console.

### Issue:
- In collaborative mode, the read-only indicator and warning popup were blocked.

- The writable attribute was always set to false (I'm not sure why this was done)

### Fix:
The writable attribute is now determined based on the file system permissions.

The read-only indicator and warning popup are now displayed even in collaborative mode when opening read-only files.

### Note:
This fix applies to file-system read-only permissions and not user permissions. While anyone with access to the collaborative session can still modify the read-only file which are visible to other users of session, they cannot save it to disk.