### PR TITLE
Debugger: Only send the `configurationDone` message once as per the DAP

### DIFF
--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -593,7 +593,6 @@ export class DebuggerService implements IDebugger, IDisposable {
 
     // Update the local model and finish kernel configuration.
     this._model.breakpoints.setBreakpoints(path, updatedBreakpoints);
-    await this.session.sendRequest('configurationDone', {});
   }
 
   /**


### PR DESCRIPTION
## References

Fix https://github.com/jupyterlab/jupyterlab/issues/17673

## Code changes

Remove the wrong `configurationDone` message when communicating breakpoints
