### PR TITLE
Update React to version `18.3.1`

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -146,8 +146,8 @@
     "@lumino/widgets": "^2.3.1-alpha.1",
     "@microsoft/fast-element": "^1.12.0",
     "@microsoft/fast-foundation": "^2.49.2",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "yjs": "^13.5.40"
   },
   "dependencies": {

--- a/examples/app/package.json
+++ b/examples/app/package.json
@@ -40,8 +40,8 @@
     "@jupyterlab/translation": "^4.6.0-alpha.4",
     "@jupyterlab/translation-extension": "^4.6.0-alpha.4",
     "@jupyterlab/ui-components-extension": "^4.6.0-alpha.4",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@rspack/cli": "^1.7.8",

--- a/examples/federated/core_package/package.json
+++ b/examples/federated/core_package/package.json
@@ -91,8 +91,8 @@
     "@lumino/signaling": "^2.0.0",
     "@lumino/virtualdom": "^2.0.0",
     "@lumino/widgets": "^2.3.1-alpha.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "yjs": "^13.5.40"
   },
   "dependencies": {

--- a/jupyterlab/staging/package.json
+++ b/jupyterlab/staging/package.json
@@ -146,8 +146,8 @@
     "@lumino/widgets": "^2.3.1-alpha.1",
     "@microsoft/fast-element": "^1.12.0",
     "@microsoft/fast-foundation": "^2.49.2",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "yjs": "^13.5.40"
   },
   "dependencies": {

--- a/jupyterlab/staging/package.json
+++ b/jupyterlab/staging/package.json
@@ -146,8 +146,8 @@
     "@lumino/widgets": "^2.3.1-alpha.1",
     "@microsoft/fast-element": "^1.12.0",
     "@microsoft/fast-foundation": "^2.49.2",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "yjs": "^13.5.40"
   },
   "dependencies": {

--- a/jupyterlab/staging/yarn.lock
+++ b/jupyterlab/staging/yarn.lock
@@ -10586,15 +10586,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^18.3.1":
-  version: 18.3.1
-  resolution: "react-dom@npm:18.3.1"
+"react-dom@npm:^18.2.0":
+  version: 18.2.0
+  resolution: "react-dom@npm:18.2.0"
   dependencies:
     loose-envify: ^1.1.0
-    scheduler: ^0.23.2
+    scheduler: ^0.23.0
   peerDependencies:
-    react: ^18.3.1
-  checksum: 298954ecd8f78288dcaece05e88b570014d8f6dce5db6f66e6ee91448debeb59dcd31561dddb354eee47e6c1bb234669459060deb238ed0213497146e555a0b9
+    react: ^18.2.0
+  checksum: 7d323310bea3a91be2965f9468d552f201b1c27891e45ddc2d6b8f717680c95a75ae0bc1e3f5cf41472446a2589a75aed4483aee8169287909fcd59ad149e8cc
   languageName: node
   linkType: hard
 
@@ -10662,12 +10662,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^18.3.1":
-  version: 18.3.1
-  resolution: "react@npm:18.3.1"
+"react@npm:^18.2.0":
+  version: 18.2.0
+  resolution: "react@npm:18.2.0"
   dependencies:
     loose-envify: ^1.1.0
-  checksum: a27bcfa8ff7c15a1e50244ad0d0c1cb2ad4375eeffefd266a64889beea6f6b64c4966c9b37d14ee32d6c9fcd5aa6ba183b6988167ab4d127d13e7cb5b386a376
+  checksum: 88e38092da8839b830cda6feef2e8505dec8ace60579e46aa5490fc3dc9bba0bd50336507dc166f43e3afc1c42939c09fe33b25fae889d6f402721dcd78fca1b
   languageName: node
   linkType: hard
 
@@ -10994,12 +10994,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.23.2":
-  version: 0.23.2
-  resolution: "scheduler@npm:0.23.2"
+"scheduler@npm:^0.23.0":
+  version: 0.23.0
+  resolution: "scheduler@npm:0.23.0"
   dependencies:
     loose-envify: ^1.1.0
-  checksum: 3e82d1f419e240ef6219d794ff29c7ee415fbdc19e038f680a10c067108e06284f1847450a210b29bbaf97b9d8a97ced5f624c31c681248ac84c80d56ad5a2c4
+  checksum: d79192eeaa12abef860c195ea45d37cbf2bbf5f66e3c4dcd16f54a7da53b17788a70d109ee3d3dde1a0fd50e6a8fc171f4300356c5aee4fc0171de526bf35f8a
   languageName: node
   linkType: hard
 

--- a/jupyterlab/staging/yarn.lock
+++ b/jupyterlab/staging/yarn.lock
@@ -10586,15 +10586,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^18.2.0":
-  version: 18.2.0
-  resolution: "react-dom@npm:18.2.0"
+"react-dom@npm:^18.3.1":
+  version: 18.3.1
+  resolution: "react-dom@npm:18.3.1"
   dependencies:
     loose-envify: ^1.1.0
-    scheduler: ^0.23.0
+    scheduler: ^0.23.2
   peerDependencies:
-    react: ^18.2.0
-  checksum: 7d323310bea3a91be2965f9468d552f201b1c27891e45ddc2d6b8f717680c95a75ae0bc1e3f5cf41472446a2589a75aed4483aee8169287909fcd59ad149e8cc
+    react: ^18.3.1
+  checksum: 298954ecd8f78288dcaece05e88b570014d8f6dce5db6f66e6ee91448debeb59dcd31561dddb354eee47e6c1bb234669459060deb238ed0213497146e555a0b9
   languageName: node
   linkType: hard
 
@@ -10662,12 +10662,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^18.2.0":
-  version: 18.2.0
-  resolution: "react@npm:18.2.0"
+"react@npm:^18.3.1":
+  version: 18.3.1
+  resolution: "react@npm:18.3.1"
   dependencies:
     loose-envify: ^1.1.0
-  checksum: 88e38092da8839b830cda6feef2e8505dec8ace60579e46aa5490fc3dc9bba0bd50336507dc166f43e3afc1c42939c09fe33b25fae889d6f402721dcd78fca1b
+  checksum: a27bcfa8ff7c15a1e50244ad0d0c1cb2ad4375eeffefd266a64889beea6f6b64c4966c9b37d14ee32d6c9fcd5aa6ba183b6988167ab4d127d13e7cb5b386a376
   languageName: node
   linkType: hard
 
@@ -10994,12 +10994,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.23.0":
-  version: 0.23.0
-  resolution: "scheduler@npm:0.23.0"
+"scheduler@npm:^0.23.2":
+  version: 0.23.2
+  resolution: "scheduler@npm:0.23.2"
   dependencies:
     loose-envify: ^1.1.0
-  checksum: d79192eeaa12abef860c195ea45d37cbf2bbf5f66e3c4dcd16f54a7da53b17788a70d109ee3d3dde1a0fd50e6a8fc171f4300356c5aee4fc0171de526bf35f8a
+  checksum: 3e82d1f419e240ef6219d794ff29c7ee415fbdc19e038f680a10c067108e06284f1847450a210b29bbaf97b9d8a97ced5f624c31c681248ac84c80d56ad5a2c4
   languageName: node
   linkType: hard
 

--- a/package.json
+++ b/package.json
@@ -106,12 +106,12 @@
     "watch:packages": "python scripts/watch_packages.py"
   },
   "resolutions": {
-    "@types/react": "^18.0.26",
+    "@types/react": "^18.3.12",
     "lodash": "^4.17.23",
     "lodash-es": "^4.17.23",
     "marked": "^17.0.4",
     "prettier": "^3.8.1",
-    "react": "^18.2.0",
+    "react": "^18.3.1",
     "type-fest": "^4.30.0",
     "yjs": "^13.5.40"
   },

--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -51,7 +51,7 @@
     "@lumino/coreutils": "^2.2.2",
     "@lumino/disposable": "^2.1.5",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "rimraf": "~5.0.5",

