### PR TITLE
Prevent overlay of content from other columns when renaming a file in the file browser

### DIFF
--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -423,6 +423,7 @@
   border: none;
   color: var(--jp-ui-font-color1);
   background-color: var(--jp-layout-color1);
+  z-index: 0;
 }
 
 .jp-DirListing-item.jp-mod-running .jp-DirListing-itemIcon::before {


### PR DESCRIPTION
## References

https://github.com/jupyterlab/jupyterlab/issues/17855 (UI bug: creating directory with a very long has weird artifact of having white "now" written on top of it from Modified section)

## Testing

I observe in binder that the new behaviour matches the expected one by creating folder and renaming it to a very long name.

## Code changes

Simply adding z-index to the class of "editor"

## User-facing changes

Behaviour described in issue is fixed. Text from Modified section no longer overlays currently typed name of the directory
