### PR TITLE
Fix stdin input triggering cell re-execution on Shift+Enter

### DIFF
--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -1188,6 +1188,8 @@ export class Stdin extends Widget implements IStdin {
    * not be called directly by user code.
    */
   handleEvent(event: KeyboardEvent): void {
+    // Stop bubbling
+    event.stopPropagation();
     if (this._resolved) {
       // Do not handle any more key events if the promise was resolved.
       event.preventDefault();


### PR DESCRIPTION
### Fixes https://github.com/jupyterlab/jupyterlab/issues/17564

### Description

This PR updates the `Stdin` widget to call `event.stopPropagation()` at the very beginning of the `handleEvent` method. This ensures that key events like `Shift+Enter` do not bubble up to notebook-level handlers, preventing unintended cell re-execution.