### PR TITLE
Fix spurious scrollbar in output area due to prompt overlay

### DIFF
--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -381,8 +381,8 @@ export class OutputArea extends Widget {
       ) as HTMLElement;
       if (panel) {
         overlay.style.height = `${Math.max(
-          panel.scrollHeight,
-          this.node.clientHeight
+          panel.getBoundingClientRect().height,
+          this.node.getBoundingClientRect().height
         )}px`;
       }
     };


### PR DESCRIPTION
The integer values returned by `scrollHeight` and `clientHeight` do not account for fractional pixel heights, which would sometimes cause the prompt to measure as slightly taller than its wrapper, resulting in scrolling. For example, content with height 415.5px would result in a prompt 416px tall.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

Fixes #17980. 
Issue introduced in #17863.

## Code changes

Use `getBoundingClientRect().height` instead of `scrollHeight` and `clientHeight` when comparing node heights in the prompt overlay resize observer callback.

## User-facing changes

Fixes user-facing issue depicted in source ticket.

## Backwards-incompatible changes

No changes to Jupyter APIs.
