### PR TITLE
Auto-open uploaded files with size and settings control

### DIFF
--- a/galata/test/galata/filebrowser.spec.ts
+++ b/galata/test/galata/filebrowser.spec.ts
@@ -2,6 +2,8 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { expect, test } from '@jupyterlab/galata';
+import * as fs from 'fs';
+import * as path from 'path';
 
 const DEFAULT_NAME = 'Untitled.ipynb';
 
@@ -44,5 +46,74 @@ test.describe('filebrowser helper', () => {
     await expect(
       page.getByRole('main').getByRole('tab', { name: DEFAULT_NAME })
     ).toHaveCount(2);
+  });
+});
+
+test.describe('upload auto-open behavior', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.activity.closeAll();
+  });
+
+  test('small notebook uploads and opens automatically', async ({
+    page,
+    tmpPath
+  }) => {
+    const nbName = 'small.ipynb';
+    const nbPath = path.join(tmpPath, nbName);
+    fs.mkdirSync(tmpPath, { recursive: true });
+    fs.writeFileSync(
+      nbPath,
+      JSON.stringify({
+        cells: [],
+        metadata: {},
+        nbformat: 4,
+        nbformat_minor: 5
+      })
+    );
+
+    await page.filebrowser.openDirectory(tmpPath);
+
+    // Intercept the file chooser that the Upload button triggers
+    const [fileChooser] = await Promise.all([
+      page.waitForEvent('filechooser'),
+      page.getByTitle('Upload').click()
+    ]);
+    await fileChooser.setFiles(nbPath);
+    await page
+      .locator('.jp-Dialog')
+      .getByRole('button', { name: 'Select Kernel', exact: true })
+      .click();
+    expect(await page.activity.isTabActive(nbName)).toBe(true);
+  });
+
+  test('large notebook (>50 MB) uploads but does not auto-open (notification shown)', async ({
+    page,
+    tmpPath
+  }) => {
+    const bigName = 'big.ipynb';
+    const bigPath = path.join(tmpPath, bigName);
+    const minimal = JSON.stringify({
+      cells: [],
+      metadata: {},
+      nbformat: 4,
+      nbformat_minor: 5
+    });
+    const repeat = Math.ceil((52 * 1024 * 1024) / minimal.length);
+    fs.mkdirSync(tmpPath, { recursive: true });
+    fs.writeFileSync(bigPath, minimal.repeat(repeat));
+
+    await page.filebrowser.openDirectory(tmpPath);
+
+    const [fileChooser] = await Promise.all([
+      page.waitForEvent('filechooser'),
+      page.getByTitle('Upload').click()
+    ]);
+    await fileChooser.setFiles(bigPath);
+
+    expect(await page.activity.isTabActive(bigName)).toBe(false);
+    await page.getByRole('button', { name: 'Upload', exact: true }).click();
+    //Wait for upload to finish
+    await page.waitForTimeout(1500);
+    await expect(page.getByText(/Uploaded big\.ipynb.*/)).toBeVisible();
   });
 });

--- a/packages/filebrowser-extension/schema/browser.json
+++ b/packages/filebrowser-extension/schema/browser.json
@@ -242,6 +242,18 @@
       "title": "Navigate files and directories with single click",
       "description": "Whether to allow single click selection on file browser items",
       "default": false
+    },
+    "autoOpenUploads": {
+      "type": "boolean",
+      "title": "Auto-open uploads",
+      "description": "Automatically open uploaded notebooks",
+      "default": true
+    },
+    "maxAutoOpenSizeMB": {
+      "type": "number",
+      "title": "Max auto-open size",
+      "description": "Maximum file size (MB) to auto-open",
+      "default": 50
     }
   },
   "additionalProperties": false,

--- a/packages/filebrowser/src/upload.ts
+++ b/packages/filebrowser/src/upload.ts
@@ -9,6 +9,8 @@ import {
 } from '@jupyterlab/translation';
 import { fileUploadIcon, ToolbarButton } from '@jupyterlab/ui-components';
 import { FileBrowserModel } from './model';
+import { Contents } from '@jupyterlab/services';
+import { ISignal, Signal } from '@lumino/signaling';
 
 /**
  * A widget which provides an upload button.
@@ -35,6 +37,13 @@ export class Uploader extends ToolbarButton {
   }
 
   /**
+   * A signal emitted with file info when a batch of upload completes .
+   */
+  get filesUploaded(): ISignal<this, Contents.IModel[]> {
+    return this._filesUploaded;
+  }
+
+  /**
    * The underlying file browser fileBrowserModel for the widget.
    *
    * This cannot be named model as that conflicts with the model property of VDomRenderer.
@@ -47,12 +56,17 @@ export class Uploader extends ToolbarButton {
   private _onInputChanged = () => {
     const files = Array.prototype.slice.call(this._input.files) as File[];
     const pending = files.map(file => this.fileBrowserModel.upload(file));
-    void Promise.all(pending).catch(error => {
-      void showErrorMessage(
-        this._trans._p('showErrorMessage', 'Upload Error'),
-        error
-      );
-    });
+    void Promise.all(pending)
+      .then(models => {
+        // emit the batch
+        this._filesUploaded.emit(models);
+      })
+      .catch(error => {
+        void showErrorMessage(
+          this._trans._p('showErrorMessage', 'Upload Error'),
+          error
+        );
+      });
   };
 
   /**
@@ -67,6 +81,7 @@ export class Uploader extends ToolbarButton {
   protected translator: ITranslator;
   private _trans: TranslationBundle;
   private _input = Private.createUploadInput();
+  private _filesUploaded = new Signal<this, Contents.IModel[]>(this);
 }
 
 /**

--- a/packages/filebrowser/src/uploadstatus.tsx
+++ b/packages/filebrowser/src/uploadstatus.tsx
@@ -212,7 +212,7 @@ export namespace FileUploadStatus {
           this._items,
           val => val.path === uploads.newValue.path
         );
-      }
+      } else return;
 
       this.stateChanged.emit(void 0);
     };


### PR DESCRIPTION
## Fixes #17493 

### Description:

This PR adds a new plugin that improves the UX of file uploads in the File Browser:

- Automatically opens uploaded files if it's a single file and within a size threshold.
- Shows a notification with “Open All” for multiple uploads or large files.
 ![image](https://github.com/user-attachments/assets/27ebcc7e-b9b9-4791-9f68-32d77371f26b)
- Introduces two new user settings under filebrowser:
  - `autoOpenUploads` (default: `true`)
  - `maxAutoOpenSizeMB` (default: `50`)

Since `FileBrowserModel` does not distinguish between single and multiple file uploads, I added a new `filesUploaded` signal in the `Uploader` class to emit upload results, which this plugin listens to.
