### PR TITLE
Exclude version 6.30.0 of ipykernel, which add a regression on the debugger

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "async_lru>=1.0.0",
     "httpx>=0.25.0",
     "importlib-metadata>=4.8.3;python_version<\"3.10\"",
-    "ipykernel>=6.5.0",
+    "ipykernel>=6.5.0,!=6.30.0",
     "jinja2>=3.0.3",
     "jupyter_core",
     "jupyter_server>=2.4.0,<3",


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/17739
Related to https://github.com/ipython/ipykernel/issues/1412

## Code changes

Exclude the version 6.30.0 of `ipykernel` in _pyproject.toml_.
This exclusion assume that the debugger will be fixed in version 6.30.1, otherwise we'll have to exclude a range of version.

## User-facing changes

Fix the debugger that is broken with ipykernel 6.30.0.

## Backwards-incompatible changes

None
