### PR TITLE
Add toggle main menu functionality for presentation mode

### DIFF
--- a/packages/application-extension/schema/commands.json
+++ b/packages/application-extension/schema/commands.json
@@ -291,6 +291,10 @@
                   "rank": 0
                 },
                 {
+                  "command": "application:toggle-main-menu",
+                  "rank": 5
+                },
+                {
                   "command": "application:toggle-fullscreen-mode",
                   "rank": 0
                 },

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -115,6 +115,8 @@ namespace CommandIDs {
   export const toggleFullscreenMode: string =
     'application:toggle-fullscreen-mode';
 
+  export const toggleMainMenu: string = 'application:toggle-main-menu';
+
   export const tree: string = 'router:tree';
 
   export const switchSidebar = 'sidebar:switch';
@@ -558,6 +560,21 @@ const mainCommands: JupyterFrontEndPlugin<void> = {
         isVisible: () => true
       });
 
+      commands.addCommand(CommandIDs.toggleMainMenu, {
+        label: trans.__('Show Main Menu'),
+        describedBy: {
+          args: {
+            type: 'object',
+            properties: {}
+          }
+        },
+        execute: () => {
+          labShell.menuBarVisible = !labShell.menuBarVisible;
+        },
+        isToggled: () => labShell.menuBarVisible,
+        isVisible: () => true
+      });
+
       commands.addCommand(CommandIDs.toggleFullscreenMode, {
         label: trans.__('Fullscreen Mode'),
         describedBy: {
@@ -689,6 +706,14 @@ const mainCommands: JupyterFrontEndPlugin<void> = {
           // - by listening to this command execution.
         }
       });
+
+      // Alt+M key handler to toggle menu visibility
+      commands.addKeyBinding({
+        command: CommandIDs.toggleMainMenu,
+        keys: ['Alt M'],
+        selector: 'body',
+        preventDefault: true
+      });
     }
 
     if (palette) {
@@ -705,6 +730,7 @@ const mainCommands: JupyterFrontEndPlugin<void> = {
         CommandIDs.toggleLeftArea,
         CommandIDs.toggleRightArea,
         CommandIDs.togglePresentationMode,
+        CommandIDs.toggleMainMenu,
         CommandIDs.toggleFullscreenMode,
         CommandIDs.toggleMode,
         CommandIDs.resetLayout

--- a/packages/application/src/layoutrestorer.ts
+++ b/packages/application/src/layoutrestorer.ts
@@ -188,7 +188,7 @@ export class LayoutRestorer implements ILayoutRestorer {
         return blank;
       }
 
-      const { main, down, left, right, relativeSizes, top } =
+      const { main, down, left, right, relativeSizes, top, menuArea } =
         data as Private.ILayout;
 
       // If any data exists, then this is not a fresh session.
@@ -218,7 +218,8 @@ export class LayoutRestorer implements ILayoutRestorer {
         leftArea,
         rightArea,
         relativeSizes: relativeSizes || null,
-        topArea: (top as any) ?? null
+        topArea: (top as any) ?? null,
+        menuArea: (menuArea as any) ?? null
       };
     } catch (error) {
       return blank;
@@ -354,7 +355,7 @@ export class LayoutRestorer implements ILayoutRestorer {
     dehydrated.right = this._dehydrateSideArea(layout.rightArea);
     dehydrated.relativeSizes = layout.relativeSizes;
     dehydrated.top = { ...layout.topArea };
-
+    dehydrated.menuArea = { ...layout.menuArea };
     return this._connector.save(KEY, dehydrated);
   }
 
@@ -633,6 +634,11 @@ namespace Private {
      * The restorable description of the top area in the user interface.
      */
     top?: ITopArea | null;
+
+    /**
+     * The restorable description of the menu area in the user interface.
+     */
+    menuArea?: IMenuArea | null;
   }
 
   /**
@@ -708,6 +714,16 @@ namespace Private {
      * Top area visibility in simple mode.
      */
     readonly simpleVisibility?: boolean;
+  }
+
+  /**
+   * The restorable description of the menu area in the user interface.
+   */
+  export interface IMenuArea extends PartialJSONObject {
+    /**
+     * Whether the menu bar is visible.
+     */
+    readonly visible?: boolean;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Implement ability to hide/show main menu bar to provide more screen space for presentations or embedded use cases.
- Add View > Appearance menu entry for toggle functionality
- Add Alt+M keyboard shortcut for quick access
- Menu visibility state persists across page reloads and mode switches
- Works in both Simple and Multiple Document modes

Maybe helps with #7214