### PR TITLE
Do not show banner in console when testing with galata (for now)

### DIFF
--- a/galata/src/galata.ts
+++ b/galata/src/galata.ts
@@ -33,13 +33,6 @@ export namespace galata {
       checkForUpdates: false,
       fetchNews: 'false'
     },
-    '@jupyterlab/console-extension:tracker': {
-      // Do not show IPython banner as it includes variable elements,
-      // see https://github.com/jupyterlab/jupyterlab/issues/18552
-      // once https://github.com/ipython/ipython/pull/15144 is released
-      // we can use SOURCE_DATE_EPOCH env variable instead
-      showBanner: false
-    },
     '@jupyterlab/fileeditor-extension:plugin': {},
     '@jupyterlab/notebook-extension:tracker': {},
     '@jupyterlab/codemirror-extension:plugin': {

--- a/galata/test/documentation/general.test.ts
+++ b/galata/test/documentation/general.test.ts
@@ -15,7 +15,17 @@ import {
 test.use({
   autoGoto: false,
   mockState: galata.DEFAULT_DOCUMENTATION_STATE,
-  viewport: { height: 720, width: 1280 }
+  viewport: { height: 720, width: 1280 },
+  mockSettings: {
+    ...galata.DEFAULT_SETTINGS,
+    '@jupyterlab/console-extension:tracker': {
+      // Do not show IPython banner as it includes variable elements,
+      // see https://github.com/jupyterlab/jupyterlab/issues/18552
+      // once https://github.com/ipython/ipython/pull/15144 is released
+      // we can use SOURCE_DATE_EPOCH env variable instead
+      showBanner: false
+    }
+  }
 });
 
 test.describe('General', () => {


### PR DESCRIPTION
## References

Alleviates #18552 for now

## Code changes

Hide banner in console extension as it varies across IPython versions

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

No
