### PR TITLE
Add installation instructions for JupyterLab with uv

### DIFF
--- a/docs/source/getting_started/installation.md
+++ b/docs/source/getting_started/installation.md
@@ -32,6 +32,14 @@ If you use `mamba`, you can install it with:
 mamba install -c conda-forge jupyterlab
 ```
 
+## uv
+
+If you use `uv`, you can install it with:
+
+```bash
+uv tool install jupyterlab --with pip
+```
+
 ## pip
 
 If you use `pip`, you can install it with:


### PR DESCRIPTION
Added installation instructions for JupyterLab using uv.

## References

Fixes: https://github.com/jupyterlab/jupyterlab/issues/17375

## Code changes

Adding in the instructions to install via `uv` (that doesn't include `pip` by default). Outlined [here](https://til.simonwillison.net/jupyter/jupyterlab-uv-tool-install) and [here](https://www.jimangel.io/posts/jupyterlab-local-mac-apple-silicon/).

## User-facing changes

n/a

## Backwards-incompatible changes

n/a
