### PR TITLE
Add a `selectionChanged` signal to the file browser

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -9,6 +9,15 @@ Extension Migration Guide
 JupyterLab 4.4 to 4.5
 ---------------------
 
+File Browser updates
+^^^^^^^^^^^^^^^^^^^^
+
+The file browser now emits a ``selectionChanged`` signal when the selected files and folders change.
+
+If you maintain an extension which implements a subclass of ``DirListing`` that changes selection, it is recommended to
+emit the ``selectionChanged`` signal when the selection changes. This will ensure that any listeners to the
+``selectionChanged`` signal are notified of the change.
+
 API updates
 ^^^^^^^^^^^
 

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -13,6 +13,7 @@ import {
   SidePanel,
   Toolbar
 } from '@jupyterlab/ui-components';
+import { ISignal, Signal } from '@lumino/signaling';
 import { Panel } from '@lumino/widgets';
 import { createRef } from 'react';
 import { BreadCrumbs } from './crumbs';
@@ -128,6 +129,9 @@ export class FileBrowser extends SidePanel {
       state: options.state
     });
     this.listing.addClass(LISTING_CLASS);
+    this.listing.selectionChanged.connect(() => {
+      this._selectionChanged.emit();
+    });
 
     this.mainPanel.addWidget(this.crumbs);
     this.mainPanel.addWidget(this.filterToolbar);
