### PR TITLE
Send code to console

### DIFF
--- a/galata/test/jupyterlab/file-edit.test.ts
+++ b/galata/test/jupyterlab/file-edit.test.ts
@@ -19,23 +19,17 @@ test.beforeEach(async ({ page }) => {
 test.describe('File Edit Operations', () => {
   test('Should remove a line on Control + D', async ({ page }) => {
     await page.getByRole('textbox').getByText('second').last().dblclick();
-
     await page.keyboard.press('Control+d');
-
     expect(await getEditorText(page)).toBe('first\nthird');
   });
-
   test('Should toggle line comment on Control + /', async ({ page }) => {
     // Select "second" and "third"
     await page.getByRole('textbox').getByText('second').last().dblclick();
     await page.keyboard.press('Shift+ArrowDown');
-
     // Toggle line comment
     await page.keyboard.press('Control+/');
-
     expect(await getEditorText(page)).toBe('first\n# second\n# third');
   });
-
   test('Should toggle a block comment on Alt + A', async ({ page }) => {
     const currentDir = await page.filebrowser.getCurrentDirectory();
     await page.contents.renameFile(
@@ -45,11 +39,34 @@ test.describe('File Edit Operations', () => {
     // Select "second" and "third"
     await page.getByRole('textbox').getByText('second').last().dblclick();
     await page.keyboard.press('Shift+ArrowDown');
-
     // Toggle block comment
     await page.keyboard.press('Alt+A');
-
     expect(await getEditorText(page)).toBe('first\n/* second\nthird */');
+  });
+});
+
+test.describe('Console Interactions', () => {
+  test('Should send line to console on Shift + Enter', async ({ page }) => {
+    await page.locator('[role="main"] .cm-content').fill('123\n12');
+    await page.getByText('12312').click({
+      button: 'right'
+    });
+
+    await page.getByText('Create Console for Editor').click();
+    await page.getByRole('button', { name: 'Select Kernel' }).click();
+
+    await page
+      .getByText("Type 'copyright', 'credits'")
+      .waitFor({ state: 'visible' });
+
+    await page.getByText('123', { exact: true }).click();
+
+    await expect(page.getByText("Type 'copyright', 'credits'")).toBeVisible();
+    await page.keyboard.press('Shift+Enter');
+
+    await expect(
+      page.getByLabel('Code Cell Content with Output').locator('span')
+    ).toContainText('123');
   });
 });
 

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -242,7 +242,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
    * Returns the content for the given line number.
    */
   getLine(line: number): string | undefined {
-    // TODO: CM6 remove +1 when CM6 first line number has propagated
+    // Jupyter uses a 0-based index for line numbers, CodeMirror 6 uses a 1-based index
     line = line + 1;
     return line <= this.doc.lines ? this.doc.line(line).text : undefined;
   }
@@ -251,7 +251,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
    * Find an offset for the given position.
    */
   getOffsetAt(position: CodeEditor.IPosition): number {
-    // TODO: CM6 remove +1 when CM6 first line number has propagated
+    // Jupyter uses a 0-based index for line numbers, CodeMirror 6 uses a 1-based index
     return this.doc.line(position.line + 1).from + position.column;
   }
 
@@ -259,7 +259,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
    * Find a position for the given offset.
    */
   getPositionAt(offset: number): CodeEditor.IPosition {
-    // TODO: CM6 remove -1 when CM6 first line number has propagated
+    // Jupyter uses a 0-based index for line numbers, CodeMirror 6 uses a 1-based index
     const line = this.doc.lineAt(offset);
     return { line: line.number - 1, column: offset - line.from };
   }

--- a/packages/codemirror/src/factory.ts
+++ b/packages/codemirror/src/factory.ts
@@ -3,7 +3,6 @@
 
 import { CodeEditor, IEditorFactoryService } from '@jupyterlab/codeeditor';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
-import { EditorView, keymap } from '@codemirror/view';
 import { EditorExtensionRegistry } from './extension';
 import { CodeMirrorEditor } from './editor';
 import { EditorLanguageRegistry } from './language';
@@ -59,16 +58,7 @@ export class CodeMirrorEditorFactory implements IEditorFactoryService {
       ...options,
       config: { ...this.documentCodeMirrorConfig, ...(options.config ?? {}) },
       inline: false,
-      extensions: [
-        keymap.of([
-          {
-            key: 'Shift-Enter',
-            run: (target: EditorView) => {
-              return true;
-            }
-          }
-        ])
-      ].concat(options.extensions ?? [])
+      extensions: options.extensions ?? []
     });
   };
 

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -865,13 +865,16 @@ export namespace Commands {
           // no selection, submit whole line and advance
           code = editor.getLine(selection.start.line);
           const cursor = editor.getCursorPosition();
+          const nextLine = editor.getLine(cursor.line + 1);
+
           if (cursor.line + 1 === editor.lineCount) {
             const text = editor.model.sharedModel.getSource();
             editor.model.sharedModel.setSource(text + '\n');
           }
+
           editor.setCursorPosition({
             line: cursor.line + 1,
-            column: cursor.column
+            column: nextLine?.length ?? 0 // Place cursor at end of line if line has content else place at start of line
           });
         }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
Fix #16272

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
This removes the code that disabled the `Shift+Enter` keybind and changes how the value for `column` sent to `setCursorPosition` is determined.
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
This re-enables the `Shift+Enter` shortcut to send a line of code from the file editor to the console.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