--- a/packages/apputils-extension/package.json
+++ b/packages/apputils-extension/package.json
@@ -62,8 +62,8 @@
     "@lumino/domutils": "^2.0.4",
     "@lumino/polling": "^2.1.5",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "react-toastify": "^9.0.8"
   },
   "devDependencies": {

--- a/packages/apputils-extension/src/notificationplugin.tsx
+++ b/packages/apputils-extension/src/notificationplugin.tsx
@@ -106,7 +106,9 @@ interface INotificationCenterProps {
 /**
  * Notification center view
  */
-function NotificationCenter(props: INotificationCenterProps): JSX.Element {
+function NotificationCenter(
+  props: INotificationCenterProps
+): React.JSX.Element {
   const { manager, onClose, trans } = props;
 
   // Markdown parsed notifications
@@ -333,7 +335,9 @@ interface INotificationStatusProps {
 /**
  * Status view
  */
-function NotificationStatus(props: INotificationStatusProps): JSX.Element {
+function NotificationStatus(
+  props: INotificationStatusProps
+): React.JSX.Element {
   return (
     <GroupItem
       role="button"

--- a/packages/apputils-extension/src/shortcuts.tsx
+++ b/packages/apputils-extension/src/shortcuts.tsx
@@ -60,10 +60,10 @@ export function displayShortcuts(options: IOptions) {
    * `data-p-suppress-shortcuts` attributes are found.
    */
 
-  function formatKeys(keys: string[]): JSX.Element {
-    const topContainer: JSX.Element[] = [];
+  function formatKeys(keys: string[]): React.JSX.Element {
+    const topContainer: React.JSX.Element[] = [];
     keys.forEach((key, index) => {
-      const container: JSX.Element[] = [];
+      const container: React.JSX.Element[] = [];
       key.split(' ').forEach((ch, chIndex) => {
         container.push(
           <span className={SHORTCUT_KEY_CLASS} key={`ch-${chIndex}`}>

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -62,8 +62,8 @@
     "@lumino/signaling": "^2.1.5",
     "@lumino/virtualdom": "^2.0.4",
     "@lumino/widgets": "^2.7.5",
-    "@types/react": "^18.0.26",
-    "react": "^18.2.0",
+    "@types/react": "^18.3.12",
+    "react": "^18.3.1",
     "sanitize-html": "~2.12.1"
   },
   "devDependencies": {

--- a/packages/apputils/src/kernelstatuses.tsx
+++ b/packages/apputils/src/kernelstatuses.tsx
@@ -127,7 +127,7 @@ export class KernelStatus extends VDomRenderer<KernelStatus.Model> {
   /**
    * Render the kernel status item.
    */
-  render(): JSX.Element | null {
+  render(): React.JSX.Element | null {
     if (this.model === null) {
       return null;
     } else {

--- a/packages/apputils/src/licenses.tsx
+++ b/packages/apputils/src/licenses.tsx
@@ -568,7 +568,7 @@ export namespace Licenses {
       this.addClass('jp-RenderedHTMLCommon');
     }
 
-    protected render(): JSX.Element {
+    protected render(): React.JSX.Element {
       const { trans } = this.model;
       return (
         <div>
@@ -603,7 +603,7 @@ export namespace Licenses {
     /**
      * Render a filter input
      */
-    protected renderFilter = (key: TFilterKey): JSX.Element => {
+    protected renderFilter = (key: TFilterKey): React.JSX.Element => {
       const value = this.model.packageFilter[key] || '';
       return (
         <input
@@ -687,7 +687,7 @@ export namespace Licenses {
     /**
      * Render a grid of package license information
      */
-    protected render(): JSX.Element {
+    protected render(): React.JSX.Element {
       const { bundles, currentBundleName, trans } = this.model;
       const filteredPackages = this.model.getFilteredPackages(
         bundles && currentBundleName
@@ -724,7 +724,7 @@ export namespace Licenses {
     protected renderRow = (
       row: Licenses.IPackageLicenseInfo,
       index: number
-    ): JSX.Element => {
+    ): React.JSX.Element => {
       const selected = index === this.model.currentPackageIndex;
       const onCheck = () => (this.model.currentPackageIndex = index);
       return (

--- a/packages/apputils/src/runningSessions.tsx
+++ b/packages/apputils/src/runningSessions.tsx
@@ -137,7 +137,7 @@ export class RunningSessions extends VDomRenderer<RunningSessions.Model> {
   /**
    * Render the running sessions widget.
    */
-  render(): JSX.Element | null {
+  render(): React.JSX.Element | null {
     if (!this.model) {
       return null;
     }

--- a/packages/apputils/test/dialog.spec.tsx
+++ b/packages/apputils/test/dialog.spec.tsx
@@ -188,7 +188,7 @@ describe('@jupyterlab/apputils', () => {
               this.addClass('jp-Dialog-body');
             }
 
-            render(): JSX.Element {
+            render(): React.JSX.Element {
               return (
                 <div>
                   <textarea data-testid="dialog-textarea" />

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -69,12 +69,12 @@
     "@lumino/signaling": "^2.1.5",
     "@lumino/virtualdom": "^2.0.4",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "@jupyterlab/testing": "^4.6.0-alpha.4",
     "@types/jest": "^29.2.0",
-    "@types/react": "^18.0.26",
+    "@types/react": "^18.3.12",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
     "typescript": "~5.9.3"

--- a/packages/celltags-extension/package.json
+++ b/packages/celltags-extension/package.json
@@ -46,7 +46,7 @@
     "@jupyterlab/ui-components": "^4.6.0-alpha.4",
     "@lumino/algorithm": "^2.0.4",
     "@rjsf/utils": "^5.13.4",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "rimraf": "~5.0.5",

--- a/packages/celltags-extension/src/celltag.tsx
+++ b/packages/celltags-extension/src/celltag.tsx
@@ -156,7 +156,7 @@ export class CellTagField {
     props.formContext.updateMetadata({ [props.name]: data }, true);
   }
 
-  render(props: FieldProps): JSX.Element {
+  render(props: FieldProps): React.JSX.Element {
     const allTags: string[] = this.pullTags();
 
     return (

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -56,7 +56,7 @@
     "@lumino/messaging": "^2.0.4",
     "@lumino/signaling": "^2.1.5",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "@jupyterlab/testing": "^4.6.0-alpha.4",

--- a/packages/codeeditor/src/lineCol.tsx
+++ b/packages/codeeditor/src/lineCol.tsx
@@ -273,7 +273,7 @@ export class LineCol extends VDomRenderer<LineCol.Model> {
   /**
    * Render the status item.
    */
-  render(): JSX.Element | null {
+  render(): React.JSX.Element | null {
     if (this.model === null) {
       return null;
     } else {

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -58,10 +58,10 @@
     "@lumino/widgets": "^2.7.5",
     "@rjsf/utils": "^5.13.4",
     "@rjsf/validator-ajv8": "^5.13.4",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
-    "@types/react": "^18.0.26",
+    "@types/react": "^18.3.12",
     "rimraf": "~5.0.5",
     "typescript": "~5.9.3"
   },

--- a/packages/completer-extension/package.json
+++ b/packages/completer-extension/package.json
@@ -46,7 +46,7 @@
     "@lumino/commands": "^2.3.3",
     "@lumino/coreutils": "^2.2.2",
     "@rjsf/utils": "^5.13.4",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "rimraf": "~5.0.5",

--- a/packages/completer-extension/src/renderer.tsx
+++ b/packages/completer-extension/src/renderer.tsx
@@ -13,7 +13,7 @@ const AVAILABLE_PROVIDERS = 'availableProviders';
 /**
  * Custom setting renderer for provider rank.
  */
-export function renderAvailableProviders(props: FieldProps): JSX.Element {
+export function renderAvailableProviders(props: FieldProps): React.JSX.Element {
   const { schema } = props;
   const title = schema.title;
   const desc = schema.description;

--- a/packages/core-meta/core.package.json
+++ b/packages/core-meta/core.package.json
@@ -146,8 +146,8 @@
     "@lumino/widgets": "^2.3.1-alpha.1",
     "@microsoft/fast-element": "^1.12.0",
     "@microsoft/fast-foundation": "^2.49.2",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "yjs": "^13.5.40"
   },
   "dependencies": {

--- a/packages/core-meta/core.package.json
+++ b/packages/core-meta/core.package.json
@@ -146,8 +146,8 @@
     "@lumino/widgets": "^2.3.1-alpha.1",
     "@microsoft/fast-element": "^1.12.0",
     "@microsoft/fast-foundation": "^2.49.2",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "yjs": "^13.5.40"
   },
   "dependencies": {

--- a/packages/debugger-extension/package.json
+++ b/packages/debugger-extension/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@jupyterlab/testing": "^4.6.0-alpha.4",
     "@types/jest": "^29.2.0",
-    "@types/react-dom": "^18.0.9",
+    "@types/react-dom": "^18.3.1",
     "rimraf": "~5.0.5",
     "typescript": "~5.9.3"
   },

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -77,7 +77,7 @@
     "@lumino/signaling": "^2.1.5",
     "@lumino/widgets": "^2.7.5",
     "@vscode/debugprotocol": "^1.51.0",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "@jupyterlab/testing": "^4.6.0-alpha.4",

--- a/packages/debugger/src/panels/breakpoints/body.tsx
+++ b/packages/debugger/src/panels/breakpoints/body.tsx
@@ -31,7 +31,7 @@ export class BreakpointsBody extends ReactWidget {
     this.addClass('jp-DebuggerBreakpoints-body');
   }
 
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     return (
       <BreakpointsComponent model={this._model} translator={this._translator} />
     );
@@ -54,7 +54,7 @@ const BreakpointsComponent = ({
 }: {
   model: IDebugger.Model.IBreakpoints;
   translator: ITranslator;
-}): JSX.Element => {
+}): React.JSX.Element => {
   const trans = translator.load('jupyterlab');
   const [breakpoints, setBreakpoints] = useState(
     Array.from(model.breakpoints.entries())
@@ -131,7 +131,7 @@ const BreakpointCellComponent = ({
   model: IDebugger.Model.IBreakpoints;
   selectedBreakpoint: IDebugger.IBreakpoint | null;
   trans: TranslationBundle;
-}): JSX.Element => {
+}): React.JSX.Element => {
   return (
     <>
       {breakpoints
@@ -172,7 +172,7 @@ const BreakpointComponent = ({
   model: IDebugger.Model.IBreakpoints;
   isSelected: boolean;
   trans: TranslationBundle;
-}): JSX.Element => {
+}): React.JSX.Element => {
   const display = model.getDisplayName(breakpoint);
 
   return (

--- a/packages/debugger/src/panels/breakpoints/pauseonexceptions.tsx
+++ b/packages/debugger/src/panels/breakpoints/pauseonexceptions.tsx
@@ -70,7 +70,7 @@ export class PauseOnExceptionsWidget extends ToolbarButton {
     );
   };
 
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     return <ToolbarButtonComponent {...this._props} onClick={this.onclick} />;
   }
 

--- a/packages/debugger/src/panels/callstack/body.tsx
+++ b/packages/debugger/src/panels/callstack/body.tsx
@@ -23,7 +23,7 @@ export class CallstackBody extends ReactWidget {
   /**
    * Render the FramesComponent.
    */
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     return <FramesComponent model={this._model} />;
   }
 
@@ -41,7 +41,7 @@ const FramesComponent = ({
   model
 }: {
   model: IDebugger.Model.ICallstack;
-}): JSX.Element => {
+}): React.JSX.Element => {
   const [frames, setFrames] = useState(model.frames);
   const [selected, setSelected] = useState(model.frame);
 

--- a/packages/debugger/src/panels/sources/sourcepath.tsx
+++ b/packages/debugger/src/panels/sources/sourcepath.tsx
@@ -18,10 +18,10 @@ export const SourcePathComponent = ({
 }: {
   model: IDebugger.Model.ISources;
   trans: TranslationBundle;
-}): JSX.Element => {
+}): React.JSX.Element => {
   return (
     <UseSignal signal={model.currentSourceChanged} initialSender={model}>
-      {(model): JSX.Element => (
+      {(model): React.JSX.Element => (
         <span
           onClick={(event): void => {
             if (event.ctrlKey) {

--- a/packages/debugger/src/panels/variables/scope.tsx
+++ b/packages/debugger/src/panels/variables/scope.tsx
@@ -30,7 +30,7 @@ const ScopeSwitcherComponent = ({
   tree: VariablesBodyTree;
   grid: VariablesBodyGrid;
   trans: TranslationBundle;
-}): JSX.Element => {
+}): React.JSX.Element => {
   const [value, setValue] = useState('-');
   const scopes = model.scopes;
 
@@ -77,10 +77,10 @@ export class ScopeSwitcher extends ReactWidget {
   /**
    * Render the scope switcher.
    */
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     return (
       <UseSignal signal={this._model.changed} initialSender={this._model}>
-        {(): JSX.Element => (
+        {(): React.JSX.Element => (
           <ScopeSwitcherComponent
             model={this._model}
             trans={this._trans}

--- a/packages/debugger/src/panels/variables/tree.tsx
+++ b/packages/debugger/src/panels/variables/tree.tsx
@@ -52,7 +52,7 @@ export class VariablesBodyTree extends ReactWidget {
   /**
    * Render the VariablesBodyTree.
    */
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     const scope =
       this._scopes.find(scope => scope.name === this._scope) ?? this._scopes[0];
 
@@ -149,7 +149,7 @@ interface IVariablesBranchProps {
  * @param props.service The debugger service.
  * @param props.filter Optional variable filter list.
  */
-const VariablesBranch = (props: IVariablesBranchProps): JSX.Element => {
+const VariablesBranch = (props: IVariablesBranchProps): React.JSX.Element => {
   const { commands, data, service, filter, translator, handleSelectVariable } =
     props;
   const [variables, setVariables] = useState(data);
@@ -236,7 +236,9 @@ function _prepareDetail(variable: IDebugger.IVariable) {
  * @param props.service The debugger service.
  * @param props.filter Optional variable filter list.
  */
-const VariableComponent = (props: IVariableComponentProps): JSX.Element => {
+const VariableComponent = (
+  props: IVariableComponentProps
+): React.JSX.Element => {
   const { commands, data, service, filter, translator, onSelect } = props;
   const [variable] = useState(data);
   const [showDetailsButton, setShowDetailsButton] = useState<boolean>(false);

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -55,7 +55,7 @@
     "@lumino/disposable": "^2.1.5",
     "@lumino/signaling": "^2.1.5",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "rimraf": "~5.0.5",

--- a/packages/docmanager/package.json
+++ b/packages/docmanager/package.json
@@ -58,7 +58,7 @@
     "@lumino/properties": "^2.0.4",
     "@lumino/signaling": "^2.1.5",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "@jupyterlab/testing": "^4.6.0-alpha.4",

--- a/packages/docmanager/src/pathstatus.tsx
+++ b/packages/docmanager/src/pathstatus.tsx
@@ -57,7 +57,7 @@ export class PathStatus extends VDomRenderer<PathStatus.Model> {
   /**
    * Render the status item.
    */
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     return (
       <PathStatusComponent
         fullPath={this.model!.path}

--- a/packages/docmanager/src/savingstatus.tsx
+++ b/packages/docmanager/src/savingstatus.tsx
@@ -65,7 +65,7 @@ export class SavingStatus extends VDomRenderer<SavingStatus.Model> {
   /**
    * Render the SavingStatus item.
    */
-  render(): JSX.Element | null {
+  render(): React.JSX.Element | null {
     if (this.model === null || this.model.status === null) {
       return null;
     } else {

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -58,7 +58,7 @@
     "@lumino/properties": "^2.0.4",
     "@lumino/signaling": "^2.1.5",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "@jupyterlab/testing": "^4.6.0-alpha.4",

--- a/packages/documentsearch/package.json
+++ b/packages/documentsearch/package.json
@@ -48,7 +48,7 @@
     "@lumino/polling": "^2.1.5",
     "@lumino/signaling": "^2.1.5",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "@jupyterlab/testing": "^4.6.0-alpha.4",

--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -74,7 +74,7 @@ export interface ISearchKeyBindings {
   readonly toggleSearchInSelection?: CommandRegistry.IKeyBinding;
 }
 
-function SearchInput(props: ISearchInputProps): JSX.Element {
+function SearchInput(props: ISearchInputProps): React.JSX.Element {
   const [rows, setRows] = useState<number>(1);
 
   const updateDimensions = useCallback(
@@ -149,7 +149,7 @@ interface ISearchEntryProps {
   translator?: ITranslator;
 }
 
-function SearchEntry(props: ISearchEntryProps): JSX.Element {
+function SearchEntry(props: ISearchEntryProps): React.JSX.Element {
   const trans = (props.translator ?? nullTranslator).load('jupyterlab');
 
   const caseButtonToggleClass = classes(
@@ -222,7 +222,7 @@ interface IReplaceEntryProps {
   translator?: ITranslator;
 }
 
-function ReplaceEntry(props: IReplaceEntryProps): JSX.Element {
+function ReplaceEntry(props: IReplaceEntryProps): React.JSX.Element {
   const trans = (props.translator ?? nullTranslator).load('jupyterlab');
 
   const preserveCaseButtonToggleClass = classes(
@@ -359,7 +359,7 @@ interface IFilterToggleProps {
   trans: TranslationBundle;
 }
 
-function FilterToggle(props: IFilterToggleProps): JSX.Element {
+function FilterToggle(props: IFilterToggleProps): React.JSX.Element {
   let className = `${FILTER_BUTTON_CLASS} ${BUTTON_CONTENT_CLASS}`;
   if (props.visible) {
     className = `${className} ${FILTER_BUTTON_ENABLED_CLASS}`;
@@ -391,7 +391,7 @@ interface IFilterSelectionProps {
   onToggle: () => void;
 }
 
-function FilterSelection(props: IFilterSelectionProps): JSX.Element {
+function FilterSelection(props: IFilterSelectionProps): React.JSX.Element {
   return (
     <label
       className={

--- a/packages/extensionmanager-extension/examples/listings/package.json
+++ b/packages/extensionmanager-extension/examples/listings/package.json
@@ -38,8 +38,8 @@
     "@jupyterlab/theme-light-extension": "^2.0.2",
     "@jupyterlab/tooltip-extension": "^2.0.2",
     "@jupyterlab/ui-components-extension": "^2.0.2",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@rspack/cli": "^0.5.1",

--- a/packages/extensionmanager/package.json
+++ b/packages/extensionmanager/package.json
@@ -44,12 +44,12 @@
     "@lumino/messaging": "^2.0.4",
     "@lumino/polling": "^2.1.5",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0",
+    "react": "^18.3.1",
     "react-paginate": "^6.3.2",
     "semver": "^7.5.2"
   },
   "devDependencies": {
-    "@types/react": "^18.0.26",
+    "@types/react": "^18.3.12",
     "@types/react-paginate": "^6.2.1",
     "@types/semver": "^7.5.2",
     "jest": "^29.2.0",

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -350,7 +350,7 @@ class Header extends ReactWidget {
     this.addClass('jp-extensionmanager-header');
   }
 
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     return (
       <>
         <div className="jp-extensionmanager-title">

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -61,7 +61,7 @@
     "@lumino/virtualdom": "^2.0.4",
     "@lumino/widgets": "^2.7.5",
     "jest-environment-jsdom": "^29.3.0",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "@jupyterlab/testing": "^4.6.0-alpha.4",

--- a/packages/filebrowser/src/uploadstatus.tsx
+++ b/packages/filebrowser/src/uploadstatus.tsx
@@ -84,7 +84,7 @@ export class FileUploadStatus extends VDomRenderer<FileUploadStatus.Model> {
   /**
    * Render the FileUpload status.
    */
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     const uploadPaths = this.model!.items;
     if (uploadPaths.length > 0) {
       const item = this.model!.items[0];

--- a/packages/fileeditor/package.json
+++ b/packages/fileeditor/package.json
@@ -56,7 +56,7 @@
     "@lumino/coreutils": "^2.2.2",
     "@lumino/messaging": "^2.0.4",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0",
+    "react": "^18.3.1",
     "regexp-match-indices": "^1.0.2"
   },
   "devDependencies": {

--- a/packages/fileeditor/src/syntaxstatus.tsx
+++ b/packages/fileeditor/src/syntaxstatus.tsx
@@ -85,7 +85,7 @@ export class EditorSyntaxStatus extends VDomRenderer<EditorSyntaxStatus.Model> {
   /**
    * Render the status item.
    */
-  render(): JSX.Element | null {
+  render(): React.JSX.Element | null {
     if (!this.model) {
       return null;
     }

--- a/packages/fileeditor/src/tabspacestatus.tsx
+++ b/packages/fileeditor/src/tabspacestatus.tsx
@@ -87,7 +87,7 @@ export class TabSpaceStatus extends VDomRenderer<TabSpaceStatus.Model> {
   /**
    * Render the TabSpace status item.
    */
-  render(): JSX.Element | null {
+  render(): React.JSX.Element | null {
     if (!this.model?.indentUnit) {
       return null;
     } else {

--- a/packages/help-extension/package.json
+++ b/packages/help-extension/package.json
@@ -45,7 +45,7 @@
     "@jupyterlab/translation": "^4.6.0-alpha.4",
     "@jupyterlab/ui-components": "^4.6.0-alpha.4",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "rimraf": "~5.0.5",

--- a/packages/htmlviewer/package.json
+++ b/packages/htmlviewer/package.json
@@ -41,7 +41,7 @@
     "@lumino/coreutils": "^2.2.2",
     "@lumino/signaling": "^2.1.5",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "rimraf": "~5.0.5",

--- a/packages/htmlviewer/src/widget.tsx
+++ b/packages/htmlviewer/src/widget.tsx
@@ -350,7 +350,7 @@ namespace Private {
    */
   export function TrustButtonComponent(
     props: TrustButtonComponent.IProps
-  ): JSX.Element {
+  ): React.JSX.Element {
     const translator = props.translator || nullTranslator;
     const trans = translator.load('jupyterlab');
     return (

--- a/packages/json-extension/package.json
+++ b/packages/json-extension/package.json
@@ -41,15 +41,15 @@
     "@lumino/coreutils": "^2.2.2",
     "@lumino/messaging": "^2.0.4",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "react-highlight-words": "^0.20.0",
     "react-json-tree": "^0.18.0",
     "style-mod": "^4.0.0"
   },
   "devDependencies": {
-    "@types/react": "^18.0.26",
-    "@types/react-dom": "^18.0.9",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
     "@types/react-highlight-words": "^0.16.4",
     "rimraf": "~5.0.5",
     "typescript": "~5.9.3"

--- a/packages/json-extension/src/component.tsx
+++ b/packages/json-extension/src/component.tsx
@@ -64,7 +64,7 @@ export class Component extends React.Component<IProps, IState> {
     }, 300);
   };
 
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     const translator = this.props.translator || nullTranslator;
     const trans = translator.load('jupyterlab');
 

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -50,12 +50,12 @@
     "@lumino/disposable": "^2.1.5",
     "@lumino/properties": "^2.0.4",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "@jupyterlab/testing": "^4.6.0-alpha.4",
     "@types/jest": "^29.2.0",
-    "@types/react": "^18.0.26",
+    "@types/react": "^18.3.12",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
     "typescript": "~5.9.3"

--- a/packages/logconsole-extension/package.json
+++ b/packages/logconsole-extension/package.json
@@ -47,7 +47,7 @@
     "@lumino/coreutils": "^2.2.2",
     "@lumino/signaling": "^2.1.5",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "rimraf": "~5.0.5",

--- a/packages/logconsole-extension/src/index.tsx
+++ b/packages/logconsole-extension/src/index.tsx
@@ -417,7 +417,7 @@ export class LogLevelSwitcher extends ReactWidget {
     }
   };
 
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     const logger = this._logConsole.logger;
     return (
       <>

--- a/packages/logconsole-extension/src/status.tsx
+++ b/packages/logconsole-extension/src/status.tsx
@@ -111,7 +111,7 @@ export class LogConsoleStatus extends VDomRenderer<LogConsoleStatus.Model> {
   /**
    * Render the log console status item.
    */
-  render(): JSX.Element | null {
+  render(): React.JSX.Element | null {
     if (this.model === null || this.model.version === 0) {
       return null;
     }

--- a/packages/lsp-extension/package.json
+++ b/packages/lsp-extension/package.json
@@ -47,7 +47,7 @@
     "@lumino/polling": "^2.1.5",
     "@lumino/signaling": "^2.1.5",
     "@rjsf/utils": "^5.13.4",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "rimraf": "~5.0.5",

--- a/packages/lsp-extension/src/renderer.tsx
+++ b/packages/lsp-extension/src/renderer.tsx
@@ -67,7 +67,7 @@ interface ISettingFormProps {
 /**
  * The React component of the setting field
  */
-function BuildSettingForm(props: ISettingFormProps): JSX.Element {
+function BuildSettingForm(props: ISettingFormProps): React.JSX.Element {
   const { [SERVER_SETTINGS]: serverSettingsSchema, ...otherSettingsSchema } =
     props.schema;
   const {
@@ -319,7 +319,7 @@ function PropertyFrom(props: {
   property: ISettingProperty;
   removeProperty: (hash: string) => void;
   setProperty: Debouncer<void, any, [hash: string, property: ISettingProperty]>;
-}): JSX.Element {
+}): React.JSX.Element {
   const [state, setState] = useState<{
     property: string;
     type: 'boolean' | 'string' | 'number';
@@ -551,7 +551,7 @@ class SettingRenderer extends React.Component<IProps, IState> {
     });
     this._setting.set(SETTING_NAME, settings).catch(console.error);
   };
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     return (
       <div>
         <fieldset>
@@ -619,6 +619,6 @@ class SettingRenderer extends React.Component<IProps, IState> {
 export function renderServerSetting(
   props: FieldProps,
   translator: ITranslator
-): JSX.Element {
+): React.JSX.Element {
   return <SettingRenderer {...props} translator={translator} />;
 }

--- a/packages/metadataform/package.json
+++ b/packages/metadataform/package.json
@@ -57,12 +57,12 @@
     "@rjsf/core": "^5.13.4",
     "@rjsf/validator-ajv8": "^5.13.4",
     "json-schema": "^0.4.0",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "@jupyterlab/testing": "^4.6.0-alpha.4",
     "@types/jest": "^29.2.0",
-    "@types/react": "^18.0.26",
+    "@types/react": "^18.3.12",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
     "typescript": "~5.9.3"

--- a/packages/metadataform/src/form.tsx
+++ b/packages/metadataform/src/form.tsx
@@ -32,7 +32,7 @@ export class FormWidget extends ReactWidget {
    * Render the form.
    * @returns - The rendered form
    */
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     const formContext = {
       defaultFormData: this._props.settings.default(),
       updateMetadata: this._props.metadataFormWidget.updateMetadata

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -75,7 +75,7 @@
     "@lumino/polling": "^2.1.5",
     "@lumino/widgets": "^2.7.5",
     "@rjsf/utils": "^5.13.4",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "rimraf": "~5.0.5",

--- a/packages/notebook-extension/src/tool-widgets/activeCellToolWidget.tsx
+++ b/packages/notebook-extension/src/tool-widgets/activeCellToolWidget.tsx
@@ -95,7 +95,7 @@ export class ActiveCellTool extends NotebookTools.Tool {
     this._refreshDebouncer = new Debouncer(update, 150);
   }
 
-  render(props: FieldProps): JSX.Element {
+  render(props: FieldProps): React.JSX.Element {
     const activeCell = this._tracker.activeCell;
     if (activeCell) this._cellModel = activeCell?.model || null;
     (this._cellModel?.sharedModel as ISharedText).changed.connect(

--- a/packages/notebook-extension/src/tool-widgets/metadataEditorFields.tsx
+++ b/packages/notebook-extension/src/tool-widgets/metadataEditorFields.tsx
@@ -75,7 +75,7 @@ export class CellMetadataField extends NotebookTools.MetadataEditorTool {
     }
   }
 
-  render(props: FieldProps): JSX.Element {
+  render(props: FieldProps): React.JSX.Element {
     const cell = this._tracker.activeCell;
     this.editor.source = cell
       ? new ObservableJSON({ values: cell.model.metadata as JSONObject })
@@ -118,7 +118,7 @@ export class NotebookMetadataField extends NotebookTools.MetadataEditorTool {
     }
   }
 
-  render(props: FieldProps): JSX.Element {
+  render(props: FieldProps): React.JSX.Element {
     const notebook = this._tracker.currentWidget;
     this.editor.source = notebook
       ? new ObservableJSON({ values: notebook.model?.metadata as JSONObject })

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -70,7 +70,7 @@
     "@lumino/signaling": "^2.1.5",
     "@lumino/virtualdom": "^2.0.4",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "@jupyterlab/testing": "^4.6.0-alpha.4",

--- a/packages/notebook/src/default-toolbar.tsx
+++ b/packages/notebook/src/default-toolbar.tsx
@@ -368,7 +368,7 @@ export class CellTypeSwitcher extends ReactWidget {
     }
   };
 
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     let value = '-';
     if (this._notebook.activeCell) {
       value = this._notebook.activeCell.model.type;

--- a/packages/notebook/src/executionindicator.tsx
+++ b/packages/notebook/src/executionindicator.tsx
@@ -33,7 +33,7 @@ import { NotebookActions } from './actions';
  */
 export function ExecutionIndicatorComponent(
   props: ExecutionIndicatorComponent.IProps
-): JSX.Element {
+): React.JSX.Element {
   const translator = props.translator || nullTranslator;
   const kernelStatuses = translateKernelStatuses(translator);
   const trans = translator.load('jupyterlab');
@@ -100,9 +100,9 @@ export function ExecutionIndicatorComponent(
 
   const reactElement = (
     status: ISessionContext.KernelDisplayStatus,
-    circle: JSX.Element,
-    popup: JSX.Element[]
-  ): JSX.Element => (
+    circle: React.JSX.Element,
+    popup: React.JSX.Element[]
+  ): React.JSX.Element => (
     <div
       className={'jp-Notebook-ExecutionIndicator'}
       title={showProgress ? '' : titleFactory(kernelStatuses[status])}
@@ -233,7 +233,7 @@ export class ExecutionIndicator extends VDomRenderer<ExecutionIndicator.Model> {
   /**
    * Render the execution status item.
    */
-  render(): JSX.Element | null {
+  render(): React.JSX.Element | null {
     if (this.model === null || !this.model.renderFlag) {
       return <div></div>;
     } else {

--- a/packages/notebook/src/modestatus.tsx
+++ b/packages/notebook/src/modestatus.tsx
@@ -73,7 +73,7 @@ export class CommandEditStatus extends VDomRenderer<CommandEditStatus.Model> {
   /**
    * Render the CommandEdit status item.
    */
-  render(): JSX.Element | null {
+  render(): React.JSX.Element | null {
     if (!this.model) {
       return null;
     }

--- a/packages/notebook/src/truststatus.tsx
+++ b/packages/notebook/src/truststatus.tsx
@@ -111,7 +111,7 @@ export class NotebookTrustStatus extends VDomRenderer<NotebookTrustStatus.Model>
   /**
    * Render the NotebookTrust status item.
    */
-  render(): JSX.Element | null {
+  render(): React.JSX.Element | null {
     if (!this.model) {
       return null;
     }

--- a/packages/pluginmanager/package.json
+++ b/packages/pluginmanager/package.json
@@ -48,7 +48,7 @@
     "@lumino/coreutils": "^2.2.2",
     "@lumino/signaling": "^2.1.5",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "@jupyterlab/testing": "^4.6.0-alpha.4",

--- a/packages/pluginmanager/src/widget.tsx
+++ b/packages/pluginmanager/src/widget.tsx
@@ -56,7 +56,7 @@ class AvailableList extends VDomRenderer<PluginListModel> {
     this.addClass('jp-pluginmanager-AvailableList');
   }
 
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     return (
       <>
         {this.model.statusError !== null ? (

--- a/packages/property-inspector/package.json
+++ b/packages/property-inspector/package.json
@@ -41,7 +41,7 @@
     "@lumino/disposable": "^2.1.5",
     "@lumino/signaling": "^2.1.5",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "jest": "^29.2.0",

--- a/packages/running-extension/package.json
+++ b/packages/running-extension/package.json
@@ -52,7 +52,7 @@
     "@lumino/polling": "^2.1.5",
     "@lumino/signaling": "^2.1.5",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "rimraf": "~5.0.5",

--- a/packages/running/package.json
+++ b/packages/running/package.json
@@ -47,7 +47,7 @@
     "@lumino/messaging": "^2.0.4",
     "@lumino/signaling": "^2.1.5",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "rimraf": "~5.0.5",

--- a/packages/running/src/index.tsx
+++ b/packages/running/src/index.tsx
@@ -355,7 +355,7 @@ class FilterWidget extends ReactWidget implements IFilterProvider {
     return this._filterChanged;
   }
 
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     return (
       <FilterBox
         placeholder={this._trans.__('Search')}
@@ -452,7 +452,7 @@ class ListWidget extends ReactWidget {
     this._update.emit();
   }
 
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     const options = this._options;
     let cached = true;
     return (

--- a/packages/settingeditor-extension/package.json
+++ b/packages/settingeditor-extension/package.json
@@ -50,7 +50,7 @@
     "@jupyterlab/translation": "^4.6.0-alpha.4",
     "@jupyterlab/ui-components": "^4.6.0-alpha.4",
     "@lumino/disposable": "^2.1.5",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "rimraf": "~5.0.5",

--- a/packages/settingeditor-extension/src/importSettingsWidget.tsx
+++ b/packages/settingeditor-extension/src/importSettingsWidget.tsx
@@ -29,7 +29,7 @@ namespace ImportSettings {
   }
 }
 
-const SettingsImport = (props: ImportSettings.IOptions): JSX.Element => {
+const SettingsImport = (props: ImportSettings.IOptions): React.JSX.Element => {
   const trans = props.translator.load('jupyterlab');
   const [checkedStates, setCheckedStates] = useState<Record<string, boolean>>(
     props.importedSettings.reduce(

--- a/packages/settingeditor/package.json
+++ b/packages/settingeditor/package.json
@@ -62,15 +62,15 @@
     "@rjsf/utils": "^5.13.4",
     "@rjsf/validator-ajv8": "^5.13.4",
     "json-schema": "^0.4.0",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "@jupyterlab/testing": "^4.6.0-alpha.4",
     "@types/jest": "^29.2.0",
-    "@types/react": "^18.0.26",
+    "@types/react": "^18.3.12",
     "@types/react-test-renderer": "^18.0.0",
     "jest": "^29.2.0",
-    "react-test-renderer": "^18.2.0",
+    "react-test-renderer": "^18.3.1",
     "rimraf": "~5.0.5",
     "ts-jest": "^29.1.0",
     "typescript": "~5.9.3"

--- a/packages/settingeditor/src/SettingsFormEditor.tsx
+++ b/packages/settingeditor/src/SettingsFormEditor.tsx
@@ -198,7 +198,7 @@ export class SettingsFormEditor extends React.Component<
     }));
   };
 
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     const trans = this.props.translator.load('jupyterlab');
 
     return (

--- a/packages/settingeditor/src/pluginlist.tsx
+++ b/packages/settingeditor/src/pluginlist.tsx
@@ -338,7 +338,7 @@ export class PluginList extends ReactWidget {
     }
   }
 
-  mapPlugins(plugin: ISettingRegistry.IPlugin): JSX.Element {
+  mapPlugins(plugin: ISettingRegistry.IPlugin): React.JSX.Element {
     const { id, schema, version } = plugin;
     const trans = this.translator.load('jupyterlab');
     const title =
@@ -409,7 +409,7 @@ export class PluginList extends ReactWidget {
     );
   }
 
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     const trans = this.translator.load('jupyterlab');
     // Filter all plugins based on search value before displaying list.
     const allPlugins = this._model.plugins.filter(plugin => {

--- a/packages/settingeditor/src/settingspanel.tsx
+++ b/packages/settingeditor/src/settingspanel.tsx
@@ -81,7 +81,7 @@ export const SettingsPanel: React.FC<ISettingsPanelProps> = ({
   updateFilterSignal,
   translator,
   initialFilter
-}: ISettingsPanelProps): JSX.Element => {
+}: ISettingsPanelProps): React.JSX.Element => {
   const [activePluginId, setActivePluginId] = useState<string | null>(null);
   const [filterPlugin, setFilter] = useState<SettingsEditor.PluginSearchFilter>(
     initialFilter ? () => initialFilter : null

--- a/packages/shortcuts-extension/package.json
+++ b/packages/shortcuts-extension/package.json
@@ -55,7 +55,7 @@
     "@lumino/keyboard": "^2.0.4",
     "@lumino/signaling": "^2.1.5",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "@jupyterlab/testing": "^4.6.0-alpha.4",

--- a/packages/shortcuts-extension/src/components/ShortcutItem.tsx
+++ b/packages/shortcuts-extension/src/components/ShortcutItem.tsx
@@ -130,13 +130,13 @@ export class ShortcutItem extends React.Component<
       .join(' ');
   };
 
-  getCategoryCell(): JSX.Element {
+  getCategoryCell(): React.JSX.Element {
     return (
       <div className="jp-Shortcuts-Cell">{this.props.shortcut.category}</div>
     );
   }
 
-  getLabelCell(): JSX.Element {
+  getLabelCell(): React.JSX.Element {
     if (this.props.newShortcutUtils) {
       const filteredShortcuts = this._getFilteredCommands();
       return (
@@ -174,7 +174,7 @@ export class ShortcutItem extends React.Component<
     }
   }
 
-  getResetShortCutLink(): JSX.Element {
+  getResetShortCutLink(): React.JSX.Element {
     return (
       <a
         className="jp-Shortcuts-Reset"
@@ -187,7 +187,7 @@ export class ShortcutItem extends React.Component<
     );
   }
 
-  getSourceCell(): JSX.Element {
+  getSourceCell(): React.JSX.Element {
     const allDefault = this.props.shortcut.keybindings.every(
       binding => binding.isDefault
     );
@@ -263,7 +263,7 @@ export class ShortcutItem extends React.Component<
     );
   }
 
-  getOptionalSelectorCell(): JSX.Element | null {
+  getOptionalSelectorCell(): React.JSX.Element | null {
     return this.props.showSelectors ? (
       <div className="jp-Shortcuts-Cell">
         <div className="jp-selector">{this.props.shortcut.selector}</div>

--- a/packages/shortcuts-extension/src/components/ShortcutList.tsx
+++ b/packages/shortcuts-extension/src/components/ShortcutList.tsx
@@ -25,7 +25,7 @@ export interface IShortcutListProps {
 
 /** React component for list of shortcuts */
 export class ShortcutList extends React.Component<IShortcutListProps> {
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     return (
       <div
         className="jp-Shortcuts-ShortcutListContainer"

--- a/packages/shortcuts-extension/src/components/ShortcutTitleItem.tsx
+++ b/packages/shortcuts-extension/src/components/ShortcutTitleItem.tsx
@@ -15,7 +15,7 @@ export interface IShortcutTitleItemProps {
 }
 
 export class ShortcutTitleItem extends React.Component<IShortcutTitleItemProps> {
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     return (
       <div
         className={

--- a/packages/shortcuts-extension/src/components/ShortcutUI.tsx
+++ b/packages/shortcuts-extension/src/components/ShortcutUI.tsx
@@ -390,7 +390,7 @@ export class ShortcutUI
     }
   };
 
-  render(): JSX.Element | null {
+  render(): React.JSX.Element | null {
     if (!this.state.shortcutsFetched) {
       return null;
     }

--- a/packages/shortcuts-extension/src/components/TopNav.tsx
+++ b/packages/shortcuts-extension/src/components/TopNav.tsx
@@ -21,7 +21,7 @@ export interface IAdvancedOptionsProps {
 
 export interface ISymbolsProps {}
 
-function AdvancedOptions(props: IAdvancedOptionsProps): JSX.Element {
+function AdvancedOptions(props: IAdvancedOptionsProps): React.JSX.Element {
   const trans = props.translator.load('jupyterlab');
   return (
     <div className="jp-Shortcuts-AdvancedOptions">

--- a/packages/shortcuts-extension/src/renderer.tsx
+++ b/packages/shortcuts-extension/src/renderer.tsx
@@ -9,6 +9,6 @@ import type { IShortcutUI } from './types';
 
 export const renderShortCut = (props: {
   external: IShortcutUI.IExternalBundle;
-}): JSX.Element => {
+}): React.JSX.Element => {
   return <ShortcutUI external={props.external} height={1000} width={1000} />;
 };

--- a/packages/statusbar-extension/package.json
+++ b/packages/statusbar-extension/package.json
@@ -43,8 +43,8 @@
     "@jupyterlab/translation": "^4.6.0-alpha.4"
   },
   "devDependencies": {
-    "@types/react": "^18.0.26",
-    "@types/react-dom": "^18.0.9",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
     "rimraf": "~5.0.5",
     "typescript": "~5.9.3"
   },

--- a/packages/statusbar/package.json
+++ b/packages/statusbar/package.json
@@ -43,7 +43,7 @@
     "@lumino/messaging": "^2.0.4",
     "@lumino/signaling": "^2.1.5",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "@jupyterlab/testing": "^4.6.0-alpha.4",

--- a/packages/statusbar/src/components/progressBar.tsx
+++ b/packages/statusbar/src/components/progressBar.tsx
@@ -31,7 +31,7 @@ export namespace ProgressBar {
 /**
  * A functional tsx component for a progress bar.
  */
-export function ProgressBar(props: ProgressBar.IProps): JSX.Element {
+export function ProgressBar(props: ProgressBar.IProps): React.JSX.Element {
   const { width, percentage, ...rest } = props;
   return (
     <div

--- a/packages/statusbar/src/components/progressCircle.tsx
+++ b/packages/statusbar/src/components/progressCircle.tsx
@@ -32,7 +32,9 @@ export namespace ProgressCircle {
   }
 }
 
-export function ProgressCircle(props: ProgressCircle.IProps): JSX.Element {
+export function ProgressCircle(
+  props: ProgressCircle.IProps
+): React.JSX.Element {
   const radius = 104;
   const d = (progress: number): string => {
     const angle = Math.max(progress * 3.6, 0.1);

--- a/packages/toc/package.json
+++ b/packages/toc/package.json
@@ -54,12 +54,12 @@
     "@lumino/messaging": "^2.0.4",
     "@lumino/signaling": "^2.1.5",
     "@lumino/widgets": "^2.7.5",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "@jupyterlab/testing": "^4.6.0-alpha.4",
     "@types/jest": "^29.2.0",
-    "@types/react": "^18.0.26",
+    "@types/react": "^18.3.12",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
     "typescript": "~5.9.3"

--- a/packages/toc/src/tocitem.tsx
+++ b/packages/toc/src/tocitem.tsx
@@ -41,7 +41,7 @@ export class TableOfContentsItem extends React.PureComponent<
    *
    * @returns rendered entry
    */
-  render(): JSX.Element | null {
+  render(): React.JSX.Element | null {
     const { children, isActive, heading, onCollapse, onMouseDown } = this.props;
 
     // Handling toggle of collapse and expand

--- a/packages/toc/src/toctree.tsx
+++ b/packages/toc/src/toctree.tsx
@@ -39,7 +39,7 @@ export class TableOfContentsTree extends React.PureComponent<ITableOfContentsTre
   /**
    * Renders a table of contents tree.
    */
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     const { documentType } = this.props;
     return (
       <TreeView
@@ -54,14 +54,16 @@ export class TableOfContentsTree extends React.PureComponent<ITableOfContentsTre
   /**
    * Convert the flat headings list to a nested tree list
    */
-  protected buildTree(): JSX.Element[] {
+  protected buildTree(): React.JSX.Element[] {
     if (this.props.headings.length === 0) {
       return [];
     }
 
-    const buildOneTree = (currentIndex: number): [JSX.Element, number] => {
+    const buildOneTree = (
+      currentIndex: number
+    ): [React.JSX.Element, number] => {
       const items = this.props.headings;
-      const children = new Array<JSX.Element>();
+      const children = new Array<React.JSX.Element>();
       const current = items[currentIndex];
       let nextCandidateIndex = currentIndex + 1;
 
@@ -90,7 +92,7 @@ export class TableOfContentsTree extends React.PureComponent<ITableOfContentsTre
       return [currentTree, nextCandidateIndex];
     };
 
-    const trees = new Array<JSX.Element>();
+    const trees = new Array<React.JSX.Element>();
     let currentIndex = 0;
     while (currentIndex < this.props.headings.length) {
       const [tree, nextIndex] = buildOneTree(currentIndex);

--- a/packages/toc/src/treeview.tsx
+++ b/packages/toc/src/treeview.tsx
@@ -27,7 +27,7 @@ export class TableOfContentsWidget extends VDomRenderer<TableOfContents.IModel<T
    * This method will be called anytime the widget needs to be rendered, which
    * includes layout triggered rendering.
    */
-  render(): JSX.Element | null {
+  render(): React.JSX.Element | null {
     if (!this.model || this.model.headings.length === 0) {
       return (
         <div className="jp-TableOfContents-placeholder">

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -58,21 +58,21 @@
     "@lumino/widgets": "^2.7.5",
     "@rjsf/core": "^5.13.4",
     "@rjsf/utils": "^5.13.4",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "typestyle": "^2.0.4"
   },
   "devDependencies": {
     "@jupyterlab/testing": "^4.6.0-alpha.4",
     "@types/jest": "^29.2.0",
-    "@types/react": "^18.0.26",
+    "@types/react": "^18.3.12",
     "jest": "^29.2.0",
     "rimraf": "~5.0.5",
     "svgo": "^3.3.2",
     "typescript": "~5.9.3"
   },
   "peerDependencies": {
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-components/src/components/button.tsx
+++ b/packages/ui-components/src/components/button.tsx
@@ -26,7 +26,7 @@ export interface IButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEleme
  * @param props Component properties
  * @returns Component
  */
-export function Button(props: IButtonProps): JSX.Element {
+export function Button(props: IButtonProps): React.JSX.Element {
   const { minimal, small, children, ...others } = props;
   return (
     <button

--- a/packages/ui-components/src/components/form.tsx
+++ b/packages/ui-components/src/components/form.tsx
@@ -111,9 +111,9 @@ export namespace FormComponent {
  */
 export const MoveButton = (
   props: FormComponent.IMoveButtonProps
-): JSX.Element => {
+): React.JSX.Element => {
   const trans = (props.translator ?? nullTranslator).load('jupyterlab');
-  let buttonContent: JSX.Element | string;
+  let buttonContent: React.JSX.Element | string;
 
   /**
    * Whether the button is disabled or not.
@@ -172,9 +172,9 @@ export const MoveButton = (
  */
 export const DropButton = (
   props: FormComponent.IDropButtonProps
-): JSX.Element => {
+): React.JSX.Element => {
   const trans = (props.translator ?? nullTranslator).load('jupyterlab');
-  let buttonContent: JSX.Element | string;
+  let buttonContent: React.JSX.Element | string;
 
   if (props.buttonStyle === 'icons') {
     buttonContent = <deleteIcon.react tag="span" elementPosition="center" />;
@@ -207,7 +207,7 @@ export const DropButton = (
  */
 export const AddButton = (
   props: FormComponent.IAddButtonProps
-): JSX.Element => {
+): React.JSX.Element => {
   const trans = (props.translator ?? nullTranslator).load('jupyterlab');
   let buttonContent: JSX.Element | string;
 

--- a/packages/ui-components/src/components/htmlselect.tsx
+++ b/packages/ui-components/src/components/htmlselect.tsx
@@ -46,7 +46,7 @@ export interface IHTMLSelectProps
 }
 
 export class HTMLSelect extends React.Component<IHTMLSelectProps> {
-  public render(): JSX.Element {
+  public render(): React.JSX.Element {
     const {
       className,
       defaultStyle = true,

--- a/packages/ui-components/src/components/inputgroup.tsx
+++ b/packages/ui-components/src/components/inputgroup.tsx
@@ -27,7 +27,7 @@ export interface IInputGroupProps extends React.InputHTMLAttributes<HTMLInputEle
  * @param props Component properties
  * @returns Component
  */
-export function InputGroup(props: IInputGroupProps): JSX.Element {
+export function InputGroup(props: IInputGroupProps): React.JSX.Element {
   const { className, inputRef, rightIcon, ...others } = props;
   return (
     <div className={classes('jp-InputGroup', className)}>

--- a/packages/ui-components/src/components/search.tsx
+++ b/packages/ui-components/src/components/search.tsx
@@ -158,7 +158,7 @@ export const updateFilterFunction = (
   };
 };
 
-export const FilterBox = (props: IFilterBoxProps): JSX.Element => {
+export const FilterBox = (props: IFilterBoxProps): React.JSX.Element => {
   const [filter, setFilter] = useState(props.initialQuery ?? '');
 
   if (props.forceRefresh) {
@@ -251,7 +251,7 @@ class FilenameSearcherWidget extends ReactWidget {
     }, this);
   }
 
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     return <FilterBox {...this._filterBoxProps} />;
   }
 

--- a/packages/ui-components/src/icon/labicon.tsx
+++ b/packages/ui-components/src/icon/labicon.tsx
@@ -151,7 +151,7 @@ export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
     iconClass,
     fallback,
     ...props
-  }: Partial<LabIcon.IResolverProps> & LabIcon.IReactProps): JSX.Element {
+  }: Partial<LabIcon.IResolverProps> & LabIcon.IReactProps): React.JSX.Element {
     if (!Private.isResolvable(icon)) {
       if (!iconClass && fallback) {
         // if neither icon nor iconClass are defined/resolvable, use fallback

--- a/packages/workspaces-extension/package.json
+++ b/packages/workspaces-extension/package.json
@@ -45,7 +45,7 @@
     "@jupyterlab/translation": "^4.6.0-alpha.4",
     "@jupyterlab/ui-components": "^4.6.0-alpha.4",
     "@jupyterlab/workspaces": "^4.6.0-alpha.4",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "@types/jest": "^29.2.0",

--- a/packages/workspaces-extension/src/top_indicator.tsx
+++ b/packages/workspaces-extension/src/top_indicator.tsx
@@ -142,7 +142,7 @@ export class WorkspaceSelectorWidget extends ReactWidget {
     });
   }
 
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     return (
       <WorkspaceSelector
         currentWorkspace={this._currentWorkspace}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10804,14 +10804,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:3.0.10, csstype@npm:^3.0.10":
+"csstype@npm:3.0.10":
   version: 3.0.10
   resolution: "csstype@npm:3.0.10"
   checksum: 20a8fa324f2b33ddf94aa7507d1b6ab3daa6f3cc308888dc50126585d7952f2471de69b2dbe0635d1fdc31223fef8e070842691877e725caf456e2378685a631
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.2.2":
+"csstype@npm:^3.0.10, csstype@npm:^3.2.2":
   version: 3.2.3
   resolution: "csstype@npm:3.2.3"
   checksum: cb882521b3398958a1ce6ca98c011aec0bde1c77ecaf8a1dd4db3b112a189939beae3b1308243b2fe50fc27eb3edeb0f73a5a4d91d928765dc6d5ecc7bda92ee
@@ -18921,10 +18921,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.12.0 || ^17.0.0 || ^18.0.0, react-is@npm:^18.0.0, react-is@npm:^18.2.0":
-  version: 18.2.0
-  resolution: "react-is@npm:18.2.0"
-  checksum: e72d0ba81b5922759e4aff17e0252bd29988f9642ed817f56b25a3e217e13eea8a7f2322af99a06edb779da12d5d636e9fda473d620df9a3da0df2a74141d53e
+"react-is@npm:^16.12.0 || ^17.0.0 || ^18.0.0, react-is@npm:^18.0.0, react-is@npm:^18.2.0, react-is@npm:^18.3.1":
+  version: 18.3.1
+  resolution: "react-is@npm:18.3.1"
+  checksum: e20fe84c86ff172fc8d898251b7cc2c43645d108bf96d0b8edf39b98f9a2cae97b40520ee7ed8ee0085ccc94736c4886294456033304151c3f94978cec03df21
   languageName: node
   linkType: hard
 
@@ -18932,13 +18932,6 @@ __metadata:
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
-  languageName: node
-  linkType: hard
-
-"react-is@npm:^18.3.1":
-  version: 18.3.1
-  resolution: "react-is@npm:18.3.1"
-  checksum: e20fe84c86ff172fc8d898251b7cc2c43645d108bf96d0b8edf39b98f9a2cae97b40520ee7ed8ee0085ccc94736c4886294456033304151c3f94978cec03df21
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2369,7 +2369,7 @@ __metadata:
     "@lumino/coreutils": ^2.2.2
     "@lumino/disposable": ^2.1.5
     "@lumino/widgets": ^2.7.5
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -2514,8 +2514,8 @@ __metadata:
     "@lumino/widgets": ^2.7.5
     "@types/jest": ^29.2.0
     jest: ^29.2.0
-    react: ^18.2.0
-    react-dom: ^18.2.0
+    react: ^18.3.1
+    react-dom: ^18.3.1
     react-toastify: ^9.0.8
     rimraf: ~5.0.5
     typescript: ~5.9.3
@@ -2546,10 +2546,10 @@ __metadata:
     "@lumino/virtualdom": ^2.0.4
     "@lumino/widgets": ^2.7.5
     "@types/jest": ^29.2.0
-    "@types/react": ^18.0.26
+    "@types/react": ^18.3.12
     "@types/sanitize-html": ^2.11.0
     jest: ^29.2.0
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     sanitize-html: ~2.12.1
     typescript: ~5.9.3
@@ -2745,9 +2745,9 @@ __metadata:
     "@lumino/virtualdom": ^2.0.4
     "@lumino/widgets": ^2.7.5
     "@types/jest": ^29.2.0
-    "@types/react": ^18.0.26
+    "@types/react": ^18.3.12
     jest: ^29.2.0
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -2763,7 +2763,7 @@ __metadata:
     "@jupyterlab/ui-components": ^4.6.0-alpha.4
     "@lumino/algorithm": ^2.0.4
     "@rjsf/utils": ^5.13.4
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -2791,7 +2791,7 @@ __metadata:
     "@lumino/widgets": ^2.7.5
     "@types/jest": ^29.2.0
     jest: ^29.2.0
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -2822,8 +2822,8 @@ __metadata:
     "@lumino/widgets": ^2.7.5
     "@rjsf/utils": ^5.13.4
     "@rjsf/validator-ajv8": ^5.13.4
-    "@types/react": ^18.0.26
-    react: ^18.2.0
+    "@types/react": ^18.3.12
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -2889,7 +2889,7 @@ __metadata:
     "@lumino/commands": ^2.3.3
     "@lumino/coreutils": ^2.2.2
     "@rjsf/utils": ^5.13.4
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -3082,7 +3082,7 @@ __metadata:
     "@lumino/commands": ^2.3.3
     "@lumino/widgets": ^2.7.5
     "@types/jest": ^29.2.0
-    "@types/react-dom": ^18.0.9
+    "@types/react-dom": ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -3126,7 +3126,7 @@ __metadata:
     "@vscode/debugprotocol": ^1.51.0
     jest: ^29.2.0
     jest-canvas-mock: ^2.5.2
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -3154,7 +3154,7 @@ __metadata:
     "@lumino/disposable": ^2.1.5
     "@lumino/signaling": ^2.1.5
     "@lumino/widgets": ^2.7.5
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -3184,7 +3184,7 @@ __metadata:
     "@lumino/widgets": ^2.7.5
     "@types/jest": ^29.2.0
     jest: ^29.2.0
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -3214,7 +3214,7 @@ __metadata:
     "@lumino/widgets": ^2.7.5
     "@types/jest": ^29.2.0
     jest: ^29.2.0
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -3253,7 +3253,7 @@ __metadata:
     "@lumino/widgets": ^2.7.5
     "@types/jest": ^29.2.0
     jest: ^29.2.0
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -3302,8 +3302,8 @@ __metadata:
     fs-extra: ^10.1.0
     glob: ~7.1.6
     mini-svg-data-uri: ^1.4.4
-    react: ^18.2.0
-    react-dom: ^18.2.0
+    react: ^18.3.1
+    react-dom: ^18.3.1
     rimraf: ~5.0.5
     style-loader: ~3.3.1
   languageName: unknown
@@ -3607,11 +3607,11 @@ __metadata:
     "@lumino/messaging": ^2.0.4
     "@lumino/polling": ^2.1.5
     "@lumino/widgets": ^2.7.5
-    "@types/react": ^18.0.26
+    "@types/react": ^18.3.12
     "@types/react-paginate": ^6.2.1
     "@types/semver": ^7.5.2
     jest: ^29.2.0
-    react: ^18.2.0
+    react: ^18.3.1
     react-paginate: ^6.3.2
     rimraf: ~5.0.5
     semver: ^7.5.2
@@ -3671,7 +3671,7 @@ __metadata:
     "@types/jest": ^29.2.0
     jest: ^29.2.0
     jest-environment-jsdom: ^29.3.0
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -3740,7 +3740,7 @@ __metadata:
     "@lumino/widgets": ^2.7.5
     "@types/jest": ^29.2.0
     jest: ^29.2.0
-    react: ^18.2.0
+    react: ^18.3.1
     regexp-match-indices: ^1.0.2
     rimraf: ~5.0.5
     typescript: ~5.9.3
@@ -3808,7 +3808,7 @@ __metadata:
     "@jupyterlab/translation": ^4.6.0-alpha.4
     "@jupyterlab/ui-components": ^4.6.0-alpha.4
     "@lumino/widgets": ^2.7.5
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -3843,7 +3843,7 @@ __metadata:
     "@lumino/coreutils": ^2.2.2
     "@lumino/signaling": ^2.1.5
     "@lumino/widgets": ^2.7.5
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -3963,11 +3963,11 @@ __metadata:
     "@lumino/coreutils": ^2.2.2
     "@lumino/messaging": ^2.0.4
     "@lumino/widgets": ^2.7.5
-    "@types/react": ^18.0.26
-    "@types/react-dom": ^18.0.9
+    "@types/react": ^18.3.12
+    "@types/react-dom": ^18.3.1
     "@types/react-highlight-words": ^0.16.4
-    react: ^18.2.0
-    react-dom: ^18.2.0
+    react: ^18.3.1
+    react-dom: ^18.3.1
     react-highlight-words: ^0.20.0
     react-json-tree: ^0.18.0
     rimraf: ~5.0.5
@@ -4009,9 +4009,9 @@ __metadata:
     "@lumino/properties": ^2.0.4
     "@lumino/widgets": ^2.7.5
     "@types/jest": ^29.2.0
-    "@types/react": ^18.0.26
+    "@types/react": ^18.3.12
     jest: ^29.2.0
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -4034,7 +4034,7 @@ __metadata:
     "@lumino/coreutils": ^2.2.2
     "@lumino/signaling": ^2.1.5
     "@lumino/widgets": ^2.7.5
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -4078,7 +4078,7 @@ __metadata:
     "@lumino/polling": ^2.1.5
     "@lumino/signaling": ^2.1.5
     "@rjsf/utils": ^5.13.4
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -4293,10 +4293,10 @@ __metadata:
     "@rjsf/core": ^5.13.4
     "@rjsf/validator-ajv8": ^5.13.4
     "@types/jest": ^29.2.0
-    "@types/react": ^18.0.26
+    "@types/react": ^18.3.12
     jest: ^29.2.0
     json-schema: ^0.4.0
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -4545,7 +4545,7 @@ __metadata:
     "@lumino/polling": ^2.1.5
     "@lumino/widgets": ^2.7.5
     "@rjsf/utils": ^5.13.4
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -4588,7 +4588,7 @@ __metadata:
     "@lumino/widgets": ^2.7.5
     "@types/jest": ^29.2.0
     jest: ^29.2.0
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -4681,7 +4681,7 @@ __metadata:
     "@lumino/widgets": ^2.7.5
     "@types/jest": ^29.2.0
     jest: ^29.2.0
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -4699,7 +4699,7 @@ __metadata:
     "@lumino/signaling": ^2.1.5
     "@lumino/widgets": ^2.7.5
     jest: ^29.2.0
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -4799,7 +4799,7 @@ __metadata:
     "@lumino/polling": ^2.1.5
     "@lumino/signaling": ^2.1.5
     "@lumino/widgets": ^2.7.5
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -4820,7 +4820,7 @@ __metadata:
     "@lumino/messaging": ^2.0.4
     "@lumino/signaling": ^2.1.5
     "@lumino/widgets": ^2.7.5
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -4881,7 +4881,7 @@ __metadata:
     "@jupyterlab/translation": ^4.6.0-alpha.4
     "@jupyterlab/ui-components": ^4.6.0-alpha.4
     "@lumino/disposable": ^2.1.5
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -4913,12 +4913,12 @@ __metadata:
     "@rjsf/utils": ^5.13.4
     "@rjsf/validator-ajv8": ^5.13.4
     "@types/jest": ^29.2.0
-    "@types/react": ^18.0.26
+    "@types/react": ^18.3.12
     "@types/react-test-renderer": ^18.0.0
     jest: ^29.2.0
     json-schema: ^0.4.0
-    react: ^18.2.0
-    react-test-renderer: ^18.2.0
+    react: ^18.3.1
+    react-test-renderer: ^18.3.1
     rimraf: ~5.0.5
     ts-jest: ^29.1.0
     typescript: ~5.9.3
@@ -4970,7 +4970,7 @@ __metadata:
     "@lumino/widgets": ^2.7.5
     "@types/jest": ^29.2.0
     jest: ^29.2.0
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -5002,8 +5002,8 @@ __metadata:
     "@jupyterlab/settingregistry": ^4.6.0-alpha.4
     "@jupyterlab/statusbar": ^4.6.0-alpha.4
     "@jupyterlab/translation": ^4.6.0-alpha.4
-    "@types/react": ^18.0.26
-    "@types/react-dom": ^18.0.9
+    "@types/react": ^18.3.12
+    "@types/react-dom": ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -5023,7 +5023,7 @@ __metadata:
     "@lumino/widgets": ^2.7.5
     "@types/jest": ^29.2.0
     jest: ^29.2.0
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -5203,9 +5203,9 @@ __metadata:
     "@lumino/signaling": ^2.1.5
     "@lumino/widgets": ^2.7.5
     "@types/jest": ^29.2.0
-    "@types/react": ^18.0.26
+    "@types/react": ^18.3.12
     jest: ^29.2.0
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -5315,16 +5315,16 @@ __metadata:
     "@rjsf/core": ^5.13.4
     "@rjsf/utils": ^5.13.4
     "@types/jest": ^29.2.0
-    "@types/react": ^18.0.26
+    "@types/react": ^18.3.12
     jest: ^29.2.0
-    react: ^18.2.0
-    react-dom: ^18.2.0
+    react: ^18.3.1
+    react-dom: ^18.3.1
     rimraf: ~5.0.5
     svgo: ^3.3.2
     typescript: ~5.9.3
     typestyle: ^2.0.4
   peerDependencies:
-    react: ^18.2.0
+    react: ^18.3.1
   languageName: unknown
   linkType: soft
 
@@ -5383,7 +5383,7 @@ __metadata:
     "@jupyterlab/ui-components": ^4.6.0-alpha.4
     "@jupyterlab/workspaces": ^4.6.0-alpha.4
     "@types/jest": ^29.2.0
-    react: ^18.2.0
+    react: ^18.3.1
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -7909,12 +7909,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:^18.0.9":
-  version: 18.0.11
-  resolution: "@types/react-dom@npm:18.0.11"
-  dependencies:
-    "@types/react": "*"
-  checksum: 579691e4d5ec09688087568037c35edf8cfb1ab3e07f6c60029280733ee7b5c06d66df6fcc90786702c93ac8cb13bc7ff16c79ddfc75d082938fbaa36e1cdbf4
+"@types/react-dom@npm:^18.3.1":
+  version: 18.3.7
+  resolution: "@types/react-dom@npm:18.3.7"
+  peerDependencies:
+    "@types/react": ^18.0.0
+  checksum: c8b63ec944d2a68992b4dba474003fe55ee1d949c4b9c8fe97eecb2290de23f76acfb670b2f7ceb46a5fc8e46808d1745369b03edda48a7a0cf730eff4c5d315
   languageName: node
   linkType: hard
 
@@ -7945,14 +7945,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:^18.0.26":
-  version: 18.0.28
-  resolution: "@types/react@npm:18.0.28"
+"@types/react@npm:^18.3.12":
+  version: 18.3.28
+  resolution: "@types/react@npm:18.3.28"
   dependencies:
     "@types/prop-types": "*"
-    "@types/scheduler": "*"
-    csstype: ^3.0.2
-  checksum: e752df961105e5127652460504785897ca6e77259e0da8f233f694f9e8f451cde7fa0709d4456ade0ff600c8ce909cfe29f9b08b9c247fa9b734e126ec53edd7
+    csstype: ^3.2.2
+  checksum: 9d59fb3def4e712d4f8fa15998791a07f9799462f8d581d17039a9503017bfce3463d57fc737ce1d28d6aa3f482f4a3a5bae5a662d97560a9359aab111556c97
   languageName: node
   linkType: hard
 
@@ -7978,13 +7977,6 @@ __metadata:
   dependencies:
     htmlparser2: ^8.0.0
   checksum: a901d55d31cd946a7fce0130cc7cf6bcf56602af9c87291be77d8149c60e7afc47c83ca74c67c2d84e6ba029fe9bbd6f14f89a8cb30fbd185766eebc5722c251
-  languageName: node
-  linkType: hard
-
-"@types/scheduler@npm:*":
-  version: 0.16.2
-  resolution: "@types/scheduler@npm:0.16.2"
-  checksum: b6b4dcfeae6deba2e06a70941860fb1435730576d3689225a421280b7742318d1548b3d22c1f66ab68e414f346a9542f29240bc955b6332c5b11e561077583bc
   languageName: node
   linkType: hard
 
@@ -10812,10 +10804,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:3.0.10, csstype@npm:^3.0.10, csstype@npm:^3.0.2":
+"csstype@npm:3.0.10, csstype@npm:^3.0.10":
   version: 3.0.10
   resolution: "csstype@npm:3.0.10"
   checksum: 20a8fa324f2b33ddf94aa7507d1b6ab3daa6f3cc308888dc50126585d7952f2471de69b2dbe0635d1fdc31223fef8e070842691877e725caf456e2378685a631
+  languageName: node
+  linkType: hard
+
+"csstype@npm:^3.2.2":
+  version: 3.2.3
+  resolution: "csstype@npm:3.2.3"
+  checksum: cb882521b3398958a1ce6ca98c011aec0bde1c77ecaf8a1dd4db3b112a189939beae3b1308243b2fe50fc27eb3edeb0f73a5a4d91d928765dc6d5ecc7bda92ee
   languageName: node
   linkType: hard
 
@@ -18897,15 +18896,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^18.2.0":
-  version: 18.2.0
-  resolution: "react-dom@npm:18.2.0"
+"react-dom@npm:^18.3.1":
+  version: 18.3.1
+  resolution: "react-dom@npm:18.3.1"
   dependencies:
     loose-envify: ^1.1.0
-    scheduler: ^0.23.0
+    scheduler: ^0.23.2
   peerDependencies:
-    react: ^18.2.0
-  checksum: 7d323310bea3a91be2965f9468d552f201b1c27891e45ddc2d6b8f717680c95a75ae0bc1e3f5cf41472446a2589a75aed4483aee8169287909fcd59ad149e8cc
+    react: ^18.3.1
+  checksum: 298954ecd8f78288dcaece05e88b570014d8f6dce5db6f66e6ee91448debeb59dcd31561dddb354eee47e6c1bb234669459060deb238ed0213497146e555a0b9
   languageName: node
   linkType: hard
 
@@ -18933,6 +18932,13 @@ __metadata:
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
+  languageName: node
+  linkType: hard
+
+"react-is@npm:^18.3.1":
+  version: 18.3.1
+  resolution: "react-is@npm:18.3.1"
+  checksum: e20fe84c86ff172fc8d898251b7cc2c43645d108bf96d0b8edf39b98f9a2cae97b40520ee7ed8ee0085ccc94736c4886294456033304151c3f94978cec03df21
   languageName: node
   linkType: hard
 
@@ -18973,16 +18979,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-test-renderer@npm:^18.2.0":
-  version: 18.2.0
-  resolution: "react-test-renderer@npm:18.2.0"
+"react-test-renderer@npm:^18.3.1":
+  version: 18.3.1
+  resolution: "react-test-renderer@npm:18.3.1"
   dependencies:
-    react-is: ^18.2.0
+    react-is: ^18.3.1
     react-shallow-renderer: ^16.15.0
-    scheduler: ^0.23.0
+    scheduler: ^0.23.2
   peerDependencies:
-    react: ^18.2.0
-  checksum: 6b6980ced93fa2b72662d5e4ab3b4896833586940047ce52ca9aca801e5432adf05fcbe28289b0af3ce6a2a7c590974e25dcc8aa43d0de658bfe8bbcd686f958
+    react: ^18.3.1
+  checksum: e8e58e738835fab3801afb63f6bfe0fcf6e68ea39619fae5bdf47feefc36b1e4acb48c9dd139c7533611466eff1dfce6ffdda4b317e06aee663dda7d91438f26
   languageName: node
   linkType: hard
 
@@ -18998,12 +19004,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^18.2.0":
-  version: 18.2.0
-  resolution: "react@npm:18.2.0"
+"react@npm:^18.3.1":
+  version: 18.3.1
+  resolution: "react@npm:18.3.1"
   dependencies:
     loose-envify: ^1.1.0
-  checksum: 88e38092da8839b830cda6feef2e8505dec8ace60579e46aa5490fc3dc9bba0bd50336507dc166f43e3afc1c42939c09fe33b25fae889d6f402721dcd78fca1b
+  checksum: a27bcfa8ff7c15a1e50244ad0d0c1cb2ad4375eeffefd266a64889beea6f6b64c4966c9b37d14ee32d6c9fcd5aa6ba183b6988167ab4d127d13e7cb5b386a376
   languageName: node
   linkType: hard
 
@@ -19678,12 +19684,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.23.0":
-  version: 0.23.0
-  resolution: "scheduler@npm:0.23.0"
+"scheduler@npm:^0.23.2":
+  version: 0.23.2
+  resolution: "scheduler@npm:0.23.2"
   dependencies:
     loose-envify: ^1.1.0
-  checksum: d79192eeaa12abef860c195ea45d37cbf2bbf5f66e3c4dcd16f54a7da53b17788a70d109ee3d3dde1a0fd50e6a8fc171f4300356c5aee4fc0171de526bf35f8a
+  checksum: 3e82d1f419e240ef6219d794ff29c7ee415fbdc19e038f680a10c067108e06284f1847450a210b29bbaf97b9d8a97ced5f624c31c681248ac84c80d56ad5a2c4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## References

 - #18664

## Code changes

This commit fixes #18664 by updating the following packages:

- `react` and `react-dom` from `^18.2.0` to `18.3.1`
- `@types/react` from `^18.0.26` to `^18.3.12`
- `@types/react-dom` from `^18.0.9` to `^18.3.1`

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

NO
