### PR TITLE
Add `standby` callback to lumino polls

### DIFF
--- a/packages/services-extension/src/index.ts
+++ b/packages/services-extension/src/index.ts
@@ -133,12 +133,18 @@ const eventManagerPlugin: ServiceManagerPlugin<Event.IManager> = {
   description: 'The event manager plugin.',
   autoStart: true,
   provides: IEventManager,
-  optional: [IServerSettings],
+  optional: [IServerSettings, IConnectionStatus],
   activate: (
     _: null,
-    serverSettings: ServerConnection.ISettings | undefined
+    serverSettings: ServerConnection.ISettings | undefined,
+    connectionStatus: IConnectionStatus | undefined
   ): Event.IManager => {
-    return new EventManager({ serverSettings });
+    return new EventManager({
+      serverSettings,
+      standby: () => {
+        return !connectionStatus?.isConnected || 'when-hidden';
+      }
+    });
   }
 };
 
@@ -150,12 +156,18 @@ const kernelManagerPlugin: ServiceManagerPlugin<Kernel.IManager> = {
   description: 'The kernel manager plugin.',
   autoStart: true,
   provides: IKernelManager,
-  optional: [IServerSettings],
+  optional: [IServerSettings, IConnectionStatus],
   activate: (
     _: null,
-    serverSettings: ServerConnection.ISettings | undefined
+    serverSettings: ServerConnection.ISettings | undefined,
+    connectionStatus: IConnectionStatus | undefined
   ): Kernel.IManager => {
-    return new KernelManager({ serverSettings });
+    return new KernelManager({
+      serverSettings,
+      standby: () => {
+        return !connectionStatus?.isConnected || 'when-hidden';
+      }
+    });
   }
 };
 
@@ -167,12 +179,18 @@ const kernelSpecManagerPlugin: ServiceManagerPlugin<KernelSpec.IManager> = {
   description: 'The kernel spec manager plugin.',
   autoStart: true,
   provides: IKernelSpecManager,
-  optional: [IServerSettings],
+  optional: [IServerSettings, IConnectionStatus],
   activate: (
     _: null,
-    serverSettings: ServerConnection.ISettings | undefined
+    serverSettings: ServerConnection.ISettings | undefined,
+    connectionStatus: IConnectionStatus | undefined
   ): KernelSpec.IManager => {
-    return new KernelSpecManager({ serverSettings });
+    return new KernelSpecManager({
+      serverSettings,
+      standby: () => {
+        return !connectionStatus?.isConnected || 'when-hidden';
+      }
+    });
   }
 };
 
@@ -202,13 +220,20 @@ const sessionManagerPlugin: ServiceManagerPlugin<Session.IManager> = {
   autoStart: true,
   provides: ISessionManager,
   requires: [IKernelManager],
-  optional: [IServerSettings],
+  optional: [IServerSettings, IConnectionStatus],
   activate: (
     _: null,
     kernelManager: Kernel.IManager,
-    serverSettings: ServerConnection.ISettings | undefined
+    serverSettings: ServerConnection.ISettings | undefined,
+    connectionStatus: IConnectionStatus | undefined
   ): Session.IManager => {
-    return new SessionManager({ kernelManager, serverSettings });
+    return new SessionManager({
+      kernelManager,
+      serverSettings,
+      standby: () => {
+        return !connectionStatus?.isConnected || 'when-hidden';
+      }
+    });
   }
 };
 
@@ -237,12 +262,18 @@ const terminalManagerPlugin: ServiceManagerPlugin<Terminal.IManager> = {
   description: 'The terminal manager plugin.',
   autoStart: true,
   provides: ITerminalManager,
-  optional: [IServerSettings],
+  optional: [IServerSettings, IConnectionStatus],
   activate: (
     _: null,
-    serverSettings: ServerConnection.ISettings | undefined
+    serverSettings: ServerConnection.ISettings | undefined,
+    connectionStatus: IConnectionStatus | undefined
   ): Terminal.IManager => {
-    return new TerminalManager({ serverSettings });
+    return new TerminalManager({
+      serverSettings,
+      standby: () => {
+        return !connectionStatus?.isConnected || 'when-hidden';
+      }
+    });
   }
 };
 
