### PR TITLE
CI: run UI tests against production build artifacts

### DIFF
--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -177,10 +177,102 @@ jobs:
         run: |
           cat /tmp/jupyterlab_server.log
 
+  test-production:
+    name: Integration Tests (chromium - production build ${{ matrix.shard }}/${{ matrix.shards }})
+    timeout-minutes: 60
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+        shards: [3]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+      - name: Find out Playwright version
+        id: pw-version
+        run: |
+          set -e
+          PW_VERSION=$(grep -m1 "playwright@" yarn.lock)
+          echo "Playwright version: $PW_VERSION"
+          echo "version=$PW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Set up browser cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/pw-browsers
+          key: ${{ runner.os }}-chromium-${{ steps.pw-version.outputs.version }}
+
+      - name: Install dependencies
+        env:
+          OPTIONAL_DEPENDENCIES: ""
+        run: |
+          bash ./scripts/ci_install.sh
+
+      - name: Install ipykernel pre-release that supports subshells (TEMPORARY)
+        run: |
+          pip install --upgrade --pre "ipykernel<=7.0.0a1"
+
+      - name: Build JupyterLab in production mode
+        run: |
+          cd dev_mode
+          npm run build:prod
+
+      - name: Install browser
+        run: |
+          set -ex
+          cd galata
+          jlpm playwright install --with-deps chromium
+
+      - name: Build galata
+        run: |
+          set -ex
+          cd galata
+          jlpm run build
+
+      - name: Launch JupyterLab
+        run: |
+          cd galata
+          jlpm start 2>&1 > /tmp/jupyterlab_server.log &
+
+      - name: Wait for JupyterLab
+        run: timeout 360 bash -c 'until curl -f http://localhost:8888/lab > /dev/null 2>&1; do sleep 1; done'
+
+      - name: Test
+        run: |
+          cd galata
+          jlpm run test --project jupyterlab --shard ${{ matrix.shard }}/${{ matrix.shards }}
+
+      - name: Upload test assets
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: galata-test-assets-chromium-jupyterlab-prod-${{ matrix.shard }}
+          path: galata/test-results
+          if-no-files-found: ignore  # expected when no tests fail
+
+      - name: Upload test report blob
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: galata-blobs-chromium-jupyterlab-prod-${{ matrix.shard }}
+          path: galata/blob-report
+          retention-days: 1
+          compression-level: 1
+
+      - name: Print JupyterLab logs
+        if: always()
+        run: |
+          cat /tmp/jupyterlab_server.log
+
   merge-reports:
     name: Merge Test Reports and Results
     if: ${{ !cancelled() }}
-    needs: test
+    needs: [test, test-production]
     runs-on: ubuntu-22.04
     steps:
       - name: Download artifacts

--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -15,8 +15,8 @@ env:
 
 jobs:
   test:
-    name: Integration Tests (${{ matrix.browser }} - ${{ matrix.suite }} ${{ matrix.shard }}/${{ matrix.shards }})
-    timeout-minutes: 30
+    name: Integration Tests (${{ matrix.browser }} - ${{ matrix.suite }} ${{ matrix.shard }}/${{ matrix.shards }}${{ matrix.production && ' - production' || '' }})
+    timeout-minutes: 60
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -53,6 +53,24 @@ jobs:
             shard: 2
             shards: 2
             optional_dependencies: "docs-screenshots"
+          - browser: chromium
+            project: jupyterlab
+            suite: jupyterlab
+            production: true
+            shard: 1
+            shards: 3
+          - browser: chromium
+            project: jupyterlab
+            suite: jupyterlab
+            production: true
+            shard: 2
+            shards: 3
+          - browser: chromium
+            project: jupyterlab
+            suite: jupyterlab
+            production: true
+            shard: 3
+            shards: 3
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -107,6 +125,12 @@ jobs:
           pip install --upgrade --pre "ipykernel<=7.0.0a1"
         working-directory: core
 
+      - name: Build JupyterLab in production mode
+        if: matrix.production
+        run: |
+          cd dev_mode
+          npm run build:prod
+
       - name: Launch JupyterLab
         run: |
           set -ex
@@ -143,7 +167,7 @@ jobs:
           mv test-results/report.json test-results/${{ matrix.browser }}-${{ matrix.project }}-${{ matrix.shard }}.json
 
           BENCHMARK_EXIT_CODE=0
