### PR TITLE
Fix undo/redo in cells created in `none` windowing mode

### DIFF
--- a/examples/cell/package.json
+++ b/examples/cell/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@jupyter/web-components": "^0.16.6",
-    "@jupyter/ydoc": "^3.0.0",
+    "@jupyter/ydoc": "^3.0.4",
     "@jupyterlab/application": "^4.4.0",
     "@jupyterlab/apputils": "^4.5.0",
     "@jupyterlab/cells": "^4.4.0",

--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@jupyter/web-components": "^0.16.6",
-    "@jupyter/ydoc": "^3.0.0",
+    "@jupyter/ydoc": "^3.0.4",
     "@jupyterlab/application": "^4.4.0",
     "@jupyterlab/codemirror": "^4.4.0",
     "@jupyterlab/console": "^4.4.0",

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@jupyter/web-components": "^0.16.6",
-    "@jupyter/ydoc": "^3.0.0",
+    "@jupyter/ydoc": "^3.0.4",
     "@jupyterlab/application": "^4.4.0",
     "@jupyterlab/apputils": "^4.5.0",
     "@jupyterlab/codemirror": "^4.4.0",

--- a/packages/cell-toolbar/package.json
+++ b/packages/cell-toolbar/package.json
@@ -40,7 +40,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^3.0.0",
+    "@jupyter/ydoc": "^3.0.4",
     "@jupyterlab/apputils": "^4.5.0",
     "@jupyterlab/cells": "^4.4.0",
     "@jupyterlab/docregistry": "^4.4.0",

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@codemirror/state": "^6.5.0",
     "@codemirror/view": "^6.35.3",
-    "@jupyter/ydoc": "^3.0.0",
+    "@jupyter/ydoc": "^3.0.4",
     "@jupyterlab/apputils": "^4.5.0",
     "@jupyterlab/attachments": "^4.4.0",
     "@jupyterlab/codeeditor": "^4.4.0",

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@codemirror/state": "^6.5.0",
-    "@jupyter/ydoc": "^3.0.0",
+    "@jupyter/ydoc": "^3.0.4",
     "@jupyterlab/apputils": "^4.5.0",
     "@jupyterlab/coreutils": "^6.4.0",
     "@jupyterlab/nbformat": "^4.4.0",

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -43,7 +43,7 @@
     "@codemirror/legacy-modes": "^6.4.2",
     "@codemirror/search": "^6.5.8",
     "@codemirror/view": "^6.35.3",
-    "@jupyter/ydoc": "^3.0.0",
+    "@jupyter/ydoc": "^3.0.4",
     "@jupyterlab/application": "^4.4.0",
     "@jupyterlab/codeeditor": "^4.4.0",
     "@jupyterlab/codemirror": "^4.4.0",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -57,7 +57,7 @@
     "@codemirror/search": "^6.5.8",
     "@codemirror/state": "^6.5.0",
     "@codemirror/view": "^6.35.3",
-    "@jupyter/ydoc": "^3.0.0",
+    "@jupyter/ydoc": "^3.0.4",
     "@jupyterlab/codeeditor": "^4.4.0",
     "@jupyterlab/coreutils": "^6.4.0",
     "@jupyterlab/documentsearch": "^4.4.0",

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@codemirror/state": "^6.5.0",
     "@codemirror/view": "^6.35.3",
-    "@jupyter/ydoc": "^3.0.0",
+    "@jupyter/ydoc": "^3.0.4",
     "@jupyterlab/apputils": "^4.5.0",
     "@jupyterlab/codeeditor": "^4.4.0",
     "@jupyterlab/codemirror": "^4.4.0",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -42,7 +42,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^3.0.0",
+    "@jupyter/ydoc": "^3.0.4",
     "@jupyterlab/apputils": "^4.5.0",
     "@jupyterlab/cells": "^4.4.0",
     "@jupyterlab/codeeditor": "^4.4.0",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -50,7 +50,7 @@
     "@codemirror/state": "^6.5.0",
     "@codemirror/view": "^6.35.3",
     "@jupyter/react-components": "^0.16.6",
-    "@jupyter/ydoc": "^3.0.0",
+    "@jupyter/ydoc": "^3.0.4",
     "@jupyterlab/application": "^4.4.0",
     "@jupyterlab/apputils": "^4.5.0",
     "@jupyterlab/cells": "^4.4.0",

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -41,7 +41,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^3.0.0",
+    "@jupyter/ydoc": "^3.0.4",
     "@jupyterlab/apputils": "^4.5.0",
     "@jupyterlab/codeeditor": "^4.4.0",
     "@jupyterlab/coreutils": "^6.4.0",