@@ -254,12 +285,18 @@ const userManagerPlugin: ServiceManagerPlugin<User.IManager> = {
   description: 'The user manager plugin.',
   autoStart: true,
   provides: IUserManager,
-  optional: [IServerSettings],
+  optional: [IServerSettings, IConnectionStatus],
   activate: (
     _: null,
-    serverSettings: ServerConnection.ISettings | undefined
+    serverSettings: ServerConnection.ISettings | undefined,
+    connectionStatus: IConnectionStatus | undefined
   ): User.IManager => {
-    return new UserManager({ serverSettings });
+    return new UserManager({
+      serverSettings,
+      standby: () => {
+        return !connectionStatus?.isConnected || 'when-hidden';
+      }
+    });
   }
 };
 

--- a/packages/services/src/event/index.ts
+++ b/packages/services/src/event/index.ts
@@ -25,7 +25,10 @@ export class EventManager implements Event.IManager {
       options.serverSettings ?? ServerConnection.makeSettings();
 
     // If subscription fails, the poll attempts to reconnect and backs off.
-    this._poll = new Poll({ factory: () => this._subscribe() });
+    this._poll = new Poll({
+      factory: () => this._subscribe(),
+      standby: options.standby ?? 'when-hidden'
+    });
     this._stream = new Stream(this);
 
     // Subscribe to the events socket.
@@ -129,6 +132,11 @@ export namespace EventManager {
    * The instantiation options for an event manager.
    */
   export interface IOptions {
+    /**
+     * When the manager stops polling the API. Defaults to `when-hidden`.
+     */
+    standby?: Poll.Standby | (() => boolean | Poll.Standby);
+
     /**
      * The server settings used to make API requests.
      */

--- a/packages/workspaces-extension/src/index.ts
+++ b/packages/workspaces-extension/src/index.ts
@@ -8,7 +8,8 @@
  */
 import {
   JupyterFrontEnd,
-  JupyterFrontEndPlugin
+  JupyterFrontEndPlugin,
+  JupyterLab
 } from '@jupyterlab/application';
 import {
   IWorkspaceCommands,
@@ -30,9 +31,16 @@ const workspacesModel: JupyterFrontEndPlugin<IWorkspacesModel> = {
   description: 'Provides a model for available workspaces.',
   provides: IWorkspacesModel,
   autoStart: true,
-  activate: (app: JupyterFrontEnd) => {
+  optional: [JupyterLab.IInfo],
+  activate: (app: JupyterFrontEnd, info: JupyterLab.IInfo | null) => {
     return new WorkspacesModel({
-      manager: app.serviceManager.workspaces
+      manager: app.serviceManager.workspaces,
+      refreshStandby: () => {
+        if (info) {
+          return !info.isConnected || 'when-hidden';
+        }
+        return 'when-hidden';
+      }
     });
   }
 };


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes #17566

## Code changes

`standby` callbacks have been added to `EventManager`, `KernelManager`, `KernelspecManager`, `SessionsManager`, `TerminalManager`, `WorkspacesManager` to put poll on `stand-by` when connection to the server is lost. This ensures that browser will stop making API requests to the server once the connection is marked as lost.

**An example illustrating the change with JupyterHub:**

*With current stable JupyterLab:*
Browser console:
![Before_fix](https://github.com/user-attachments/assets/35a7efb5-fe7b-4758-9bbb-cf957229e490)

Server Logs:
```
[I 2025-05-14 20:19:42.308 JupyterHub base:1349] User paipuri server took 0.591 seconds to stop
[I 2025-05-14 20:19:42.309 JupyterHub log:192] 204 DELETE /hub/api/users/paipuri/server?_xsrf=[secret] (paipuri@::ffff:127.0.0.1) 603.36ms
[I 2025-05-14 20:19:42.413 JupyterHub log:192] 302 GET /user/paipuri/api/events/subscribe -> /hub/user/paipuri/api/events/subscribe (@::ffff:127.0.0.1) 0.94ms
[I 2025-05-14 20:19:43.337 JupyterHub log:192] 302 GET /user/paipuri/api/events/subscribe -> /hub/user/paipuri/api/events/subscribe (@::ffff:127.0.0.1) 0.90ms
[I 2025-05-14 20:19:44.872 JupyterHub log:192] 302 GET /user/paipuri/api/kernels?1747246784865 -> /hub/user/paipuri/api/kernels?1747246784865 (@::ffff:127.0.0.1) 0.70ms
[I 2025-05-14 20:19:44.875 JupyterHub log:192] 302 GET /user/paipuri/api/terminals?1747246784867 -> /hub/user/paipuri/api/terminals?1747246784867 (@::ffff:127.0.0.1) 0.36ms
[I 2025-05-14 20:19:44.877 JupyterHub log:192] 302 GET /user/paipuri/api/sessions?1747246784869 -> /hub/user/paipuri/api/sessions?1747246784869 (@::ffff:127.0.0.1) 0.62ms
[I 2025-05-14 20:19:44.879 JupyterHub log:192] 302 GET /user/paipuri/lab/api/workspaces?1747246784871 -> /hub/user/paipuri/lab/api/workspaces?1747246784871 (@::ffff:127.0.0.1) 0.58ms
[W 2025-05-14 20:19:44.886 JupyterHub base:1637] Failing suspected API request to not-running server: /hub/user/paipuri/api/kernels
[W 2025-05-14 20:19:44.886 JupyterHub log:192] 424 GET /hub/user/paipuri/api/kernels?1747246784865 (paipuri@::ffff:127.0.0.1) 3.81ms
[W 2025-05-14 20:19:44.889 JupyterHub base:1637] Failing suspected API request to not-running server: /hub/user/paipuri/api/terminals
[W 2025-05-14 20:19:44.889 JupyterHub log:192] 424 GET /hub/user/paipuri/api/terminals?1747246784867 (paipuri@::ffff:127.0.0.1) 2.73ms
[W 2025-05-14 20:19:44.892 JupyterHub base:1637] Failing suspected API request to not-running server: /hub/user/paipuri/api/sessions
[W 2025-05-14 20:19:44.893 JupyterHub log:192] 424 GET /hub/user/paipuri/api/sessions?1747246784869 (paipuri@::ffff:127.0.0.1) 3.56ms
[W 2025-05-14 20:19:44.897 JupyterHub base:1637] Failing suspected API request to not-running server: /hub/user/paipuri/lab/api/workspaces
[W 2025-05-14 20:19:44.898 JupyterHub log:192] 424 GET /hub/user/paipuri/lab/api/workspaces?1747246784871 (paipuri@::ffff:127.0.0.1) 4.44ms
[I 2025-05-14 20:19:44.942 JupyterHub log:192] 302 GET /user/paipuri/api/events/subscribe -> /hub/user/paipuri/api/events/subscribe (@::ffff:127.0.0.1) 0.40ms
[I 2025-05-14 20:19:46.851 JupyterHub log:192] 302 GET /user/paipuri/api/events/subscribe -> /hub/user/paipuri/api/events/subscribe (@::ffff:127.0.0.1) 1.01ms
[I 2025-05-14 20:19:48.940 JupyterHub log:192] 302 GET /user/paipuri/api/events/subscribe -> /hub/user/paipuri/api/events/subscribe (@::ffff:127.0.0.1) 0.58ms
[I 2025-05-14 20:19:51.773 JupyterHub log:192] 302 GET /user/paipuri/api/events/subscribe -> /hub/user/paipuri/api/events/subscribe (@::ffff:127.0.0.1) 1.18ms
[I 2025-05-14 20:19:56.328 JupyterHub log:192] 302 GET /user/paipuri/api/terminals?1747246796318 -> /hub/user/paipuri/api/terminals?1747246796318 (@::ffff:127.0.0.1) 0.86ms
[W 2025-05-14 20:19:56.343 JupyterHub base:1637] Failing suspected API request to not-running server: /hub/user/paipuri/api/terminals
[W 2025-05-14 20:19:56.344 JupyterHub log:192] 424 GET /hub/user/paipuri/api/terminals?1747246796318 (paipuri@::ffff:127.0.0.1) 7.22ms
[I 2025-05-14 20:19:57.017 JupyterHub log:192] 302 GET /user/paipuri/api/events/subscribe -> /hub/user/paipuri/api/events/subscribe (@::ffff:127.0.0.1) 0.87ms
[I 2025-05-14 20:20:00.928 JupyterHub log:192] 302 GET /user/paipuri/api/sessions?1747246800924 -> /hub/user/paipuri/api/sessions?1747246800924 (@::ffff:127.0.0.1) 0.58ms
[W 2025-05-14 20:20:00.936 JupyterHub base:1637] Failing suspected API request to not-running server: /hub/user/paipuri/api/sessions
[W 2025-05-14 20:20:00.937 JupyterHub log:192] 424 GET /hub/user/paipuri/api/sessions?1747246800924 (paipuri@::ffff:127.0.0.1) 4.65ms
[I 2025-05-14 20:20:03.655 JupyterHub log:192] 302 GET /user/paipuri/lab/api/workspaces?1747246803647 -> /hub/user/paipuri/lab/api/workspaces?1747246803647 (@::ffff:127.0.0.1) 0.93ms
[W 2025-05-14 20:20:03.666 JupyterHub base:1637] Failing suspected API request to not-running server: /hub/user/paipuri/lab/api/workspaces
[W 2025-05-14 20:20:03.667 JupyterHub log:192] 424 GET /hub/user/paipuri/lab/api/workspaces?1747246803647 (paipuri@::ffff:127.0.0.1) 5.59ms
[I 2025-05-14 20:20:04.420 JupyterHub log:192] 302 GET /user/paipuri/api/events/subscribe -> /hub/user/paipuri/api/events/subscribe (@::ffff:127.0.0.1) 0.84ms
[I 2025-05-14 20:20:06.645 JupyterHub log:192] 302 GET /user/paipuri/api/kernels?1747246806637 -> /hub/user/paipuri/api/kernels?1747246806637 (@::ffff:127.0.0.1) 0.98ms
[W 2025-05-14 20:20:06.659 JupyterHub base:1637] Failing suspected API request to not-running server: /hub/user/paipuri/api/kernels
[W 2025-05-14 20:20:06.660 JupyterHub log:192] 424 GET /hub/user/paipuri/api/kernels?1747246806637 (paipuri@::ffff:127.0.0.1) 7.35ms
[I 2025-05-14 20:20:17.074 JupyterHub log:192] 302 GET /user/paipuri/api/terminals?1747246817065 -> /hub/user/paipuri/api/terminals?1747246817065 (@::ffff:127.0.0.1) 0.75ms
[W 2025-05-14 20:20:17.085 JupyterHub base:1637] Failing suspected API request to not-running server: /hub/user/paipuri/api/terminals
[W 2025-05-14 20:20:17.085 JupyterHub log:192] 424 GET /hub/user/paipuri/api/terminals?1747246817065 (paipuri@::ffff:127.0.0.1) 5.77ms
[I 2025-05-14 20:20:23.080 JupyterHub log:192] 302 GET /user/paipuri/api/events/subscribe -> /hub/user/paipuri/api/events/subscribe (@::ffff:127.0.0.1) 0.90ms
[I 2025-05-14 20:20:35.869 JupyterHub log:192] 302 GET /user/paipuri/api/kernelspecs?1747246835859 -> /hub/user/paipuri/api/kernelspecs?1747246835859 (@::ffff:127.0.0.1) 0.83ms
[W 2025-05-14 20:20:35.883 JupyterHub base:1637] Failing suspected API request to not-running server: /hub/user/paipuri/api/kernelspecs
[W 2025-05-14 20:20:35.884 JupyterHub log:192] 424 GET /hub/user/paipuri/api/kernelspecs?1747246835859 (paipuri@::ffff:127.0.0.1) 6.67ms
[I 2025-05-14 20:20:36.119 JupyterHub log:192] 302 GET /user/paipuri/api/me?1747246836111 -> /hub/user/paipuri/api/me?1747246836111 (@::ffff:127.0.0.1) 1.19ms
[W 2025-05-14 20:20:36.135 JupyterHub base:1637] Failing suspected API request to not-running server: /hub/user/paipuri/api/me
[W 2025-05-14 20:20:36.137 JupyterHub log:192] 424 GET /hub/user/paipuri/api/me?1747246836111 (paipuri@::ffff:127.0.0.1) 9.11ms
[I 2025-05-14 20:20:36.648 JupyterHub log:192] 302 GET /user/paipuri/lab/api/workspaces?1747246836640 -> /hub/user/paipuri/lab/api/workspaces?1747246836640 (@::ffff:127.0.0.1) 0.78ms
[W 2025-05-14 20:20:36.660 JupyterHub base:1637] Failing suspected API request to not-running server: /hub/user/paipuri/lab/api/workspaces
[W 2025-05-14 20:20:36.660 JupyterHub log:192] 424 GET /hub/user/paipuri/lab/api/workspaces?1747246836640 (paipuri@::ffff:127.0.0.1) 6.04ms
[I 2025-05-14 20:20:40.383 JupyterHub log:192] 302 GET /user/paipuri/api/kernels?1747246840374 -> /hub/user/paipuri/api/kernels?1747246840374 (@::ffff:127.0.0.1) 0.85ms
[W 2025-05-14 20:20:40.395 JupyterHub base:1637] Failing suspected API request to not-running server: /hub/user/paipuri/api/kernels
[W 2025-05-14 20:20:40.395 JupyterHub log:192] 424 GET /hub/user/paipuri/api/kernels?1747246840374 (paipuri@::ffff:127.0.0.1) 6.15ms
[I 2025-05-14 20:20:44.565 JupyterHub log:192] 302 GET /user/paipuri/api/sessions?1747246844557 -> /hub/user/paipuri/api/sessions?1747246844557 (@::ffff:127.0.0.1) 0.94ms
[W 2025-05-14 20:20:44.578 JupyterHub base:1637] Failing suspected API request to not-running server: /hub/user/paipuri/api/sessions
[W 2025-05-14 20:20:44.579 JupyterHub log:192] 424 GET /hub/user/paipuri/api/sessions?1747246844557 (paipuri@::ffff:127.0.0.1) 6.45ms
[I 2025-05-14 20:20:51.096 JupyterHub log:192] 302 GET /user/paipuri/api/events/subscribe -> /hub/user/paipuri/api/events/subscribe (@::ffff:127.0.0.1) 0.65ms
[I 2025-05-14 20:20:52.688 JupyterHub log:192] 302 GET /user/paipuri/lab/api/workspaces?1747246852680 -> /hub/user/paipuri/lab/api/workspaces?1747246852680 (@::ffff:127.0.0.1) 0.77ms
[W 2025-05-14 20:20:52.701 JupyterHub base:1637] Failing suspected API request to not-running server: /hub/user/paipuri/lab/api/workspaces
[W 2025-05-14 20:20:52.701 JupyterHub log:192] 424 GET /hub/user/paipuri/lab/api/workspaces?1747246852680 (paipuri@::ffff:127.0.0.1) 7.11ms
```
As we can the browser keeps making API requests and we get a lot of these 424 messages on the server.

*With proposed patch:*
Browser console:
![After_fix](https://github.com/user-attachments/assets/88645268-de48-41d4-9d02-c586b27bfeff)

Server Logs:
```
[I 2025-05-14 20:15:20.638 JupyterHub base:1349] User paipuri server took 0.569 seconds to stop
[I 2025-05-14 20:15:20.639 JupyterHub log:192] 204 DELETE /hub/api/users/paipuri/server?_xsrf=[secret] (paipuri@::ffff:127.0.0.1) 605.59ms
[I 2025-05-14 20:15:21.047 JupyterHub log:192] 302 GET /user/paipuri/api/events/subscribe -> /hub/user/paipuri/api/events/subscribe (@::ffff:127.0.0.1) 1.35ms
[I 2025-05-14 20:15:22.917 JupyterHub log:192] 302 GET /user/paipuri/api/metrics/v1?1747246522906 -> /hub/user/paipuri/api/metrics/v1?1747246522906 (@::ffff:127.0.0.1) 1.60ms
[I 2025-05-14 20:15:22.922 JupyterHub log:192] 302 GET /user/paipuri/api/metrics/v1?1747246522909 -> /hub/user/paipuri/api/metrics/v1?1747246522909 (@::ffff:127.0.0.1) 1.50ms
[W 2025-05-14 20:15:22.939 JupyterHub base:1637] Failing suspected API request to not-running server: /hub/user/paipuri/api/metrics/v1
[W 2025-05-14 20:15:22.939 JupyterHub log:192] 424 GET /hub/user/paipuri/api/metrics/v1?1747246522906 (paipuri@::ffff:127.0.0.1) 12.96ms
[W 2025-05-14 20:15:22.946 JupyterHub base:1637] Failing suspected API request to not-running server: /hub/user/paipuri/api/metrics/v1
[W 2025-05-14 20:15:22.947 JupyterHub log:192] 424 GET /hub/user/paipuri/api/metrics/v1?1747246522909 (paipuri@::ffff:127.0.0.1) 7.12ms
[I 2025-05-14 20:15:23.262 JupyterHub log:192] 302 GET /user/paipuri/api/events/subscribe -> /hub/user/paipuri/api/events/subscribe (@::ffff:127.0.0.1) 1.10ms
[I 2025-05-14 20:15:26.922 JupyterHub log:192] 302 GET /user/paipuri/api/events/subscribe -> /hub/user/paipuri/api/events/subscribe (@::ffff:127.0.0.1) 1.03ms
[I 2025-05-14 20:15:27.249 JupyterHub log:192] 302 GET /user/paipuri/api/kernels?1747246527239 -> /hub/user/paipuri/api/kernels?1747246527239 (@::ffff:127.0.0.1) 1.00ms
[I 2025-05-14 20:15:27.252 JupyterHub log:192] 302 GET /user/paipuri/api/terminals?1747246527243 -> /hub/user/paipuri/api/terminals?1747246527243 (@::ffff:127.0.0.1) 0.57ms
[I 2025-05-14 20:15:27.253 JupyterHub log:192] 302 GET /user/paipuri/api/sessions?1747246527245 -> /hub/user/paipuri/api/sessions?1747246527245 (@::ffff:127.0.0.1) 0.43ms
[W 2025-05-14 20:15:27.262 JupyterHub base:1637] Failing suspected API request to not-running server: /hub/user/paipuri/api/kernels
[W 2025-05-14 20:15:27.262 JupyterHub log:192] 424 GET /hub/user/paipuri/api/kernels?1747246527239 (paipuri@::ffff:127.0.0.1) 3.94ms
[W 2025-05-14 20:15:27.267 JupyterHub base:1637] Failing suspected API request to not-running server: /hub/user/paipuri/api/terminals
[W 2025-05-14 20:15:27.267 JupyterHub log:192] 424 GET /hub/user/paipuri/api/terminals?1747246527243 (paipuri@::ffff:127.0.0.1) 4.74ms
[W 2025-05-14 20:15:27.271 JupyterHub base:1637] Failing suspected API request to not-running server: /hub/user/paipuri/api/sessions
[W 2025-05-14 20:15:27.272 JupyterHub log:192] 424 GET /hub/user/paipuri/api/sessions?1747246527245 (paipuri@::ffff:127.0.0.1) 8.86ms
[I 2025-05-14 20:18:00.905 JupyterHub log:192] 200 GET /hub/home (paipuri@::ffff:127.0.0.1) 31.17ms
[I 2025-05-14 20:18:05.783 JupyterHub log:192] 200 GET /hub/home (paipuri@::ffff:127.0.0.1) 6.49ms
[I 2025-05-14 20:18:06.126 JupyterHub log:192] 200 GET /hub/home (paipuri@::ffff:127.0.0.1) 3.52ms
[I 2025-05-14 20:18:06.475 JupyterHub log:192] 200 GET /hub/home (paipuri@::ffff:127.0.0.1) 11.16ms
[I 2025-05-14 20:18:06.804 JupyterHub log:192] 200 GET /hub/home (paipuri@::ffff:127.0.0.1) 7.00ms
```

Now we can see as soon as the server stops, the browser polls are put in standby mode and no more API requests are made to server

## User-facing changes

N/A

## Backwards-incompatible changes

N/A

@jtpio Here we go!! Pretty straight-forward changes!!