### PR TITLE
false in saveAs to avoid fetching file body

### DIFF
--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -319,7 +319,8 @@ export class Context<
     try {
       await this._manager.ready;
       await this._manager.contents.get(newPath, {
-        contentProviderId: this._contentProviderId
+        contentProviderId: this._contentProviderId,
+        content: false
       });
       await this._maybeOverWrite(newPath);
     } catch (err) {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
Closes #15153

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
This PR adds `content: false` to the `contents.get()` call in the `saveAs()` method. Previously, `saveAs()` fetched the full file content just to check if the file exists (to prompt for overwrite). By setting `content: false`, we only fetch the file metadata without the body, making the check more efficient.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes
None.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
