### PR TITLE
Follow changes to stream outputs

### DIFF
--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -119,6 +119,17 @@ export class OutputArea extends Widget {
     ) {
       const output = model.get(i);
       this._insertOutput(i, output);
+      if (output.type === 'stream') {
+        // This is a stream output, follow changes to the text.
+        output.streamText!.changed.connect(
+          (
+            sender: IObservableString,
+            event: IObservableString.IChangedArgs
+          ) => {
+            this._setOutput(i, output);
+          }
+        );
+      }
     }
     model.changed.connect(this.onModelChanged, this);
     model.stateChanged.connect(this.onStateChanged, this);

--- a/packages/outputarea/test/widget.spec.ts
+++ b/packages/outputarea/test/widget.spec.ts
@@ -323,6 +323,19 @@ describe('outputarea/widget', () => {
         expect(widget.widgets.length).toBe(0);
       });
 
+      it('should follow changes to initial stdout stream', () => {
+        model = new OutputAreaModel({
+          values: [DEFAULT_OUTPUTS[0]],
+          trusted: true
+        });
+        widget = new LogOutputArea({ rendermime, model });
+        // A stream output appended to the model should be seen in the widget.
+        const streamOutput = 'nctvjd745fdk56';
+        expect(widget.node.innerHTML).not.toContain(streamOutput);
+        widget.model.appendStreamOutput(streamOutput);
+        expect(widget.node.innerHTML).toContain(streamOutput);
+      });
+
       it('should handle stream outputs of same name', () => {
         widget.model.clear();
         // An initial stdout stream creates an output.


### PR DESCRIPTION
## References

Together with https://github.com/jupyter-server/jupyverse/pull/480, this fixes server-side execution in Jupyverse (but it's a general bug fix).

## Code changes

Changes to a cell stream output must be observed if initially present in the model, not just when a new stream output is added.

## User-facing changes

In particular, this fixes server-side execution, e.g. when reloading a page with a long-running cell execution.

## Backwards-incompatible changes

None.