### PR TITLE
Video and Audio Content Providers: Fix JupyterLite support

### DIFF
--- a/packages/audio-extension/src/index.ts
+++ b/packages/audio-extension/src/index.ts
@@ -248,7 +248,10 @@ class AudioContentProvider implements IContentProvider {
     localPath: string,
     options: Partial<Contents.IModel> & Contents.IContentProvisionOptions = {}
   ): Promise<Contents.IModel> {
-    return this._drive.save(localPath, options);
+    return this._drive.save(localPath, {
+      ...options,
+      contentProviderId: undefined
+    });
   }
 
   private _drive: Contents.IDrive;

--- a/packages/audio-extension/src/index.ts
+++ b/packages/audio-extension/src/index.ts
@@ -18,8 +18,8 @@ import type {
   IDocumentWidget
 } from '@jupyterlab/docregistry';
 import { ABCWidgetFactory, DocumentWidget } from '@jupyterlab/docregistry';
-import type { Contents } from '@jupyterlab/services';
-import { IDefaultDrive, RestContentProvider } from '@jupyterlab/services';
+import type { Contents, IContentProvider } from '@jupyterlab/services';
+import { IDefaultDrive } from '@jupyterlab/services';
 import { ITranslator } from '@jupyterlab/translation';
 import { Widget } from '@lumino/widgets';
 
