### PR TITLE
Add more retries on the frequently failing test

### DIFF
--- a/galata/test/jupyterlab/outputarea-stdin.test.ts
+++ b/galata/test/jupyterlab/outputarea-stdin.test.ts
@@ -106,6 +106,14 @@ test.describe('Stdin for ipdb', () => {
       );
     });
   }
+});
+
+test.describe('Stdin for ipdb (flaky)', () => {
+  test.describe.configure({ retries: 4 });
+
+  test.beforeEach(async ({ page }) => {
+    await page.notebook.createNew();
+  });
 
   test('Subsequent execution in short succession', async ({ page }) => {
     await page.notebook.setCell(0, 'code', loopedInput);


### PR DESCRIPTION
## References

Trying to address https://github.com/jupyterlab/jupyterlab/issues/17479

## Code changes

Bump retries from default 2 to 4..

## User-facing changes

None

## Backwards-incompatible changes

None