### PR TITLE
Add missing build step in services browser example README

### DIFF
--- a/packages/services/examples/browser/README.md
+++ b/packages/services/examples/browser/README.md
@@ -8,7 +8,8 @@ The base url of the notebook server is to the HTML template as part of a JSON
 script tag. The script starts a python notebook session and interacts
 with it, printing messages to the browser console.
 
-The example can be installed as `npm install` and run as `python main.py`.
+The example can be installed and built as `npm install && npm run build`, then
+run as `python main.py`.
 
 Notes:
 


### PR DESCRIPTION
## References

Closes #6536

## Code changes

- Updated `packages/services/examples/browser/README.md` to include the missing `npm run build` step before running `python main.py`.

## User-facing changes

- Developers following this example now get complete setup instructions and avoid the missing `bundle.js` error from skipping the build step.

## Backwards-incompatible changes

- None.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Codex (GPT-5)
