### PR TITLE
Remove `enableImmutableInstalls` from docs

### DIFF
--- a/docs/source/extension/extension_migration.md
+++ b/docs/source/extension/extension_migration.md
@@ -436,7 +436,6 @@ package configuration.
 - Create a file `.yarnrc.yml` containing:
 
 ```yaml
-enableImmutableInstalls: false
 nodeLinker: node-modules
 ```
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Removed the suggestion to set `enableImmutableInstalls: false` from the migration docs to align with the `.yarnrc.yml` template.

This came up in review of https://github.com/jupyterlab/jupyterlab-plugin-playground/pull/65#discussion_r2873463503 and was implemented in jupyterlab/extension-template#39.
<!-- Describe the code changes and how they address the issue. -->

## AI usage

- **NO**: Some or all of the content of this PR was generated by AI.

