### PR TITLE
Docs: clarify file creation behavior with multiple drives

### DIFF
--- a/docs/source/user/files.md
+++ b/docs/source/user/files.md
@@ -160,15 +160,15 @@ or by extensions.
 When creating a new file or notebook, JupyterLab determines the target drive based on
 the current context:
 
-- **File Browser**:  
+- **File Browser**:
   New files created via right-click or toolbar actions are created in the currently
   active directory and drive.
 
-- **File → New** and **Launcher**:  
-  New items are created in the directory currently selected in the File Browser.  
+- **File → New** and **Launcher**:
+  New items are created in the directory currently selected in the File Browser.
   If no directory is selected, the file is created in the default drive.
 
-- **Command Palette**:  
+- **Command Palette**:
   Commands that create new files rely on the current File Browser context to determine
   the target directory and drive.
 


### PR DESCRIPTION
## Summary
Document how JupyterLab determines the target drive when creating new files in
multi-drive setups.

## Changes
- Clarify file creation behavior for File Browser, File menu, Launcher, and Command Palette.

Fixes   #14594