--- a/packages/fileeditor/package.json
+++ b/packages/fileeditor/package.json
@@ -39,7 +39,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^3.0.0",
+    "@jupyter/ydoc": "^3.0.4",
     "@jupyterlab/apputils": "^4.5.0",
     "@jupyterlab/codeeditor": "^4.4.0",
     "@jupyterlab/codemirror": "^4.4.0",

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -36,7 +36,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^3.0.0",
+    "@jupyter/ydoc": "^3.0.4",
     "@jupyterlab/application": "^4.4.0",
     "@jupyterlab/apputils": "^4.5.0",
     "@jupyterlab/cells": "^4.4.0",

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -40,7 +40,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^3.0.0",
+    "@jupyter/ydoc": "^3.0.4",
     "@jupyterlab/apputils": "^4.5.0",
     "@jupyterlab/cells": "^4.4.0",
     "@jupyterlab/codeeditor": "^4.4.0",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -45,7 +45,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyter/ydoc": "^3.0.0",
+    "@jupyter/ydoc": "^3.0.4",
     "@jupyterlab/coreutils": "^6.4.0",
     "@jupyterlab/nbformat": "^4.4.0",
     "@jupyterlab/settingregistry": "^4.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2185,9 +2185,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyter/ydoc@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@jupyter/ydoc@npm:3.0.0"
+"@jupyter/ydoc@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@jupyter/ydoc@npm:3.0.4"
   dependencies:
     "@jupyterlab/nbformat": ^3.0.0 || ^4.0.0-alpha.21 || ^4.0.0
     "@lumino/coreutils": ^1.11.0 || ^2.0.0
@@ -2195,7 +2195,7 @@ __metadata:
     "@lumino/signaling": ^1.10.0 || ^2.0.0
     y-protocols: ^1.0.5
     yjs: ^13.5.40
-  checksum: e9419a461f33d2685db346b19806865fe37f61b2ca33eb39c4ea905d765794a928442adf1bbffda67b665bdeba3be9a082189a57eaab5367aeaf6b57caeda822
+  checksum: 85ca033a51c0f26080bcea7c0aac7cbd4ef66bc745fd48786aa1a2f9bdf06b99b67f40d8775ff04bb700e78782fbfdc6c97d2e94b45bd65ad5288c44ca158e19
   languageName: node
   linkType: hard
 
@@ -2520,7 +2520,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/cell-toolbar@workspace:packages/cell-toolbar"
   dependencies:
-    "@jupyter/ydoc": ^3.0.0
+    "@jupyter/ydoc": ^3.0.4
     "@jupyterlab/apputils": ^4.5.0
     "@jupyterlab/cells": ^4.4.0
     "@jupyterlab/docregistry": ^4.4.0
@@ -2547,7 +2547,7 @@ __metadata:
   dependencies:
     "@codemirror/state": ^6.5.0
     "@codemirror/view": ^6.35.3
-    "@jupyter/ydoc": ^3.0.0
+    "@jupyter/ydoc": ^3.0.4
     "@jupyterlab/apputils": ^4.5.0
     "@jupyterlab/attachments": ^4.4.0
     "@jupyterlab/codeeditor": ^4.4.0
@@ -2603,7 +2603,7 @@ __metadata:
   resolution: "@jupyterlab/codeeditor@workspace:packages/codeeditor"
   dependencies:
     "@codemirror/state": ^6.5.0
-    "@jupyter/ydoc": ^3.0.0
+    "@jupyter/ydoc": ^3.0.4
     "@jupyterlab/apputils": ^4.5.0
     "@jupyterlab/coreutils": ^6.4.0
     "@jupyterlab/nbformat": ^4.4.0
@@ -2636,7 +2636,7 @@ __metadata:
     "@codemirror/legacy-modes": ^6.4.2
     "@codemirror/search": ^6.5.8
     "@codemirror/view": ^6.35.3
-    "@jupyter/ydoc": ^3.0.0
+    "@jupyter/ydoc": ^3.0.4
     "@jupyterlab/application": ^4.4.0
     "@jupyterlab/codeeditor": ^4.4.0
     "@jupyterlab/codemirror": ^4.4.0
@@ -2679,7 +2679,7 @@ __metadata:
     "@codemirror/search": ^6.5.8
     "@codemirror/state": ^6.5.0
     "@codemirror/view": ^6.35.3
-    "@jupyter/ydoc": ^3.0.0
+    "@jupyter/ydoc": ^3.0.4
     "@jupyterlab/codeeditor": ^4.4.0
     "@jupyterlab/coreutils": ^6.4.0
     "@jupyterlab/documentsearch": ^4.4.0
@@ -2727,7 +2727,7 @@ __metadata:
   dependencies:
     "@codemirror/state": ^6.5.0
     "@codemirror/view": ^6.35.3
