### PR TITLE
Fix race condition renaming unnamed files on first save

### DIFF
--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -1096,8 +1096,12 @@ function addCommands(
           try {
             await context.save();
 
+            if (newName !== oldName) {
+              await context.rename(newName);
+            }
+
             if (!widget?.isDisposed) {
-              return await context!.createCheckpoint();
+              await context!.createCheckpoint();
             }
           } catch (err) {
             // If the save was canceled by user-action, do nothing.
@@ -1107,9 +1111,6 @@ function addCommands(
             throw err;
           } finally {
             saveInProgress.delete(context);
-            if (newName !== oldName) {
-              await context.rename(newName);
-            }
           }
         }
       }


### PR DESCRIPTION
## References

Fixes #17896

## Code changes

Await `createCheckpoint()` to ensure it is completed first before performing rename when saving a file.

## User-facing changes

This does not fix a user-facing issue.

## Backwards-incompatible changes

This does not change Jupyter APIs. It technically does change the return value of the Save command callback, but I do not believe this is used.