### PR TITLE
Update default font family to honor macOS system-wide ui-monospace

### DIFF
--- a/packages/terminal-extension/schema/plugin.json
+++ b/packages/terminal-extension/schema/plugin.json
@@ -58,7 +58,7 @@
       "title": "Font family",
       "description": "The font family used to render text.",
       "$ref": "#/definitions/fontFamily",
-      "default": "monospace"
+      "default": "ui-monospace, monospace"
     },
     "fontSize": {
       "title": "Font size",


### PR DESCRIPTION
Safari font customisation is not easily available in the Safari's settings. You can however configure a system-wide ui-monospace font in System Settings for macOS applications.

It seems Safari is also the only browser that has the ui-monospace font-family so it seems pretty safe to enable it here as the default with a fallback to the browser's monospace font-family for other browsers/OSs.

https://caniuse.com/mdn-css_properties_font-family_ui-monospace

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

https://github.com/jupyterlab/jupyterlab/issues/1317
https://github.com/jupyterlab/jupyterlab/pull/1377
https://github.com/jupyterlab/jupyterlab/pull/5732

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Default font for Terminals is now set as:

```css
font-family: "ui-monospace, monospace"
```

It only affects Safari/macOS since ui-monospace is only available there and keeps the existing behaviour for all other browser combinations.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

## AI usage

NO
