### PR TITLE
Fix link to zulip and icon in docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -268,7 +268,7 @@ html_theme_options = {
         {
             "name": "Zulip",
             "url": "https://jupyter.zulipchat.com/#narrow/channel/469762-jupyterlab",
-            "icon": "fab fa-comments",
+            "icon": "fa-solid fa-comments",
         },
     ],
     "logo": {


### PR DESCRIPTION

## References

Follow up to #17031

## Code changes

None

## User-facing changes

| Before | After |
|--|--|
| ![image](https://github.com/user-attachments/assets/d64f7a16-9493-4c6e-bbd7-c1a354140af5) | ![image](https://github.com/user-attachments/assets/2823fd25-8ee8-4039-a716-b44bf449b0e9) |
| ![Screenshot_20250620_204101_Firefox.jpg](https://github.com/user-attachments/assets/1ef45a10-a7dc-4394-a939-71872fe563ee) | ![Screenshot_20250620_203918_Firefox.jpg](https://github.com/user-attachments/assets/ab6986f3-d327-41a5-8319-fffc9e5efc90) |



Although we could use a real Zulip icons as [optimagic does](https://github.com/optimagic-dev/optimagic/blob/fe0dcf7b7fc5ff86872dd210fabefbbb320e25a2/docs/source/conf.py#L235-L238) the `fa-comments` icons seems to be more commonly used for zulip in docs and it conveys the meaning for anyone who does not even know what Zulip is:
- [zarr-specs](https://github.com/zarr-developers/zarr-specs/blob/b880fb385bedb18dd78ffef1bd683e7e93270c74/docs/conf.py#L67)
- [surface-dynamics](https://github.com/flatsurf/surface-dynamics/blob/948425a7a3f764b14d04cf90463d968b15b74c72/doc/source/conf.py#L55-L58)
- [movement](https://github.com/neuroinformatics-unit/movement/blob/6fe3ffcd31c1639ae272be7f14317790fcf1584e/docs/source/conf.py#L143-L146)

## Backwards-incompatible changes

None