### PR TITLE
Fix terminal visual regression snapshots test failures

### DIFF
--- a/examples/example_check.py
+++ b/examples/example_check.py
@@ -16,6 +16,7 @@ import os
 import shutil
 import sys
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 
 from jupyterlab.browser_check import run_async_process, run_test
 from jupyterlab.labapp import get_app_dir
@@ -34,6 +35,10 @@ def main():
     spec.loader.exec_module(mod)
     sys.modules[__name__] = mod
 
+    with NamedTemporaryFile(mode="w", delete=False) as tmp:
+        tmp.write('PS1="$ "\n')
+        rcfile_path = tmp.name
+
     class App(mod.ExampleApp):
         """An app that launches an example and waits for it to start up, checking for
         JS console errors, JS errors, and Python logged errors.
@@ -46,6 +51,7 @@ def main():
             "base_url": "/foo/",
             "root_dir": str(example_dir.resolve()),
             "preferred_dir": str(example_dir.resolve()),
+            "terminado_settings": {"shell_command": ["/bin/bash", "--rcfile", rcfile_path]},
         }
         ip = "127.0.0.1"
 

--- a/jupyterlab/galata/__init__.py
+++ b/jupyterlab/galata/__init__.py
@@ -33,6 +33,7 @@ def configure_jupyter_server(c):
 
     c.LabApp.workspaces_dir = mkdtemp(prefix="galata-workspaces-")
 
+    c.ServerApp.terminado_settings='{"shell_command": ["PS1=\'$ \'", "/bin/bash"]}'
     c.ServerApp.root_dir = os.environ.get(
         "JUPYTERLAB_GALATA_ROOT_DIR", mkdtemp(prefix="galata-test-")
     )

--- a/jupyterlab/galata/__init__.py
+++ b/jupyterlab/galata/__init__.py
@@ -4,7 +4,7 @@
 import getpass
 import os
 from pathlib import Path
-from tempfile import mkdtemp
+from tempfile import NamedTemporaryFile, mkdtemp
 
 
 def configure_jupyter_server(c):
@@ -33,9 +33,11 @@ def configure_jupyter_server(c):
 
     c.LabApp.workspaces_dir = mkdtemp(prefix="galata-workspaces-")
 
-    c.ServerApp.terminado_settings = {
-        "shell_command": ["/bin/bash", "-c", "PS1='$ '; bash -noprofile --norc"]
-    }
+    with NamedTemporaryFile(mode="w", delete=False) as tmp:
+        tmp.write('PS1="$ "\n')
+        rcfile_path = tmp.name
+
+    c.ServerApp.terminado_settings = {"shell_command": ["/bin/bash", "--rcfile", rcfile_path]}
     c.ServerApp.root_dir = os.environ.get(
         "JUPYTERLAB_GALATA_ROOT_DIR", mkdtemp(prefix="galata-test-")
     )

--- a/jupyterlab/galata/__init__.py
+++ b/jupyterlab/galata/__init__.py
@@ -33,7 +33,7 @@ def configure_jupyter_server(c):
 
     c.LabApp.workspaces_dir = mkdtemp(prefix="galata-workspaces-")
 
-    c.ServerApp.terminado_settings = '{"shell_command": ["PS1=\'$ \'", "/bin/bash"]}'
+    c.ServerApp.terminado_settings = '{"shell_command": ["/bin/bash", "-c", "\'PS1=\"$ \"; exec bash\'"]}'
     c.ServerApp.root_dir = os.environ.get(
         "JUPYTERLAB_GALATA_ROOT_DIR", mkdtemp(prefix="galata-test-")
     )

--- a/jupyterlab/galata/__init__.py
+++ b/jupyterlab/galata/__init__.py
@@ -33,7 +33,7 @@ def configure_jupyter_server(c):
 
     c.LabApp.workspaces_dir = mkdtemp(prefix="galata-workspaces-")
 
-    c.ServerApp.terminado_settings='{"shell_command": ["PS1=\'$ \'", "/bin/bash"]}'
+    c.ServerApp.terminado_settings = '{"shell_command": ["PS1=\'$ \'", "/bin/bash"]}'
     c.ServerApp.root_dir = os.environ.get(
         "JUPYTERLAB_GALATA_ROOT_DIR", mkdtemp(prefix="galata-test-")
     )

--- a/jupyterlab/galata/__init__.py
+++ b/jupyterlab/galata/__init__.py
@@ -33,7 +33,9 @@ def configure_jupyter_server(c):
 
     c.LabApp.workspaces_dir = mkdtemp(prefix="galata-workspaces-")
 
-    c.ServerApp.terminado_settings = '{"shell_command": ["/bin/bash", "-c", "\'PS1=\"$ \"; exec bash\'"]}'
+    c.ServerApp.terminado_settings = {
+        "shell_command": ["/bin/bash", "-c", "PS1='$ '; bash -noprofile --norc"]
+    }
     c.ServerApp.root_dir = os.environ.get(
         "JUPYTERLAB_GALATA_ROOT_DIR", mkdtemp(prefix="galata-test-")
     )


### PR DESCRIPTION
## References

Fixes #17652 

## Code changes

Sets `PS1` env variable for terminals spawned by galata.

## User-facing changes

None

## Backwards-incompatible changes

None
