### PR TITLE
Fix broken toolbar updates due to missing `'clear'` cases in switch statements for `ObservableList`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,6 +72,7 @@ module.exports = {
     '@typescript-eslint/no-empty-interface': 'off',
     '@typescript-eslint/triple-slash-reference': 'warn',
     '@typescript-eslint/no-inferrable-types': 'off',
+    '@typescript-eslint/switch-exhaustiveness-check': 'error',
     camelcase: [
       'error',
       {

--- a/galata/test/jupyterlab/toolbars.test.ts
+++ b/galata/test/jupyterlab/toolbars.test.ts
@@ -81,3 +81,12 @@ test.describe('Toolbar Button', () => {
     expect(labelColor).toEqual(color);
   });
 });
+test('Toolbar widget visibility', async ({ page }) => {
+  const workspaceSelector = page.locator('div.jp-WorkspaceSelector');
+  await expect(workspaceSelector).toHaveCount(0);
+  await page.menu.clickMenuItem('View>Appearance>Show Workspace Indicator');
+  await expect(workspaceSelector).toHaveCount(1);
+  await expect(workspaceSelector).toHaveText('default');
+  await page.menu.clickMenuItem('View>Appearance>Show Workspace Indicator');
+  await expect(workspaceSelector).toHaveCount(0);
+});

--- a/packages/application/src/utils.ts
+++ b/packages/application/src/utils.ts
@@ -116,6 +116,7 @@ export function addSemanticCommand(options: ISemanticCommandOptions): void {
           []
         );
         if (commandIds.includes(args.id)) {
+          // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
           switch (args.type) {
             case 'changed':
             case 'many-changed':

--- a/packages/apputils/src/toolbar/factory.ts
+++ b/packages/apputils/src/toolbar/factory.ts
@@ -300,6 +300,9 @@ export function createToolbarFactory(
             })
           );
           break;
+        case 'clear':
+          toolbar.clear();
+          break;
       }
     };
 
@@ -429,6 +432,11 @@ export function setToolbar(
               item.name,
               item.widget
             );
+          });
+          break;
+        case 'clear':
+          Array.from(toolbar_.children()).forEach(child => {
+            child.parent = null;
           });
           break;
       }

--- a/packages/mermaid/src/manager.ts
+++ b/packages/mermaid/src/manager.ts
@@ -352,6 +352,7 @@ namespace Private {
     let promises: Promise<any>[] = [];
 
     for (const match of [...text.matchAll(RE_DEFAULT_RENDERER)]) {
+      // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
       switch ((match && match[2]) || null) {
         case 'elk':
           promises.push(Private.ensureMermaidElk());

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -405,6 +405,8 @@ close the notebook without saving it.`,
         break;
       case 'remove':
         break;
+      case 'clear':
+        break;
       case 'set':
         change.newValues.forEach(cell => {
           cell.contentChanged.connect(this.triggerContentChange, this);

--- a/packages/notebook/src/notebooklspadapter.ts
+++ b/packages/notebook/src/notebooklspadapter.ts
@@ -299,7 +299,8 @@ export class NotebookAdapter extends WidgetLSPAdapter<NotebookPanel> {
       cellsAdded.length ||
       change.type === 'set' ||
       change.type === 'move' ||
-      change.type === 'remove'
+      change.type === 'remove' ||
+      change.type === 'clear'
     ) {
       // in contrast to the file editor document which can be only changed by the modification of the editor content,
       // the notebook document can also get modified by a change in the number or arrangement of editors themselves;

--- a/packages/notebook/src/searchprovider.ts
+++ b/packages/notebook/src/searchprovider.ts
@@ -584,7 +584,15 @@ export class NotebookSearchProvider extends SearchProvider<NotebookPanel> {
           this._addCellProvider(changes.newIndex + index);
           this._removeCellProvider(changes.newIndex + index + 1);
         });
-
+        break;
+      case 'clear':
+        for (
+          let index = this._searchProviders.length - 1;
+          index >= 0;
+          index--
+        ) {
+          this._removeCellProvider(index);
+        }
         break;
     }
     this._stateChanged.emit();

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1406,6 +1406,7 @@ class ScrollbarItem implements WindowedList.IRenderer.IScrollbarItem {
       'trusted' | 'isDirty' | 'executionCount' | 'executionState'
     >
   ) => {
+    // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
     switch (change.name) {
       case 'executionCount':
       case 'executionState':

--- a/packages/observables/src/undoablelist.ts
+++ b/packages/observables/src/undoablelist.ts
@@ -213,6 +213,12 @@ export class ObservableUndoableList<T>
       case 'move':
         this.move(change.newIndex, change.oldIndex);
         break;
+      case 'clear':
+        index = 0;
+        for (const value of change.oldValues) {
+          this.insert(index++, serializer.fromJSON(value));
+        }
+        break;
       default:
         return;
     }
@@ -244,6 +250,9 @@ export class ObservableUndoableList<T>
         break;
       case 'move':
         this.move(change.oldIndex, change.newIndex);
+        break;
+      case 'clear':
+        this.clear();
         break;
       default:
         return;

--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -447,6 +447,13 @@ export class OutputAreaModel implements IOutputAreaModel {
           item.changed.disconnect(this._onGenericChange, this);
         });
         break;
+      case 'move':
+        break;
+      case 'clear':
+        args.oldValues.forEach(item => {
+          item.changed.disconnect(this._onGenericChange, this);
+        });
+        break;
     }
     this._changed.emit(args);
   }

--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -639,6 +639,10 @@ export abstract class WindowedListModel implements WindowedList.IModel {
       case 'set':
         this.resetAfterIndex(changes.newIndex - 1);
         break;
+      case 'clear':
+        this._widgetSizers.length = 0;
+        this.resetAfterIndex(-1);
+        break;
     }
   }
 


### PR DESCRIPTION
## Fixes #17781 

## Summary
PR https://github.com/jupyterlab/jupyterlab/pull/17672 introduced a 'clear' option to `IObservableList's ChangedType`, but the corresponding case was missing from the `updateToolbar` method's switch statement, causing toolbar widgets to not clear properly.
Fixes toolbar widget visibility issue by adding the missing 'clear' case to the updateToolbar switch statement.

## Changes
- Added `case 'clear'` to handle `IObservableList.ChangedType.clear` operations in updateToolbar method
- Fixed all other non-exhaustive switch statements by adding missing 'clear' cases
- Added `'@typescript-eslint/switch-exhaustiveness-check': 'error'` to catch similar missing cases at compile time.
