### PR TITLE
Add a new `addExtraLineOnCellMerge` setting

### DIFF
--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -842,7 +842,7 @@
       "type": "boolean",
       "default": false
     },
-    "mergeCellsAddExtraLine": {
+    "addExtraLineOnCellMerge": {
       "title": "Add extra line when merging cells",
       "description": "Whether to add an extra blank line between cells when merging them. When enabled, cells are joined with double newlines. When disabled, cells are joined with single newlines.",
       "type": "boolean",

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -841,6 +841,12 @@
       "description": "Enable kernel history access from notebook cells. Enabling this allows you to scroll through kernel history from a given notebook cell.",
       "type": "boolean",
       "default": false
+    },
+    "mergeCellsAddExtraLine": {
+      "title": "Add extra line when merging cells",
+      "description": "Whether to add an extra blank line between cells when merging them. When enabled, cells are joined with double newlines. When disabled, cells are joined with single newlines.",
+      "type": "boolean",
+      "default": true
     }
   },
   "additionalProperties": false,

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -3325,7 +3325,10 @@ function addCommands(
       const current = getCurrent(tracker, shell, args);
 
       if (current) {
-        return NotebookActions.mergeCells(current.content);
+        const addExtraLine =
+          (settings?.get('mergeCellsAddExtraLine').composite as boolean) ??
+          true;
+        return NotebookActions.mergeCells(current.content, false, addExtraLine);
       }
     },
     isEnabled,
@@ -3342,7 +3345,10 @@ function addCommands(
       const current = getCurrent(tracker, shell, args);
 
       if (current) {
-        return NotebookActions.mergeCells(current.content, true);
+        const addExtraLine =
+          (settings?.get('mergeCellsAddExtraLine').composite as boolean) ??
+          true;
+        return NotebookActions.mergeCells(current.content, true, addExtraLine);
       }
     },
     isEnabled,
@@ -3359,7 +3365,10 @@ function addCommands(
       const current = getCurrent(tracker, shell, args);
 
       if (current) {
-        return NotebookActions.mergeCells(current.content, false);
+        const addExtraLine =
+          (settings?.get('mergeCellsAddExtraLine').composite as boolean) ??
+          true;
+        return NotebookActions.mergeCells(current.content, false, addExtraLine);
       }
     },
     isEnabled,

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -3326,7 +3326,7 @@ function addCommands(
 
       if (current) {
         const addExtraLine =
-          (settings?.get('mergeCellsAddExtraLine').composite as boolean) ??
+          (settings?.get('addExtraLineOnCellMerge').composite as boolean) ??
           true;
         return NotebookActions.mergeCells(current.content, false, addExtraLine);
       }
@@ -3346,7 +3346,7 @@ function addCommands(
 
       if (current) {
         const addExtraLine =
-          (settings?.get('mergeCellsAddExtraLine').composite as boolean) ??
+          (settings?.get('addExtraLineOnCellMerge').composite as boolean) ??
           true;
         return NotebookActions.mergeCells(current.content, true, addExtraLine);
       }
@@ -3366,7 +3366,7 @@ function addCommands(
 
       if (current) {
         const addExtraLine =
-          (settings?.get('mergeCellsAddExtraLine').composite as boolean) ??
+          (settings?.get('addExtraLineOnCellMerge').composite as boolean) ??
           true;
         return NotebookActions.mergeCells(current.content, false, addExtraLine);
       }

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -285,6 +285,9 @@ export namespace NotebookActions {
    * @param mergeAbove - If only one cell is selected, indicates whether to merge it
    *    with the cell above (true) or below (false, default).
    *
+   * @param addExtraLine - Whether to add an extra newline between merged cell contents
+   *    (true, default) or use only a single newline (false).
+   *
    * #### Notes
    * The widget mode will be preserved.
    * If only one cell is selected and `mergeAbove` is true, the above cell will be selected.
@@ -296,7 +299,8 @@ export namespace NotebookActions {
    */
   export function mergeCells(
     notebook: Notebook,
-    mergeAbove: boolean = false
+    mergeAbove: boolean = false,
+    addExtraLine: boolean = true
   ): void {
     if (!notebook.model || !notebook.activeCell) {
       return;
@@ -365,7 +369,7 @@ export namespace NotebookActions {
     const newModel = {
       cell_type,
       metadata,
-      source: toMerge.join('\n\n'),
+      source: toMerge.join(addExtraLine ? '\n\n' : '\n'),
       attachments:
         primaryModel.cell_type === 'markdown' ||
         primaryModel.cell_type === 'raw'

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -433,6 +433,36 @@ describe('@jupyterlab/notebook', () => {
         expect(model.cell_type).toEqual('code');
         expect(model.attachments).toBeUndefined();
       });
+
+      it('should merge cells with double newline when addExtraLine is true (default)', () => {
+        const firstCell = widget.activeCell!;
+        const firstSource = firstCell.model.sharedModel.getSource();
+        const secondCell = widget.widgets[1];
+        const secondSource = secondCell.model.sharedModel.getSource();
+        widget.select(secondCell);
+
+        NotebookActions.mergeCells(widget, false, true);
+
+        const expectedSource = firstSource + '\n\n' + secondSource;
+        expect(widget.activeCell!.model.sharedModel.getSource()).toBe(
+          expectedSource
+        );
+      });
+
+      it('should merge cells with single newline when addExtraLine is false', () => {
+        const firstCell = widget.activeCell!;
+        const firstSource = firstCell.model.sharedModel.getSource();
+        const secondCell = widget.widgets[1];
+        const secondSource = secondCell.model.sharedModel.getSource();
+        widget.select(secondCell);
+
+        NotebookActions.mergeCells(widget, false, false);
+
+        const expectedSource = firstSource + '\n' + secondSource;
+        expect(widget.activeCell!.model.sharedModel.getSource()).toBe(
+          expectedSource
+        );
+      });
     });
 
     describe('#deleteCells()', () => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/5212

Having an extra line when merging cells can be confusing to some users. According to https://github.com/jupyterlab/jupyterlab/issues/5212#issuecomment-416886089, this is mostly for historical reasons while emulating the behavior of the classic notebook.

Instead of changing the default for everyone, this PR proposes adding a new setting to allow removing that extra line.

## Code changes

- [x] Add a new `mergeCellsAddExtraLine` notebook setting to allow not 
- [x] Add tests

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

https://github.com/user-attachments/assets/6ae6134e-6690-412e-8543-cdddb9efd27c


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
