### PR TITLE
Do not try to prettier `.mypy_cache`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,7 @@
 **/static
 **/.ipynb_checkpoints
 **/coverage
+**/.mypy_cache
 CHANGELOG.md
 
 .eggs


### PR DESCRIPTION
## References

Running `jlpm lint` can take ages if there is `.mypy_cache` in any of the subdirectories. This adds it to ignored patterns.

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None