### PR TITLE
Feature/jump to last modified

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1286,7 +1286,7 @@ function activateNotebookTools(
   if (inspectorProvider) {
     tracker.widgetAdded.connect((sender, panel) => {
       const inspector = inspectorProvider.register(panel);
-      inspector.render(notebookTools);
+      void inspector.render(notebookTools);
     });
   }
 
@@ -1861,7 +1861,7 @@ function activateNotebookHandler(
       ) {
         notebook.activeCellIndex = previousIndex;
         const cell = notebook.widgets[previousIndex];
-        notebook.scrollToCell(cell);
+        void notebook.scrollToCell(cell);
       }
     }
   });


### PR DESCRIPTION
## References

Closes #18195
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- Added notebook:jump-to-last-modified command to scroll to the most recently edited cell.
- Implemented cell modification tracking via contentChanged signals in activateNotebookHandler.
- Registered the command in the Command Palette and added an icon-only button to the Table of Contents toolbar.

## User-facing changes

- New Command: "Jump to Last Modified Cell" is available in the Command Palette
- UI Addition: A new "Edit" icon button is added to the Table of Contents sidebar toolbar for quick access.

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->
https://github.com/user-attachments/assets/9bfda04c-5563-4304-a6eb-86710540d6dc

## Backwards-incompatible changes
None
