### PR TITLE
Update `@codemirror/view` to `v6.38.1`, fixing `lineWrap` in `defer` mode

### DIFF
--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@codemirror/state": "^6.5.2",
-    "@codemirror/view": "^6.36.6",
+    "@codemirror/view": "^6.38.1",
     "@jupyter/ydoc": "^3.0.4",
     "@jupyterlab/apputils": "^4.6.0-alpha.1",
     "@jupyterlab/attachments": "^4.5.0-alpha.1",

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -42,7 +42,7 @@
     "@codemirror/language": "^6.11.0",
     "@codemirror/legacy-modes": "^6.5.1",
     "@codemirror/search": "^6.5.10",
-    "@codemirror/view": "^6.36.6",
+    "@codemirror/view": "^6.38.1",
     "@jupyter/ydoc": "^3.0.4",
     "@jupyterlab/application": "^4.5.0-alpha.1",
     "@jupyterlab/codeeditor": "^4.5.0-alpha.1",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -56,7 +56,7 @@
     "@codemirror/legacy-modes": "^6.5.1",
     "@codemirror/search": "^6.5.10",
     "@codemirror/state": "^6.5.2",
-    "@codemirror/view": "^6.36.6",
+    "@codemirror/view": "^6.38.1",
     "@jupyter/ydoc": "^3.0.4",
     "@jupyterlab/codeeditor": "^4.5.0-alpha.1",
     "@jupyterlab/coreutils": "^6.5.0-alpha.1",

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@codemirror/state": "^6.5.2",
-    "@codemirror/view": "^6.36.6",
+    "@codemirror/view": "^6.38.1",
     "@jupyter/ydoc": "^3.0.4",
     "@jupyterlab/apputils": "^4.6.0-alpha.1",
     "@jupyterlab/codeeditor": "^4.5.0-alpha.1",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@codemirror/state": "^6.5.2",
-    "@codemirror/view": "^6.36.6",
+    "@codemirror/view": "^6.38.1",
     "@jupyter/react-components": "^0.16.6",
     "@jupyter/ydoc": "^3.0.4",
     "@jupyterlab/application": "^4.5.0-alpha.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1631,14 +1631,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemirror/view@npm:^6.0.0, @codemirror/view@npm:^6.17.0, @codemirror/view@npm:^6.23.0, @codemirror/view@npm:^6.27.0, @codemirror/view@npm:^6.36.6":
-  version: 6.36.6
-  resolution: "@codemirror/view@npm:6.36.6"
+"@codemirror/view@npm:^6.0.0, @codemirror/view@npm:^6.17.0, @codemirror/view@npm:^6.23.0, @codemirror/view@npm:^6.27.0, @codemirror/view@npm:^6.38.1":
+  version: 6.38.1
+  resolution: "@codemirror/view@npm:6.38.1"
   dependencies:
     "@codemirror/state": ^6.5.0
+    crelt: ^1.0.6
     style-mod: ^4.1.0
     w3c-keyname: ^2.2.4
-  checksum: a36662e61743d379a4bc8f5a5e441b23d6612e029e4d4f494aec974adb81752488be2fc55a9105a8b6c0e846b4a26ed570d9d1df4577affb3fc7c63de9407a45
+  checksum: a6432f1cf4a9a400eb66619d33b2841d986024677fc95c564b283f7e896fe43b17d7665ca7816b9f6b01a44522d76b928aac8f8778ddd9dfb313b125e2c31643
   languageName: node
   linkType: hard
 
@@ -2562,7 +2563,7 @@ __metadata:
   resolution: "@jupyterlab/cells@workspace:packages/cells"
   dependencies:
     "@codemirror/state": ^6.5.2
-    "@codemirror/view": ^6.36.6
+    "@codemirror/view": ^6.38.1
     "@jupyter/ydoc": ^3.0.4
     "@jupyterlab/apputils": ^4.6.0-alpha.1
     "@jupyterlab/attachments": ^4.5.0-alpha.1
@@ -2651,7 +2652,7 @@ __metadata:
     "@codemirror/language": ^6.11.0
     "@codemirror/legacy-modes": ^6.5.1
     "@codemirror/search": ^6.5.10
-    "@codemirror/view": ^6.36.6
+    "@codemirror/view": ^6.38.1
     "@jupyter/ydoc": ^3.0.4
     "@jupyterlab/application": ^4.5.0-alpha.1
     "@jupyterlab/codeeditor": ^4.5.0-alpha.1
