### PR TITLE
Add updatable fields in user manager

### DIFF
--- a/galata/src/galata.ts
+++ b/galata/src/galata.ts
@@ -271,7 +271,8 @@ export namespace galata {
         initials: 'JP',
         color: 'var(--jp-collaborator-color1)'
       },
-      permissions: {}
+      permissions: {},
+      updatableFields: []
     };
     if (mockUser) {
       if (typeof mockUser !== 'boolean') {

--- a/packages/services/src/testutils.ts
+++ b/packages/services/src/testutils.ts
@@ -764,6 +764,7 @@ export class FakeUserManager extends BaseManager implements User.IManager {
 
   private _identity: User.IIdentity;
   private _permissions: ReadonlyJSONObject;
+  private _updatableFields: User.UpdatableUserField[];
 
   private _userChanged = new Signal<this, User.IUser>(this);
   private _connectionFailure = new Signal<this, Error>(this);
@@ -774,7 +775,8 @@ export class FakeUserManager extends BaseManager implements User.IManager {
   constructor(
     options: UserManager.IOptions = {},
     identity: User.IIdentity,
-    permissions: ReadonlyJSONObject
+    permissions: ReadonlyJSONObject,
+    updatableFields: User.UpdatableUserField[] = []
   ) {
     super(options);
 
@@ -784,10 +786,12 @@ export class FakeUserManager extends BaseManager implements User.IManager {
       setTimeout(() => {
         this._identity = identity;
         this._permissions = permissions;
+        this._updatableFields = updatableFields;
 
         this._userChanged.emit({
           identity: this._identity,
-          permissions: this._permissions as PartialJSONObject
+          permissions: this._permissions as PartialJSONObject,
+          updatableFields: this._updatableFields
         });
 
         resolve();
@@ -833,6 +837,13 @@ export class FakeUserManager extends BaseManager implements User.IManager {
    */
   get permissions(): ReadonlyJSONObject | null {
     return this._permissions;
+  }
+
+  /**
+   * Get the most recently fetched updatable fields.
+   */
+  get updatableFields(): User.UpdatableUserField[] | null {
+    return this._updatableFields;
   }
 
   /**


### PR DESCRIPTION
This PR add a `updatableFields` property to the user manager.
This property is optional, and will be populated by the server API after https://github.com/jupyter-server/jupyter_server/pull/1518

## References

Related to:
- https://github.com/jupyterlab/jupyterlab/issues/14327
- https://github.com/jupyterlab/jupyter-collaboration/issues/350

## Code changes

- add a new type `UpdatableUserField` in `User` namespace.
- add a new private variable in `UserManager`, and a getter. This variable can be populated when refreshing the user information from the server, but the information is not required.
- Update the tests that mock user.

## User-facing changes

None

## Backwards-incompatible changes

None