@@ -299,6 +303,13 @@ export class FileBrowser extends SidePanel {
    */
   selectedItems(): IterableIterator<Contents.IModel> {
     return this.listing.selectedItems();
+  }
+
+  /**
+   * A signal emitted when the selection changes in the file browser.
+   */
+  get selectionChanged(): ISignal<this, void> {
+    return this._selectionChanged;
   }
 
   /**
@@ -539,6 +550,7 @@ export class FileBrowser extends SidePanel {
   private _showHiddenFiles: boolean = false;
   private _showLastModifiedColumn: boolean = true;
   private _sortNotebooksFirst: boolean = false;
+  private _selectionChanged = new Signal<this, void>(this);
 }
 
 /**

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1747,6 +1747,7 @@ export class DirListing extends Widget {
           } else {
             this.selection[path] = true;
           }
+          this._selectionChanged.emit();
 
           this.update();
           // Key was handled, so return.

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -317,6 +317,13 @@ export class DirListing extends Widget {
   }
 
   /**
+   * A signal fired when the selection changes.
+   */
+  get selectionChanged(): ISignal<DirListing, void> {
+    return this._selectionChanged;
+  }
+
+  /**
    * Create an iterator over the listing's selected items.
    *
    * @returns A new iterator over the listing's selected items.
@@ -710,6 +717,7 @@ export class DirListing extends Widget {
    */
   clearSelectedItems(): void {
     this.selection = Object.create(null);
+    this._selectionChanged.emit();
   }
 
   /**
@@ -1357,6 +1365,7 @@ export class DirListing extends Widget {
           this._sortedItems.forEach(
             (item: Contents.IModel) => (this.selection[item.path] = true)
           );
+          this._selectionChanged.emit();
         } else {
           // Unselect all items
           this.clearSelectedItems();
@@ -1487,6 +1496,7 @@ export class DirListing extends Widget {
       if (!altered && event.button === 0) {
         this.clearSelectedItems();
         this.selection[this._softSelection] = true;
+        this._selectionChanged.emit();
         this.update();
       }
       this._softSelection = '';
@@ -2138,6 +2148,7 @@ export class DirListing extends Widget {
       } else {
         this.selection[path] = true;
       }
+      this._selectionChanged.emit();
       this._focusItem(index);
       // Handle multiple select.
     } else if (event.shiftKey) {
@@ -2217,7 +2228,10 @@ export class DirListing extends Widget {
       // the focussed item to gain but not lose selected status on shift-click.
       // (MacOS is irrelevant here because MacOS Finder has no notion of a
       // focused-but-not-selected state.)
-      this.selection[target.path] = true;
+      if (!this.selection[target.path]) {
+        this.selection[target.path] = true;
+        this._selectionChanged.emit();
+      }
       return;
     }
 
@@ -2247,6 +2261,7 @@ export class DirListing extends Widget {
           (!anteAnchor || !this.selection[anteAnchor.path])
         ) {
           delete this.selection[anchor.path];
+          this._selectionChanged.emit();
         }
       } else if (this._allSelectedBetween(fromIndex, index)) {
         shouldAdd = false;
@@ -2256,20 +2271,32 @@ export class DirListing extends Widget {
     // Select (or unselect) the rows between chosen index (target) and the last
     // focussed.
     const step = fromIndex < index ? 1 : -1;
+    let selectionModified = false;
+
     for (let i = fromIndex; i !== index + step; i += step) {
       if (shouldAdd) {
         if (i === fromIndex) {
           // Do not change the selection state of the starting (fromIndex) item.
           continue;
         }
-        this.selection[items[i].path] = true;
+        if (!this.selection[items[i].path]) {
+          this.selection[items[i].path] = true;
+          selectionModified = true;
+        }
       } else {
         if (i === index) {
           // Do not unselect the target item.
           continue;
         }
-        delete this.selection[items[i].path];
+        if (this.selection[items[i].path]) {
+          delete this.selection[items[i].path];
+          selectionModified = true;
+        }
       }
+    }
+
+    if (selectionModified) {
+      this._selectionChanged.emit();
     }
   }
 
@@ -2425,10 +2452,12 @@ export class DirListing extends Widget {
     }
     const path = items[index].path;
     this.selection[path] = true;
+    this._selectionChanged.emit();
 
     if (focus) {
       this._focusItem(index);
     }
+
     this.update();
   }
 
@@ -2515,6 +2544,7 @@ export class DirListing extends Widget {
     key: 'name'
   };
   private _onItemOpened = new Signal<DirListing, Contents.IModel>(this);
+  private _selectionChanged = new Signal<DirListing, void>(this);
   private _drag: Drag | null = null;
   private _dragData: {
     pressX: number;

--- a/packages/filebrowser/test/browser.spec.ts
+++ b/packages/filebrowser/test/browser.spec.ts
@@ -105,6 +105,7 @@ describe('filebrowser/browser', () => {
         expect(items.length).toBeGreaterThan(1);
 
         let selectionChanged = signalToPromise(fileBrowser.selectionChanged);
+        // Select the first item
         await fileBrowser.selectItemByName(items[0].name);
         await selectionChanged;
 
@@ -114,6 +115,7 @@ describe('filebrowser/browser', () => {
         expect(itemNodes.length).toBeGreaterThan(1);
 
         selectionChanged = signalToPromise(fileBrowser.selectionChanged);
+        // Select the second item with shift key to select multiple items
         simulate(
           fileBrowser.node.querySelectorAll(`.${ITEM_CLASS}`)[1]!,
           'mousedown',

--- a/packages/filebrowser/test/browser.spec.ts
+++ b/packages/filebrowser/test/browser.spec.ts
@@ -153,7 +153,6 @@ describe('filebrowser/browser', () => {
         const items = Array.from(model.items());
         expect(items.length).toBeGreaterThan(0);
 
-        let selectionChanged = signalToPromise(fileBrowser.selectionChanged);
         await fileBrowser.selectItemByName(items[1].name);
 
         simulate(
@@ -164,7 +163,7 @@ describe('filebrowser/browser', () => {
         let selectedItems = Array.from(fileBrowser.selectedItems());
         expect(selectedItems.length).toBe(1);
 
-        selectionChanged = signalToPromise(fileBrowser.selectionChanged);
+        const selectionChanged = signalToPromise(fileBrowser.selectionChanged);
 
         // Simulate Ctrl+Space on the focused item
         simulate(

--- a/packages/filebrowser/test/browser.spec.ts
+++ b/packages/filebrowser/test/browser.spec.ts
@@ -54,6 +54,7 @@ describe('filebrowser/browser', () => {
     await contents.newUntitled({ type: 'directory' });
     await contents.newUntitled({ type: 'file' });
     await contents.newUntitled({ type: 'notebook' });
+    await model.cd();
   });
 
   describe('FileBrowser', () => {
@@ -77,6 +78,54 @@ describe('filebrowser/browser', () => {
         const toolbar = fileBrowser.toolbar.node;
         expect(toolbar.getAttribute('aria-label')).toEqual('file browser');
         expect(toolbar.getAttribute('role')).toEqual('toolbar');
+      });
+    });
+
+    describe('#selectionChanged', () => {
+      it('should emit when a file is selected', async () => {
+        let selectionChanged = false;
+        fileBrowser.selectionChanged.connect(() => {
+          selectionChanged = true;
+        });
+
+        // Get a file name to select
+        const items = Array.from(model.items());
+        expect(items.length).toBeGreaterThan(0);
+
+        const fileName = items[0].name;
+        await fileBrowser.selectItemByName(fileName);
+
+        expect(selectionChanged).toBe(true);
+      });
+
+      it('should emit when multiple files are selected', async () => {
+        fileBrowser.clearSelectedItems();
+
+        const items = Array.from(model.items());
+        expect(items.length).toBeGreaterThan(1);
+
+        let selectionChanged = signalToPromise(fileBrowser.selectionChanged);
+        await fileBrowser.selectItemByName(items[0].name);
+        await selectionChanged;
+
+        const itemNodes = Array.from(
+          document.querySelectorAll(`.${ITEM_CLASS}`)
+        );
+        expect(itemNodes.length).toBeGreaterThan(1);
+
+        selectionChanged = signalToPromise(fileBrowser.selectionChanged);
+        simulate(
+          fileBrowser.node.querySelectorAll(`.${ITEM_CLASS}`)[1]!,
+          'mousedown',
+          {
+            shiftKey: true
+          }
+        );
+        await selectionChanged;
+
+        // Verify that multiple items are selected
+        const selectedItems = Array.from(fileBrowser.selectedItems());
+        expect(selectedItems.length).toBe(2);
       });
     });
 

--- a/packages/filebrowser/test/browser.spec.ts
+++ b/packages/filebrowser/test/browser.spec.ts
@@ -115,6 +115,7 @@ describe('filebrowser/browser', () => {
         expect(itemNodes.length).toBeGreaterThan(1);
 
         selectionChanged = signalToPromise(fileBrowser.selectionChanged);
+
         // Select the second item with shift key to select multiple items
         simulate(
           fileBrowser.node.querySelectorAll(`.${ITEM_CLASS}`)[1]!,
@@ -144,6 +145,42 @@ describe('filebrowser/browser', () => {
 
         const newSelectedItems = Array.from(fileBrowser.selectedItems());
         expect(newSelectedItems.length).toBe(0);
+      });
+
+      it('should emit when selection is toggled with Ctrl+Space', async () => {
+        fileBrowser.clearSelectedItems();
+
+        const items = Array.from(model.items());
+        expect(items.length).toBeGreaterThan(0);
+
+        let selectionChanged = signalToPromise(fileBrowser.selectionChanged);
+        await fileBrowser.selectItemByName(items[1].name);
+
+        simulate(
+          fileBrowser.node.querySelectorAll(`.${ITEM_CLASS}`)[1]!,
+          'mousedown'
+        );
+
+        let selectedItems = Array.from(fileBrowser.selectedItems());
+        expect(selectedItems.length).toBe(1);
+
+        selectionChanged = signalToPromise(fileBrowser.selectionChanged);
+
+        // Simulate Ctrl+Space on the focused item
+        simulate(
+          fileBrowser.node.querySelectorAll(`.${ITEM_CLASS}`)[1]!,
+          'keydown',
+          {
+            ctrlKey: true,
+            key: ' ',
+            keyCode: 32
+          }
+        );
+
+        await selectionChanged;
+
+        selectedItems = Array.from(fileBrowser.selectedItems());
+        expect(selectedItems.length).toBe(0);
       });
     });
 

--- a/packages/filebrowser/test/browser.spec.ts
+++ b/packages/filebrowser/test/browser.spec.ts
@@ -129,6 +129,22 @@ describe('filebrowser/browser', () => {
         const selectedItems = Array.from(fileBrowser.selectedItems());
         expect(selectedItems.length).toBe(2);
       });
+
+      it('should emit when selection is cleared', async () => {
+        const items = Array.from(model.items());
+        expect(items.length).toBeGreaterThan(0);
+        await fileBrowser.selectItemByName(items[0].name);
+
+        const selectedItems = Array.from(fileBrowser.selectedItems());
+        expect(selectedItems.length).toBeGreaterThan(0);
+
+        const selectionChanged = signalToPromise(fileBrowser.selectionChanged);
+        fileBrowser.clearSelectedItems();
+        await selectionChanged;
+
+        const newSelectedItems = Array.from(fileBrowser.selectedItems());
+        expect(newSelectedItems.length).toBe(0);
+      });
     });
 
     describe('#createNewDirectory', () => {


### PR DESCRIPTION
## References

Fixes #14598 

## Code changes

- [x] Add a `selectionChanged` signal to the file browser and emit it when the file browser selection changes
- [x] Add tests

## User-facing changes

None for regular users.

This will mostly be useful for Notebook 7 which displays some action buttons based on the current selection, and had to workaround that for now in https://github.com/jupyter/notebook/pull/6888

## Backwards-incompatible changes

None.

Of note, the handling of the selection could have been moved to a proper class (owning the signal and the selected path), had `selection` not been `protected` in `DirListing`. But since it's `protected` and may be used in derived classes, better not change it and keep it as it is.
