### PR TITLE
Fix undefined tab count in workspace tooltip

### DIFF
--- a/packages/workspaces-extension/src/sidebar.ts
+++ b/packages/workspaces-extension/src/sidebar.ts
@@ -70,7 +70,7 @@ export const workspacesSidebar: JupyterFrontEndPlugin<void> = {
           '%1 workspace with %2 tabs, last modified on %3',
           this._workspace.metadata.id,
           (this._workspace.data['layout-restorer:data'] as any)?.main?.dock
-            ?.widgets?.length,
+            ?.widgets?.length ?? 0,
           this._workspace.metadata['last_modified']
         );
       }


### PR DESCRIPTION
Issue #18106 

The workspace tooltip could show `undefined` when layout restorer data is missing.
This change adds a safe fallback so the tab count is always numeric.