### PR TITLE
Add an optional `exportAs` method to `NbConvert.IManager`

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -13,8 +13,10 @@ API updates
 ^^^^^^^^^^^
 
 - The ``NbConvert.IManager`` interface was fixed to not require classes implementing the interface to provide a
-  concrete ``NbConvertManager`` class. In addition, this interface now include an optional ``export`` method
+  concrete ``NbConvertManager`` class. In addition, this interface now include an optional ``exportAs`` method
   to export (and optional download) a notebook to a specific format.
+- The ``NbConvertManager.IExportFormats`` interface was moved to the ``NbConvert`` namespace. We should now be using ``NbConvert.IExportFormats`` instead of ``NbConvertManager.IExportFormats``.
+  ``NbConvertManager.IExportFormats`` was however kept for backward compatibility.
 
 JupyterLab 4.3 to 4.4
 ---------------------

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -6,6 +6,16 @@
 Extension Migration Guide
 =========================
 
+JupyterLab 4.4 to 4.5
+---------------------
+
+API updates
+^^^^^^^^^^^
+
+- The ``NbConvert.IManager`` interface was fixed to not require classes implementing the interface to provide a
+  concrete ``NbConvertManager`` class. In addition, this interface now include an optional ``export`` method
+  to export (and optional download) a notebook to a specific format.
+
 JupyterLab 4.3 to 4.4
 ---------------------
 

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -13,9 +13,9 @@ API updates
 ^^^^^^^^^^^
 
 - The ``NbConvert.IManager`` interface was fixed to not require classes implementing the interface to provide a
-  concrete ``NbConvertManager`` class. In addition, this interface now include an optional ``exportAs`` method
-  to export (and optional download) a notebook to a specific format.
-- The ``NbConvertManager.IExportFormats`` interface was moved to the ``NbConvert`` namespace. We should now be using ``NbConvert.IExportFormats`` instead of ``NbConvertManager.IExportFormats``.
+  concrete ``NbConvertManager`` class. In addition, this interface now includes an optional ``exportAs`` method
+  to export (and optionally download) a notebook to a specific format.
+- The ``NbConvertManager.IExportFormats`` interface was moved to the ``NbConvert`` namespace. You should now use ``NbConvert.IExportFormats`` instead of ``NbConvertManager.IExportFormats``.
   ``NbConvertManager.IExportFormats`` was however kept for backward compatibility.
 
 JupyterLab 4.3 to 4.4

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -603,7 +603,7 @@ export const exportPlugin: JupyterFrontEndPlugin<void> = {
           ? trans.__('Save and Export Notebook: %1', formatLabel)
           : formatLabel;
       },
-      execute: args => {
+      execute: async args => {
         const current = getCurrent(tracker, shell, args);
 
         if (!current) {
@@ -621,15 +621,10 @@ export const exportPlugin: JupyterFrontEndPlugin<void> = {
         };
 
         if (context.model.dirty && !context.model.readOnly) {
-          return context.save().then(() => {
-            void services.nbconvert.exportAs?.(exportOptions);
-          });
+          await context.save();
         }
 
-        return new Promise<void>(resolve => {
-          void services.nbconvert.exportAs?.(exportOptions);
-          resolve(undefined);
-        });
+        return services.nbconvert.exportAs?.(exportOptions);
       },
       isEnabled
     });

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -93,6 +93,7 @@ import {
   IRenderMime,
   IRenderMimeRegistry
 } from '@jupyterlab/rendermime';
+import { NbConvert } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IStateDB } from '@jupyterlab/statedb';
 import { IStatusBar } from '@jupyterlab/statusbar';