@@ -212,16 +212,16 @@ export namespace AudioViewerFactory {
  *
  * This overrides the default behavior of the RestContentProvider to not include the file content.
  */
-class AudioContentProvider extends RestContentProvider {
-  constructor(options: RestContentProvider.IOptions) {
-    super(options);
+class AudioContentProvider implements IContentProvider {
+  constructor(options: { drive: Contents.IDrive }) {
+    this._drive = options.drive;
   }
 
   /**
    * Get a file or directory.
    *
    * @param localPath - The path to the file.
-   * @param options - The options used to fetch the file.
+   * @param options - The options used to get the file.
    *
    * @returns A promise which resolves with the file content.
    */
@@ -229,8 +229,29 @@ class AudioContentProvider extends RestContentProvider {
     localPath: string,
     options?: Contents.IFetchOptions
   ): Promise<Contents.IModel> {
-    return super.get(localPath, { ...options, content: false });
+    return this._drive.get(localPath, {
+      ...options,
+      contentProviderId: undefined,
+      content: false
+    });
   }
+
+  /**
+   * Save a file.
+   *
+   * @param localPath - The path to the file.
+   * @param options - The options used to save the file.
+   *
+   * @returns A promise which resolves with the file content.
+   */
+  async save(
+    localPath: string,
+    options: Partial<Contents.IModel> & Contents.IContentProvisionOptions = {}
+  ): Promise<Contents.IModel> {
+    return this._drive.save(localPath, options);
+  }
+
+  private _drive: Contents.IDrive;
 }
 
 /**
@@ -250,7 +271,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
   ): void => {
     const trans = translator.load('jupyterlab');
 
-    const { contents, serverSettings } = app.serviceManager;
+    const { contents } = app.serviceManager;
 
     // Get audio file types from the document registry
     const audioFileTypes = getAudioFileTypes(app.docRegistry);
@@ -259,8 +280,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     const registry = defaultDrive.contentProviderRegistry;
     if (registry) {
       const audioContentProvider = new AudioContentProvider({
-        apiEndpoint: '/api/contents',
-        serverSettings
+        drive: defaultDrive
       });
       registry.register(AUDIO_CONTENT_PROVIDER_ID, audioContentProvider);
     }

--- a/packages/video-extension/src/index.ts
+++ b/packages/video-extension/src/index.ts
@@ -245,7 +245,10 @@ class VideoContentProvider implements IContentProvider {
     localPath: string,
     options: Partial<Contents.IModel> & Contents.IContentProvisionOptions = {}
   ): Promise<Contents.IModel> {
-    return this._drive.save(localPath, options);
+    return this._drive.save(localPath, {
+      ...options,
+      contentProviderId: undefined
+    });
   }
 
   private _drive: Contents.IDrive;

--- a/packages/video-extension/src/index.ts
+++ b/packages/video-extension/src/index.ts
@@ -18,8 +18,8 @@ import type {
   IDocumentWidget
 } from '@jupyterlab/docregistry';
 import { ABCWidgetFactory, DocumentWidget } from '@jupyterlab/docregistry';
-import type { Contents } from '@jupyterlab/services';
-import { IDefaultDrive, IContentProvider } from '@jupyterlab/services';
+import type { Contents, IContentProvider } from '@jupyterlab/services';
+import { IDefaultDrive } from '@jupyterlab/services';
 import { ITranslator } from '@jupyterlab/translation';
 import { Widget } from '@lumino/widgets';
 

--- a/packages/video-extension/src/index.ts
+++ b/packages/video-extension/src/index.ts
@@ -19,7 +19,7 @@ import type {
 } from '@jupyterlab/docregistry';
 import { ABCWidgetFactory, DocumentWidget } from '@jupyterlab/docregistry';
 import type { Contents } from '@jupyterlab/services';
-import { IDefaultDrive, RestContentProvider } from '@jupyterlab/services';
+import { IDefaultDrive, IContentProvider } from '@jupyterlab/services';
 import { ITranslator } from '@jupyterlab/translation';
 import { Widget } from '@lumino/widgets';
 
@@ -209,16 +209,16 @@ export namespace VideoViewerFactory {
  *
  * This overrides the default behavior of the RestContentProvider to not include the file content.
  */
-class VideoContentProvider extends RestContentProvider {
-  constructor(options: RestContentProvider.IOptions) {
-    super(options);
+class VideoContentProvider implements IContentProvider {
+  constructor(options: { drive: Contents.IDrive }) {
+    this._drive = options.drive;
   }
 
   /**
    * Get a file or directory.
    *
    * @param localPath - The path to the file.
-   * @param options - The options used to fetch the file.
+   * @param options - The options used to get the file.
    *
    * @returns A promise which resolves with the file content.
    */
@@ -226,8 +226,29 @@ class VideoContentProvider extends RestContentProvider {
     localPath: string,
     options?: Contents.IFetchOptions
   ): Promise<Contents.IModel> {
-    return super.get(localPath, { ...options, content: false });
+    return this._drive.get(localPath, {
+      ...options,
+      contentProviderId: undefined,
+      content: false
+    });
   }
+
+  /**
+   * Save a file.
+   *
+   * @param localPath - The path to the file.
+   * @param options - The options used to save the file.
+   *
+   * @returns A promise which resolves with the file content.
+   */
+  async save(
+    localPath: string,
+    options: Partial<Contents.IModel> & Contents.IContentProvisionOptions = {}
+  ): Promise<Contents.IModel> {
+    return this._drive.save(localPath, options);
+  }
+
+  private _drive: Contents.IDrive;
 }
 
 /**
@@ -246,7 +267,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     restorer: ILayoutRestorer | null
   ): void => {
     const trans = translator.load('jupyterlab');
-    const { contents, serverSettings } = app.serviceManager;
+    const { contents } = app.serviceManager;
 
     // Get video file types from the document registry
     const videoFileTypes = getVideoFileTypes(app.docRegistry);
@@ -255,8 +276,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     const registry = defaultDrive.contentProviderRegistry;
     if (registry) {
       const videoContentProvider = new VideoContentProvider({
-        apiEndpoint: '/api/contents',
-        serverSettings
+        drive: defaultDrive
       });
       registry.register(VIDEO_CONTENT_PROVIDER_ID, videoContentProvider);
     }


### PR DESCRIPTION
## References

This PR is similar to https://github.com/jupyterlab/jupyter-collaboration/pull/525

## Code changes

Do not rely anymore on the JupyterLab's specific `RestContentProvider`. 

## User-facing changes

This brings back support for opening video and audio files in JupyterLite.

## Backwards-incompatible changes

None