### PR TITLE
Only show hidden part of the path in the tooltip of ellipsis

### DIFF
--- a/packages/filebrowser/src/crumbs.ts
+++ b/packages/filebrowser/src/crumbs.ts
@@ -504,11 +504,12 @@ namespace Private {
         const hiddenStartIndex = minimumLeftItems;
         const hiddenEndIndex = parts.length - minimumRightItems;
         const hiddenParts = parts.slice(hiddenStartIndex, hiddenEndIndex);
+        const hiddenFolders = hiddenParts.join('/');
         const hiddenPath =
           hiddenParts.length > 0
             ? parts.slice(0, hiddenEndIndex).join('/')
             : parts.slice(0, minimumLeftItems).join('/');
-        breadcrumbs[Crumb.Ellipsis].title = hiddenPath;
+        breadcrumbs[Crumb.Ellipsis].title = hiddenFolders;
         breadcrumbs[Crumb.Ellipsis].dataset.path = hiddenPath;
         node.appendChild(createCrumbSeparator());
 


### PR DESCRIPTION
## References

Fixes #18017

## Code changes

Change the title of file browser breadcrumbs ellipsis to only show the hidden part of the path.

## User-facing changes

| Before | After |
|--|--|
| <img width="582" height="229" alt="image" src="https://github.com/user-attachments/assets/e604b738-da0e-4ec0-8afb-85d8045dacb9" /> | <img width="649" height="260" alt="image" src="https://github.com/user-attachments/assets/8124df6e-f6cc-4598-ada1-9f9a79ae0040" /> |

## Backwards-incompatible changes

None
