### PR TITLE
Fix notebook windowing behavior for empty outputs 

### DIFF
--- a/packages/notebook/src/windowing.ts
+++ b/packages/notebook/src/windowing.ts
@@ -13,7 +13,7 @@ import { Message, MessageLoop } from '@lumino/messaging';
 import { Debouncer, Throttler } from '@lumino/polling';
 import { Widget } from '@lumino/widgets';
 import { DROP_SOURCE_CLASS, DROP_TARGET_CLASS } from './constants';
-const DEFAULT_RICH_OUTPUT_LINES = 5;
+//const DEFAULT_RICH_OUTPUT_LINES = 5;
 /**
  * Check whether the element is in a scrolling notebook.
  * Traverses open shadow DOM roots if needed.
@@ -157,7 +157,7 @@ export class NotebookViewModel extends WindowedListModel {
   ) {
     super(options);
     // Set default cell size
-    this._estimateWidgetSize = NotebookViewModel.DEFAULT_CELL_SIZE;
+    this._estimatedWidgetSize = NotebookViewModel.DEFAULT_CELL_SIZE;
   }
 
   /**
@@ -258,7 +258,7 @@ export class NotebookViewModel extends WindowedListModel {
   protected cellsEstimatedHeight = new Map<string, number>();
 
   private _emitEstimatedHeightChanged = new Debouncer(() => {
-    this.stateChanged.emit({
+    this._stateChanged.emit({
       name: 'estimatedWidgetSize',
       newValue: null,
       oldValue: null


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs.

## Summary 
Fixes an issue in the notebook windowing logic where cells with empty outputs could result in incorrect height estimation.

## Code Changes 
- Ensure a minimum number of output lines is considered when outputs are empty 
- Correct estimated widget size assignment 
- Emit the appropriate state change signal for size updates 

## User-friendly changes 
No visible UI changes. Improves scrolling and virtualization stability for notebooks with empty output cells. 

## Backwards-incomplete changes  -->
None.