### PR TITLE
Clear execution metadata on cell duplication

### DIFF
--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1492,6 +1492,9 @@ export namespace NotebookActions {
             typeof cell.id === 'string'
               ? cell.id
               : undefined;
+          if (cell.metadata.hasOwnProperty('execution')) {
+            delete cell.metadata['execution'];
+          }
           return cell;
         })
       );


### PR DESCRIPTION
### Description

When duplicating a cell, all of its contents and metadata are copied. This includes the `execution_start` timestamp. However, the duplicated cell never receives a corresponding `execution_end` timestamp because it was never actually executed. This results in incomplete or misleading execution metadata, which can break extensions that rely on execution timing information.

Relevant issue: https://github.com/deshaw/jupyterlab-execute-time/issues/136