-    "@jupyter/ydoc": ^3.0.0
+    "@jupyter/ydoc": ^3.0.4
     "@jupyterlab/apputils": ^4.5.0
     "@jupyterlab/codeeditor": ^4.4.0
     "@jupyterlab/codemirror": ^4.4.0
@@ -2783,7 +2783,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/console@workspace:packages/console"
   dependencies:
-    "@jupyter/ydoc": ^3.0.0
+    "@jupyter/ydoc": ^3.0.4
     "@jupyterlab/apputils": ^4.5.0
     "@jupyterlab/cells": ^4.4.0
     "@jupyterlab/codeeditor": ^4.4.0
@@ -2912,7 +2912,7 @@ __metadata:
     "@codemirror/state": ^6.5.0
     "@codemirror/view": ^6.35.3
     "@jupyter/react-components": ^0.16.6
-    "@jupyter/ydoc": ^3.0.0
+    "@jupyter/ydoc": ^3.0.4
     "@jupyterlab/application": ^4.4.0
     "@jupyterlab/apputils": ^4.5.0
     "@jupyterlab/cells": ^4.4.0
@@ -3008,7 +3008,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/docregistry@workspace:packages/docregistry"
   dependencies:
-    "@jupyter/ydoc": ^3.0.0
+    "@jupyter/ydoc": ^3.0.4
     "@jupyterlab/apputils": ^4.5.0
     "@jupyterlab/codeeditor": ^4.4.0
     "@jupyterlab/coreutils": ^6.4.0
@@ -3129,7 +3129,7 @@ __metadata:
   resolution: "@jupyterlab/example-cell@workspace:examples/cell"
   dependencies:
     "@jupyter/web-components": ^0.16.6
-    "@jupyter/ydoc": ^3.0.0
+    "@jupyter/ydoc": ^3.0.4
     "@jupyterlab/application": ^4.4.0
     "@jupyterlab/apputils": ^4.5.0
     "@jupyterlab/cells": ^4.4.0
@@ -3158,7 +3158,7 @@ __metadata:
   resolution: "@jupyterlab/example-console@workspace:examples/console"
   dependencies:
     "@jupyter/web-components": ^0.16.6
-    "@jupyter/ydoc": ^3.0.0
+    "@jupyter/ydoc": ^3.0.4
     "@jupyterlab/application": ^4.4.0
     "@jupyterlab/codemirror": ^4.4.0
     "@jupyterlab/console": ^4.4.0
@@ -3304,7 +3304,7 @@ __metadata:
   resolution: "@jupyterlab/example-notebook@workspace:examples/notebook"
   dependencies:
     "@jupyter/web-components": ^0.16.6
-    "@jupyter/ydoc": ^3.0.0
+    "@jupyter/ydoc": ^3.0.4
     "@jupyterlab/application": ^4.4.0
     "@jupyterlab/apputils": ^4.5.0
     "@jupyterlab/codemirror": ^4.4.0
@@ -3545,7 +3545,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/fileeditor@workspace:packages/fileeditor"
   dependencies:
-    "@jupyter/ydoc": ^3.0.0
+    "@jupyter/ydoc": ^3.0.4
     "@jupyterlab/apputils": ^4.5.0
     "@jupyterlab/codeeditor": ^4.4.0
     "@jupyterlab/codemirror": ^4.4.0
@@ -4313,7 +4313,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/notebook-extension@workspace:packages/notebook-extension"
   dependencies:
-    "@jupyter/ydoc": ^3.0.0
+    "@jupyter/ydoc": ^3.0.4
     "@jupyterlab/application": ^4.4.0
     "@jupyterlab/apputils": ^4.5.0
     "@jupyterlab/cells": ^4.4.0
@@ -4361,7 +4361,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/notebook@workspace:packages/notebook"
   dependencies:
-    "@jupyter/ydoc": ^3.0.0
+    "@jupyter/ydoc": ^3.0.4
     "@jupyterlab/apputils": ^4.5.0
     "@jupyterlab/cells": ^4.4.0
     "@jupyterlab/codeeditor": ^4.4.0
@@ -4648,7 +4648,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/services@workspace:packages/services"
   dependencies:
-    "@jupyter/ydoc": ^3.0.0
+    "@jupyter/ydoc": ^3.0.4
     "@jupyterlab/coreutils": ^6.4.0
     "@jupyterlab/nbformat": ^4.4.0
     "@jupyterlab/settingregistry": ^4.4.0


### PR DESCRIPTION
## References

Fixes #17247 

## Code changes

- [x] add a unit test for `undoManager` being defined in notebook cells editor in each mode
- [x] upgrade `jupyter-ydoc` npm package to pull https://github.com/jupyter-server/jupyter_ydoc/pull/321

## User-facing changes

Undo/redo works in `none` windowing mode

## Backwards-incompatible changes

None
