### PR TITLE
Debugger: Handle the case for editor being null

### DIFF
--- a/packages/debugger/src/handlers/editor.ts
+++ b/packages/debugger/src/handlers/editor.ts
@@ -384,7 +384,10 @@ export class EditorHandler implements IDisposable {
    * Add the breakpoints to the editor.
    */
   private _addBreakpointsToEditor(): void {
-    if (!this.editor || this._id !== this._debuggerService.session?.connection?.id) {
+    if (
+      !this.editor ||
+      this._id !== this._debuggerService.session?.connection?.id
+    ) {
       return;
     }
 

--- a/packages/debugger/src/handlers/editor.ts
+++ b/packages/debugger/src/handlers/editor.ts
@@ -384,7 +384,7 @@ export class EditorHandler implements IDisposable {
    * Add the breakpoints to the editor.
    */
   private _addBreakpointsToEditor(): void {
-    if (this._id !== this._debuggerService.session?.connection?.id) {
+    if (!this.editor || this._id !== this._debuggerService.session?.connection?.id) {
       return;
     }
 
@@ -411,6 +411,10 @@ export class EditorHandler implements IDisposable {
    * Retrieve the breakpoints from the editor.
    */
   private _getBreakpointsFromEditor(): number[] {
+    if (!this.editor) {
+      return [];
+    }
+
     const editor = this.editor as CodeMirrorEditor;
     const breakpoints = editor.editor.state.field(this._breakpointState);
     let lines: number[] = [];


### PR DESCRIPTION
## References

This should fix the error seen in the console for https://github.com/jupyter/notebook/issues/7769

We have `this.editor as CodeMirrorEditor` in multiple places there although `this.editor` is possibly null.

I added simple watchdogs to prevent the error from showing up. This PR does not fix the mentioned highlighting issue though.