### PR TITLE
Add plausible.io stats to the jupyterlab docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -519,6 +519,13 @@ intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
 
 def setup(app):
+    # Enable Plausible.io stats
+    app.add_js_file("https://plausible.io/js/pa-Tem97Eeu4LJFfSRY89aW1.js", loading_method="async")
+    app.add_js_file(
+        filename=None,
+        body="window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()",
+    )
+
     dest = HERE / "getting_started/changelog.md"
     shutil.copy(str(HERE.parent.parent / "CHANGELOG.md"), str(dest))
     app.add_css_file("css/custom.css")  # may also be an URL

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -523,7 +523,7 @@ def setup(app):
     app.add_js_file("https://plausible.io/js/pa-Tem97Eeu4LJFfSRY89aW1.js", loading_method="async")
     app.add_js_file(
         filename=None,
-        body="window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()",
+        body="window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init({hashBasedRouting:true})",
     )
 
     dest = HERE / "getting_started/changelog.md"

--- a/docs/source/privacy_policies.rst
+++ b/docs/source/privacy_policies.rst
@@ -67,8 +67,16 @@ Users can also disable the plugin by executing:
 External web services
 ---------------------
 
-JupyterLab Docs site
-^^^^^^^^^^^^^^^^^^^^
+GitHub Pages
+^^^^^^^^^^^^
+
+The service hosting the https://jupyterlab.github.io website stores access logs.
+That data is not accessible to and not readable by the JupyterLab development team.
+
+GitHub's privacy policy can be found at https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement .
+
+JupyterLab Docs
+^^^^^^^^^^^^^^^
 
 The service hosting the https://jupyterlab.readthedocs.io website stores access
 logs. Only aggregate statistics are made available to Project Jupyter. See the

--- a/docs/source/privacy_policies.rst
+++ b/docs/source/privacy_policies.rst
@@ -67,13 +67,18 @@ Users can also disable the plugin by executing:
 External web services
 ---------------------
 
-GitHub Pages
-^^^^^^^^^^^^
+JupyterLab Docs site
+^^^^^^^^^^^^^^^^^^^^
 
-The service hosting the https://jupyterlab.github.io website stores access logs.
-That data is not accessible to and not readable by the JupyterLab development team.
+The service hosting the https://jupyterlab.readthedocs.io website stores access
+logs. Only aggregate statistics are made available to Project Jupyter. See the
+privacy policy at
+https://docs.readthedocs.com/platform/stable/privacy-policy.html.
 
-GitHub's privacy policy can be found at https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement .
+Additional website statistics are collected using Plausible.io and aggregate statistics
+are accessible to Project Jupyter. See the privacy policy at
+https://plausible.io/privacy and the data policy at
+https://plausible.io/data-policy.
 
 PyPI.org
 ^^^^^^^^

--- a/docs/source/privacy_policies.rst
+++ b/docs/source/privacy_policies.rst
@@ -4,7 +4,7 @@
 Privacy policies
 ================
 
-Last modified: December 15, 2022
+Last modified: October 29, 2025
 
 Introduction
 ------------


### PR DESCRIPTION
## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

This adds plausible.io stats to the jupyterlab docs.

## User-facing changes


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