@@ -611,10 +612,12 @@ export const exportPlugin: JupyterFrontEndPlugin<void> = {
 
         const { context } = current;
 
-        const exportOptions = {
+        const exportOptions: NbConvert.IExportOptions = {
           format: args['format'] as string,
           path: current.context.path,
-          download: true
+          exporterOptions: {
+            download: true
+          }
         };
 
         if (context.model.dirty && !context.model.readOnly) {

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -619,12 +619,12 @@ export const exportPlugin: JupyterFrontEndPlugin<void> = {
 
         if (context.model.dirty && !context.model.readOnly) {
           return context.save().then(() => {
-            void services.nbconvert.export?.(exportOptions);
+            void services.nbconvert.exportAs?.(exportOptions);
           });
         }
 
         return new Promise<void>(resolve => {
-          void services.nbconvert.export?.(exportOptions);
+          void services.nbconvert.exportAs?.(exportOptions);
           resolve(undefined);
         });
       },

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -609,21 +609,22 @@ export const exportPlugin: JupyterFrontEndPlugin<void> = {
           return;
         }
 
-        const url = PageConfig.getNBConvertURL({
-          format: args['format'] as string,
-          download: true,
-          path: current.context.path
-        });
         const { context } = current;
+
+        const exportOptions = {
+          format: args['format'] as string,
+          path: current.context.path,
+          download: true
+        };
 
         if (context.model.dirty && !context.model.readOnly) {
           return context.save().then(() => {
-            window.open(url, '_blank', 'noopener');
+            void services.nbconvert.export?.(exportOptions);
           });
         }
 
         return new Promise<void>(resolve => {
-          window.open(url, '_blank', 'noopener');
+          void services.nbconvert.export?.(exportOptions);
           resolve(undefined);
         });
       },

--- a/packages/services/src/nbconvert/index.ts
+++ b/packages/services/src/nbconvert/index.ts
@@ -91,7 +91,7 @@ export class NbConvertManager implements NbConvert.IManager {
    */
   async exportAs(options: NbConvert.IExportOptions): Promise<void> {
     const { format, path } = options;
-    const { download = false } = options;
+    const { download = false } = options.exporterOptions || {};
 
     const baseUrl = this.serverSettings.baseUrl;
     const notebookPath = URLExt.encodeParts(path);
@@ -121,6 +121,14 @@ export namespace NbConvertManager {
      */
     serverSettings?: ServerConnection.ISettings;
   }
+
+  /**
+   * The interface for the export formats.
+   *
+   * Note: this interface is kept for backward compatibility.
+   * It is recommended to use `NbConvert.IExportFormats` instead.
+   */
+  export interface IExportFormats extends NbConvert.IExportFormats {}
 }
 
 /**
@@ -128,7 +136,7 @@ export namespace NbConvertManager {
  */
 export namespace NbConvert {
   /**
-   * A namespace for nbconvert API interfaces.
+   * The interface for the export formats.
    */
   export interface IExportFormats {
     /**
@@ -152,9 +160,9 @@ export namespace NbConvert {
     path: string;
 
     /**
-     * Whether to download the file or open it in a new tab. Defaults to false.
+     * Additional options for the exporter.
      */
-    download?: boolean;
+    exporterOptions?: { [key: string]: any };
   }
 
   /**

--- a/packages/services/src/nbconvert/index.ts
+++ b/packages/services/src/nbconvert/index.ts
@@ -37,7 +37,7 @@ export class NbConvertManager implements NbConvert.IManager {
   /**
    * Fetch and cache the export formats from the expensive nbconvert handler.
    */
-  protected async fetchExportFormats(): Promise<NbConvertManager.IExportFormats> {
+  protected async fetchExportFormats(): Promise<NbConvert.IExportFormats> {
     this._requestingFormats = new PromiseDelegate();
     this._exportFormats = null;
     const base = this.serverSettings.baseUrl;
@@ -53,7 +53,7 @@ export class NbConvertManager implements NbConvert.IManager {
       throw err;
     }
     const data = await response.json();
-    const exportList: NbConvertManager.IExportFormats = {};
+    const exportList: NbConvert.IExportFormats = {};
     const keys = Object.keys(data);
     keys.forEach(function (key) {
       const mimeType: string = data[key].output_mimetype;
@@ -69,7 +69,7 @@ export class NbConvertManager implements NbConvert.IManager {
    */
   async getExportFormats(
     force: boolean = true
-  ): Promise<NbConvertManager.IExportFormats> {
+  ): Promise<NbConvert.IExportFormats> {
     if (this._requestingFormats) {
       return this._requestingFormats.promise;
     }
@@ -89,12 +89,9 @@ export class NbConvertManager implements NbConvert.IManager {
    * @param options.path - The path to the notebook to export.
    * @param options.download - Whether to download the file or open it in a new tab. Defaults to false.
    */
-  async export(options: {
-    format: string;
-    path: string;
-    download?: boolean;
-  }): Promise<void> {
-    const { format, path, download = false } = options;
+  async exportAs(options: NbConvert.IExportOptions): Promise<void> {
+    const { format, path } = options;
+    const { download = false } = options;
 
     const baseUrl = this.serverSettings.baseUrl;
     const notebookPath = URLExt.encodeParts(path);
@@ -107,16 +104,16 @@ export class NbConvertManager implements NbConvert.IManager {
     window?.open(url, '_blank', 'noopener');
   }
 
-  protected _requestingFormats: PromiseDelegate<NbConvertManager.IExportFormats> | null;
-  protected _exportFormats: NbConvertManager.IExportFormats | null = null;
+  protected _requestingFormats: PromiseDelegate<NbConvert.IExportFormats> | null;
+  protected _exportFormats: NbConvert.IExportFormats | null = null;
 }
 
 /**
- * A namespace for `BuildManager` statics.
+ * A namespace for `NbConvertManager` statics.
  */
 export namespace NbConvertManager {
   /**
-   * The instantiation options for a setting manager.
+   * The instantiation options for a nbconvert manager.
    */
   export interface IOptions {
     /**
@@ -124,7 +121,12 @@ export namespace NbConvertManager {
      */
     serverSettings?: ServerConnection.ISettings;
   }
+}
 
+/**
+ * A namespace for nbconvert API interfaces.
+ */
+export namespace NbConvert {
   /**
    * A namespace for nbconvert API interfaces.
    */
@@ -134,14 +136,29 @@ export namespace NbConvertManager {
      */
     [key: string]: { output_mimetype: string };
   }
-}
 
-/**
- * A namespace for builder API interfaces.
- */
-export namespace NbConvert {
   /**
-   * The interface for the build manager.
+   * The interface for the nbconvert export options.
+   */
+  export interface IExportOptions {
+    /**
+     * The export format (e.g., 'html', 'pdf').
+     */
+    format: string;
+
+    /**
+     * The path to the notebook to export.
+     */
+    path: string;
+
+    /**
+     * Whether to download the file or open it in a new tab. Defaults to false.
+     */
+    download?: boolean;
+  }
+
+  /**
+   * The interface for the nbconvert manager.
    */
   export interface IManager {
     /**
@@ -155,7 +172,7 @@ export namespace NbConvert {
      * @param force - Whether to force a refresh or use cached formats if available.
      * @returns A promise that resolves with the list of export formats.
      */
-    getExportFormats(force?: boolean): Promise<NbConvertManager.IExportFormats>;
+    getExportFormats(force?: boolean): Promise<NbConvert.IExportFormats>;
 
     /**
      * Export a notebook to a given format.
@@ -165,10 +182,6 @@ export namespace NbConvert {
      * @param options.path - The path to the notebook to export.
      * @param options.download - Whether to download the file or open it in a new tab. Defaults to false.
      */
-    export?(options: {
-      format: string;
-      path: string;
-      download?: boolean;
-    }): Promise<void>;
+    exportAs?(options: NbConvert.IExportOptions): Promise<void>;
   }
 }

--- a/packages/services/src/nbconvert/index.ts
+++ b/packages/services/src/nbconvert/index.ts
@@ -125,8 +125,7 @@ export namespace NbConvertManager {
   /**
    * The interface for the export formats.
    *
-   * Note: this interface is kept for backward compatibility.
-   * It is recommended to use `NbConvert.IExportFormats` instead.
+   * @deprecated Kept for backward compatibility, use `NbConvert.IExportFormats` instead.
    */
   export interface IExportFormats extends NbConvert.IExportFormats {}
 }

--- a/packages/services/src/nbconvert/index.ts
+++ b/packages/services/src/nbconvert/index.ts
@@ -87,7 +87,7 @@ export class NbConvertManager implements NbConvert.IManager {
    * @param options - The export options.
    * @param options.format - The export format (e.g., 'html', 'pdf').
    * @param options.path - The path to the notebook to export.
-   * @param options.download - Whether to download the file or open it in a new tab. Defaults to false.
+   * @param exporterOptions.download - Whether to download the file or open it in a new tab. Defaults to false.
    */
   async exportAs(options: NbConvert.IExportOptions): Promise<void> {
     const { format, path } = options;
@@ -187,7 +187,7 @@ export namespace NbConvert {
      * @param options - The export options.
      * @param options.format - The export format (e.g., 'html', 'pdf').
      * @param options.path - The path to the notebook to export.
-     * @param options.download - Whether to download the file or open it in a new tab. Defaults to false.
+     * @param exporterOptions.download - Whether to download the file or open it in a new tab. Defaults to false.
      */
     exportAs?(options: NbConvert.IExportOptions): Promise<void>;
   }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/17478

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Add an optional `export` method to `NbConvert.IManager`
- [x] Update `@jupyterlab/notebook-extension:plugin` accordingly
- [x] Mention the change of the `NbConvert.IManager` definition in the migration guide, which does not directly extend `NbConvertManager` anymore


## User-facing changes

None for JupyterLab users.

But this will allow adding in-browser exporters to JupyterLite, as mentioned in https://github.com/jupyterlite/jupyterlite/pull/1625#issuecomment-2812961794

## Backwards-incompatible changes

The optional `export` method should not be breaking.

However this PR also take the opportunity to fix the definition of the `NbConvert.IManager` interface, so downstream that want to implement a `NbConvert.IManager` don't need to provide the exact `NbConvertManager`. This is likely fine as unlikely to be extended by third-party extensions at the moment, but still worth documenting.
