### PR TITLE
Debugger: fix adding a breakpoint on an empty line of code and reclicking after addition

### DIFF
--- a/packages/debugger/src/handlers/editor.ts
+++ b/packages/debugger/src/handlers/editor.ts
@@ -350,11 +350,10 @@ export class EditorHandler implements IDisposable {
           );
 
           if (this._selectedBreakpoint) {
-            /* if the breakpoint is a selected one: unset selection*/
+            /* if the breakpoint is a selected one: remove it*/
             breakpoints = breakpoints.filter(
               ele => ele.line !== this._selectedBreakpoint?.line
             );
-            this._debuggerService.model.breakpoints.selectedBreakpoint = null;
           }
         } else {
           /* if the clicked line of code is empty, find the breakpoint at the effective clicked line

--- a/packages/debugger/src/handlers/editor.ts
+++ b/packages/debugger/src/handlers/editor.ts
@@ -91,7 +91,6 @@ export class EditorHandler implements IDisposable {
 
     this._debuggerService.model.breakpoints.selectedChanged.connect(
       (_, breakpoint) => {
-        console.log('selected changed');
         this._selectedBreakpoint = breakpoint;
         this._addBreakpointsToEditor();
       }

--- a/packages/debugger/src/tokens.ts
+++ b/packages/debugger/src/tokens.ts
@@ -863,7 +863,7 @@ export namespace IDebugger {
       /**
        * Selected breakpoint
        */
-      selectedBreakpoint: IDebugger.IBreakpoint;
+      selectedBreakpoint: IDebugger.IBreakpoint | null;
 
       /**
        * Get the breakpoints for a given id (path).


### PR DESCRIPTION
When clicking on an empty line of code, a breakpoint is added to the first non empty previous line. In case there is already a breakpoint at this line, a second breakpoint was temporarily added in a second gutter line, in the time lapse of the click. To get rid of this behavior and in order to not remove the already present breakpoint, a modification of the `_onGutterClick` method was proposed.

Previously
[Screencast From 2025-09-25 08-57-52.webm](https://github.com/user-attachments/assets/a96b90b2-e100-4542-9743-de458432b3ef)

With the solution of this PR (kernel blinking indicates the clicks on the gutter without any addition of a second breakpoint)
[Screencast From 2025-09-25 08-59-32.webm](https://github.com/user-attachments/assets/6bfa4af8-1248-4989-9579-ca7c139bfb50)


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Should fix issue https://github.com/jupyterlab/jupyterlab/issues/17903

## Code changes

Update the `_onGutterClick` method from `EditorHandler` class.
Introduce a private `_getEffectiveClickedLine` method that:
- finds the first previous non empty line (the effective clicked line)  if the initially clicked line is empty and return `isLineEmpty` set to true
- returns directly the clicked line if the line is non empty and a `isLineEmpty` set to `false`

In the `__onGutterClick`, when clicking at the effective clicked position:
- if there is no breakpoint, always add one
- if there is already a breakpoint at the effective clicked position:
       - remove it if the line is not empty
       - make the already present breakpoint the selected to inform the user of what happens if the initially clicked position is not empty



## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
