### PR TITLE
Fix Notebook Debugger: Missing Current-Line Highlight

### DIFF
--- a/packages/debugger/src/handlers/editor.ts
+++ b/packages/debugger/src/handlers/editor.ts
@@ -96,12 +96,25 @@ export class EditorHandler implements IDisposable {
       }
     );
 
-    this._debuggerService.model.callstack.currentFrameChanged.connect(() => {
-      const editor = this.editor;
-      if (editor) {
-        EditorHandler.clearHighlight(editor);
+    this._debuggerService.model.callstack.currentFrameChanged.connect(
+      (_, frame: IDebugger.IStackFrame) => {
+        const editor = this.editor;
+        if (editor) {
+          EditorHandler.clearHighlight(editor);
+          const framePath = frame?.source?.path ?? '';
+          const editorPath =
+            this._path ||
+            this._debuggerService.getCodeId(this._src.getSource());
+
+          // If the current frame belongs to this editor, highlight its line.
+          if (framePath && editorPath && framePath === editorPath) {
+            if (typeof frame?.line === 'number') {
+              EditorHandler.showCurrentLine(editor, frame.line);
+            }
+          }
+        }
       }
-    });
+    );
 
     this._breakpointEffect = StateEffect.define<
       { pos: number; selected: boolean }[]


### PR DESCRIPTION
## References

Potential fix for https://github.com/jupyter/notebook/issues/7769

Notebook uses JupyterLab’s debugger internals, but Notebook editors don’t provide file paths like JupyterLab’s text editors. Because of this, the debugger fails to match frames to Notebook editors.

## Code changes

This patch updates the highlight logic to also match Notebook editors by their codeId instead of only by filesystem paths.

## User-facing changes

https://github.com/user-attachments/assets/4ba2b1e3-f977-48b3-a309-bdbeecef5188




