### PR TITLE
Fix cell height heuristic to consider stderr/stdout output types

### DIFF
--- a/packages/notebook/src/windowing.ts
+++ b/packages/notebook/src/windowing.ts
@@ -184,21 +184,24 @@ export class NotebookViewModel extends WindowedListModel {
     const nLines = model.sharedModel.getSource().split('\n').length;
     let outputsLines = 0;
     if (model instanceof CodeCellModel && !model.isDisposed) {
-      const textOutputTypes = [
+      const supportedOutputTypes = [
+        'text/markdown',
+        'text/plain',
         'application/vnd.jupyter.stderr',
         'application/vnd.jupyter.stdout',
-        'text/plain'
+        'text'
       ];
       for (let outputIdx = 0; outputIdx < model.outputs.length; outputIdx++) {
         const output = model.outputs.get(outputIdx);
-        for (const mimeType of textOutputTypes) {
-          const data = output.data[mimeType];
+        const preferredType = supportedOutputTypes.find(
+          mimeType => output.data[mimeType] !== undefined
+        );
+        if (preferredType) {
+          const data = output.data[preferredType];
           if (typeof data === 'string') {
-            outputsLines += data.split('\n').length;
-            break;
+            outputsLines += data.split('\n').filter(l => l.trim() !== '').length;
           } else if (Array.isArray(data)) {
-            outputsLines += data.join('').split('\n').length;
-            break;
+            outputsLines += data.join('').split('\n').filter(l => l.trim() !== '').length;
           }
         }
       }

--- a/packages/notebook/test/modelfactory.spec.ts
+++ b/packages/notebook/test/modelfactory.spec.ts
@@ -128,6 +128,151 @@ describe('@jupyterlab/notebook', () => {
       expect(height).toBe(56); // (1 source_line + 1 output_line) * 17 (line_height) + 22 (cell_margin)
     });
 
+    test('should prefer text/markdown over text/plain for height estimation', () => {
+      const outputObj = [
+        {
+          output_type: 'execute_result',
+          data: {
+            'text/markdown': '# Header\n\nSome paragraph\n\nAnother paragraph',
+            'text/plain': 'short fallback'
+          },
+          execution_count: 1,
+          metadata: {}
+        }
+      ];
+      const sharedModel = createStandaloneCell({
+        cell_type: 'code',
+        execution_count: 1,
+        outputs: outputObj,
+        source: ['display(md)'],
+        metadata: {}
+      }) as YCodeCell;
+
+      const model: ICodeCellModel = new CodeCellModel({ sharedModel });
+      notebook.cells.push({ model } as Cell<ICodeCellModel>);
+
+      const height = notebook.estimateWidgetSize(0);
+      // markdown has 3 non-empty lines: "# Header", "Some paragraph", "Another paragraph"
+      // source has 1 line
+      expect(height).toBe(90); // (1 + 3) * 17 + 22
+    });
+
+    test('should count lines from stdout stream output', () => {
+      const outputObj = [
+        {
+          output_type: 'stream',
+          name: 'stdout',
+          text: 'line 1\nline 2\nline 3\n',
+          data: {
+            'application/vnd.jupyter.stdout': 'line 1\nline 2\nline 3\n'
+          }
+        }
+      ];
+      const sharedModel = createStandaloneCell({
+        cell_type: 'code',
+        execution_count: 1,
+        outputs: outputObj,
+        source: ['print("line 1")\nprint("line 2")\nprint("line 3")'],
+        metadata: {}
+      }) as YCodeCell;
+
+      const model: ICodeCellModel = new CodeCellModel({ sharedModel });
+      notebook.cells.push({ model } as Cell<ICodeCellModel>);
+
+      const height = notebook.estimateWidgetSize(0);
+      // 3 source lines, 3 non-empty output lines
+      expect(height).toBe(124); // (3 + 3) * 17 + 22
+    });
+
+    test('should count lines from stderr stream output', () => {
+      const outputObj = [
+        {
+          output_type: 'stream',
+          name: 'stderr',
+          text: 'Warning: something\nTraceback:\n  File "test.py"\n',
+          data: {
+            'application/vnd.jupyter.stderr':
+              'Warning: something\nTraceback:\n  File "test.py"\n'
+          }
+        }
+      ];
+      const sharedModel = createStandaloneCell({
+        cell_type: 'code',
+        execution_count: 1,
+        outputs: outputObj,
+        source: ['import warnings\nwarnings.warn("something")'],
+        metadata: {}
+      }) as YCodeCell;
+
+      const model: ICodeCellModel = new CodeCellModel({ sharedModel });
+      notebook.cells.push({ model } as Cell<ICodeCellModel>);
+
+      const height = notebook.estimateWidgetSize(0);
+      // 2 source lines, 3 non-empty stderr lines
+      expect(height).toBe(107); // (2 + 3) * 17 + 22
+    });
+
+    test('should handle multiple outputs from different cells', () => {
+      const outputObj = [
+        {
+          output_type: 'stream',
+          name: 'stdout',
+          data: {
+            'application/vnd.jupyter.stdout': 'hello\nworld'
+          }
+        },
+        {
+          output_type: 'execute_result',
+          data: {
+            'text/plain': '42'
+          },
+          execution_count: 1,
+          metadata: {}
+        }
+      ];
+      const sharedModel = createStandaloneCell({
+        cell_type: 'code',
+        execution_count: 1,
+        outputs: outputObj,
+        source: ['print("hello")\nprint("world")\n42'],
+        metadata: {}
+      }) as YCodeCell;
+
+      const model: ICodeCellModel = new CodeCellModel({ sharedModel });
+      notebook.cells.push({ model } as Cell<ICodeCellModel>);
+
+      const height = notebook.estimateWidgetSize(0);
+      // 3 source lines, 2 stdout lines + 1 text/plain line = 3 output lines
+      expect(height).toBe(124); // (3 + 3) * 17 + 22
+    });
+
+    test('should skip empty lines in output for height estimation', () => {
+      const outputObj = [
+        {
+          output_type: 'execute_result',
+          data: {
+            'text/plain': 'line1\n\n\nline2\n\n'
+          },
+          execution_count: 1,
+          metadata: {}
+        }
+      ];
+      const sharedModel = createStandaloneCell({
+        cell_type: 'code',
+        execution_count: 1,
+        outputs: outputObj,
+        source: ['x'],
+        metadata: {}
+      }) as YCodeCell;
+
+      const model: ICodeCellModel = new CodeCellModel({ sharedModel });
+      notebook.cells.push({ model } as Cell<ICodeCellModel>);
+
+      const height = notebook.estimateWidgetSize(0);
+      // 1 source line, 2 non-empty output lines ("line1", "line2")
+      expect(height).toBe(73); // (1 + 2) * 17 + 22
+    });
+
     test('should calculate height based on number of lines in source and output (string[] output)', () => {
       const outputObj = [
         {
@@ -157,7 +302,7 @@ describe('@jupyterlab/notebook', () => {
       notebook.cells.push({ model } as Cell<ICodeCellModel>);
 
       const height = notebook.estimateWidgetSize(0);
-      expect(height).toBe(124); // (2 source_line + 4 output_line) * 17 (line_height) + 22 (cell_margin)
+      expect(height).toBe(107); // (2 source_lines + 3 non-empty output_lines) * 17 (line_height) + 22 (cell_margin)
     });
   });
 });


### PR DESCRIPTION
## References

Closes #16636

Builds on the approach from #16706 by @doshi-kevin.

## Code changes

- Expanded supported output types in cell height estimation to include `text/markdown`, `text`, alongside existing `text/plain`, `application/vnd.jupyter.stderr`, and `application/vnd.jupyter.stdout`
- Use preferred type selection via `.find()` to pick the best available mime type per output
- Filter out empty lines when counting output lines for more accurate height estimates
- Added tests covering markdown outputs, stdout/stderr streams, multiple outputs per cell, and empty line filtering

## User-facing changes

Cells with markdown or stream outputs get better initial height estimates when using windowed rendering, reducing visual jumps during scrolling.

## Backwards-incompatible changes

None

## AI usage

- **NO**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code
- AI tools and models used: N/A
