### PR TITLE
Enable virtual minimap in 'defer' and 'none' windowing modes

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -3611,9 +3611,7 @@ function addCommands(
 
   commands.addCommand(CommandIDs.virtualScrollbar, {
     label: trans.__('Show Minimap'),
-    caption: trans.__(
-      'Show Minimap (virtual scrollbar, enabled with windowing mode: full)'
-    ),
+    caption: trans.__('Show Minimap'),
     execute: args => {
       const current = getCurrent(tracker, shell, args);
 
@@ -3623,20 +3621,14 @@ function addCommands(
     },
     icon: args => (args.toolbar ? tableRowsIcon : undefined),
     isEnabled: args => {
-      const enabled =
-        (args.toolbar ? true : isEnabled()) &&
-        (settings?.composite.windowingMode === 'full' ?? false);
-      return enabled;
+      return args.toolbar ? true : isEnabled();
     },
     isToggled: () => {
       const current = tracker.currentWidget;
       return current?.content.scrollbar ?? false;
     },
     isVisible: args => {
-      const visible =
-        (args.toolbar ? true : isEnabled()) &&
-        (settings?.composite.windowingMode === 'full' ?? false);
-      return visible;
+      return args.toolbar ? true : isEnabled();
     }
   });
 

--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -461,7 +461,7 @@ export abstract class WindowedListModel implements WindowedList.IModel {
 
     const previousLastMeasuredIndex = this._measuredAllUntilIndex;
     if (this.windowingActive) {
-      newWindowIndex = this._getRangeToRender();
+      newWindowIndex = this.getVirtualRangeToRender();
     }
     const [startIndex, stopIndex] = newWindowIndex;
 
@@ -759,7 +759,7 @@ export abstract class WindowedListModel implements WindowedList.IModel {
     );
   }
 
-  private _getRangeToRender(): WindowedList.WindowIndex {
+  getVirtualRangeToRender(): WindowedList.WindowIndex {
     const widgetCount = this.widgetCount;
 
     if (widgetCount === 0) {
@@ -1012,6 +1012,8 @@ export class WindowedList<
    * @deprecated since v4 This is an internal helper. Prefer calling `scrollToItem`.
    */
   scrollTo(scrollOffset: number): void {
+    this._renderScrollbar();
+
     if (!this.viewModel.windowingActive) {
       this._outerElement.scrollTo({ top: scrollOffset });
       return;
@@ -1164,21 +1166,26 @@ export class WindowedList<
         Math.min(scrollTop, scrollHeight - clientHeight)
       );
       this.viewModel.scrollOffset = scrollOffset;
-      this._scrollUpdateWasRequested = false;
 
-      if (this._viewport.dataset.isScrolling != 'true') {
-        this._viewport.dataset.isScrolling = 'true';
-      }
+      this._renderScrollbar();
 
-      if (this._timerToClearScrollStatus) {
-        window.clearTimeout(this._timerToClearScrollStatus);
+      if (this.viewModel.windowingActive) {
+        this._scrollUpdateWasRequested = false;
+
+        if (this._viewport.dataset.isScrolling != 'true') {
+          this._viewport.dataset.isScrolling = 'true';
+        }
+
+        if (this._timerToClearScrollStatus) {
+          window.clearTimeout(this._timerToClearScrollStatus);
+        }
+        // TODO: remove once `scrollend` event is supported by Safari
+        this._timerToClearScrollStatus = window.setTimeout(() => {
+          this._onScrollEnd();
+        }, 750);
+        this.update();
+        // }
       }
-      // TODO: remove once `scrollend` event is supported by Safari
-      this._timerToClearScrollStatus = window.setTimeout(() => {
-        this._onScrollEnd();
-      }, 750);
-      this.update();
-      // }
     }
   }
 
@@ -1315,7 +1322,6 @@ export class WindowedList<
           () => this._itemsResizeObserver?.unobserve(widget.node)
         );
       }
-      this._outerElement.addEventListener('scroll', this, passiveIfSupported);
 
       this._scrollbarResizeObserver = new ResizeObserver(
         this._adjustDimensionsForScrollbar.bind(this)
@@ -1330,6 +1336,8 @@ export class WindowedList<
         this._areaResizeObserver.observe(this._innerElement);
       }
     }
+
+    this._outerElement.addEventListener('scroll', this, passiveIfSupported);
   }
 
   /**
@@ -1374,17 +1382,9 @@ export class WindowedList<
     const newWindowIndex = this.viewModel.getRangeToRender();
 
     if (newWindowIndex !== null) {
-      const [startIndex, stopIndex, firstVisibleIndex, lastVisibleIndex] =
-        newWindowIndex;
+      const [startIndex, stopIndex] = newWindowIndex;
 
-      if (this.scrollbar) {
-        const scrollbarItems = this._renderScrollbar();
-        const first = scrollbarItems[firstVisibleIndex];
-        const last = scrollbarItems[lastVisibleIndex];
-        this._viewportIndicator.style.top = first.offsetTop - 1 + 'px';
-        this._viewportIndicator.style.height =
-          last.offsetTop - first.offsetTop + last.offsetHeight + 'px';
-      }
+      this._renderScrollbar();
 
       const toAdd: Widget[] = [];
       if (stopIndex >= 0) {
@@ -1602,6 +1602,20 @@ export class WindowedList<
       !oldNodes.every((node, index) => elements[index] === node)
     ) {
       content.replaceChildren(...elements);
+    }
+
+    if (this.scrollbar) {
+      const newWindowIndex = this.viewModel.getVirtualRangeToRender();
+
+      if (newWindowIndex !== null) {
+        const [firstVisibleIndex, lastVisibleIndex] = newWindowIndex;
+
+        const first = elements[firstVisibleIndex];
+        const last = elements[lastVisibleIndex];
+        this._viewportIndicator.style.top = first.offsetTop - 1 + 'px';
+        this._viewportIndicator.style.height =
+          last.offsetTop - first.offsetTop + last.offsetHeight + 'px';
+      }
     }
 
     return elements;
@@ -1962,6 +1976,15 @@ export namespace WindowedList {
      * @returns The current items range to display
      */
     getRangeToRender(): WindowIndex | null;
+
+    /**
+     * Compute the items range to display.
+     *
+     * It returns ``null`` if the range does not need to be updated. Same as `getRangeToRender` in full windowing mode.
+     *
+     * @returns The current items range to display
+     */
+    getVirtualRangeToRender(): WindowIndex | null;
 
     /**
      * Return the viewport top position and height for range spanning from


### PR DESCRIPTION
## References

As discussed in https://github.com/jupyterlab/jupyterlab/pull/17681

## Code changes

Enable the virtual minimap for 'defer' and 'none' windowing modes.

## User-facing changes

https://github.com/user-attachments/assets/498d828b-6789-4d06-92ec-8d58364a60d6

## Backwards-incompatible changes

None