### PR TITLE
Fix stringmd5 in docker image if both md5sum and md5 are present

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -26,6 +26,7 @@ stringmd5() {
             num=$(( 0x$(echo "$1" | command "${cmd}" | cut -d ' ' -f 1 | head -c 15) ))
             [[ $num -lt 0 ]] && num=$((num * -1))
             echo $num
+            break
         fi
     done
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/17589

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Adding break if image tag is parsed
If both md5sum and md5 are present, the tag becomes `jupyterlab_dev:741666173777324442 741666173777324442`
Which leads to `ERROR: "docker buildx build" requires exactly 1 argument.`


## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
No

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
