### PR TITLE
Fix incorrect modifications in collaborative save events

### DIFF
--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -418,6 +418,11 @@ export class Context<
     change: Contents.IChangedArgs
   ): void {
     if (change.type === 'save' && this._model.collaborative) {
+      //skip if the change isn't related to current file
+      if (this._contentsModel?.path !== change.newValue?.path) {
+        return;
+      }
+
       // Update the contents model with the new values provided on save.
       // This is needed for save operations performed on the server-side
       // by the collaborative drive which needs to update the `hash`

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -418,7 +418,7 @@ export class Context<
     change: Contents.IChangedArgs
   ): void {
     if (change.type === 'save' && this._model.collaborative) {
-      //skip if the change isn't related to current file
+      // Skip if the change isn't related to current file.
       if (this._contentsModel?.path !== change.newValue?.path) {
         return;
       }


### PR DESCRIPTION
## Fixes #17462

https://github.com/jupyterlab/jupyterlab/pull/16695 introduced an enhancement to update the contents model of a file when the hash value is changed by the server. However, the signal is currently broadcasted to all open files, causing every file’s contents model to be overwritten with the data from the newly saved file.

This leads to several issues:
- Incorrect filenames shown on hover
- Unexpected behavior in read-only files
- Other potential inconsistencies in code which relies on contents model of files

This PR addresses the problem by adding a check to ensure that the signal corresponds to the correct file. If the file does not match, the contents model will not be updated.