### PR TITLE
Update example for disabling `buildAvailable`

### DIFF
--- a/docs/source/user/directories.md
+++ b/docs/source/user/directories.md
@@ -52,7 +52,7 @@ equivalent) in any of the `config` locations returned by `jupyter
 
 ```json
 {
-  "LabApp": {
+  "ServerApp": {
     "tornado_settings": {
       "page_config_data": {
         "buildCheck": false,


### PR DESCRIPTION
The json code doesn't work (i.e. not disable the update checks) unless changing LabApp to ServerApp and removing the comma after the last "false"

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
#18010 

## Code changes
The settings must be done for ServerApp, not LapApp, so the keyword has been changed. And the comma after the last "false" causes a syntax error, so that the jupyter_server_config.json file is ignored. So the comma was removed.

