### PR TITLE
Ensure strings with yellow background in tracebacks are visible

### DIFF
--- a/packages/rendermime/style/base.css
+++ b/packages/rendermime/style/base.css
@@ -213,6 +213,11 @@
   padding-top: var(--jp-code-padding);
 }
 
+/* fix illegible yellow text with yellow background in exception stacktrace */
+.jp-RenderedText pre .ansi-yellow-bg.ansi-yellow-fg {
+  color: black;
+}
+
 /*-----------------------------------------------------------------------------
 | RenderedLatex
 |----------------------------------------------------------------------------*/


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
Fixes #17576
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

As the bug is not not specific to any of the three built-in themes, I opted to move the existing rule in the base CSS file, and remove the `:where` CSS function that reduced its specificity. I believe this is a better solution than using `!important` or duplicating the same rule across multiple theme files. In all cases, black text on a yellow background is very readable. Feedback is welcome!
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Users will now be able to read strings that are part of exceptions where content has a yellow background.

![image](https://github.com/user-attachments/assets/7d4564ee-f888-4fdc-aff5-776b218c7424)

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

# :snake: :man_juggling: 