### PR TITLE
Use past tense in README when referencing JupyterLab 3 security fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To learn more about extensions, see the [user documentation](https://jupyterlab.
 Read the current JupyterLab documentation on [ReadTheDocs](http://jupyterlab.readthedocs.io/en/stable/).
 
 > [!IMPORTANT]
-> JupyterLab 3 reached its end of maintenance date on May 15, 2024. Fixes for critical issues will still be backported until December 31, 2024. If you are still running JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible.** For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.
+> JupyterLab 3 reached its end of maintenance date on May 15, 2024. Fixes for critical issues were backported until December 31, 2024. If you are still running JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible.** For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.
 
 ---
 


### PR DESCRIPTION
## References

The real motivation for this PR is to check if auto-requesting copilot reviews works after temporarily enabling it when investigating report that it does not work in [#jupyterlab > PR Reviews @ 💬](https://jupyter.zulipchat.com/#narrow/channel/469762-jupyterlab/topic/PR.20Reviews/near/571750088)

<img width="749" height="227" alt="image" src="https://github.com/user-attachments/assets/e707f17e-41fc-4562-a446-0902e07ba1a9" />

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None