### PR TITLE
Keep cell `id` when the user changes cell type

### DIFF
--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2781,6 +2781,7 @@ namespace Private {
             raw.metadata.trusted = undefined;
           }
           const newCell = notebookSharedModel.insertCell(index, {
+            id: raw.id,
             cell_type: value,
             source: raw.source,
             metadata: raw.metadata


### PR DESCRIPTION
When a user changes cell type in a notebook in JupyterLab today, the cell `id` of that cell changes. And if the user immediately changes the cell back to the original type, the `id` changes again. Strictly speaking this is not a bug but it seems incorrect.

This PR keeps the cell's original `id` when a user changes its type. This seems more inline with the intent of [JEP 62: Cell ID Addition to Notebook Format](https://jupyter.org/enhancement-proposals/62-cell-id/cell-id.html). In particular, though not directly addressed, the ["Questions"](https://jupyter.org/enhancement-proposals/62-cell-id/cell-id.html#questions) section seems relevant here.

## References

https://github.com/jupyterlab/jupyterlab/issues/9729
https://github.com/jupyterlab/jupyterlab/pull/10018

## Code changes
In the notebook actions utility for changing cell type, this PR keeps the `id` value of the original cell when a new cell with a new type is created to replace the original.

## User-facing changes

N/A

## Backwards-incompatible changes
It is backwards-compatible.

However, it's possible downstream code exists that works around the original behavior and would benefit from this change.