### PR TITLE
Fix persistent text highlight in inactive cells

### DIFF
--- a/packages/notebook/src/searchprovider.ts
+++ b/packages/notebook/src/searchprovider.ts
@@ -351,7 +351,6 @@ export class NotebookSearchProvider extends SearchProvider<NotebookPanel> {
     }
     await this.endQuery();
     this._searchActive = true;
-    this.widget.content.isSearchActive = true;
     let cells = this.widget.content.widgets;
 
     this._query = query;
@@ -421,7 +420,6 @@ export class NotebookSearchProvider extends SearchProvider<NotebookPanel> {
     );
 
     this._searchActive = false;
-    this.widget.content.isSearchActive = false;
     this._searchProviders.length = 0;
     this._currentProviderIndex = null;
   }

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -283,11 +283,6 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
   }
 
   /**
-   * Whether the notebook is currently in a search operation.
-   */
-  isSearchActive = false;
-
-  /**
    * The cell factory used by the widget.
    */
   readonly contentFactory: StaticNotebook.IContentFactory;
@@ -3398,12 +3393,10 @@ export class Notebook extends StaticNotebook {
         const cell = this.widgets[i];
         if (!cell.model.isDisposed && cell.editor) {
           cell.model.selections.delete(cell.editor.uuid);
-          // clear the editor's visual selection to avoid
-          // multiple cells showing highlighted text,
-          // but not during search to avoid interfering with search decorations.
-          if (!this.isSearchActive) {
-            cell.editor.setSelections([]);
-          }
+          // Collapse the editor's visual selection to the cursor position
+          // to avoid multiple cells showing highlighted text.
+          const cursor = cell.editor.getCursorPosition();
+          cell.editor.setCursorPosition(cursor, { scroll: false });
         }
       }
     }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
Fixes #11353
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
This update fixes a visual issue where text highlights would remain visible in previously active cells after selecting text in a new cell. It ensures that only the current active selection is highlighted

## User-facing changes
### Before
https://github.com/user-attachments/assets/e7efb6bb-d835-4160-b455-6c23ba8d611a

### After
https://github.com/user-attachments/assets/ff0e269b-c551-47f8-9c37-94e3967c8fdd

## Backwards-incompatible changes
None
