### PR TITLE
Debugger: Preserve variables panel contents when switching editor focus

### DIFF
--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -709,7 +709,7 @@ export class DebuggerService implements IDebugger, IDisposable {
    */
   private _clearModel(): void {
     this._model.callstack.frames = [];
-    this._model.variables.scopes = [];
+    // this._model.variables.scopes = [];
   }
 
   /**

--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -709,7 +709,6 @@ export class DebuggerService implements IDebugger, IDisposable {
    */
   private _clearModel(): void {
     this._model.callstack.frames = [];
-    // this._model.variables.scopes = [];
   }
 
   /**

--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -460,7 +460,7 @@ export class DebuggerService implements IDebugger, IDisposable {
     if (stoppedThreads.size !== 0) {
       await this._getAllFrames();
     } else if (this.isStarted) {
-      this._clearModel();
+      this._model.callstack.frames = [];
       this._clearSignals();
     }
 
@@ -709,6 +709,7 @@ export class DebuggerService implements IDebugger, IDisposable {
    */
   private _clearModel(): void {
     this._model.callstack.frames = [];
+    this._model.variables.scopes = [];
   }
 
   /**


### PR DESCRIPTION
## References

Potential fix for #17829 

## Code changes

Currently, when switching focus between editors, the debugger’s `_clearModel()` method clears both the callstack and variables scopes:

https://github.com/jupyterlab/jupyterlab/blob/11a9a7c46cffa2b63fd53a12ce0d2bbf1286590d/packages/debugger/src/service.ts#L710-L713

This causes the Variables panel to be emptied whenever focus changes, even if a debugging session is still active. In contrast, the Breakpoints panel correctly persists its state across focus changes.

This PR modifies `_clearModel()` to only clear the callstack frames, allowing the Variables panel to preserve the last known state until updated by the active session.

## User-facing changes

https://github.com/user-attachments/assets/d88e37a4-2928-4cda-b5ea-da142af0f6b6


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
