### PR TITLE
Allow reset query parameter with values (e.g. ?reset=1)

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -651,7 +651,7 @@ const state: JupyterFrontEndPlugin<IStateDB> = {
 
     router.register({
       command: CommandIDs.resetOnLoad,
-      pattern: /(\?reset|\&reset)($|&)/,
+      pattern: /(\?reset|\&reset)(=[^&]*)?($|&)/,
       rank: 20 // High priority: 20:100.
     });
 


### PR DESCRIPTION
The router pattern for the workspace reset command only matched bare `?reset` query parameters (no `=` sign). This caused `?reset=1`, `?reset=true`, etc. to be silently ignored.

This is problematic when URLs pass through authentication proxies that strip bare query parameters without values during their redirect flow, making it impossible to reset the workspace.

Updated the regex to include an optional value group `(=[^&]*)?` so that both `?reset` and `?reset=<value>` are matched.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

https://github.com/jupyterlab/jupyterlab/issues/18700

Follow on PR to add tests: https://github.com/jupyterlab/jupyterlab/pull/18702

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

## AI usage

- **<!-- YES or NO -->**: Some or all of the content of this PR was generated by AI.
- **<!-- YES or NO -->**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: <!-- FILL IN -->
