### PR TITLE
Fix UI tests: config useSystemClipboardForCells=true for notebook toolbar test

### DIFF
--- a/galata/test/jupyterlab/notebook-toolbar.test.ts
+++ b/galata/test/jupyterlab/notebook-toolbar.test.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { expect, IJupyterLabPageFixture, test } from '@jupyterlab/galata';
+import {
+  expect,
+  galata,
+  IJupyterLabPageFixture,
+  test
+} from '@jupyterlab/galata';
 
 const fileName = 'notebook.ipynb';
 
@@ -69,6 +74,15 @@ async function addWidgetsInNotebookToolbar(
 }
 
 test.describe('Notebook Toolbar', () => {
+  test.use({
+    mockSettings: {
+      ...galata.DEFAULT_SETTINGS,
+      '@jupyterlab/notebook-extension:tracker': {
+        useSystemClipboardForCells: true
+      }
+    }
+  });
+
   test.beforeEach(async ({ page }) => {
     await page.notebook.createNew(fileName);
     await populateNotebook(page);


### PR DESCRIPTION
This PR should fix the UI tests on Notebook toolbar in Firefox.

The recent PRs tests fails on Firefox, when trying to use the toolbar buttons to copy/paste/cut a cell.

## References

It may be related to #18250, which added the option that is updated for the tests to pass in this PR.

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None
