### PR TITLE
Bump `ruff` target to `py310`

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -23,7 +23,6 @@ from glob import glob
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from threading import Event
-from typing import Optional
 from urllib.error import URLError
 from urllib.request import Request, quote, urljoin, urlopen
 
@@ -2427,7 +2426,7 @@ def _is_disabled(name, disabled=None):
 class LockStatus:
     entire_extension_locked: bool
     # locked plugins are only given if extension is not locked as a whole
-    locked_plugins: Optional[frozenset[str]] = None
+    locked_plugins: frozenset[str] | None = None
 
 
 def _is_locked(name, locked=None) -> LockStatus:

--- a/jupyterlab/extensions/__init__.py
+++ b/jupyterlab/extensions/__init__.py
@@ -3,20 +3,13 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import sys
-from typing import Optional
+from importlib.metadata import entry_points
 
 from traitlets.config import Configurable
 
 from .manager import ActionResult, ExtensionManager, ExtensionPackage  # noqa: F401
 from .pypi import PyPIExtensionManager
 from .readonly import ReadOnlyExtensionManager
-
-# See compatibility note on `group` keyword in https://docs.python.org/3/library/importlib.metadata.html#entry-points
-if sys.version_info < (3, 10):
-    from importlib_metadata import entry_points
-else:
-    from importlib.metadata import entry_points
 
 # Supported third-party services
 MANAGERS = {}
@@ -29,18 +22,18 @@ for entry in entry_points(group="jupyterlab.extension_manager_v1"):
 
 
 def get_readonly_manager(
-    app_options: Optional[dict] = None,
-    ext_options: Optional[dict] = None,
-    parent: Optional[Configurable] = None,
+    app_options: dict | None = None,
+    ext_options: dict | None = None,
+    parent: Configurable | None = None,
 ) -> ExtensionManager:
     """Read-Only Extension Manager factory"""
     return ReadOnlyExtensionManager(app_options, ext_options, parent)
 
 
 def get_pypi_manager(
-    app_options: Optional[dict] = None,
-    ext_options: Optional[dict] = None,
-    parent: Optional[Configurable] = None,
+    app_options: dict | None = None,
+    ext_options: dict | None = None,
+    parent: Configurable | None = None,
 ) -> ExtensionManager:
     """PyPi Extension Manager factory"""
     return PyPIExtensionManager(app_options, ext_options, parent)

--- a/jupyterlab/extensions/pypi.py
+++ b/jupyterlab/extensions/pypi.py
@@ -12,6 +12,7 @@ import re
 import sys
 import tempfile
 import xmlrpc.client
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from functools import partial
 from itertools import groupby
@@ -19,7 +20,7 @@ from os import environ
 from pathlib import Path
 from subprocess import CalledProcessError, run
 from tarfile import TarFile
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 from urllib.parse import urlparse
 from zipfile import ZipFile
 
@@ -140,9 +141,9 @@ class PyPIExtensionManager(ExtensionManager):
 
     def __init__(
         self,
-        app_options: Optional[dict] = None,
-        ext_options: Optional[dict] = None,
-        parent: Optional[config.Configurable] = None,
+        app_options: dict | None = None,
+        ext_options: dict | None = None,
+        parent: config.Configurable | None = None,
     ) -> None:
         super().__init__(app_options, ext_options, parent)
         self._httpx_client = httpx.AsyncClient(**_httpx_client_args)
@@ -169,7 +170,7 @@ class PyPIExtensionManager(ExtensionManager):
         """Extension manager metadata."""
         return ExtensionManagerMetadata("PyPI", True, sys.prefix)
 
-    async def get_latest_version(self, pkg: str) -> Optional[str]:
+    async def get_latest_version(self, pkg: str) -> str | None:
         """Return the latest available version for a given extension.
 
         Args:
@@ -253,7 +254,7 @@ class PyPIExtensionManager(ExtensionManager):
 
     async def list_packages(
         self, query: str, page: int, per_page: int
-    ) -> tuple[dict[str, ExtensionPackage], Optional[int]]:
+    ) -> tuple[dict[str, ExtensionPackage], int | None]:
         """List the available extensions.
 
         Note:

--- a/jupyterlab/extensions/readonly.py
+++ b/jupyterlab/extensions/readonly.py
@@ -4,7 +4,6 @@
 # Distributed under the terms of the Modified BSD License.
 
 import sys
-from typing import Optional
 
 from jupyterlab_server.translation_utils import translator
 
@@ -19,7 +18,7 @@ class ReadOnlyExtensionManager(ExtensionManager):
         """Extension manager metadata."""
         return ExtensionManagerMetadata("read-only", install_path=sys.prefix)
 
-    async def get_latest_version(self, pkg: str) -> Optional[str]:
+    async def get_latest_version(self, pkg: str) -> str | None:
         """Return the latest available version for a given extension.
 
         Args:
@@ -31,7 +30,7 @@ class ReadOnlyExtensionManager(ExtensionManager):
 
     async def list_packages(
         self, query: str, page: int, per_page: int
-    ) -> tuple[dict[str, ExtensionPackage], Optional[int]]:
+    ) -> tuple[dict[str, ExtensionPackage], int | None]:
         """List the available extensions.
 
         Args:
