### PR TITLE
Fix token extraction for incomplete paths

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -534,10 +534,14 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
           }
           // If the relevant leaf token has been found, stop iterating.
           if (offset >= ref.from && offset <= ref.to) {
+            let currentNode = ref;
+            if (ref.name === '⚠' && ref.from === ref.to && ref.node.parent) {
+              currentNode = ref.node.parent;
+            }
             token = {
-              value: this.state.sliceDoc(ref.from, ref.to),
-              offset: ref.from,
-              type: ref.name
+              value: this.state.sliceDoc(currentNode.from, currentNode.to),
+              offset: currentNode.from,
+              type: currentNode.name
             };
             return false;
           }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->
The token returned by the `getTokenAt` function when looking at a syntax tree ending in an incomplete path is erroneous, returning a warning sign as the type, an empty value and the already given offset: 
```
{value: '', offset: 8, type: '⚠' }
```

This causes the path auto-completion in `jupyterlab-lsp` to not consider the already typed prefix when inserting the selected completion item, as the incorrect token computed when fetching the `LSP` suggestions [here](https://github.com/jupyter-lsp/jupyterlab-lsp/blob/4628ce6bfcf1910c98b6f575d0e89e4f805c7670/packages/jupyterlab-lsp/src/features/completion/provider.ts#L198-L218), causes the completions to not have their `insertText` recomputed to eliminate the overlap with the token prefix [here](https://github.com/jupyter-lsp/jupyterlab-lsp/blob/4628ce6bfcf1910c98b6f575d0e89e4f805c7670/packages/jupyterlab-lsp/src/features/completion/provider.ts#L322-L418).

## References
Fixes: https://github.com/jupyter-lsp/jupyterlab-lsp/issues/1119.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
An extra check was added to the `getTokenAt` function in the `codemirror` package. If the relevant leaf found from the syntax tree is erroneous, so it has the name as  `⚠` and the properties `to` and `from` are equal,  we look at the parent of the node, and if it exists, we consider it the new current node to compute the token from.

This solution was chosen as the syntax tree of the lines of code ending with an incomplete path create a child of the last node as the error one shown above.  

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

**Before** - when choosing a completion for the path, the typed prefix is not considered:

[Before.webm](https://github.com/user-attachments/assets/4c48726d-f3bd-49bb-918f-057a84b6950e)


**After** - when choosing a completion for the path, the typed prefix is considered:

[After.webm](https://github.com/user-attachments/assets/35587a46-a545-4b82-9813-0024b319a352)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes
None.
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

cc: @trungleduc 