### PR TITLE
Clear incomplete execution metadata when splitting running cells

### DIFF
--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -205,21 +205,31 @@ export namespace NotebookActions {
 
     offsets.push(orig.length);
 
+    const { cell_type, metadata } = child.model.sharedModel.toJSON();
+    const baseMetadata = JSON.parse(JSON.stringify(metadata ?? {}));
+
+    // If execution metadata is present but missing execute_reply (i.e., it is in running state),
+    // remove execution metadata entirely for new cells
+    if (
+      cell_type === 'code' &&
+      baseMetadata.execution &&
+      baseMetadata.execution['iopub.execute_input'] &&
+      !baseMetadata.execution['shell.execute_reply']
+    ) {
+      delete baseMetadata.execution;
+    }
+
     // Create new cells for all content pieces EXCEPT the last one
     // The last piece will remain in the original cell to preserve kernel connection
-    const newCells = offsets.slice(0, -2).map((offset, offsetIdx) => {
-      const { cell_type, metadata } = child.model.sharedModel.toJSON();
-
-      return {
-        cell_type,
-        metadata,
-        source: orig
-          .slice(offset, offsets[offsetIdx + 1])
-          .replace(/^\n+/, '')
-          .replace(/\n+$/, ''),
-        outputs: undefined
-      };
-    });
+    const newCells = offsets.slice(0, -2).map((offset, offsetIdx) => ({
+      cell_type,
+      metadata: JSON.parse(JSON.stringify(baseMetadata)),
+      source: orig
+        .slice(offset, offsets[offsetIdx + 1])
+        .replace(/^\n+/, '')
+        .replace(/\n+$/, ''),
+      outputs: undefined
+    }));
 
     // Prepare the content for the original cell (last piece)
     const lastPieceStart = offsets[offsets.length - 2];


### PR DESCRIPTION
### Fixes #17794

### Description
When splitting a running cell, incomplete execution metadata was previously left in the non-running cells, causing extensions like `jupyterlab-execute-time` to behave incorrectly.

This PR updates the behavior to:
- Clear execution metadata in newly created cells when `iopub.execute_input` is present but `shell.execute_reply` is missing.

Tests have been added to verify this behavior.
