### PR TITLE
Normalize `ToolbarButtonComponent` dataset attributes with the `data-` prefix

### DIFF
--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -870,7 +870,7 @@ export function ToolbarButtonComponent(
       aria-disabled={disabled}
       aria-label={props.label || title}
       aria-pressed={props.pressed}
-      {...props.dataset}
+      {...Private.normalizeDataset(props.dataset)}
       disabled={disabled}
       onClick={handleClick}
       onMouseDown={handleMouseDown}
@@ -1310,6 +1310,25 @@ class ToolbarPopupOpener extends ToolbarButton {
  * A namespace for private data.
  */
 namespace Private {
+  /**
+   * Ensures all dataset keys have the 'data-' prefix.
+   * @param dataset object
+   */
+  export function normalizeDataset(
+    dataset?: DOMStringMap
+  ): DOMStringMap | undefined {
+    if (!dataset) {
+      return undefined;
+    }
+
+    const normalized: DOMStringMap = {};
+    for (const [key, value] of Object.entries(dataset)) {
+      const normalizedKey = key.startsWith('data-') ? key : `data-${key}`;
+      normalized[normalizedKey] = value;
+    }
+    return normalized;
+  }
+
   export function propsFromCommand(
     options: CommandToolbarButtonComponent.IProps
   ): ToolbarButtonComponent.IProps {


### PR DESCRIPTION
## References
Resolves #17695

## Code changes
Adds a function that processes dataset attributes in `ToolbarButtonComponent`, to make sure that all dataset attributes contain the `data-` prefix

## User-facing changes
None

## Backwards-incompatible changes
None to my knowledge.

## Other
Extension authors passing in dataset attributes to `ToolbarButtonComponent` can observe that those attributes are always prefixed with `data-`. 