### PR TITLE
Add stylelint-declaration-strict-value plugin to enforce CSS variable usage

### DIFF
--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -7,6 +7,7 @@ extends:
 
 plugins:
   - stylelint-csstree-validator
+  - stylelint-declaration-strict-value
 
 rules:
   import-notation: null
@@ -45,3 +46,10 @@ rules:
   # TODO: decrease to 0
   selector-max-universal: 1
   csstree/validator: true
+  # Enforce CSS variables for certain properties (issue #18540)
+  declaration-property-value-allowed-list:
+    - ["^font-family$", ["var\\(--.+\\)"]]
+    - ["^font-size$", ["var\\(--.+\\)"]]
+    - ["^color$", ["var\\(--.+\\)", "^[a-zA-Z]+$"]]
+    - ["^background-color$", ["var\\(--.+\\)", "^[a-zA-Z]+$"]]
+    - ["^border.*$", ["var\\(--.+\\)", "^[0-9]+", "^#[a-fA-F0-9"]]


### PR DESCRIPTION
This adds the stylelint-declaration-strict-value plugin and configures it to enforce using CSS variables for font-family, font-size, color, background-color, and border properties.

Addresses issue #18540