### PR TITLE
Do not silently change when executing an empty cell

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1739,13 +1739,9 @@ export namespace CodeCell {
     const model = cell.model;
     const code = model.sharedModel.getSource();
     if (!code.trim() || !sessionContext.session?.kernel) {
-      model.sharedModel.transact(
-        () => {
-          model.clearExecution();
-        },
-        false,
-        'silent-change'
-      );
+      model.sharedModel.transact(() => {
+        model.clearExecution();
+      }, false);
       return;
     }
     const cellId = { cellId: model.sharedModel.getId() };


### PR DESCRIPTION
## References

After https://github.com/jupyterlab/jupyterlab/pull/16498, executing an empty code cell (which is mostly clearing outputs and execution state) doesn't trigger the `changed` signal.

This PR restores it, by removing the `silent-change` argument.

Fixes #17638

## Code changes

Remove the `silent-change` argument when executing an empty cell.

## User-facing changes

None

## Backwards-incompatible changes

None

cc. @davidbrochart who added this `silent-change` argument, in case I missed something.
