### PR TITLE
Fix rendering of long cell editors in windowed notebook

### DIFF
--- a/packages/notebook/src/windowing.ts
+++ b/packages/notebook/src/windowing.ts
@@ -37,6 +37,16 @@ function isInScrollingNotebook(element: Element | null): boolean {
 }
 
 /**
+ * Check whether the element is part of a CodeMirror editor.
+ */
+function isCodeMirrorElement(element: Element | null): boolean {
+  if (!element) {
+    return false;
+  }
+  return !!element.closest('.cm-editor');
+}
+
+/**
  * Subclass IntersectionObserver to allow suspending callbacks when notebook is scrolling.
  */
 window.IntersectionObserver = class extends window.IntersectionObserver {
@@ -62,7 +72,11 @@ window.IntersectionObserver = class extends window.IntersectionObserver {
     const entriesInScrollingNotebook = [];
     const nonOutputEntries = [];
     for (const entry of entries) {
-      if (isInScrollingNotebook(entry.target)) {
+      // Do not delay callbacks to CodeMirror editor logic
+      if (
+        isInScrollingNotebook(entry.target) &&
+        !isCodeMirrorElement(entry.target)
+      ) {
         entriesInScrollingNotebook.push(entry);
       } else {
         nonOutputEntries.push(entry);


### PR DESCRIPTION
## References

- Fixes https://github.com/jupyterlab/jupyterlab/issues/17507

## Code changes

Does not delay the intersection observer callbacks for CodeMirror editor so that the lines can be rendered as user scrolls through the notebook

## User-facing changes

All lines render again,

## Backwards-incompatible changes

None
