### PR TITLE
Fix `filebrowser:create-new-file` context menu selector

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -513,7 +513,7 @@ const createNewLanguageFilePlugin: JupyterFrontEndPlugin<void> = {
         filebrowsermenuDisposables.add(
           app.contextMenu.addItem({
             command: CommandIDs.createNewFile,
-            selector: '.jp-DirListing',
+            selector: '.jp-DirListing-content',
             args: {
               ext: filetype.extensions[0],
               label: trans.__('New %1 File', filetype.displayName),


### PR DESCRIPTION

## References

Some entries were showing up in the file browser context menu when right clicking on the header bar, while they should only be displayed for the file browser content.

## Code changes

- [x] Fix `filebrowser:create-new-file` context menu selector

## User-facing changes

Right click on the file browser header.

**Before**

<img width="962" height="570" alt="image" src="https://github.com/user-attachments/assets/90b6fb58-1afa-4b4d-a83a-0243a598ca67" />


**After**

<img width="1084" height="550" alt="image" src="https://github.com/user-attachments/assets/a8d55a6a-6dc8-44ca-99fa-9290efb94b76" />


## Backwards-incompatible changes



## AI usage

N/A