### PR TITLE
fix: handle undefined tab count in workspace tooltip

### DIFF
--- a/packages/workspaces-extension/src/sidebar.ts
+++ b/packages/workspaces-extension/src/sidebar.ts
@@ -67,11 +67,13 @@ export const workspacesSidebar: JupyterFrontEndPlugin<void> = {
         return this._workspace.metadata.id;
       }
       labelTitle() {
+        const tabCount =
+          (this._workspace.data['layout-restorer:data'] as any)?.main?.dock
+            ?.widgets?.length ?? 0;
         return trans.__(
           '%1 workspace with %2 tabs, last modified on %3',
           this._workspace.metadata.id,
-          (this._workspace.data['layout-restorer:data'] as any)?.main?.dock
-            ?.widgets?.length,
+          tabCount,
           this._workspace.metadata['last_modified']
         );
       }


### PR DESCRIPTION
## Description

Fixes #18106 

When a workspace has no layout data or the `widgets` array doesn't exist, the `labelTitle()` function was passing `undefined` to the translation string, resulting in 'undefined' being displayed in the tooltip instead of a number.

## Changes

- Added nullish coalescing operator (`??`) to default to `0` when the tab count cannot be determined from `layout-restorer:data.main.dock.widgets.length`

## Before/After

**Before:** Tooltip shows "workspace with undefined tabs"
**After:** Tooltip shows "workspace with 0 tabs"

## Testing

The fix handles the case when:
- The workspace has no layout-restorer data
- The `main` property doesn't exist
- The `dock` property doesn't exist
- The `widgets` array doesn't exist or is empty

This is a minimal, targeted fix that doesn't change behavior for workspaces with valid tab counts.