### PR TITLE
Prevent updating npm `next` tag for some versions of `@jupyterlab/rendermime-interfaces`

### DIFF
--- a/buildutils/src/update-dist-tag.ts
+++ b/buildutils/src/update-dist-tag.ts
@@ -11,7 +11,9 @@ import semver from 'semver';
 
 // Versions to ignore when determining dist-tags.
 // These were published prematurely and should not affect tag resolution.
-// See https://github.com/jupyterlab/jupyterlab/issues/14335
+// See:
+// - https://github.com/jupyterlab/jupyterlab/pull/12581
+// - https://github.com/jupyterlab/jupyterlab/issues/14335
 const IGNORED_VERSIONS: Record<string, string[]> = {
   '@jupyterlab/rendermime-interfaces': [
     '4.0.0-alpha.1',


### PR DESCRIPTION
## References

Workaround for https://github.com/jupyterlab/jupyterlab/issues/14335

This will help reduce toil when making new pre-releases, as noticed in https://github.com/jupyterlab/jupyterlab/issues/17993#issuecomment-3657387034

## Code changes

- [x] Filter known versions of `@jupyterlab/rendermime-interfaces`

## User-facing changes

None

## Backwards-incompatible changes

None