### PR TITLE
Keep debugger state though kernel restarts

### DIFF
--- a/packages/debugger/src/handler.ts
+++ b/packages/debugger/src/handler.ts
@@ -130,10 +130,10 @@ export class DebuggerHandler implements DebuggerHandler.IHandler {
     this._kernelChangedHandlers[widget.id] = kernelChanged;
     connection.kernelChanged.connect(kernelChanged);
 
-    const statusChanged = (
+    const statusChanged = async (
       _: Session.ISessionConnection,
       status: Kernel.Status
-    ): void => {
+    ): Promise<void> => {
       if (status.endsWith('restarting')) {
         void this.updateWidget(widget, connection);
       }
@@ -362,14 +362,19 @@ export class DebuggerHandler implements DebuggerHandler.IHandler {
         connection,
         config: this._service.config
       });
-      await this._service.restoreState(false);
     } else {
       this._previousConnection = this._service.session!.connection?.kernel
         ? this._service.session.connection
         : null;
       this._service.session.connection = connection;
-      await this._service.restoreState(true);
     }
+
+    if (this._service.session.isStarted) {
+      await this._service.restoreState(true);
+    } else {
+      await this._service.restoreState(false);
+    }
+
     if (this._service.isStarted && !this._service.hasStoppedThreads()) {
       await this._service.displayDefinedVariables();
       if (this._service.session?.capabilities?.supportsModulesRequest) {

--- a/packages/debugger/src/handler.ts
+++ b/packages/debugger/src/handler.ts
@@ -130,10 +130,10 @@ export class DebuggerHandler implements DebuggerHandler.IHandler {
     this._kernelChangedHandlers[widget.id] = kernelChanged;
     connection.kernelChanged.connect(kernelChanged);
 
-    const statusChanged = async (
+    const statusChanged = (
       _: Session.ISessionConnection,
       status: Kernel.Status
-    ): Promise<void> => {
+    ): void => {
       if (status.endsWith('restarting')) {
         void this.updateWidget(widget, connection);
       }

--- a/packages/debugger/src/handler.ts
+++ b/packages/debugger/src/handler.ts
@@ -362,13 +362,14 @@ export class DebuggerHandler implements DebuggerHandler.IHandler {
         connection,
         config: this._service.config
       });
+      await this._service.restoreState(false);
     } else {
       this._previousConnection = this._service.session!.connection?.kernel
         ? this._service.session.connection
         : null;
       this._service.session.connection = connection;
+      await this._service.restoreState(true);
     }
-    await this._service.restoreState(false);
     if (this._service.isStarted && !this._service.hasStoppedThreads()) {
       await this._service.displayDefinedVariables();
       if (this._service.session?.capabilities?.supportsModulesRequest) {

--- a/packages/debugger/src/handler.ts
+++ b/packages/debugger/src/handler.ts
@@ -369,7 +369,7 @@ export class DebuggerHandler implements DebuggerHandler.IHandler {
       this._service.session.connection = connection;
     }
 
-    if (this._service.session.isStarted) {
+    if (isDebuggerOn()) {
       await this._service.restoreState(true);
     } else {
       await this._service.restoreState(false);

--- a/packages/debugger/src/handlers/editor.ts
+++ b/packages/debugger/src/handlers/editor.ts
@@ -260,6 +260,8 @@ export class EditorHandler implements IDisposable {
    * Send the breakpoints from the editor UI via the debug service.
    */
   private _sendEditorBreakpoints(): void {
+    // console.log('dev _sendEditorBreakpoints');
+    // console.trace();
     if (this.editor?.isDisposed) {
       return;
     }
@@ -417,6 +419,7 @@ export class EditorHandler implements IDisposable {
     breakpoints.between(0, editor.doc.length, (from: number) => {
       lines.push(editor.doc.lineAt(from).number);
     });
+    console.log('lines', lines);
 
     return lines;
   }

--- a/packages/debugger/src/handlers/editor.ts
+++ b/packages/debugger/src/handlers/editor.ts
@@ -260,8 +260,6 @@ export class EditorHandler implements IDisposable {
    * Send the breakpoints from the editor UI via the debug service.
    */
   private _sendEditorBreakpoints(): void {
-    // console.log('dev _sendEditorBreakpoints');
-    // console.trace();
     if (this.editor?.isDisposed) {
       return;
     }
@@ -419,7 +417,6 @@ export class EditorHandler implements IDisposable {
     breakpoints.between(0, editor.doc.length, (from: number) => {
       lines.push(editor.doc.lineAt(from).number);
     });
-    console.log('lines', lines);
 
     return lines;
   }

--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -457,7 +457,7 @@ export class DebuggerService implements IDebugger, IDisposable {
         ? this.session?.connection?.name || '-'
         : '-';
     }
-    const breakpoints = this.migrateBreakpoints(
+    const breakpoints = this._migrateBreakpoints(
       this._model.breakpoints.breakpoints
     );
 
@@ -717,7 +717,7 @@ export class DebuggerService implements IDebugger, IDisposable {
       await this._dumpCell(cell);
     }
 
-    const breakpoints = this.migrateBreakpoints(state.breakpoints);
+    const breakpoints = this._migrateBreakpoints(state.breakpoints);
 
     await this._restoreBreakpoints(breakpoints);
     const config = await this.session!.sendRequest('configurationDone', {});
@@ -730,7 +730,9 @@ export class DebuggerService implements IDebugger, IDisposable {
    * @param breakpoints
    * @returns
    */
-  migrateBreakpoints(breakpoints: Map<string, IDebugger.IBreakpoint[]>) {
+  private _migrateBreakpoints(
+    breakpoints: Map<string, IDebugger.IBreakpoint[]>
+  ) {
     const migratedBreakpoints = new Map<string, IDebugger.IBreakpoint[]>();
     const kernel = this.session?.connection?.kernel?.name ?? '';
     const { prefix, suffix } = this._config.getTmpFileParams(kernel);

--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -572,11 +572,16 @@ export class DebuggerService implements IDebugger, IDisposable {
     }
 
     const state = await this.session.restoreState();
-    const localBreakpoints = breakpoints
-      .filter(({ line }) => typeof line === 'number')
-      .map(({ line }) => ({ line: line! }));
+    const localBreakpoints = [
+      ...this._inMemoryBreakpoints
+        .filter(({ line }) => typeof line === 'number')
+        .map(({ line }) => ({ line: line! })),
+      ...breakpoints
+        .filter(({ line }) => typeof line === 'number')
+        .map(({ line }) => ({ line: line! }))
+    ];
     const remoteBreakpoints = this._mapBreakpoints(state.body.breakpoints);
-
+    console.log('localBreakpoints', localBreakpoints);
     // Set the local copy of breakpoints to reflect only editors that exist.
     if (this._debuggerSources) {
       const filtered = this._filterBreakpoints(remoteBreakpoints);
@@ -598,6 +603,8 @@ export class DebuggerService implements IDebugger, IDisposable {
       addedLines.add(val.line!);
       return cond1 && cond2;
     });
+
+    this._inMemoryBreakpoints = updatedBreakpoints;
 
     // Update the local model and finish kernel configuration.
     this._model.breakpoints.setBreakpoints(path, updatedBreakpoints);
@@ -1020,6 +1027,7 @@ export class DebuggerService implements IDebugger, IDisposable {
   private _specsManager: KernelSpec.IManager | null;
   private _trans: TranslationBundle;
   private _pauseOnExceptionChanged = new Signal<IDebugger, void>(this);
+  private _inMemoryBreakpoints: DebugProtocol.Breakpoint[] = [];
 }
 
 /**

--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -427,7 +427,6 @@ export class DebuggerService implements IDebugger, IDisposable {
       return;
     }
 
-    // ! this is the debug info message
     const reply = await this.session.restoreState();
     const { body } = reply;
     const kernelBreakpoints = this._mapBreakpoints(body.breakpoints);
@@ -487,8 +486,6 @@ export class DebuggerService implements IDebugger, IDisposable {
     // restore in kernel AND model
     await this._restoreBreakpoints(breakpoints);
 
-    // restore in model which also happen in _restoreBreakpoints
-    // ? is this necessary?
     if (this._debuggerSources) {
       const filtered = this._filterBreakpoints(breakpoints);
       this._model.breakpoints.restoreBreakpoints(filtered);
@@ -603,17 +600,12 @@ export class DebuggerService implements IDebugger, IDisposable {
     }
 
     const state = await this.session.restoreState();
-    const allBreakpoints = [
-      ...breakpoints
-        .filter(({ line }) => typeof line === 'number')
-        .map(({ line }) => ({ line: line! }))
-    ];
+    const localBreakpoints = breakpoints
+      .filter(({ line }) => typeof line === 'number')
+      .map(({ line }) => ({ line: line! }));
 
-    // Deduplicate based on line number
-    const localBreakpoints = allBreakpoints.filter(
-      (bp, index, arr) => arr.findIndex(b => b.line === bp.line) === index
-    );
     const remoteBreakpoints = this._mapBreakpoints(state.body.breakpoints);
+
     // Set the local copy of breakpoints to reflect only editors that exist.
     if (this._debuggerSources) {
       const filtered = this._filterBreakpoints(remoteBreakpoints);

--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -461,26 +461,20 @@ export class DebuggerService implements IDebugger, IDisposable {
       this._model.breakpoints.breakpoints
     );
 
-    // Add kernel breakpoints, merging with existing ones if path already exists
-    for (const [path, bpList] of kernelBreakpoints) {
-      if (breakpoints.has(path)) {
-        // Merge breakpoints for the same path, avoiding duplicates
-        const existingBps = breakpoints.get(path)!;
-        const mergedBps = [...existingBps];
+    // Merge kernel breakpoints with existing breakpoints, avoiding duplicates
+    for (const [path, kernelBpList] of kernelBreakpoints) {
+      const existingBreakpoints = breakpoints.get(path) ?? [];
 
-        for (const kernelBp of bpList) {
-          const exists = existingBps.some(
+      // Filter out kernel breakpoints that already exist at the same line
+      const newBreakpoints = kernelBpList.filter(
+        kernelBp =>
+          !existingBreakpoints.some(
             existingBp => existingBp.line === kernelBp.line
-          );
-          if (!exists) {
-            mergedBps.push(kernelBp);
-          }
-        }
+          )
+      );
 
-        breakpoints.set(path, mergedBps);
-      } else {
-        breakpoints.set(path, bpList);
-      }
+      // Merge existing and new breakpoints
+      breakpoints.set(path, [...existingBreakpoints, ...newBreakpoints]);
     }
 
     // restore in kernel AND model

--- a/packages/debugger/test/service.spec.ts
+++ b/packages/debugger/test/service.spec.ts
@@ -1,11 +1,22 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { KernelSpec, KernelSpecManager, Session } from '@jupyterlab/services';
+import {
+  KernelManager,
+  KernelSpec,
+  KernelSpecManager,
+  Session,
+  SessionManager
+} from '@jupyterlab/services';
 
 import { createSession } from '@jupyterlab/docregistry/lib/testutils';
 
-import { JupyterServer, signalToPromise } from '@jupyterlab/testing';
+import {
+  acceptDialog,
+  JupyterServer,
+  signalToPromise,
+  testEmission
+} from '@jupyterlab/testing';
 
 import { JSONExt, UUID } from '@lumino/coreutils';
 
@@ -14,6 +25,7 @@ import { Debugger } from '../src/debugger';
 import { IDebugger } from '../src/tokens';
 
 import { handleRequest, KERNELSPECS } from './utils';
+import { SessionContext, SessionContextDialogs } from '@jupyterlab/apputils';
 
 /**
  * A Test class to mock a KernelSpecManager
@@ -238,6 +250,49 @@ describe('DebuggerService', () => {
         await service.restoreState(true);
         const bpList = model.breakpoints.getBreakpoints(sourceId);
         expect(bpList).toEqual(breakpoints);
+      });
+
+      it('should preserve breakpoints after kernel restart', async () => {
+        const kernelManager = new KernelManager();
+        const sessionManager = new SessionManager({ kernelManager });
+        const specsManager = new KernelSpecManager();
+        await Promise.all([
+          sessionManager.ready,
+          kernelManager.ready,
+          specsManager.ready
+        ]);
+
+        const path = UUID.uuid4();
+        const sessionContext = new SessionContext({
+          kernelManager,
+          path,
+          sessionManager,
+          specsManager,
+          kernelPreference: { name: specsManager.specs?.default }
+        });
+
+        const sessionContextDialogs = new SessionContextDialogs();
+
+        // Get initial breakpoints
+        const initialBps = service.model.breakpoints.getBreakpoints(sourceId);
+        expect(initialBps.length).toBeGreaterThan(0);
+
+        const emission = testEmission(sessionContext.statusChanged, {
+          find: (_, args) => args === 'restarting'
+        });
+
+        await sessionContext.initialize();
+        const restart = sessionContextDialogs.restart(sessionContext);
+
+        await acceptDialog();
+        expect(await restart).toBe(true);
+        await emission;
+
+        // Verify breakpoints are still present
+        const restoredBps = service.model.breakpoints.getBreakpoints(sourceId);
+        expect(restoredBps.length).toEqual(initialBps.length);
+        expect(restoredBps[0].line).toEqual(initialBps[0].line);
+        expect(restoredBps[1].line).toEqual(initialBps[1].line);
       });
     });
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
This stems from #17916 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
This modifies the call to `restoreState` in the `updateWidget` handler to automatically start the debugger if the current session had the debugger started, and modifies the `restoreState` function to also retrieve the breakpoints from the model and merge them with the breakpoints from  the kernel 
<!-- Describe the code changes and how they address the issue. -->

https://github.com/user-attachments/assets/0029926e-e132-4b2c-b880-996c51d7d8ba


## User-facing changes
When a user runs the `Restart and run and all cells` command while the debugger is active, the debugger will remain active and restore any set breakpoints
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
