### PR TITLE
Document a change in the Code Editor source updates via `sharedModel` in JupyterLab 4

### DIFF
--- a/docs/source/extension/extension_migration.md
+++ b/docs/source/extension/extension_migration.md
@@ -731,15 +731,9 @@ In JupyterLab 3.x, the following pattern was commonly used:
 ```ts
 widget.content.model.value.text = 'some text';
 ```
-In JupyterLab 4.x, extensions should update editor contents through the shared
-model API. For full text replacement, use setSource:
-
-```ts
-widget.content.model.sharedModel.setSource('some text');
-```
 
 In JupyterLab 4.x, extensions should update editor contents exclusively through
-the shared model APIs to ensure correct synchronization and collaboration.
+the shared model APIs to ensure correct synchronization and collaboration, e.g.:
 
 ```ts
 widget.content.model.sharedModel.setSource('some text');


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/13427

## Summary
This PR adds a clarification to the Extension Migration Guide for
JupyterLab 3.x → 4.x regarding how extensions should update editor text.

## Details
In JupyterLab 4.x, extension authors should no longer mutate editor text
directly via `model.value.text`.

Instead, editor contents should be updated exclusively through the
shared model APIs, which ensures correct synchronization and
collaboration behavior, especially in real-time collaborative contexts.

The documentation now explicitly highlights this change and contrasts it
with the commonly used JupyterLab 3.x pattern.

## Scope
- Documentation-only change
- No API changes
- No runtime behavior affected

## Motivation
This clarification helps extension authors avoid subtle bugs when
migrating extensions from JupyterLab 3.x to 4.x, particularly around
shared models and collaborative editing.
