### PR TITLE
fix Incorrect use of aria-hidden with LabIcon

### DIFF
--- a/packages/ui-components/src/icon/labicon.tsx
+++ b/packages/ui-components/src/icon/labicon.tsx
@@ -459,6 +459,7 @@ export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
           title,
           slot,
           tag = 'div',
+          'aria-hidden': ariaHidden,
           ...styleProps
         }: LabIcon.IProps = { ...this._props, ...props };
 
@@ -496,7 +497,8 @@ export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
                 ? classes(className, LabIconStyle.styleClass(styleProps))
                 : undefined,
             title: title,
-            slot: slot
+            slot: slot,
+            'aria-hidden': ariaHidden
           });
         }
 
@@ -527,7 +529,8 @@ export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
                   ? classes(className, LabIconStyle.styleClass(styleProps))
                   : undefined,
               title: title,
-              slot: slot
+              slot: slot,
+              'aria-hidden': ariaHidden
             };
           }
           return (
@@ -718,6 +721,11 @@ export namespace LabIcon {
      * Optional slot property to specify the position of the icon in the template
      */
     slot?: string | null;
+
+    /**
+     * Optional aria-hidden attribute for accessibility
+     */
+    'aria-hidden'?: boolean | 'true' | 'false';
   }
 
   export interface IResolverProps {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
#16167 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Problem: ```aria-hidden``` was not being destructured from the props, so it was getting included in the ...styleProps spread operator.

Fix: Destructuring to pull the incoming aria-hidden prop out of the generic props bag and assign its value to a variable for properly forwarding the aria-hidden prop on LabIcon wrappers so it’s applied as a real HTML attribute for correct accessibility.
<!-- Describe the code changes and how they address the issue. -->
Results in:
<img width="1710" height="987" alt="Screenshot 2025-07-24 at 5 00 42 PM" src="https://github.com/user-attachments/assets/ddb9b96b-f1a4-4e18-9f5f-ec66c3223026" />

