### PR TITLE
Add tests for single-click navigation in filebrowser

### DIFF
--- a/packages/filebrowser/test/listing.spec.ts
+++ b/packages/filebrowser/test/listing.spec.ts
@@ -1094,8 +1094,12 @@ describe('filebrowser/listing', () => {
       it('should navigate to directory on single click', async () => {
         dirListing.setAllowSingleClickNavigation(true);
 
+        const directoryOpened = jest.fn();
+        dirListing.onItemOpened.connect(directoryOpened);
+
         simulate(directoryNode, 'click');
         await signalToPromise(dirListing.updated);
+        expect(directoryOpened).toHaveBeenCalled();
         expect(getItemTitles(dirListing)).toHaveLength(0);
       });
 
@@ -1108,11 +1112,11 @@ describe('filebrowser/listing', () => {
         simulate(fileNode!, 'click');
         expect(fileOpened).not.toHaveBeenCalled();
 
+        const directoryOpened = jest.fn();
+        dirListing.onItemOpened.connect(directoryOpened);
+
         simulate(directoryNode!, 'click');
-        await Promise.race([
-          signalToPromise(dirListing.updated),
-          new Promise(r => setTimeout(r, 100))
-        ]);
+        expect(directoryOpened).not.toHaveBeenCalled();
         expect(getItemTitles(dirListing)).toHaveLength(5);
 
         dirListing.onItemOpened.disconnect(fileOpened);
@@ -1129,8 +1133,12 @@ describe('filebrowser/listing', () => {
         const openedFile = fileOpened.mock.calls[0][1];
         expect(openedFile.type).toBe('file');
 
+        const directoryOpened = jest.fn();
+        dirListing.onItemOpened.connect(directoryOpened);
+
         simulate(directoryNode!, 'dblclick');
         await signalToPromise(dirListing.updated);
+        expect(directoryOpened).toHaveBeenCalled();
         expect(getItemTitles(dirListing)).toHaveLength(0);
 
         dirListing.onItemOpened.disconnect(fileOpened);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Addresses #16640, with file browser tests ensuring that single click navigation enabled opens files, navigates to directories while allowing users to check items with checkboxes. Also tests that when disabled, single click does not open files/navigate to directories, while double click continues to behave as expected.

## Code changes

<!-- Describe the code changes and how they address the issue. -->
None

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->
None

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None

## AI usage

- **<!-- NO -->**: Some or all of the content of this PR was generated by AI.
- **<!-- NO -->**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: N/A
