### PR TITLE
Add tests for browser window's selection

### DIFF
--- a/galata/test/jupyterlab/notebook-search.test.ts
+++ b/galata/test/jupyterlab/notebook-search.test.ts
@@ -161,6 +161,34 @@ test.describe('Notebook Search', () => {
     await expect(page.locator('.jp-DocumentSearch-overlay')).toBeVisible();
   });
 
+  test('Populate search box with text selected in rendered markdown', async ({
+    page
+  }) => {
+    // Render the markdown cell to be able to select text from it.
+    await page.notebook.runCell(1, true);
+    const cell = await page.notebook.getCellLocator(1);
+
+    // Select a word for example here using "JupyterLab" by double clicking on it.
+    await cell!.getByText('JupyterLab').dblclick();
+
+    // Open the search box.
+    await page.keyboard.press('Control+f');
+
+    const searchInput = page.getByPlaceholder('Find');
+    // Check if the search box is populated with the selected text.
+    await expect(searchInput).toHaveValue('JupyterLab');
+    await expect(searchInput).toBeFocused();
+
+    // Check that the search box content is selected.
+    expect(await searchInput.evaluate(getSelectionRange)).toStrictEqual({
+      start: 0,
+      end: 'JupyterLab'.length
+    });
+
+    // Expect that the search found a match.
+    await page.locator('text=1/1').waitFor();
+  });
+
   test('Restore previous search query if there is no selection', async ({
     page
   }) => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
#15992 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
This pull request introduces a new Galata integration test to verify the notebook search functionality. The core change being tested is the ability of the search provider to use text selected anywhere in the browser window (window.getSelection()) as the initial search query ( #15834)
<!-- Describe the code changes and how they address the issue. -->

This test performs the following actions:
- Ensures a markdown cell is in its rendered state.
- selects a word within that rendered output.
- Opens the search panel.
- Asserts that the search input field is correctly populated with the selected word and is focused.
- Verifies that the new query is immediately active by checking the match count.
