### PR TITLE
Export the `ContentProviderRegistry`

### DIFF
--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -1633,7 +1633,7 @@ namespace Private {
 /**
  * The default registry of content providers.
  */
-class ContentProviderRegistry implements IContentProviderRegistry {
+export class ContentProviderRegistry implements IContentProviderRegistry {
   /**
    * Construct a new content provider registry.
    *


### PR DESCRIPTION
## References

jupyter-collaboration now relies on the new `ContentProviderRegistry` feature, which jupyterlite does not implement yet. 

In order to implement this in JupyterLite, I understand we'd need to reuse the `ContentProviderRegistry` from here