### PR TITLE
Remove dependencies for Python < 3.9

### DIFF
--- a/jupyterlab/tests/test_app.py
+++ b/jupyterlab/tests/test_app.py
@@ -9,12 +9,7 @@ import os
 import shutil
 import sys
 import tempfile
-
-try:
-    from importlib.resources import files
-except ImportError:
-    from importlib_resources import files
-
+from importlib.resources import files
 from os import path as osp
 from os.path import join as pjoin
 from stat import S_IRGRP, S_IROTH, S_IRUSR

--- a/jupyterlab/upgrade_extension.py
+++ b/jupyterlab/upgrade_extension.py
@@ -14,10 +14,7 @@ try:
 except ImportError:
     import tomli as tomllib
 
-try:
-    from importlib.resources import files
-except ImportError:
-    from importlib_resources import files
+from importlib.resources import files
 from pathlib import Path
 
 try:

--- a/packages/lsp/schema.js
+++ b/packages/lsp/schema.js
@@ -39,10 +39,7 @@ function getSchemaPath() {
   const schemaLocalPath = 'schema/schema.json';
 
   const cmd = `python -c '
-try:
-    from importlib.resources import files
-except ImportError:
-    from importlib_resources import files
+from importlib.resources import files
 print(files("${serverPackage}")/ "${schemaLocalPath}")
   '`;
   let schemaPath;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
     "async_lru>=1.0.0",
     "httpx>=0.25.0",
     "importlib-metadata>=4.8.3;python_version<\"3.10\"",
-    "importlib-resources>=1.4;python_version<\"3.9\"",
     "ipykernel>=6.5.0",
     "jinja2>=3.0.3",
     "jupyter_core",


### PR DESCRIPTION
## References

Closes #17452 

## Code changes

* Remove obsolete importlib-resources dependency from pyproject.toml
* Remove imports from importlib_resources (available as importlib.resources on Python 3.9+)

## User-facing changes

None

## Backwards-incompatible changes

None
