### PR TITLE
Workflow to trigger delayed merging of PRs

### DIFF
--- a/.github/workflows/delayed-merge.yml
+++ b/.github/workflows/delayed-merge.yml
@@ -186,6 +186,12 @@ jobs:
                   repo: context.repo.repo,
                   pull_number: prNumber
                 });
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body: 'This PR was automatically merged after the 24-hour delayed merge period.'
+                });
               } catch (mergeError) {
                 console.log(`  Merge failed: ${mergeError.message}`);
                 await github.rest.issues.createComment({


### PR DESCRIPTION
## References

## Code changes

We explore an action that automatically merges PRs after a delay. This attempts to solve the situation where a maintainer would like to merge a PR, but would also like to delay merging for a short period of time to give other contributors a chance to weigh in, which currently requires a maintainer to remember to come back and merge the PR.

Shortcomings:
- This does not take into account the order of PR merges, so we can't order merges to make sure they work
- Checks are done in a batch job, so we are not immediately responsive to check failures
- If during the delay, a contributor adds a comment or PR approval to show their support for merging, that counts as activity that aborts the delayed merge. The reasoning here is that even a PR approval may include a comment that should be considered before merging. However, aborting the delayed merge may discourage others from vocalizing support for a PR, which is not great.
- It opens up a new security surface capable of merging PRs

Other ways of implementing this include:
* Turning on github merge queues and figuring out how to delay merges (for example, having a CI check fail until it's been 24 hours with no activity). Merge queues solve the PR ordering problem, for example.

Claude Code (Opus 4.6) helped in this PR.

## User-facing changes

A maintainer can add the `delayed-merge` label to a PR. This will trigger a merge in approximately 24 hours if the following conditions are met:

1. The label was added by a maintainer that currently has merge rights
2. No other activity happened on the PR after the label was added
3. The PR passes CI checks
4. The PR is mergeable

If any of those checks fail, the `delayed-merge` label is removed. If a merge is attempted, a comment is posted noting the result and the label is removed.



## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
