### PR TITLE
Enable moving the console prompt if the console is visible

### DIFF
--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -798,7 +798,8 @@ async function activateConsole(
         }
         current.console.setConfig({ promptCellPosition: position });
       },
-      isEnabled: isEnabled,
+      isEnabled: () =>
+        !!tracker.currentWidget && tracker.currentWidget.isVisible,
       label: trans.__(`Prompt to ${position}`),
       icon: args => (args['isPalette'] ? undefined : iconMap[position]),
       describedBy: {


### PR DESCRIPTION
## References

> > Also when testing locally there seems to be an issue about not being able to change the prompt position when the scratchpad is open
>
> In https://github.com/jupyterlab/jupyterlab/pull/18238, we added a way to enable the commands when the console is not in main area, but missed this use case. It uses the fact that the current console contains the `activeElement`. The menu to change the prompt position is attached to the root of the DOM, not to the node of the console.

_Originally posted by @brichet in https://github.com/jupyter/notebook/issues/7790#issuecomment-3743200226_

## Code changes

Change the function to enable the commands to move the console prompt.
these commands are now enabled if the console tracker has a current widget and if this widget is visible.

## User-facing changes

None

## Backwards-incompatible changes

None
