### PR TITLE
Allow to swap the URL resolver

### DIFF
--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -37,6 +37,7 @@ import {
   SavingStatus
 } from '@jupyterlab/docmanager';
 import { DocumentRegistry, IDocumentWidget } from '@jupyterlab/docregistry';
+import { IUrlResolverFactory } from '@jupyterlab/rendermime';
 import { Contents, Kernel } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IStatusBar } from '@jupyterlab/statusbar';
@@ -175,7 +176,8 @@ const manager: JupyterFrontEndPlugin<IDocumentManager> = {
     ILabStatus,
     ISessionContextDialogs,
     JupyterLab.IInfo,
-    IRecentsManager
+    IRecentsManager,
+    IUrlResolverFactory
   ],
   activate: (
     app: JupyterFrontEnd,
@@ -184,7 +186,8 @@ const manager: JupyterFrontEndPlugin<IDocumentManager> = {
     status: ILabStatus | null,
     sessionDialogs_: ISessionContextDialogs | null,
     info: JupyterLab.IInfo | null,
-    recentsManager: IRecentsManager | null
+    recentsManager: IRecentsManager | null,
+    urlResolverFactory: IUrlResolverFactory | null
   ) => {
     const { serviceManager: manager, docRegistry: registry } = app;
     const translator = translator_ ?? nullTranslator;
@@ -206,7 +209,8 @@ const manager: JupyterFrontEndPlugin<IDocumentManager> = {
         }
         return true;
       },
-      recentsManager: recentsManager ?? undefined
+      recentsManager: recentsManager ?? undefined,
+      urlResolverFactory: urlResolverFactory ?? undefined
     });
 
     return docManager;

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -8,6 +8,8 @@ import {
   DocumentRegistry,
   IDocumentWidget
 } from '@jupyterlab/docregistry';
+import { IUrlResolverFactory } from '@jupyterlab/rendermime';
+
 import { Contents, Kernel, ServiceManager } from '@jupyterlab/services';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { ArrayExt, find } from '@lumino/algorithm';
@@ -59,6 +61,7 @@ export class DocumentManager implements IDocumentManager {
     widgetManager.stateChanged.connect(this._onWidgetStateChanged, this);
     this._widgetManager = widgetManager;
     this._setBusy = options.setBusy;
+    this._urlResolverFactory = options.urlResolverFactory;
   }
 
   /**
@@ -578,7 +581,8 @@ export class DocumentManager implements IDocumentManager {
       sessionDialogs: this._dialogs,
       lastModifiedCheckMargin: this._lastModifiedCheckMargin,
       translator: this.translator,
-      contentProviderId
+      contentProviderId,
+      urlResolverFactory: this._urlResolverFactory
     });
     const handler = new SaveHandler({
       context,
@@ -730,6 +734,7 @@ export class DocumentManager implements IDocumentManager {
   private _renameUntitledFileOnSave = true;
   private _when: Promise<void>;
   private _setBusy: (() => IDisposable) | undefined;
+  private _urlResolverFactory?: IUrlResolverFactory;
   private _dialogs: ISessionContext.IDialogs;
   private _isConnectedCallback: () => boolean;
   private _stateChanged = new Signal<DocumentManager, IChangedArgs<any>>(this);
@@ -788,6 +793,11 @@ export namespace DocumentManager {
      * The manager for recent documents.
      */
     recentsManager?: IRecentsManager;
+
+    /**
+     * A factory for the URL resolver.
+     */
+    urlResolverFactory?: IUrlResolverFactory;
   }
 }
 

--- a/packages/docregistry/test/context.spec.ts
+++ b/packages/docregistry/test/context.spec.ts
@@ -673,10 +673,25 @@ describe('docregistry/context', () => {
     });
 
     describe('#urlResolver', () => {
+      class TestResolver extends RenderMimeRegistry.UrlResolver {
+        // no-op
+      }
       it('should be a url resolver', () => {
         expect(context.urlResolver).toBeInstanceOf(
           RenderMimeRegistry.UrlResolver
         );
+        expect(context.urlResolver).not.toBeInstanceOf(TestResolver);
+      });
+      it('should use preferred url resolver', () => {
+        context = new Context({
+          manager,
+          factory,
+          path: UUID.uuid4() + '.txt',
+          urlResolverFactory: {
+            createResolver: options => new TestResolver(options)
+          }
+        });
+        expect(context.urlResolver).toBeInstanceOf(TestResolver);
       });
     });
 

--- a/packages/rendermime/src/registry.ts
+++ b/packages/rendermime/src/registry.ts
@@ -322,10 +322,17 @@ export namespace RenderMimeRegistry {
     translator?: ITranslator;
   }
 
+  export interface IUrlResolver extends IRenderMime.IResolver {
+    /**
+     * The path of the object, from which local urls can be derived.
+     */
+    path: string;
+  }
+
   /**
    * A default resolver that uses a given reference path and a contents manager.
    */
-  export class UrlResolver implements IRenderMime.IResolver {
+  export class UrlResolver implements IUrlResolver {
     /**
      * Create a new url resolver.
      */
@@ -473,6 +480,18 @@ export namespace RenderMimeRegistry {
      * The contents manager used by the resolver.
      */
     contents: Contents.IManager;
+  }
+
+  /**
+   * The factory of resolvers.
+   */
+  export interface IUrlResolverFactory {
+    /**
+     * Create an URL resolver.
+     */
+    createResolver(
+      options: RenderMimeRegistry.IUrlResolverOptions
+    ): IUrlResolver;
   }
 }
 

--- a/packages/rendermime/src/tokens.ts
+++ b/packages/rendermime/src/tokens.ts
@@ -7,6 +7,7 @@ import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 import { ITranslator } from '@jupyterlab/translation';
 import { ReadonlyPartialJSONObject, Token } from '@lumino/coreutils';
 import { MimeModel } from './mimemodel';
+import type { RenderMimeRegistry } from './registry';
 
 /**
  * The rendermime token.
@@ -204,3 +205,15 @@ export const IMarkdownParser = new Token<IRenderMime.IMarkdownParser>(
 );
 
 export interface IMarkdownParser extends IRenderMime.IMarkdownParser {}
+
+/**
+ * The URL resolver factory.
+ */
+export const IUrlResolverFactory =
+  new Token<RenderMimeRegistry.IUrlResolverFactory>(
+    '@jupyterlab/rendermime:IUrlResolverFactory',
+    'A factory for resolver of asset URLs.'
+  );
+
+export interface IUrlResolverFactory
+  extends RenderMimeRegistry.IUrlResolverFactory {}


### PR DESCRIPTION
## References

Fixes #17770 

## Code changes

- Adds `IUrlResolverFactory`

## User-facing changes

None, but JupyterLite users will ultimately be able to view images embedded in markdown even if they reference local files.

## Backwards-incompatible changes

None
