### PR TITLE
Fix continued flakiness in 'Search in multiple selected cells' test

### DIFF
--- a/galata/test/jupyterlab/notebook-search.test.ts
+++ b/galata/test/jupyterlab/notebook-search.test.ts
@@ -346,20 +346,20 @@ test.describe('Notebook Search', () => {
     let cell = await page.notebook.getCellLocator(0);
     await cell!.locator('.jp-InputPrompt').click();
 
-    // Select two cells below
+    // Select three cells below
+    await page.keyboard.press('Shift+ArrowDown');
     await page.keyboard.press('Shift+ArrowDown');
     await page.keyboard.press('Shift+ArrowDown');
 
     // Expect the filter text to be updated
-    await page.locator('text=Search in 3 Selected Cells').waitFor();
+    await page.locator('text=Search in 4 Selected Cells').waitFor();
 
-    // Reset selection, switch to first cell, preserving command mode
-    // Switch to the first cell to avoid https://github.com/jupyterlab/jupyterlab/issues/18487
-    cell = await page.notebook.getCellLocator(0);
-    await cell!.locator('.jp-InputPrompt').click();
+    // Wait for the counter to be properly updated
+    await page
+      .locator('.jp-DocumentSearch-index-counter:has-text("1/19")')
+      .waitFor({ timeout: 10000 });
 
-    await page.locator('text=Search in 1 Selected Cell').waitFor();
-
+    // Reset selection, switch to a middle cell, preserving command mode.
     cell = await page.notebook.getCellLocator(2);
     await cell!.locator('.jp-InputPrompt').click();
 


### PR DESCRIPTION
## References

Followup to #18488 to make the test more reliable.

## Code changes

We noticed that a few test runs are still failing this test sometimes (runs 21939005804 and 21939895804, for example), where with the current test we click on the first cell in the selection. This PR implements the working case from #18487 by clicking on a middle cell, which more reliably updates the search results. 

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
