### PR TITLE
Fix empty math block throws codemirror's error

### DIFF
--- a/packages/codemirror/src/extensions/ipython-md.ts
+++ b/packages/codemirror/src/extensions/ipython-md.ts
@@ -139,18 +139,21 @@ export function parseMathIPython(latexParser?: Parser): MarkdownConfig {
           // Test if the node type is one of the math expression
           const delimiterLength = DELIMITER_LENGTH[node.type.name];
           if (delimiterLength) {
-            return {
-              parser: latexParser,
-              // Remove delimiter from LaTeX parser otherwise it won't be highlighted
-              overlay: [
-                {
-                  from: node.from + delimiterLength,
-                  to: node.to - delimiterLength
-                }
-              ]
-            };
+            const contentFrom = node.from + delimiterLength;
+            const contentTo = node.to - delimiterLength;
+            if (contentTo - contentFrom > 0) {
+              return {
+                parser: latexParser,
+                // Remove delimiter from LaTeX parser otherwise it won't be highlighted
+                overlay: [
+                  {
+                    from: contentFrom,
+                    to: contentTo
+                  }
+                ]
+              };
+            }
           }
-
           return null;
         })
       : undefined

--- a/packages/codemirror/test/mathparser.spec.ts
+++ b/packages/codemirror/test/mathparser.spec.ts
@@ -9,8 +9,13 @@
 import { parseMathIPython } from '@jupyterlab/codemirror';
 import { Tree } from '@lezer/common';
 import { MarkdownParser, parser } from '@lezer/markdown';
+import { StreamLanguage } from '@codemirror/language';
+import { stexMath } from '@codemirror/legacy-modes/mode/stex';
 
 const ipythonParser = parser.configure([parseMathIPython()]);
+const mixedParser = parser.configure([
+  parseMathIPython(StreamLanguage.define(stexMath).parser)
+]);
 
 function compareTree(a: Tree, b: Tree) {
   let curA = a.cursor(),
@@ -294,3 +299,10 @@ test(
 {maBB:\\\\]}}}
 `
 );
+
+describe('markdown parser', () => {
+  it('should parse empty math block $$$$ without error', () => {
+    const inputText = '$$$$';
+    expect(() => mixedParser.parse(inputText)).not.toThrow();
+  });
+});


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

This PR fixes #16757.

When entering something like "$$$$", an exception was thrown inside the Markdown parser,
which left CodeMirror in an inconsistent state.

The root cause is that, as shown in the changes in this PR, the nested parser’s overlay
range calculation could produce a 0-length range (`from === to`). Lezer’s overlay parser
does not expect zero-length input, and this situation caused the exception to be thrown.

This is the error output from the unit test I added, as it appeared before the fix.

```
Error name:    "RangeError"
    Error message: "Invalid inner parse ranges given: [{\"from\":2,\"to\":2}]"
          302 |   it('parse empty math block $$$$ without error', () => {
          303 |     const inputText = "$$$$";
        > 304 |     expect(() => nestedParser.parse(inputText)).not.toThrow();
              |                               ^
          305 |   });
          306 | });
          307 |
          at checkRanges (../../node_modules/@lezer/common/dist/index.cjs:1777:15)
          at MixedParse.startInner (../../node_modules/@lezer/common/dist/index.cjs:1891:25)
          at MixedParse.advance (../../node_modules/@lezer/common/dist/index.cjs:1812:18)
          at MarkdownParser.parse (../../node_modules/@lezer/common/dist/index.cjs:1740:30)
          at test/mathparser.spec.ts:304:31
          at Object.<anonymous> (../../node_modules/expect/build/toThrowMatchers.js:74:11)
          at Object.throwingMatcher [as toThrow] (../../node_modules/expect/build/index.js:312:21)
          at Object.<anonymous> (test/mathparser.spec.ts:304:53)

      302 |   it('parse empty math block $$$$ without error', () => {
      303 |     const inputText = "$$$$";
    > 304 |     expect(() => nestedParser.parse(inputText)).not.toThrow();
          |                                                     ^
      305 |   });
      306 | });
      307 |
```

I would appreciate it if you could review this.

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

fixes #16757

## Code changes

<!-- Describe the code changes and how they address the issue. -->

This PR adds a range check for overlays and avoids invoking the nested parser when the
content is empty.

For reference, inline `$$` does not trigger the issue because it is interpreted as the
start of a block math mode rather than an empty inline math string.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

Fix the behavior demonstrated in #16757

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
No
