### PR TITLE
Update ui test triggers

### DIFF
--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -1,12 +1,19 @@
 name: UI Tests
 
 on:
-  issue_comment:
-    types: [created]
+  # We currently turned off Galata snapshot updates via issue comments
+  # We comment this trigger so the workflow runs are not swamped by comments triggering skipped runs
+  # TODO: re-enable once snapshot updates via comments are enabled again
+  # issue_comment:
+  #   types: [created]
   push:
     branches:
       - main
   pull_request:
+  schedule:
+    # Run every 6 hours to establish a baseline for flaky tests
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
 
 env:
   PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/pw-browsers


### PR DESCRIPTION
## References

Follows up on some of the test infra improvements and deflaking started in #18216 and #18240.


## Code changes

Run UI tests on main regularly (every 6 hours) for a baseline for flaky test metrics. Also allow triggering manually.

Additionally, comment out the issue creation trigger, since we have turned off galata snapshot updates. Right now our workflow run listing is swamped by skipped runs from every comment made on a PR.

This lays the groundwork for doing some analysis on which tests are flaky and how flaky they are.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
