### PR TITLE
Add a setting to configure the default log level for the Log Console

### DIFF
--- a/packages/logconsole-extension/schema/plugin.json
+++ b/packages/logconsole-extension/schema/plugin.json
@@ -39,6 +39,13 @@
       "title": "Status Bar Item flash",
       "description": "Whether to flash on new log message or not",
       "default": true
+    },
+    "defaultLogLevel": {
+      "type": "string",
+      "title": "Default Log Level",
+      "description": "Default log level for loggers",
+      "enum": ["critical", "error", "warning", "info", "debug"],
+      "default": "warning"
     }
   },
   "additionalProperties": false,

--- a/packages/logconsole-extension/src/index.tsx
+++ b/packages/logconsole-extension/src/index.tsx
@@ -298,6 +298,8 @@ function activateLogConsole(
       loggerRegistry.maxLength = settings.get('maxLogEntries')
         .composite as number;
       status.model.flashEnabled = settings.get('flash').composite as boolean;
+      loggerRegistry.defaultLogLevel = settings.get('defaultLogLevel')
+        .composite as LogLevel;
     };
 
     Promise.all([settingRegistry.load(LOG_CONSOLE_PLUGIN_ID), app.restored])

--- a/packages/logconsole/src/logger.ts
+++ b/packages/logconsole/src/logger.ts
@@ -414,7 +414,13 @@ export class Logger implements ILogger {
   private _level: LogLevel = 'warning';
 }
 
+/**
+ * The namespace for Logger class statics.
+ */
 export namespace Logger {
+  /**
+   * The options used to initialize a Logger.
+   */
   export interface IOptions {
     /**
      * The log source identifier.
@@ -431,7 +437,13 @@ export namespace Logger {
   }
 }
 
+/**
+ * The namespace for Logger class private statics.
+ */
 namespace Private {
+  /**
+   * The log level enum.
+   */
   export enum LogLevel {
     debug,
     info,

--- a/packages/logconsole/src/logger.ts
+++ b/packages/logconsole/src/logger.ts
@@ -201,6 +201,9 @@ export class Logger implements ILogger {
       contentFactory: new LogConsoleModelContentFactory(),
       maxLength: options.maxLength
     });
+    if (options.level) {
+      this._level = options.level;
+    }
   }
 
   /**
@@ -421,6 +424,10 @@ export namespace Logger {
      * The maximum number of messages to store.
      */
     maxLength: number;
+    /**
+     * The default log level.
+     */
+    level?: LogLevel;
   }
 }
 

--- a/packages/logconsole/src/logger.ts
+++ b/packages/logconsole/src/logger.ts
@@ -201,9 +201,7 @@ export class Logger implements ILogger {
       contentFactory: new LogConsoleModelContentFactory(),
       maxLength: options.maxLength
     });
-    if (options.level) {
-      this._level = options.level;
-    }
+    this._level = options.level ?? 'warning';
   }
 
   /**
@@ -411,7 +409,7 @@ export class Logger implements ILogger {
   private _stateChanged = new Signal<this, IStateChange>(this);
   private _rendermime: IRenderMimeRegistry | null = null;
   private _version = 0;
-  private _level: LogLevel = 'warning';
+  private _level: LogLevel;
 }
 
 /**

--- a/packages/logconsole/src/registry.ts
+++ b/packages/logconsole/src/registry.ts
@@ -24,7 +24,7 @@ export class LoggerRegistry implements ILoggerRegistry {
   constructor(options: LoggerRegistry.IOptions) {
     this._defaultRendermime = options.defaultRendermime;
     this._maxLength = options.maxLength;
-    this._defaultLogLevel = 'warning';
+    this._defaultLogLevel = options.defaultLogLevel ?? 'warning';
   }
 
   /**
@@ -85,15 +85,13 @@ export class LoggerRegistry implements ILoggerRegistry {
 
   /**
    * The default log level for new loggers.
+   * Applies to loggers created after the change.
    */
   get defaultLogLevel(): LogLevel {
     return this._defaultLogLevel;
   }
   set defaultLogLevel(value: LogLevel) {
     this._defaultLogLevel = value;
-    this._loggers.forEach(logger => {
-      logger.level = value;
-    });
   }
 
   /**
@@ -123,9 +121,26 @@ export class LoggerRegistry implements ILoggerRegistry {
   private _isDisposed = false;
 }
 
+/**
+ * The namespace for LoggerRegistry class statics.
+ */
 export namespace LoggerRegistry {
+  /**
+   * The options used to initialize a LoggerRegistry.
+   */
   export interface IOptions {
+    /**
+     * The default rendermime to render outputs with when logger is not
+     * supplied with one.
+     */
     defaultRendermime: IRenderMimeRegistry;
+    /**
+     * The maximum length of the log messages.
+     */
     maxLength: number;
+    /**
+     * The default log level for the loggers.
+     */
+    defaultLogLevel?: LogLevel;
   }
 }

