### PR TITLE
Pin to `httpx<1`

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - hatchling >=1.5.0
   # run
   - async-lru >=1.0.0
-  - httpx >=0.25.0
+  - httpx >=0.25.0,<1
   - ipykernel
   - jinja2 >=3.0.3
   - jupyter_core

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 ]
 dependencies = [
     "async_lru>=1.0.0",
-    "httpx>=0.25.0",
+    "httpx>=0.25.0,<1",
     "importlib-metadata>=4.8.3;python_version<\"3.10\"",
     "ipykernel>=6.5.0,!=6.30.0",
     "jinja2>=3.0.3",


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

As noticed in the notebook repo pulling pre-releases: https://github.com/jupyter/notebook/actions/runs/16725211938/job/47338909982?pr=7689

And discussed in [#jupyterlab > Release coordination @ 💬](https://jupyter.zulipchat.com/#narrow/channel/469762-jupyterlab/topic/Release.20coordination/near/532738163)

<img width="2440" height="1164" alt="image" src="https://github.com/user-attachments/assets/7252388e-dc90-4fd0-ba74-323bf42ff8e7" />

Also linking to https://github.com/encode/httpx/discussions/3619 for reference.

## Code changes

Pin to `httpx<1` to future proof some breaking changes.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Hopefully no bad surprises when `httpx` 1.0 is released.

## Backwards-incompatible changes

None
