### PR TITLE
Make DocumentManager dialogs customizable

### DIFF
--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -30,7 +30,9 @@ import {
 import { IChangedArgs, PathExt, Time } from '@jupyterlab/coreutils';
 import {
   DocumentManager,
+  DocumentManagerDialogs,
   IDocumentManager,
+  IDocumentManagerDialogs,
   IDocumentWidgetOpener,
   IRecentsManager,
   PathStatus,
@@ -178,7 +180,8 @@ const manager: JupyterFrontEndPlugin<IDocumentManager> = {
     ISessionContextDialogs,
     JupyterLab.IInfo,
     IRecentsManager,
-    IUrlResolverFactory
+    IUrlResolverFactory,
+    IDocumentManagerDialogs
   ],
   activate: (
     app: JupyterFrontEnd,
@@ -188,12 +191,15 @@ const manager: JupyterFrontEndPlugin<IDocumentManager> = {
     sessionDialogs_: ISessionContextDialogs | null,
     info: JupyterLab.IInfo | null,
     recentsManager: IRecentsManager | null,
-    urlResolverFactory: IUrlResolverFactory | null
+    urlResolverFactory: IUrlResolverFactory | null,
+    docManagerDialogs_: IDocumentManagerDialogs | null
   ) => {
     const { serviceManager: manager, docRegistry: registry } = app;
     const translator = translator_ ?? nullTranslator;
     const sessionDialogs =
       sessionDialogs_ ?? new SessionContextDialogs({ translator });
+    const docManagerDialogs =
+      docManagerDialogs_ ?? new DocumentManagerDialogs({ translator });
     const when = app.restored.then(() => void 0);
 
     const docManager = new DocumentManager({
@@ -211,7 +217,8 @@ const manager: JupyterFrontEndPlugin<IDocumentManager> = {
         return true;
       },
       recentsManager: recentsManager ?? undefined,
-      urlResolverFactory: urlResolverFactory ?? undefined
+      urlResolverFactory: urlResolverFactory ?? undefined,
+      docManagerDialogs: docManagerDialogs
     });
 
     return docManager;

--- a/packages/docmanager/src/index.ts
+++ b/packages/docmanager/src/index.ts
@@ -13,3 +13,4 @@ export * from './savingstatus';
 export * from './tokens';
 export * from './widgetmanager';
 export * from './recents';
+export * from './plugins';

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -789,7 +789,7 @@ export namespace DocumentManager {
     sessionDialogs?: ISessionContext.IDialogs;
 
     /**
-     * ...
+     * The provider for document manager dialogs.
      */
     docManagerDialogs?: IDocumentManagerDialogs;
 

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -21,10 +21,12 @@ import { Widget } from '@lumino/widgets';
 import { SaveHandler } from './savehandler';
 import {
   IDocumentManager,
+  IDocumentManagerDialogs,
   IDocumentWidgetOpener,
   IRecentsManager
 } from './tokens';
 import { DocumentWidgetManager } from './widgetmanager';
+import { DocumentManagerDialogs } from '.';
 
 /**
  * The document manager.
@@ -44,6 +46,9 @@ export class DocumentManager implements IDocumentManager {
     this.translator = options.translator || nullTranslator;
     this.registry = options.registry;
     this.services = options.manager;
+    this._docManagerDialogs =
+      options.docManagerDialogs ??
+      new DocumentManagerDialogs({ translator: this.translator });
     this._dialogs =
       options.sessionDialogs ??
       new SessionContextDialogs({ translator: options.translator });
@@ -55,7 +60,8 @@ export class DocumentManager implements IDocumentManager {
     const widgetManager = new DocumentWidgetManager({
       registry: this.registry,
       translator: this.translator,
-      recentsManager: options.recentsManager
+      recentsManager: options.recentsManager,
+      dialogs: this._docManagerDialogs
     });
     widgetManager.activateRequested.connect(this._onActivateRequested, this);
     widgetManager.stateChanged.connect(this._onWidgetStateChanged, this);
@@ -741,6 +747,7 @@ export class DocumentManager implements IDocumentManager {
   private _dialogs: ISessionContext.IDialogs;
   private _isConnectedCallback: () => boolean;
   private _stateChanged = new Signal<DocumentManager, IChangedArgs<any>>(this);
+  private _docManagerDialogs: IDocumentManagerDialogs;
 }
 
 /**
@@ -780,6 +787,11 @@ export namespace DocumentManager {
      * The provider for session dialogs.
      */
     sessionDialogs?: ISessionContext.IDialogs;
+
+    /**
+     * ...
+     */
+    docManagerDialogs?: IDocumentManagerDialogs;
 
     /**
      * The application language translator.

--- a/packages/docmanager/src/plugins.ts
+++ b/packages/docmanager/src/plugins.ts
@@ -1,0 +1,23 @@
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+import { ITranslator } from '@jupyterlab/translation';
+import { IDocumentManagerDialogs } from './tokens';
+import { DocumentManagerDialogs } from './dialogs';
+
+/**
+ * The default document manager dialogs provider.
+ */
+const dialogsPlugin: JupyterFrontEndPlugin<IDocumentManagerDialogs> = {
+  id: '@jupyterlab/docmanager-extension:dialogs',
+  description: 'Provides default dialogs for document management operations.',
+  autoStart: true,
+  provides: IDocumentManagerDialogs,
+  requires: [ITranslator],
+  activate: (app: JupyterFrontEnd, translator: ITranslator) => {
+    return new DocumentManagerDialogs({ translator });
+  }
+};
+
+export default dialogsPlugin;

--- a/packages/docmanager/src/tokens.ts
+++ b/packages/docmanager/src/tokens.ts
@@ -37,6 +37,55 @@ export const IRecentsManager = new Token<IRecentsManager>(
 );
 
 /**
+ * The document manager dialogs token.
+ */
+export const IDocumentManagerDialogs = new Token<IDocumentManagerDialogs>(
+  '@jupyterlab/docmanager:IDocumentManagerDialogs',
+  'A service for displaying dialogs related to document management.'
+);
+
+/**
+ * An interface for dialogs related to document management.
+ */
+export interface IDocumentManagerDialogs {
+  /**
+   * Show a dialog to rename a file.
+   *
+   * @param context - The document context
+   * @returns A promise that resolves when rename is complete or null if cancelled
+   */
+  rename(context: DocumentRegistry.Context): Promise<void | null>;
+
+  /**
+   * Show a dialog asking whether to close a document.
+   *
+   * This dialog is shown when closing a clean (non-dirty) document
+   * and confirmClosingDocument is true.
+   *
+   * @param context - The document context
+   * @returns A promise that resolves to [shouldClose, shouldDiscard, doNotAskAgain]
+   */
+  confirmClose(
+    fileName: string,
+    isDirty: boolean
+  ): Promise<[boolean, boolean, boolean]>;
+
+  /**
+   * Show a dialog asking whether to save before closing a dirty document.
+   *
+   * @param context - The document context
+   * @returns A promise that resolves to [shouldClose, shouldDiscard]
+   *          - shouldClose: true if user chose Save or Discard
+   *          - shouldDiscard: true if user chose Discard (don't save)
+   */
+  saveBeforeClose(
+    fileName: string,
+    isDirty: boolean,
+    writable?: boolean
+  ): Promise<[boolean, boolean]>;
+}
+
+/**
  * The interface for a document manager.
  */
 export interface IDocumentManager extends IDisposable {

--- a/packages/docmanager/src/widgetmanager.ts
+++ b/packages/docmanager/src/widgetmanager.ts
@@ -571,7 +571,7 @@ export namespace DocumentWidgetManager {
     registry: DocumentRegistry;
 
     /**
-     * ..
+     * The provider for document manager dialogs.
      */
     dialogs?: IDocumentManagerDialogs;
 


### PR DESCRIPTION
## Fixes #17942 

## Code changes

- Added `IDocumentManagerDialogs` token for dependency injection
- Created `DocumentManagerDialogs` class implementing `IDocumentManagerDialogs`
   - Provides default behavior for `rename`, `confirmClose` and `saveBeforeClose` matching current hardcoded dialogs.
- Created default plugin that provides `DocumentManagerDialogs` implementation
- Modified `_maybeClose()` method to use `IDocumentManagerDialogs` instead of hardcoded dialogs.

## User-facing changes
**For end users**: No visible changes. All dialogs look and behave exactly as before.

**For extension developers**: New capability to customize document management dialogs and register them via plugin  just as current `SessionDialogs`.

## Backwards-incompatible changes