### PR TITLE
Don't open default editor if a different kind of editor is already open

### DIFF
--- a/galata/test/jupyterlab/workspace.test.ts
+++ b/galata/test/jupyterlab/workspace.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { expect, galata, test } from '@jupyterlab/galata';
+import { expect, galata, JupyterLabPage, test } from '@jupyterlab/galata';
 import { Page } from '@playwright/test';
 import * as path from 'path';
 
@@ -20,8 +20,9 @@ test.use({
 });
 
 test.describe('Workspace', () => {
-  test.beforeAll(async ({ request, tmpPath }) => {
+  test.beforeAll(async ({ request, tmpPath, page, waitForApplication }) => {
     const contents = galata.newContentsHelper(request);
+    await waitForApplication(page, page);
     await contents.uploadFile(
       path.resolve(__dirname, `./notebooks/${nbFile}`),
       `${tmpPath}/${nbFile}`
@@ -407,6 +408,158 @@ test.describe('Workspace in doc mode', () => {
     await expect(
       page.locator('#jp-main-dock-panel .jp-MainAreaWidget .jp-Notebook')
     ).toHaveCount(1);
+
+    await expect(
+      page.locator('#jp-main-dock-panel .jp-MainAreaWidget')
+    ).toHaveCount(1);
+  });
+});
+
+test.describe('Restore non-default-type editor', () => {
+  test.beforeAll(async ({ request, tmpPath }) => {
+    const contents = galata.newContentsHelper(request);
+    await contents.uploadFile(
+      path.resolve(__dirname, `./notebooks/${nbFile}`),
+      `${tmpPath}/${nbFile}`
+    );
+  });
+
+  test.afterAll(async ({ request, tmpPath }) => {
+    const contents = galata.newContentsHelper(request);
+    await contents.deleteDirectory(tmpPath);
+  });
+
+  // Use non-default state to have the running session panel displayed
+  test.use({
+    mockState: {
+      'layout-restorer:data': {
+        main: {
+          current: 'editor:workspace-test/simple_notebook.ipynb',
+          dock: {
+            type: 'tab-area',
+            currentIndex: 0,
+            widgets: ['editor:workspace-test/simple_notebook.ipynb'] // notebook open with file editor, not NotebookPanel
+          }
+        },
+        down: {
+          size: 0,
+          widgets: []
+        },
+        left: {
+          collapsed: false,
+          visible: true,
+          current: 'filebrowser',
+          widgets: [
+            'filebrowser',
+            'running-sessions',
+            '@jupyterlab/toc:plugin',
+            'extensionmanager.main-view'
+          ],
+          widgetStates: {
+            ['jp-running-sessions']: {
+              sizes: [0.25, 0.25, 0.25, 0.25],
+              expansionStates: [false, false, false, false]
+            },
+            ['extensionmanager.main-view']: {
+              sizes: [
+                0.3333333333333333, 0.3333333333333333, 0.3333333333333333
+              ],
+              expansionStates: [false, false, false]
+            }
+          }
+        },
+        right: {
+          collapsed: true,
+          visible: true,
+          widgets: ['jp-property-inspector', 'debugger-sidebar'],
+          widgetStates: {
+            ['jp-debugger-sidebar']: {
+              sizes: [0.2, 0.2, 0.2, 0.2, 0.2],
+              expansionStates: [false, false, false, false, false]
+            }
+          }
+        },
+        relativeSizes: [0.4, 0.6, 0],
+        top: {
+          simpleVisibility: true
+        }
+      },
+      'file-browser-filebrowser:cwd': {
+        path: 'workspace-test'
+      },
+      'editor:workspace-test/simple_notebook.ipynb': {
+        // File Editor, not Notebook
+        data: {
+          path: 'workspace-test/simple_notebook.ipynb',
+          factory: 'Editor'
+        }
+      }
+    } as any
+  });
+
+  test('should restore file editor of `.ipynb` file when reloading, and not open a Notebook', async ({
+    baseURL,
+    page,
+    tmpPath
+  }) => {
+    // load page and wait for workspace to be saved
+    await Promise.all([
+      page.waitForResponse(
+        response =>
+          response.request().method() === 'PUT' &&
+          /api\/workspaces/.test(response.request().url()) &&
+          response.request().postDataJSON().data[
+            `editor:workspace-test/simple_notebook.ipynb`
+          ]
+      ),
+      page.goto(`${baseURL}/lab/workspaces/default?path=${tmpPath}/${nbFile}`)
+    ]);
+
+    // Ensure that there is only the document opened, no matter the workspace content.
+    await expect(
+      page.locator('#jp-main-dock-panel .jp-MainAreaWidget .jp-FileEditor')
+    ).toHaveCount(1);
+
+    await expect(
+      page.locator('#jp-main-dock-panel .jp-MainAreaWidget .jp-Notebook')
+    ).toHaveCount(0); // opened as a File, not a Notebook
+
+    await expect(
+      page.locator('#jp-main-dock-panel .jp-MainAreaWidget')
+    ).toHaveCount(1);
+
+    // Reload, which should restore the loaded workspace, which means a file editor and not opening a new Notebook.
+    await Promise.all([page.reload()]);
+    // Requires manual wait due to firefox resolving page.reload() before restore completes.
+    await new Promise(r => setTimeout(r, 2000));
+    await page.evaluate(async () => {
+      await window.jupyterapp.restored;
+    });
+
+    // Ensure that there is STILL only the file editor document opened, and no new Notebook
+    await expect(
+      page.locator('#jp-main-dock-panel .jp-MainAreaWidget .jp-FileEditor')
+    ).toHaveCount(1);
+
+    await expect(
+      page.locator('#jp-main-dock-panel .jp-MainAreaWidget .jp-Notebook')
+    ).toHaveCount(0); // opened as a File, not a Notebook
+
+    await expect(
+      page.locator('#jp-main-dock-panel .jp-MainAreaWidget')
+    ).toHaveCount(1);
+
+    // try to open the already open file from the filebrowser, and confirm it doesn't open a new Notebook editor.
+    await Promise.all([page.filebrowser.open('simple_notebook.ipynb')]);
+
+    // Ensure that there is STILL only the file editor document opened, and no new Notebook
+    await expect(
+      page.locator('#jp-main-dock-panel .jp-MainAreaWidget .jp-FileEditor')
+    ).toHaveCount(1);
+
+    await expect(
+      page.locator('#jp-main-dock-panel .jp-MainAreaWidget .jp-Notebook')
+    ).toHaveCount(0); // opened as a File, not a Notebook
 
     await expect(
       page.locator('#jp-main-dock-panel .jp-MainAreaWidget')

--- a/galata/test/jupyterlab/workspace.test.ts
+++ b/galata/test/jupyterlab/workspace.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { expect, galata, JupyterLabPage, test } from '@jupyterlab/galata';
+import { expect, galata, test } from '@jupyterlab/galata';
 import { Page } from '@playwright/test';
 import * as path from 'path';
 
@@ -20,9 +20,8 @@ test.use({
 });
 
 test.describe('Workspace', () => {
-  test.beforeAll(async ({ request, tmpPath, page, waitForApplication }) => {
+  test.beforeAll(async ({ request, tmpPath }) => {
     const contents = galata.newContentsHelper(request);
-    await waitForApplication(page, page);
     await contents.uploadFile(
       path.resolve(__dirname, `./notebooks/${nbFile}`),
       `${tmpPath}/${nbFile}`

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -475,7 +475,7 @@ export class DocumentManager implements IDocumentManager {
    */
   openOrReveal(
     path: string,
-    widgetName = 'default',
+    widgetName: string | null = null,
     kernel?: Partial<Kernel.IModel>,
     options?: DocumentRegistry.IOpenOptions,
     kernelPreference?: ISessionContext.IKernelPreference
@@ -483,12 +483,12 @@ export class DocumentManager implements IDocumentManager {
     const widget = this.findWidget(path, widgetName);
     if (widget) {
       this._opener.open(widget, {
-        type: widgetName,
+        type: widgetName || 'default',
         ...options
       });
       return widget;
     }
-    return this.open(path, widgetName, kernel, options ?? {}, kernelPreference);
+    return this.open(path, widgetName || 'default', kernel, options ?? {}, kernelPreference);
   }
 
   /**

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -488,7 +488,13 @@ export class DocumentManager implements IDocumentManager {
       });
       return widget;
     }
-    return this.open(path, widgetName || 'default', kernel, options ?? {}, kernelPreference);
+    return this.open(
+      path,
+      widgetName || 'default',
+      kernel,
+      options ?? {},
+      kernelPreference
+    );
   }
 
   /**


### PR DESCRIPTION
Reloading no longer duplicates a non-default editor with a new default editor.

Previously, calling openOrReveal without a `widgetName` argument makes it open the default editor. This is usually OK, except when a different editor is already open. For example, if editing a notebook `.ipynb` with the JSON editor, reloading the browser will execute a `CommandIDs.openPath` without a `widgetName` specified, leading to a new `NotebookPanel` widget opened, in addition to the original JSON editor. (At: https://github.com/jupyterlab/jupyterlab/blob/f37154e23ae423bfb77d6e6b7aee33eb087f7fcf/packages/filebrowser-extension/src/index.ts#L1988C11-L1991C14)


https://github.com/user-attachments/assets/b2225596-0567-4026-8479-6bfc61ba11ee

<i>Video is an example of the previous behaviour, where a NotebookPanel would open after restoring the workspace, when only a JSON editor was open previously.</i>



Now, by using `null` in `findWidget` it will try to find the <b>first</b> already open widget editing the file (in the preferrence order returned by `DocumentManager.registry.preferredWidgetFactories`)  so <b>reloading no longer duplicates the non-default editor with a new default editor</b>.
(given `widgetName === null`, `DocumentManager.findWidget` will find the first (in preference order) open widget  or return `undefined`.)
https://github.com/jupyterlab/jupyterlab/blob/f37154e23ae423bfb77d6e6b7aee33eb087f7fcf/packages/docmanager/src/manager.ts#L397-L413

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->


## Code changes

Change the default value of `widgetName` in `DocumentManager.openOrReveal` to `null` rather than `'default'`, to use the `widgetName===null` functionality of `DocumentManager.findWidget`. Also add a fallback to 'default' in the function calls not compatible with a `null` value for `widgetName`.

## User-facing changes

Upon reloading the browser and restoring the workspace, if a non-default editor was open (e.g. a JSON editor editing a notebook `.ipynb` file), no longer opens a new editor of the default type (an automatically opened NotebookPanel in addition to the user-opened JSON editor).

Additionally, double-clicking a file in the file browser column which is open with a non-default editor *won't* open a new editor of the default type. In most use-cases this new behavior makes more sense, since instead of opening a different editor of the same file, it will reveal any type of open editor for the file (in preference order). It is also safer (avoids overwriting and un-syncing of the model) if a second editor of the same type isn't opened, unless the context or model of the editors can be synced. To open the default editor type, the user must close any existing editor of the file.


## Backwards-incompatible changes

Expect to be compatible, fallback to default `'default'` value specified.