### PR TITLE
Fix stdin input styling to match JupyterLab theme (#14458)

### DIFF
--- a/packages/outputarea/style/base.css
+++ b/packages/outputarea/style/base.css
@@ -246,19 +246,18 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated::before {
 
 .jp-Stdin-input {
   font-family: var(--jp-code-font-family);
-  font-size: inherit;
-  color: inherit;
-  background-color: inherit;
-  width: 42%;
+  font-size: var(--jp-code-font-size);
+  color: var(--jp-content-font-color0);
+  background-color: var(--jp-input-background);
   min-width: 200px;
+  border: var(--jp-border-width) solid var(--jp-input-border-color);
+  border-radius: 0;
+  padding: 4px 8px;
+  margin: 0 0.25em;
+  flex: 1 1 auto;
 
   /* make sure input baseline aligns with prompt */
   vertical-align: baseline;
-
-  /* padding + margin = 0.5em between prompt and cursor */
-  padding: 0 0.25em;
-  margin: 0 0.25em;
-  flex: 0 0 70%;
 }
 
 .jp-Stdin-input::placeholder {
@@ -266,7 +265,10 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated::before {
 }
 
 .jp-Stdin-input:focus {
-  box-shadow: none;
+  border-color: var(--jp-input-active-border-color);
+  box-shadow: var(--jp-input-box-shadow);
+  background-color: var(--jp-input-active-background);
+  outline: none;
 }
 
 .jp-Stdin-input:focus::placeholder {


### PR DESCRIPTION
## References

Closes #14458

## Code changes

`packages/outputarea/style/base.css` — Updated `.jp-Stdin-input` and `.jp-Stdin-input:focus` to use JupyterLab's `--jp-input-*` CSS variables instead of `inherit`, so the stdin input box styling matches the rest of the JupyterLab UI across all themes.

## User-facing changes

The stdin input box (`input()`) now has a visible border, themed background, and proper font sizing. On focus, the input shows a blue border and box shadow consistent with other JupyterLab inputs. Works correctly in both light and dark themes.

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude (Anthropic) — used for identifying the CSS fix, which was reviewed and adapted by the author.