### PR TITLE
Avoid ipykernel 7.0.0a2 in CI

### DIFF
--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install ipykernel pre-release that supports subshells (TEMPORARY)
         run: |
-          pip install --upgrade --pre ipykernel>=7
+          pip install --upgrade --pre ipykernel!=7.0.0a2
 
       - name: Launch JupyterLab
         run: |

--- a/scripts/ci_install.sh
+++ b/scripts/ci_install.sh
@@ -37,7 +37,7 @@ jlpm config
 if [[ $GROUP == js-services ]]; then
     # Install ipykernel pre-release that supports subshells for ikernel.spec.ts
     # Remove when ipykernel 7 is released
-    pip install --upgrade --pre ipykernel>=7
+    pip install --upgrade --pre ipykernel!=7.0.0a2
 fi
 
 if [[ $GROUP == nonode ]]; then


### PR DESCRIPTION
Today's release of `ipykernel` 7.0.0a2 breaks the `js-services` tests with a timeout on `input`:
```bash
FAIL  test/kernel/ikernel.spec.ts (279.927 s)
  ● Kernel.IKernel › #pendingInput › should be a signal following input request
    thrown: "Exceeded timeout of 10000 ms for a test.
```

This PR avoids the use of the problem version of `ipykernel` in CI.

I am investigating the cause of the problem and hope to have a fix soon.