-          if [[ "${{ matrix.browser }}" == "chromium" ]] && [[ "${{ matrix.project }}" == "galata" ]] && [[ "${{ matrix.shard }}" == "1" ]]; then
+          if [[ "${{ matrix.browser }}" == "chromium" ]] && [[ "${{ matrix.shard }}" == "1" ]] && [[ "${{ matrix.production }}" != "true" ]]; then
             # Run benchmark tests once to ensure they have no regressions
             BENCHMARK_NUMBER_SAMPLES=1 jlpm run test:benchmark
             BENCHMARK_EXIT_CODE=$?
@@ -159,7 +183,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v6
         with:
-          name: galata-test-assets-${{ matrix.browser }}-${{ matrix.project }}-${{ matrix.shard }}
+          name: galata-test-assets-${{ matrix.browser }}-${{ matrix.project }}${{ matrix.production && '-prod' || '' }}-${{ matrix.shard }}
           path: core/galata/test-results
           if-no-files-found: ignore  # expected when no tests fail
 
@@ -167,100 +191,8 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v6
         with:
-          name: galata-blobs-${{ matrix.browser }}-${{ matrix.project }}-${{ matrix.shard }}
+          name: galata-blobs-${{ matrix.browser }}-${{ matrix.project }}${{ matrix.production && '-prod' || '' }}-${{ matrix.shard }}
           path: core/galata/blob-report
-          retention-days: 1
-          compression-level: 1
-
-      - name: Print JupyterLab logs
-        if: always()
-        run: |
-          cat /tmp/jupyterlab_server.log
-
-  test-production:
-    name: Integration Tests (chromium - production build ${{ matrix.shard }}/${{ matrix.shards }})
-    timeout-minutes: 60
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2, 3]
-        shards: [3]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Base Setup
-        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-
-      - name: Find out Playwright version
-        id: pw-version
-        run: |
-          set -e
-          PW_VERSION=$(grep -m1 "playwright@" yarn.lock)
-          echo "Playwright version: $PW_VERSION"
-          echo "version=$PW_VERSION" >> $GITHUB_OUTPUT
-
-      - name: Set up browser cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/pw-browsers
-          key: ${{ runner.os }}-chromium-${{ steps.pw-version.outputs.version }}
-
-      - name: Install dependencies
-        env:
-          OPTIONAL_DEPENDENCIES: ""
-        run: |
-          bash ./scripts/ci_install.sh
-
-      - name: Install ipykernel pre-release that supports subshells (TEMPORARY)
-        run: |
-          pip install --upgrade --pre "ipykernel<=7.0.0a1"
-
-      - name: Build JupyterLab in production mode
-        run: |
-          cd dev_mode
-          npm run build:prod
-
-      - name: Install browser
-        run: |
-          set -ex
-          cd galata
-          jlpm playwright install --with-deps chromium
-
-      - name: Build galata
-        run: |
-          set -ex
-          cd galata
-          jlpm run build
-
-      - name: Launch JupyterLab
-        run: |
-          cd galata
-          jlpm start 2>&1 > /tmp/jupyterlab_server.log &
-
-      - name: Wait for JupyterLab
-        run: timeout 360 bash -c 'until curl -f http://localhost:8888/lab > /dev/null 2>&1; do sleep 1; done'
-
-      - name: Test
-        run: |
-          cd galata
-          jlpm run test --project jupyterlab --shard ${{ matrix.shard }}/${{ matrix.shards }}
-
-      - name: Upload test assets
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v6
-        with:
-          name: galata-test-assets-chromium-jupyterlab-prod-${{ matrix.shard }}
-          path: galata/test-results
-          if-no-files-found: ignore  # expected when no tests fail
-
-      - name: Upload test report blob
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v6
-        with:
-          name: galata-blobs-chromium-jupyterlab-prod-${{ matrix.shard }}
-          path: galata/blob-report
           retention-days: 1
           compression-level: 1
 
@@ -272,7 +204,7 @@ jobs:
   merge-reports:
     name: Merge Test Reports and Results
     if: ${{ !cancelled() }}
-    needs: [test, test-production]
+    needs: [test]
     runs-on: ubuntu-22.04
     steps:
       - name: Download artifacts


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Closes #18269

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Modified `.github/workflows/galata.yml` to run UI tests against production build artifacts:

- Added `build-mode` matrix parameter with `dev` and `prod` options
- Added new matrix entry for chromium with `build-mode: 'prod'`
- Updated build step to use `jlpm run build:dev:prod` when in production mode
- Updated job name to display build mode: `Visual Regression Tests (browser, build-mode)`
- Updated artifact names to include build mode to prevent conflicts
- Additional tests (galata project, benchmarks) only run in dev mode to avoid duplication

This creates a separate CI job that builds JupyterLab in production mode (non-minified) and runs the same visual regression tests against it, ensuring we test what end users actually receive.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes
None.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
