### PR TITLE
Update locking workflow

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -14,7 +14,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7
+      - uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7 # v6
         with:
           github-token: ${{ github.token }}
           issue-inactive-days: '180'


### PR DESCRIPTION
## References


## Code changes

Update the issue/pr lock cron job. Looking at the [run history](https://github.com/jupyterlab/jupyterlab/actions/workflows/lock.yml), this hasn't worked since at least December 2024. This PR updates the configuration to lock issues and PRs that have been closed and not updated for 180 days. Issues and PRs that are locked like this have a `status:resolved-locked` label that has a description describing why it was locked and encouraging people to open a new issue instead of comment on an old closed issue.

We originally implemented this because people were commenting on old closed issues, which meant we would not see the comments or it would resurrect an old resolved issue for a new different issue.

On the other hand, if we feel like we haven't had a problem with these sorts of comments, we can delete this job. Thoughts?


## User-facing changes

Closed issues and PRs will start to be locked after 180 days of no activity. It looks like right now that would mean locking [176 closed inactive issues](https://github.com/jupyterlab/jupyterlab/issues?q=is%3Aissue%20state%3Aclosed%20sort%3Aupdated-desc%20updated%3A%3C%40today-180d%20is%3Aunlocked) and [282 closed inactive PRs](https://github.com/jupyterlab/jupyterlab/issues?q=is%3Apr%20state%3Aclosed%20sort%3Aupdated-desc%20updated%3A%3C%40today-180d%20is%3Aunlocked).


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
