### PR TITLE
Separate verdaccio install and startup to fix flaky `release_test` CI job

### DIFF
--- a/buildutils/src/local-repository.ts
+++ b/buildutils/src/local-repository.ts
@@ -84,6 +84,13 @@ packages:
     fs.unlinkSync(log_file);
   }
 
+  // Warm up npx cache to avoid conflating install time with startup time,
+  // also get and print out the version info for debugging while at it.
+  const version = child_process
+    .execFileSync('npx', ['verdaccio', '--version'], { encoding: 'utf-8' })
+    .trim();
+  console.log(`Verdaccio version: ${version}`);
+
   // Assign as `any`` for compatibility with spawn `OpenMode`` options
   const out: any = fs.openSync(log_file, 'a');
   const err: any = fs.openSync(log_file, 'a');

--- a/buildutils/src/local-repository.ts
+++ b/buildutils/src/local-repository.ts
@@ -87,7 +87,9 @@ packages:
   // Warm up npx cache to avoid conflating install time with startup time,
   // also get and print out the version info for debugging while at it.
   const version = child_process
-    .execFileSync('npx', ['verdaccio', '--version'], { encoding: 'utf-8' })
+    .execFileSync('npx', ['verdaccio@6.2.1', '--version'], {
+      encoding: 'utf-8'
+    })
     .trim();
   console.log(`Verdaccio version: ${version}`);
 
@@ -99,7 +101,7 @@ packages:
 
   const subproc = child_process.spawn(
     'npx',
-    ['verdaccio'].concat(args.split(' ')),
+    ['verdaccio@6.2.1'].concat(args.split(' ')),
     options
   );
   subproc.unref();


### PR DESCRIPTION
## References

#16473

## Code changes

Warm up `npx` cache before starting up `verdaccio`

## User-facing changes

None

## Backwards-incompatible changes

None