### PR TITLE
Fix the path of the uploaded artifiacts of galata report

### DIFF
--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           name: jupyterlab-galata-report-${{ matrix.browser }}
           path: |
-            galata/playwright-report-*
+            galata/playwright-report*
 
       - name: Print JupyterLab logs
         if: always()


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/18287

## Code changes

The wildcard pattern of the galata report path

## User-facing changes

None

## Backwards-incompatible changes

None

cc. @jasongrout
