### PR TITLE
Upgrade `@codemirror/view`, fixing slow selection when line wrapping is enabled

### DIFF
--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@codemirror/state": "^6.5.4",
-    "@codemirror/view": "^6.39.13",
+    "@codemirror/view": "^6.39.14",
     "@jupyter/ydoc": "^3.1.0",
     "@jupyterlab/apputils": "^4.7.0-alpha.2",
     "@jupyterlab/attachments": "^4.6.0-alpha.2",

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -43,7 +43,7 @@
     "@codemirror/legacy-modes": "^6.5.2",
     "@codemirror/search": "^6.6.0",
     "@codemirror/state": "^6.5.4",
-    "@codemirror/view": "^6.39.13",
+    "@codemirror/view": "^6.39.14",
     "@jupyter/ydoc": "^3.1.0",
     "@jupyterlab/application": "^4.6.0-alpha.2",
     "@jupyterlab/apputils": "^4.7.0-alpha.2",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -56,7 +56,7 @@
     "@codemirror/legacy-modes": "^6.5.2",
     "@codemirror/search": "^6.6.0",
     "@codemirror/state": "^6.5.4",
-    "@codemirror/view": "^6.39.13",
+    "@codemirror/view": "^6.39.14",
     "@jupyter/ydoc": "^3.1.0",
     "@jupyterlab/codeeditor": "^4.6.0-alpha.2",
     "@jupyterlab/coreutils": "^6.6.0-alpha.2",

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@codemirror/language": "^6.12.1",
     "@codemirror/state": "^6.5.4",
-    "@codemirror/view": "^6.39.13",
+    "@codemirror/view": "^6.39.14",
     "@jupyter/ydoc": "^3.1.0",
     "@jupyterlab/apputils": "^4.7.0-alpha.2",
     "@jupyterlab/codeeditor": "^4.6.0-alpha.2",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@codemirror/state": "^6.5.4",
-    "@codemirror/view": "^6.39.13",
+    "@codemirror/view": "^6.39.14",
     "@jupyter/react-components": "^0.16.6",
     "@jupyter/ydoc": "^3.1.0",
     "@jupyterlab/application": "^4.6.0-alpha.2",

--- a/packages/settingeditor-extension/package.json
+++ b/packages/settingeditor-extension/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@codemirror/commands": "^6.10.2",
-    "@codemirror/view": "^6.39.13",
+    "@codemirror/view": "^6.39.14",
     "@jupyterlab/application": "^4.6.0-alpha.2",
     "@jupyterlab/apputils": "^4.7.0-alpha.2",
     "@jupyterlab/codeeditor": "^4.6.0-alpha.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1631,15 +1631,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemirror/view@npm:^6.0.0, @codemirror/view@npm:^6.17.0, @codemirror/view@npm:^6.23.0, @codemirror/view@npm:^6.27.0, @codemirror/view@npm:^6.37.0, @codemirror/view@npm:^6.39.13":
-  version: 6.39.13
-  resolution: "@codemirror/view@npm:6.39.13"
+"@codemirror/view@npm:^6.0.0, @codemirror/view@npm:^6.17.0, @codemirror/view@npm:^6.23.0, @codemirror/view@npm:^6.27.0, @codemirror/view@npm:^6.37.0, @codemirror/view@npm:^6.39.14":
+  version: 6.39.14
+  resolution: "@codemirror/view@npm:6.39.14"
   dependencies:
     "@codemirror/state": ^6.5.0
     crelt: ^1.0.6
     style-mod: ^4.1.0
     w3c-keyname: ^2.2.4
-  checksum: ff50b788ac5cbcdfd6eda5ff2a0d79319932d6284a9f814c776e393e11b99f6995b51e2f5e3fc1597a359cff7067e11577bb4bb8227ba40f7bc65750fa522544
+  checksum: cbd91511af189c53b3aca722f62f03b9941086edaa07f3a068d6c491d2f7a6f53b651cf1250aa00002dfd2a58343146611547993030a3fcc0d7e4ca92f3877f4
   languageName: node
   linkType: hard
 
@@ -2658,7 +2658,7 @@ __metadata:
   resolution: "@jupyterlab/cells@workspace:packages/cells"
   dependencies:
     "@codemirror/state": ^6.5.4
-    "@codemirror/view": ^6.39.13
+    "@codemirror/view": ^6.39.14
     "@jupyter/ydoc": ^3.1.0
     "@jupyterlab/apputils": ^4.7.0-alpha.2
     "@jupyterlab/attachments": ^4.6.0-alpha.2
@@ -2748,7 +2748,7 @@ __metadata:
     "@codemirror/legacy-modes": ^6.5.2
     "@codemirror/search": ^6.6.0
     "@codemirror/state": ^6.5.4
-    "@codemirror/view": ^6.39.13
+    "@codemirror/view": ^6.39.14
     "@jupyter/ydoc": ^3.1.0
     "@jupyterlab/application": ^4.6.0-alpha.2
     "@jupyterlab/apputils": ^4.7.0-alpha.2
@@ -2793,7 +2793,7 @@ __metadata:
     "@codemirror/legacy-modes": ^6.5.2
     "@codemirror/search": ^6.6.0
     "@codemirror/state": ^6.5.4
-    "@codemirror/view": ^6.39.13
+    "@codemirror/view": ^6.39.14
     "@jupyter/ydoc": ^3.1.0
     "@jupyterlab/codeeditor": ^4.6.0-alpha.2
     "@jupyterlab/coreutils": ^6.6.0-alpha.2
@@ -2842,7 +2842,7 @@ __metadata:
   dependencies:
     "@codemirror/language": ^6.12.1
     "@codemirror/state": ^6.5.4
-    "@codemirror/view": ^6.39.13
+    "@codemirror/view": ^6.39.14
     "@jupyter/ydoc": ^3.1.0
     "@jupyterlab/apputils": ^4.7.0-alpha.2
     "@jupyterlab/codeeditor": ^4.6.0-alpha.2
@@ -3027,7 +3027,7 @@ __metadata:
   resolution: "@jupyterlab/debugger@workspace:packages/debugger"
   dependencies:
     "@codemirror/state": ^6.5.4
-    "@codemirror/view": ^6.39.13
+    "@codemirror/view": ^6.39.14
     "@jupyter/react-components": ^0.16.6
     "@jupyter/ydoc": ^3.1.0
     "@jupyterlab/application": ^4.6.0-alpha.2
@@ -4800,7 +4800,7 @@ __metadata:
   resolution: "@jupyterlab/settingeditor-extension@workspace:packages/settingeditor-extension"
   dependencies:
     "@codemirror/commands": ^6.10.2
-    "@codemirror/view": ^6.39.13
+    "@codemirror/view": ^6.39.14
     "@jupyterlab/application": ^4.6.0-alpha.2
     "@jupyterlab/apputils": ^4.7.0-alpha.2
     "@jupyterlab/codeeditor": ^4.6.0-alpha.2


### PR DESCRIPTION
## References

- Fixes https://github.com/jupyterlab/jupyterlab/issues/18456

## Code changes

Upgrade to [`@codemirror/view`](https://codemirror.net/docs/ref/#view) 6.39.14 (2026-02-12)
> - Improve performance of posAtCoords on long lines.
> - Fix a regression where copy and cut in a shadow DOM on Safari would fall back to the native behavior, often copying the wrong text.

## User-facing changes

Selection with `lineWrap` enabled is faster. It can still stutter once the selection is excessively large, but there is a perceivable improvement.

https://github.com/user-attachments/assets/ba370b62-bb4e-4fb0-bc40-2e412eccd4d2

## Backwards-incompatible changes

None
