### PR TITLE
Fix layout trashing when navigating notebook cell-by-cell

### DIFF
--- a/galata/test/jupyterlab/notebook-navigate.test.ts
+++ b/galata/test/jupyterlab/notebook-navigate.test.ts
@@ -1,0 +1,86 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { expect, test } from '@jupyterlab/galata';
+
+const fileName = 'notebook.ipynb';
+
+const READ_WRITE_CLASS = 'jp-mod-readWrite';
+
+test.describe('Notebook Navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.notebook.createNew(fileName);
+  });
+
+  test('Move to cell below with arrow down', async ({ page }) => {
+    await page.notebook.addCell('code', 'first');
+    await page.notebook.addCell('code', 'second');
+
+    const firstCell = await page.notebook.getCellInputLocator(1);
+    const secondCell = await page.notebook.getCellInputLocator(2);
+
+    await page.notebook.enterCellEditingMode(1);
+
+    // Check if first cell has focus
+    await expect(firstCell!.locator('.cm-content')).toBeFocused();
+    await expect(secondCell!.locator('.cm-content')).not.toBeFocused();
+
+    // Make sure that .jp-mod-readWrite does not flicker when changing focus
+    // from one cell to another, as that would cause layout trashing.
+    await page.evaluate(attachNotebookMutationObserver);
+
+    // Navigate to second cell
+    await firstCell!.press('ArrowDown');
+
+    // Check that second cell has focus
+    await expect(firstCell!.locator('.cm-content')).not.toBeFocused();
+    await expect(secondCell!.locator('.cm-content')).toBeFocused();
+
+    const mutations = await page.evaluate(getNotebookMutations);
+
+    // There should be zero changes to .jp-mod-readWrite (no flicker at all)
+    const readWriteTransitions = mutations.filter(m => {
+      return (
+        m.type === 'attributes' &&
+        m.name === 'class' &&
+        m.old?.includes(READ_WRITE_CLASS) != m.new?.includes(READ_WRITE_CLASS)
+      );
+    });
+    expect(readWriteTransitions.length).toBe(0);
+  });
+});
+
+type WindowWithMutationObserver = Window & {
+  notebookMutations: {
+    old: string | null;
+    new: string | null;
+    type: string;
+    name: string | null;
+  }[];
+};
+
+function attachNotebookMutationObserver() {
+  const win = window as unknown as WindowWithMutationObserver;
+  win.notebookMutations = [];
+  const notebook = document.querySelector('.jp-Notebook');
+  if (!notebook) return;
+  const observer = new MutationObserver((mutations: MutationRecord[]) => {
+    for (const mutation of mutations) {
+      win.notebookMutations.push({
+        old: mutation.oldValue,
+        new: notebook?.className ?? null,
+        type: mutation.type,
+        name: mutation.attributeName
+      });
+    }
+  });
+  observer.observe(notebook, {
+    attributes: true,
+    attributeOldValue: true
+  });
+}
+
+function getNotebookMutations() {
+  const win = window as unknown as WindowWithMutationObserver;
+  return win.notebookMutations;
+}

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -289,6 +289,10 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
    * Brings browser focus to this editor text.
    */
   focus(): void {
+    // Add the focused class before the editor focus even fires
+    // to avoid layout trashing when it getcs called in response
+    // to focus event from CodeMirror.
+    this.host.classList.add('jp-mod-focused');
     this._editor.focus();
   }
 

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -289,8 +289,8 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
    * Brings browser focus to this editor text.
    */
   focus(): void {
-    // Add the focused class before the editor focus even fires
-    // to avoid layout trashing when it getcs called in response
+    // Add the focused class before the editor focus event fires
+    // to avoid layout trashing when it gets called in response
     // to focus event from CodeMirror.
     this.host.classList.add('jp-mod-focused');
     this._editor.focus();

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -2545,7 +2545,9 @@ export class Notebook extends StaticNotebook {
     editor: CodeEditor.IEditor,
     location: CodeEditor.EdgeLocation
   ): void {
-    // Ensure edit mode but do not focus yet
+    // Ensure edit mode but do not focus yet; we ensure the edit mode
+    // with focus trigger at the end, as a side-effect of `this.mode = 'edit'`,
+    // which could be simplified in the future.
     this.setMode('edit', { focus: false });
 
     const prev = this.activeCellIndex;
@@ -2569,6 +2571,7 @@ export class Notebook extends StaticNotebook {
         }
       }
     }
+    // This is potentially no longer needed with the `setMode` call at the top.
     this.mode = 'edit';
   }
 

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -2545,6 +2545,9 @@ export class Notebook extends StaticNotebook {
     editor: CodeEditor.IEditor,
     location: CodeEditor.EdgeLocation
   ): void {
+    // Ensure edit mode but do not focus yet
+    this.setMode('edit', { focus: false });
+
     const prev = this.activeCellIndex;
     if (location === 'top') {
       this.activeCellIndex--;
@@ -3212,6 +3215,9 @@ export class Notebook extends StaticNotebook {
    */
   private _updateReadWrite(): void {
     const inReadWrite = DOMUtils.hasActiveEditableElement(this.node);
+    if (this.node.classList.contains(READ_WRITE_CLASS) === inReadWrite) {
+      return;
+    }
     this.node.classList.toggle(READ_WRITE_CLASS, inReadWrite);
   }
 
@@ -3277,14 +3283,13 @@ export class Notebook extends StaticNotebook {
    * Handle `focusout` events for the notebook.
    */
   private _evtFocusOut(event: FocusEvent): void {
-    // Update read-write class state.
-    this._updateReadWrite();
-
     const relatedTarget = event.relatedTarget as HTMLElement;
 
     // Bail if the window is losing focus, to preserve edit mode. This test
     // assumes that we explicitly focus things rather than calling blur()
     if (!relatedTarget) {
+      // Update read-write class state.
+      this._updateReadWrite();
       return;
     }
 
@@ -3294,6 +3299,8 @@ export class Notebook extends StaticNotebook {
     if (index !== -1) {
       const widget = this.widgets[index];
       if (widget.editorWidget?.node.contains(relatedTarget)) {
+        // Do not update read-write state as there is no real loss of focus,
+        // instead we are just switching to a different cell
         return;
       }
     }
@@ -3302,6 +3309,8 @@ export class Notebook extends StaticNotebook {
     if (this.mode !== 'command') {
       this.setMode('command', { focus: false });
     }
+    // Update read-write class state.
+    this._updateReadWrite();
   }
 
   /**


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/18076

## Code changes

- [x] Adds a test which should fail in the first commit
- [x] Limits DOM modifications to minimum by avoiding flipping `.jp-mod-readWrite` back and forth when switching cells
- [x] Applies `jp-mod-focused` before focusing the CodeMirror editor to avoid style recalculation when CodeMirror checks `scrollTop` for its own windowing logic

## User-facing changes

Much faster notebook navigation!

| Before | After |
|--|--|
| <img width="1047" height="428" alt="image" src="https://github.com/user-attachments/assets/334401d1-b074-4d1f-ab7b-07b5644b48d0" /> | <img width="1126" height="425" alt="image" src="https://github.com/user-attachments/assets/e4881c14-ca27-4cb4-bbed-1ed672062fa2" /> |


## Backwards-incompatible changes

None