### PR TITLE
Fix console commands enabled status if not in main area

### DIFF
--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -638,7 +638,8 @@ async function activateConsole(
   function isEnabled(): boolean {
     return (
       tracker.currentWidget !== null &&
-      tracker.currentWidget.node.contains(document.activeElement)
+      (tracker.currentWidget === shell.currentWidget ||
+        tracker.currentWidget.node.contains(document.activeElement))
     );
   }
 


### PR DESCRIPTION
This PR allows to use a console out of the main area.

Most of the commands associated to the console (`run`, `clear`, `restart-kernel`...) are currently enabled only if the console is in the main area.
This PR updates the `isEnabled()` function to allow running these commands as soon as the console has the focus.

## References

Related to https://github.com/jupyter/notebook/pull/7790, where we'd like to open a console in the side panel, next to a Notebook. This `isEnabled()` function has to be patched.

## Code changes

Ensure that the console has the focus instead of expecting the console to be the main area current widget.

## User-facing changes

None

## Backwards-incompatible changes

None
