### PR TITLE
Update benchmark snapshots even if base snapshots require changes

### DIFF
--- a/galata/package.json
+++ b/galata/package.json
@@ -41,7 +41,7 @@
     "test:doc": "jlpm run test --project documentation",
     "test:doc:update": "jlpm run test --project documentation --update-snapshots",
     "test:report": "playwright show-report",
-    "test:update": "jlpm test:base:update && jlpm test:benchmark:update"
+    "test:update": "jlpm test:base:update ; jlpm test:benchmark:update"
   },
   "dependencies": {
     "@jupyterlab/application": "^4.6.0-alpha.2",


### PR DESCRIPTION
## References

As seen in #18535 the benchmark snapshots were not updated because the base snapshot job exited with status code 1.

## Code changes

Instead of using `&&` use `;`

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

No