### PR TITLE
Add plausible and logos to API docs

### DIFF
--- a/docs/typedoc-custom.css
+++ b/docs/typedoc-custom.css
@@ -1,0 +1,33 @@
+header.tsd-page-toolbar .title {
+  --lab-logo-light: url(../../_static/logo-rectangle.svg);
+  --lab-logo-dark: url(../../_static/logo-rectangle-dark.svg);
+
+  background: var(--lab-logo-light) left center / contain no-repeat;
+  color: transparent;
+}
+
+@media (prefers-color-scheme: dark) {
+  header.tsd-page-toolbar .title {
+    background-image: var(--lab-logo-dark);
+  }
+}
+
+:root[data-theme='light'] header.tsd-page-toolbar .title {
+  background-image: var(--lab-logo-light);
+}
+
+:root[data-theme='dark'] header.tsd-page-toolbar .title {
+  background-image: var(--lab-logo-dark);
+}
+
+#tsd-toolbar-links {
+  --favicon-size: 16px;
+}
+#tsd-toolbar-links a[href="https://jupyter.org"]
+{
+  background: url(../../_static/jupyter_logo.svg) left center /
+    var(--favicon-size) no-repeat;
+  color: transparent;
+  font-size: 0;
+  min-width: var(--favicon-size);
+}

--- a/docs/typedoc-customizations.js
+++ b/docs/typedoc-customizations.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+const { JSX } = require('typedoc');
+
+/**
+ * @param {import('typedoc').Application} app
+ */
+exports.load = function (app) {
+  // Inject JupyterLab favicon
+  app.renderer.hooks.on('head.begin', context => {
+    return JSX.createElement(
+      JSX.Fragment,
+      null,
+      // Add favicon
+      JSX.createElement('link', {
+        rel: 'icon',
+        type: 'image/png',
+        href: '../_static/logo-icon.png'
+      })
+    );
+  });
+  // Inject Plausible.io analytics in the footer of the head section
+  app.renderer.hooks.on('head.end', context => {
+    return JSX.createElement(
+      JSX.Fragment,
+      null,
+      // Plausible.io main script (async)
+      JSX.createElement('script', {
+        src: 'https://plausible.io/js/pa-Tem97Eeu4LJFfSRY89aW1.js',
+        async: true
+      }),
+      // Plausible.io initialization script with hash-based routing
+      JSX.createElement(
+        'script',
+        null,
+        'window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init({hashBasedRouting:true});'
+      )
+    );
+  });
+};

--- a/typedoc.js
+++ b/typedoc.js
@@ -232,11 +232,12 @@ module.exports = {
   },
   githubPages: false,
   navigationLinks: {
-    GitHub: 'https://github.com/jupyterlab/jupyterlab',
-    Jupyter: 'https://jupyter.org'
+    Jupyter: 'https://jupyter.org',
+    GitHub: 'https://github.com/jupyterlab/jupyterlab'
   },
   name: '@jupyterlab',
-  plugin: ['typedoc-plugin-mdn-links'],
+  plugin: ['typedoc-plugin-mdn-links', './docs/typedoc-customizations.js'],
+  customCss: './docs/typedoc-custom.css',
   out: 'docs/source/api',
   readme: 'README.md',
   theme: 'default',


### PR DESCRIPTION
## References

- Follow-up to #18041 

## Code changes

- Adds custom CSS, favicon, and plausible scripts in API Reference docs
- Swaps Jupyter and GitHub links to align the toolbar with the main docs page; out of scope for this PR but in principle we could make the navigation bar of API Reference even more aligned with the main docs by:
  - using font-awesome icons for GitHub link (possibly with CSS)
  - adding links to discord and zulip
  - moving the theme toggle into the toolbar with some JS (see below) 
    ```js
    const toggle = document.querySelector(".tsd-theme-toggle");
    const links = document.querySelector("#tsd-toolbar-links");
    links.insertBefore(toggle, links.firstElementChild);
    ```

## Developer-facing changes

| Before | After |
|--|--|
| <img width="1023" height="273" alt="image" src="https://github.com/user-attachments/assets/353b58a4-99ac-4cc5-9b52-4ba98b26145a" /> | <img width="1023" height="273" alt="image" src="https://github.com/user-attachments/assets/06142ea1-95c6-4473-b2a4-38aa0bf299cd" /> |

Hopefully we will be able to see the stats on https://plausible.io/jupyterlab.readthedocs.io

## Backwards-incompatible changes

None
