### PR TITLE
Binder: allow yarn install to fail during Rspack transition

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -17,7 +17,9 @@ mkdir _reports_
 (time yarn build:dev:prod:minimize:report || true)             2>&1 | tee _reports_/01_build.txt
 
 # hoist report to where a reviewer might see it
-mv dev_mode/static/webpack-bundle-analyzer.html _reports_/
+if [ -f dev_mode/static/webpack-bundle-analyzer.html ]; then
+    mv dev_mode/static/webpack-bundle-analyzer.html _reports_/
+fi
 
 # overload best-effort versions from conda-forge for all deps
 (time pip install -v -e .[dev] --no-build-isolation)  2>&1 | tee _reports_/02_pip_install.txt


### PR DESCRIPTION
I’ve updated the Binder postBuild to allow the initial yarn step to fail without aborting the build, which should make Binder more resilient during the ongoing Rspack transition. Please let me know if you’d prefer a different approach.