### PR TITLE
Use hatch to get the version

### DIFF
--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -42,7 +42,7 @@ jobs:
             # Set job status as failed if
             # - branch is not "main"
             # - and current version is not a pre release of a zeroed patch version
-            if [[ "${GITHUB_BASE_REF}" != "main" && ! ( $(python setup.py --version) =~ ^[0-9]+\.[0-9]+\.0(\.dev|a|b|rc)[0-9]+$ ) ]]; then
+            if [[ "${GITHUB_BASE_REF}" != "main" && ! ( $(hatch version) =~ ^[0-9]+\.[0-9]+\.0(\.dev|a|b|rc)[0-9]+$ ) ]]; then
               exit 1
             fi
           fi

--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install -U pip jupyterlab-translate~=1.0
+          python -m pip install -U pip jupyterlab-translate~=1.0 hatch
 
       - name: Compute hash
         id: currentHash


### PR DESCRIPTION
## References

Fixes #17558 

## Code changes

Replaces `python setup.py --version` with `hatch version`


To test this change, run:

```
if [[ ( $(hatch version) =~ ^[0-9]+\.[0-9]+\.0(\.dev|a|b|rc)[0-9]+$ )]]; then echo "pre-release"; fi
```

on both `main` and `4.4.x ` branch and see that it correctly prints `pre-release` on `main` and nothing on `4.4.x`

## User-facing changes

None

## Backwards-incompatible changes

None