### PR TITLE
Revise team section in README with governance updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ copyright on their contributions. All code is licensed under the terms of the re
 JupyterLab is part of [Project Jupyter](https://jupyter.org/) and is developed by an open community. The maintenance team is assisted by a much larger group of contributors to JupyterLab and Project Jupyter as a whole. JupyterLab falls under the [Jupyter Frontends Council](https://jupyterlab-team-compass.readthedocs.io/en/latest/index.html).
 
 The team of maintainers includes:
+
 - decision-making contributors listed on the [council team members](https://jupyterlab-team-compass.readthedocs.io/en/latest/team.html) page
 - code contributors listed on the [contributors graph](https://github.com/jupyterlab/jupyterlab/graphs/contributors) page
 


### PR DESCRIPTION
## References

- Extracted from #18442 as suggested by https://github.com/jupyterlab/jupyterlab/pull/18442#issuecomment-3885985944

## Code changes

Updated team section with new governance model details and move archival list of maintainers to a summary tag.

## User-facing changes

None

## Backwards-incompatible changes

None
