### PR TITLE
Turn on the Typescript alwaysStrict option

### DIFF
--- a/tsconfigbase.json
+++ b/tsconfigbase.json
@@ -2,6 +2,7 @@
   "$schema": "http://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
+    "alwaysStrict": true,
     "composite": true,
     "declaration": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## References

See https://github.com/jupyterlab/jupyterlab/issues/18422

## Code changes

This option ensures our files are parsed in ECMAScript strict mode, and emits 'use strict' for each source file. The option is on by default if Typescript is working in strict mode

See https://www.typescriptlang.org/tsconfig/\#alwaysStrict

> [ECMAScript strict](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Strict_mode) mode was introduced in ES5 and provides behavior tweaks to the runtime of the JavaScript engine to improve performance, and makes a set of errors throw instead of silently ignoring them.

## User-facing changes

I don't think there should be visible changes from this. It seems our code compiles with it on just fine, for example.


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
