### PR TITLE
Update announcement from JupyterCon to JupyterLab 4.5.0 RC

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -363,7 +363,7 @@ html_favicon = "_static/logo-icon.png"
 # documentation.
 #
 html_theme_options = {
-    "announcement": '🚀 Join us in San Diego · JupyterCon 2025 · Nov 4-5 · <a href="https://events.linuxfoundation.org/jupytercon/program/schedule/">SCHEDULE</a> · <a href="https://events.linuxfoundation.org/jupytercon/register/">REGISTER NOW</a>',
+    "announcement": '🚀 You can now test JupyterLab 4.5.0 Release Candidate · <a href="https://jupyterlab.rtfd.io/en/latest/getting_started/installation.html">INSTALL</a> · <a href="https://jupyterlab.rtfd.io/en/latest/getting_started/changelog.html#v4-5">RELEASE NOTES</a>',
     "icon_links": [
         {
             "name": "jupyter.org",


### PR DESCRIPTION
## References

Follow-up to:
- #17906
- #18061

<img width="1260" height="105" alt="image" src="https://github.com/user-attachments/assets/560fe6a0-ef4a-4e89-8c23-dee276a93d4a" />

https://jupyterlab--18074.org.readthedocs.build/en/18074/