### PR TITLE
Enable testing on Firefox

### DIFF
--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -13,10 +13,17 @@ env:
 
 jobs:
   test:
-    name: Visual Regression Tests
+    name: Visual Regression Tests (${{ matrix.browser }})
     if: ${{ (github.event_name != 'issue_comment') || (github.event.issue.pull_request && (contains(github.event.comment.body, 'Galata snapshots updated.'))) }}
     timeout-minutes: 80
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - project: 'jupyterlab'
+            browser: 'chromium'
+          - project: 'jupyterlab-firefox'
+            browser: 'firefox'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,8 +57,8 @@ jobs:
         run: |
           cd galata
           jlpm playwright install-deps
-          # Install only Chromium browser
-          jlpm playwright install chromium
+          # Install only the relevant browser for this matrix job
+          jlpm playwright install ${{ matrix.browser }}
           jlpm run build
 
       - name: Wait for JupyterLab
@@ -60,7 +67,7 @@ jobs:
       - name: Test
         run: |
           cd galata
-          jlpm run test --project galata jupyterlab
+          jlpm run test --project galata ${{ matrix.project }}
           mv galata/test-results galata/test-jupyterlab-results || true
           # Run once benchmark tests to ensure they have no regression
           BENCHMARK_NUMBER_SAMPLES=1 jlpm run test:benchmark

--- a/galata/playwright.config.js
+++ b/galata/playwright.config.js
@@ -34,6 +34,19 @@ module.exports = {
           permissions: ['clipboard-read', 'clipboard-write']
         }
       }
+    },
+    {
+      name: 'jupyterlab-firefox',
+      testMatch: 'test/jupyterlab/**/*.test.ts',
+      testIgnore: '**/.ipynb_checkpoints/**',
+      use: {
+        contextOptions: {
+          permissions: ['clipboard-read', 'clipboard-write']
+        },
+        browserName: 'firefox'
+      },
+      // We do not want to match exactly on Firefox
+      expect: { toMatchSnapshot: { maxDiffPixels: 500 } }
     }
   ],
   // Switch to 'always' to keep raw assets for all tests


### PR DESCRIPTION
## References

- Partially resolves https://github.com/jupyterlab/jupyterlab/issues/15088
- Related to https://github.com/jupyterlab/jupyterlab/issues/17941 which is only reproducible on Firefox
 
## Code changes

Run tests on Firefox but ignore most of snapshot differences between browsers.

## User-facing changes

None

## Backwards-incompatible changes

None
