### PR TITLE
Fix cell height heuristic to consider stderr and stdout outputs

### DIFF
--- a/packages/notebook/src/windowing.ts
+++ b/packages/notebook/src/windowing.ts
@@ -187,10 +187,10 @@ export class NotebookViewModel extends WindowedListModel {
     if (model instanceof CodeCellModel && !model.isDisposed) {
       for (let outputIdx = 0; outputIdx < model.outputs.length; outputIdx++) {
         const output = model.outputs.get(outputIdx);
-        
+
         // Check for multiple output types including stderr and stdout
         const outputTypes = ['text/plain', 'application/vnd.jupyter.stderr', 'application/vnd.jupyter.stdout'];
-        
+
         for (const outputType of outputTypes) {
           const data = output.data[outputType];
           if (typeof data === 'string') {

--- a/packages/notebook/src/windowing.ts
+++ b/packages/notebook/src/windowing.ts
@@ -187,11 +187,19 @@ export class NotebookViewModel extends WindowedListModel {
     if (model instanceof CodeCellModel && !model.isDisposed) {
       for (let outputIdx = 0; outputIdx < model.outputs.length; outputIdx++) {
         const output = model.outputs.get(outputIdx);
-        const data = output.data['text/plain'];
-        if (typeof data === 'string') {
-          outputsLines += data.split('\n').length;
-        } else if (Array.isArray(data)) {
-          outputsLines += data.join('').split('\n').length;
+        
+        // Check for multiple output types including stderr and stdout
+        const outputTypes = ['text/plain', 'application/vnd.jupyter.stderr', 'application/vnd.jupyter.stdout'];
+        
+        for (const outputType of outputTypes) {
+          const data = output.data[outputType];
+          if (typeof data === 'string') {
+            outputsLines += data.split('\n').length;
+            break; // Only count each output once
+          } else if (Array.isArray(data)) {
+            outputsLines += data.join('').split('\n').length;
+            break; // Only count each output once
+          }
         }
       }
     }


### PR DESCRIPTION
## Description

Fixes #16636 by updating the cell height heuristic in windowing.ts to consider additional output types.

## Problem
Currently, the heuristic only checks for `text/plain` output, missing long-running outputs like tracebacks and stdout streams that use `application/vnd.jupyter.stderr` and `application/vnd.jupyter.stdout`.

## Solution
- Update `estimateWidgetSize` to check for multiple output types
- Follow the pattern from `cells/src/widget.ts` for supported output types
- Add support for `application/vnd.jupyter.stderr` and `application/vnd.jupyter.stdout`
- Only count each output once to avoid double-counting

## Changes
- Modified `packages/notebook/src/windowing.ts`
- Added loop through output types: `['text/plain', 'application/vnd.jupyter.stderr', 'application/vnd.jupyter.stdout']`
- Added break statements to prevent double-counting
- Applied pre-commit formatting fixes

## Testing
Tested with various output types including long-running stdout streams and tracebacks.

## Fixes
Fixes #16636

**Note:** Pre-commit CI formatting fixes have been applied.