### PR TITLE
Fix YAML syntax in stylelint declaration-property-value-allowed-list config

### DIFF
--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -48,8 +48,8 @@ rules:
   csstree/validator: true
   # Enforce CSS variables for certain properties (issue #18540)
   declaration-property-value-allowed-list:
-    font-family: [/^var\\(/]
-    font-size: [/^var\\(/]
-    color: [/^var\\(/, /^[a-zA-Z]+$/]
-    background-color: [/^var\\(/, /^[a-zA-Z]+$/]
-    border: [/^var\\(/]
+    font-family: ['/^var\(/']
+    font-size: ['/^var\(/']
+    color: ['/^var\(/', '/^[a-zA-Z]+$/']
+    background-color: ['/^var\(/', '/^[a-zA-Z]+$/']
+    border: ['/^var\(/']


### PR DESCRIPTION
## Summary
Fixed YAML syntax error in `.stylelintrc.yaml` for the `declaration-property-value-allowed-list` rule.
## Changes
- Changed array syntax from `[/^var\\/]` to `['/^var\(/']` 
- Added single quotes around regex patterns to ensure proper YAML parsing
- Fixed escaping for parentheses in regex patterns (`\(` instead of `\\(`)
