### PR TITLE
Fix case of 'Debugger console' to 'Debugger Console'

### DIFF
--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -1246,7 +1246,7 @@ const debugConsole: JupyterFrontEndPlugin<void> = {
       app.shell.add(debugConsoleWidget, 'main', {
         mode: 'split-bottom',
         activate: true,
-        type: 'Debugger console'
+        type: 'Debugger Console'
       });
 
       void debugConsoleTracker.add(debugConsoleWidget);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/17892

Noticed in https://github.com/jupyter/notebook/pull/7739

To follow the convention used for most of the other widget types.

## Code changes

Normalize the `type` when calling `app.shell.add()`.

## User-facing changes

None

## Backwards-incompatible changes

None