### PR TITLE
Harmonize translation wrappers in Python files to use `gettext` methods

### DIFF
--- a/jupyterlab/handlers/announcements.py
+++ b/jupyterlab/handlers/announcements.py
@@ -109,8 +109,8 @@ class CheckForUpdate(CheckForUpdateABC):
             if parse(self.version) < parse(last_version):
                 trans = translator.load("jupyterlab")
                 return (
-                    trans.__(f"A newer version ({last_version}) of JupyterLab is available."),
-                    (trans.__("Read more…"), f"{JUPYTERLAB_RELEASE_URL}{last_version}"),
+                    trans.gettext(f"A newer version ({last_version}) of JupyterLab is available."),
+                    (trans.gettext("Read more…"), f"{JUPYTERLAB_RELEASE_URL}{last_version}"),
                 )
             else:
                 return None


### PR DESCRIPTION
Translation messages using `trans.__ `in Python files are not extracted into the generated .pot file, while messages using `trans.gettext` are. This PR changes all uses of `trans.__` to `trans.gettext`.

## References

See the relevant issue here:

https://github.com/jupyterlab/jupyterlab-translate/issues/36

## Code changes
Changed all uses of `trans.__` to `trans.gettext`. The only file affected is https://github.com/jupyterlab/jupyterlab/blob/main/jupyterlab/handlers/announcements.py

## User-facing changes

Since the extraction of messages from `trans.__` was broken it should now be possible to properly translate the messages in `announcements.py`

## Backwards-incompatible changes

The extraction was broken already so there are no backwards incompatible changes.

## AI usage

- **NO**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: None
