### PR TITLE
Update @lezer/python to fix code folding issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "watch:packages": "python scripts/watch_packages.py"
   },
   "resolutions": {
+    "@lezer/python": "^1.1.18",
     "@types/react": "^18.0.26",
     "lodash": "^4.17.23",
     "lodash-es": "^4.17.23",


### PR DESCRIPTION
Fixes #17859

## Summary
Added `@lezer/python` `^1.1.18` to the root package.json resolutions to pull in fixes for code folding of Python functions with complex type annotations.

The current locked version (1.1.14) has known issues with folding functions like:
```python
def func1(*args: tuple[int]) -> int:
    return 1
```

Newer versions of @lezer/python fix these parsing issues as noted in codemirror/dev#1536.

## Test plan
- Open a notebook with Python functions using subscript type annotations
- Verify code folding works correctly for return type annotations and parameter types