### PR TITLE
Fix useless assignments to local variables noted by GitHub CodeQL

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -1636,8 +1636,6 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
       return;
     }
 
-    options = options || {};
-
     const { title } = widget;
     // Add widget ID to tab so that we can get a handle on the tab's widget
     // (for context menu support)

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -470,7 +470,6 @@ export class Context<
 
       if (oldPath !== this._path) {
         newPath = this._path.replace(new RegExp(`^${oldPath}/`), `${newPath}/`);
-        oldPath = this._path;
 
         // Update client file model from folder change
         changeModel = {

--- a/packages/observables/src/undoablelist.ts
+++ b/packages/observables/src/undoablelist.ts
@@ -241,7 +241,7 @@ export class ObservableUndoableList<T>
       case 'set':
         index = change.newIndex;
         for (const value of change.newValues) {
-          this.set(change.newIndex++, serializer.fromJSON(value));
+          this.set(index++, serializer.fromJSON(value));
         }
         break;
       case 'remove':

--- a/packages/observables/src/undoablelist.ts
+++ b/packages/observables/src/undoablelist.ts
@@ -241,7 +241,7 @@ export class ObservableUndoableList<T>
       case 'set':
         index = change.newIndex;
         for (const value of change.newValues) {
-          this.set(index++, serializer.fromJSON(value));
+          this.set(change.newIndex++, serializer.fromJSON(value));
         }
         break;
       case 'remove':

--- a/packages/services/src/validate.ts
+++ b/packages/services/src/validate.ts
@@ -18,7 +18,7 @@ export function validateProperty(
   const value = object[name];
 
   if (typeName !== void 0) {
-    let valid = true;
+    let valid;
     switch (typeName) {
       case 'array':
         valid = Array.isArray(value);
@@ -34,7 +34,7 @@ export function validateProperty(
     }
 
     if (values.length > 0) {
-      let valid = true;
+      let valid;
       switch (typeName) {
         case 'string':
         case 'number':

--- a/packages/services/test/config/config.spec.ts
+++ b/packages/services/test/config/config.spec.ts
@@ -172,8 +172,8 @@ describe('jupyter.services - ConfigWithDefaults', () => {
       const className = 'testclass';
       const section = await configSectionManager.create({ name: randomName() });
       const config = new ConfigWithDefaults({ section, className });
-      let data: any = await config.set('foo', 'bar');
-      data = section.data['testclass'] as JSONObject;
+      await config.set('foo', 'bar');
+      const data = section.data['testclass'] as JSONObject;
       expect(data['foo']).toBe('bar');
     });
 


### PR DESCRIPTION
## References

Follow-up on issues from a recent [CodeQL run](https://github.com/jupyterlab/jupyterlab/security/quality/rules/js%2Fuseless-assignment-to-local)


## Code changes

Fix some unnecessary/ignored variable assignments

Claude Code (Opus 4.6) helped in this PR.

## User-facing changes

Should be none

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
