### PR TITLE
Temporarily use ipykernel < 7 (no subshells) in CI

### DIFF
--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -37,9 +37,9 @@ jobs:
           # Build dev-mode
           jlpm run build
 
-      - name: Install ipykernel pre-release that supports subshells (TEMPORARY)
-        run: |
-          pip install --upgrade --pre ipykernel!=7.0.0a2
+      #- name: Install ipykernel pre-release that supports subshells (TEMPORARY)
+      #  run: |
+      #    pip install --upgrade --pre ipykernel!=7.0.0a2
 
       - name: Launch JupyterLab
         run: |

--- a/galata/test/jupyterlab/kernel.test.ts
+++ b/galata/test/jupyterlab/kernel.test.ts
@@ -105,6 +105,7 @@ test.describe('Kernel', () => {
       );
     });
 
+    /*
     test('Should support opening subshell in separate code console', async ({
       page
     }) => {
@@ -177,6 +178,7 @@ test.describe('Kernel', () => {
       expect(text3[0]).toEqual('subshell id: None');
       expect(text3[5]).toEqual(`subshell list: ['${subshellId}']`);
     });
+    */
   });
 
   test.describe('Console', () => {

--- a/packages/services/test/kernel/comm.spec.ts
+++ b/packages/services/test/kernel/comm.spec.ts
@@ -4,7 +4,7 @@
 import { isFulfilled, JupyterServer } from '@jupyterlab/testing';
 import { PromiseDelegate } from '@lumino/coreutils';
 import {
-  CommsOverSubshells,
+  //CommsOverSubshells,
   Kernel,
   KernelManager,
   KernelMessage
@@ -85,6 +85,7 @@ describe('jupyter.services - Comm', () => {
         expect(comm.subshellId).toBeNull();
       });
 
+      /*
       it('should spawn a subshell per-comm', async () => {
         await echoKernel.info;
 
@@ -179,6 +180,7 @@ describe('jupyter.services - Comm', () => {
 
         expect(comm.subshellId).not.toEqual(comm2.subshellId);
       });
+      */
 
       it('should use the given id', () => {
         const comm = kernel.createComm('test', '1234');

--- a/packages/services/test/kernel/ikernel.spec.ts
+++ b/packages/services/test/kernel/ikernel.spec.ts
@@ -1579,6 +1579,7 @@ describe('Kernel.IKernel', () => {
     });
   });
 
+  /*
   describe('should support subshells', () => {
     it('#supportsSubshells should return true', () => {
       expect(defaultKernel.supportsSubshells).toBeTruthy();
@@ -1611,4 +1612,5 @@ describe('Kernel.IKernel', () => {
       expect(listReply2.content.subshell_id).toEqual([]);
     });
   });
+  */
 });

--- a/scripts/ci_install.sh
+++ b/scripts/ci_install.sh
@@ -34,11 +34,11 @@ pip install -e ".[dev,test]" || pip install -v -e ".[dev,test]"
 node -p process.versions
 jlpm config
 
-if [[ $GROUP == js-services ]]; then
+#if [[ $GROUP == js-services ]]; then
     # Install ipykernel pre-release that supports subshells for ikernel.spec.ts
     # Remove when ipykernel 7 is released
-    pip install --upgrade --pre ipykernel!=7.0.0a2
-fi
+#    pip install --upgrade --pre ipykernel!=7.0.0a2
+#fi
 
 if [[ $GROUP == nonode ]]; then
     # Build the wheel


### PR DESCRIPTION
This should never be merged. It pins `ipykernel < 7` and comments out subshell tests to run the full CI suite against pre-subshell `ipykernel`. It is intended for comparison with #17788 to see what is responsible for CI failures and/or flakiness.