@@ -44,7 +43,7 @@ class ReadOnlyExtensionManager(ExtensionManager):
         """
         return {}, None
 
-    async def install(self, extension: str, version: Optional[str] = None) -> ActionResult:
+    async def install(self, extension: str, version: str | None = None) -> ActionResult:
         """Install the required extension.
 
         Note:

--- a/jupyterlab/handlers/announcements.py
+++ b/jupyterlab/handlers/announcements.py
@@ -10,7 +10,6 @@ import xml.etree.ElementTree as ET
 from collections.abc import Awaitable
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
-from typing import Optional, Union
 
 from jupyter_server.base.handlers import APIHandler
 from jupyterlab_server.translation_utils import translator
@@ -64,7 +63,7 @@ class CheckForUpdateABC(abc.ABC):
         self.version = version
 
     @abc.abstractmethod
-    async def __call__(self) -> Awaitable[Union[None, str, tuple[str, tuple[str, str]]]]:
+    async def __call__(self) -> Awaitable[None | str | tuple[str, tuple[str, str]]]:
         """Get the notification message if a new version is available.
 
         Returns:
@@ -151,7 +150,7 @@ class CheckForUpdateHandler(APIHandler):
 
     def initialize(
         self,
-        update_checker: Optional[CheckForUpdate] = None,
+        update_checker: CheckForUpdate | None = None,
     ) -> None:
         super().initialize()
         self.update_checker = (
@@ -197,7 +196,7 @@ class NewsHandler(APIHandler):
 
     def initialize(
         self,
-        news_url: Optional[str] = None,
+        news_url: str | None = None,
     ) -> None:
         super().initialize()
         self.news_url = news_url
@@ -231,7 +230,7 @@ class NewsHandler(APIHandler):
                 tree = ET.fromstring(response.body)  # noqa S314
 
                 def build_entry(node):
-                    def get_xml_text(attr: str, default: Optional[str] = None) -> str:
+                    def get_xml_text(attr: str, default: str | None = None) -> str:
                         node_item = node.find(f"atom:{attr}", xml_namespaces)
                         if node_item is not None:
                             return node_item.text

--- a/jupyterlab/upgrade_extension.py
+++ b/jupyterlab/upgrade_extension.py
@@ -7,7 +7,6 @@ import re
 import shutil
 import subprocess
 import sys
-from typing import Optional
 
 try:
     import tomllib
@@ -57,7 +56,7 @@ JUPYTER_SERVER_REQUIREMENT = re.compile("^jupyter_server([^\\w]|$)")
 
 
 def update_extension(  # noqa
-    target: str, vcs_ref: Optional[str] = None, interactive: bool = True
+    target: str, vcs_ref: str | None = None, interactive: bool = True
 ) -> None:
     """Update an extension to the current JupyterLab
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,7 +246,7 @@ after-publish-assets = "npm run after:publish:assets"
 
 [tool.ruff]
 exclude = ["*.ipynb"]
-target-version = "py39"
+target-version = "py310"
 line-length = 100
 lint.select = [
   "A", "B", "C", "DTZ", "E", "EM", "F", "FBT", "I", "ICN", "N",
@@ -254,8 +254,6 @@ lint.select = [
   "W", "YTT",
 ]
 lint.ignore = [
-# Q000 Single quotes found but double quotes preferred
-"Q000",
 # FBT001 Boolean positional arg in function definition
 "FBT001", "FBT002", "FBT003",
 # E501 Line too long (158 > 100 characters)
@@ -278,11 +276,9 @@ lint.ignore = [
 # T201 `print` found
 "galata/*" = ["T201"]
 # F821 Undefined name `c`
-# S104 Possible binding to all interfaces
-# S105 Possible hardcoded password: `""`
-"galata/jupyter_server_test_config.py" = ["F821", "S104", "S105"]
-# T201 `print` found
-"jupyterlab/browser_check.py" = ["RUF012", "T201"]
+"galata/jupyter_server_test_config.py" = ["F821"]
+# RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
+"jupyterlab/browser_check.py" = ["RUF012"]
 # C901 method is too complex
 "jupyterlab/commands.py" = ["C901"]
 # B028 No explicit `stacklevel` keyword argument found
@@ -305,10 +301,9 @@ lint.ignore = [
 "scripts/milestone_check.py" = ["T201", "UP031"]
 # N806 Variable `tM` in function should be lowercase
 # N816 Variable `comparatorTrimReplace` in global scope should not be mixedCase
-# PLC1901 test can be simplified as an empty string is falsey
 # PLR1714 Consider merging multiple comparisons
 # PLR5501 Use `elif` instead of `else` then `if`, to reduce indentation
-"jupyterlab/semver.py" = ["C901", "EM101", "EM102", "N806", "N816", "PLC1901", "PLR1714", "PLR5501"]
+"jupyterlab/semver.py" = ["C901", "EM101", "EM102", "N806", "N816", "PLR1714", "PLR5501"]
 # T201 `print` found
 "jupyterlab/upgrade_extension.py" = ["T201"]
 # RUF012 Mutable class attributes should be annotated with `typing.ClassVar`


### PR DESCRIPTION
## References

Since we now require Python 3.10+

## Code changes

- [x] Bump `ruff` target to `py310`
- [x] Clean up the code base accordingly

## User-facing changes

None

## Backwards-incompatible changes

None