### PR TITLE
Docs: document how links are handled in notebooks

### DIFF
--- a/docs/source/user/notebook.md
+++ b/docs/source/user/notebook.md
@@ -282,14 +282,22 @@ Interactive plots, widgets, or plotting with other kernels may require additiona
 JupyterLab supports several types of links inside Markdown cells in notebooks.
 
 ### External links
-Links to external websites (for example, `https://jupyter.org/`) open in a new browser tab when clicked.
+
+Links to external websites (for example, <https://google.com>) open in a new
+browser tab when clicked.
 
 ### Links to files and notebooks
-Links pointing to files or notebooks in the same directory (for example, `test.ipynb`) open in JupyterLab if the referenced file exists.
 
-If the referenced file does not exist, clicking the link has no effect. Using a modified click (such as opening the link in a new tab) may result in a 404 *Not Found* error.
+Links pointing to files or notebooks in the same directory (for example,
+`test.ipynb`) open in JupyterLab if the referenced file exists.
+
+If the referenced file does not exist, clicking the link has no effect. Using a
+modified click (such as opening the link in a new tab) may result in a
+*404 Not Found* error.
 
 ### Anchor links
-Links to headings within the same notebook (for example, `#My-Section`) scroll to the referenced section if the heading exists.
+
+Links to headings within the same notebook (for example, `#my-section`) scroll to
+the referenced section if the heading exists.
 
 If the referenced heading does not exist, clicking the link has no effect.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes #7883

## Code changes

Added documentation describing how links are handled in JupyterLab notebooks.
This includes behavior for:
- external links
- links to local files and notebooks
- anchor links within a notebook
- behavior when the referenced target does not exist

## User-facing changes

Improves the user documentation by clearly explaining how different types of
Markdown links behave in notebooks. There are no changes to JupyterLab
functionality or UI.

## Backwards-incompatible changes

None.
