### PR TITLE
Show `git status` on CI when integrity check fails

### DIFF
--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -78,6 +78,7 @@ if [[ $GROUP == integrity ]]; then
     # output of `yarn-berry-deduplicate`
     jlpm install
     if [[ "$(git status --porcelain | wc -l | sed -e "s/^[[:space:]]*//" -e "s/[[:space:]]*$//")" != "0" ]]; then
+        git status
         git diff
         exit 1
     fi


### PR DESCRIPTION

## References

The integrity job started failing due to `git status` returning some unexpected output.

However, the CI only shows `git diff` which is empty if untracked files were added so it's hard to understand what's happening.

## Code changes

Add `git status` to show unexpectedly created files

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

No
