### PR TITLE
Add galata's `__init__.py` to ignored links to due 429 error

### DIFF
--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -153,4 +153,4 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
         with:
           ignore_glob: "docs/api packages/ui-components/docs/source/ui_components.rst images"
-          ignore_links: ".*/images/[\\w-]+.png https://docs.github.com/en/.* https://jupyterlab.github.io https://mybinder.org/v2/gh/jupyterlab/.* https://github.com/[^/]+/?$ https://blog.jupyter.org/.* https://pypi.org/.* https://code.visualstudio.com/.*"
+          ignore_links: ".*/images/[\\w-]+.png https://docs.github.com/en/.* https://jupyterlab.github.io https://mybinder.org/v2/gh/jupyterlab/.* https://github.com/[^/]+/?$ https://blog.jupyter.org/.* https://pypi.org/.* https://code.visualstudio.com/.* https://github.com/jupyterlab/jupyterlab/tree/.*/jupyterlab/galata/__init__.py"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

The check links job now more often fails than not with `429: Too Many Requests` on the `jupyterlab/galata/__init__.py` link:

```
_ /home/runner/work/jupyterlab/jupyterlab/galata/README.md: https://github.com/jupyterlab/jupyterlab/tree/main/jupyterlab/galata/__init__.py _
https://github.com/jupyterlab/jupyterlab/tree/main/jupyterlab/galata/__init__.py: 429: Too Many Requests
```

This PR disables checking of that link.

Also see https://github.com/jupyterlab/jupyterlab/pull/17537#issuecomment-2851184465


## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None