### PR TITLE
fix: toolbars to have unique accessible labels

### DIFF
--- a/packages/application-extension/src/topbar.ts
+++ b/packages/application-extension/src/topbar.ts
@@ -35,6 +35,7 @@ export const topbar: JupyterFrontEndPlugin<void> = {
   ) => {
     const toolbar = new Toolbar();
     toolbar.id = 'jp-top-bar';
+    toolbar.addAttribute('aria-label', 'Topbar toolbar');
 
     // Set toolbar
     setToolbar(

--- a/packages/cell-toolbar/src/celltoolbartracker.ts
+++ b/packages/cell-toolbar/src/celltoolbartracker.ts
@@ -195,6 +195,7 @@ export class CellToolbarTracker implements IDisposable {
       // Note: CELL_MENU_CLASS is deprecated.
       toolbarWidget.addClass(CELL_MENU_CLASS);
       toolbarWidget.addClass(CELL_TOOLBAR_CLASS);
+      toolbarWidget.addAttribute('aria-label', 'Cell toolbar');
       const promises: Promise<void>[] = [cell.ready];
       if (this._toolbarFactory) {
         setToolbar(cell, this._toolbarFactory, toolbarWidget);

--- a/packages/debugger/src/panels/breakpoints/index.ts
+++ b/packages/debugger/src/panels/breakpoints/index.ts
@@ -33,6 +33,7 @@ export class Breakpoints extends PanelWithToolbar {
 
     const body = new BreakpointsBody(model);
 
+    this.toolbar.addAttribute('aria-label', 'Breakpoints panel toolbar');
     this.toolbar.addItem(
       'pauseOnException',
       new PauseOnExceptionsWidget({

--- a/packages/debugger/src/panels/callstack/index.ts
+++ b/packages/debugger/src/panels/callstack/index.ts
@@ -27,6 +27,7 @@ export class Callstack extends PanelWithToolbar {
     this.title.label = trans.__('Callstack');
     const body = new CallstackBody(model);
 
+    this.toolbar.addAttribute('aria-label', 'Callstack panel toolbar');
     this.toolbar.addItem(
       'continue',
       new CommandToolbarButton({

--- a/packages/debugger/src/panels/kernelSources/index.tsx
+++ b/packages/debugger/src/panels/kernelSources/index.tsx
@@ -32,7 +32,7 @@ export class KernelSources extends PanelWithToolbar {
     const trans = (options.translator ?? nullTranslator).load('jupyterlab');
     this.title.label = trans.__('Kernel Sources');
     this.toolbar.addClass('jp-DebuggerKernelSources-header');
-
+    this.toolbar.addAttribute('aria-label', 'Callstack panel toolbar');
     this._body = new KernelSourcesBody({
       service,
       model,

--- a/packages/debugger/src/panels/sources/index.tsx
+++ b/packages/debugger/src/panels/sources/index.tsx
@@ -32,6 +32,7 @@ export class Sources extends PanelWithToolbar {
     this.title.label = trans.__('Source');
 
     this.toolbar.addClass('jp-DebuggerSources-header');
+    this.toolbar.addAttribute('aria-label', 'Sources preview panel toolbar');
     const body = new SourcesBody({
       service,
       model,

--- a/packages/debugger/src/panels/variables/index.ts
+++ b/packages/debugger/src/panels/variables/index.ts
@@ -32,6 +32,7 @@ export class Variables extends PanelWithToolbar {
     const trans = translator.load('jupyterlab');
     this.title.label = trans.__('Variables');
     this.toolbar.addClass('jp-DebuggerVariables-toolbar');
+    this.toolbar.addAttribute('aria-label', 'Variables toolbar');
     this._tree = new VariablesBodyTree({
       model,
       service,

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -645,6 +645,7 @@ export class ExtensionsPanel extends SidePanel {
 
     const installed = new PanelWithToolbar();
     installed.addClass('jp-extensionmanager-installedlist');
+    installed.toolbar.addAttribute('aria-label', 'Extensions panel toolbar');
     installed.title.label = this.trans.__('Installed');
 
     installed.toolbar.addItem(

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -114,6 +114,7 @@ export class FileBrowser extends SidePanel {
 
     this.filterToolbar = new Toolbar();
     this.filterToolbar.addClass(FILTER_TOOLBAR_CLASS);
+    this.filterToolbar.addAttribute('aria-label', 'File browser toolbar');
     this.filterToolbar.addItem('fileNameSearcher', searcher);
     this.filterToolbar.setHidden(!this.showFileFilter);
 

--- a/packages/running/src/index.tsx
+++ b/packages/running/src/index.tsx
@@ -689,6 +689,7 @@ class Section extends PanelWithToolbar {
       );
     }
     this.toolbar.addClass('jp-RunningSessions-toolbar');
+    this._toolbar.addAttribute('aria-label', this.title.label + ' toolbar');
   }
 
   private _onListChanged(): void {

--- a/packages/settingeditor/src/raweditor.ts
+++ b/packages/settingeditor/src/raweditor.ts
@@ -365,6 +365,7 @@ namespace Private {
     const layout = (widget.layout = new BoxLayout({ spacing: 0 }));
     const banner = new Widget();
     const bar = new Toolbar();
+    bar.addAttribute('aria-label', 'Default editor toolbar');
     const defaultTitle = trans.__('System Defaults');
 
     banner.node.innerText = defaultTitle;

--- a/packages/toc-extension/src/index.ts
+++ b/packages/toc-extension/src/index.ts
@@ -215,6 +215,7 @@ async function activateTOC(
     label: ''
   });
   numbering.addClass('jp-toc-numberingButton');
+  toc.toolbar.addAttribute('aria-label', 'Table of contents sidepanel toolbar');
   toc.toolbar.addItem('display-numbering', numbering);
 
   toc.toolbar.addItem('spacer', Toolbar.createSpacerItem());

--- a/packages/ui-components/src/components/sidepanel.ts
+++ b/packages/ui-components/src/components/sidepanel.ts
@@ -112,10 +112,6 @@ export class SidePanel extends Widget {
   private addToolbar(toolbar?: Toolbar) {
     const theToolbar = (this._toolbar = toolbar ?? new Toolbar());
     theToolbar.addClass('jp-SidePanel-toolbar');
-    theToolbar.node.setAttribute(
-      'aria-label',
-      this._trans.__('side panel actions')
-    );
     (this.layout as PanelLayout).insertWidget(
       (this.layout as PanelLayout).widgets.length - 1,
       theToolbar

--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -181,6 +181,13 @@ export class Toolbar<T extends Widget = Widget> extends Widget {
   }
 
   /**
+   * Add an HTML attribute on the node element
+   */
+  addAttribute(name: string, value: string) {
+    this.node.setAttribute(name, value);
+  }
+
+  /**
    * Get an iterator over the ordered toolbar item names.
    *
    * @returns An iterator over the toolbar item names.
@@ -1136,6 +1143,7 @@ class ToolbarPopup extends Widget {
    */
   constructor() {
     super({ node: document.createElement('jp-toolbar') });
+    this.node.setAttribute('aria-label', 'Responsive popup toolbar');
     this.addClass('jp-Toolbar');
     this.addClass('jp-Toolbar-responsive-popup');
     this.addClass('jp-ThemedContainer');


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
https://github.com/jupyterlab/jupyterlab/issues/16905
https://github.com/jupyter/notebook/issues/7482

<!-- Note any other pull requests that address this issue and how this pull request is different. -->
## Code changes

<!-- Describe the code changes and how they address the issue. -->
Found quite a few `jp-toolbar` components with `role=“toolbar”` loaded on the UI which were missing accessible labels. Note: Tested by loading the initial page with a “Notebook” tab open.

This PR will add unique accessible labels for the toolbar components and therefore fix specific issues mentioned above.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
The screen readers can now correctly announce labels for the toolbars. 

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->
## Backwards-incompatible changes
NA
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->