### PR TITLE
Fix flaky subshell test

### DIFF
--- a/galata/test/jupyterlab/kernel.test.ts
+++ b/galata/test/jupyterlab/kernel.test.ts
@@ -121,17 +121,20 @@ test.describe('Kernel', () => {
       await page.notebook.setCell(0, 'code', '%subshell');
       await page.notebook.runCell(0);
 
-      const output1 = notebook.locator('.jp-OutputArea-output').locator('pre');
-      const text1 = (await output1.innerText()).split('\n');
-
+      const notebookOutput = notebook
+        .locator('.jp-OutputArea-output')
+        .locator('pre');
       // Confirm that subshells are supported by %subshell printing something useful.
       // Subshell ID for this main shell is None, and no subshells have been created
       // yet so the subshell list is empty.
-      expect(text1[0]).toEqual('subshell id: None');
-      expect(text1[5]).toEqual('subshell list: []');
+      await expect(async () => {
+        const text = (await notebookOutput.innerText()).split('\n');
+        expect(text[0]).toEqual('subshell id: None');
+        expect(text[5]).toEqual('subshell list: []');
+      }).toPass();
 
       // Open subshell console
-      await output1.click({ button: 'right' });
+      await notebookOutput.click({ button: 'right' });
       await page
         .getByRole('menuitem', { name: 'New Subshell Console for Notebook' })
         .click();
@@ -149,18 +152,21 @@ test.describe('Kernel', () => {
         .fill('%subshell');
       await page.menu.clickMenuItem('Run>Run Cell (forced)');
 
+      let subshellId: string;
       // Confirm that this is a subshell using "subshell id" printed by %subshell magic
       // which will be something other than None (None means main shell not subshell).
       // The subshell ID should also be the one and only entry in the "subshell list",
       // and wrapped in quotes as it is a string.
-      const output2 = subshellConsole
+      const consoleOutput = subshellConsole
         .locator('.jp-OutputArea-output')
         .locator('pre');
-      const text2 = (await output2.innerText()).split('\n');
-      expect(text2[0]).toMatch(/^subshell id:/);
-      const subshellId = text2[0].split(':')[1].trim();
-      expect(subshellId).not.toEqual('None');
-      expect(text2[5]).toEqual(`subshell list: ['${subshellId}']`);
+      await expect(async () => {
+        const text = (await consoleOutput.innerText()).split('\n');
+        expect(text[0]).toMatch(/^subshell id:/);
+        subshellId = text[0].split(':')[1].trim();
+        expect(subshellId).not.toEqual('None');
+        expect(text[5]).toEqual(`subshell list: ['${subshellId}']`);
+      }).toPass();
 
       // Rerun %subshell in notebook now that subshell exists.
       await notebook
@@ -172,10 +178,11 @@ test.describe('Kernel', () => {
 
       // Confirm that the parent shell is still a parent shell (subshell ID is None),
       // and that the new subshell appears in the "subshell list".
-      const output3 = notebook.locator('.jp-OutputArea-output').locator('pre');
-      const text3 = (await output3.innerText()).split('\n');
-      expect(text3[0]).toEqual('subshell id: None');
-      expect(text3[5]).toEqual(`subshell list: ['${subshellId}']`);
+      await expect(async () => {
+        const text = (await notebookOutput.innerText()).split('\n');
+        expect(text[0]).toEqual('subshell id: None');
+        expect(text[5]).toEqual(`subshell list: ['${subshellId}']`);
+      }).toPass();
     });
   });
 


### PR DESCRIPTION
## References

In https://github.com/jupyterlab/jupyterlab/pull/18486 we saw a flaky subshell test [fail](https://github.com/jupyterlab/jupyterlab/actions/runs/21924358895/job/63312864602?pr=18486) the `Should support opening subshell in separate code console` test. One failure more is due to incorrect use of `Locator.innerText()` for assertions. This can be verified by watching the recording of the test - the expected text is indeed there

```
Error: expect(received).toEqual(expected) // deep equality

Expected: "subshell list: ['512e4299-8e4c-466b-8c5f-d6684ca769cf']"
Received: undefined

  161 |       const subshellId = text2[0].split(':')[1].trim();
  162 |       expect(subshellId).not.toEqual('None');
> 163 |       expect(text2[5]).toEqual(`subshell list: ['${subshellId}']`);
      |                        ^
  164 |
  165 |       // Rerun %subshell in notebook now that subshell exists.
  166 |       await notebook
    at /home/runner/work/jupyterlab/jupyterlab/galata/test/jupyterlab/kernel.test.ts:163:24
```

[subshell.webm](https://github.com/user-attachments/assets/d714c01d-c8ff-40c1-ac7e-f075df431a80)


## Code changes

Playwright documentation of  `Locator.innerText()` suggests:

> NOTE If you need to assert text on the page, prefer expect(locator).toHaveText(expected[, options]) with useInnerText option to avoid flakiness. See assertions guide for more details.

However, this does not work if we want to assert that text in specific line has a given value, so instead I am using the `expect().toPass()` pattern to retry the relevant fragment.

Also, replaced `output1`, `output2` and `output3` (which was the same as `output1`) with more descriptive `notebookOutput` and `consoleOutput` for readability.

## User-facing changes

None

## Backwards-incompatible changes

None
