### PR TITLE
Fix flaky completer tokens test

### DIFF
--- a/galata/test/jupyterlab/completer.test.ts
+++ b/galata/test/jupyterlab/completer.test.ts
@@ -141,6 +141,13 @@ test.describe('Completer', () => {
       );
       await expect(editor).toHaveClass(/jp-mod-completer-enabled/);
 
+      // For the token completion specifically we need to wait for CodeMirror
+      // to actually generate the tokens. This corresponds to the editor having
+      // syntax highlighting already painted over.
+      // `int` will have `cm-builtin` class once highlighting was applied.
+      const cell = await page.notebook.getCellLocator(0);
+      await cell!.locator('.cm-builtin').waitFor();
+
       await page.keyboard.press('Tab');
       let completer = page.locator(COMPLETER_SELECTOR);
       await completer.waitFor({ timeout: COMPLETER_TIMEOUT });


### PR DESCRIPTION
## References

- Follow up to #18495 

## Code changes

Wait for syntax highlighting to settle to avoid the test failure for token completion, as seen in the last run on #18495:

[flaky-completer-test.webm](https://github.com/user-attachments/assets/d37c4a2b-ad1f-4495-b8af-e46f1806ada6)

The reason why highlighting was not available is that the kernel has not started up yet (so notebook did not know which language/highlighting mode to use). Other completer tests first run a cell - which ensures kernel is already started, but this one does not.

## User-facing changes

None

## Backwards-incompatible changes

None
