### PR TITLE
Add layout containment on viewport in windowed mode

### DIFF
--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -1337,6 +1337,7 @@ export class WindowedList<
    */
   private _applyNoWindowingStyles() {
     this._viewport.style.position = 'relative';
+    this._viewport.style.contain = 'layout';
     this._viewport.style.top = '0px';
     this._viewport.style.minHeight = '';
     this._innerElement.style.height = '';
@@ -1346,6 +1347,7 @@ export class WindowedList<
    */
   private _applyWindowingStyles() {
     this._viewport.style.position = 'absolute';
+    this._viewport.style.contain = '';
   }
 
   /**


### PR DESCRIPTION
## References

- This will help with #15968
- This might help with #17023

## Code changes

When scrolling past a long cell the size of the `jp-WindowedPanel-viewport` changes when we scroll. This is because the `top` and `transform` add to the viewport container size. This causes the scrollbar to jump, and scrolling to be jittery; previously we tried to workaround this by setting a `min-height` but that:
- added to the problem as the two do not interact the way one would expected
- was causing layout recalculatioon which in some browsers (Chrome) causes involuntary scrollbar jitter (https://issues.chromium.org/issues/40065619)

Adding `contain: layout` causes the scrollbar positioning to become independent from `top` and `transform`.


Further, the old behaviour meant cells could have been skipped when scrolling, which may have led to cells not being rendered, but this is speculation at this point, it might be that #17023 has a different root cause altogether.

## User-facing changes


| viewport top position | Before | After |
|--|--|--|
| just after a large cell | ![image](https://github.com/user-attachments/assets/84ed31b0-2f3b-40f6-9cf8-888b18869679) | ![image](https://github.com/user-attachments/assets/116f666b-e6cc-4435-97a9-2ffda76fbbbf) |
| one cell below it | ![image](https://github.com/user-attachments/assets/23cadcdb-38b9-489a-a623-0758555585d5) | ![image](https://github.com/user-attachments/assets/fe3a0294-b836-4cba-9ace-9ac228b41eb4) |

Note the scrollbar jump in "before" when scrolling to once cell below a large cell and that it does not occur "after" adding `contain: layout`.

## Backwards-incompatible changes

None
