### PR TITLE
Fix flaky test `Drag file from nested directory to parent via breadcrumb`

### DIFF
--- a/galata/test/jupyterlab/filebrowser.test.ts
+++ b/galata/test/jupyterlab/filebrowser.test.ts
@@ -19,11 +19,15 @@ test('Drag file from nested directory to parent via breadcrumb', async ({
 
   const fileName = 'testfile.txt';
   await page.menu.clickMenuItem('File>New>Text File');
+  await page
+    .locator('.jp-DirListing-item:has-text("untitled.txt")')
+    .waitFor({ state: 'visible' });
   await page.contents.renameFile(
     `${tmpPath}/dir1/dir2/untitled.txt`,
     `${tmpPath}/dir1/dir2/${fileName}`
   );
   const fileItem = page.locator(`.jp-DirListing-item:has-text("${fileName}")`);
+  await fileItem.waitFor({ state: 'visible' });
 
   await fileItem.dragTo(dir1Breadcrumb);
 


### PR DESCRIPTION
### Fixes #18008

### Description

Based on the logs from [this CI](https://github.com/jupyterlab/jupyterlab/actions/runs/18562844268/job/52915925416?pr=17797), the issue seems to be a race condition.

The error shows a dialog appearing: `File Load Error for untitled.txt Invalid response: 404 Not Found`. 
This indicates that the test renames `untitled.txt` to `testfile.txt` while JupyterLab is still loading the original file, triggering a `404 Not Found` dialog that blocks the drag operation.

### Fix
Let's wait for the file creation and rename before dragging it.