### PR TITLE
Docs: fix 404 for extension documents page

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -49,6 +49,7 @@ See the sections below (and the top-level links above) for more information abou
 getting_started/overview
 user/index
 extension/extension_dev
+extension/documents
 developer/contributing
 API Reference <developer/api>
 ```


### PR DESCRIPTION
This PR fixes a reported 404 in the JupyterLab documentation by exposing the existing extension/documents page in the root toctree for the latest docs.

The change is intentionally scoped to a single page to keep the review simple. Follow-up PRs can address other reported 404s if needed.

Fixes #13423