### PR TITLE
Remove the need for `ILabShell` for the inspector plugins

### DIFF
--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -6,7 +6,6 @@
  */
 
 import {
-  ILabShell,
   ILayoutRestorer,
   JupyterFrontEnd,
   JupyterFrontEndPlugin
@@ -190,13 +189,12 @@ const consoles: JupyterFrontEndPlugin<void> = {
   // FIXME This should be in @jupyterlab/console-extension
   id: '@jupyterlab/inspector-extension:consoles',
   description: 'Adds code introspection support to consoles.',
-  requires: [IInspector, IConsoleTracker, ILabShell],
+  requires: [IInspector, IConsoleTracker],
   autoStart: true,
   activate: (
     app: JupyterFrontEnd,
     manager: IInspector,
     consoles: IConsoleTracker,
-    labShell: ILabShell,
     translator: ITranslator
   ): void => {
     // Maintain association of new consoles with their respective handlers.
@@ -234,8 +232,12 @@ const consoles: JupyterFrontEndPlugin<void> = {
         manager.source = handlers[widget.id];
       }
     };
-    labShell.currentChanged.connect((_, args) => setSource(args.newValue));
-    void app.restored.then(() => setSource(labShell.currentWidget));
+    if (app.shell.currentChanged) {
+      app.shell.currentChanged.connect((_, args) => setSource(args.newValue));
+    } else {
+      setSource(app.shell.currentWidget);
+    }
+    void app.restored.then(() => setSource(app.shell.currentWidget));
   }
 };
 
@@ -246,13 +248,12 @@ const notebooks: JupyterFrontEndPlugin<void> = {
   // FIXME This should be in @jupyterlab/notebook-extension
   id: '@jupyterlab/inspector-extension:notebooks',
   description: 'Adds code introspection to notebooks.',
-  requires: [IInspector, INotebookTracker, ILabShell],
+  requires: [IInspector, INotebookTracker],
   autoStart: true,
   activate: (
     app: JupyterFrontEnd,
     manager: IInspector,
-    notebooks: INotebookTracker,
-    labShell: ILabShell
+    notebooks: INotebookTracker
   ): void => {
     // Maintain association of new notebooks with their respective handlers.
     const handlers: { [id: string]: InspectionHandler } = {};
@@ -293,8 +294,12 @@ const notebooks: JupyterFrontEndPlugin<void> = {
         manager.source = handlers[widget.id];
       }
     };
-    labShell.currentChanged.connect((_, args) => setSource(args.newValue));
-    void app.restored.then(() => setSource(labShell.currentWidget));
+    if (app.shell.currentChanged) {
+      app.shell.currentChanged.connect((_, args) => setSource(args.newValue));
+    } else {
+      setSource(app.shell.currentWidget);
+    }
+    void app.restored.then(() => setSource(app.shell.currentWidget));
   }
 };
 

--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -232,11 +232,7 @@ const consoles: JupyterFrontEndPlugin<void> = {
         manager.source = handlers[widget.id];
       }
     };
-    if (app.shell.currentChanged) {
-      app.shell.currentChanged.connect((_, args) => setSource(args.newValue));
-    } else {
-      setSource(app.shell.currentWidget);
-    }
+    app.shell.currentChanged?.connect((_, args) => setSource(args.newValue));
     void app.restored.then(() => setSource(app.shell.currentWidget));
   }
 };
@@ -294,11 +290,7 @@ const notebooks: JupyterFrontEndPlugin<void> = {
         manager.source = handlers[widget.id];
       }
     };
-    if (app.shell.currentChanged) {
-      app.shell.currentChanged.connect((_, args) => setSource(args.newValue));
-    } else {
-      setSource(app.shell.currentWidget);
-    }
+    app.shell.currentChanged?.connect((_, args) => setSource(args.newValue));
     void app.restored.then(() => setSource(app.shell.currentWidget));
   }
 };


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

This will be useful to Notebook as it could reuse the JupyterLab inspector for the pager directly: https://github.com/jupyter/notebook/issues/6692

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Use `app.shell.currentChanged?` instead of requiring `ILabShell`

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None for JupyterLab users.

Will likely help implement https://github.com/jupyter/notebook/issues/6692 for Notebook users.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
