### PR TITLE
Fix initial column sizes in `FileDialog.getOpenFiles` dialog

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1068,6 +1068,8 @@ export class DirListing extends Widget {
     // Fetch common variables.
     const items = this._sortedItems;
     const nodes = this._items;
+    // If we didn't get any item yet, we'll need to resize once items are added
+    const needsResize = nodes.length === 0;
     const content = DOMUtils.findElement(this.node, CONTENT_CLASS);
     const renderer = this._renderer;
 
@@ -1142,6 +1144,11 @@ export class DirListing extends Widget {
     }
 
     this.updateNodes(items, nodes);
+
+    if (needsResize) {
+      this._width = this._computeContentWidth();
+      this._updateColumnSizes();
+    }
 
     this._prevPath = this._model.path;
   }

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -852,6 +852,7 @@ export class DirListing extends Widget {
     content.addEventListener('lm-dragleave', this);
     content.addEventListener('lm-dragover', this);
     content.addEventListener('lm-drop', this);
+    this._updateColumnSizes();
   }
 
   /**
@@ -889,6 +890,8 @@ export class DirListing extends Widget {
       this.sort(this.sortState);
       this.update();
     }
+
+    this._updateColumnSizes();
   }
 
   private _onContentResize(): void {

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -890,8 +890,6 @@ export class DirListing extends Widget {
       this.sort(this.sortState);
       this.update();
     }
-
-    this._updateColumnSizes();
   }
 
   private _onContentResize(): void {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fix one issue mentioned in https://github.com/jupyterlab/jupyterlab/issues/17724

It seems I could only reproduce the issue on Firefox. With this PR both Firefox and Chromium now behave correctly.

## Code changes

Filebrowser UI: compute correct column sizes on `after-attach` and `after-show` events, since those impact the `getBoundingClientRect` behavior

## User-facing changes

On core-JupyterLab it affects mostly the look of the `import workspace` command. It will also fixes the issue for any labextension that uses the `FileDialog.getOpenFiles` function.

Before this PR :

<img width="990" height="961" alt="Screenshot From 2025-07-30 16-28-43" src="https://github.com/user-attachments/assets/9fc1fc65-fdee-4414-99e0-301e5e458010" />

After this PR:

<img width="990" height="961" alt="Screenshot From 2025-07-30 16-27-35" src="https://github.com/user-attachments/assets/6ce07adc-df17-4d95-9b0a-31e0ab718e9f" />

## Backwards-incompatible changes

None