### PR TITLE
Fix flaky search test by working around bug

### DIFF
--- a/galata/test/jupyterlab/notebook-search.test.ts
+++ b/galata/test/jupyterlab/notebook-search.test.ts
@@ -353,16 +353,12 @@ test.describe('Notebook Search', () => {
     // Expect the filter text to be updated
     await page.locator('text=Search in 3 Selected Cells').waitFor();
 
-    // Reset selection, switch to second cell, preserving command mode
-    // Switch to the second cell first to avoid https://github.com/jupyterlab/jupyterlab/issues/18487
-    cell = await page.notebook.getCellLocator(1);
+    // Reset selection, switch to first cell, preserving command mode
+    // Switch to the first cell to avoid https://github.com/jupyterlab/jupyterlab/issues/18487
+    cell = await page.notebook.getCellLocator(0);
     await cell!.locator('.jp-InputPrompt').click();
 
     await page.locator('text=Search in 1 Selected Cell').waitFor();
-    // Wait for the counter to be properly updated
-    await page
-      .locator('.jp-DocumentSearch-index-counter:has-text("1/5")')
-      .waitFor({ timeout: 10000 });
 
     cell = await page.notebook.getCellLocator(2);
     await cell!.locator('.jp-InputPrompt').click();


### PR DESCRIPTION
## References

See the bug tracked at #18487.

## Code changes

Fix a flaky test by working around the bug tracked at https://github.com/jupyterlab/jupyterlab/issues/18487. We do this by clicking on an extra cell in the test.

## User-facing changes



## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
