### PR TITLE
Pass context down in attachments resolver

### DIFF
--- a/packages/attachments/src/model.ts
+++ b/packages/attachments/src/model.ts
@@ -341,9 +341,12 @@ export class AttachmentsResolver implements IRenderMime.IResolver {
   /**
    * Resolve a relative url to a correct server path.
    */
-  async resolveUrl(url: string): Promise<string> {
+  async resolveUrl(
+    url: string,
+    context?: IRenderMime.IResolveUrlContext
+  ): Promise<string> {
     if (this._parent && !url.startsWith('attachment:')) {
-      return this._parent.resolveUrl(url);
+      return this._parent.resolveUrl(url, context);
     }
     return url;
   }


### PR DESCRIPTION
## References

- Required for https://github.com/jupyterlite/jupyterlite/pull/1740
- Follow-up to https://github.com/jupyterlab/jupyterlab/pull/17882

## Code changes

Pass down the context if given in `AttachmentsResolver`

## User-facing changes

None in JupyterLab, helps JupyterLite to render images and links correctly.

## Backwards-incompatible changes

None.
