### PR TITLE
Enable save in collaborative mode

### DIFF
--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -841,12 +841,6 @@ function addCommands(
 
   const caption = () => {
     if (shell.currentWidget) {
-      const context = docManager.contextForWidget(shell.currentWidget);
-      if (context?.model.collaborative) {
-        return trans.__(
-          'In collaborative mode, the document is saved automatically after every change'
-        );
-      }
       if (!isWritable()) {
         return trans.__(
           `Document is read-only. "Save" is disabled; use "Save as…" instead`

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -948,8 +948,7 @@ or load the version on disk (revert)?`,
     }
   }
 
-  private _createSaveOptions(): Partial<Contents.IModel> &
-    Contents.IContentProvisionOptions {
+  private _createSaveOptions(): Partial<Contents.IModel> {
     let content: PartialJSONValue = null;
     if (this._factory.fileFormat === 'json') {
       content = this._model.toJSON();
@@ -963,8 +962,7 @@ or load the version on disk (revert)?`,
     return {
       type: this._factory.contentType,
       format: this._factory.fileFormat,
-      content,
-      contentProviderId: this._contentProviderId
+      content
     };
   }
 

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -755,9 +755,11 @@ export class Context<
           );
           return this._raiseConflict(model, options);
         }
-
         return this._manager.contents
-          .save(path, options)
+          .save(path, {
+            ...options,
+            contentProviderId: this._contentProviderId
+          })
           .then(async contentsModel => {
             const model = await this._manager.contents.get(path, {
               content: false,

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -604,13 +604,6 @@ export class Context<
 
     try {
       await this._manager.ready;
-      if (this._model.collaborative) {
-        // Files cannot be saved in collaborative mode. The "save" command
-        // is disabled in the UI, but if the user tries to save anyway, act
-        // as though it succeeded.
-        this._saveState.emit('completed');
-        return Promise.resolve();
-      }
 
       const value = await this._maybeSave(options);
       if (this.isDisposed) {
@@ -955,7 +948,8 @@ or load the version on disk (revert)?`,
     }
   }
 
-  private _createSaveOptions(): Partial<Contents.IModel> {
+  private _createSaveOptions(): Partial<Contents.IModel> &
+    Contents.IContentProvisionOptions {
     let content: PartialJSONValue = null;
     if (this._factory.fileFormat === 'json') {
       content = this._model.toJSON();
@@ -969,7 +963,8 @@ or load the version on disk (revert)?`,
     return {
       type: this._factory.contentType,
       format: this._factory.fileFormat,
-      content
+      content,
+      contentProviderId: this._contentProviderId
     };
   }
 

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -454,7 +454,7 @@ export namespace Contents {
      */
     save(
       path: string,
-      options?: Partial<IModel> & Contents.IContentProvisionOptions
+      options?: Partial<IModel> & Partial<Contents.IContentProvisionOptions>
     ): Promise<IModel>;
 
     /**
@@ -957,7 +957,8 @@ export class ContentsManager implements Contents.IManager {
    */
   save(
     path: string,
-    options: Partial<Contents.IModel> & Contents.IContentProvisionOptions = {}
+    options: Partial<Contents.IModel> &
+      Partial<Contents.IContentProvisionOptions> = {}
   ): Promise<Contents.IModel> {
     const globalPath = this.normalize(path);
     const [drive, localPath] = this._driveForPath(path);

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -608,7 +608,10 @@ export namespace Contents {
      * @returns A promise which resolves with the file content model when the
      *   file is saved.
      */
-    save(localPath: string, options?: Partial<IModel>): Promise<IModel>;
+    save(
+      localPath: string,
+      options?: Partial<IModel> & Contents.IContentProvisionOptions
+    ): Promise<IModel>;
 
     /**
      * Copy a file into a given directory.
@@ -954,7 +957,7 @@ export class ContentsManager implements Contents.IManager {
    */
   save(
     path: string,
-    options: Partial<Contents.IModel> = {}
+    options: Partial<Contents.IModel> & Contents.IContentProvisionOptions = {}
   ): Promise<Contents.IModel> {
     const globalPath = this.normalize(path);
     const [drive, localPath] = this._driveForPath(path);


### PR DESCRIPTION
## References #14619 

When `jupyter-collaboration` is installed, files were always autosaved regardless of the autosave setting and manual saving is disabled. This PR restores manual save functionality in RTC by re-enabling the save action and removing the tooltip.

This is part of a broader fix and relates to the corresponding PR in [`jupyter-collaboration`](https://github.com/jupyterlab/jupyter-collaboration/pull/479).
