### PR TITLE
Pin playwright in merge reports step of visual regression testing

### DIFF
--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -193,7 +193,7 @@ jobs:
         id: pw-version
         run: |
           set -e
-          PW_VERSION=$(grep -m1 "playwright@" yarn.lock | sed -E 's/.*playwright@([^": ]+).*/\1/' | sed -E 's/^npm://')
+          PW_VERSION=$(grep -m1 '^"playwright@npm:' yarn.lock | sed -E 's/^"playwright@npm:([^"]+)":/\1/')
           echo "Playwright version: $PW_VERSION"
           echo "version=$PW_VERSION" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION


## References

- Noticed in https://github.com/jupyterlab/jupyterlab/pull/18710 and https://github.com/jupyterlab/jupyterlab/pull/18681
- Compatibility with new version is getting fixed in https://github.com/jupyterlab/maintainer-tools/pull/285

## Code changes

Retrieve the locked version of playwright from the yarn lockfile

## Developer-facing changes

- Merge reports step will now pass, even if new breaking playwright version is released
- Should there ever be a compromise of playwright npm package we would no longer install the latest version and be somewhat shielded

## Backwards-incompatible changes

None

