### PR TITLE
Reduce UI blocking time when saving large notebooks by using file stream

### DIFF
--- a/packages/filebrowser/jest.config.js
+++ b/packages/filebrowser/jest.config.js
@@ -4,4 +4,6 @@
  */
 
 const func = require('@jupyterlab/testing/lib/jest-config');
-module.exports = func(__dirname);
+const config = func(__dirname);
+config['testEnvironment'] = './lib/jest-env.js';
+module.exports = config;

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -60,6 +60,7 @@
     "@lumino/signaling": "^2.1.4",
     "@lumino/virtualdom": "^2.0.3",
     "@lumino/widgets": "^2.7.1",
+    "jest-environment-jsdom": "^29.3.0",
     "react": "^18.2.0"
   },
   "devDependencies": {

--- a/packages/filebrowser/src/jest-env.ts
+++ b/packages/filebrowser/src/jest-env.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+// From: https://github.com/jsdom/jsdom/issues/1724#issuecomment-1446858041
+// Mostly the same as in @jupyterlab/testing, but using jsdom version of `File`
+// so that it is compatible with `FileReader` from jsdom.
+
+import JSDOMEnvironment from 'jest-environment-jsdom';
+
+export default class FixJSDOMEnvironment extends JSDOMEnvironment {
+  constructor(...args: ConstructorParameters<typeof JSDOMEnvironment>) {
+    super(...args);
+
+    this.global.fetch = fetch;
+    this.global.Headers = Headers;
+    this.global.Request = Request;
+    this.global.Response = Response;
+  }
+}

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -1792,9 +1792,35 @@ export class RestContentProvider implements IContentProvider {
   ): Promise<Contents.IModel> {
     const settings = this._options.serverSettings;
     const url = this._getUrl(localPath);
+    // requires http2 in tornado!
+    /*
+    function createJSONStreamFromString(str: string, chunkSize = 65536) {
+      let offset = 0;
+      return new ReadableStream({
+        pull(controller) {
+          if (offset >= str.length) {
+            controller.close();
+            return;
+          }
+          const chunk = str.slice(offset, offset + chunkSize);
+          controller.enqueue(new TextEncoder().encode(chunk));
+          offset += chunkSize;
+        }
+      });
+    }
+    const stream = createJSONStreamFromString(JSON.stringify(options));
     const init = {
       method: 'PUT',
-      body: JSON.stringify(options)
+      body: stream,
+      duplex: 'half'
+    };
+    */
+    const file = new File([JSON.stringify(options)], 'data.json', {
+      type: 'application/json'
+    });
+    const init = {
+      method: 'PUT',
+      body: file
     };
     const response = await ServerConnection.makeRequest(url, init, settings);
     // will return 200 for an existing file and 201 for a new file

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -1792,29 +1792,6 @@ export class RestContentProvider implements IContentProvider {
   ): Promise<Contents.IModel> {
     const settings = this._options.serverSettings;
     const url = this._getUrl(localPath);
-    // requires http2 in tornado!
-    /*
-    function createJSONStreamFromString(str: string, chunkSize = 65536) {
-      let offset = 0;
-      return new ReadableStream({
-        pull(controller) {
-          if (offset >= str.length) {
-            controller.close();
-            return;
-          }
-          const chunk = str.slice(offset, offset + chunkSize);
-          controller.enqueue(new TextEncoder().encode(chunk));
-          offset += chunkSize;
-        }
-      });
-    }
-    const stream = createJSONStreamFromString(JSON.stringify(options));
-    const init = {
-      method: 'PUT',
-      body: stream,
-      duplex: 'half'
-    };
-    */
     const file = new File([JSON.stringify(options)], 'data.json', {
       type: 'application/json'
     });

--- a/packages/services/test/utils.ts
+++ b/packages/services/test/utils.ts
@@ -132,7 +132,7 @@ export function handleRequest(item: IService, status: number, body: any): void {
     (item.serverSettings as any).fetch = oldFetch;
 
     // Normalize the body.
-    if (typeof body !== 'string') {
+    if (typeof body !== 'string' && !(body instanceof File)) {
       body = JSON.stringify(body);
     }
     // Body should be null for these status codes

--- a/packages/testing/src/jest-env.ts
+++ b/packages/testing/src/jest-env.ts
@@ -17,5 +17,7 @@ export default class FixJSDOMEnvironment extends JSDOMEnvironment {
     this.global.Headers = Headers;
     this.global.Request = Request;
     this.global.Response = Response;
+    // While jsdom has it's own File, it clashes with instance checks in fetch, so we use one from Node.js
+    this.global.File = File;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3514,6 +3514,7 @@ __metadata:
     "@lumino/widgets": ^2.7.1
     "@types/jest": ^29.2.0
     jest: ^29.2.0
+    jest-environment-jsdom: ^29.3.0
     react: ^18.2.0
     rimraf: ~5.0.5
     typescript: ~5.5.4


### PR DESCRIPTION
## References

- Alleviates https://github.com/jupyterlab/jupyterlab/issues/17017

## Code changes

Instead of sending the string via HTTP PUT request in one chunk, send the contents via File upload which allows the tornado server to receive it in chunks.

## User-facing changes

### UI blocking time

| Browser | Before | After | Speedup |
|--|--|--|--|
| Chrome | 580ms, 550ms, 564ms | 422ms, 409ms, 414ms | 26.5% |
| Firefox |  322ms, 322ms, 326ms | 133ms, 131ms, 133ms |59.0% |

<details>

For Chrome and Firefox I used a notebook of 98.7 MB with the result of printing out 10**7 lines as in the issue reproducer. This was too much for Safari/Webkit to render so instead I generated a single image output which weighs 100MB when saved with:

```python
import numpy as np
from PIL import Image
import io
import base64
from IPython.display import display, HTML

# Desired final output: ~100 MB base64 string
# So raw image should be ~75 MB
target_raw_bytes = int(75 * 1024 * 1024)  # 75 MB
channels = 3
bytes_per_pixel = 1  # uint8

# Compute image size (square image)
total_pixels = target_raw_bytes // (channels * bytes_per_pixel)
side = int(np.ceil(np.sqrt(total_pixels)))

# Generate random image (not compressible)
array = np.random.randint(0, 256, (side, side, channels), dtype=np.uint8)
img = Image.fromarray(array, 'RGB')

# Save as PNG (mild compression, but adds headers)
buf = io.BytesIO()
img.save(buf, format='PNG', compress_level=0)  # use lowest compression
buf.seek(0)

# Base64 encode
b64 = base64.b64encode(buf.read()).decode('utf-8')
data_uri = f'data:image/png;base64,{b64}'

# Display using HTML
html = f'<img src="{data_uri}" />'
display(HTML(html))
```

But I was not able to find a way to measure time take on Safari/WebKit. In any case this was tested on Safari  and GNOME Web too.

</details>

## Backwards-incompatible changes

None

Tested against `jupyter-server` v2 and against `jupyverse` 0.10.3.