--- a/packages/logconsole/src/registry.ts
+++ b/packages/logconsole/src/registry.ts
@@ -85,7 +85,7 @@ export class LoggerRegistry implements ILoggerRegistry {
 
   /**
    * The default log level for new loggers.
-   * Applies to loggers created after the change.
+   * The new value will be applied to new loggers only.
    */
   get defaultLogLevel(): LogLevel {
     return this._defaultLogLevel;

--- a/packages/logconsole/src/registry.ts
+++ b/packages/logconsole/src/registry.ts
@@ -4,7 +4,12 @@
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { ISignal, Signal } from '@lumino/signaling';
 import { Logger } from './logger';
-import { ILogger, ILoggerRegistry, ILoggerRegistryChange } from './tokens';
+import {
+  ILogger,
+  ILoggerRegistry,
+  ILoggerRegistryChange,
+  LogLevel
+} from './tokens';
 
 /**
  * A concrete implementation of ILoggerRegistry.
@@ -19,6 +24,7 @@ export class LoggerRegistry implements ILoggerRegistry {
   constructor(options: LoggerRegistry.IOptions) {
     this._defaultRendermime = options.defaultRendermime;
     this._maxLength = options.maxLength;
+    this._defaultLogLevel = 'warning';
   }
 
   /**
@@ -35,7 +41,11 @@ export class LoggerRegistry implements ILoggerRegistry {
       return logger;
     }
 
-    logger = new Logger({ source, maxLength: this.maxLength });
+    logger = new Logger({
+      source,
+      maxLength: this.maxLength,
+      level: this.defaultLogLevel
+    });
     logger.rendermime = this._defaultRendermime;
     loggers.set(source, logger);
 
@@ -74,6 +84,19 @@ export class LoggerRegistry implements ILoggerRegistry {
   }
 
   /**
+   * The default log level for new loggers.
+   */
+  get defaultLogLevel(): LogLevel {
+    return this._defaultLogLevel;
+  }
+  set defaultLogLevel(value: LogLevel) {
+    this._defaultLogLevel = value;
+    this._loggers.forEach(logger => {
+      logger.level = value;
+    });
+  }
+
+  /**
    * Whether the register is disposed.
    */
   get isDisposed(): boolean {
@@ -95,6 +118,7 @@ export class LoggerRegistry implements ILoggerRegistry {
   private _defaultRendermime: IRenderMimeRegistry;
   private _loggers = new Map<string, ILogger>();
   private _maxLength: number;
+  private _defaultLogLevel: LogLevel;
   private _registryChanged = new Signal<this, ILoggerRegistryChange>(this);
   private _isDisposed = false;
 }


### PR DESCRIPTION
## References

Currently the log level for the log console needs to be manually changed each time a new logger is created (potentially for each notebook), if the default `warning` log level is not what the user wants.

This change proposes a way to change the default log level by exposing a new setting.

This will also be useful to JupyterLite users who may want to configure the log level to `info` by default: https://github.com/jupyterlite/jupyterlite/pull/1642

## Code changes

- [x] Add a new `defaultLogLevel` setting to configure the default log level of the Log Console (still defaulting to `warning` as before)

## User-facing changes

https://github.com/user-attachments/assets/45fd3f92-7479-4853-a9ef-202acf102508

## Backwards-incompatible changes

None
