### PR TITLE
Only turn off overflow anchor when windowing is active

### DIFF
--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -932,10 +932,6 @@ export class WindowedList<
     if (options.scrollbar) {
       node.classList.add('jp-mod-virtual-scrollbar');
     }
-    node.classList.toggle(
-      'jp-mod-windowing-active',
-      this.viewModel.windowingActive
-    );
 
     this.viewModel.stateChanged.connect(this.onStateChanged, this);
   }
@@ -1375,7 +1371,7 @@ export class WindowedList<
    * Turn off windowing related styles in the viewport.
    */
   private _applyNoWindowingStyles() {
-    this.node.classList.remove('jp-mod-windowing-active');
+    this._outerElement.style.removeProperty('overflow-anchor');
     this._viewport.style.position = 'relative';
     this._viewport.style.contain = '';
     this._viewport.style.top = '0px';
@@ -1386,7 +1382,7 @@ export class WindowedList<
    * Turn on windowing related styles in the viewport.
    */
   private _applyWindowingStyles() {
-    this.node.classList.add('jp-mod-windowing-active');
+    this._outerElement.style.setProperty('overflow-anchor', 'none');
     this._viewport.style.position = 'absolute';
     this._viewport.style.contain = 'layout';
   }

--- a/packages/ui-components/style/windowedlist.css
+++ b/packages/ui-components/style/windowedlist.css
@@ -9,10 +9,6 @@
   overflow: auto;
 }
 
-.jp-WindowedPanel.jp-mod-windowing-active > .jp-WindowedPanel-outer {
-  overflow-anchor: none;
-}
-
 .jp-WindowedPanel-inner {
   position: relative;
 }


### PR DESCRIPTION
## References

Fixes #18502

## Code changes

Turn off overflow anchoring in a windowed list only when the windowing is actually active. I followed the convention in this code where style settings that change based on windowing are explicitly set, instead of setting a class and using CSS to apply these settings.

GPT-5.3-Codex assisted in this PR

## User-facing changes

With the default contentVisibility windowing mode:

Before:


https://github.com/user-attachments/assets/644f3548-3ea8-4f41-8dad-b79fd3f5d2c8



After:


https://github.com/user-attachments/assets/c962fdc5-1c48-4cde-a0cf-f4e58b1b39ff



## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
