### PR TITLE
Fix file browser root initialization

### DIFF
--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -63,9 +63,10 @@ export class FileBrowserModel implements IDisposable {
     this._driveName = options.driveName || '';
     this._root = options.root || '';
     this._allowFileUploads = options.allowFileUploads ?? true;
+    const initialPath = this._root || this.rootPath;
     this._model = {
-      path: this.rootPath,
-      name: PathExt.basename(this.rootPath),
+      path: initialPath,
+      name: PathExt.basename(initialPath),
       type: 'directory',
       content: undefined,
       writable: false,

--- a/packages/filebrowser/test/model.spec.ts
+++ b/packages/filebrowser/test/model.spec.ts
@@ -232,6 +232,15 @@ describe('filebrowser/model', () => {
         restrictedModel.dispose();
       });
 
+      it('should initialize path to the root when set', () => {
+        const restrictedModel = new FileBrowserModel({
+          manager,
+          root: subDir
+        });
+        expect(restrictedModel.path).toBe(subDir);
+        restrictedModel.dispose();
+      });
+
       it('should block navigation outside the root', async () => {
         const restrictedModel = new FileBrowserModel({
           manager,

--- a/packages/filebrowser/test/openfiledialog.spec.ts
+++ b/packages/filebrowser/test/openfiledialog.spec.ts
@@ -279,6 +279,22 @@ describe('@jupyterlab/filebrowser', () => {
       expect(items[0].path).toBe('');
     });
 
+    it('should return the root path if nothing is selected and root is set', async () => {
+      const dialog = FileDialog.getOpenFiles({
+        manager,
+        root: testDirectory
+      });
+
+      await acceptDialog();
+
+      const result = await dialog;
+      const items = result.value!;
+
+      expect(items.length).toBe(1);
+      expect(items[0].type).toBe('directory');
+      expect(items[0].path).toBe(testDirectory);
+    });
+
     it('should return one selected file whose path matches default path', async () => {
       const node = document.createElement('div');
 
@@ -327,6 +343,25 @@ describe('@jupyterlab/filebrowser', () => {
       expect(fileDirectory).toEqual(testDirectory);
 
       document.body.removeChild(node);
+    });
+
+    it('should fall back to the root when defaultPath is outside the root', async () => {
+      const dialog = FileDialog.getOpenFiles({
+        manager,
+        root: testDirectory,
+        defaultPath: '',
+        filter: (value: Contents.IModel) =>
+          value.type === 'notebook' ? {} : null
+      });
+
+      await acceptDialog();
+
+      const result = await dialog;
+      const items = result.value!;
+
+      expect(items.length).toBe(1);
+      expect(items[0].type).toBe('directory');
+      expect(items[0].path).toBe(testDirectory);
     });
   });
 


### PR DESCRIPTION
## Summary
- initialize root-restricted file browser models at the configured root path
- add a regression test for the restricted model initial path
- cover open file dialog fallbacks when selection is empty or defaultPath is outside the root

## Testing
- not run (this workspace does not have JS dependencies installed)
