### PR TITLE
Add default labels and behavior documentations for dialog buttons

### DIFF
--- a/docs/source/extension/ui_helpers.md
+++ b/docs/source/extension/ui_helpers.md
@@ -46,6 +46,7 @@ showDialog({
 
 :::{note}
 If no options are specified, the dialog will only contain _OK_ and _Cancel_ buttons.
+:::
 
 ### Dialog Button Helpers and Defaults
 


### PR DESCRIPTION
## Code changes
This adds short documentation about default dialog button behavior so extension authors can rely on consistent labels and avoid setting button text when not needed.

This came up in the review discussion here: https://github.com/jupyterlab/jupyterlab-plugin-playground/pull/82#discussion_r2885684215 


## AI usage

- **NO**: Some or all of the content of this PR was generated by AI.

