### PR TITLE
Allow configuring `toSkip` for the `SettingsEditor`

### DIFF
--- a/docs/source/user/interface_customization.rst
+++ b/docs/source/user/interface_customization.rst
@@ -320,3 +320,62 @@ Custom CSS
 ==========
 
 .. include:: custom_css.rst
+
+.. _settings-editor-filtering:
+
+Settings Editor Plugin Filtering
+=================================
+
+The Settings Editor supports configurable filtering of plugins to hide specific plugins from the settings interface. This allows administrators and power users to hide complex or sensitive plugins while keeping them fully functional.
+
+Configuration Options
+---------------------
+
+Via Settings UI
+^^^^^^^^^^^^^^^
+
+1. Open JupyterLab Settings Editor (*Settings > Settings Editor*)
+2. Search for "Settings Editor Form UI"
+3. Find the "Additional plugins to skip in settings editor" field
+4. Add plugin IDs in the format ``package:plugin``
+5. Save the settings
+
+Via overrides.json
+^^^^^^^^^^^^^^^^^^
+
+Add the following to your ``overrides.json`` file:
+
+.. code-block:: json
+
+    {
+      "@jupyterlab/settingeditor-extension:form-ui": {
+        "toSkip": [
+          "my-extension:plugin-to-hide",
+          "another-extension:config-plugin"
+        ]
+      }
+    }
+
+Always Hidden Plugins
+---------------------
+
+The following plugins are hidden by default from the settings editor:
+
+- ``@jupyterlab/application-extension:context-menu``
+- ``@jupyterlab/mainmenu-extension:plugin``
+
+Plugin ID Format
+----------------
+
+Plugin IDs usually follow the format: ``package-name:plugin-name``
+
+For a complete list of core plugin IDs, see the :ref:`Core Plugins <core-plugins>` documentation.
+
+Alternatives
+------------
+
+If you need to completely disable plugin functionality, consider:
+
+- Disabling extensions entirely via the Extension Manager
+- Using ``page_config.json`` to disable specific plugins
+- Using the command line: ``jupyter labextension disable package-name:plugin-name``

--- a/packages/settingeditor-extension/schema/form-ui.json
+++ b/packages/settingeditor-extension/schema/form-ui.json
@@ -7,6 +7,17 @@
       "description": "Set the type of editor to use while editing your settings.",
       "enum": ["json", "ui"],
       "default": "ui"
+    },
+    "toSkip": {
+      "title": "Additional plugins to skip in settings editor",
+      "description": "List of additional plugin IDs that should not be displayed in the settings editor. These plugins can still be configured programmatically or via overrides.json. Note: Some core plugins like context-menu and main-menu are always hidden and cannot be made visible.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "title": "Plugin ID",
+        "description": "Plugin ID to skip"
+      },
+      "default": []
     }
   },
   "additionalProperties": false,

--- a/packages/settingeditor/test/pluginlist.spec.tsx
+++ b/packages/settingeditor/test/pluginlist.spec.tsx
@@ -2,38 +2,8 @@
 // Distributed under the terms of the Modified BSD License.
 import { PluginList } from '../src/pluginlist';
 import { signalToPromise } from '@jupyterlab/coreutils';
