### PR TITLE
Temporarily pin `ipykernel` to avoid CI breakage with 7.0 pre-release

### DIFF
--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install ipykernel pre-release that supports subshells (TEMPORARY)
         run: |
-          pip install --upgrade --pre ipykernel!=7.0.0a2
+          pip install --upgrade --pre "ipykernel<=7.0.0a1"
 
       - name: Launch JupyterLab
         run: |


### PR DESCRIPTION
## References

Shall address #17955

Integration tests started failing on CI after ipykernel 7.0 release (7.0.0a2) was published, causing cells to hang in the busy state and several debugger and completer tests to fail. Until upstream issues are diagnosed, this PR soft-pins ipykernel to the last working prerelease (7.0.0a1) to restore CI stability.

cc: @krassowski @ianthomas23 

## Code changes

Soft-pinned test dependency `ipykernel` installation in CI

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
