### PR TITLE
Fix a few issues in config tests

### DIFF
--- a/packages/services/test/config/config.spec.ts
+++ b/packages/services/test/config/config.spec.ts
@@ -136,14 +136,12 @@ describe('jupyter.services - ConfigWithDefaults', () => {
 
     it('should get a default config value with no class', async () => {
       const defaults: JSONObject = { spam: 'eggs' };
-      const className = 'testclass';
       const section = await configSectionManager.create({
         name: randomName()
       });
       const config = new ConfigWithDefaults({
         section,
-        defaults,
-        className
+        defaults
       });
       const data = config.get('spam');
       expect(data).toBe('eggs');

--- a/packages/services/test/config/config.spec.ts
+++ b/packages/services/test/config/config.spec.ts
@@ -70,7 +70,7 @@ describe('config', () => {
       const config = await configSectionManager.create({
         name: randomName()
       });
-      const data: any = await config.update({ foo: 'baz', spam: 'eggs' });
+      const data: JSONObject = await config.update({ foo: 'baz', spam: 'eggs' });
       expect(data.foo).toBe('baz');
       expect(config.data['foo']).toBe('baz');
       expect(data['spam']).toBe('eggs');

--- a/packages/services/test/config/config.spec.ts
+++ b/packages/services/test/config/config.spec.ts
@@ -40,10 +40,12 @@ describe('config', () => {
     });
 
     it('should accept server settings', async () => {
-      const config = await configSectionManager.create({
+      const serverSettings = getRequestHandler(200, { foo: 'bar' });
+      const manager = new ConfigSectionManager({ serverSettings });
+      const config = await manager.create({
         name: randomName()
       });
-      expect(Object.keys(config.data).length).toBe(0);
+      expect(config.data['foo']).toBe('bar');
     });
 
     it('should fail for an incorrect response', async () => {

--- a/packages/services/test/config/config.spec.ts
+++ b/packages/services/test/config/config.spec.ts
@@ -72,7 +72,10 @@ describe('config', () => {
       const config = await configSectionManager.create({
         name: randomName()
       });
-      const data: JSONObject = await config.update({ foo: 'baz', spam: 'eggs' });
+      const data: JSONObject = await config.update({
+        foo: 'baz',
+        spam: 'eggs'
+      });
       expect(data.foo).toBe('baz');
       expect(config.data['foo']).toBe('baz');
       expect(data['spam']).toBe('eggs');


### PR DESCRIPTION
_This PR applies 3/5 suggestions from code quality [AI findings](https://github.com/jupyterlab/jupyterlab/security/quality/ai-findings). 2 suggestions were skipped to avoid creating conflicts._

* Update server settings test to actually use a mock server settings
* type any -> JSONObject
* Fix test that nominally tests having no class option to test not having a class option