### PR TITLE
Fix command palette accessibility test

### DIFF
--- a/packages/apputils-extension/test/palette.spec.ts
+++ b/packages/apputils-extension/test/palette.spec.ts
@@ -1,29 +1,30 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { CommandRegistry } from '@lumino/commands';
 import { Palette } from '../src/palette';
-import { CommandPalette } from '@lumino/widgets';
+import { nullTranslator } from '@jupyterlab/translation';
+import type { JupyterFrontEnd } from '@jupyterlab/application';
+import { Application } from '@lumino/application';
+import { Widget } from '@lumino/widgets';
 
-describe('palette', () => {
-  let palette: Palette;
-  let commandPalette: CommandPalette = new CommandPalette({
-    commands: new CommandRegistry()
-  });
+class DummyShell extends Widget {
+  add(widget: Widget): void {
+    document.body.appendChild(widget.node);
+  }
+}
 
-  beforeEach(() => {
-    palette = new Palette(commandPalette);
-  });
+describe('Palette', () => {
+  describe('#activate()', () => {
+    it('command palette should have aria-label and role for accessibility', async () => {
+      const app = new Application({ shell: new DummyShell() });
+      const settingRegistry = null;
+      Palette.activate(app as JupyterFrontEnd, nullTranslator, settingRegistry);
 
-  describe('#ariaLabelsAndRoles', () => {
-    // Test is currently failing; skipping for now.
-    it.skip('command palette should have aria-label and role for accessibility', () => {
-      palette.activate();
-      const node = document.getElementById('command-palette');
-      expect(node?.getAttribute('aria-label')).toEqual(
+      const node = document.getElementById('command-palette')!;
+      expect(node.getAttribute('aria-label')).toEqual(
         'Command Palette Section'
       );
-      expect(node?.getAttribute('role')).toEqual('region');
+      expect(node.getAttribute('role')).toEqual('region');
     });
   });
 });


### PR DESCRIPTION
## References

Fixes #18241

## Code changes

The original code incorrectly used `palette.activate` (lowercase - class method) rather than `Palette.activate` - function from the module. This PR unskips the test after making sure it can actually get the command palette node.

## User-facing changes

None

## Backwards-incompatible changes

None
