### PR TITLE
Add JupyterCon banner and Jupyter colors

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -358,6 +358,7 @@ html_favicon = "_static/logo-icon.png"
 # documentation.
 #
 html_theme_options = {
+    "announcement": "🚀 Join us in San Diego · JupyterCon 2025 · Nov 4-5 · <a href=\"https://events.linuxfoundation.org/jupytercon/program/schedule/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463\">SCHEDULE</a> · <a href=\"https://events.linuxfoundation.org/jupytercon/register/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463\">REGISTER NOW</a>",
     "icon_links": [
         {
             "name": "jupyter.org",
@@ -546,3 +547,7 @@ def setup(app):
     )
 
     app.connect("build-finished", partial(clean_code_files, tmp_files))
+
+    # Inherit some Jupyter branding CSS rules from the Jupyter Documentation
+    app.add_css_file("https://docs.jupyter.org/en/latest/_static/jupyter.css")
+


### PR DESCRIPTION
This PR does a couple of things:

- Adds an announcement banner for JupyterCon
- Links a CSS file from the Jupyter documentation that we can use for jupyter colors in our docs, this file sets the secondary color to jupyter orange.