-import { StateDB } from '@jupyterlab/statedb';
-import { ISettingRegistry, SettingRegistry } from '@jupyterlab/settingregistry';
-
-class TestConnector extends StateDB {
-  schemas: { [key: string]: ISettingRegistry.ISchema } = {};
-
-  async fetch(id: string): Promise<ISettingRegistry.IPlugin | undefined> {
-    const fetched = await super.fetch(id);
-    if (!fetched && !this.schemas[id]) {
-      return undefined;
-    }
-
-    const schema: ISettingRegistry.ISchema = this.schemas[id] || {
-      type: 'object'
-    };
-    const composite = {};
-    const user = {};
-    const raw = (fetched as string) || '{ }';
-    const version = 'test';
-    return { id, data: { composite, user }, raw, schema, version };
-  }
-
-  async list(): Promise<any> {
-    return Promise.reject('list method not implemented');
-  }
-}
-
-class TestRegistry extends SettingRegistry {
-  get preloaded() {
-    return this.ready;
-  }
-}
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import { TestConnector, TestRegistry } from './utils';
 
 describe('@jupyterlab/settingeditor', () => {
   describe('PluginList.Model', () => {

--- a/packages/settingeditor/test/settingsformeditor.spec.tsx
+++ b/packages/settingeditor/test/settingsformeditor.spec.tsx
@@ -4,37 +4,13 @@ import { nullTranslator } from '@jupyterlab/translation';
 import { SettingsFormEditor } from '../src/SettingsFormEditor';
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { StateDB } from '@jupyterlab/statedb';
 import {
   ISettingRegistry,
   SettingRegistry,
   Settings
 } from '@jupyterlab/settingregistry';
 import { FormComponent } from '@jupyterlab/ui-components';
-
-class TestConnector extends StateDB {
-  schemas: { [key: string]: ISettingRegistry.ISchema } = {};
-
-  async fetch(id: string): Promise<ISettingRegistry.IPlugin | undefined> {
-    const fetched = await super.fetch(id);
-    if (!fetched && !this.schemas[id]) {
-      return undefined;
-    }
-
-    const schema: ISettingRegistry.ISchema = this.schemas[id] || {
-      type: 'object'
-    };
-    const composite = {};
-    const user = {};
-    const raw = (fetched as string) || '{ }';
-    const version = 'test';
-    return { id, data: { composite, user }, raw, schema, version };
-  }
-
-  async list(): Promise<any> {
-    return Promise.reject('list method not implemented');
-  }
-}
+import { TestConnector } from './utils';
 
 describe('@jupyterlab/settingeditor', () => {
   describe('SettingFormEditor', () => {

--- a/packages/settingeditor/test/toSkip.spec.ts
+++ b/packages/settingeditor/test/toSkip.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * Test file to verify the configurable toSkip functionality
+ * This would be part of a proper test suite
+ */
+
+import { expect } from '@jest/globals';
+import { PluginList } from '../src/pluginlist';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import { TestConnector, TestRegistry } from './utils';
+
+describe('Configurable toSkip functionality', () => {
+  let connector: TestConnector;
+  let registry: TestRegistry;
+
+  const plugins = ['test-plugin-1', 'test-plugin-2', 'test-plugin-3'];
+
+  const schemas: { [key: string]: ISettingRegistry.ISchema } = {
+    'test-plugin-1': {
+      type: 'object',
+      properties: {
+        setting1: {
+          type: 'string',
+          default: 'default1'
+        }
+      }
+    },
+    'test-plugin-2': {
+      type: 'object',
+      properties: {
+        setting2: {
+          type: 'string',
+          default: 'default2'
+        }
+      }
+    },
+    'test-plugin-3': {
+      type: 'object',
+      properties: {
+        setting3: {
+          type: 'string',
+          default: 'default3'
+        }
+      }
+    }
+  };
+
+  beforeAll(() => {
+    connector = new TestConnector();
+  });
+
+  beforeEach(async () => {
+    registry = new TestRegistry({ connector });
+    connector.schemas = schemas;
+
+    // Load all plugins
+    for (const id of plugins) {
+      await registry.load(id);
+    }
+  });
+
+  afterEach(async () => {
+    connector.schemas = {};
+    await connector.clear();
+  });
+
+  it('should filter plugins based on toSkip configuration in constructor', async () => {
+    // Create model with initial toSkip list
+    const model1 = new PluginList.Model({
+      registry,
+      toSkip: ['test-plugin-2']
+    });
+    await model1.ready;
+
+    // Should exclude test-plugin-2
+    const plugins1 = model1.plugins.map(p => p.id);
+    expect(plugins1).toContain('test-plugin-1');
+    expect(plugins1).not.toContain('test-plugin-2');
+    expect(plugins1).toContain('test-plugin-3');
+
+    // Create another model with different toSkip list
+    const model2 = new PluginList.Model({
+      registry,
+      toSkip: ['test-plugin-1', 'test-plugin-3']
+    });
+    await model2.ready;
+
+    // Should exclude test-plugin-1 and test-plugin-3
+    const plugins2 = model2.plugins.map(p => p.id);
+    expect(plugins2).not.toContain('test-plugin-1');
+    expect(plugins2).toContain('test-plugin-2');
+    expect(plugins2).not.toContain('test-plugin-3');
+  });
+});

--- a/packages/settingeditor/test/utils.ts
+++ b/packages/settingeditor/test/utils.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { StateDB } from '@jupyterlab/statedb';
+import { ISettingRegistry, SettingRegistry } from '@jupyterlab/settingregistry';
+
+export class TestConnector extends StateDB {
+  schemas: { [key: string]: ISettingRegistry.ISchema } = {};
+
+  async fetch(id: string): Promise<ISettingRegistry.IPlugin | undefined> {
+    const fetched = await super.fetch(id);
+    if (!fetched && !this.schemas[id]) {
+      return undefined;
+    }
+
+    const schema: ISettingRegistry.ISchema = this.schemas[id] || {
+      type: 'object'
+    };
+    const composite = {};
+    const user = {};
+    const raw = (fetched as string) || '{ }';
+    const version = 'test';
+    return { id, data: { composite, user }, raw, schema, version };
+  }
+
+  async list(): Promise<any> {
+    return Promise.reject('list method not implemented');
+  }
+}
+
+export class TestRegistry extends SettingRegistry {
+  get preloaded() {
+    return this.ready;
+  }
+}


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/17832

## Code changes

- [x] Add a new setting to be able to configure `toSkip` for the `SettingsEditor`
- [x] Keep the default `toSkip` list like before with hardcoded plugins
- [x] Add docs
- [x] Unit test

## User-facing changes

This may mostly be useful to administrators that would like to configure plugins to not be displayed in the setting editor, for example via an `overrides.json` file in their deployment.

https://github.com/user-attachments/assets/3ad9d26e-1ad4-4e83-b530-e2bec9b18008


## Backwards-incompatible changes

None

