### PR TITLE
Dockerfile: Install less, vim, and nano

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,6 +34,8 @@ ENV PATH="/home/${MAMBA_USER}/.local/bin:${PATH}"
 RUN --mount=type=cache,target=/jupyterlab/conda-cache,uid=${NEW_MAMBA_USER_ID},gid=${NEW_MAMBA_USER_GID} \
     CONDA_PKGS_DIRS="/jupyterlab/conda-cache" micromamba install -c nodefaults -c conda-forge -yn base nodejs=20.1 yarn=3 git python=3 less vim nano
 
+ENV EDITOR=nano
+
 WORKDIR /home/$MAMBA_USER/jupyterlab_cache
 
 COPY --chown=$MAMBA_USER:$MAMBA_USER pyproject.toml LICENSE README.md ./

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ ENV PATH="/home/${MAMBA_USER}/.local/bin:${PATH}"
 
 # Install base dev tools with conda
 RUN --mount=type=cache,target=/jupyterlab/conda-cache,uid=${NEW_MAMBA_USER_ID},gid=${NEW_MAMBA_USER_GID} \
-    CONDA_PKGS_DIRS="/jupyterlab/conda-cache" micromamba install -c nodefaults -c conda-forge -yn base nodejs=20.1 yarn=3 git python=3
+    CONDA_PKGS_DIRS="/jupyterlab/conda-cache" micromamba install -c nodefaults -c conda-forge -yn base nodejs=20.1 yarn=3 git python=3 less vim nano
 
 WORKDIR /home/$MAMBA_USER/jupyterlab_cache
 


### PR DESCRIPTION
## References

Solves #17668.

## Code changes

This installs less, vim, and nano through micromamba.  I'm guess that this is the preferred method, so we don't have to worry about which package manager the base image is actually using.

`git commit` seems to assume EDITOR=vi, if it's not set, and the conda-forge vim package doesn't install or link vi.  Thus, `git commit` still fails to work until you set $EDITOR yourself.  Perhaps there's a vi-is-vim package in conda-forge, but I haven't found it.  We could also set $EDITOR in the Dockerfile, if we can agree on what it should be.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

## Backwards-incompatible changes

None