### PR TITLE
Fix editing shortcuts on Safari (allow shortcut edit button to receive focus)

### DIFF
--- a/packages/shortcuts-extension/src/components/ShortcutInput.tsx
+++ b/packages/shortcuts-extension/src/components/ShortcutInput.tsx
@@ -385,6 +385,7 @@ export class ShortcutInput extends React.Component<
           }
           disabled={!this.state.isAvailable || !this.state.isFunctional}
           onClick={this.handleSubmit}
+          tabIndex={0}
         >
           {this.state.isAvailable ? <checkIcon.react /> : <errorIcon.react />}
         </button>


### PR DESCRIPTION
The onBlur event in ShortcutInput assumes the button can receive focus, but this is [not the case in Safari](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#clicking_and_focus) unless tabIndex is set.

As a result, in [this check in onBlur](https://github.com/jupyterlab/jupyterlab/blob/a0253d2d5db86c862dbf434041eafc9affcec860/packages/shortcuts-extension/src/components/ShortcutInput.tsx#L396), `event.relatedTarget` was not the button, but rather the nearest focusable element (the Panel).

I'm not sure if there's a better way for what onBlur is meant to achieve that doesn't involve being sensitive to what is gaining focus for an element that's not really getting focused? In any case, this fixes setting keyboard shortcuts for me in Safari. I'm not 100% sure dismissing the input on blur is entirely desirable, so removing the onBlur callback altogether also fixes the problem.

## References

closes #16186 

## Code changes

sets tabindex=0 on the submit button for keyboard shortcuts to fix `onBlur` target detection.

## User-facing changes

For Safari users, editing keyboard shortcuts should work now.

## Backwards-incompatible changes

N/A
