### PR TITLE
Select file and accept dialog on file double click in `FileDialog.getOpenFiles`

### DIFF
--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -126,7 +126,8 @@ export class FileBrowser extends SidePanel {
       model,
       renderer,
       translator,
-      state: options.state
+      state: options.state,
+      handleOpenFile: options.handleOpenFile
     });
     this.listing.addClass(LISTING_CLASS);
     this.listing.selectionChanged.connect(() => {
@@ -623,6 +624,11 @@ export namespace FileBrowser {
      * the columns sizes
      */
     state?: IStateDB;
+
+    /**
+     * Callback for when a file is being open by the file browser
+     */
+    handleOpenFile?: (path: string) => void;
   }
 
   /**

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -626,7 +626,8 @@ export namespace FileBrowser {
     state?: IStateDB;
 
     /**
-     * Callback for when a file is being open by the file browser
+     * Callback overriding action performed when user asks to open a file.
+     * The default is to open the file in the main area if it is not open already, or to reveal it otherwise.
      */
     handleOpenFile?: (path: string) => void;
   }

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -239,6 +239,11 @@ export class DirListing extends Widget {
     this._renderer = options.renderer || DirListing.defaultRenderer;
     this._state = options.state || null;
     this._allowDragDropUpload = options.allowDragDropUpload ?? true;
+    this._handleOpenFile =
+      options.handleOpenFile ||
+      ((path: string) => {
+        this._manager.openOrReveal(path);
+      });
 
     // Get the width of the "modified" column
     this._updateModifiedSize(this.node);
@@ -1618,7 +1623,7 @@ export class DirListing extends Widget {
         );
     } else {
       const path = item.path;
-      this._manager.openOrReveal(path);
+      this._handleOpenFile(path);
     }
   }
 
@@ -2593,6 +2598,7 @@ export class DirListing extends Widget {
     direction: 'ascending',
     key: 'name'
   };
+  private _handleOpenFile: (path: string) => void;
   private _onItemOpened = new Signal<DirListing, Contents.IModel>(this);
   private _selectionChanged = new Signal<DirListing, void>(this);
   private _drag: Drag | null = null;
@@ -2694,6 +2700,11 @@ export namespace DirListing {
      * The default is `true`.
      */
     allowDragDropUpload?: boolean;
+
+    /**
+     * Callback for when a file is being open by the file browser
+     */
+    handleOpenFile?: (path: string) => void;
   }
 
   /**

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -2702,7 +2702,8 @@ export namespace DirListing {
     allowDragDropUpload?: boolean;
 
     /**
-     * Callback for when a file is being open by the file browser
+     * Callback overriding action performed when user asks to open a file.
+     * The default is to open the file in the main area if it is not open already, or to reveal it otherwise.
      */
     handleOpenFile?: (path: string) => void;
   }

--- a/packages/filebrowser/src/opendialog.ts
+++ b/packages/filebrowser/src/opendialog.ts
@@ -89,32 +89,8 @@ export namespace FileDialog {
   export async function getOpenFiles(
     options: IFileOptions
   ): Promise<Dialog.IResult<Contents.IModel[]>> {
-    const translator = options.translator || nullTranslator;
-    const trans = translator.load('jupyterlab');
-    const openDialog = new OpenDialog(
-      options.manager,
-      options.filter,
-      translator,
-      options.defaultPath,
-      options.label
-    );
-    const dialogOptions: Partial<Dialog.IOptions<Contents.IModel[]>> = {
-      title: options.title,
-      buttons: [
-        Dialog.cancelButton(),
-        Dialog.okButton({
-          label: trans.__('Select')
-        })
-      ],
-      focusNodeSelector: options.focusNodeSelector,
-      host: options.host,
-      renderer: options.renderer,
-      body: openDialog
-    };
+    const dialog = new OpenDialog(options);
 
-    await openDialog.ready;
-
-    const dialog = new Dialog(dialogOptions);
     return dialog.launch();
   }
 
@@ -140,10 +116,46 @@ export namespace FileDialog {
   }
 }
 
+class OpenDialog extends Dialog<Contents.IModel[]> {
+  constructor(options: FileDialog.IFileOptions) {
+    const translator = options.translator || nullTranslator;
+    const trans = translator.load('jupyterlab');
+
+    const handleOpenFile = () => {
+      // Resolve the dialog with current filebrowser selection
+      this.resolve();
+    };
+
+    const openDialog = new OpenDialogBody(
+      options.manager,
+      options.filter,
+      translator,
+      options.defaultPath,
+      options.label,
+      true,
+      handleOpenFile
+    );
+
+    super({
+      title: options.title,
+      buttons: [
+        Dialog.cancelButton(),
+        Dialog.okButton({
+          label: trans.__('Select')
+        })
+      ],
+      focusNodeSelector: options.focusNodeSelector,
+      host: options.host,
+      renderer: options.renderer,
+      body: openDialog
+    });
+  }
+}
+
 /**
  * Open dialog widget
  */
-class OpenDialog
+class OpenDialogBody
   extends Widget
   implements Dialog.IBodyWidget<Contents.IModel[]>
 {
@@ -153,7 +165,8 @@ class OpenDialog
     translator?: ITranslator,
     defaultPath?: string,
     label?: string,
-    filterDirectories?: boolean
+    filterDirectories?: boolean,
+    handleOpenFile?: (path: string) => void
   ) {
     super();
     translator = translator ?? nullTranslator;
@@ -167,7 +180,8 @@ class OpenDialog
       {},
       translator,
       defaultPath,
-      filterDirectories
+      filterDirectories,
+      handleOpenFile
     )
       .then(browser => {
         this._browser = browser;
@@ -212,7 +226,7 @@ class OpenDialog
         layout.addWidget(this._browser);
 
         /**
-         * Dispose browser model when OpenDialog
+         * Dispose browser model when OpenDialogBody
          * is disposed.
          */
         this.dispose = () => {
@@ -303,7 +317,8 @@ namespace Private {
     options: IFileBrowserFactory.IOptions = {},
     translator?: ITranslator,
     defaultPath?: string,
-    filterDirectories?: boolean
+    filterDirectories?: boolean,
+    handleOpenFile?: (path: string) => void
   ): Promise<FileBrowser> => {
     translator = translator || nullTranslator;
     const model = new FilterFileBrowserModel({
@@ -318,7 +333,8 @@ namespace Private {
     const widget = new FileBrowser({
       id,
       model,
-      translator
+      translator,
+      handleOpenFile
     });
 
     if (defaultPath) {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fix the first item mentioned in https://github.com/jupyterlab/jupyterlab/issues/17724

In combination with https://github.com/jupyterlab/jupyterlab/pull/17737, fixes https://github.com/jupyterlab/jupyterlab/issues/17724 entirely

Now, `getOpenFiles` will not open the file on which the user double clicks, instead it will resolve the dialog with the selection.

## User-facing changes

Before this PR, double-clicking on a file in the `getOpenFiles` dialog would open the file in a new tab, which isn't the expected user experience, as seen in JupyterGIS:

https://github.com/user-attachments/assets/3751734c-204e-4e30-946c-bce6193e1242

After this PR, we properly submit the dialog with the selected file:

https://github.com/user-attachments/assets/40186d96-9522-4c69-b870-7f18dbfbe758


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
