### PR TITLE
Add new CSS rule for expanding linked output to 100% height

### DIFF
--- a/packages/outputarea/style/base.css
+++ b/packages/outputarea/style/base.css
@@ -264,6 +264,10 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated::before {
   display: block;
 }
 
+.jp-LinkedOutputView .jp-OutputArea-child:only-child {
+  height: 100%;
+}
+
 .jp-LinkedOutputView .jp-OutputArea-output:only-child {
   height: 100%;
 }


### PR DESCRIPTION
This allows outputs such as ipyleaflet or JupyterGIS maps to make use of the full height of the linked output panel.