### PR TITLE
Fix inconsistent JupyterLab capitalization

### DIFF
--- a/docs/source/extension/extension_dev.md
+++ b/docs/source/extension/extension_dev.md
@@ -442,7 +442,7 @@ When an extension (the "consumer") is optionally using a service identified by a
 %
 % Prebuilt extensions need to deduplicate many of their dependencies with other prebuilt extensions and with source extensions. This deduplication happens in two phases:
 %
-% 1. When JupyterLab is initialized in the browser, the core Jupyterlab build (including all source extensions) and each prebuilt extension can share copies of dependencies with a package cache in the browser.
+% 1. When JupyterLab is initialized in the browser, the core JupyterLab build (including all source extensions) and each prebuilt extension can share copies of dependencies with a package cache in the browser.
 % 2. A source or prebuilt extension can import a dependency from the cache while JupyterLab is running.
 %
 % The main options controlling how things work in this deduplication are as follows. If a package is listed in this sharing config, it will be requested from the package cache.

--- a/docs/source/extension/extension_migration.md
+++ b/docs/source/extension/extension_migration.md
@@ -311,7 +311,7 @@ See <https://github.com/jupyterlab/frontends-team-compass/issues/143> for more c
 
 - Some CSS rules for `button` with the class `.jp-ToolbarButtonComponent` has been kept for backward compatibility.
 
-  These rules are now **deprecated** and will be removed in Jupyterlab 5.
+  These rules are now **deprecated** and will be removed in JupyterLab 5.
   The `button` elements in toolbars must be updated to `jp-button`, from
   [jupyter-ui-toolkit](https://github.com/jupyterlab-contrib/jupyter-ui-toolkit).
 

--- a/docs/source/extension/extension_points.md
+++ b/docs/source/extension/extension_points.md
@@ -343,7 +343,7 @@ declaring default keyboard shortcuts for a command:
 
 Shortcuts added to the settings system will be editable by users.
 
-From Jupyterlab version 3.1 onwards, it is possible to execute multiple commands with a single shortcut.
+From JupyterLab version 3.1 onwards, it is possible to execute multiple commands with a single shortcut.
 This requires you to define a keyboard shortcut for `apputils:run-all-enabled` command:
 
 ```json

--- a/docs/source/extension/ui_components.md
+++ b/docs/source/extension/ui_components.md
@@ -303,7 +303,7 @@ _rendered icon:_
 
 ### Background
 
-#### Icon handling in Jupyterlab
+#### Icon handling in JupyterLab
 
 Pre JupyterLab 2.0, most icons were created using the icons-as-css-background
 pattern:

--- a/docs/source/getting_started/faq.md
+++ b/docs/source/getting_started/faq.md
@@ -47,7 +47,7 @@ Why are `id` and `name` attributes removed from Markdown?
 > \- Use headings in Markdown cells to create anchor points safely.
 > \- Optionally, enable the "Allow named properties" setting in **Settings** -> **Settings Editor** -> **Sanitizer** (not recommended for untrusted sources).
 
-How Jupyterlab handles anchor navigation?
+How JupyterLab handles anchor navigation?
 
 > During sanitization, the id attributes of the DOM elements are replaced with `data-jupyter-id` attributes.
 > When resolving an URL, if a fragment exists (e.g. `#my-id`), it will find and scroll to the element with the corresponding `data-jupyter-id`.

--- a/docs/source/getting_started/starting.md
+++ b/docs/source/getting_started/starting.md
@@ -38,7 +38,7 @@ JupyterLab provides a way for users to copy URLs that
 {ref}`open a specific notebook or file <url-tree>`. Additionally,
 JupyterLab URLs are an advanced part of the user interface that allows for
 managing {ref}`workspaces <url-workspaces>`. To learn more about URLs in
-Jupyterlab, visit {ref}`urls`.
+JupyterLab, visit {ref}`urls`.
 
 JupyterLab runs on top of Jupyter Server, so see the [security
 section](https://jupyter-server.readthedocs.io/en/latest/operators/security.html)

--- a/docs/source/user/interface.md
+++ b/docs/source/user/interface.md
@@ -31,7 +31,7 @@ the layout of the application areas and tabs, etc.
 Workspaces can be saved on the server with
 {ref}`named workspace URLs <url-workspaces>` or
 {ref}`using workspace commands <workspaces-gui>` available in the menu and sidebar.
-To learn more about URLs in Jupyterlab, visit {ref}`urls`.
+To learn more about URLs in JupyterLab, visit {ref}`urls`.
 
 In the user interface, the current workspace can be changed using the workspace
 selector widget located in the top bar.


### PR DESCRIPTION
This PR fixes 7 instances where 'Jupyterlab' was used instead of 'JupyterLab' in the documentation files.

Changes made:
- faq.md: Fix 'Jupyterlab' in anchor navigation section
- starting.md: Fix 'Jupyterlab' in URL documentation
- extension_points.md: Fix 'Jupyterlab' in keyboard shortcuts section
- extension_dev.md: Fix 'Jupyterlab' in deduplication explanation
- ui_components.md: Fix 'Jupyterlab' in icon handling section
- interface.md: Fix 'Jupyterlab' in URLs documentation
- extension_migration.md: Fix 'Jupyterlab' in CSS deprecation notice