### PR TITLE
Prevent memory leak when rendering text stream

### DIFF
--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -605,6 +605,16 @@ namespace Private {
     return { text, index: idx0 };
   }
 
+  /**
+   * Reallocate the string to prevent memory leak,
+   * workaround for issue in Chrome and Firefox:
+   * - https://issues.chromium.org/issues/41480525
+   * - https://bugzilla.mozilla.org/show_bug.cgi?id=727615
+   */
+  function unleakString(s: string) {
+    return JSON.parse(JSON.stringify(s));
+  }
+
   /*
    * Concatenate a string to an observable string, handling backspaces.
    */
@@ -627,12 +637,12 @@ namespace Private {
         }
       } else if (idx === curText.text.length) {
         if (idx !== text.length) {
-          curText.insert(curText.text.length, text.slice(idx));
+          curText.insert(curText.text.length, unleakString(text.slice(idx)));
           done = true;
         }
       } else if (text[idx] !== curText.text[idx]) {
         curText.remove(idx, curText.text.length);
-        curText.insert(idx, text.slice(idx));
+        curText.insert(idx, unleakString(text.slice(idx)));
         done = true;
       } else {
         idx++;


### PR DESCRIPTION
## References

Fixes #17624 

## Code changes

`unleakString` after slice operation.

## User-facing changes

Running:

```python
from time import sleep
for i in range(10_000):
    print('X' * 40, flush=True)
    sleep(0.001)
```

| Metric | Before | After |
|--|--|--|
| Total allocation | 2257 MB | 208 MB |
| String allocation | 2,146,683 kB | 98,266 kB |
| Summary | ![image](https://github.com/user-attachments/assets/b3c8d5cd-fc0b-4ac9-a3dd-40a057c71de0) | ![image](https://github.com/user-attachments/assets/6f68dec7-0290-40f4-8375-78bfea69b503)  |

Running:

```python
import logging
for i in range(5_000):
    logging.warning('hello')
```

| Before (browser crashes first) | After (kernel crashes before browser) |
|--|--|
| ![image](https://github.com/user-attachments/assets/2acd4ec1-0071-42a5-98c9-ad0b2e9eb289) | ![image](https://github.com/user-attachments/assets/c93e4b45-7747-4f59-82b0-9e55058a6cf2) |

## Backwards-incompatible changes

None
