### PR TITLE
Optimize `content-visibility` application

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1015,7 +1015,10 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
     // Apply content visibility when notebook settings update (without reload)
     const isContentVisibility =
       this._notebookConfig.windowingMode === 'contentVisibility';
-    this.toggleClass('jp-content-visibility', isContentVisibility);
+    this.viewportNode.classList.toggle(
+      'jp-content-visibility-mode',
+      isContentVisibility
+    );
 
     if (isContentVisibility) {
       requestAnimationFrame(() => {
@@ -1037,7 +1040,7 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
 
     // Apply content visibility when notebook widget is attached to the DOM
     if (this._notebookConfig.windowingMode === 'contentVisibility') {
-      this.toggleClass('jp-content-visibility', true);
+      this.viewportNode.classList.toggle('jp-content-visibility-mode', true);
 
       // Update intrinsic sizes for all cells initially
       requestAnimationFrame(() => {

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -940,6 +940,13 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
               );
               this.layout.removeWidget(cell);
             });
+          } else if (
+            this.notebookConfig.windowingMode === 'contentVisibility'
+          ) {
+            // Update height estimate in the view model
+            const height = cell.node.getBoundingClientRect().height;
+            this.viewModel.setEstimatedWidgetSize(cell.model.id, height);
+            cell.node.style.containIntrinsicSize = `auto ${height}px`;
           }
         }
       }
@@ -972,12 +979,6 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
     cellIdx: number
   ): Promise<void> {
     cell.dataset.windowedListIndex = `${cellIdx}`;
-
-    // Apply content visibility to this newly created cell
-    if (this._notebookConfig.windowingMode === 'contentVisibility') {
-      this._applyContentVisibility(cell, cellIdx);
-    }
-
     this.layout.insertWidget(cellIdx, cell);
     await cell.ready;
   }
@@ -1012,12 +1013,20 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
       this._notebookConfig.windowingMode === 'full';
 
     // Apply content visibility when notebook settings update (without reload)
-    if (this._notebookConfig.windowingMode === 'contentVisibility') {
-      this._applyContentVisibilityToAllCells();
+    const isContentVisibility =
+      this._notebookConfig.windowingMode === 'contentVisibility';
+    this.toggleClass('jp-content-visibility', isContentVisibility);
+
+    if (isContentVisibility) {
+      requestAnimationFrame(() => {
+        this.cellsArray.forEach((cell, i) => {
+          const estHeight = this._viewModel.estimateWidgetSize(i);
+          cell.node.style.containIntrinsicSize = `auto ${estHeight}px`;
+        });
+      });
     } else {
-      // Remove content-visibility from all cells
-      this.cellsArray.forEach((cell, i) => {
-        cell.toggleClass('jp-content-visibility', false);
+      // Remove intrinsic size styling when disabling content visibility
+      this.cellsArray.forEach(cell => {
         cell.node.style.removeProperty('contain-intrinsic-size');
       });
     }
@@ -1028,46 +1037,26 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
 
     // Apply content visibility when notebook widget is attached to the DOM
     if (this._notebookConfig.windowingMode === 'contentVisibility') {
-      // Apply content visibility to all cells initially
-      this._applyContentVisibilityToAllCells();
+      this.toggleClass('jp-content-visibility', true);
 
-      // watch for newly added cells
+      // Update intrinsic sizes for all cells initially
+      requestAnimationFrame(() => {
+        this.cellsArray.forEach((cell, i) => {
+          const estHeight = this._viewModel.estimateWidgetSize(i);
+          cell.node.style.containIntrinsicSize = `auto ${estHeight}px`;
+        });
+      });
+
+      // Watch for newly added cells and set intrinsic size for them too
       this.model?.cells.changed.connect(() => {
-        this._applyContentVisibilityToAllCells();
+        requestAnimationFrame(() => {
+          this.cellsArray.forEach((cell, i) => {
+            const estHeight = this._viewModel.estimateWidgetSize(i);
+            cell.node.style.containIntrinsicSize = `auto ${estHeight}px`;
+          });
+        });
       });
     }
-  }
-
-  private _applyContentVisibilityToAllCells(): void {
-    requestAnimationFrame(() => {
-      this.cellsArray.forEach((cell, i) => {
-        this._applyContentVisibility(cell, i);
-      });
-    });
-  }
-
-  private _applyContentVisibility(cell: Cell<ICellModel>, index: number): void {
-    const isContentVisibility =
-      this._notebookConfig.windowingMode === 'contentVisibility';
-
-    if (!isContentVisibility) {
-      cell.node.style.removeProperty('contain-intrinsic-size');
-      cell.toggleClass('jp-content-visibility', false);
-      return;
-    }
-
-    const estHeight = this._viewModel.estimateWidgetSize(index);
-
-    requestAnimationFrame(() => {
-      cell.toggleClass('jp-content-visibility', true);
-      cell.node.style.containIntrinsicSize = `auto ${estHeight}px`;
-
-      // Update height estimate in the view model
-      this.viewModel.setEstimatedWidgetSize(
-        cell.model.id,
-        cell.node.getBoundingClientRect().height
-      );
-    });
   }
 
   protected cellsArray: Array<Cell>;

--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -546,7 +546,7 @@ div.jp-Cell-Placeholder-content-3 {
 }
 
 /* Lazy rendering to notebook cells: content outside viewport won't be rendered until scrolled into view */
-.jp-content-visibility-mode .jp-Notebook-cell {
+.jp-content-visibility-mode > .jp-Notebook-cell {
   content-visibility: auto;
   contain: layout style paint; /* Isolates layout, style, and paint for this element */
 }

--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -546,7 +546,7 @@ div.jp-Cell-Placeholder-content-3 {
 }
 
 /* Lazy rendering to notebook cells: content outside viewport won't be rendered until scrolled into view */
-.jp-content-visibility .jp-Notebook-cell {
+.jp-content-visibility-mode .jp-Notebook-cell {
   content-visibility: auto;
   contain: layout style paint; /* Isolates layout, style, and paint for this element */
 }

--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -546,7 +546,7 @@ div.jp-Cell-Placeholder-content-3 {
 }
 
 /* Lazy rendering to notebook cells: content outside viewport won't be rendered until scrolled into view */
-.jp-Notebook-cell.jp-content-visibility {
+.jp-content-visibility .jp-Notebook-cell {
   content-visibility: auto;
   contain: layout style paint; /* Isolates layout, style, and paint for this element */
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/18005.
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- Replaced per-cell `jp-content-visibility` class assignment with a single notebook-level class (.jp-content-visibility).
- Updated `_updateNotebookConfig()` and `onAfterAttach()` to apply and remove this class dynamically based on the windowing mode.
- Set `contain-intrinsic-size` for each cell using estimated heights.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Improved UI performance.
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes
None.
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
