### PR TITLE
Correctly dispose `TerminalManager` even if terminals are not available

### DIFF
--- a/packages/services/src/terminal/manager.ts
+++ b/packages/services/src/terminal/manager.ts
@@ -34,7 +34,7 @@ export class TerminalManager extends BaseManager implements Terminal.IManager {
     }
 
     // Start polling with exponential backoff.
-    this._pollModels = new Poll({
+    const pollModels = (this._pollModels = new Poll({
       auto: false,
       factory: () => this.requestRunning(),
       frequency: {
@@ -44,12 +44,12 @@ export class TerminalManager extends BaseManager implements Terminal.IManager {
       },
       name: `@jupyterlab/services:TerminalManager#models`,
       standby: options.standby ?? 'when-hidden'
-    });
+    }));
 
     // Initialize internal data.
     this._ready = (async () => {
-      await this._pollModels.start();
-      await this._pollModels.tick;
+      await pollModels.start();
+      await pollModels.tick;
       this._isReady = true;
     })();
   }
@@ -96,7 +96,7 @@ export class TerminalManager extends BaseManager implements Terminal.IManager {
     }
     this._names.length = 0;
     this._terminalConnections.forEach(x => x.dispose());
-    this._pollModels.dispose();
+    this._pollModels?.dispose();
     super.dispose();
   }
 
@@ -155,8 +155,10 @@ export class TerminalManager extends BaseManager implements Terminal.IManager {
    * since the manager maintains its internal state.
    */
   async refreshRunning(): Promise<void> {
-    await this._pollModels.refresh();
-    await this._pollModels.tick;
+    if (this._pollModels) {
+      await this._pollModels.refresh();
+      await this._pollModels.tick;
+    }
   }
 
   /**
@@ -277,7 +279,7 @@ export class TerminalManager extends BaseManager implements Terminal.IManager {
     });
   }
 
-  private _pollModels: Poll;
+  private _pollModels: Poll | undefined;
   private _terminalConnections = new Set<Terminal.ITerminalConnection>();
   private _ready: Promise<void>;
   private _runningChanged = new Signal<this, Terminal.IModel[]>(this);

--- a/packages/services/test/terminal/manager.spec.ts
+++ b/packages/services/test/terminal/manager.spec.ts
@@ -110,7 +110,7 @@ describe('terminal', () => {
       it('should dispose without errors when terminals are not available', async () => {
         const terminalAPIClient = new UnavailableTerminalAPIClient();
         const manager = new TerminalManager({ terminalAPIClient });
-        expect(manager.dispose).not.toThrow();
+        expect(manager.dispose.bind(manager)).not.toThrow();
       });
     });
 

--- a/packages/services/test/terminal/manager.spec.ts
+++ b/packages/services/test/terminal/manager.spec.ts
@@ -8,6 +8,7 @@ import {
   TerminalAPI,
   TerminalManager
 } from '../../src';
+import { TerminalAPIClient } from '../../src/terminal/restapi';
 
 const server = new JupyterServer();
 
@@ -18,6 +19,12 @@ beforeAll(async () => {
 afterAll(async () => {
   await server.shutdown();
 });
+
+class UnavailableTerminalAPIClient extends TerminalAPIClient {
+  override get isAvailable() {
+    return false;
+  }
+}
 
 describe('terminal', () => {
   afterAll(async () => {
@@ -85,8 +92,25 @@ describe('terminal', () => {
     });
 
     describe('#isAvailable()', () => {
-      it('should test whether terminal sessions are available', () => {
+      it('should return true from exposed function if available', async () => {
         expect(Terminal.isAvailable()).toBe(true);
+      });
+      it('should return true from method if available', async () => {
+        expect(manager.isAvailable()).toBe(true);
+      });
+      it('should return false if unavailable', async () => {
+        const terminalAPIClient = new UnavailableTerminalAPIClient();
+        const manager = new TerminalManager({ terminalAPIClient });
+        expect(manager.isAvailable()).toBe(false);
+        manager.dispose();
+      });
+    });
+
+    describe('#dispose()', () => {
+      it('should dispose without errors when terminals are not available', async () => {
+        const terminalAPIClient = new UnavailableTerminalAPIClient();
+        const manager = new TerminalManager({ terminalAPIClient });
+        expect(manager.dispose).not.toThrow();
       });
     });
 


### PR DESCRIPTION

## References

Fixes #17875

## Code changes

- [x] Fixes typing
- [x] Fixes usage

## User-facing changes

None

## Backwards-incompatible changes

None
