### PR TITLE
Document proxy environment variables for extension manager

### DIFF
--- a/docs/source/user/extensions.md
+++ b/docs/source/user/extensions.md
@@ -195,7 +195,6 @@ The following environment variables are respected
 2. `HTTP_PROXY`
 3. `ALL_PROXY`
 
-
 ### Extension manager implementations
 
 By default, there are two extension managers provided by JupyterLab:


### PR DESCRIPTION
### Summary

This PR documents the proxy environment variables respected by the JupyterLab
Extension Manager when accessing remote resources.

The following environment variables are supported:

- `ALL_PROXY`
- `HTTP_PROXY`
- `HTTPS_PROXY`

If multiple variables are set, the Extension Manager follows the precedence:
`HTTPS_PROXY` → `HTTP_PROXY` → `ALL_PROXY`.

This is particularly useful in enterprise or restricted network environments
where outbound connections must go through a proxy.

### Related issue

Closes #15425.
