### PR TITLE
Fix error handing in extension manager (typo and undefined variable)

### DIFF
--- a/jupyterlab/extensions/pypi.py
+++ b/jupyterlab/extensions/pypi.py
@@ -487,7 +487,7 @@ class PyPIExtensionManager(ExtensionManager):
 
                 return ActionResult(status="ok", needs_restart=follow_ups)
             else:
-                self.log.error(f"Failed to installed {filename}: code {result.returncode}\n{error}")
+                self.log.error(f"Failed to install {name}: code {result.returncode}\n{error}")
                 return ActionResult(status="error", message=error)
 
     async def uninstall(self, extension: str) -> ActionResult:


### PR DESCRIPTION
## References: #17572 

This PR fixes an undefined variable `filename` in the else clause to `name`.  Also corrected a grammatical mistake.
