### PR TITLE
Active cell preservation on `ydoc` reload

### DIFF
--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -239,6 +239,7 @@ export abstract class CellModel extends CodeEditor.Model implements ICellModel {
 
     this.sharedModel.changed.connect(this.onGenericChange, this);
     this.sharedModel.metadataChanged.connect(this._onMetadataChanged, this);
+    this._id = this.sharedModel.getId();
   }
 
   readonly sharedModel: ISharedCell;
@@ -276,7 +277,7 @@ export abstract class CellModel extends CodeEditor.Model implements ICellModel {
    * The id for the cell.
    */
   get id(): string {
-    return this.sharedModel.getId();
+    return this._id;
   }
 
   /**
@@ -379,6 +380,7 @@ export abstract class CellModel extends CodeEditor.Model implements ICellModel {
 
   private _metadataChanged = new Signal<this, IMapChange>(this);
   private _trusted = false;
+  private _id: string;
 }
 
 /**

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1690,7 +1690,13 @@ export class Notebook extends StaticNotebook {
         cell => cell.getId() === activeCellId
       );
       if (newActiveCellIndex != undefined && newActiveCellIndex !== -1) {
+        // This will scroll to restored active cell if the notebook is in the edit mode.
         this.activeCellIndex = newActiveCellIndex;
+        if (this.mode === 'command' && this.activeCell) {
+          // We also want to scroll back to the cell in the command mode,
+          // we do not use `scrollToCell` method as that switches to edit mode.
+          this.scrollToItem(this.activeCellIndex);
+        }
       }
     }
   }

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1695,7 +1695,7 @@ export class Notebook extends StaticNotebook {
         if (this.mode === 'command' && this.activeCell) {
           // We also want to scroll back to the cell in the command mode,
           // we do not use `scrollToCell` method as that switches to edit mode.
-          this.scrollToItem(this.activeCellIndex);
+          void this.scrollToItem(this.activeCellIndex);
         }
       }
     }

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -837,7 +837,11 @@ describe('@jupyter/notebook', () => {
 
       it('should keep active cell when cells get reloaded', () => {
         const widget = createActiveWidget();
-        widget.model!.fromJSON(utils.DEFAULT_CONTENT);
+        widget.model!.fromJSON({
+          ...utils.DEFAULT_CONTENT,
+          nbformat: 4,
+          nbformat_minor: 5
+        });
 
         // Select fourth cell
         const expectedIndex = 3;
@@ -850,12 +854,14 @@ describe('@jupyter/notebook', () => {
         // Reload all cells
         const source = widget.model!.sharedModel.getSource();
         widget.model!.sharedModel.setSource(source);
+        const sourceAfter = widget.model!.sharedModel.getSource();
+        expect(sourceAfter).toEqual(source);
         const activeAfter = widget.activeCell!;
 
         // The active cell after will be a different instance
-        expect(activeBefore).not.toBe(activeAfter);
+        expect(activeAfter).not.toBe(activeBefore);
         // But still the same ID
-        expect(idBefore).toBe(activeAfter.model.id);
+        expect(activeAfter.model.id).toBe(idBefore);
         // And the same index
         expect(widget.activeCellIndex).toBe(expectedIndex);
       });

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -834,6 +834,31 @@ describe('@jupyter/notebook', () => {
         widget.activeCellIndex = 1;
         expect(child.rendered).toBe(true);
       });
+
+      it('should keep active cell when cells get reloaded', () => {
+        const widget = createActiveWidget();
+        widget.model!.fromJSON(utils.DEFAULT_CONTENT);
+
+        // Select fourth cell
+        const expectedIndex = 3;
+        widget.activeCellIndex = expectedIndex;
+        expect(widget.activeCellIndex).toBe(expectedIndex);
+        const activeBefore = widget.activeCell!;
+        const idBefore = activeBefore.model.id;
+        expect(activeBefore).not.toBe(null);
+
+        // Reload all cells
+        const source = widget.model!.sharedModel.getSource();
+        widget.model!.sharedModel.setSource(source);
+        const activeAfter = widget.activeCell!;
+
+        // The active cell after will be a different instance
+        expect(activeBefore).not.toBe(activeAfter);
+        // But still the same ID
+        expect(idBefore).toBe(activeAfter.model.id);
+        // And the same index
+        expect(widget.activeCellIndex).toBe(expectedIndex);
+      });
     });
 
     describe('#activeCell', () => {

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -839,6 +839,7 @@ describe('@jupyter/notebook', () => {
         const widget = createActiveWidget();
         widget.model!.fromJSON({
           ...utils.DEFAULT_CONTENT,
+          // Cell IDs are only guaranteed in nbformat 4.5
           nbformat: 4,
           nbformat_minor: 5
         });
@@ -860,10 +861,41 @@ describe('@jupyter/notebook', () => {
 
         // The active cell after will be a different instance
         expect(activeAfter).not.toBe(activeBefore);
-        // But still the same ID
+        // but still the same ID
         expect(activeAfter.model.id).toBe(idBefore);
-        // And the same index
+        // and the same index.
         expect(widget.activeCellIndex).toBe(expectedIndex);
+      });
+
+      it('should keep active cell when all cells get re-arranged', () => {
+        const widget = createActiveWidget();
+        widget.model!.fromJSON({
+          ...utils.DEFAULT_CONTENT,
+          // Cell IDs are only guaranteed in nbformat 4.5
+          nbformat: 4,
+          nbformat_minor: 5
+        });
+
+        // Select third cell
+        const expectedIndex = 2;
+        widget.activeCellIndex = expectedIndex;
+        expect(widget.activeCellIndex).toBe(expectedIndex);
+        const activeBefore = widget.activeCell!;
+        const idBefore = activeBefore.model.id;
+        expect(activeBefore).not.toBe(null);
+
+        // Reload all cells, but revert the order
+        const source = widget.model!.sharedModel.getSource() as any;
+        (source.cells as []).reverse();
+        widget.model!.sharedModel.setSource(source);
+        const activeAfter = widget.activeCell!;
+
+        // The active cell after will be a different instance
+        expect(activeAfter).not.toBe(activeBefore);
+        // but still the same ID
+        expect(activeAfter.model.id).toBe(idBefore);
+        // and this time a different index.
+        expect(widget.activeCellIndex).not.toBe(expectedIndex);
       });
     });
 


### PR DESCRIPTION
## References

- [x] Adds a failing test
- [x] Fixes #18100

## Code changes

- store cell ID so that it can be accessed after the disposal of the shared model
- store active cell ID in between the two phases of cell reloading if all cells get reloaded

## User-facing changes

#### Before: active cell changes to the first one, scroll jumps to top

https://github.com/user-attachments/assets/6de5d8b8-4641-4a83-ae0a-22ef3082d031

#### After, command mode: active cell stays the same, scroll (still) changes slightly

https://github.com/user-attachments/assets/a674c58b-e917-4979-b41e-5fd937833c3e

#### After, edit mode: active cell stays the same, scroll (still) changes slightly, cursor still shifts in cell


https://github.com/user-attachments/assets/1dbcb7f7-7ae6-4220-afdb-dd193abbd621

## Backwards-incompatible changes

None
