### PR TITLE
Mention JupyterLab 4.5.0 RC in the installation instructions

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -6,6 +6,18 @@
 Installation
 ============
 
+.. hint::
+    JupyterLab 4.5 Release Candidate is now available and includes enhancements
+    to the debugger, terminal, file browser, and the overall notebook experience.
+    If you are an experienced user, or just would like to test out the latest
+    improvements, please consider installing the pre-release, for example with:
+    
+    .. code:: bash
+    
+        pip install --pre --upgrade jupyterlab==4.5.0rc0
+
+    For the full release notes please see the `Release Notes <https://jupyterlab.readthedocs.io/en/latest/getting_started/changelog.html#v4-5>`__ 
+
 JupyterLab can be installed as a terminal-launched application accessible via a web browser (default), or as a desktop application which is running in its own window and can be opened by clicking on a desktop shortcut (`JupyterLab Desktop <https://github.com/jupyterlab/jupyterlab-desktop>`__). This page describes installation of the default (terminal-launched) JupyterLab application using ``conda``, ``mamba``, ``pip``, ``pipenv`` or ``docker`` and assumes basic knowledge of the terminal. For JupyterLab Desktop instructions see the `Installation section <https://github.com/jupyterlab/jupyterlab-desktop#installation>`__ in the JupyterLab Desktop repository.
 
 .. warning::

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -11,12 +11,12 @@ Installation
     to the debugger, terminal, file browser, and the overall notebook experience.
     If you are an experienced user, or just would like to test out the latest
     improvements, please consider installing the pre-release, for example with:
-    
+
     .. code:: bash
-    
+
         pip install --pre --upgrade jupyterlab==4.5.0rc0
 
-    For the full release notes please see the `Release Notes <https://jupyterlab.readthedocs.io/en/latest/getting_started/changelog.html#v4-5>`__ 
+    For the full release notes please see the `Release Notes <https://jupyterlab.readthedocs.io/en/latest/getting_started/changelog.html#v4-5>`__
 
 JupyterLab can be installed as a terminal-launched application accessible via a web browser (default), or as a desktop application which is running in its own window and can be opened by clicking on a desktop shortcut (`JupyterLab Desktop <https://github.com/jupyterlab/jupyterlab-desktop>`__). This page describes installation of the default (terminal-launched) JupyterLab application using ``conda``, ``mamba``, ``pip``, ``pipenv`` or ``docker`` and assumes basic knowledge of the terminal. For JupyterLab Desktop instructions see the `Installation section <https://github.com/jupyterlab/jupyterlab-desktop#installation>`__ in the JupyterLab Desktop repository.
 


### PR DESCRIPTION
## References

This is one way we could potentially encourage more testing. The installation instructions page gets the most visitors and since someone is already installing a JupyterLab it is possibly a smaller ask to install an RC compared to displaying a message to users who may not have admin rights to update.

<img width="1111" height="1011" alt="image" src="https://github.com/user-attachments/assets/16064132-69ea-4f69-a972-1531b0303117" />

Other avenues are:
- use a banner (currently we have a banner for JupyterCon, maybe we could swap it out next week)
- send a notification - we did not do that before for any release but we did consider for 4.0rc (https://github.com/jupyterlab/assets/pull/3); I think maybe this should be reserved for major releases
- write a blog post (this usually takes a long time to get written and published, we are short on time if we want to release during JupyterCon)