### PR TITLE
Add the 'jupyterlab' entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,11 @@ dynamic = [
 
 [project.scripts]
 jlpm = "jupyterlab.jlpmapp:main"
-jupyter-lab = "jupyterlab.labapp:main"
 jupyter-labextension = "jupyterlab.labextensions:main"
 jupyter-labhub = "jupyterlab.labhubapp:main"
+# The two following entry points must be duplicated.
+jupyter-lab = "jupyterlab.labapp:main"
+jupyterlab = "jupyterlab.labapp:main"
 
 [project.entry-points."jupyterlab.extension_manager_v1"]
 readonly = "jupyterlab.extensions:get_readonly_manager"


### PR DESCRIPTION
This PR adds the `jupyterlab` entry point, in addition to the hitoric one `jupyter-lab`.

It doesn't seem possible to add aliases in *pyproject.toml* file, therefore it duplicates the `jupyter-lab` entry point.


## References

Fixes #3906

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None
