### PR TITLE
Prevent some supply-chain attack vectors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 14
   # Set update schedule for pip
   - package-ecosystem: "pip"
     directory: "/"

--- a/.github/workflows/reject-staging-checks.yml
+++ b/.github/workflows/reject-staging-checks.yml
@@ -32,7 +32,7 @@ jobs:
           # Filter to staging dir and exclude allowed files
           DISALLOWED=$(echo "$CHANGED_FILES" \
             | grep '^jupyterlab/staging/' \
-            | grep -v -E '^jupyterlab/staging/(yarn\.js|\.yarnrc)$' || true)
+            | grep -v -E '^jupyterlab/staging/(yarn\.js|\.yarnrc\.yml)$' || true)
 
           if [[ -n "$DISALLOWED" ]]; then
             echo "Disallowed changes detected in jupyterlab/staging:" >&2
@@ -47,7 +47,7 @@ jobs:
             echo "$DISALLOWED" >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Only \`yarn.js\` and \`.yarnrc\` files are allowed to be modified in this directory." >> $GITHUB_STEP_SUMMARY
+            echo "Only \`yarn.js\` and \`.yarnrc.yml\` files are allowed to be modified in this directory." >> $GITHUB_STEP_SUMMARY
 
             exit 1
           else

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -23,3 +23,4 @@ nodeLinker: node-modules
 npmRegistryServer: "https://registry.yarnpkg.com"
 
 yarnPath: ./jupyterlab/staging/yarn.js
+enableScripts: false

--- a/jupyterlab/staging/.yarnrc.yml
+++ b/jupyterlab/staging/.yarnrc.yml
@@ -4,3 +4,4 @@ enableTelemetry: false
 httpTimeout: 60000
 nodeLinker: node-modules
 yarnPath: "./yarn.js"
+enableScripts: false

--- a/jupyterlab/tests/mock_packages/.yarnrc.yml
+++ b/jupyterlab/tests/mock_packages/.yarnrc.yml
@@ -5,3 +5,4 @@ unsafeHttpWhitelist:
   - '0.0.0.0'
 httpTimeout: 60000
 nodeLinker: node-modules
+enableScripts: false


### PR DESCRIPTION
## References

See #17913 for some discussion about this.

## Code changes

* Disable yarn postinstall scripts for dependencies: [yarn docs](https://yarnpkg.com/configuration/yarnrc#enableScripts). Note that we do have a postinstall script in our root package.json, but IIRC this yarn config only turns off postinstall for dependencies, not for our top-level package.
* Add a 14-day dependabot cooldown: [dependabot docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-)



## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
