### PR TITLE
Upload standalone playwright report for instant preview

### DIFF
--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -153,8 +153,14 @@ jobs:
         run: |
           npx playwright merge-reports --reporter html,github ./artifacts/
 
+      - name: Upload merged reports
+        uses: actions/upload-artifact@v6
+        with:
+          name: visual-regression-report
+          path: playwright-report
+
       - name: Inline the report
-        uses: krassowski/maintainer-tools/.github/actions/inline-playwright-report@2c7237e8251543baf60ddf9667719b5f7230c717
+        uses: jupyterlab/maintainer-tools/.github/actions/inline-playwright-report@v1
         with:
           path: playwright-report
 
@@ -169,12 +175,6 @@ jobs:
       - name: Add report link to job summary
         run: |
           echo "**[View Visual Regression Report](${{ steps.upload-report.outputs.artifact-url }})**" >> $GITHUB_STEP_SUMMARY
-
-      - name: Upload merged reports
-        uses: actions/upload-artifact@v6
-        with:
-          name: visual-regression-report
-          path: playwright-report
 
       - name: Check for test assets
         id: check-assets


### PR DESCRIPTION
## References

- Depends on https://github.com/jupyterlab/maintainer-tools/pull/279
- Closes #15416 
- Related to:
   - #10968
   - #17831

## Code changes

None

## Developer-facing changes

New "View Visual Regression Report" link on summary page, [example](https://github.com/jupyterlab/jupyterlab/actions/runs/23003871025/artifacts/5891374718).

<img width="1383" height="798" alt="image" src="https://github.com/user-attachments/assets/259c3677-80f3-4bca-b0b1-84e399c265e8" />

With working screenshots _and_ videos (capped at 200 MB in case if lots of things fail):

<img width="1135" height="991" alt="image" src="https://github.com/user-attachments/assets/42f86ca8-3180-4041-8239-55bae6971037" />


## Backwards-incompatible changes

None

## AI usage

- **No/Yes**: Some or all of the content of this PR was generated by AI (none in this PR yes in maintainer-tools PR)
- **Yes**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Codex 5.3