### PR TITLE
Fix inconsistent default content behavior in RestContentProvider

### DIFF
--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -1784,7 +1784,7 @@ export class RestContentProvider implements IContentProvider {
       if (options.type === 'notebook') {
         delete options['format'];
       }
-      const content = options.content !== undefined ? (options.content ? '1' : '0') : '1';
+      const content = options && options.content ? '1' : '0';
       const hash = options.hash ? '1' : '0';
       const params: PartialJSONObject = { ...options, content, hash };
       url += URLExt.objectToQueryString(params);

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -1784,7 +1784,7 @@ export class RestContentProvider implements IContentProvider {
       if (options.type === 'notebook') {
         delete options['format'];
       }
-      const content = options.content ? '1' : '0';
+      const content = options.content !== undefined ? (options.content ? '1' : '0') : '1';
       const hash = options.hash ? '1' : '0';
       const params: PartialJSONObject = { ...options, content, hash };
       url += URLExt.objectToQueryString(params);

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -1784,7 +1784,7 @@ export class RestContentProvider implements IContentProvider {
       if (options.type === 'notebook') {
         delete options['format'];
       }
-      const content = options && options.content ? '1' : '0';
+      const content = options?.content !== undefined ? (options.content ? '1' : '0') : '1';
       const hash = options.hash ? '1' : '0';
       const params: PartialJSONObject = { ...options, content, hash };
       url += URLExt.objectToQueryString(params);


### PR DESCRIPTION

## References

Fixes #18695 

## Code changes

Updated the handling of `options.content` in `RestContentProvider` to ensure consistent default behavior.

Previously, when no options were provided, the default value of `content` differed from the Jupyter server's behavior. This change ensures that when `options.content` is undefined, it defaults to `'1'` (true), aligning with the expected behavior.

## User-facing changes

Fixes inconsistent behavior when fetching file contents. Users will now get consistent results regardless of whether options are provided or not.

## Backwards-incompatible changes

None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code.
- AI tools and models used:  ChatGPT