### PR TITLE
Remove process and path polyfill

### DIFF
--- a/builder/src/webpack.config.base.ts
+++ b/builder/src/webpack.config.base.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-import * as rspack from '@rspack/core';
 import miniSVGDataURI from 'mini-svg-data-uri';
 
 const rules = [
@@ -72,10 +71,7 @@ module.exports = {
     fallback: {
       url: false,
       buffer: false,
-      crypto: false,
-      // See https://github.com/webpack/webpack/blob/3471c776059ac2d26593ea39f9c47c1874253dbb/lib/ModuleNotFoundError.js#L13-L42
-      path: require.resolve('path-browserify'),
-      process: require.resolve('process/browser')
+      crypto: false
     }
   },
   watchOptions: {
@@ -84,10 +80,5 @@ module.exports = {
   },
   output: {
     hashFunction: 'xxhash64'
-  },
-  plugins: [
-    new rspack.ProvidePlugin({
-      process: 'process/browser'
-    })
-  ]
+  }
 };


### PR DESCRIPTION
## References

This is a follow-up to https://github.com/jupyterlab/jupyterlab/pull/12461

## Code changes

Removes the process and path polyfills from the rspack configuration.

## User-facing changes

Should be none

## Backwards-incompatible changes

3rd party extensions potentially rely on these polyfills, so I think we should not merge this until a major release. At that point, if an extension relies on these polyfills, they would have to specify the polyfill in their build configuration.