### PR TITLE
Add a signal when cells are pasted in the Notebook

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1624,7 +1624,7 @@ export class Notebook extends StaticNotebook {
   /**
    * A signal emitted when cells are pasted to the notebook.
    */
-  get cellsPasted(): ISignal<this, Notebook.IPasteCells> {
+  get cellsPasted(): ISignal<this, Notebook.IPastedCells> {
     return this._cellsPasted;
   }
 
@@ -3250,7 +3250,7 @@ export class Notebook extends StaticNotebook {
   private _activeCellChanged = new Signal<this, Cell | null>(this);
   private _stateChanged = new Signal<this, IChangedArgs<any>>(this);
   private _selectionChanged = new Signal<this, void>(this);
-  private _cellsPasted = new Signal<this, Notebook.IPasteCells>(this);
+  private _cellsPasted = new Signal<this, Notebook.IPastedCells>(this);
   private _localCopy: nbformat.IBaseCell[] = [];
   // Attributes for optimized cell refresh:
   private _cellLayoutStateCache?: { width: number };
@@ -3302,16 +3302,16 @@ export namespace Notebook {
   }
 
   /**
-   * An interface for the paste cell event.
+   * An interface for the pasted cells event.
    */
-  export interface IPasteCells {
+  export interface IPastedCells {
     /**
-     * The previous local clipboard interaction related to this pasted cell.
+     * The previous local clipboard interaction related to the pasted cells.
      *
-     * If the pasted cell(s) has been copied or cut from the same notebook, this value
+     * If the pasted cells have been copied or cut from the same notebook, this value
      * will be the last interaction that was performed on the local clipboard. It should
-     * be either `copy` or `cut`.
-     * If the pasted cell(s) has been copied or cut from another notebook, this value
+     * be either `copy`, `cut` or `paste`.
+     * If the pasted cells have been copied or cut from another notebook, this value
      * will be `null`.
      */
     previousInteraction: 'copy' | 'cut' | 'paste' | null;

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -1700,9 +1700,9 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should emit a signal with cut action', async () => {
-        let signals: Notebook.IPasteCells[] = [];
+        let signals: Notebook.IPastedCells[] = [];
         widget.cellsPasted.connect(
-          (_: Notebook, interaction: Notebook.IPasteCells) => {
+          (_: Notebook, interaction: Notebook.IPastedCells) => {
             signals.push(interaction);
           }
         );
@@ -1714,9 +1714,9 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should emit a signal with copy action', async () => {
-        let signals: Notebook.IPasteCells[] = [];
+        let signals: Notebook.IPastedCells[] = [];
         widget.cellsPasted.connect(
-          (_: Notebook, interaction: Notebook.IPasteCells) => {
+          (_: Notebook, interaction: Notebook.IPastedCells) => {
             signals.push(interaction);
           }
         );
@@ -1728,9 +1728,9 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should emit a signal with the number of copied cells', async () => {
-        let signals: Notebook.IPasteCells[] = [];
+        let signals: Notebook.IPastedCells[] = [];
         widget.cellsPasted.connect(
-          (_: Notebook, interaction: Notebook.IPasteCells) => {
+          (_: Notebook, interaction: Notebook.IPastedCells) => {
             signals.push(interaction);
           }
         );
@@ -1744,9 +1744,9 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should emit a signal with action to null', async () => {
-        let signals: Notebook.IPasteCells[] = [];
+        let signals: Notebook.IPastedCells[] = [];
         widget.cellsPasted.connect(
-          (_: Notebook, interaction: Notebook.IPasteCells) => {
+          (_: Notebook, interaction: Notebook.IPastedCells) => {
             signals.push(interaction);
           }
         );

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -1699,7 +1699,7 @@ describe('@jupyterlab/notebook', () => {
         expect(widget.widgets.length).toBe(count - 2);
       });
 
-      it('should emit a signal with cut action', () => {
+      it('should emit a signal with cut action', async () => {
         let signals: {
           action: 'copy' | 'cut' | 'paste' | null;
           count: number;
@@ -1715,14 +1715,14 @@ describe('@jupyterlab/notebook', () => {
             signals.push(interaction);
           }
         );
-        NotebookActions.cut(widget);
+        await NotebookActions.cutToSystemClipboard(widget);
         widget.activeCellIndex = 1;
-        NotebookActions.paste(widget);
+        await NotebookActions.pasteFromSystemClipboard(widget);
         expect(signals.length).toBe(1);
         expect(signals[0].action).toBe('cut');
       });
 
-      it('should emit a signal with copy action', () => {
+      it('should emit a signal with copy action', async () => {
         let signals: {
           action: 'copy' | 'cut' | 'paste' | null;
           count: number;
@@ -1738,14 +1738,14 @@ describe('@jupyterlab/notebook', () => {
             signals.push(interaction);
           }
         );
-        NotebookActions.copy(widget);
+        await NotebookActions.copyToSystemClipboard(widget);
         widget.activeCellIndex = 1;
-        NotebookActions.paste(widget);
+        await NotebookActions.pasteFromSystemClipboard(widget);
         expect(signals.length).toBe(1);
         expect(signals[0].action).toBe('copy');
       });
 
-      it('should emit a signal with the number of copied cells', () => {
+      it('should emit a signal with the number of copied cells', async () => {
         let signals: {
           action: 'copy' | 'cut' | 'paste' | null;
           count: number;
@@ -1763,14 +1763,14 @@ describe('@jupyterlab/notebook', () => {
         );
         const next = widget.widgets[1];
         widget.select(next);
-        NotebookActions.copy(widget);
+        await NotebookActions.copyToSystemClipboard(widget);
         widget.activeCellIndex = 1;
-        NotebookActions.paste(widget);
+        await NotebookActions.pasteFromSystemClipboard(widget);
         expect(signals.length).toBe(1);
         expect(signals[0].count).toBe(2);
       });
 
-      it('should emit a signal with action to null', () => {
+      it('should emit a signal with action to null', async () => {
         let signals: {
           action: 'copy' | 'cut' | 'paste' | null;
           count: number;
@@ -1803,8 +1803,8 @@ describe('@jupyterlab/notebook', () => {
         model2.sharedModel.clearUndoHistory();
 
         widget2.activeCellIndex = 0;
-        NotebookActions.copy(widget2);
-        NotebookActions.paste(widget);
+        await NotebookActions.copyToSystemClipboard(widget2);
+        await NotebookActions.pasteFromSystemClipboard(widget);
         expect(signals.length).toBe(1);
         expect(signals[0].count).toBe(1);
         expect(signals[0].action).toBeNull();

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -1698,6 +1698,117 @@ describe('@jupyterlab/notebook', () => {
         NotebookActions.undo(widget);
         expect(widget.widgets.length).toBe(count - 2);
       });
+
+      it('should emit a signal with cut action', () => {
+        let signals: {
+          action: 'copy' | 'cut' | 'paste' | null;
+          count: number;
+        }[] = [];
+        widget.cellsPasted.connect(
+          (
+            _: Notebook,
+            interaction: {
+              action: 'copy' | 'cut' | 'paste' | null;
+              count: number;
+            }
+          ) => {
+            signals.push(interaction);
+          }
+        );
+        NotebookActions.cut(widget);
+        widget.activeCellIndex = 1;
+        NotebookActions.paste(widget);
+        expect(signals.length).toBe(1);
+        expect(signals[0].action).toBe('cut');
+      });
+
+      it('should emit a signal with copy action', () => {
+        let signals: {
+          action: 'copy' | 'cut' | 'paste' | null;
+          count: number;
+        }[] = [];
+        widget.cellsPasted.connect(
+          (
+            _: Notebook,
+            interaction: {
+              action: 'copy' | 'cut' | 'paste' | null;
+              count: number;
+            }
+          ) => {
+            signals.push(interaction);
+          }
+        );
+        NotebookActions.copy(widget);
+        widget.activeCellIndex = 1;
+        NotebookActions.paste(widget);
+        expect(signals.length).toBe(1);
+        expect(signals[0].action).toBe('copy');
+      });
+
+      it('should emit a signal with the number of copied cells', () => {
+        let signals: {
+          action: 'copy' | 'cut' | 'paste' | null;
+          count: number;
+        }[] = [];
+        widget.cellsPasted.connect(
+          (
+            _: Notebook,
+            interaction: {
+              action: 'copy' | 'cut' | 'paste' | null;
+              count: number;
+            }
+          ) => {
+            signals.push(interaction);
+          }
+        );
+        const next = widget.widgets[1];
+        widget.select(next);
+        NotebookActions.copy(widget);
+        widget.activeCellIndex = 1;
+        NotebookActions.paste(widget);
+        expect(signals.length).toBe(1);
+        expect(signals[0].count).toBe(2);
+      });
+
+      it('should emit a signal with action to null', () => {
+        let signals: {
+          action: 'copy' | 'cut' | 'paste' | null;
+          count: number;
+        }[] = [];
+        widget.cellsPasted.connect(
+          (
+            _: Notebook,
+            interaction: {
+              action: 'copy' | 'cut' | 'paste' | null;
+              count: number;
+            }
+          ) => {
+            signals.push(interaction);
+          }
+        );
+
+        // Create another notebook widget
+        const widget2 = new Notebook({
+          rendermime,
+          contentFactory: utils.createNotebookFactory(),
+          mimeTypeService: utils.mimeTypeService,
+          notebookConfig: {
+            ...StaticNotebook.defaultNotebookConfig,
+            windowingMode: 'none'
+          }
+        });
+        const model2 = new NotebookModel();
+        model2.fromJSON(utils.DEFAULT_CONTENT);
+        widget2.model = model2;
+        model2.sharedModel.clearUndoHistory();
+
+        widget2.activeCellIndex = 0;
+        NotebookActions.copy(widget2);
+        NotebookActions.paste(widget);
+        expect(signals.length).toBe(1);
+        expect(signals[0].count).toBe(1);
+        expect(signals[0].action).toBeNull();
+      });
     });
 
     describe('#pasteFromSystemClipboard()', () => {

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -1700,18 +1700,9 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should emit a signal with cut action', async () => {
-        let signals: {
-          action: 'copy' | 'cut' | 'paste' | null;
-          count: number;
-        }[] = [];
+        let signals: Notebook.IPasteCells[] = [];
         widget.cellsPasted.connect(
-          (
-            _: Notebook,
-            interaction: {
-              action: 'copy' | 'cut' | 'paste' | null;
-              count: number;
-            }
-          ) => {
+          (_: Notebook, interaction: Notebook.IPasteCells) => {
             signals.push(interaction);
           }
         );
@@ -1719,22 +1710,13 @@ describe('@jupyterlab/notebook', () => {
         widget.activeCellIndex = 1;
         await NotebookActions.pasteFromSystemClipboard(widget);
         expect(signals.length).toBe(1);
-        expect(signals[0].action).toBe('cut');
+        expect(signals[0].previousInteraction).toBe('cut');
       });
 
       it('should emit a signal with copy action', async () => {
-        let signals: {
-          action: 'copy' | 'cut' | 'paste' | null;
-          count: number;
-        }[] = [];
+        let signals: Notebook.IPasteCells[] = [];
         widget.cellsPasted.connect(
-          (
-            _: Notebook,
-            interaction: {
-              action: 'copy' | 'cut' | 'paste' | null;
-              count: number;
-            }
-          ) => {
+          (_: Notebook, interaction: Notebook.IPasteCells) => {
             signals.push(interaction);
           }
         );
@@ -1742,22 +1724,13 @@ describe('@jupyterlab/notebook', () => {
         widget.activeCellIndex = 1;
         await NotebookActions.pasteFromSystemClipboard(widget);
         expect(signals.length).toBe(1);
-        expect(signals[0].action).toBe('copy');
+        expect(signals[0].previousInteraction).toBe('copy');
       });
 
       it('should emit a signal with the number of copied cells', async () => {
-        let signals: {
-          action: 'copy' | 'cut' | 'paste' | null;
-          count: number;
-        }[] = [];
+        let signals: Notebook.IPasteCells[] = [];
         widget.cellsPasted.connect(
-          (
-            _: Notebook,
-            interaction: {
-              action: 'copy' | 'cut' | 'paste' | null;
-              count: number;
-            }
-          ) => {
+          (_: Notebook, interaction: Notebook.IPasteCells) => {
             signals.push(interaction);
           }
         );
@@ -1767,22 +1740,13 @@ describe('@jupyterlab/notebook', () => {
         widget.activeCellIndex = 1;
         await NotebookActions.pasteFromSystemClipboard(widget);
         expect(signals.length).toBe(1);
-        expect(signals[0].count).toBe(2);
+        expect(signals[0].cellCount).toBe(2);
       });
 
       it('should emit a signal with action to null', async () => {
-        let signals: {
-          action: 'copy' | 'cut' | 'paste' | null;
-          count: number;
-        }[] = [];
+        let signals: Notebook.IPasteCells[] = [];
         widget.cellsPasted.connect(
-          (
-            _: Notebook,
-            interaction: {
-              action: 'copy' | 'cut' | 'paste' | null;
-              count: number;
-            }
-          ) => {
+          (_: Notebook, interaction: Notebook.IPasteCells) => {
             signals.push(interaction);
           }
         );
@@ -1806,8 +1770,8 @@ describe('@jupyterlab/notebook', () => {
         await NotebookActions.copyToSystemClipboard(widget2);
         await NotebookActions.pasteFromSystemClipboard(widget);
         expect(signals.length).toBe(1);
-        expect(signals[0].count).toBe(1);
-        expect(signals[0].action).toBeNull();
+        expect(signals[0].cellCount).toBe(1);
+        expect(signals[0].previousInteraction).toBeNull();
       });
     });
 


### PR DESCRIPTION
This PR adds a signal when cells are pasted to the notebook.

This signal contains an "interaction" object:

```ts
{
  // 'null' if the pasted cell doesn't provide from the same Notebook.
  // Otherwise it should be one of `copy` or `cut`.
  action: 'copy' | 'cut' | 'paste' | null;

  // Number of cells pasted.
  count: number; 
}
```


## References

Fixes:
- https://github.com/jupyterlab/jupyterlab/issues/17488

Related to
- https://github.com/jupyterlab/jupyterlab/issues/13228
- https://github.com/jupyter/nbgrader/issues/1083

## Code changes

- Add a new signal to the `Notebook` widget, which emits when the `lastClipboardInteraction` is set to `'paste'`.
- Add a new private variable `_localCopy` to the notebook widget, which get the last copied (or cut) cell.
- Add unit tests

## User-facing changes

None

## Backwards-incompatible changes

None
