### PR TITLE
Refine order of precedence for `DocumentRegistry.getFileTypeForModel()` method

### DIFF
--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -727,7 +727,7 @@ export class DocumentRegistry implements IDisposable {
     // Look for a pattern match first.
     let ft = find(this._fileTypes, ft => {
       return !!(
-        (!type || (type && ft.contentType == type)) &&
+        (!type || ft.contentType == type) &&
         ft.pattern &&
         name.match(ft.pattern) !== null
       );

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -672,7 +672,7 @@ export class DocumentRegistry implements IDisposable {
     let ft: DocumentRegistry.IFileType | null = null;
     if (model.name || model.path) {
       const name = model.name || PathExt.basename(model.path!);
-      const fts = this.getFileTypesForPath(name);
+      const fts = this._getFileTypesForPath(name, model.type);
       if (fts.length > 0) {
         ft = fts[0];
       }
@@ -714,12 +714,23 @@ export class DocumentRegistry implements IDisposable {
    * @returns An ordered list of matching file types.
    */
   getFileTypesForPath(path: string): DocumentRegistry.IFileType[] {
+    return this._getFileTypesForPath(path);
+  }
+
+  private _getFileTypesForPath(
+    path: string,
+    type?: string
+  ): DocumentRegistry.IFileType[] {
     const fts: DocumentRegistry.IFileType[] = [];
     const name = PathExt.basename(path);
 
     // Look for a pattern match first.
     let ft = find(this._fileTypes, ft => {
-      return !!(ft.pattern && name.match(ft.pattern) !== null);
+      return !!(
+        (!type || (type && ft.contentType == type)) &&
+        ft.pattern &&
+        name.match(ft.pattern) !== null
+      );
     });
     if (ft) {
       fts.push(ft);

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -662,6 +662,12 @@ export class DocumentRegistry implements IDisposable {
   /**
    * Get the best file type given a contents model.
    *
+   * The order of precedence is defined as:
+   * - matching by pattern (and extension/content type if specified)
+   * - matching by extension (and content type if specified)
+   * - matching by content type only
+   * - fallback to file types defined as defaults for the given content type
+   *
    * @param model - The contents model of interest.
    *
    * @returns The best matching file type.
@@ -670,8 +676,8 @@ export class DocumentRegistry implements IDisposable {
     model: Partial<Contents.IModel>
   ): DocumentRegistry.IFileType {
     let ft: DocumentRegistry.IFileType | null = null;
-    if (model.name || model.path) {
-      const name = model.name || PathExt.basename(model.path!);
+    if (model.name || model.path || model.type) {
+      const name = model.name || PathExt.basename(model.path || '');
       const fts = this._getFileTypesForPath(name, model.type);
       if (fts.length > 0) {
         ft = fts[0];
@@ -721,32 +727,70 @@ export class DocumentRegistry implements IDisposable {
     path: string,
     type?: string
   ): DocumentRegistry.IFileType[] {
-    const fts: DocumentRegistry.IFileType[] = [];
+    const withPattern: DocumentRegistry.IFileType[] = [];
+    const withExtension: DocumentRegistry.IFileType[] = [];
+    const typeOnly: DocumentRegistry.IFileType[] = [];
     const name = PathExt.basename(path);
 
-    // Look for a pattern match first.
-    let ft = find(this._fileTypes, ft => {
-      return !!(
-        (!type || ft.contentType == type) &&
-        ft.pattern &&
-        name.match(ft.pattern) !== null
-      );
-    });
-    if (ft) {
-      fts.push(ft);
-    }
-
-    // Then look by extension name, starting with the longest
+    // Check by extension, longest first
     let ext = Private.extname(name);
     while (ext.length > 1) {
-      const ftSubset = this._fileTypes.filter(ft =>
-        // In Private.extname, the extension is transformed to lower case
-        ft.extensions.map(extension => extension.toLowerCase()).includes(ext)
-      );
-      fts.push(...ftSubset);
+      for (const ft of this._fileTypes) {
+        // Cheap comparison first
+        if (type && ft.contentType !== type) {
+          continue;
+        }
+        // Comparison with cost linear in term of extensions list length second
+        let matchesExtension = false;
+        for (const extension of ft.extensions) {
+          if (extension.toLowerCase() === ext) {
+            matchesExtension = true;
+            break;
+          }
+        }
+        if (!matchesExtension) {
+          continue;
+        }
+        // Expensive pattern matching last if all others conditions were met
+        if (ft.pattern && name.match(ft.pattern) !== null) {
+          // Separate pattern matches as these have a higher priority
+          withPattern.push(ft);
+        } else if (!ft.pattern) {
+          withExtension.push(ft);
+        }
+      }
       ext = '.' + ext.split('.').slice(2).join('.');
     }
-    return fts;
+
+    // Check for pattern match with no extensions
+    for (const ft of this._fileTypes) {
+      if (
+        // Cheap comparisons first
+        !!ft.pattern &&
+        ft.extensions.length === 0 &&
+        (!type || ft.contentType == type) &&
+        // Expensive pattern matching last
+        name.match(ft.pattern) !== null
+      ) {
+        withPattern.push(ft);
+      }
+    }
+
+    // Check for type-only matches (no pattern, no extensions)
+    if (type) {
+      for (const ft of this._fileTypes) {
+        if (
+          ft.contentType == type &&
+          !ft.pattern &&
+          ft.extensions.length === 0
+        ) {
+          typeOnly.push(ft);
+        }
+      }
+    }
+
+    // Return: pattern matches, extension matches, then type-only matches
+    return [...withPattern, ...withExtension, ...typeOnly];
   }
 
   protected translator: ITranslator;

--- a/packages/docregistry/test/registry.spec.ts
+++ b/packages/docregistry/test/registry.spec.ts
@@ -737,6 +737,30 @@ describe('docregistry/registry', () => {
         expect(customNotebookType.name).toBe('test_ipynb');
       });
 
+      it('should consider both pattern and content type', () => {
+        registry.addFileType({
+          name: 'node_modules_directory',
+          contentType: 'directory',
+          pattern: '^node_modules'
+        });
+
+        registry.addFileType({
+          name: 'node_modules_notebook',
+          contentType: 'notebook',
+          pattern: '^node_modules'
+        });
+        const nodeModuleDirFt = registry.getFileTypeForModel({
+          path: '/foo/node_modules',
+          type: 'directory'
+        });
+        expect(nodeModuleDirFt.name).toBe('node_modules_directory');
+        const nodeModuleNbFt = registry.getFileTypeForModel({
+          path: '/foo/node_modules.ipynb',
+          type: 'notebook'
+        });
+        expect(nodeModuleNbFt.name).toBe('node_modules_notebook');
+      });
+
       it('should handle a python file', () => {
         const ft = registry.getFileTypeForModel({
           name: 'foo.py'

--- a/packages/docregistry/test/registry.spec.ts
+++ b/packages/docregistry/test/registry.spec.ts
@@ -737,6 +737,43 @@ describe('docregistry/registry', () => {
         expect(customNotebookType.name).toBe('test_ipynb');
       });
 
+      it('should consider all three: pattern, extension, content type', () => {
+        registry.addFileType({
+          name: 'pattern_and_extension_and_type',
+          pattern: 'foo',
+          extensions: ['.bar'],
+          contentType: 'baz'
+        });
+
+        registry.addFileType({
+          name: 'extension_and_type',
+          extensions: ['.bar'],
+          contentType: 'baz'
+        });
+
+        registry.addFileType({
+          name: 'type',
+          contentType: 'baz'
+        });
+
+        let ft = registry.getFileTypeForModel({
+          path: '/foo.bar',
+          type: 'baz'
+        });
+        expect(ft.name).toBe('pattern_and_extension_and_type');
+
+        ft = registry.getFileTypeForModel({
+          path: '/.bar',
+          type: 'baz'
+        });
+        expect(ft.name).toBe('extension_and_type');
+
+        ft = registry.getFileTypeForModel({
+          type: 'baz'
+        });
+        expect(ft.name).toBe('type');
+      });
+
       it('should consider both pattern and content type', () => {
         registry.addFileType({
           name: 'node_modules_directory',
@@ -749,16 +786,47 @@ describe('docregistry/registry', () => {
           contentType: 'notebook',
           pattern: '^node_modules'
         });
+
         const nodeModuleDirFt = registry.getFileTypeForModel({
           path: '/foo/node_modules',
           type: 'directory'
         });
         expect(nodeModuleDirFt.name).toBe('node_modules_directory');
+
         const nodeModuleNbFt = registry.getFileTypeForModel({
           path: '/foo/node_modules.ipynb',
           type: 'notebook'
         });
         expect(nodeModuleNbFt.name).toBe('node_modules_notebook');
+      });
+
+      it('should consider both pattern and file extension', () => {
+        registry.addFileType({
+          name: 'code',
+          extensions: ['.py', '.js']
+        });
+
+        registry.addFileType({
+          name: 'code_backup',
+          extensions: ['.py', '.js'],
+          pattern: 'backup'
+        });
+
+        registry.addFileType({
+          name: 'archive_backup',
+          extensions: ['.zip', '.gz'],
+          pattern: 'backup'
+        });
+
+        const archiveBackupFt = registry.getFileTypeForModel({
+          path: '/foo/my_archive_backup.gz'
+        });
+        expect(archiveBackupFt.name).toBe('archive_backup');
+
+        const codeBackupFt = registry.getFileTypeForModel({
+          path: '/foo/my_code_backup.py'
+        });
+        expect(codeBackupFt.name).toBe('code_backup');
       });
 
       it('should handle a python file', () => {
@@ -844,15 +912,11 @@ describe('docregistry/registry', () => {
       it('should support pattern matching', () => {
         registry.addFileType({
           name: 'test',
-          extensions: ['.temp'],
           pattern: '.*\\.test$'
         });
 
         const ft = registry.getFileTypesForPath('foo/bar/baz.test');
         expect(ft[0].name).toBe('test');
-
-        const ft2 = registry.getFileTypesForPath('foo/bar/baz.temp');
-        expect(ft2[0].name).toBe('test');
       });
 
       it('should returns all file types', () => {

--- a/packages/docregistry/test/registry.spec.ts
+++ b/packages/docregistry/test/registry.spec.ts
@@ -919,6 +919,34 @@ describe('docregistry/registry', () => {
         expect(ft[0].name).toBe('test');
       });
 
+      it('should return all file types matching provided pattern', () => {
+        registry.addFileType({
+          name: 'a',
+          // Starts with 'a'
+          pattern: '^a'
+        });
+        registry.addFileType({
+          name: 'b',
+          // Has 'b'
+          pattern: 'b'
+        });
+        registry.addFileType({
+          name: 'c',
+          // Ends with 'c'
+          pattern: 'c$'
+        });
+
+        // Should return all three matches
+        let fts = registry.getFileTypesForPath('abc');
+        expect(fts.length).toBe(3);
+        expect(fts.map(f => f.name)).toEqual(['a', 'b', 'c']);
+
+        // Should return the single match
+        fts = registry.getFileTypesForPath('cba');
+        expect(fts.length).toBe(1);
+        expect(fts.map(f => f.name)).toEqual(['b']);
+      });
+
       it('should returns all file types', () => {
         registry.addFileType({
           name: 'test',


### PR DESCRIPTION
## References

Builds on top of https://github.com/jupyterlab/jupyterlab/pull/18409.

This PR addresses multiple inconsistencies/undefined behaviors which would be unexpected but exist on the `main` branch:
- when using `DocumentRegistry.getFileTypeForModel`:
  - pattern-matching has precedence over extension matching (ok)
  - extension matching has precedence over fallback file types (ok)
  - file types which include only content-type are disregarded (bad)
  - when pattern matching is performed the extension match and content type match are disregarded (bad)
  - when extension matching is performed, the content type match is disregarded (bad)
- in `DocumentRegistry.getFileTypesForPath()`:
  - the code path matching by pattern only ever returns a single file type, even though extension matching returns multiple file types

TODO;
 - [ ] update `IFileType` docs
 - [ ] document the `extensions: []` behaiour
 - [ ] mention during the next Jupyter Contributors meeting to get more feedback
 - [ ] search for any usage in public third-party extensions that would be broken

## Code changes

Defines the order of precedence for "best" match of a file type to a model as:
 - matching by pattern (and extension/content type if specified)
 - matching by extension (and content type if specified)
 - matching by content type only
 - fallback to file types defined as defaults for the given content type

## User-facing changes

- File types intended only for notebooks will not interfere with directories and non-notebook files and vice versa (as in [#18409](https://github.com/jupyterlab/jupyterlab/pull/18409))
- Extension authors will be able to define file types with higher specificity than before resulting in more capable extensions

## Backwards-incompatible changes

File types where conflicting pattern and extension are defined will no longer be returned by `DocumentRegistry.getFileTypeForModel()` and `DocumentRegistry.getFileTypesForPath()` 

```ts
registry.addFileType({
  name: 'test',
  extensions: ['.temp'],
  pattern: '.*\\.test$'
});

// This would have passed in 4.5.x but will fail in 4.6.0
const ft2 = registry.getFileTypesForPath('foo/bar/baz.temp');
expect(ft2[0].name).toBe('test');
```

The following remains valid:

```ts
registry.addFileType({
  name: 'test',
  extensions: ['.temp'],
  pattern: '^prefix'
});

const ft2 = registry.getFileTypesForPath('foo/bar/prefixed_name.temp');
expect(ft2[0].name).toBe('test');
```