### PR TITLE
Switch the default windowing mode to `defer`

### DIFF
--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -834,7 +834,7 @@
       "title": "Windowing mode",
       "description": "'defer': Improve loading time - Wait for idle CPU cycles to attach out of viewport cells - 'full': Best performance with side effects - Attach to the DOM only cells in viewport - 'none': Worst performance without side effects - Attach all cells to the viewport",
       "enum": ["defer", "full", "none"],
-      "default": "full"
+      "default": "defer"
     },
     "accessKernelHistory": {
       "title": "Kernel history access",


### PR DESCRIPTION


## References

- #17023
- #17516
- #16373
- #15968

and more. Not closing the associated issues as they still will affect the `full` mode.

## Code changes

Switches the default windowing mode to `defer`

## User-facing changes

- Slower long notebooks
- Less edge cases and weird scrolling behaviour

## Backwards-incompatible changes

None, users can opt back to full widowing mode
