### PR TITLE
Fix status bar focus outlines

### DIFF
--- a/packages/application/style/buttons.css
+++ b/packages/application/style/buttons.css
@@ -22,7 +22,7 @@
 }
 
 .jp-ThemedContainer button:focus-visible {
-  outline: 1px solid var(--jp-accept-color-active, var(--jp-brand-color1));
+  outline: 2px solid var(--accent-fill-focus, var(--jp-brand-color1));
   outline-offset: -1px;
 }
 

--- a/packages/statusbar/style/base.css
+++ b/packages/statusbar/style/base.css
@@ -78,6 +78,11 @@
   flex-direction: row;
 }
 
+.jp-StatusBar-GroupItem:focus-visible {
+  outline: 2px solid var(--accent-fill-focus, var(--jp-brand-color1));
+  outline-offset: -1px;
+}
+
 .jp-Statusbar-ProgressCircle > svg {
   display: block;
   margin: 0 auto;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
- #18584 

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
- Increase the outline width to `2px` for visibility
- Change outline color to `--accent-fill-focus` which is a more accessible color computed by jp-toolkit

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

### Before
![statusbar_before_dark](https://github.com/user-attachments/assets/05e6305e-e174-4f32-b095-9bdd1214c656)

![statusbar_before_light](https://github.com/user-attachments/assets/ab3aa0d7-5bb4-4b0e-a9ef-0f3526c21e47)


### After

![statusbar_after_dark](https://github.com/user-attachments/assets/0aa2bb6c-af23-4441-b377-f91a365557ad)

![statusbar_after_light](https://github.com/user-attachments/assets/f6480ea6-ad9f-4b59-bb9b-f2846acae60a)


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

None

## AI usage

- **NO**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: none
