### PR TITLE
Fix colors for CodeMirror panels

### DIFF
--- a/packages/codemirror/src/theme.ts
+++ b/packages/codemirror/src/theme.ts
@@ -23,6 +23,40 @@ export const jupyterEditorTheme = EditorView.theme({
     color: 'var(--jp-content-font-color1)'
   },
 
+  /* Panels and buttons used by the native CodeMirror search function
+     (rarely used in JupyterLab, but still accessible)
+     and by the vim extension (among others).
+  */
+  '.cm-panels': {
+    color: 'var(--jp-ui-font-color2)',
+    backgroundColor: 'var(--jp-layout-color2)'
+  },
+
+  '.cm-panels.cm-panels-bottom': {
+    borderTop: '1px solid var(--jp-border-color2)'
+  },
+
+  '.cm-button': {
+    background: 'var(--jp-layout-color2)',
+    border: 'var(--jp-border-width) solid var(--jp-border-color1)',
+    color: 'var(--jp-ui-font-color1)',
+    borderRadius: 'var(--jp-border-radius)'
+  },
+
+  '.cm-button:hover': {
+    background: 'var(--jp-layout-color1)'
+  },
+
+  '.cm-panel.cm-search > label': {
+    color: 'var(--jp-ui-font-color1)'
+  },
+
+  '.cm-textfield': {
+    backgroundColor: 'var(--jp-layout-color2)',
+    color: 'var(--jp-ui-font-color1)',
+    border: 'var(--jp-border-width) solid var(--jp-border-color1)'
+  },
+
   /* In the notebook, we want this styling to be handled by its container */
   '.jp-CodeConsole &, .jp-Notebook &': {
     background: 'transparent'


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab-contrib/jupyterlab-vim/issues/153

## Code changes

Adds style overrides using Jupyter theme variables.

## User-facing changes

### Advanced Settings Editor → <kbd>Ctrl</kbd> + <kbd>F</kbd>

| Before | After |
|--|--|
| ![Screenshot from 2025-06-27 15-29-28](https://github.com/user-attachments/assets/9fd6a947-80c2-4b9b-9fec-818cedb74199) | ![Screenshot from 2025-06-27 15-28-50](https://github.com/user-attachments/assets/077edca2-60f5-4d93-890f-54b626eebfde) |

### jupyterlab-vim `/` search

| Before | After |
|--|--|
| ![Screenshot from 2025-06-27 15-30-13](https://github.com/user-attachments/assets/88e44b0d-bf07-4e84-8cd0-a494e8144cc3) | ![Screenshot from 2025-06-27 15-30-33](https://github.com/user-attachments/assets/3c0774ef-4146-4710-96e6-b7e0c1e4c322) |


### After across themes

| Theme | After |
|--|--|
| Light | ![image](https://github.com/user-attachments/assets/9b87fdbe-dbb5-488f-a6de-b909a9a4ed91) |
| Dark | ![Screenshot from 2025-06-27 15-31-35](https://github.com/user-attachments/assets/cf7feb0e-aa64-4654-bd44-cd543769e74b)|
| Dark High Contrast | ![image](https://github.com/user-attachments/assets/86feaed9-10e2-4427-9234-082ca07d90f9) |
| Night | ![image](https://github.com/user-attachments/assets/894dbf63-387b-43ec-8518-86a012ea78ab) |

Note: the "(JavaScript regexp)" text uses inline CSS and comes from jupyterlab-vim so there is nothing we can do about its contrast in this repo.

## Backwards-incompatible changes

None