### PR TITLE
Fixing Settings Editor Filtered View's Defaulting Behavior in SettingsFormEditor

### DIFF
--- a/packages/settingeditor/src/SettingsFormEditor.tsx
+++ b/packages/settingeditor/src/SettingsFormEditor.tsx
@@ -239,15 +239,37 @@ export class SettingsFormEditor extends React.Component<
     );
   }
 
+  //LYNN ADDITION !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   private _onChange = (e: IChangeEvent<ReadonlyPartialJSONObject>): void => {
     this.props.hasError(e.errors.length !== 0);
-    this._formData = e.formData as ReadonlyJSONObject;
+
+    // Create a deep copy of the current form data to work with
+    const updatedFormData = JSONExt.deepCopy(
+      this._formData as PartialJSONObject
+    );
+
+    // Only update fields that are actually present in the filtered view
+    if (e.formData) {
+      // Safely iterate over the keys in e.formData
+      Object.keys(e.formData).forEach(key => {
+        // Use type assertion to tell TypeScript this is safe
+        const formData = e.formData as PartialJSONObject;
+        if (formData && key in formData) {
+          updatedFormData[key] = formData[key];
+        }
+      });
+    }
+
+    // Convert back to ReadonlyJSONObject for this._formData
+    this._formData = updatedFormData as ReadonlyJSONObject;
+
     if (e.errors.length === 0) {
       this.props.updateDirtyState(true);
       void this._debouncer.invoke();
     }
     this.props.onSelect(this.props.settings.id);
   };
+  //LYNN ADDITION !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   private _setUiSchema(prevRenderers?: { [id: string]: Field }) {
     const renderers = this.props.renderers[this.props.settings.id];
@@ -315,6 +337,7 @@ export class SettingsFormEditor extends React.Component<
     if (!filteredSchema?.properties) {
       return this._formData;
     }
+
     const filteredFormData = JSONExt.deepCopy(
       this._formData as PartialJSONObject
     );

--- a/packages/settingeditor/src/SettingsFormEditor.tsx
+++ b/packages/settingeditor/src/SettingsFormEditor.tsx
@@ -239,7 +239,6 @@ export class SettingsFormEditor extends React.Component<
     );
   }
 
-  //LYNN ADDITION !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   private _onChange = (e: IChangeEvent<ReadonlyPartialJSONObject>): void => {
     this.props.hasError(e.errors.length !== 0);
 
@@ -269,7 +268,6 @@ export class SettingsFormEditor extends React.Component<
     }
     this.props.onSelect(this.props.settings.id);
   };
-  //LYNN ADDITION !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   private _setUiSchema(prevRenderers?: { [id: string]: Field }) {
     const renderers = this.props.renderers[this.props.settings.id];


### PR DESCRIPTION
## References
Fixes #16697 

## Problem Description
As described in the referenced issue, when users interact with a filtered view of the settings editor (e.g., after performing a search), only the matching settings fields are rendered. If a user modifies a setting while a filter is active, the component saves only the filtered subset of the settings (formData), discarding any previously configured settings that were not visible at the time.

This results in a significant data loss issue: unrendered fields, even if previously customized, are removed from the saved configuration, effectively resetting them to defaults. This behavior violates user expectations, especially in workflows where filtering is used to find and tweak individual settings.

## Code changes

The previous implementation of the _onChange method directly replaced this._formData with e._formData which only contains the fields that are currently visible in the UI. This causes all settings not currently visible to be lost, as described in #16697. 

In our implementation, we create a deep clone of the existing form data and only update fields changed in the current view. We iterate through e.formData keys and apply the changed fields while keeping all other settings not visible in the current UI.

## User-facing changes
None in terms of updating UI, but the backend change update makes sure that when the user selects an filtered item (checkbox or input), the previously selected setting preferences do not reset.

## Backwards-incompatible changes
N/A

## Notes
The change is fully contained within SettingsFormEditor and does not affect the plugin registry, plugin list, or external APIs. No breaking changes were introduced.
