### PR TITLE
Add types for interrupt messages, and move them from `shell` to `control` channel

### DIFF
--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -87,6 +87,12 @@ export function createMessage<T extends IInspectReplyMsg>(
 export function createMessage<T extends IInspectRequestMsg>(
   options: IOptions<T>
 ): T;
+export function createMessage<T extends IInterruptReplyMsg>(
+  options: IOptions<T>
+): T;
+export function createMessage<T extends IInterruptRequestMsg>(
+  options: IOptions<T>
+): T;
 export function createMessage<T extends IIsCompleteReplyMsg>(
   options: IOptions<T>
 ): T;
@@ -187,8 +193,6 @@ export type ShellMessageType =
   | 'history_request'
   | 'inspect_reply'
   | 'inspect_request'
-  | 'interrupt_reply'
-  | 'interrupt_request'
   | 'is_complete_reply'
   | 'is_complete_request'
   | 'kernel_info_reply'
@@ -205,6 +209,8 @@ export type ShellMessageType =
  * considered part of the public API, and may change without notice.
  */
 export type ControlMessageType =
+  | 'interrupt_reply'
+  | 'interrupt_request'
   | 'debug_request'
   | 'debug_reply'
   | 'create_subshell_request'
@@ -412,6 +418,8 @@ export type Message =
   | IInputRequestMsg
   | IInspectReplyMsg
   | IInspectRequestMsg
+  | IInterruptReplyMsg
+  | IInterruptRequestMsg
   | IIsCompleteReplyMsg
   | IIsCompleteRequestMsg
   | IStatusMsg
@@ -905,6 +913,43 @@ export interface IInspectReply extends IReplyOkContent {
 export interface IInspectReplyMsg extends IShellMessage<'inspect_reply'> {
   parent_header: IHeader<'inspect_request'>;
   content: ReplyContent<IInspectReply>;
+}
+
+/**
+ * An `'interrupt_request'` message.
+ *
+ * The interrupt messages can only be used for kernels which specify `interrupt_mode: 'message'`.
+ * By default JupyterLab interrupts kernels via jupyter-server Kernels REST API instead.
+ *
+ * See [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html#kernel-interrupt).
+ *
+ * **See also:** [[IInterruptReplyMsg]], [[[IKernel.interrupt]]]
+ */
+export interface IInterruptRequestMsg
+  extends IControlMessage<'interrupt_request'> {
+  content: Record<string, never>;
+}
+
+/**
+ * A `'interrupt_reply'` message content.
+ *
+ * See [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html#kernel-interrupt).
+ *
+ * **See also:** [[IInterruptRequestMsg]], [[IKernel.interrupt]]
+ */
+
+export interface IInterruptReply extends IReplyOkContent {}
+
+/**
+ * A `'interrupt_reply'` message on the `'control'` channel.
+ *
+ * See [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html#kernel-interrupt).
+ *
+ * **See also:** [[IInterruptRequestMsg]], [[IKernel.interrupt]]
+ */
+export interface IInterruptReplyMsg extends IControlMessage<'interrupt_reply'> {
+  parent_header: IHeader<'interrupt_request'>;
+  content: ReplyContent<IInterruptReply>;
 }
 
 /**


### PR DESCRIPTION
## References

- Exploring how we can implement https://github.com/jupyterlite/jupyterlite/issues/459 I noticed we do not have types for interrupt messages defined.
- Jupyter Messaging protocol `v5.3` (8 years ago) added `interrupt_request` and `interrupt_reply` on the `control` channel; they were never listed on the `shell` channel; see:
  - https://jupyter-client.readthedocs.io/en/latest/messaging.html#kernel-interrupt
  -https://github.com/jupyter/jupyter_client/pull/294
- JupyterLab never used `interrupt_request` nor `interrupt_reply` because we use jupyter-server for interrupts which uses system signals according to:
  https://github.com/jupyterlab/jupyterlab/blob/22562319f14b87e46df9d984f47bf587593f52f3/packages/services/src/kernel/kernel.ts#L190-L203

## Code changes

- Moved `interrupt_request` and `interrupt_reply` from shell to control type
- Added `IInterruptRequestMsg`, `IInterruptReply`, `IInterruptReplyMsg`.

## User-facing changes

None

## Backwards-incompatible changes

Not sure if removing incorrectly set interrupt values from `ShellMessageType` is breaking, but probably should go to a minor patch not a bugfix.
