### PR TITLE
Update PyPI Downloads badge in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 # [JupyterLab](https://jupyterlab.readthedocs.io)
 
 [![PyPI version](https://badge.fury.io/py/jupyterlab.svg)](https://badge.fury.io/py/jupyterlab)
-[![Downloads](https://static.pepy.tech/badge/jupyterlab/month)](https://pepy.tech/project/jupyterlab)
+[![PyPI Downloads](https://static.pepy.tech/personalized-badge/jupyterlab?period=monthly&units=INTERNATIONAL_SYSTEM&left_color=GRAY&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/jupyterlab)
 [![Build Status](https://github.com/jupyterlab/jupyterlab/workflows/Linux%20Tests/badge.svg)](https://github.com/jupyterlab/jupyterlab/actions?query=branch%3Amain+workflow%3A%22Linux+Tests%22)
 [![Build Status](https://github.com/jupyterlab/jupyterlab/workflows/Windows%20Tests/badge.svg)](https://github.com/jupyterlab/jupyterlab/actions?query=branch%3Amain+workflow%3A%22Windows+Tests%22)
 [![Documentation Status](https://readthedocs.org/projects/jupyterlab/badge/?version=stable)](http://jupyterlab.readthedocs.io/en/stable/)


### PR DESCRIPTION

## References

`check_links` appears to be failing on CI lately:

<img width="2036" height="570" alt="image" src="https://github.com/user-attachments/assets/bc5e7d6e-262b-4805-a634-d49808c7379c" />



The badge also does not render in the README anymore. 

<img height="238" alt="image" src="https://github.com/user-attachments/assets/ba18afad-e2b3-497d-92a1-67cbd8850f84" />

This is likely due to a recent change on pepy.tech.

## Code changes

Generate a new download badge from https://pepy.tech/projects/jupyterlab?timeRange=threeMonths&category=version&includeCIDownloads=true&granularity=daily&viewType=line&versions=4.4.10%2C4.4.9%2C4.4.8

## User-facing changes

The download badge is displayed in the README.

## Backwards-incompatible changes

None

