### PR TITLE
Check `app.shell.currentWidget` for updating the tab title, if available

### DIFF
--- a/docs/source/extension/extension_points.rst
+++ b/docs/source/extension/extension_points.rst
@@ -822,12 +822,12 @@ providing a different rank or adding ``"disabled": true`` to remove the item).
 
    You need to set ``jupyter.lab.transform`` to ``true`` in the plugin id that will gather all items.
 
-**What are transforms?** The ``jupyter.lab.transform`` flag tells JupyterLab to wait for 
-a transform function before loading the plugin. This allows dynamic modification of settings 
+**What are transforms?** The ``jupyter.lab.transform`` flag tells JupyterLab to wait for
+a transform function before loading the plugin. This allows dynamic modification of settings
 schemas, commonly used to merge toolbar/menu definitions from multiple extensions.
 
-**Loading order pitfall**: Extensions providing transforms must register them early in 
-activation, before dependent plugins load, otherwise those plugins will timeout waiting 
+**Loading order pitfall**: Extensions providing transforms must register them early in
+activation, before dependent plugins load, otherwise those plugins will timeout waiting
 for the transform.
 
 The current widget factories supporting the toolbar customization are:

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -388,7 +388,6 @@ async function updateTabTitle(options: {
       workspace === 'default' ? '' : ` (${workspace})`
     }`;
   } else {
-    // File name from current path
     let currentFile: string;
     // If we have a DocumentWidget, use its context.path for more reliable file name
     // rather than parsing the URL which may not always reflect the actual file,
@@ -397,6 +396,7 @@ async function updateTabTitle(options: {
     if (currentWidget instanceof DocumentWidget) {
       currentFile = PathExt.basename(currentWidget.context.path);
     } else {
+      // File name from current path
       currentFile = PathExt.basename(decodeURIComponent(window.location.href));
     }
     // Truncate to first 12 characters of current document name + ... if length > 15

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -371,12 +371,13 @@ export const toggleHeader: JupyterFrontEndPlugin<void> = {
  * Update the browser title based on the workspace and the current
  * active item.
  */
-async function updateTabTitle(
-  workspace: string,
-  db: IStateDB,
-  name: string,
-  currentWidget?: Widget
-) {
+async function updateTabTitle(options: {
+  workspace: string;
+  db: IStateDB;
+  name: string;
+  currentWidget?: Widget;
+}) {
+  const { workspace, db, name, currentWidget } = options;
   const data: any = await db.toJSON();
   let current: string = data['layout-restorer:data']?.main?.current;
   if (
@@ -403,14 +404,14 @@ async function updateTabTitle(
       currentFile.length > 15
         ? currentFile.slice(0, 12).concat(`…`)
         : currentFile;
-    workspace =
+    const truncatedWorkspace =
       workspace.length > 15 ? workspace.slice(0, 12).concat(`…`) : workspace;
     // Number of restorable items that are either notebooks or editors
     const count: number = Object.keys(data).filter(
       item => item.startsWith('notebook') || item.startsWith('editor')
     ).length;
     document.title = `${currentFile}${count > 1 ? ` (${count})` : ``} - ${
-      workspace === 'default' ? name : workspace
+      workspace === 'default' ? name : truncatedWorkspace
     }`;
   }
 }
@@ -459,7 +460,12 @@ const state: JupyterFrontEndPlugin<IStateDB> = {
     // Any time the local state database changes, save the workspace.
     db.changed.connect(() => void save.invoke(), db);
     db.changed.connect(() =>
-      updateTabTitle(workspace, db, name, app.shell.currentWidget ?? undefined)
+      updateTabTitle({
+        workspace,
+        db,
+        name,
+        currentWidget: app.shell.currentWidget ?? undefined
+      })
     );
 
     commands.addCommand(CommandIDs.loadState, {

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -390,8 +390,9 @@ async function updateTabTitle(
     // File name from current path
     let currentFile: string;
     // If we have a DocumentWidget, use its context.path for more reliable file name
-    // rather than parsing the URL which may not always reflect the actual file, or may be formatted
-    // in a different way in other lab-based applications (for example ?path=example.ipynb)
+    // rather than parsing the URL which may not always reflect the actual file,
+    // may be missing, or may be formatted in a different way in other lab-based
+    // applications (for example with a query string parameter such as ?path=example.ipynb)
     if (currentWidget instanceof DocumentWidget) {
       currentFile = PathExt.basename(currentWidget.context.path);
     } else {


### PR DESCRIPTION
## References

This should help JupyterLite reuse the lab plugin without modifications for https://github.com/jupyterlite/jupyterlite/pull/1684, instead of having to redefine a full plugin providing `StateDB`.

Currently the function checks the URL to find the name of the file: https://github.com/jupyterlab/jupyterlab/blob/0feb1d368a0e241b62118b19f4f38d58a77c7dc1/packages/apputils-extension/src/index.ts#L383-L386

## Code changes

- [x] Update the internal `updateTabTitle` to take options
- [x] Check `app.shell.currentWidget` if available, default back to checking `window.location.href` otherwise

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None for JupyterLab users.

JupyterLite users will see a tab title reflecting the path of the current widget. Testing this patch locally in JupyterLite with https://github.com/jupyterlite/jupyterlite/pull/1684 :

**Before**

<img width="3392" height="1942" alt="image" src="https://github.com/user-attachments/assets/8c1749c3-e3a7-4206-800b-122bf7b3de95" />


**After**

<img width="3390" height="1944" alt="image" src="https://github.com/user-attachments/assets/6473ed0a-51fd-4c7c-b837-682c26113122" />


## Backwards-incompatible changes

None