### PR TITLE
Add `vega` resolution pins

### DIFF
--- a/packages/vega5-extension/package.json
+++ b/packages/vega5-extension/package.json
@@ -56,6 +56,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "resolutions": {
+    "vega-expression": "5.2.0",
+    "vega-functions": "5.18.0",
+    "vega-interpreter": "1.2.0"
+  },
   "jupyterlab": {
     "mimeExtension": true
   },


### PR DESCRIPTION
## References

- Checking if we can fix https://github.com/jupyterlab/jupyterlab/issues/18039 easily
- upstream: https://github.com/vega/vega/issues/4160

## Code changes

Add `resolutions` for `vega` versions which do not have packaging issues.

## User-facing changes

None

## Backwards-incompatible changes

None
