### PR TITLE
Make file browser optional in file editor extension

### DIFF
--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -224,7 +224,7 @@ export namespace Commands {
     id: string,
     isEnabled: () => boolean,
     tracker: WidgetTracker<IDocumentWidget<FileEditor>>,
-    defaultBrowser: IDefaultFileBrowser,
+    defaultBrowser: IDefaultFileBrowser | null,
     extensions: IEditorExtensionRegistry,
     languages: IEditorLanguageRegistry,
     consoleTracker: IConsoleTracker | null,

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -982,7 +982,7 @@ export namespace Commands {
               icon: (args.iconName as string) ?? textEditorIcon
             }),
       execute: args => {
-        const cwd = args.cwd || defaultBrowser.model.path;
+        const cwd = args.cwd || (defaultBrowser?.model.path ?? '.');
         return createNew(
           commands,
           cwd as string,
@@ -1038,7 +1038,7 @@ export namespace Commands {
       caption: trans.__('Create a new markdown file'),
       icon: args => (args['isPalette'] ? undefined : markdownIcon),
       execute: args => {
-        const cwd = args['cwd'] || defaultBrowser.model.path;
+        const cwd = args['cwd'] || (defaultBrowser?.model.path ?? '.');
         return createNew(commands, cwd as string, 'md');
       },
       describedBy: {

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -93,10 +93,11 @@ const plugin: JupyterFrontEndPlugin<IEditorTracker> = {
     IEditorExtensionRegistry,
     IEditorLanguageRegistry,
     IEditorThemeRegistry,
-    IDefaultFileBrowser,
     ISettingRegistry
   ],
   optional: [
+    //change made
+    IDefaultFileBrowser,
     IConsoleTracker,
     ICommandPalette,
     ILauncher,
@@ -330,7 +331,9 @@ function activate(
   extensions: IEditorExtensionRegistry,
   languages: IEditorLanguageRegistry,
   themes: IEditorThemeRegistry,
-  fileBrowser: IDefaultFileBrowser,
+  // fileBrowser: IDefaultFileBrowser, 
+  // change made
+  fileBrowser: IDefaultFileBrowser | null,
   settingRegistry: ISettingRegistry,
   consoleTracker: IConsoleTracker | null,
   palette: ICommandPalette | null,

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -331,7 +331,7 @@ function activate(
   extensions: IEditorExtensionRegistry,
   languages: IEditorLanguageRegistry,
   themes: IEditorThemeRegistry,
-  // fileBrowser: IDefaultFileBrowser, 
+  // fileBrowser: IDefaultFileBrowser,
   // change made
   fileBrowser: IDefaultFileBrowser | null,
   settingRegistry: ISettingRegistry,

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -96,7 +96,6 @@ const plugin: JupyterFrontEndPlugin<IEditorTracker> = {
     ISettingRegistry
   ],
   optional: [
-    //change made
     IDefaultFileBrowser,
     IConsoleTracker,
     ICommandPalette,
@@ -331,10 +330,8 @@ function activate(
   extensions: IEditorExtensionRegistry,
   languages: IEditorLanguageRegistry,
   themes: IEditorThemeRegistry,
-  // fileBrowser: IDefaultFileBrowser,
-  // change made
-  fileBrowser: IDefaultFileBrowser | null,
   settingRegistry: ISettingRegistry,
+  fileBrowser: IDefaultFileBrowser | null,
   consoleTracker: IConsoleTracker | null,
   palette: ICommandPalette | null,
   launcher: ILauncher | null,


### PR DESCRIPTION
**References**

Fixes issue: [#17905](https://github.com/jupyterlab/jupyterlab/issues/17905)

- This PR allows the File Editor to function without requiring the file browser.

**Code changes**

- Moved IDefaultFileBrowser from requires to optional in the FileEditor plugin.
- Updated the activate function to accept fileBrowser: IDefaultFileBrowser | null.
- Added fallbacks for defaultBrowser.model.path references in commands.ts to use '.' if no file browser is present.
- Minor TypeScript type updates to handle null values for optional file browser.

**User-facing changes**

- Users can now close the file browser panel and still:
- Open existing files.
- Create new files.
- Use all standard File Editor functionality.
- No visual or functional regressions in the editor.


✅ Screenshots/GIFs can be added here to demonstrate behavior with and without the file browser.

<img width="1366" height="768" alt="ss1 5" src="https://github.com/user-attachments/assets/fe0036e2-32f9-4142-8b19-f8b5146f2ef4" />

<img width="1366" height="768" alt="ss1 4" src="https://github.com/user-attachments/assets/71935d75-6f58-4126-80d1-28f7c550e3ba" />

<img width="1366" height="768" alt="ss1 3" src="https://github.com/user-attachments/assets/2eea7f25-b117-404b-9751-24002ebe9b86" />

<img width="1366" height="768" alt="ss1 2" src="https://github.com/user-attachments/assets/876c3a42-db48-4a17-92cb-157c9fc4b690" />

<img width="1366" height="768" alt="ss1 1" src="https://github.com/user-attachments/assets/1051810f-6d76-4cf1-ac4e-c7e0d595a891" />
 
**Backwards-incompatible changes**

- None. Existing functionality with the file browser remains unchanged.

**How I tested this**

Disabled the File Browser extension (jupyter labextension disable @jupyterlab/filebrowser-extension).

- Rebuilt JupyterLab and started it in the browser.

**Verified that:**

1. The File Browser panel can be closed.
2. Creating a new text or Markdown file still works.
3. Opening existing files works correctly.
4. Commands and menus related to the editor function as expected.
5. No errors or warnings appeared in the console.
6. Tested both scenarios: with and without the file browser open, confirming consistent behavior.