### PR TITLE
Make test reliable by Increasing delay in activatePlugin mock implementation

### DIFF
--- a/packages/coreutils/test/pluginregistry.spec.ts
+++ b/packages/coreutils/test/pluginregistry.spec.ts
@@ -41,7 +41,7 @@ describe('JupyterPluginRegistry', () => {
     jest
       .spyOn(PluginRegistry.prototype, 'activatePlugin')
       .mockImplementation(
-        () => new Promise(resolve => setTimeout(() => resolve(), 500))
+        () => new Promise(resolve => setTimeout(() => resolve(), 520))
       );
 
     await registry.activatePlugin('slow-plugin');


### PR DESCRIPTION
### Description

The test added in #18181 sometime fails due to <1ms error. Here is an instance: https://github.com/jupyterlab/jupyterlab/actions/runs/20390408326/job/58598748919?pr=18250

I propose increasing the timeout value to 500ms so it passes the constraint of `500ms or more` everytime.