### PR TITLE
Respect the `activate` option when opening document widgets

### DIFF
--- a/galata/jupyter_server_test_config.py
+++ b/galata/jupyter_server_test_config.py
@@ -6,5 +6,7 @@ from jupyterlab.galata import configure_jupyter_server
 configure_jupyter_server(c)
 c.LabApp.dev_mode = True
 
+c.FileContentsManager.delete_to_trash = False
+
 # Uncomment to set server log level to debug level
 # c.ServerApp.log_level = "DEBUG"

--- a/galata/jupyter_server_test_config.py
+++ b/galata/jupyter_server_test_config.py
@@ -6,7 +6,5 @@ from jupyterlab.galata import configure_jupyter_server
 configure_jupyter_server(c)
 c.LabApp.dev_mode = True
 
-c.FileContentsManager.delete_to_trash = False
-
 # Uncomment to set server log level to debug level
 # c.ServerApp.log_level = "DEBUG"

--- a/galata/test/jupyterlab/docmanager.test.ts
+++ b/galata/test/jupyterlab/docmanager.test.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+import { test } from '@jupyterlab/galata';
+import { expect } from '@playwright/test';
+
+const DEFAULT_NAME = 'untitled.txt';
+
+test.beforeEach(async ({ page }) => {
+  await page.menu.clickMenuItem('File>New>Text File');
+  await page.locator(`[role="main"] >> text=${DEFAULT_NAME}`).waitFor();
+  await page.activity.closeAll();
+});
+
+test.afterEach(async ({ page, tmpPath }) => {
+  if (
+    await page.filebrowser.contents.fileExists(`${tmpPath}/${DEFAULT_NAME}`)
+  ) {
+    await page.filebrowser.contents.deleteFile(`${tmpPath}/${DEFAULT_NAME}`);
+  }
+});
+
+test('Should open the document and activate it by default', async ({
+  page,
+  tmpPath
+}) => {
+  await page.evaluate(async filename => {
+    await window.jupyterapp.commands.execute('docmanager:open', {
+      path: filename
+    });
+  }, `${tmpPath}/${DEFAULT_NAME}`);
+
+  const tab = page.activity.getTabLocator(DEFAULT_NAME);
+  await expect(tab).toHaveClass(/jp-mod-active/);
+});
+
+test('Should open the document and not activate it', async ({
+  page,
+  tmpPath
+}) => {
+  await page.evaluate(async filename => {
+    await window.jupyterapp.commands.execute('docmanager:open', {
+      path: filename,
+      options: {
+        activate: false
+      }
+    });
+  }, `${tmpPath}/${DEFAULT_NAME}`);
+
+  const tab = page.activity.getTabLocator(DEFAULT_NAME);
+  await expect(tab).not.toHaveClass(/jp-mod-active/);
+});

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -123,7 +123,9 @@ const openerPlugin: JupyterFrontEndPlugin<IDocumentWidgetOpener> = {
         if (!widget.isAttached) {
           shell.add(widget, 'main', options || {});
         }
-        shell.activateById(widget.id);
+        if (options?.activate ?? true) {
+          shell.activateById(widget.id);
+        }
         this._opened.emit(widget);
       }
 


### PR DESCRIPTION
## References

When adding a widget to the shell, there is an option to activate the widget or not.
For some reasons, this option is not taken into account when opening a document widget using the document opener widget https://github.com/jupyterlab/jupyterlab/blob/6e6744cd2355263d7f6548ba009502f1767dbae4/packages/docmanager-extension/src/index.tsx#L126

This PR fixes it

### BEFORE

[record-2025-11-14_14.28.04.webm](https://github.com/user-attachments/assets/95191126-8bb9-4774-9166-9bc7c8bd5be5)

### AFTER

[record-2025-11-14_14.30.19.webm](https://github.com/user-attachments/assets/b3540cf2-178b-4f3d-99a6-2a4041fcd2c2)

## Code changes

Check for the activate options before activating the document widget after creation. If the option is not provided, the widget is activated.

## User-facing changes

Do not activate the document widget if explicitly requested.

## Backwards-incompatible changes

None
