### PR TITLE
Use the system clipboard for copying and pasting cells

### DIFF
--- a/examples/notebook/src/commands.ts
+++ b/examples/notebook/src/commands.ts
@@ -290,21 +290,21 @@ export const setupCommands = (
     label: args => (args.toolbar ? '' : 'Cut the selected cells'),
     caption: 'Cut the selected cells',
     icon: args => (args.toolbar ? cutIcon : undefined),
-    execute: () => NotebookActions.cut(nbWidget.content)
+    execute: () => NotebookActions.cutToSystemClipboard(nbWidget.content)
   });
 
   commands.addCommand(COMMAND_IDS.copy, {
     label: args => (args.toolbar ? '' : 'Copy the selected cells'),
     caption: 'Copy the selected cells',
     icon: args => (args.toolbar ? copyIcon : undefined),
-    execute: () => NotebookActions.copy(nbWidget.content)
+    execute: () => NotebookActions.copyToSystemClipboard(nbWidget.content)
   });
 
   commands.addCommand(COMMAND_IDS.paste, {
     label: args => (args.toolbar ? '' : 'Paste cells from the clipboard'),
     caption: 'Paste cells from the clipboard',
     icon: args => (args.toolbar ? pasteIcon : undefined),
-    execute: () => NotebookActions.paste(nbWidget.content)
+    execute: () => NotebookActions.pasteFromSystemClipboard(nbWidget.content)
   });
 
   commands.addCommand(COMMAND_IDS.restartAndRun, {

--- a/packages/apputils/src/clipboard.ts
+++ b/packages/apputils/src/clipboard.ts
@@ -12,6 +12,8 @@ export type ClipboardData = string | MimeData;
 export namespace Clipboard {
   /**
    * Get the application clipboard instance.
+   *
+   * @deprecated To use `SystemClipboard.getInstance` for copy/cut/paste cells.
    */
   export function getInstance(): MimeData {
     return Private.instance;
@@ -19,6 +21,8 @@ export namespace Clipboard {
 
   /**
    * Set the application clipboard instance.
+   *
+   * @deprecated will be removed in a future release. Use `SystemClipboard.getInstance`.
    */
   export function setInstance(value: MimeData): void {
     Private.instance = value;
@@ -97,11 +101,207 @@ export namespace Clipboard {
 }
 
 /**
+ * The clipboard interface supporting the native clipboard API.
+ */
+export namespace SystemClipboard {
+  /**
+   * Get the system clipboard instance.
+   */
+  export function getInstance(): IClipboard {
+    return Private.systemInstance;
+  }
+
+  /**
+   * The interface for the system clipboard.
+   */
+  export interface IClipboard {
+    /**
+     * Whether the clipboard has data for a given mime type.
+     * Returns `false` if the data does not exist.
+     *
+     * @param mime - The mime type to check.
+     */
+    hasData(mime: string): Promise<boolean>;
+
+    /**
+     * Retrieve the data for a given mime type.
+     * Returns `null` if the data does not exist.
+     *
+     * @param mime - The mime type to retrieve.
+     */
+    getData(mime: string): Promise<unknown | null>;
+
+    /**
+     * Set the data for a given mime type.
+     *
+     * @param mime - The mime type to set.
+     * @param data - The data to set.
+     */
+    setData(mime: string, data: unknown): Promise<void>;
+
+    /**
+     * Clear the clipboard.
+     */
+    clear(): void;
+  }
+}
+
+/**
  * The namespace for module private data.
  */
 namespace Private {
   /**
+   * The mimetype used for Jupyter cell data.
+   */
+  const JUPYTER_CELL_MIME = 'application/vnd.jupyter.cells';
+
+  /**
+   * An implementation of the clipboard interface.
+   * This uses the native clipboard API when available, with a fallback to
+   * a MimeData instance otherwise - The native clipboard API only works in
+   * secure contexts (pages served over HTTPS or localhost).
+   */
+  class ClipboardImpl implements SystemClipboard.IClipboard {
+    /**
+     * The fallback clipboard instance.
+     */
+    fallback: MimeData;
+
+    /**
+     * Create a new clipboard instance.
+     */
+    constructor(fallback?: MimeData) {
+      this.fallback = fallback || new MimeData();
+      const { systemClipboard } = this;
+      if (!systemClipboard) {
+        console.warn('Clipboard API not available');
+      }
+    }
+
+    /**
+     * Clear the clipboard.
+     * This is a no-op for the native clipboard API.
+     * The fallback clipboard is cleared by setting the data to an empty
+     */
+    clear(): void {
+      this.fallback.clear();
+    }
+
+    /**
+     * Whether the clipboard has data for a given mime type.
+     * Returns `false` if the data does not exist.
+     *
+     * @param mime - The mime type to check.
+     */
+    async hasData(mime: string): Promise<boolean> {
+      const { systemClipboard } = this;
+      if (!systemClipboard) {
+        return this.fallback.hasData(mime);
+      }
+      let text: string;
+      try {
+        text = await systemClipboard.readText();
+      } catch (reason) {
+        console.warn('Failed to read data from clipboard:', reason);
+        if (reason.name === 'NotAllowedError') {
+          // If the clipboard API is not allowed, fall back to the
+          // internal clipboard.
+          return this.fallback.hasData(mime);
+        }
+        return false;
+      }
+      try {
+        this.convertStringToData(mime, text);
+        return true;
+      } catch (reason) {
+        return false;
+      }
+    }
+
+    /**
+     * Retrieve the data for a given mime type.
+     *
+     * @param mime - The mime type to retrieve.
+     * @returns A promise that resolves with the data for the given mime type.
+     */
+    async getData(mime: string): Promise<unknown> {
+      const { systemClipboard } = this;
+      if (!systemClipboard) {
+        return this.fallback.getData(mime);
+      }
+      try {
+        const text = await systemClipboard.readText();
+        return this.convertStringToData(mime, text);
+      } catch (reason) {
+        console.warn('Failed to read data from clipboard:', reason);
+        if (reason.name === 'NotAllowedError') {
+          // If the clipboard API is not allowed, fall back to the
+          // internal clipboard.
+          return this.fallback.getData(mime);
+        }
+        return null;
+      }
+    }
+
+    /**
+     * Set the data for a given mime type.
+     *
+     * @param mime - The mime type to set.
+     * @param data - The data to set.
+     */
+    async setData(mime: string, data: unknown): Promise<void> {
+      const { systemClipboard } = this;
+      if (!systemClipboard) {
+        this.fallback.clear();
+        this.fallback.setData(mime, data);
+        return;
+      }
+      try {
+        await systemClipboard.writeText(this.convertDataToString(mime, data));
+      } catch (reason) {
+        console.warn('Failed to write data to clipboard:', reason);
+        // If the clipboard API is not allowed, fall back to the
+        // internal clipboard.
+        this.fallback.clear();
+        this.fallback.setData(mime, data);
+      }
+    }
+
+    /**
+     * Convert the data to a string for the given mime type.
+     */
+    convertDataToString(mime: string, data: unknown): string {
+      if (mime === JUPYTER_CELL_MIME) {
+        return JSON.stringify(data);
+      }
+      return (data || '').toString();
+    }
+
+    /**
+     * Convert the string to data for the given mime type.
+     */
+    convertStringToData(mime: string, text: string): unknown {
+      if (mime === JUPYTER_CELL_MIME) {
+        return JSON.parse(text);
+      }
+      return text;
+    }
+
+    /**
+     * Get the system clipboard instance.
+     */
+    get systemClipboard() {
+      return navigator.clipboard;
+    }
+  }
+
+  /**
    * The application clipboard instance.
    */
   export let instance = new MimeData();
+
+  /**
+   * The system clipboard instance.
+   */
+  export let systemInstance = new ClipboardImpl();
 }

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -2658,11 +2658,11 @@ function addCommands(
         current?.content.selectedCells.length ?? 1
       );
     },
-    execute: args => {
+    execute: async args => {
       const current = getCurrent(tracker, shell, args);
 
       if (current) {
-        return NotebookActions.cut(current.content);
+        return await NotebookActions.cutToSystemClipboard(current.content);
       }
     },
     icon: args => (args.toolbar ? cutIcon : undefined),
@@ -2685,11 +2685,11 @@ function addCommands(
         current?.content.selectedCells.length ?? 1
       );
     },
-    execute: args => {
+    execute: async args => {
       const current = getCurrent(tracker, shell, args);
 
       if (current) {
-        return NotebookActions.copy(current.content);
+        return await NotebookActions.copyToSystemClipboard(current.content);
       }
     },
     icon: args => (args.toolbar ? copyIcon : undefined),
@@ -2712,11 +2712,14 @@ function addCommands(
         current?.content.selectedCells.length ?? 1
       );
     },
-    execute: args => {
+    execute: async args => {
       const current = getCurrent(tracker, shell, args);
 
       if (current) {
-        return NotebookActions.paste(current.content, 'below');
+        return await NotebookActions.pasteFromSystemClipboard(
+          current.content,
+          'below'
+        );
       }
     },
     icon: args => (args.toolbar ? pasteIcon : undefined),
@@ -2739,11 +2742,14 @@ function addCommands(
         current?.content.selectedCells.length ?? 1
       );
     },
-    execute: args => {
+    execute: async args => {
       const current = getCurrent(tracker, shell, args);
 
       if (current) {
-        return NotebookActions.paste(current.content, 'above');
+        return await NotebookActions.pasteFromSystemClipboard(
+          current.content,
+          'above'
+        );
       }
     },
     isEnabled
@@ -2784,11 +2790,14 @@ function addCommands(
         current?.content.selectedCells.length ?? 1
       );
     },
-    execute: args => {
+    execute: async args => {
       const current = getCurrent(tracker, shell, args);
 
       if (current) {
-        return NotebookActions.paste(current.content, 'replace');
+        return await NotebookActions.pasteFromSystemClipboard(
+          current.content,
+          'replace'
+        );
       }
     },
     isEnabled

--- a/packages/notebook/src/default-toolbar.tsx
+++ b/packages/notebook/src/default-toolbar.tsx
@@ -135,8 +135,8 @@ export namespace ToolbarItems {
     const trans = (translator || nullTranslator).load('jupyterlab');
     return new ToolbarButton({
       icon: cutIcon,
-      onClick: () => {
-        NotebookActions.cut(panel.content);
+      onClick: async (): Promise<void> => {
+        await NotebookActions.cutToSystemClipboard(panel.content);
       },
       tooltip: trans.__('Cut the selected cells')
     });
@@ -155,8 +155,8 @@ export namespace ToolbarItems {
     const trans = (translator || nullTranslator).load('jupyterlab');
     return new ToolbarButton({
       icon: copyIcon,
-      onClick: () => {
-        NotebookActions.copy(panel.content);
+      onClick: async (): Promise<void> => {
+        await NotebookActions.copyToSystemClipboard(panel.content);
       },
       tooltip: trans.__('Copy the selected cells')
     });
@@ -175,8 +175,8 @@ export namespace ToolbarItems {
     const trans = (translator || nullTranslator).load('jupyterlab');
     return new ToolbarButton({
       icon: pasteIcon,
-      onClick: () => {
-        NotebookActions.paste(panel.content);
+      onClick: async (): Promise<void> => {
+        await NotebookActions.pasteFromSystemClipboard(panel.content);
       },
       tooltip: trans.__('Paste cells from the clipboard')
     });

--- a/packages/notebook/src/testutils.ts
+++ b/packages/notebook/src/testutils.ts
@@ -4,7 +4,8 @@
 import {
   Clipboard,
   ISessionContext,
-  SessionContextDialogs
+  SessionContextDialogs,
+  SystemClipboard
 } from '@jupyterlab/apputils';
 import { Cell, CodeCellModel } from '@jupyterlab/cells';
 import { CodeEditorWrapper, IEditorServices } from '@jupyterlab/codeeditor';
@@ -139,6 +140,8 @@ export namespace NBTestUtils {
   }
 
   export const clipboard = Clipboard.getInstance();
+
+  export const systemClipboard = SystemClipboard.getInstance();
 
   /**
    * Create a base cell content factory.

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -1527,6 +1527,51 @@ describe('@jupyterlab/notebook', () => {
       });
     });
 
+    describe('#copyToSystemClipboard()', () => {
+      it('should copy the selected cells to a utils.systemClipboard', async () => {
+        const next = widget.widgets[1];
+        widget.select(next);
+        await NotebookActions.copyToSystemClipboard(widget);
+        expect(await utils.systemClipboard.hasData(JUPYTER_CELL_MIME)).toBe(
+          true
+        );
+        const data = (await utils.systemClipboard.getData(
+          JUPYTER_CELL_MIME
+        )) as JSONArray;
+        expect(data.length).toBe(2);
+      });
+
+      it('should be a no-op if there is no model', async () => {
+        widget.model = null;
+        utils.systemClipboard.clear();
+        await NotebookActions.copyToSystemClipboard(widget);
+        expect(await utils.systemClipboard.hasData(JUPYTER_CELL_MIME)).toBe(
+          false
+        );
+      });
+
+      it('should change to command mode', async () => {
+        widget.mode = 'edit';
+        await NotebookActions.copyToSystemClipboard(widget);
+        expect(widget.mode).toBe('command');
+      });
+
+      it('should delete metadata.deletable', async () => {
+        const next = widget.widgets[1];
+        widget.select(next);
+        next.model.setMetadata('deletable', false);
+        await NotebookActions.copyToSystemClipboard(widget);
+        const data = (await utils.systemClipboard.getData(
+          JUPYTER_CELL_MIME
+        )) as JSONArray;
+        data.map(cell => {
+          expect(
+            ((cell as JSONObject).metadata as JSONObject).deletable
+          ).toBeUndefined();
+        });
+      });
+    });
+
     describe('#cut()', () => {
       it('should cut the selected cells to a utils.clipboard', () => {
         const next = widget.widgets[1];
@@ -1560,6 +1605,48 @@ describe('@jupyterlab/notebook', () => {
           widget.select(widget.widgets[i]);
         }
         NotebookActions.cut(widget);
+        await sleep();
+        expect(widget.widgets.length).toBe(1);
+        expect(widget.activeCell).toBeInstanceOf(CodeCell);
+      });
+    });
+
+    describe('#cutToSystemClipboard()', () => {
+      it('should cut the selected cells to a utils.systemClipboard', async () => {
+        const next = widget.widgets[1];
+        widget.select(next);
+        const count = widget.widgets.length;
+        await NotebookActions.cutToSystemClipboard(widget);
+        expect(widget.widgets.length).toBe(count - 2);
+      });
+
+      it('should be a no-op if there is no model', async () => {
+        widget.model = null;
+        utils.systemClipboard.clear();
+        await NotebookActions.cutToSystemClipboard(widget);
+        expect(await utils.systemClipboard.hasData(JUPYTER_CELL_MIME)).toBe(
+          false
+        );
+      });
+
+      it('should change to command mode', async () => {
+        widget.mode = 'edit';
+        await NotebookActions.cutToSystemClipboard(widget);
+        expect(widget.mode).toBe('command');
+      });
+
+      it('should be undo-able', async () => {
+        const source = widget.activeCell!.model.sharedModel.getSource();
+        await NotebookActions.cutToSystemClipboard(widget);
+        NotebookActions.undo(widget);
+        expect(widget.widgets[0].model.sharedModel.getSource()).toBe(source);
+      });
+
+      it('should add a new code cell if all cells were cut', async () => {
+        for (let i = 0; i < widget.widgets.length; i++) {
+          widget.select(widget.widgets[i]);
+        }
+        await NotebookActions.cutToSystemClipboard(widget);
         await sleep();
         expect(widget.widgets.length).toBe(1);
         expect(widget.activeCell).toBeInstanceOf(CodeCell);
@@ -1608,6 +1695,54 @@ describe('@jupyterlab/notebook', () => {
         widget.activeCellIndex = 1;
         widget.model?.sharedModel.clearUndoHistory();
         NotebookActions.paste(widget);
+        NotebookActions.undo(widget);
+        expect(widget.widgets.length).toBe(count - 2);
+      });
+    });
+
+    describe('#pasteFromSystemClipboard()', () => {
+      it('should paste cells from a utils.systemClipboard', async () => {
+        const source = widget.activeCell!.model.sharedModel.getSource();
+        const next = widget.widgets[1];
+        widget.select(next);
+        const count = widget.widgets.length;
+        await NotebookActions.cutToSystemClipboard(widget);
+        widget.activeCellIndex = 1;
+        await NotebookActions.pasteFromSystemClipboard(widget);
+        expect(widget.widgets.length).toBe(count);
+        expect(widget.widgets[2].model.sharedModel.getSource()).toBe(source);
+        expect(widget.activeCellIndex).toBe(3);
+      });
+
+      it('should be a no-op if there is no model', async () => {
+        await NotebookActions.copyToSystemClipboard(widget);
+        widget.model = null;
+        await NotebookActions.pasteFromSystemClipboard(widget);
+        expect(widget.activeCellIndex).toBe(-1);
+      });
+
+      it('should be a no-op if there is no cell data on the utils.systemClipboard', async () => {
+        utils.systemClipboard.clear();
+        const count = widget.widgets.length;
+        await NotebookActions.pasteFromSystemClipboard(widget);
+        expect(widget.widgets.length).toBe(count);
+      });
+
+      it('should change to command mode', async () => {
+        widget.mode = 'edit';
+        await NotebookActions.cutToSystemClipboard(widget);
+        await NotebookActions.pasteFromSystemClipboard(widget);
+        expect(widget.mode).toBe('command');
+      });
+
+      it('should be undo-able', async () => {
+        const next = widget.widgets[1];
+        widget.select(next);
+        const count = widget.widgets.length;
+        await NotebookActions.cutToSystemClipboard(widget);
+        widget.activeCellIndex = 1;
+        widget.model?.sharedModel.clearUndoHistory();
+        await NotebookActions.pasteFromSystemClipboard(widget);
         NotebookActions.undo(widget);
         expect(widget.widgets.length).toBe(count - 2);
       });

--- a/packages/notebook/test/utils.ts
+++ b/packages/notebook/test/utils.ts
@@ -63,6 +63,7 @@ export const editorFactory = NBTestUtils.editorFactory;
 export const mimeTypeService = NBTestUtils.mimeTypeService;
 export const defaultEditorConfig = NBTestUtils.defaultEditorConfig;
 export const clipboard = NBTestUtils.clipboard;
+export const systemClipboard = NBTestUtils.systemClipboard;
 
 export function defaultRenderMime(): any {
   return NBTestUtils.defaultRenderMime();


### PR DESCRIPTION
## References

Related to #1644

Especially with Jupyter Notebook 7, a browser tab is opened for each notebook, making it impossible to copy cells between notebooks: https://github.com/jupyter/notebook/issues/7214


## Code changes

<!-- Describe the code changes and how they address the issue. -->

The clipboard object obtained with `Clipboard.getInstance()` has been changed to use the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API) to save and load data.
Because the Clipboard API is only available in secure contexts(localhost or https), in order to keep backward compatibility, the same behavior as before (saving values to MimeData objects) is used in cases where the Clipboard API cannot be used.

- Change the object obtained by `Clipboard.getInstance()` from `MimeData` to `IClipboard`. `IClipboard` has almost the same interface as `MimeData`, but the function is declared as async because the Clipboard API uses asynchronous methods.
- In the implementation of `IClipboard`, values are saved and read through the Clipboard API. This process uses `Clipboard.writeText` and `Clipboard.readText` to save data as JSON-formatted text for cells. `ClipboardItem` allows us to explicitly specify the MIME type and save the value, but I didn't use this class because it is a new feature that was just released in 2024.
- The caller of `IClipboard` has also been switched to an async function where necessary. The tests have also been modified accordingly.

## User-facing changes

Users will be able to copy(cut) and paste cells across browser tabs. This will be of particular value to Notebook 7 users.
When a user pastes to the server for the first time, the browser may open a pop-up asking for permission to access the clipboard.

As before, users can copy cells using the copy, cut and paste buttons on the toolbar. I have not considered shortcut keys such as Cmd+C this time.


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

There are no such changes. Even if the user runs in an insecure context where the Clipboard API cannot be used (e.g. in a plain HTTP environment), the data is held in-memory and pasted using the `MimeData` object as before. In that case, users will not be able to copy across tabs, but backward compatibility will be preserved.