### PR TITLE
Hide “Paused in Debugger” overlay when session terminates

### DIFF
--- a/packages/debugger/src/handlers/console.ts
+++ b/packages/debugger/src/handlers/console.ts
@@ -69,7 +69,7 @@ export class ConsoleHandler implements IDisposable {
 
       if (event.event === 'stopped') {
         void this._pausedOverlay.show();
-      } else if (event.event === 'continued') {
+      } else if (event.event === 'continued' || event.event === 'terminated') {
         void this._pausedOverlay.hide();
       }
     });

--- a/packages/debugger/src/handlers/file.ts
+++ b/packages/debugger/src/handlers/file.ts
@@ -59,7 +59,7 @@ export class FileHandler implements IDisposable {
 
       if (event.event === 'stopped') {
         void this._pausedOverlay.show();
-      } else if (event.event === 'continued') {
+      } else if (event.event === 'continued' || event.event === 'terminated') {
         void this._pausedOverlay.hide();
       }
     });

--- a/packages/debugger/src/handlers/notebook.ts
+++ b/packages/debugger/src/handlers/notebook.ts
@@ -51,7 +51,7 @@ export class NotebookHandler implements IDisposable {
 
       if (event.event === 'stopped') {
         void this._pausedOverlay.show();
-      } else if (event.event === 'continued') {
+      } else if (event.event === 'continued' || event.event === 'terminated') {
         void this._pausedOverlay.hide();
       }
     });


### PR DESCRIPTION

## References

Shall fix https://github.com/jupyterlab/jupyterlab/issues/18065

This PR ensures that the “Paused in Debugger” overlay is properly hidden when a debugger session terminates.
Previously, the overlay remained visible even after the session was stopped

## Code changes

Updated handlers to listen for the terminated event from the debugger session.

## User-facing changes


https://github.com/user-attachments/assets/aa2e9a3b-15af-45bc-b188-cbf029a413d3



## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
