### PR TITLE
Docs: clarify edit mode vs command mode in notebooks

### DIFF
--- a/docs/source/user/notebook.md
+++ b/docs/source/user/notebook.md
@@ -67,12 +67,14 @@ number of new things are possible with notebooks in JupyterLab.
 JupyterLab notebooks operate in two primary modes: **Edit Mode** and **Command Mode**.
 
 **Edit Mode**
+
 - Used to edit the contents of a cell.
 - Activated by pressing {kbd}`Enter` on a selected cell.
 - A blue cell border indicates Edit Mode.
 - Keyboard input affects the cell contents.
 
 **Command Mode**
+
 - Used to perform notebook-level actions such as running cells, adding cells, or changing cell types.
 - Activated by pressing {kbd}`Esc` when not editing text.
 - A gray cell border indicates Command Mode.


### PR DESCRIPTION
## References

N/A

## Code changes

No code changes. This PR adds a short documentation section clarifying the difference between Edit Mode and Command Mode in JupyterLab notebooks.

## User-facing changes

Adds documentation explaining:
- What Edit Mode and Command Mode are
- How to switch between them using `Enter` and `Esc`

This helps new users better understand notebook interaction.

## Backwards-incompatible changes

None.
