### PR TITLE
Fix `pre-commit` `prettier` entry after upgrade to a new version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,8 @@ repos:
     hooks:
       - id: prettier
         name: prettier
-        entry: 'npm run prettier:files'
+        entry: jlpm
+        args: [run, 'prettier:files']
         language: node
         types_or: [json, ts, tsx, javascript, jsx, css]
         exclude: \.ipynb$


### PR DESCRIPTION
## References

- Fixes #18451 (for me)
- Follow up to https://github.com/jupyterlab/jupyterlab/pull/18420

## Code changes

Uses `jlpm` to run pre-commit.

## User-facing changes

None

## Backwards-incompatible changes

None