### PR TITLE
Fix `@jupyterlab/services` import

### DIFF
--- a/packages/notebook/src/executionindicator.tsx
+++ b/packages/notebook/src/executionindicator.tsx
@@ -17,10 +17,7 @@ import {
 
 import { Notebook } from './widget';
 import { KernelMessage } from '@jupyterlab/services';
-import {
-  IAnyMessageArgs,
-  IKernelConnection
-} from '@jupyterlab/services/src/kernel/kernel';
+import { Kernel } from '@jupyterlab/services';
 import { NotebookPanel } from './panel';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { Widget } from '@lumino/widgets';
@@ -345,8 +342,8 @@ export namespace ExecutionIndicator {
             ctx.statusChanged.disconnect(contextStatusChanged, this);
           });
           const handleKernelMsg = (
-            sender: IKernelConnection,
-            msg: IAnyMessageArgs
+            sender: Kernel.IKernelConnection,
+            msg: Kernel.IAnyMessageArgs
           ) => {
             const message = msg.msg;
             const msgId = message.header.msg_id;
@@ -379,8 +376,8 @@ export namespace ExecutionIndicator {
           const kernelChangedSlot = (
             _: ISessionContext,
             kernelData: IChangedArgs<
-              IKernelConnection | null,
-              IKernelConnection | null,
+              Kernel.IKernelConnection | null,
+              Kernel.IKernelConnection | null,
               'kernel'
             >
           ) => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Noticed while browsing the code base.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Import from `@jupyterlab/services` instead of `@jupyterlab/services/src/kernel/kernel', for consistency with the rest of the code base.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
