### PR TITLE
Check minimum docker version when starting docker build

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -47,15 +47,15 @@ if [[ $CMD == 'build' ]]; then
     echo "Building docker image"
     build_image
 
-    elif [[ $CMD == 'clean' ]]; then
+elif [[ $CMD == 'clean' ]]; then
     # Stop the dev container if it's running
     stop_contaniner
     docker rmi $IMAGE_TAG --force
 
-    elif [[ $CMD == 'stop' ]]; then
+elif [[ $CMD == 'stop' ]]; then
     stop_contaniner
 
-    elif [[ $CMD == 'dev' || $CMD == 'dev-detach' || $CMD == 'shell' || $CMD == '' ]]; then
+elif [[ $CMD == 'dev' || $CMD == 'dev-detach' || $CMD == 'shell' || $CMD == '' ]]; then
     if test -z "$(docker images -q $IMAGE_TAG)"; then
         echo "Image does not exist, start building!"
         build_image

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -35,6 +35,12 @@ ROOT_DIR_MD5=$(stringmd5 $ROOT_DIR)
 IMAGE_TAG="jupyterlab_dev:$ROOT_DIR_MD5"
 DEV_CONTAINER="jupyterlab_dev_container_$ROOT_DIR_MD5"
 
+DOCKER_MAJOR_VERSION=$(docker version --format '{{.Server.Version}}' | cut -d '.' -f 1)
+if [[ "$DOCKER_MAJOR_VERSION" -lt 23 ]]; then
+    echo "Docker major version must be 23 or higher. Current version: $DOCKER_MAJOR_VERSION"
+    exit 1
+fi
+
 build_image () {
     docker build  --build-arg NEW_MAMBA_USER_ID=$USER_ID --build-arg NEW_MAMBA_USER_GID=$GID $ROOT_DIR -f $SCRIPT_DIR/Dockerfile -t $IMAGE_TAG
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

#17663


## Code changes

While Dockerfiles can specify the version of the Dockerfile syntax they're using, they don't seem to be able to specify the version of the docker server that's necessary.  So this adds a check to the start.sh script instead.  I've verified that the Dockerfile runs under docker 23.0.0.  In the linked bug, we had seen it fail under 20.10.17.  Note that docker versioning apparently skips from v20 to v23.

Note that this check won't run when the Dockerfile is being used as a devcontainer.  Perhaps there's a way to do it there, too, but I don't know anything about that system.  I'd hope that a developer, seeing a failure of the devcontainer, would next try to run the start script and identify the problem from there.

## User-facing changes

None

## Backwards-incompatible changes

None
