### PR TITLE
Fix anchor on sanitized HTML

### DIFF
--- a/packages/apputils/src/sanitizer.ts
+++ b/packages/apputils/src/sanitizer.ts
@@ -741,6 +741,7 @@ export class Sanitizer implements IRenderMime.ISanitizer {
       allowedAttributes: {
         '*': [
           'class',
+          'data-jupyter-id',
           'dir',
           'draggable',
           'hidden',

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -1354,6 +1354,16 @@ namespace Private {
       // Handle internal link in the file.
       if (hash === href) {
         anchor.target = '_self';
+
+        anchor.onclick = event => {
+          const target = event.target as HTMLAnchorElement;
+          const anchorTargetId = target.href.split('#').slice(-1)[0];
+          const anchorTarget = document.querySelector(
+            `[data-jupyter-id="${anchorTargetId}"]`
+          );
+          anchorTarget?.scrollIntoView();
+        };
+
         return;
       }
       // For external links, remove the hash until we have hash handling.


### PR DESCRIPTION
## References

Fixes #17496 

## Code changes

Add an `onclick` listener on rendered anchors, that will search for the first element with attributes `data-jupyter-id` equal to the anchor `href`.

For example the following markdown would work:

```md
[GO TO TARGET](#target)

<p data-jupyter-id="target">my target</p>
```

[record-2025-07-24_21.45.02.webm](https://github.com/user-attachments/assets/84eda5fe-cddf-47cb-8186-2852fb2eb2fc)

## User-facing changes

Make anchor working with sanitized HTML for non full-windowing notebook.

## Additional questions

1. Is there a way to replace the `id` attribute by `data-jupyter-id` during sanitization, for user to be able to use regular `id` ?
2. How to handle full-windowing notebook ?

