### PR TITLE
Provide context about the tag and attribute to the URL resolver

### DIFF
--- a/packages/rendermime-interfaces/src/index.ts
+++ b/packages/rendermime-interfaces/src/index.ts
@@ -479,7 +479,7 @@ export namespace IRenderMime {
     /**
      * Resolve a relative url to an absolute url path.
      */
-    resolveUrl(url: string): Promise<string>;
+    resolveUrl(url: string, context?: IResolveUrlContext): Promise<string>;
 
     /**
      * Get the download url for a given absolute url path.
@@ -510,6 +510,40 @@ export namespace IRenderMime {
      * kernel nor jupyter-server contents manager.
      */
     resolvePath?: (path: string) => Promise<IResolvedLocation | null>;
+  }
+
+  type UrlAttributes = 'href' | 'src';
+
+  type TagsAcceptingUrls = {
+    [K in keyof HTMLElementTagNameMap]: Extract<
+      keyof HTMLElementTagNameMap[K],
+      UrlAttributes
+    > extends never
+      ? never
+      : K;
+  }[keyof HTMLElementTagNameMap];
+
+  /**
+   * Context in which the URL is being resolved.
+   *
+   * This is useful to specify for applications which wish to base64-encode
+   * contents of certain local files referenced by URLs, e.g. images, short
+   * videos, or CSS styles. Because base64-encoding is not advisable or even
+   * impossible for some combinations of tags and attributes, the resolving
+   * function needs know both the tag and the attribute to decide whether
+   * to base64-encode or not. For example, passing encoding contents to `href`
+   * in the `<link>` context can be used to provide CSS styles, but doing the
+   * same for `href` in `<a>` context URL will prevent navigation.
+   */
+  export interface IResolveUrlContext {
+    /**
+     * Attribute for which the URL is being resolved.
+     */
+    attribute?: UrlAttributes;
+    /**
+     * Tag for which the URL is being resolved, e.g. `a` or `img`.
+     */
+    tag?: TagsAcceptingUrls;
   }
 
   /**

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -1322,7 +1322,10 @@ namespace Private {
       return;
     }
     try {
-      const urlPath = await resolver.resolveUrl(source);
+      const urlPath = await resolver.resolveUrl(source, {
+        attribute: name,
+        tag: node.localName as IRenderMime.IResolveUrlContext['tag']
+      });
       let url = await resolver.getDownloadUrl(urlPath);
       if (URLExt.parse(url).protocol !== 'data:') {
         // Bust caching for local src attrs.
@@ -1369,7 +1372,7 @@ namespace Private {
     }
     // Get the appropriate file path.
     return resolver
-      .resolveUrl(href)
+      .resolveUrl(href, { attribute: 'href', tag: 'a' })
       .then(urlPath => {
         // decode encoded url from url to api path
         const path = decodeURIComponent(urlPath);


### PR DESCRIPTION


## References

Closes #17795

## Code changes

```diff
-    resolveUrl(url: string): Promise<string>;
+    resolveUrl(url: string, context?: IResolveUrlContext): Promise<string>;
```

Where `IResolveUrlContext` is:

```ts
export interface IResolveUrlContext {
  /**
   * Attribute for which the URL is being resolved.
   */
  attribute?: 'href' | 'src';
  /**
   * Tag for which the URL is being resolved, e.g. `a` or `img`.
   */
  tag?: "a" | "area" | "audio" | "base" | "embed" | "iframe" | "img" | "input" | "link" | "script" | "source" | "track" | "video";
}
```

Except that tags are not hard-coded but derived from the HTML lib shipped by TypeScript.

## User-facing changes

None in JupyterLab, but will allow to render images in JupyterLite in Markdown AND keep links working (https://github.com/jupyterlite/jupyterlite/pull/1707).

## Backwards-incompatible changes

None
