### PR TITLE
Add the "Show Workspace Indicator" command to the palette

### DIFF
--- a/packages/workspaces-extension/src/index.ts
+++ b/packages/workspaces-extension/src/index.ts
@@ -19,7 +19,11 @@ import {
 import { commandsPlugin } from './commands';
 import { workspacesSidebar } from './sidebar';
 import { WorkspaceSelectorWidget } from './top_indicator';
-import { IToolbarWidgetRegistry, IWindowResolver } from '@jupyterlab/apputils';
+import {
+  ICommandPalette,
+  IToolbarWidgetRegistry,
+  IWindowResolver
+} from '@jupyterlab/apputils';
 import { ITranslator } from '@jupyterlab/translation';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
@@ -58,8 +62,15 @@ const workspacesMenu: JupyterFrontEndPlugin<void> = {
   }
 };
 
+/**
+ * The plugin id for the workspace indicator.
+ */
 const WORKSPACE_INDICATOR_PLUGIN_ID =
   '@jupyterlab/workspaces-extension:indicator';
+
+/**
+ * The command id for the workspace indicator toggle command.
+ */
 const WORKSPACE_INDICATOR_COMMAND_ID = 'workspace-indicator:toggle';
 
 /**
@@ -76,6 +87,7 @@ const workspacesIndicator: JupyterFrontEndPlugin<void> = {
     ISettingRegistry,
     IToolbarWidgetRegistry
   ],
+  optional: [ICommandPalette],
   autoStart: true,
   activate: async (
     app: JupyterFrontEnd,
@@ -84,7 +96,8 @@ const workspacesIndicator: JupyterFrontEndPlugin<void> = {
     resolver: IWindowResolver,
     translator: ITranslator,
     registry: ISettingRegistry,
-    toolbarRegistry: IToolbarWidgetRegistry
+    toolbarRegistry: IToolbarWidgetRegistry,
+    palette: ICommandPalette | null
   ) => {
     const trans = translator.load('jupyterlab');
     const openWorkspace = async (workspace: string) => {
@@ -131,6 +144,11 @@ const workspacesIndicator: JupyterFrontEndPlugin<void> = {
         }
       }
     });
+
+    if (palette) {
+      const category = trans.__('Workspaces');
+      palette.addItem({ command: WORKSPACE_INDICATOR_COMMAND_ID, category });
+    }
   }
 };
 


### PR DESCRIPTION

## References

To make it more consistent with other commands such as "Show Status Bar".

## Code changes

Add the "Show Workspace Indicator" command to the palette

## User-facing changes

<img width="2724" height="774" alt="image" src="https://github.com/user-attachments/assets/09f51ef0-9fc8-4c4b-a503-6e752f871c78" />



## Backwards-incompatible changes

None
