### PR TITLE
Fix empty whitespace after large cell rendering

### DIFF
--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -382,7 +382,7 @@ export class OutputArea extends Widget {
       if (panel) {
         overlay.style.height = `${Math.max(
           panel.scrollHeight,
-          this.node.scrollHeight
+          this.node.clientHeight
         )}px`;
       }
     };


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/17947.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Use `clientHeight` instead of `scrollHeight` to set the height of the overlay for collapsed large outputs.
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

No more empty whitespace after rendering for large outputs.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes
None.
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
