### PR TITLE
Fix debugger icon flickering on during handler initialization

### DIFF
--- a/packages/debugger/src/handler.ts
+++ b/packages/debugger/src/handler.ts
@@ -305,8 +305,8 @@ export class DebuggerHandler implements DebuggerHandler.IHandler {
         this._iconButtons[widget.id] = updateIconButton(
           widget,
           toggleDebugging,
-          this._service.isStarted,
-          enabled
+          enabled,
+          this._service.isStarted
         );
       } else {
         updateIconButtonState(
@@ -357,9 +357,6 @@ export class DebuggerHandler implements DebuggerHandler.IHandler {
       }
     };
 
-    const debuggingEnabled = await this._service.isAvailable(connection);
-    addToolbarButton(debuggingEnabled);
-
     // listen to the disposed signals
     widget.disposed.connect(async () => {
       if (isDebuggerOn()) {
@@ -370,13 +367,23 @@ export class DebuggerHandler implements DebuggerHandler.IHandler {
       delete this._contextKernelChangedHandlers[widget.id];
     });
 
+    const hasKernel = !!connection.kernel;
+    // Delay adding the button until a kernel exists to avoid showing
+    // a transient disabled state during kernel startup.
+    if (!hasKernel && !this._iconButtons[widget.id]) {
+      return;
+    }
+
+    const debuggingEnabled = hasKernel
+      ? await this._service.isAvailable(connection)
+      : false;
+    addToolbarButton(debuggingEnabled);
+
     if (!debuggingEnabled) {
       removeHandlers();
       const debugButton = this._iconButtons[widget.id];
       if (debugButton) {
         updateIconButtonState(debugButton, false, false);
-      } else {
-        console.warn('Debugger button not found');
       }
       return;
     }

--- a/packages/debugger/test/handler.spec.ts
+++ b/packages/debugger/test/handler.spec.ts
@@ -17,13 +17,15 @@ import type { ILabShell } from '@jupyterlab/application';
 import type { Session } from '@jupyterlab/services';
 
 const DEBUGGER_ITEM_NAME = 'debugger-icon';
+type ButtonCapture = {
+  current: ToolbarButton | null;
+  insertedEnabledStates: boolean[];
+};
 
 /**
  * Mock a session widget, capturing the debugger button instance once set.
  */
-function mockSessionWidget(buttonCapture: {
-  current: ToolbarButton | null;
-}): DocumentWidget {
+function mockSessionWidget(buttonCapture: ButtonCapture): DocumentWidget {
   const toolbar = new Toolbar<ToolbarButton>();
   jest
     .spyOn(toolbar, 'insertBefore')
@@ -38,6 +40,7 @@ function mockSessionWidget(buttonCapture: {
     .mockImplementation((name: string, widget: ToolbarButton) => {
       if (name === DEBUGGER_ITEM_NAME) {
         buttonCapture.current = widget;
+        buttonCapture.insertedEnabledStates.push(widget.enabled);
       }
       return true;
     });
@@ -66,13 +69,13 @@ describe('DebuggerHandler', () => {
   describe('#updateWidget', () => {
     // Tests for DebuggerHandler toolbar button state, see #18514 - icon flicker
 
-    let buttonCapture: { current: ToolbarButton | null };
+    let buttonCapture: ButtonCapture;
     let widget: DocumentWidget;
     let connection: Session.ISessionConnection;
     let service: IDebugger;
 
     beforeEach(() => {
-      buttonCapture = { current: null };
+      buttonCapture = { current: null, insertedEnabledStates: [] };
       widget = mockSessionWidget(buttonCapture);
       const kernel = new KernelMock({});
       kernel.requestDebug = jest.fn().mockResolvedValue({});
@@ -92,26 +95,11 @@ describe('DebuggerHandler', () => {
 
       expect(buttonCapture.current).not.toBeNull();
       expect(buttonCapture.current!.enabled).toBe(true);
+      expect(buttonCapture.insertedEnabledStates).toEqual([true]);
     });
 
     it('should add debugger button as disabled when kernel does not support debugging', async () => {
       service = createMockDebugger(false);
-      const noKernelConnection = new SessionConnectionMock({}, null);
-
-      const handler = new Debugger.Handler({
-        type: 'notebook',
-        shell: { currentWidget: widget } as unknown as ILabShell,
-        service
-      });
-
-      await handler.updateWidget(widget, noKernelConnection);
-
-      expect(buttonCapture.current).not.toBeNull();
-      expect(buttonCapture.current!.enabled).toBe(false);
-    });
-
-    it('should resolve isAvailable before showing button (no disabled-then-enabled flicker)', async () => {
-      service = createMockDebugger(true);
 
       const handler = new Debugger.Handler({
         type: 'notebook',
@@ -121,8 +109,36 @@ describe('DebuggerHandler', () => {
 
       await handler.updateWidget(widget, connection);
 
+      expect(buttonCapture.current).not.toBeNull();
+      expect(buttonCapture.current!.enabled).toBe(false);
+      expect(buttonCapture.insertedEnabledStates).toEqual([false]);
+    });
+
+    it('should not add debugger button before a kernel exists', async () => {
+      service = createMockDebugger(true);
+      const noKernelConnection = {
+        ...connection,
+        kernel: null
+      } as Session.ISessionConnection;
+
+      const handler = new Debugger.Handler({
+        type: 'notebook',
+        shell: { currentWidget: widget } as unknown as ILabShell,
+        service
+      });
+
+      await handler.updateWidget(widget, noKernelConnection);
+
+      expect(service.isAvailable).not.toHaveBeenCalled();
+      expect(buttonCapture.current).toBeNull();
+      expect(buttonCapture.insertedEnabledStates).toHaveLength(0);
+
+      await handler.updateWidget(widget, connection);
+
       expect(service.isAvailable).toHaveBeenCalledWith(connection);
+      expect(buttonCapture.current).not.toBeNull();
       expect(buttonCapture.current!.enabled).toBe(true);
+      expect(buttonCapture.insertedEnabledStates).toEqual([true]);
     });
   });
 });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes #18514

The debugger toolbar icon was flickering (briefly disabled then enabled) when the kernel started, which caused flaky visual tests and wasn’t great for accessibility. This PR fixes that behavior.

## Code changes

- **`packages/debugger/src/handler.ts`**: In `updateWidget()`, we now await `isAvailable(connection)` *before* adding or updating the toolbar button. The button is then created with `addToolbarButton(debuggingEnabled)` so it appears once in the correct state instead of disabled then enabled. Added a small guard when updating the button in the “kernel doesn’t support debugging” path so we only call `updateIconButtonState` when the button exists.
- **`packages/debugger/test/handler.spec.ts`**: New tests that the debugger button is enabled when the kernel supports debugging, disabled when it doesn’t, and that `isAvailable` is resolved before the button is shown (no disabled-then-enabled flicker). Uses a mock for `../src/debugger` to avoid circular imports when running the spec in isolation.

## User-facing changes

When you open a notebook and the kernel starts, the debugger (bug) icon in the notebook toolbar no longer flickers. It appears once in the correct state: enabled when the kernel supports debugging, greyed out when it doesn’t. No other behavior or UI changes.

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None.

