### PR TITLE
Temporarily install ipykernel from parent_ident_shim branch for CI

### DIFF
--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install ipykernel pre-release that supports subshells (TEMPORARY)
         run: |
-          pip install --upgrade --pre ipykernel!=7.0.0a2
+          pip install --upgrade git+https://github.com/ianthomas23/ipykernel@parent_ident_shim
 
       - name: Launch JupyterLab
         run: |

--- a/scripts/ci_install.sh
+++ b/scripts/ci_install.sh
@@ -37,7 +37,7 @@ jlpm config
 if [[ $GROUP == js-services ]]; then
     # Install ipykernel pre-release that supports subshells for ikernel.spec.ts
     # Remove when ipykernel 7 is released
-    pip install --upgrade --pre ipykernel!=7.0.0a2
+    pip install --upgrade git+https://github.com/ianthomas23/ipykernel@parent_ident_shim
 fi
 
 if [[ $GROUP == nonode ]]; then


### PR DESCRIPTION
This should never be merged. It modifies CI to install `ipykernel` from the `parent_ident_shim` branch to test that PR ipython/ipykernel#1427 fixes issue #17785, and to check if there are any other CI failures.

This approach allows a faster development cycle compared to merging that `ipykernel` PR and making a new `ipykernel` alpha release.