### PR TITLE
Fix drive focus issue

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -2037,7 +2037,6 @@ namespace Private {
       if (widget) {
         this._sideBar.currentTitle = widget.title;
         widget.activate();
-        widget.node.focus();
       }
     }
 


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/15629


## Code changes

- Manually trigger a `FocusEvent` to make sure the underlying `FocusTracker` keeps its `currentWidget` up-to-date.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Testing with https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access, which requires manually picking a local folder on disk before being usable.

**Before**

https://github.com/user-attachments/assets/9ee11d1f-7e49-45f5-aebd-80babe8b7521


**After**


https://github.com/user-attachments/assets/5e0e623c-d297-4ab3-9d65-e7711c514936


## Backwards-incompatible changes

None


