### PR TITLE
Fix `threadId` being passed to the debugger

### DIFF
--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -109,9 +109,7 @@ export class DebuggerService implements IDebugger, IDisposable {
 
     this._session?.eventMessage.connect((_, event) => {
       if (event.event === 'stopped') {
-        if (event.body.allThreadsStopped) {
-          this._model.stoppedThreads.clear();
-        }
+        this._model.stoppedThreads.clear();
         this._model.stoppedThreads.add(event.body.threadId);
         void this._getAllFrames();
       } else if (event.event === 'continued') {

--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -752,8 +752,7 @@ export class DebuggerService implements IDebugger, IDisposable {
    * Get the current thread from the model.
    */
   private _currentThread(): number {
-    // TODO: ask the model for the current thread ID
-    return 1;
+    return this._model.stoppedThreads.values().next().value ?? 1;
   }
 
   /**

--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -109,6 +109,9 @@ export class DebuggerService implements IDebugger, IDisposable {
 
     this._session?.eventMessage.connect((_, event) => {
       if (event.event === 'stopped') {
+        if(event.body.allThreadsStopped) {
+          this._model.stoppedThreads.clear();
+        }
         this._model.stoppedThreads.add(event.body.threadId);
         void this._getAllFrames();
       } else if (event.event === 'continued') {

--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -109,7 +109,7 @@ export class DebuggerService implements IDebugger, IDisposable {
 
     this._session?.eventMessage.connect((_, event) => {
       if (event.event === 'stopped') {
-        if(event.body.allThreadsStopped) {
+        if (event.body.allThreadsStopped) {
           this._model.stoppedThreads.clear();
         }
         this._model.stoppedThreads.add(event.body.threadId);

--- a/packages/debugger/test/service.spec.ts
+++ b/packages/debugger/test/service.spec.ts
@@ -129,6 +129,31 @@ describe('DebuggerService', () => {
     });
   });
 
+  describe('#pause()', () => {
+    it('should send a pause request including a threadId', async () => {
+      service.session = session;
+      await service.start();
+      const sendRequest = jest.spyOn(service.session, 'sendRequest');
+      await service.pause();
+      expect(sendRequest).toHaveBeenCalledWith(
+        'pause',
+        expect.objectContaining({ threadId: 1 })
+      );
+    });
+
+    it('should use one of the stopped threads for pause if set', async () => {
+      service.session = session;
+      await service.start();
+      service.model.stoppedThreads = new Set([42]);
+      const sendRequest = jest.spyOn(service.session, 'sendRequest');
+      await service.pause();
+      expect(sendRequest).toHaveBeenCalledWith(
+        'pause',
+        expect.objectContaining({ threadId: 42 })
+      );
+    });
+  });
+
   describe('#session', () => {
     it('should emit the sessionChanged signal when setting the session', () => {
       const sessionChangedEvents: (IDebugger.ISession | null)[] = [];


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Instead of [DebuggerService::_currentThread](https://github.com/jupyterlab/jupyterlab/blob/72410ce1ac956d4da1769b428de369e84e0b6c17/packages/debugger/src/service.ts#L754) directly returning 1, I changed it to return the first value of threadId inside ``this._model.stoppedThreads.``.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

1. More accurate debugging behavior for kernels with multithreaded or remote execution models (like xeus-cpp).
2. Stack traces, variable inspection now work on the correct thread instead of defaulting to thread 1.


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
