### PR TITLE
Add documentation for collapsing cells showing first line

### DIFF
--- a/docs/source/user/notebook.md
+++ b/docs/source/user/notebook.md
@@ -124,7 +124,7 @@ collapser button on left of each cell:
    <iframe src="https://www.youtube-nocookie.com/embed/WgiX3ZRaTiY?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </div>
 ```
-
+Additionally, JupyterLab allows collapsing cells while still displaying the first line of the cell. This helps users quickly identify the content of a cell without expanding it fully, improving readability when working with long notebooks.
 (enable-scrolling)=
 
 Enable scrolling for long outputs by right-clicking on a cell and


### PR DESCRIPTION
Added explanation about collapsing cells while displaying the first line to improve readability.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->


