### PR TITLE
Create a subshell per target and kernel when using `CommsOverSubshells.PerCommTarget`

### DIFF
--- a/packages/services/test/kernel/comm.spec.ts
+++ b/packages/services/test/kernel/comm.spec.ts
@@ -157,6 +157,29 @@ describe('jupyter.services - Comm', () => {
         expect(before).toEqual(after);
       });
 
+      it('should spawn a subshell per-comm-target per kernel', async () => {
+        // Issue #17633
+        await kernel.info;
+        await echoKernel.info;
+
+        expect(kernel.supportsSubshells).toBeTruthy();
+        expect(echoKernel.supportsSubshells).toBeTruthy();
+
+        kernel.commsOverSubshells = CommsOverSubshells.PerCommTarget;
+
+        // First kernel
+        const comm = kernel.createComm('testTarget2') as CommHandler;
+        await comm.subshellStarted;
+        expect(comm.subshellId).not.toBeNull();
+
+        // Second kernel
+        const comm2 = echoKernel.createComm('testTarget2') as CommHandler;
+        await comm2.subshellStarted;
+        expect(comm2.subshellId).not.toBeNull();
+
+        expect(comm.subshellId).not.toEqual(comm2.subshellId);
+      });
+
       it('should use the given id', () => {
         const comm = kernel.createComm('test', '1234');
         expect(comm.targetName).toBe('test');


### PR DESCRIPTION
## References

Using subshells for comms was originally implemented in #17363. The default option for `CommsOverSubshells` is `PerCommTarget` meaning use one subshell per comm target, but this should really be one subshell per kernel per comm target as subshells are specific to a kernel.

Fixes #17633.

## Code changes

The `private static CommHandler._commTargetSubShellsId` is changed from 
```ts
    { [targetName: string]: Promise<string> | null }
```
to
```ts
    { [kernelId: string]: { [targetName: string]: Promise<string> | null }}
```
so that two kernels using the same comm-target will use different subshells, not attempt to erroneously reuse the subshell from just one of the kernels.

## User-facing changes

No user facing changes apart from fixing a bug.

## Backwards-incompatible changes

None.