### PR TITLE
Update JupyterCon 2025 announcement links

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -363,7 +363,7 @@ html_favicon = "_static/logo-icon.png"
 # documentation.
 #
 html_theme_options = {
-    "announcement": '🚀 Join us in San Diego · JupyterCon 2025 · Nov 4-5 · <a href="https://events.linuxfoundation.org/jupytercon/program/schedule/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463">SCHEDULE</a> · <a href="https://events.linuxfoundation.org/jupytercon/register/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463">REGISTER NOW</a>',
+    "announcement": '🚀 Join us in San Diego · JupyterCon 2025 · Nov 4-5 · <a href="https://events.linuxfoundation.org/jupytercon/program/schedule/">SCHEDULE</a> · <a href="https://events.linuxfoundation.org/jupytercon/register/">REGISTER NOW</a>',
     "icon_links": [
         {
             "name": "jupyter.org",


### PR DESCRIPTION
## References

- Follows the change in https://github.com/jupyter/jupyter.github.io/pull/824
- Follow-up to https://github.com/jupyterlab/jupyterlab/pull/17906

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None
