### PR TITLE
Fix debugger initialization for notebooks on reload

### DIFF
--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -283,6 +283,14 @@ const notebooks: JupyterFrontEndPlugin<IDebugger.IHandler> = {
       translator: translator
     });
 
+    if (notebookTracker.currentWidget) {
+      const widget = notebookTracker.currentWidget;
+      const { sessionContext } = widget;
+      await sessionContext.ready;
+      await handler.updateContext(widget, sessionContext);
+      await handler.updateWidget(widget, sessionContext.session);
+    }
+
     const trans = translator.load('jupyterlab');
     app.commands.addCommand(Debugger.CommandIDs.restartDebug, {
       label: trans.__('Restart Kernel and Debug…'),
@@ -327,6 +335,7 @@ const notebooks: JupyterFrontEndPlugin<IDebugger.IHandler> = {
         const { sessionContext } = widget;
         await sessionContext.ready;
         await handler.updateContext(widget, sessionContext);
+        await handler.updateWidget(widget, sessionContext.session);
       }
       updateState(app.commands, service);
     };

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -283,14 +283,6 @@ const notebooks: JupyterFrontEndPlugin<IDebugger.IHandler> = {
       translator: translator
     });
 
-    if (notebookTracker.currentWidget) {
-      const widget = notebookTracker.currentWidget;
-      const { sessionContext } = widget;
-      await sessionContext.ready;
-      await handler.updateContext(widget, sessionContext);
-      await handler.updateWidget(widget, sessionContext.session);
-    }
-
     const trans = translator.load('jupyterlab');
     app.commands.addCommand(Debugger.CommandIDs.restartDebug, {
       label: trans.__('Restart Kernel and Debug…'),

--- a/packages/debugger/src/handler.ts
+++ b/packages/debugger/src/handler.ts
@@ -212,12 +212,6 @@ export class DebuggerHandler implements DebuggerHandler.IHandler {
     if (!this._service.model || !connection) {
       return;
     }
-    console.log(
-      'updateWidget',
-      this._service.isStarted,
-      this._shell.currentWidget?.id,
-      widget.id
-    );
 
     const hasFocus = (): boolean => {
       return this._shell.currentWidget === widget;

--- a/packages/debugger/src/handler.ts
+++ b/packages/debugger/src/handler.ts
@@ -212,6 +212,12 @@ export class DebuggerHandler implements DebuggerHandler.IHandler {
     if (!this._service.model || !connection) {
       return;
     }
+    console.log(
+      'updateWidget',
+      this._service.isStarted,
+      this._shell.currentWidget?.id,
+      widget.id
+    );
 
     const hasFocus = (): boolean => {
       return this._shell.currentWidget === widget;


### PR DESCRIPTION

## References

Fix https://github.com/jupyterlab/jupyterlab/issues/17988

This PR ensures that the notebook debugger UI correctly initializes when JupyterLab is reloaded.
Previously, the debugger state (isStarted) would only sync after switching files or re-focusing the notebook, leading to inconsistent toolbar and handler states.

## Code changes

A one-line fix adds a call to `handler.updateWidget(widget, sessionContext.session)` in the `updateHandlerAndCommands` function, ensuring the handler and UI are restored as soon as the plugin activates.

## User-facing changes


https://github.com/user-attachments/assets/fccb89d2-a154-41b7-be13-5d5ecaf0233f



## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
