### PR TITLE
Introduce new token for the default `IContentProvider`

### DIFF
--- a/packages/services-extension/src/index.ts
+++ b/packages/services-extension/src/index.ts
@@ -18,7 +18,9 @@ import {
   EventManager,
   IConfigSectionManager,
   IConnectionStatus,
+  IContentProvider,
   IContentsManager,
+  IDefaultContentProviderClass,
   IDefaultDrive,
   IEventManager,
   IKernelManager,
@@ -37,6 +39,7 @@ import {
   KernelSpecManager,
   NbConvert,
   NbConvertManager,
+  RestContentProvider,
   ServerConnection,
   ServiceManager,
   ServiceManagerPlugin,
@@ -105,6 +108,21 @@ const contentsManagerPlugin: ServiceManagerPlugin<Contents.IManager> = {
       defaultDrive,
       serverSettings
     });
+  }
+};
+
+/**
+ * The default IContentProvider class plugin.
+ */
+const defaultContentProviderClass: ServiceManagerPlugin<
+  new (...args: any[]) => IContentProvider
+> = {
+  id: '@jupyterlab/services-extension:default-content-provider-class',
+  description: 'The default content provider class for the contents manager.',
+  autoStart: true,
+  provides: IDefaultContentProviderClass,
+  activate: (_: null): new (...args: any[]) => IContentProvider => {
+    return RestContentProvider;
   }
 };
 
@@ -395,6 +413,7 @@ export default [
   connectionStatusPlugin,
   contentsManagerPlugin,
   defaultDrivePlugin,
+  defaultContentProviderClass,
   eventManagerPlugin,
   kernelManagerPlugin,
   kernelSpecManagerPlugin,

--- a/packages/services-extension/src/index.ts
+++ b/packages/services-extension/src/index.ts
@@ -115,8 +115,8 @@ const contentsManagerPlugin: ServiceManagerPlugin<Contents.IManager> = {
  * The default IContentProvider plugin.
  */
 const defaultContentProvider: ServiceManagerPlugin<IContentProvider> = {
-  id: '@jupyterlab/services-extension:default-content-provider-class',
-  description: 'The default content provider class for the contents manager.',
+  id: '@jupyterlab/services-extension:default-content-provider',
+  description: 'The default content provider for the contents manager.',
   autoStart: true,
   provides: IDefaultContentProvider,
   optional: [IServerSettings],

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -1147,10 +1147,12 @@ export class Drive implements Contents.IDrive {
     this._apiEndpoint = options.apiEndpoint ?? SERVICE_DRIVE_URL;
     this.serverSettings =
       options.serverSettings ?? ServerConnection.makeSettings();
-    const restContentProvider = new RestContentProvider({
-      apiEndpoint: this._apiEndpoint,
-      serverSettings: this.serverSettings
-    });
+    const restContentProvider =
+      options.defaultContentProvider ??
+      new RestContentProvider({
+        apiEndpoint: this._apiEndpoint,
+        serverSettings: this.serverSettings
+      });
     this.contentProviderRegistry = new ContentProviderRegistry({
       defaultProvider: restContentProvider
     });
@@ -1610,6 +1612,11 @@ export namespace Drive {
      * REST API given by [Jupyter Server API](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter-server/jupyter_server/main/jupyter_server/services/api/api.yaml#!/contents).
      */
     apiEndpoint?: string;
+
+    /**
+     * The default content provider.
+     */
+    defaultContentProvider?: IContentProvider;
   }
 }
 

--- a/packages/services/src/tokens.ts
+++ b/packages/services/src/tokens.ts
@@ -5,6 +5,7 @@ import {
   ConfigSection,
   Contents,
   Event,
+  IContentProvider,
   Kernel,
   KernelSpec,
   NbConvert,
@@ -73,6 +74,16 @@ export const IConfigSectionManager = new Token<ConfigSection.IManager>(
 export const IContentsManager = new Token<Contents.IManager>(
   '@jupyterlab/services:IContentsManager',
   'The contents manager token.'
+);
+
+/**
+ * The default content provider class token.
+ */
+export const IDefaultContentProviderClass = new Token<
+  new (...args: any[]) => IContentProvider
+>(
+  '@jupyterlab/services:IDefaultContentProviderClass',
+  'The default content provider class for the contents manager.'
 );
 
 /**

--- a/packages/services/src/tokens.ts
+++ b/packages/services/src/tokens.ts
@@ -77,13 +77,11 @@ export const IContentsManager = new Token<Contents.IManager>(
 );
 
 /**
- * The default content provider class token.
+ * The default content provider token.
  */
-export const IDefaultContentProviderClass = new Token<
-  new (...args: any[]) => IContentProvider
->(
-  '@jupyterlab/services:IDefaultContentProviderClass',
-  'The default content provider class for the contents manager.'
+export const IDefaultContentProvider = new Token<IContentProvider>(
+  '@jupyterlab/services:IDefaultContentProvider',
+  'The default content provider for the contents manager.'
 );
 
 /**


### PR DESCRIPTION
## References

As discussed in https://github.com/jupyterlab/jupyter-collaboration/pull/508

We need a way to be able to inherit from the default content provider, instead of assuming it's `RestContentProvider`