### PR TITLE
docs: add Mermaid diagrams example to notebook guide

### DIFF
--- a/docs/source/user/notebook.md
+++ b/docs/source/user/notebook.md
@@ -28,24 +28,6 @@ visualizations and other rich output:
 :class: jp-screenshot
 ```
 
-## Mermaid Diagrams
-
-JupyterLab supports rendering **Mermaid diagrams** in Markdown cells and
-Markdown documents.
-
-Mermaid is a text-based diagram language that lets you create flowcharts,
-sequence diagrams, and more.
-
-To create a Mermaid diagram, use a fenced code block with the `mermaid`
-language specifier:
-
-```{code-block} mermaid
-graph TD;
-  A[Start] --> B{Decision};
-  B -->|Yes| C[Result 1];
-  B -->|No| D[Result 2];
-
-
 **Jupyter notebooks (.ipynb files) are fully supported in JupyterLab.** The
 [notebook document format](https://nbformat.readthedocs.io/en/latest/) used in
 JupyterLab is the same as in the classic Jupyter Notebook. Your existing notebooks
@@ -294,6 +276,24 @@ Interactive plots, widgets, or plotting with other kernels may require additiona
 **R:**
 
 - [ggplot2](https://ggplot2.tidyverse.org/) - Grammar of graphics for R
+
+## Mermaid Diagrams
+
+JupyterLab supports rendering **Mermaid diagrams** in Markdown cells and
+Markdown documents.
+
+Mermaid is a text-based diagram language that lets you create flowcharts,
+sequence diagrams, and more.
+
+To create a Mermaid diagram, use a fenced code block with the `mermaid`
+language specifier:
+
+```{code-block} mermaid
+graph TD;
+  A[Start] --> B{Decision};
+  B -->|Yes| C[Result 1];
+  B -->|No| D[Result 2];
+```
 
 (paste-code-cells-without-output)=
 

--- a/docs/source/user/notebook.md
+++ b/docs/source/user/notebook.md
@@ -28,6 +28,24 @@ visualizations and other rich output:
 :class: jp-screenshot
 ```
 
+## Mermaid Diagrams
+
+JupyterLab supports rendering **Mermaid diagrams** in Markdown cells and
+Markdown documents.
+
+Mermaid is a text-based diagram language that lets you create flowcharts,
+sequence diagrams, and more.
+
+To create a Mermaid diagram, use a fenced code block with the `mermaid`
+language specifier:
+
+```{code-block} mermaid
+graph TD;
+  A[Start] --> B{Decision};
+  B -->|Yes| C[Result 1];
+  B -->|No| D[Result 2];
+
+
 **Jupyter notebooks (.ipynb files) are fully supported in JupyterLab.** The
 [notebook document format](https://nbformat.readthedocs.io/en/latest/) used in
 JupyterLab is the same as in the classic Jupyter Notebook. Your existing notebooks


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds a short **Mermaid Diagrams** section to the Notebook user guide,
showing that Mermaid diagrams can be rendered inside Markdown cells and Markdown documents.

## Changes

- Added a brief explanation of Mermaid diagram support
- Included a small example code block in `docs/source/user/notebook.md`

## Related Issue

Fixes #15139
