### PR TITLE
Debugger: Fix breakpoints lost when closing modules

### DIFF
--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -726,12 +726,18 @@ export class DebuggerService implements IDebugger, IDisposable {
     const { prefix, suffix } = this._config.getTmpFileParams(kernel);
     for (const item of breakpoints) {
       const [id, list] = item;
-      const unSuffixedId = id.substring(0, id.length - suffix.length);
-      const codeHash = unSuffixedId.substring(
-        unSuffixedId.lastIndexOf('/') + 1
-      );
-      const newId = prefix.concat(codeHash).concat(suffix);
-      migratedBreakpoints.set(newId, list);
+      if (id.startsWith('/tmp/')) {
+        /* only redefine id for dump cells*/
+        const unSuffixedId = id.substring(0, id.length - suffix.length);
+        const codeHash = unSuffixedId.substring(
+          unSuffixedId.lastIndexOf('/') + 1
+        );
+        const newId = prefix.concat(codeHash).concat(suffix);
+        migratedBreakpoints.set(newId, list);
+      } else {
+        /* keep the original id for other files, i.e. the full local path */
+        migratedBreakpoints.set(id, list);
+      }
     }
 
     return migratedBreakpoints;

--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -721,7 +721,7 @@ export class DebuggerService implements IDebugger, IDisposable {
    * @returns
    */
   private _migrateBreakpoints(debuggerState: IDebugger.State) {
-    const oldSessionPrefix: string = debuggerState.tmpPrefix;
+    const oldSessionPrefix: string | undefined = debuggerState.tmpPrefix;
     const migratedBreakpoints = new Map<string, IDebugger.IBreakpoint[]>();
     const kernel = this.session?.connection?.kernel?.name ?? '';
     const { prefix } = this._config.getTmpFileParams(kernel);
@@ -729,7 +729,11 @@ export class DebuggerService implements IDebugger, IDisposable {
 
     for (const item of breakpoints) {
       const [id, list] = item;
-      if (id.startsWith(oldSessionPrefix) && oldSessionPrefix !== prefix) {
+      if (
+        oldSessionPrefix &&
+        id.startsWith(oldSessionPrefix) &&
+        oldSessionPrefix !== prefix
+      ) {
         /* replace tmpPrefix by the new prefix in newId*/
         const newId = id.replace(oldSessionPrefix, prefix);
         migratedBreakpoints.set(newId, list);

--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -721,7 +721,7 @@ export class DebuggerService implements IDebugger, IDisposable {
    * @returns
    */
   private _migrateBreakpoints(debuggerState: IDebugger.State) {
-    let tmpPrefix: string = debuggerState.tmpPrefix;
+    const oldSessionPrefix: string = debuggerState.tmpPrefix;
     const migratedBreakpoints = new Map<string, IDebugger.IBreakpoint[]>();
     const kernel = this.session?.connection?.kernel?.name ?? '';
     const { prefix } = this._config.getTmpFileParams(kernel);
@@ -729,12 +729,12 @@ export class DebuggerService implements IDebugger, IDisposable {
 
     for (const item of breakpoints) {
       const [id, list] = item;
-      if (id.startsWith(tmpPrefix)) {
+      if (id.startsWith(oldSessionPrefix) && oldSessionPrefix !== prefix) {
         /* replace tmpPrefix by the new prefix in newId*/
-        const newId = id.replace(tmpPrefix, prefix);
+        const newId = id.replace(oldSessionPrefix, prefix);
         migratedBreakpoints.set(newId, list);
       } else {
-        /* keep the original id for other files, i.e. the full local path */
+        /* keep the original id otherwise */
         migratedBreakpoints.set(id, list);
       }
     }

--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -724,18 +724,14 @@ export class DebuggerService implements IDebugger, IDisposable {
     let tmpPrefix: string = debuggerState.tmpPrefix;
     const migratedBreakpoints = new Map<string, IDebugger.IBreakpoint[]>();
     const kernel = this.session?.connection?.kernel?.name ?? '';
-    const { suffix, prefix } = this._config.getTmpFileParams(kernel);
+    const { prefix } = this._config.getTmpFileParams(kernel);
     const { breakpoints } = debuggerState;
 
     for (const item of breakpoints) {
       const [id, list] = item;
       if (id.startsWith(tmpPrefix)) {
         /* replace tmpPrefix by the new prefix in newId*/
-        const unSuffixedId = id.substring(0, id.length - suffix.length);
-        const codeHash = unSuffixedId.substring(
-          unSuffixedId.lastIndexOf('/') + 1
-        );
-        const newId = prefix.concat(codeHash).concat(suffix);
+        const newId = id.replace(tmpPrefix, prefix);
         migratedBreakpoints.set(newId, list);
       } else {
         /* keep the original id for other files, i.e. the full local path */

--- a/packages/debugger/src/tokens.ts
+++ b/packages/debugger/src/tokens.ts
@@ -289,6 +289,10 @@ export namespace IDebugger {
      * Map of breakpoints to send back to the kernel after it has restarted
      */
     breakpoints: Map<string, IDebugger.IBreakpoint[]>;
+    /**
+     * Prefix for temporary files associated with this kernel session
+     */
+    tmpPrefix: string;
   };
 
   /**

--- a/packages/debugger/src/tokens.ts
+++ b/packages/debugger/src/tokens.ts
@@ -292,7 +292,7 @@ export namespace IDebugger {
     /**
      * Prefix for temporary files associated with this kernel session
      */
-    tmpPrefix: string;
+    tmpPrefix?: string;
   };
 
   /**


### PR DESCRIPTION
When a module is opened by the kernel sources and a breakpoint is set, it is lost when the module is closed: the breakpoint is removed from the model. As a consequence, the breakpoint cannot be displayed when continuing or when stepping in. 

**Current behavior**

https://github.com/user-attachments/assets/580628e6-6143-4710-a157-8e71b5e5c228


It has appeared that some filtering made on breakpoints in `updateBreakpoints` and in `restoreState` were responsible for this behavior.

**After removing filtering**
Another issue has been observed: there was a duplication of the breakpoints set in modules, and then some transformation of the id from `localpath/module.py` to `/tmp/ipykernel_xxxxx/module.py`.

https://github.com/user-attachments/assets/9d9a3f38-27ab-41ed-9b82-962ad9b1bf44

This issue has been resolved with updating the `_migrateBreakpoints` method.

**Fixed behavior:**
https://github.com/user-attachments/assets/82494346-c408-4f24-9251-2aa28b6b1516




## References

This PR should fix issue [#https://github.com/jupyterlab/jupyterlab/issues/18045](https://github.com/jupyterlab/jupyterlab/issues/18045)


## Code changes

This PR removes the `filterBreakpoints` method from service.ts that was removing breakpoints set in closed editor. It also updates private method `_migrateBreakpoints` to only re set dumpCell ids on kernel restart and not module ones.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
