### PR TITLE
Fix 'should scroll when advancing if top is only marginally visible' test

### DIFF
--- a/galata/test/jupyterlab/notebook-scroll-no-windowing.test.ts
+++ b/galata/test/jupyterlab/notebook-scroll-no-windowing.test.ts
@@ -241,13 +241,23 @@ test.describe('Notebook scroll on execution (no windowing)', () => {
     const notebook = await page.notebook.getNotebookInPanelLocator();
     const thirdCell = await page.notebook.getCellLocator(2);
 
-    await positionCellPartiallyBelowViewport(page, notebook!, thirdCell!, 0.01);
+    // Clear the outputs of the notebook to make sure output does not affect the
+    // cell height and thus the test expectations.
+    await page.evaluate(() => {
+      return window.jupyterapp.commands.execute(
+        'notebook:clear-all-cell-outputs'
+      );
+    });
+
+    await page.notebook.runCell(0);
+
+    await positionCellPartiallyBelowViewport(page, notebook!, thirdCell!, 0.3);
     // Select second cell
     await page.notebook.selectCells(1);
 
-    // The third cell should be positioned at the bottom, revealing between 0 to 2% of its content.
+    // The third cell should be positioned at the bottom, revealing between 0 to 50% of its content.
     await expect(thirdCell!).toBeInViewport({ ratio: 0.0 });
-    await expect(thirdCell!).not.toBeInViewport({ ratio: 0.02 });
+    await expect(thirdCell!).not.toBeInViewport({ ratio: 0.4 });
     // Only a small fraction of notebook viewport should be taken up by that cell
     expect(await notebookViewportRatio(notebook!, thirdCell!)).toBeLessThan(
       0.1
@@ -256,9 +266,8 @@ test.describe('Notebook scroll on execution (no windowing)', () => {
     // Run second cell
     await page.notebook.runCell(1);
 
-    // After running the second cell, the third cell should be revealed, in at least 10%
-    // TODO: this expectation sometimes fails with a viewport ratio 0.009747706353664398
-    await expect(thirdCell!).toBeInViewport({ ratio: 0.1 });
+    // After running the second cell, the third cell should be revealed completely
+    await expect(thirdCell!).toBeInViewport({ ratio: 1 });
 
     // The third cell should now occupy about half of the notebook viewport
     expect(await notebookViewportRatio(notebook!, thirdCell!)).toBeGreaterThan(


### PR DESCRIPTION
## References

Fixes #18468

## Code changes

It seemed that the third cell in this test, the one we are trying to autoscroll, is so big with its output that when we position it using a fraction of itself, it is right on the threshold of being in the viewport enough to prevent scrolling. Our fix here is to delete the output so that our positioning is acting on just the size of the input so we can position it more precisely a little bit into the viewport.

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude Code (Opus 4.6)
