### PR TITLE
add transition to ease out the cell toolbar rendering delay

### DIFF
--- a/packages/cell-toolbar/style/base.css
+++ b/packages/cell-toolbar/style/base.css
@@ -28,6 +28,7 @@
   background-color: transparent;
   border-bottom: inherit;
   box-shadow: none;
+  animation: jp-cell-toolbar-fade-in 200ms ease-in-out;
 }
 
 /* Overrides for mobile view hiding cell toolbar */
@@ -69,4 +70,16 @@
 
 .jp-mod-active .jp-MarkdownOutput {
   border-color: var(--jp-cell-editor-border-color);
+}
+
+@keyframes jp-cell-toolbar-fade-in {
+  from {
+    opacity: 0;
+    transform: translateX(50%);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
fixes #16310

Added the transition to ease out the cell toolbar rendering delay according to the proposed solution

https://github.com/user-attachments/assets/22aa0799-d443-4b8a-8040-9495d836aa02



## Backwards-incompatible changes
None
