### PR TITLE
Add compact mode to pluginlist in settings editor

### DIFF
--- a/packages/settingeditor/src/pluginlist.tsx
+++ b/packages/settingeditor/src/pluginlist.tsx
@@ -14,7 +14,9 @@ import {
   IScore,
   LabIcon,
   settingsIcon,
-  updateFilterFunction
+  updateFilterFunction,
+  Button,
+  listIcon
 } from '@jupyterlab/ui-components';
 import { StringExt } from '@lumino/algorithm';
 import { PartialJSONObject, PromiseDelegate } from '@lumino/coreutils';
@@ -73,6 +75,7 @@ export class PluginList extends ReactWidget {
     this.setError = this.setError.bind(this);
     this._evtMousedown = this._evtMousedown.bind(this);
     this._query = options.query ?? '';
+    this._onToggle = options.onToggle;
 
     this._errors = {};
   }
@@ -429,14 +432,26 @@ export class PluginList extends ReactWidget {
 
     return (
       <div className="jp-PluginList-wrapper">
-        <FilterBox
-          updateFilter={this.setFilter}
-          useFuzzyFilter={false}
-          placeholder={trans.__('Search settings…')}
-          forceRefresh={false}
-          caseSensitive={false}
-          initialQuery={this._query}
-        />
+        <div className="jp-PluginList-header-group">
+          <FilterBox
+            updateFilter={this.setFilter}
+            useFuzzyFilter={false}
+            placeholder={trans.__('Search settings…')}
+            forceRefresh={false}
+            caseSensitive={false}
+            initialQuery={this._query}
+          />
+          {this._onToggle && (
+            <Button
+              className="jp-PluginList-toggle"
+              onClick={this._onToggle}
+              title={trans.__('Toggle compact mode')}
+              minimal
+            >
+              <listIcon.react tag="span" className="jp-Icon" />
+            </Button>
+          )}
+        </div>
         {modifiedItems.length > 0 && (
           <div>
             <h1 className="jp-PluginList-header">{trans.__('Modified')}</h1>
@@ -472,6 +487,7 @@ export class PluginList extends ReactWidget {
   private _confirm?: (id: string) => Promise<void>;
   private _scrollTop: number | undefined = 0;
   private _selection = '';
+  private _onToggle?: () => void;
 }
 
 /**
@@ -517,6 +533,11 @@ export namespace PluginList {
      * An optional initial query so the plugin list can filter on start.
      */
     query?: string;
+
+    /**
+     * Callback to toggle the compact mode.
+     */
+    onToggle?: () => void;
   }
 
   /**

--- a/packages/settingeditor/src/settingseditor.tsx
+++ b/packages/settingeditor/src/settingseditor.tsx
@@ -181,6 +181,9 @@ export class SettingsEditor extends SplitPanel {
       const fraction = 36 / width;
       this.setRelativeSizes([fraction, 1 - fraction]);
     }
+    if (width > 0 && width < 600 && !this._isCompact) {
+      this.toggleCompact();
+    }
     super.onResize(msg);
   }
 

--- a/packages/settingeditor/style/base.css
+++ b/packages/settingeditor/style/base.css
@@ -42,10 +42,14 @@
   background-color: var(--jp-border-color2);
 }
 
+.jp-SettingsEditor.jp-mod-compact > .lm-SplitPanel-handle {
+  pointer-events: none;
+}
+
 /** Plugin list **/
 
 .jp-PluginList {
-  min-width: 175px;
+  min-width: 36px;
   max-width: 275px;
 }
 
@@ -265,6 +269,48 @@
   background-color: var(--jp-warn-color-normal);
   border: 0;
   color: var(--jp-ui-inverse-font-color0);
+}
+
+.jp-PluginList-header-group {
+  display: flex;
+  flex-direction: row;
+}
+
+.jp-PluginList-toggle {
+  flex: 0 0 auto;
+  background-color: transparent;
+  border: 0;
+  margin-left: 4px;
+}
+
+/* Compact mode styles */
+.jp-PluginList.jp-mod-compact {
+  min-width: 36px !important;
+}
+
+.jp-PluginList.jp-mod-compact .jp-PluginList-entry-label-text,
+.jp-PluginList.jp-mod-compact .jp-PluginList-header,
+.jp-PluginList.jp-mod-compact .jp-FilterBox {
+  display: none;
+}
+
+.jp-PluginList.jp-mod-compact .jp-PluginList-header-group {
+  justify-content: center;
+  padding: 4px 0;
+}
+
+.jp-PluginList.jp-mod-compact .jp-PluginList-wrapper {
+  overflow-x: hidden;
+}
+
+.jp-PluginList.jp-mod-compact .jp-PluginList-entry {
+  justify-content: center;
+  padding-left: 0;
+}
+
+.jp-PluginList.jp-mod-compact .jp-PluginList-entry-icon,
+.jp-PluginList.jp-mod-compact .jp-PluginList-toggle {
+  margin: 0;
 }
 
 .jp-PluginEditor {

--- a/packages/settingeditor/style/base.css
+++ b/packages/settingeditor/style/base.css
@@ -280,10 +280,9 @@
   flex: 0 0 auto;
   background-color: transparent;
   border: 0;
-  margin-left: 4px;
 }
 
-/* Compact mode styles */
+/** Compact mode styles **/
 .jp-PluginList.jp-mod-compact {
   min-width: 36px !important;
 }
@@ -296,11 +295,22 @@
 
 .jp-PluginList.jp-mod-compact .jp-PluginList-header-group {
   justify-content: center;
-  padding: 4px 0;
+  padding-left: 0;
 }
 
 .jp-PluginList.jp-mod-compact .jp-PluginList-wrapper {
   overflow-x: hidden;
+  scrollbar-width: thin;
+}
+
+.jp-PluginList.jp-mod-compact .jp-PluginList-wrapper::-webkit-scrollbar {
+  width: 4px;
+  height: 4px;
+}
+
+.jp-PluginList.jp-mod-compact .jp-PluginList-wrapper::-webkit-scrollbar-thumb {
+  background: var(--jp-border-color2);
+  border-radius: 2px;
 }
 
 .jp-PluginList.jp-mod-compact .jp-PluginList-entry {
@@ -311,6 +321,10 @@
 .jp-PluginList.jp-mod-compact .jp-PluginList-entry-icon,
 .jp-PluginList.jp-mod-compact .jp-PluginList-toggle {
   margin: 0;
+}
+
+.jp-PluginList.jp-mod-compact .jp-PluginList-entry-label svg {
+  margin-left: 3px;
 }
 
 .jp-PluginEditor {


### PR DESCRIPTION
## References

Resolves #12243

## Code changes

In the `settingeditor` package:
-Added `toggleCompact` function in `settingseditor.tsx` to handle the logic of the toggle button.
-Added the button in `pluginlist.tsx` next to the search bar.
-Added CSS classes and styling in `base.css`.

## User-facing changes

https://github.com/user-attachments/assets/7f705641-29c1-41e9-965c-fb11ef4d4e89

## Backwards-incompatible changes

None