@@ -2694,7 +2695,7 @@ __metadata:
     "@codemirror/legacy-modes": ^6.5.1
     "@codemirror/search": ^6.5.10
     "@codemirror/state": ^6.5.2
-    "@codemirror/view": ^6.36.6
+    "@codemirror/view": ^6.38.1
     "@jupyter/ydoc": ^3.0.4
     "@jupyterlab/codeeditor": ^4.5.0-alpha.1
     "@jupyterlab/coreutils": ^6.5.0-alpha.1
@@ -2742,7 +2743,7 @@ __metadata:
   resolution: "@jupyterlab/completer@workspace:packages/completer"
   dependencies:
     "@codemirror/state": ^6.5.2
-    "@codemirror/view": ^6.36.6
+    "@codemirror/view": ^6.38.1
     "@jupyter/ydoc": ^3.0.4
     "@jupyterlab/apputils": ^4.6.0-alpha.1
     "@jupyterlab/codeeditor": ^4.5.0-alpha.1
@@ -2926,7 +2927,7 @@ __metadata:
   resolution: "@jupyterlab/debugger@workspace:packages/debugger"
   dependencies:
     "@codemirror/state": ^6.5.2
-    "@codemirror/view": ^6.36.6
+    "@codemirror/view": ^6.38.1
     "@jupyter/react-components": ^0.16.6
     "@jupyter/ydoc": ^3.0.4
     "@jupyterlab/application": ^4.5.0-alpha.1
@@ -10051,10 +10052,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"crelt@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "crelt@npm:1.0.5"
-  checksum: 04a618c5878e12a14a9a328a49ff6e37bed76abb88b72e661c56b5f161d8a9aca133650da6bcbc5224ad1f7f43a69325627f209e92a21002986d52a8f844b367
+"crelt@npm:^1.0.5, crelt@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "crelt@npm:1.0.6"
+  checksum: dad842093371ad702afbc0531bfca2b0a8dd920b23a42f26e66dabbed9aad9acd5b9030496359545ef3937c3aced0fd4ac39f7a2d280a23ddf9eb7fdcb94a69f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## References

Pulls a fixes for CodeMirror crashing when used with `lineWrap` is enabled https://github.com/codemirror/dev/issues/1588

<details>

<summary>Changelog</summary>

> ### 6.38.1 (2025-07-15)
> 
> #### Bug fixes
> 
> Make the keymap not dispatch Alt key combos on macOS by key code, because those are generally used to type special characters.
> 
> Fix a layout bug that could occur with very narrow editors.
> 
> ### 6.38.0 (2025-06-27)
> 
> #### New features
> 
> Gutters can now specify that they should be displayed after the content (which would be to the right in a left-to-right layout).
> 
> ### 6.37.2 (2025-06-12)
> 
> #### Bug fixes
> 
> Fix an issue where moving the cursor vertically from the one-but-last character on a line would sometimes move incorrectly on Safari.
> 
> Fix an issue causing coordinates between lines of text to sometimes be inappropriately placed at the end of the line by `posAtCoords`.
> 
> ### 6.37.1 (2025-05-30)
> 
> #### Bug fixes
> 
> Properly add `crelt` as a dependency.
> 
> ### 6.37.0 (2025-05-29)
> 
> #### New features
> 
> View plugins can now take an argument, in which case they must be instantiated with their `of` method in order to be added to a configuration.
> 
> The new `showDialog` function makes it easy to show a notification or prompt using a CodeMirror panel.
> 
> ### 6.36.8 (2025-05-12)
> 
> #### Bug fixes
> 
> Make `logException` log errors to the console when `onerror` returns a falsy value.
> 
> Fix an issue in `MatchDecorator` causing `updateDeco` to sometimes not do the right thing for deletions.
> 
> ### 6.36.7 (2025-05-02)
> 
> #### Bug fixes
> 
> Use the `aria-placeholder` attribute to communicate the placeholder text to screen readers.
> 
> Fix a crash when `EditorView.composing` or `.compositionStarted` are accessed during view initialization.

</details>

## Code changes

```diff
-    "@codemirror/view": "^6.36.6",
+    "@codemirror/view": "^6.38.1",
```

## User-facing changes

Using `lineWrap: true` with windowing mode = `defer` no longer breaks code insertion from extensions.

## Backwards-incompatible changes

None