### PR TITLE
Don't create empty page_config in sys_prefix when disabled is empty

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1195,6 +1195,11 @@ class _AppHandler:
         disabled = page_config.get("disabledExtensions", {})
         if isinstance(disabled, list):
             disabled = dict.fromkeys(disabled, True)
+
+        # Short circuit if disabled is empty
+        if not disabled:
+            return False
+
         page_config["lockedExtensions"] = disabled
         write_page_config(page_config, level=level)
         return True


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
Resolves #17637 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Added a short circuit to `_maybe_mirror_disabled_in_locked` if there are no disabled extensions. 
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Won't create empty `page_config.json` in the `sys_prefix` directory 
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
