### PR TITLE
Fix labeller config for audio/video extensions

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -64,7 +64,7 @@ pkg:attachments:
     - packages/attachments/**/*
     - packages/attachments/*
 
-pkg:audio-extension:
+pkg:audio:
 - changed-files:
   - any-glob-to-any-file:
     - packages/audio-extension/**/*
@@ -452,7 +452,7 @@ pkg:vega:
     - packages/vega5-extension/**/*
     - packages/vega5-extension/*
 
-pkg:video-extension:
+pkg:video:
 - changed-files:
   - any-glob-to-any-file:
     - packages/video-extension/**/*


### PR DESCRIPTION
## References

The labels that were created (and which are used for all other packages) do not have `-extension` suffix, which is the cause of CI failure as seen here https://github.com/jupyterlab/jupyterlab/actions/runs/16864979191/job/47770605154?pr=17767

- Follow-up to #17636
- Noticed in #17767

<img width="1283" height="543" alt="image" src="https://github.com/user-attachments/assets/b7162c84-dec1-45a8-a8ac-563e87aff954" />


## Code changes

Remove incorrect `-extension` suffix from labeller config

## User-facing changes

None

## Backwards-incompatible changes

None
