### PR TITLE
fix: allow inline completion to auto-trigger at empty lines (#17568)

### DIFF
--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -473,8 +473,8 @@ export class CompletionHandler implements IDisposable {
     const line = editor.getLine(position.line);
     if (
       trigger === InlineCompletionTriggerKind.Automatic &&
-      (typeof line === 'undefined' ||
-        line.slice(0, position.column).match(/^\s*$/))
+      typeof line === 'undefined' // ||
+        // line.slice(0, position.column).match(/^\s*$/))
     ) {
       // In Automatic mode we only auto-trigger on the end of line (and not on the beginning).
       // Increase the counter to avoid out-of date replies when pressing Backspace quickly.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
