### PR TITLE
Fix wrongfully scrolling to the end of cell when it's halfway visible

### DIFF
--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -421,8 +421,6 @@ export abstract class WindowedListModel implements WindowedList.IModel {
         return currentOffset;
       } else if (alignPreference !== undefined) {
         align = alignPreference;
-      } else if (crossingBottomEdge || bottomEdge <= itemBottom) {
-        align = 'end';
       } else {
         align = 'start';
       }


### PR DESCRIPTION
## References

Fix https://github.com/jupyterlab/jupyterlab/issues/17575

Opening as draft for now, I am not sure I understand in which case scrolling to the end was useful, @krassowski may know in which case this was useful? Happy to update the PR to reduce the scope of this condition 
