### PR TITLE
Fix output prompt overlay height for large outputs

### DIFF
--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -374,6 +374,7 @@ export class OutputArea extends Widget {
     this.node.appendChild(overlay);
 
     // Update overlay height so it always matches the output panel.
+    // TODO: use CSS anchor positionning level once fully supported in all browsers
     const resize = () => {
       const panel = this.node.querySelector(
         '.jp-OutputArea-child'


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->
This PR fixes an issue where the output prompt overlay did not cover the full output area when scrolling. So we can't expand the output when we scroll further down.

The problem was that the overlay had height: 100% of its parent; when the output area is collapsed, the parent becomes very short, so the overlay didn’t cover the full area and couldn’t be clicked to expand.

<img width="755" height="588" alt="image" src="https://github.com/user-attachments/assets/b3acd61e-e443-42d0-93da-09728cd91143" />

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->
Fixes https://github.com/jupyterlab/jupyterlab/issues/15967.

## Code changes

<!-- Describe the code changes and how they address the issue. -->

- Added a `ResizeObserver` to the output area container to keep the overlay height in sync with the output panel.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->
The expand/collapse prompt overlay now always matches the full height of the output area, even when outputs expand/collapse.

[Screencast from 2025-09-04 16-34-45.webm](https://github.com/user-attachments/assets/f44b770f-0971-4f74-8497-717e55029a12)

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None.