### PR TITLE
Backport PR #17992 on branch 4.4.x (Bandaid: pin ipykernel on CI to pre-7.0)

### DIFF
--- a/.github/workflows/galata-update.yml
+++ b/.github/workflows/galata-update.yml
@@ -201,7 +201,7 @@ jobs:
           # Freeze the packages to ensure consistent look and feel
           # IPython is frozen because its version is displayed in
           # the console header
-          pip install .[docs-screenshots]
+          pip install .[docs-screenshots] 'ipykernel<7.0'
           bash ./scripts/ci_install.sh
 
           # Build dev-mode

--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -137,7 +137,7 @@ jobs:
           # Freeze the packages to ensure consistent look and feel
           # IPython is frozen because its version is displayed in
           # the console header
-          pip install .[docs-screenshots]
+          pip install .[docs-screenshots] 'ipykernel<7.0'
           bash ./scripts/ci_install.sh
 
           # Build dev-mode

--- a/scripts/ci_install.sh
+++ b/scripts/ci_install.sh
@@ -37,7 +37,10 @@ jlpm config
 if [[ $GROUP == js-services ]]; then
     # Install ipykernel pre-release that supports subshells for ikernel.spec.ts
     # Remove when ipykernel 7 is released
-    pip install --upgrade --pre ipykernel!=7.0.0a2
+    pip install --upgrade --pre "ipykernel<=7.0.0a1"
+else
+    # For other groups, install ipykernel <7
+    pip install "ipykernel<7"
 fi
 
 if [[ $GROUP == nonode ]]; then


### PR DESCRIPTION
Backport PR https://github.com/jupyterlab/jupyterlab/pull/17992 on branch 4.4.x (Bandaid: pin ipykernel on CI to pre-7.0)