### PR TITLE
Add tests for Markdown edits that regressed in Firefox

### DIFF
--- a/galata/test/jupyterlab/notebook-edit.test.ts
+++ b/galata/test/jupyterlab/notebook-edit.test.ts
@@ -48,19 +48,19 @@ test.describe('Notebook Edit', () => {
     const cell = await page.notebook.getCellLocator(1);
     const image = cell!.locator('img');
     const link = cell!.locator('a');
-    expect(link).toHaveCount(0);
-    expect(image).toHaveCount(1);
+    await expect(link).toHaveCount(0);
+    await expect(image).toHaveCount(1);
 
     // Edit and re-render the cell
     await page.notebook.setCell(1, 'markdown', '[link](https://jupyter.org)');
     await page.notebook.runCell(1, true);
 
     // There should be a link but not an image
-    expect(link).toHaveCount(1);
-    expect(image).toHaveCount(0);
+    await expect(link).toHaveCount(1);
+    await expect(image).toHaveCount(0);
 
     // Double-check we see the right link
-    expect(link).toContainText('link');
+    await expect(link).toContainText('link');
   });
 
   test('Cut from code and paste into a Markdown cell', async ({ page }) => {
@@ -71,8 +71,8 @@ test.describe('Notebook Edit', () => {
     const codeCell = await page.notebook.getCellLocator(1);
     const markdownCell = await page.notebook.getCellLocator(2);
 
-    expect(codeCell!).toContainText(text);
-    expect(markdownCell!).not.toContainText(text);
+    await expect(codeCell!).toContainText(text);
+    await expect(markdownCell!).not.toContainText(text);
 
     // Cut from the code cell
     await page.notebook.enterCellEditingMode(1);
@@ -83,8 +83,8 @@ test.describe('Notebook Edit', () => {
     await page.notebook.enterCellEditingMode(2);
     await page.keyboard.press('Control+KeyV');
 
-    expect(codeCell!).not.toContainText(text);
-    expect(markdownCell!).toContainText(text);
+    await expect(codeCell!).not.toContainText(text);
+    await expect(markdownCell!).toContainText(text);
   });
 
   test('Execute again', async ({ page }) => {


### PR DESCRIPTION
## References

- we can merge this together with https://github.com/jupyterlab/jupyterlab/pull/17973
- adds tests for https://github.com/jupyterlab/jupyterlab/issues/17941 and issue seen in https://github.com/jupyterlite/jupyterlite/pull/1740

The aim of this PR is to demonstrate that these tests fail on CI.

## Code changes

Adds two new integration tests (without snapshots) which pass in Chrome but fail in Firefox

## User-facing changes

None

## Backwards-incompatible changes

None
