### PR TITLE
Use content visibility to render notebook cells and output areas more efficiently

### DIFF
--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -545,6 +545,13 @@ div.jp-Cell-Placeholder-content-3 {
   white-space: pre-line;
 }
 
+/* Lazy rendering to notebook cells: content outside viewport won't be rendered until scrolled into view */
+.jp-Notebook-cell {
+  content-visibility: auto;
+  contain: layout style paint; /* Isolates layout, style, and paint for this element */
+  contain-intrinsic-size: 300px; /* Estimated height used to avoid layout shifts before content is visible */
+}
+
 /*-----------------------------------------------------------------------------
 | Printing
 |----------------------------------------------------------------------------*/

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -802,6 +802,28 @@ export class OutputArea extends Widget {
     return panel;
   }
 
+  protected onAfterAttach(msg: Message): void {
+    super.onAfterAttach(msg);
+
+    requestAnimationFrame(() => {
+      this._updateIntrinsicSize();
+    });
+  }
+
+  // Dynamically set the intrinsic size to the real height of the node
+  private _updateIntrinsicSize(): void {
+    const node = this.node;
+
+    if (this.widgets.length > 0) {
+      const outputNode = this.widgets[0].node;
+      const rect = outputNode.getBoundingClientRect();
+
+      // Apply the real measured height to avoid layout shift
+      console.log('applying real height: ', rect.height);
+      node.style.containIntrinsicSize = `${rect.height}px`;
+    }
+  }
+
   private _displayIdMap = new Map<string, number[]>();
   private _future: Kernel.IShellFuture<
     KernelMessage.IExecuteRequestMsg,

--- a/packages/outputarea/style/base.css
+++ b/packages/outputarea/style/base.css
@@ -10,6 +10,11 @@
 
 .jp-OutputArea {
   overflow-y: auto;
+
+  /* Lazy rendering for entire output areas */
+  content-visibility: auto;
+  contain: layout style paint;
+  contain-intrinsic-size: 300px;
 }
 
 .jp-OutputArea-child {
@@ -320,4 +325,11 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated::before {
 
 .jp-TrimmedOutputs > a:hover {
   text-decoration: none;
+}
+
+/* Additional rule for heavy outputs like DataFrames */
+.jp-OutputArea-output .dataframe {
+  content-visibility: auto;
+  contain: layout paint style;
+  contain-intrinsic-size: 300px 300px;
 }


### PR DESCRIPTION
This is a draft PR that @Meriem-BenIsmail has begun to address scrolling issues.

## References
Fixes https://github.com/jupyterlab/jupyterlab/issues/16327#issuecomment-3163162939

## Code changes

## User-facing changes

## Backwards-incompatible changes
