### PR TITLE
Add language packs for French and Chinese to binder env

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -57,3 +57,6 @@ dependencies:
   - jsonschema-with-format-nongpl
   - jupyter-collaboration >= 2.0.1
   - jupyter_events >=0.7.0
+  # language packs
+  - jupyterlab-language-pack-fr-fr
+  - jupyterlab-language-pack-zh-cn


### PR DESCRIPTION
## References

This ought to make testing #18530 and similar PRs easier without the need to checkout them locally.

Why these two languages? Because these are the only two with 100% translation coverage as per https://crowdin.com/project/jupyterlab and because they cover different scripts so better to have two than only one.

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

No