### PR TITLE
Add select all command for file browser listing

### DIFF
--- a/packages/filebrowser-extension/schema/browser.json
+++ b/packages/filebrowser-extension/schema/browser.json
@@ -92,6 +92,11 @@
         "rank": 12
       },
       {
+        "command": "filebrowser:select-all",
+        "selector": ".jp-DirListing-item",
+        "rank": 12.5
+      },
+      {
         "command": "filebrowser:copy-path",
         "selector": ".jp-DirListing-item[data-isdir]",
         "rank": 14
@@ -179,6 +184,11 @@
     {
       "command": "filebrowser:duplicate",
       "keys": ["Accel D"],
+      "selector": ".jp-DirListing-content .jp-DirListing-itemText"
+    },
+    {
+      "command": "filebrowser:select-all",
+      "keys": ["Accel A"],
       "selector": ".jp-DirListing-content .jp-DirListing-itemText"
     }
   ],

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -87,6 +87,8 @@ namespace CommandIDs {
 
   export const duplicate = 'filebrowser:duplicate';
 
+  export const selectAll = 'filebrowser:select-all';
+
   // For main browser only.
   export const hideBrowser = 'filebrowser:hide-main';
 
@@ -967,6 +969,18 @@ function addCommands(
     },
     icon: copyIcon.bindprops({ stylesheet: 'menuItem' }),
     label: trans.__('Duplicate')
+  });
+
+  commands.addCommand(CommandIDs.selectAll, {
+    execute: () => {
+      const widget = tracker.currentWidget;
+
+      if (widget) {
+        return widget.selectAll();
+      }
+    },
+    icon: copyIcon.bindprops({ stylesheet: 'menuItem' }),
+    label: trans.__('Select All')
   });
 
   commands.addCommand(CommandIDs.goToPath, {

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -423,6 +423,13 @@ export class FileBrowser extends SidePanel {
   }
 
   /**
+   * Select all listing items.
+   */
+  selectAll(): void {
+    this.listing.selectAll();
+  }
+
+  /**
    * Download the currently selected item(s).
    */
   download(): Promise<void> {

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -515,6 +515,21 @@ export class DirListing extends Widget {
   }
 
   /**
+   * Select all directory listing items
+   */
+  selectAll(): void {
+    const items = this._model.items();
+    const newSelection: { [key: string]: boolean } = {};
+
+    for (const item of items) {
+      newSelection[item.path] = true;
+    }
+
+    this.selection = newSelection;
+    this.update();
+  }
+
+  /**
    * Download the currently selected item(s).
    */
   async download(): Promise<void> {


### PR DESCRIPTION
## References

This aims to address https://github.com/jupyterlab/jupyterlab/issues/16690

## Code changes

- Register select all command as a shortcut and context menu item
   - Adding the context menu option was not mentioned in the original issue, but I followed the pattern I saw for other commands. However, I can remove it if this is not the desired behavior. I did wonder if it might be redundant given that the DirListing checkbox already exists.
- Adds a `selectAll` function to the `DirListing` and `FileBrowser` classes

## User-facing changes

The user will now see the Select All option, and its corresponding shortcut, in the context menu after right-clicking on a file. 

https://github.com/user-attachments/assets/da8c6ff4-47dd-438e-99c3-2474dc40745f



## Backwards-incompatible changes

None to my knowledge
