### PR TITLE
Fix kernel status display in status bar

### DIFF
--- a/galata/test/jupyterlab/kernel.test.ts
+++ b/galata/test/jupyterlab/kernel.test.ts
@@ -235,8 +235,8 @@ test.describe('Kernel', () => {
     );
     await statusBar.getByText('Idle').waitFor();
 
-    // Execute the long running cell
-    page.notebook.runCell(0);
+    // Execute the long running cell without waiting
+    void page.notebook.runCell(0);
     await statusBar.getByText('Busy').waitFor();
 
     await page.menu.clickMenuItem('File>New>Notebook');

--- a/galata/test/jupyterlab/kernel.test.ts
+++ b/galata/test/jupyterlab/kernel.test.ts
@@ -215,4 +215,42 @@ test.describe('Kernel', () => {
         .waitFor();
     });
   });
+
+  test('Kernel status bar shows correct status when switching notebooks', async ({
+    page,
+    tmpPath
+  }) => {
+    const statusBar = page.locator('#jp-main-statusbar');
+
+    await page.menu.clickMenuItem('File>New>Notebook');
+    await page
+      .locator('.jp-Dialog-button.jp-mod-accept:has-text("select")')
+      .click();
+
+    // Add long running script to first cell
+    await page.notebook.setCell(
+      0,
+      'code',
+      'import time\nfor i in range(5):\n    print(f"Step {i}")\n    time.sleep(1)'
+    );
+    await statusBar.getByText('Idle').waitFor();
+
+    // Execute the long running cell
+    page.notebook.runCell(0);
+    await statusBar.getByText('Busy').waitFor();
+
+    await page.menu.clickMenuItem('File>New>Notebook');
+    await page
+      .locator('.jp-Dialog-button.jp-mod-accept:has-text("select")')
+      .click();
+    await statusBar.getByText('Idle').waitFor();
+
+    // Switch back to running notebook
+    await page.notebook.activate('Untitled.ipynb');
+    // The status bar should show Busy since the long running script is still executing
+    await page.waitForTimeout(500);
+
+    const statusText = await statusBar.textContent();
+    expect(statusText).toContain('Busy');
+  });
 });

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -26,6 +26,7 @@ import { KernelSpec } from '../kernelspec';
 
 import { KERNEL_SERVICE_URL, KernelAPIClient } from './restapi';
 import { KernelSpecAPIClient } from '../kernelspec/restapi';
+import { PageConfig } from '@jupyterlab/coreutils';
 
 // Stub for requirejs.
 declare let requirejs: any;
@@ -1630,7 +1631,13 @@ export class KernelConnection implements Kernel.IKernelConnection {
     if (msg.channel === 'iopub') {
       switch (msg.header.msg_type) {
         case 'status': {
-          if (msg.parent_header.msg_type == 'debug_request') {
+          const untrackedMessageTypesRaw = PageConfig.getOption(
+            'untracked_message_types'
+          );
+          let untrackedMessageTypes = JSON.parse(
+            untrackedMessageTypesRaw || '[]'
+          );
+          if (untrackedMessageTypes.includes(msg.parent_header.msg_type)) {
             break;
           }
           // Updating the status is synchronous, and we call no async user code

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -1630,6 +1630,12 @@ export class KernelConnection implements Kernel.IKernelConnection {
     if (msg.channel === 'iopub') {
       switch (msg.header.msg_type) {
         case 'status': {
+          if (
+            msg.parent_header.msg_type !== 'kernel_info_request' &&
+            msg.parent_header.msg_type !== 'execute_request'
+          ) {
+            break;
+          }
           // Updating the status is synchronous, and we call no async user code
           const executionState = (msg as KernelMessage.IStatusMsg).content
             .execution_state;

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -1630,10 +1630,7 @@ export class KernelConnection implements Kernel.IKernelConnection {
     if (msg.channel === 'iopub') {
       switch (msg.header.msg_type) {
         case 'status': {
-          if (
-            msg.parent_header.msg_type !== 'kernel_info_request' &&
-            msg.parent_header.msg_type !== 'execute_request'
-          ) {
+          if (msg.parent_header.msg_type == 'debug_request') {
             break;
           }
           // Updating the status is synchronous, and we call no async user code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "jupyter_core",
     "jupyter_server>=2.4.0,<3",
     "jupyter-lsp>=2.0.0",
-    "jupyterlab_server>=2.27.1,<3",
+    "jupyterlab_server>=2.28.0,<3",
     "notebook_shim>=0.2",
     "packaging",
     "setuptools>=41.1.0",


### PR DESCRIPTION
### Fixes #14578

### Description

As stated in https://github.com/jupyterlab/jupyterlab/issues/14578#issuecomment-1593236064:
> The root issue is that JupyterLab's status indicators are mixing the statuses of the control channel and the shell channel.

The main issue arises from the control channel, where a `debug_request` parent message sends an `'idle'` status to the frontend. This causes the status bar to misreport the kernel’s actual state.

Currently, there isn’t a direct way to identify which channel a status message originates from. However, we can filter based on the parent message’s header.  

To address this, I’ve introduced filtering logic where only status messages with specific parent types are considered valid. At the moment, the allowed parent types are:

- `kernel_info_request`  
- `execute_request`  

This prevents misleading `'idle'` statuses from `debug_request` messages.  

Open for feedback on:  
- Whether we should instead define a **blocklist** of disallowed parent types.
- Any potential consequences of this approach.