### PR TITLE
Make the plugin registry slow activation test more robust

### DIFF
--- a/packages/coreutils/test/pluginregistry.spec.ts
+++ b/packages/coreutils/test/pluginregistry.spec.ts
@@ -7,7 +7,7 @@ describe('JupyterPluginRegistry', () => {
 
   beforeEach(() => {
     registry = new JupyterPluginRegistry({
-      expectedActivationTime: 400 // 0.5 second
+      expectedActivationTime: 400 // 0.4 second
     });
     consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
   });
@@ -37,11 +37,11 @@ describe('JupyterPluginRegistry', () => {
     ];
     registry.registerPlugins(mockPlugins);
 
-    // Mock super.activatePlugin to return after 1 second
+    // Mock super.activatePlugin to return after 0.55 second
     jest
       .spyOn(PluginRegistry.prototype, 'activatePlugin')
       .mockImplementation(
-        () => new Promise(resolve => setTimeout(() => resolve(), 500))
+        () => new Promise(resolve => setTimeout(() => resolve(), 550))
       );
 
     await registry.activatePlugin('slow-plugin');
@@ -53,7 +53,7 @@ describe('JupyterPluginRegistry', () => {
       expect.stringContaining('with 2 dependants')
     );
     expect(consoleWarnSpy).toHaveBeenCalledWith(
-      expect.stringMatching(/5\d\d\.\d\dms/) // 500ms or slightly more
+      expect.stringMatching(/5\d\d\.\d\dms/) // 550ms or slightly more
     );
   });
 });


### PR DESCRIPTION
## References

- Fixes #18251


Previously we had a threshold of 400ms and activation delay of 500ms and expected the warning string to show "500" or more (but less than 600) ms. However, sometimes it showed 499.8ms or so - an inconsequential difference due to timer accuracy.

## Code changes

By increasing the activation delay to 550ms we are allowing on average 50 ms timing difference either way which should never happen in tests really.

Also fixes some comments.

## User-facing changes

None

## Backwards-incompatible changes

None
