### PR TITLE
Fix code font size not scaling with content-font-size1 override

### DIFF
--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -197,7 +197,7 @@ all of MD as it is not optimized for dense, information rich UIs.
    * Code font variables are used for typography of code and other monospaces content.
    */
 
-  --jp-code-font-size: 13px;
+  --jp-code-font-size: calc(var(--jp-content-font-size1) * 13 / 14);
   --jp-code-line-height: 1.3077; /* 17px for 13px base */
   --jp-code-padding: 5px; /* 5px for 13px base, codemirror highlighting needs integer px value */
   --jp-code-font-family-default: menlo, consolas, 'DejaVu Sans Mono', monospace;

--- a/packages/theme-dark-high-contrast-extension/style/variables.css
+++ b/packages/theme-dark-high-contrast-extension/style/variables.css
@@ -197,7 +197,7 @@ all of MD as it is not optimized for dense, information rich UIs.
    * Code font variables are used for typography of code and other monospaces content.
    */
 
-  --jp-code-font-size: 13px;
+  --jp-code-font-size: calc(var(--jp-content-font-size1) * 13 / 14);
   --jp-code-line-height: 1.3077; /* 17px for 13px base */
   --jp-code-padding: 5px; /* 5px for 13px base, codemirror highlighting needs integer px value */
   --jp-code-font-family-default: menlo, consolas, 'DejaVu Sans Mono', monospace;

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -193,7 +193,7 @@ all of MD as it is not optimized for dense, information rich UIs.
    * Code font variables are used for typography of code and other monospaces content.
    */
 
-  --jp-code-font-size: 13px;
+  --jp-code-font-size: calc(var(--jp-content-font-size1) * 13 / 14);
   --jp-code-line-height: 1.3077; /* 17px for 13px base */
   --jp-code-padding: 5px; /* 5px for 13px base, codemirror highlighting needs integer px value */
   --jp-code-font-family-default: menlo, consolas, 'DejaVu Sans Mono', monospace;


### PR DESCRIPTION
## Summary

- When users set `content-font-size1` in their theme overrides, markdown output font size changes correctly, but code cell output remains at the default `13px`
- This is because code cell output uses `--jp-code-font-size` (default `13px`), which was hardcoded independently of `--jp-content-font-size1`
- This fix derives `--jp-code-font-size` from `--jp-content-font-size1` using CSS `calc()`, preserving the default 13/14 ratio

## How it works

In each of the 3 built-in themes (Light, Dark, Dark High Contrast), the code font size definition changes from a hardcoded value to a `calc()` expression:

```css
/* Before */
--jp-code-font-size: 13px;

/* After */  
--jp-code-font-size: calc(var(--jp-content-font-size1) * 13 / 14);
```

At the default `content-font-size1` of `14px`, this computes to exactly `13px` — **no visual change whatsoever** for any existing theme or user configuration.

When a user overrides `content-font-size1` (e.g., to `18px`), the code font size now automatically scales proportionally (to `~16.7px`), fixing the jarring mismatch where markdown output grew but code output stayed at `13px`.

## Why this is non-breaking

- **Default behavior unchanged**: `calc(14px * 13 / 14)` = `13px`
- **Themes unaffected**: Any theme that explicitly sets `--jp-code-font-size` overrides the `calc()` value
- **Users unaffected**: Users who have set both `content-font-size1` and `code-font-size` in their overrides see no change — their explicit `code-font-size` takes precedence via the ThemeManager's CSS override system

## Test plan

- [ ] Verify that at default settings, code font size is still `13px`
- [ ] Verify that setting `content-font-size1: 18px` causes code font to scale to `~16.7px`
- [ ] Verify that explicitly setting `code-font-size` in overrides takes precedence
- [ ] Verify that third-party themes setting `--jp-code-font-size` are unaffected

Fixes #12178