### PR TITLE
Fix integrity checks on CI

### DIFF
--- a/packages/mathjax-extension/package.json
+++ b/packages/mathjax-extension/package.json
@@ -40,11 +40,11 @@
     "build": "tsc -b",
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
+    "eslint": "eslint . --ext .ts,.tsx --fix",
     "test": "jest",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk ../../node_modules/.bin/jest --runInBand",
     "test:debug:watch": "node --inspect-brk ../../node_modules/.bin/jest --runInBand --watch",
-    "eslint": "eslint . --ext .ts,.tsx --fix",
     "watch": "tsc -b --watch"
   },
   "dependencies": {
@@ -55,7 +55,7 @@
     "mathjax-full": "^3.2.2"
   },
   "devDependencies": {
-    "@jupyterlab/testing": "^4.5.0-alpha.3",
+    "@jupyterlab/testing": "^4.5.0-alpha.4",
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -84,7 +84,9 @@ export async function renderHTML(options: renderHTML.IOptions): Promise<void> {
     const maybePromise = latexTypesetter.typeset(host);
     if (maybePromise instanceof Promise) {
       // Harden anchors to contain secure target/rel attributes.
-      maybePromise.then(() => hardenAnchorLinks(host, resolver));
+      maybePromise
+        .then(() => hardenAnchorLinks(host, resolver))
+        .catch(console.warn);
     } else {
       hardenAnchorLinks(host, resolver);
     }
@@ -264,7 +266,7 @@ export async function renderLatex(
     const maybePromise = latexTypesetter.typeset(host);
     if (maybePromise instanceof Promise) {
       // Harden anchors to contain secure target/rel attributes.
-      maybePromise.then(() => hardenAnchorLinks(host));
+      maybePromise.then(() => hardenAnchorLinks(host)).catch(console.warn);
     } else {
       hardenAnchorLinks(host);
     }

--- a/packages/rendermime/src/widgets.ts
+++ b/packages/rendermime/src/widgets.ts
@@ -511,7 +511,9 @@ namespace Private {
     // Harden anchors to contain secure target/rel attributes.
     if (result instanceof Promise) {
       // If promised was returned, await for rendering to complete.
-      result.then(() => renderers.hardenAnchorLinks(host, resolver));
+      result
+        .then(() => renderers.hardenAnchorLinks(host, resolver))
+        .catch(console.warn);
     } else {
       renderers.hardenAnchorLinks(host, resolver);
     }


### PR DESCRIPTION

## References

Addresses CI failures seen in https://github.com/jupyterlab/jupyterlab/actions/runs/18012921332/job/51250196878

## Code changes

- synchronizes package version
- adds `.catch(console.warn)` on promises
- runs linter on `package.json`

## User-facing changes

None

## Backwards-incompatible changes

None
