### PR TITLE
Merge documentation job into the sharded galata job

### DIFF
--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -44,14 +44,12 @@ jobs:
           - browser: chromium
             project: documentation
             suite: documentation
-            python-version: '3.10.6'
             shard: 1
             shards: 2
             optional_dependencies: "docs-screenshots"
           - browser: chromium
             project: documentation
             suite: documentation
-            python-version: '3.10.6'
             shard: 2
             shards: 2
             optional_dependencies: "docs-screenshots"
@@ -104,6 +102,7 @@ jobs:
         working-directory: core
 
       - name: Install ipykernel pre-release that supports subshells (TEMPORARY)
+        if: ${{ matrix.project != 'documentation' }}
         run: |
           pip install --upgrade --pre "ipykernel<=7.0.0a1"
         working-directory: core


### PR DESCRIPTION
## References

- https://github.com/jupyterlab/jupyterlab/pull/18427 introduced sharding but did not pull documentation UI test job under it as it was already fast enough and quite different from others
- https://github.com/jupyterlab/jupyterlab/pull/18559 started depending on the sharded job output for new snapshot updates workflow; together it means that it does not support updating docs snapshots until these jobs are reconciled (as recently seen in https://github.com/jupyterlab/jupyterlab/pull/18619#issuecomment-4040705424)
- https://github.com/jupyterlab/jupyterlab/pull/18568 made the documentation workflow a little bit less special by no longer having a dedicated font installation step making merging a bit easier

## Code changes

Merge `Visual Regression Documentation` job into `Integration Tests` job as just another project.

## Developer-facing changes

- Only one report to download
- The new snapshot update workflow should pick up docs snapshot updates now
- The UI documentation tests now run twice as fast thanks to sharding

| Before | After |
|--|--|
|<img width="392" height="396" alt="image" src="https://github.com/user-attachments/assets/7b876397-5b5e-4946-aec2-ea8e20382165" /> | <img width="392" height="295" alt="image" src="https://github.com/user-attachments/assets/ddf1304d-5741-4495-aac5-4a4f982f23ad" /> |


## Backwards-incompatible changes

None

## AI usage

- Y: Some or all of the content of this PR was generated by AI.
- Y: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Copilot GPT-5.3-Codex no one likes writing yaml by hand
