### PR TITLE
Discover the app directory relative to the installed module

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -177,6 +177,20 @@ def get_app_dir():
     ):
         app_dir = "/usr/local/share/jupyter/lab"
 
+    # Check for a path relative to the site-packages directory, e.g.,
+    # `<prefix>/lib/python3.13/site-packages/jupyterlab/../../../..` This is
+    # useful for cases where the the `jupyterlab` module is outside the current
+    # Python environment, which can occur via various Python path manipulations.
+    elif not osp.exists(app_dir):
+        maybe_app_dir = pjoin(
+            osp.dirname(osp.dirname(osp.dirname(osp.dirname(HERE)))),
+            "share",
+            "jupyter",
+            "lab",
+        )
+        if osp.exists(maybe_app_dir):
+            app_dir = maybe_app_dir
+
     # We must resolve the path to get the canonical case of the path for
     # case-sensitive systems
     return str(Path(app_dir).resolve())


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Closes https://github.com/jupyterlab/jupyterlab/issues/17716

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Updates `get_app_dir` to search for an application directory relative to the `jupyterlab` module.

## User-facing changes

This should only change behavior for users who previously encountered failures where the application directory could not be found.
 
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None.
