### PR TITLE
Fix tab order for status bar items

### DIFF
--- a/packages/statusbar/src/statusbar.ts
+++ b/packages/statusbar/src/statusbar.ts
@@ -80,7 +80,6 @@ export class StatusBar extends Widget implements IStatusBar {
         this._leftSide.insertWidget(insertIndex, item);
       }
     } else if (align === 'right') {
-      
       const insertIndex = ArrayExt.findFirstIndex(
         this._rightRankItems,
         item => item.rank < rankItem.rank

--- a/packages/statusbar/src/statusbar.ts
+++ b/packages/statusbar/src/statusbar.ts
@@ -29,6 +29,8 @@ export class StatusBar extends Widget implements IStatusBar {
     middlePanel.addClass('jp-StatusBar-Middle');
     rightPanel.addClass('jp-StatusBar-Right');
 
+    rightPanel.node.style.flexDirection = 'row';
+
     rootLayout.addWidget(leftPanel);
     rootLayout.addWidget(middlePanel);
     rootLayout.addWidget(rightPanel);
@@ -78,7 +80,11 @@ export class StatusBar extends Widget implements IStatusBar {
         this._leftSide.insertWidget(insertIndex, item);
       }
     } else if (align === 'right') {
-      const insertIndex = this._findInsertIndex(this._rightRankItems, rankItem);
+      
+      const insertIndex = ArrayExt.findFirstIndex(
+        this._rightRankItems,
+        item => item.rank < rankItem.rank
+      );
       if (insertIndex === -1) {
         this._rightSide.addWidget(item);
         this._rightRankItems.push(rankItem);

--- a/packages/statusbar/test/statusbar.spec.ts
+++ b/packages/statusbar/test/statusbar.spec.ts
@@ -73,9 +73,9 @@ describe('@jupyterlab/statusbar', () => {
           align: 'right',
           rank: 1
         });
-        // Reverse order than what one might expect, as right-to-left
-        // is set in the styling of the right panel.
-        expect(item1.node.nextSibling).toBe(item2.node);
+        // The right panel uses a right-to-left ordering.
+        // Higher‑rank items are therefore placed before lower‑rank ones.
+        expect(item2.node.nextSibling).toBe(item1.node);
       });
 
       it('should allow insertion of status items in the middle', () => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
Fixes #17680 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

https://github.com/user-attachments/assets/326fe675-b83b-441c-9fa5-9064bafa24c1



## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
