### PR TITLE
Add CSV comment option to csvviewer

### DIFF
--- a/galata/test/jupyterlab/csvviewer.test.ts
+++ b/galata/test/jupyterlab/csvviewer.test.ts
@@ -112,6 +112,9 @@ test.describe('CSV Viewer - comment character', () => {
     await expect(csvLocator).toBeVisible();
 
     // The DataGrid is canvas-based — no DOM cell elements exist.
+    // Wait for initial render (RENDER_TIMEOUT in widget is 1000 ms)
+    await page.waitForTimeout(1500);
+
     // Take a screenshot with no comment char (# lines treated as data rows).
     const screenshotWithoutComment = await csvLocator.screenshot();
 
@@ -137,6 +140,9 @@ test.describe('CSV Viewer - comment character', () => {
 
     const csvLocator = page.locator('.jp-CSVViewer');
     await expect(csvLocator).toBeVisible();
+
+    // Wait for initial render (RENDER_TIMEOUT in widget is 1000 ms)
+    await page.waitForTimeout(1500);
 
     const commentDropdown = page.locator('.jp-CSVComment-dropdown select');
 

--- a/galata/test/jupyterlab/csvviewer.test.ts
+++ b/galata/test/jupyterlab/csvviewer.test.ts
@@ -95,10 +95,11 @@ test.describe('CSV Viewer - comment character', () => {
   test('should show the Comment toolbar control', async ({ page }) => {
     await page.filebrowser.open(csvFileName);
 
-    const commentDropdown = page.locator('.jp-CSVComment select');
+    // The select is wrapped by Styling.wrapSelect inside the jp-CSVComment-dropdown div
+    const commentDropdown = page.locator('.jp-CSVComment-dropdown select');
     await expect(commentDropdown).toBeVisible();
 
-    // Default value should be 'none' (empty string)
+    // Default value should be empty string (none)
     await expect(commentDropdown).toHaveValue('');
   });
 
@@ -110,13 +111,9 @@ test.describe('CSV Viewer - comment character', () => {
     const csvLocator = page.locator('.jp-CSVViewer');
     await expect(csvLocator).toBeVisible();
 
-    // Without a comment char, the first '#' comment line becomes the header.
-    // The header cell should contain the raw comment text, not 'id'.
-    const headerCell = page.locator(
-      '.jp-CSVViewer .lm-DataGrid-headerCell:first-child'
-    );
-    await expect(headerCell).not.toHaveText('id');
-
+    // Without a comment char set, the '#' lines are treated as data rows.
+    // Verify the visual state via snapshot — the DataGrid is canvas-based
+    // so there are no DOM elements for individual cells.
     expect(await csvLocator.screenshot()).toMatchSnapshot(
       'csv-comments-no-comment-char.png'
     );
@@ -130,20 +127,16 @@ test.describe('CSV Viewer - comment character', () => {
     const csvLocator = page.locator('.jp-CSVViewer');
     await expect(csvLocator).toBeVisible();
 
-    // Select '#' as comment character
-    const commentDropdown = page.locator('.jp-CSVComment select');
+    // Select '#' as comment character using the correct wrapped select selector
+    const commentDropdown = page.locator('.jp-CSVComment-dropdown select');
     await commentDropdown.selectOption('#');
     await expect(commentDropdown).toHaveValue('#');
 
     // Wait for the grid to re-render
     await page.waitForTimeout(200);
 
-    // The header row should now be 'id', 'name', etc. — not the comment line
-    const headerCell = page.locator(
-      '.jp-CSVViewer .lm-DataGrid-headerCell:first-child'
-    );
-    await expect(headerCell).toHaveText('id');
-
+    // Verify the grid now shows the data rows correctly via snapshot.
+    // The DataGrid is canvas-based — individual cells have no DOM elements.
     expect(await csvLocator.screenshot()).toMatchSnapshot(
       'csv-comments-with-comment-char.png'
     );
@@ -157,21 +150,22 @@ test.describe('CSV Viewer - comment character', () => {
     const csvLocator = page.locator('.jp-CSVViewer');
     await expect(csvLocator).toBeVisible();
 
-    const commentDropdown = page.locator('.jp-CSVComment select');
+    const commentDropdown = page.locator('.jp-CSVComment-dropdown select');
 
-    // Enable comment char
+    // Enable comment char — grid should re-render without comment rows
     await commentDropdown.selectOption('#');
     await page.waitForTimeout(200);
 
-    // Revert to 'none'
+    const withCommentScreenshot = await csvLocator.screenshot();
+
+    // Revert to none — grid should re-render including comment rows as data
     await commentDropdown.selectOption('');
     await page.waitForTimeout(200);
 
-    // Header should no longer be 'id' — raw comment line is back as header
-    const headerCell = page.locator(
-      '.jp-CSVViewer .lm-DataGrid-headerCell:first-child'
-    );
-    await expect(headerCell).not.toHaveText('id');
+    const withoutCommentScreenshot = await csvLocator.screenshot();
+
+    // The two states must produce different renders
+    expect(withCommentScreenshot).not.toEqual(withoutCommentScreenshot);
   });
 
   test.afterEach(async ({ page }) => {

--- a/galata/test/jupyterlab/csvviewer.test.ts
+++ b/galata/test/jupyterlab/csvviewer.test.ts
@@ -21,6 +21,17 @@ const testData = `id,name,ip_address,userid
 10,Stephanie Turner,206.103.246.83,sturner9
 `;
 
+// CSV data with leading comment lines prefixed with '#'
+const testDataWithComments = `# This file was exported on 2024-01-01
+# Source: internal database
+id,name,ip_address,userid
+1,Juan King,51.223.215.102,jking0
+2,Janet Robertson,94.135.163.124,jrobertson1
+3,Charles Howard,49.71.100.63,choward2
+4,Beverly Johnson,95.201.11.104,bjohnson3
+5,Robin Fowler,244.18.23.69,rfowler4
+`;
+
 test.describe('CSV Viewer', () => {
   const csvFileName = 'test-data.csv';
 
@@ -50,6 +61,117 @@ test.describe('CSV Viewer', () => {
     await page.theme.setDarkTheme();
 
     expect(await csvLocator.screenshot()).toMatchSnapshot(screenshotName);
+  });
+
+  test.afterEach(async ({ page }) => {
+    try {
+      await page.contents.deleteFile(csvFileName);
+    } catch (e) {
+      console.error(`Error deleting file ${csvFileName}: ${e}`);
+    }
+
+    try {
+      fs.unlinkSync(tempFilePath);
+      fs.rmdirSync(path.dirname(tempFilePath));
+    } catch (e) {
+      console.error(`Error cleaning up temp file: ${e}`);
+    }
+  });
+});
+
+test.describe('CSV Viewer - comment character', () => {
+  const csvFileName = 'test-data-comments.csv';
+
+  let tempFilePath: string;
+
+  test.beforeEach(async ({ page, tmpPath }) => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'csv-comment-test-'));
+    tempFilePath = path.join(tempDir, csvFileName);
+
+    fs.writeFileSync(tempFilePath, testDataWithComments);
+    await page.contents.uploadFile(tempFilePath, `${tmpPath}/${csvFileName}`);
+  });
+
+  test('should show the Comment toolbar control', async ({ page }) => {
+    await page.filebrowser.open(csvFileName);
+
+    const commentDropdown = page.locator('.jp-CSVComment select');
+    await expect(commentDropdown).toBeVisible();
+
+    // Default value should be 'none' (empty string)
+    await expect(commentDropdown).toHaveValue('');
+  });
+
+  test('should treat comment rows as data when no comment char is set', async ({
+    page
+  }) => {
+    await page.filebrowser.open(csvFileName);
+
+    const csvLocator = page.locator('.jp-CSVViewer');
+    await expect(csvLocator).toBeVisible();
+
+    // Without a comment char, the first '#' comment line becomes the header.
+    // The header cell should contain the raw comment text, not 'id'.
+    const headerCell = page.locator(
+      '.jp-CSVViewer .lm-DataGrid-headerCell:first-child'
+    );
+    await expect(headerCell).not.toHaveText('id');
+
+    expect(await csvLocator.screenshot()).toMatchSnapshot(
+      'csv-comments-no-comment-char.png'
+    );
+  });
+
+  test('should correctly parse CSV when comment char is set to #', async ({
+    page
+  }) => {
+    await page.filebrowser.open(csvFileName);
+
+    const csvLocator = page.locator('.jp-CSVViewer');
+    await expect(csvLocator).toBeVisible();
+
+    // Select '#' as comment character
+    const commentDropdown = page.locator('.jp-CSVComment select');
+    await commentDropdown.selectOption('#');
+    await expect(commentDropdown).toHaveValue('#');
+
+    // Wait for the grid to re-render
+    await page.waitForTimeout(200);
+
+    // The header row should now be 'id', 'name', etc. — not the comment line
+    const headerCell = page.locator(
+      '.jp-CSVViewer .lm-DataGrid-headerCell:first-child'
+    );
+    await expect(headerCell).toHaveText('id');
+
+    expect(await csvLocator.screenshot()).toMatchSnapshot(
+      'csv-comments-with-comment-char.png'
+    );
+  });
+
+  test('should revert to raw rendering when comment char is cleared', async ({
+    page
+  }) => {
+    await page.filebrowser.open(csvFileName);
+
+    const csvLocator = page.locator('.jp-CSVViewer');
+    await expect(csvLocator).toBeVisible();
+
+    const commentDropdown = page.locator('.jp-CSVComment select');
+
+    // Enable comment char
+    await commentDropdown.selectOption('#');
+    await page.waitForTimeout(200);
+
+    // Revert to 'none'
+    await commentDropdown.selectOption('');
+    await page.waitForTimeout(200);
+
+    // Header should no longer be 'id' — raw comment line is back as header
+    const headerCell = page.locator(
+      '.jp-CSVViewer .lm-DataGrid-headerCell:first-child'
+    );
+    await expect(headerCell).not.toHaveText('id');
   });
 
   test.afterEach(async ({ page }) => {

--- a/galata/test/jupyterlab/csvviewer.test.ts
+++ b/galata/test/jupyterlab/csvviewer.test.ts
@@ -127,7 +127,7 @@ test.describe('CSV Viewer - comment character', () => {
     const screenshotWithComment = await csvLocator.screenshot();
 
     // The two renders must differ — the comment lines affect the data layout
-    expect(screenshotWithComment).not.toEqual(screenshotWithoutComment);
+    expect(Buffer.compare(screenshotWithComment, screenshotWithoutComment)).not.toBe(0);
   });
 
   test('should revert to raw rendering when comment char is cleared', async ({
@@ -153,7 +153,7 @@ test.describe('CSV Viewer - comment character', () => {
     const withoutCommentScreenshot = await csvLocator.screenshot();
 
     // The two states must produce different renders
-    expect(withCommentScreenshot).not.toEqual(withoutCommentScreenshot);
+    expect(Buffer.compare(withCommentScreenshot, withoutCommentScreenshot)).not.toBe(0);
   });
 
   test.afterEach(async ({ page }) => {

--- a/galata/test/jupyterlab/csvviewer.test.ts
+++ b/galata/test/jupyterlab/csvviewer.test.ts
@@ -103,7 +103,7 @@ test.describe('CSV Viewer - comment character', () => {
     await expect(commentDropdown).toHaveValue('');
   });
 
-  test('should treat comment rows as data when no comment char is set', async ({
+  test('should render differently with and without comment char set', async ({
     page
   }) => {
     await page.filebrowser.open(csvFileName);
@@ -111,35 +111,23 @@ test.describe('CSV Viewer - comment character', () => {
     const csvLocator = page.locator('.jp-CSVViewer');
     await expect(csvLocator).toBeVisible();
 
-    // Without a comment char set, the '#' lines are treated as data rows.
-    // Verify the visual state via snapshot — the DataGrid is canvas-based
-    // so there are no DOM elements for individual cells.
-    expect(await csvLocator.screenshot()).toMatchSnapshot(
-      'csv-comments-no-comment-char.png'
-    );
-  });
+    // The DataGrid is canvas-based — no DOM cell elements exist.
+    // Take a screenshot with no comment char (# lines treated as data rows).
+    const screenshotWithoutComment = await csvLocator.screenshot();
 
-  test('should correctly parse CSV when comment char is set to #', async ({
-    page
-  }) => {
-    await page.filebrowser.open(csvFileName);
-
-    const csvLocator = page.locator('.jp-CSVViewer');
-    await expect(csvLocator).toBeVisible();
-
-    // Select '#' as comment character using the correct wrapped select selector
+    // Now set '#' as the comment character
     const commentDropdown = page.locator('.jp-CSVComment-dropdown select');
     await commentDropdown.selectOption('#');
     await expect(commentDropdown).toHaveValue('#');
 
-    // Wait for the grid to re-render
-    await page.waitForTimeout(200);
+    // Wait for the grid to re-render (RENDER_TIMEOUT in widget is 1000 ms)
+    await page.waitForTimeout(1500);
 
-    // Verify the grid now shows the data rows correctly via snapshot.
-    // The DataGrid is canvas-based — individual cells have no DOM elements.
-    expect(await csvLocator.screenshot()).toMatchSnapshot(
-      'csv-comments-with-comment-char.png'
-    );
+    // Take screenshot after setting comment char (# lines are now skipped)
+    const screenshotWithComment = await csvLocator.screenshot();
+
+    // The two renders must differ — the comment lines affect the data layout
+    expect(screenshotWithComment).not.toEqual(screenshotWithoutComment);
   });
 
   test('should revert to raw rendering when comment char is cleared', async ({
@@ -154,13 +142,13 @@ test.describe('CSV Viewer - comment character', () => {
 
     // Enable comment char — grid should re-render without comment rows
     await commentDropdown.selectOption('#');
-    await page.waitForTimeout(200);
+    await page.waitForTimeout(1500);
 
     const withCommentScreenshot = await csvLocator.screenshot();
 
     // Revert to none — grid should re-render including comment rows as data
     await commentDropdown.selectOption('');
-    await page.waitForTimeout(200);
+    await page.waitForTimeout(1500);
 
     const withoutCommentScreenshot = await csvLocator.screenshot();
 

--- a/packages/csvviewer/src/model.ts
+++ b/packages/csvviewer/src/model.ts
@@ -45,6 +45,7 @@ export class DSVModel extends DataModel implements IDisposable {
     let {
       data,
       delimiter = ',',
+      comment = undefined,
       rowDelimiter = undefined,
       quote = '"',
       quoteParser = undefined,
@@ -53,9 +54,11 @@ export class DSVModel extends DataModel implements IDisposable {
     } = options;
     this._rawData = data;
     this._delimiter = delimiter;
+    this._comment = comment;
     this._quote = quote;
     this._quoteEscaped = new RegExp(quote + quote, 'g');
     this._initialRows = initialRows;
+    this._hasHeader = header;
 
     // Guess the row delimiter if it was not supplied. This will be fooled if a
     // different line delimiter possibility appears in the first row.
@@ -77,14 +80,26 @@ export class DSVModel extends DataModel implements IDisposable {
     }
     this._parser = quoteParser ? 'quotes' : 'noquotes';
 
+    const firstDataRow = this._getFirstDataRow();
+    this._columnCount = firstDataRow.ncols;
+    this._preferredColumnCount = firstDataRow.ncols;
+    if (header === true) {
+      this._headerRow = firstDataRow.row;
+      this._initialRows = Math.max(this._initialRows, this._headerRow + 1);
+    }
+
     // Parse the data.
     this.parseAsync();
 
     // Cache the header row.
-    if (header === true && this._columnCount! > 0) {
+    if (
+      header === true &&
+      this._columnCount! > 0 &&
+      this._headerRow < this._rowCount!
+    ) {
       const h = [];
       for (let c = 0; c < this._columnCount!; c++) {
-        h.push(this._getField(0, c));
+        h.push(this._getField(this._headerRow, c));
       }
       this._header = h;
     }
@@ -164,10 +179,10 @@ export class DSVModel extends DataModel implements IDisposable {
    */
   rowCount(region: DataModel.RowRegion): number {
     if (region === 'body') {
-      if (this._header.length === 0) {
+      if (this._hasHeader === false) {
         return this._rowCount!;
       } else {
-        return this._rowCount! - 1;
+        return Math.max(this._rowCount! - 1, 0);
       }
     }
     return 1;
@@ -204,14 +219,10 @@ export class DSVModel extends DataModel implements IDisposable {
     // Look up the field and value for the region.
     switch (region) {
       case 'body':
-        if (this._header.length === 0) {
-          value = this._getField(row, column);
-        } else {
-          value = this._getField(row + 1, column);
-        }
+        value = this._getField(this._bodyRowToRawRow(row), column);
         break;
       case 'column-header':
-        if (this._header.length === 0) {
+        if (this._hasHeader === false) {
           value = (column + 1).toString();
         } else {
           value = this._header[column];
@@ -410,15 +421,16 @@ export class DSVModel extends DataModel implements IDisposable {
 
     // Compute the column count if we don't already have it.
     if (this._columnCount === undefined) {
-      // Get number of columns in first row
-      this._columnCount = PARSERS[this._parser]({
-        data: this._rawData,
-        delimiter: this._delimiter,
-        rowDelimiter: this._rowDelimiter,
-        quote: this._quote,
-        columnOffsets: true,
-        maxRows: 1
-      }).ncols;
+      this._columnCount =
+        this._preferredColumnCount ??
+        PARSERS[this._parser]({
+          data: this._rawData,
+          delimiter: this._delimiter,
+          rowDelimiter: this._rowDelimiter,
+          quote: this._quote,
+          columnOffsets: true,
+          maxRows: 1
+        }).ncols;
     }
 
     // `reparse` is the number of rows we are requesting to parse over again.
@@ -596,6 +608,70 @@ export class DSVModel extends DataModel implements IDisposable {
   }
 
   /**
+   * Find the first non-comment row and use it to determine the header row and
+   * column count.
+   */
+  private _getFirstDataRow(): { row: number; ncols: number } {
+    const comment = this._comment;
+    const parser = PARSERS[this._parser];
+
+    if (!comment) {
+      const { ncols } = parser({
+        data: this._rawData,
+        delimiter: this._delimiter,
+        rowDelimiter: this._rowDelimiter,
+        quote: this._quote,
+        columnOffsets: true,
+        maxRows: 1
+      });
+      return { row: 0, ncols };
+    }
+
+    let row = 0;
+    let startIndex = 0;
+    while (startIndex < this._rawData.length) {
+      if (this._rawData[startIndex] !== comment) {
+        const { ncols } = parser({
+          data: this._rawData,
+          startIndex,
+          delimiter: this._delimiter,
+          rowDelimiter: this._rowDelimiter,
+          quote: this._quote,
+          columnOffsets: true,
+          maxRows: 1
+        });
+        return { row, ncols };
+      }
+      const nextRow = this._rawData.indexOf(this._rowDelimiter, startIndex);
+      if (nextRow === -1) {
+        break;
+      }
+      startIndex = nextRow + this._rowDelimiter.length;
+      row++;
+    }
+
+    const { ncols } = parser({
+      data: this._rawData,
+      delimiter: this._delimiter,
+      rowDelimiter: this._rowDelimiter,
+      quote: this._quote,
+      columnOffsets: true,
+      maxRows: 1
+    });
+    return { row: 0, ncols };
+  }
+
+  /**
+   * Map a displayed body row to the underlying raw row, skipping the header.
+   */
+  private _bodyRowToRawRow(row: number): number {
+    if (this._hasHeader === false) {
+      return row;
+    }
+    return row < this._headerRow ? row : row + 1;
+  }
+
+  /**
    * Reset the parser state.
    */
   private _resetParser(): void {
@@ -628,6 +704,7 @@ export class DSVModel extends DataModel implements IDisposable {
 
   // Parser settings
   private _delimiter: string;
+  private _comment: string | undefined;
   private _quote: string;
   private _quoteEscaped: RegExp;
   private _parser: 'quotes' | 'noquotes';
@@ -637,12 +714,15 @@ export class DSVModel extends DataModel implements IDisposable {
   private _rawData: string;
   private _rowCount: number | undefined = 0;
   private _columnCount: number | undefined;
+  private _preferredColumnCount: number | undefined;
 
   // Cache information
   /**
    * The header strings.
    */
   private _header: string[] = [];
+  private _headerRow = 0;
+  private _hasHeader = true;
   /**
    * The column offset cache, starting with row _columnOffsetsStartingRow
    *
@@ -692,6 +772,12 @@ export namespace DSVModel {
      * The field delimiter must be a single character.
      */
     delimiter: string;
+
+    /**
+     * Optional comment character used to ignore header/column detection for
+     * matching rows while still rendering those rows in the grid.
+     */
+    comment?: string;
 
     /**
      * The data source for the data model.

--- a/packages/csvviewer/src/toolbar.ts
+++ b/packages/csvviewer/src/toolbar.ts
@@ -20,6 +20,12 @@ const CSV_DELIMITER_LABEL_CLASS = 'jp-CSVDelimiter-label';
  */
 const CSV_DELIMITER_DROPDOWN_CLASS = 'jp-CSVDelimiter-dropdown';
 
+const CSV_COMMENT_CLASS = 'jp-CSVComment';
+
+const CSV_COMMENT_LABEL_CLASS = 'jp-CSVComment-label';
+
+const CSV_COMMENT_DROPDOWN_CLASS = 'jp-CSVComment-dropdown';
+
 /**
  * A widget for selecting a delimiter.
  */
@@ -29,7 +35,20 @@ export class CSVDelimiter extends Widget {
    */
   constructor(options: CSVToolbar.IOptions) {
     super({
-      node: Private.createNode(options.widget.delimiter, options.translator)
+      node: Private.createNode({
+        selected: options.widget.delimiter,
+        label: 'Delimiter: ',
+        labelClassName: CSV_DELIMITER_LABEL_CLASS,
+        dropdownClassName: CSV_DELIMITER_DROPDOWN_CLASS,
+        translator: options.translator,
+        values: [
+          [',', ','],
+          [';', ';'],
+          ['\t', 'tab'],
+          ['|', 'pipe'],
+          ['#', 'hash']
+        ]
+      })
     });
     this._widget = options.widget;
     this.addClass(CSV_DELIMITER_CLASS);
@@ -80,6 +99,68 @@ export class CSVDelimiter extends Widget {
 }
 
 /**
+ * A widget for selecting a comment character.
+ */
+export class CSVComment extends Widget {
+  /**
+   * Construct a new csv comment widget.
+   */
+  constructor(options: CSVToolbar.IOptions) {
+    super({
+      node: Private.createNode({
+        selected: options.widget.comment ?? '',
+        label: 'Comment: ',
+        labelClassName: CSV_COMMENT_LABEL_CLASS,
+        dropdownClassName: CSV_COMMENT_DROPDOWN_CLASS,
+        translator: options.translator,
+        values: [
+          ['', 'none'],
+          ['#', 'hash']
+        ]
+      })
+    });
+    this._widget = options.widget;
+    this.addClass(CSV_COMMENT_CLASS);
+  }
+
+  /**
+   * The comment dropdown menu.
+   */
+  get selectNode(): HTMLSelectElement {
+    return this.node.getElementsByTagName('select')![0];
+  }
+
+  /**
+   * Handle DOM events for the widget.
+   */
+  handleEvent(event: Event): void {
+    switch (event.type) {
+      case 'change':
+        this._widget.comment = this.selectNode.value || null;
+        break;
+      default:
+        break;
+    }
+  }
+
+  /**
+   * Handle `after-attach` messages for the widget.
+   */
+  protected onAfterAttach(msg: Message): void {
+    this.selectNode.addEventListener('change', this);
+  }
+
+  /**
+   * Handle `before-detach` messages for the widget.
+   */
+  protected onBeforeDetach(msg: Message): void {
+    this.selectNode.removeEventListener('change', this);
+  }
+
+  protected _widget: CSVViewer;
+}
+
+/**
  * A namespace for `CSVToolbar` statics.
  */
 export namespace CSVToolbar {
@@ -103,42 +184,46 @@ export namespace CSVToolbar {
  * A namespace for private toolbar methods.
  */
 namespace Private {
-  /**
-   * Create the node for the delimiter switcher.
-   */
-  export function createNode(
-    selected: string,
-    translator?: ITranslator
-  ): HTMLElement {
-    translator = translator || nullTranslator;
-    const trans = translator?.load('jupyterlab');
+  interface ICreateNodeOptions {
+    selected: string;
+    label: string;
+    labelClassName: string;
+    dropdownClassName: string;
+    translator?: ITranslator;
+    values: Array<[string, string]>;
+  }
 
-    // The supported parsing delimiters and labels.
-    const delimiters = [
-      [',', ','],
-      [';', ';'],
-      ['\t', trans.__('tab')],
-      ['|', trans.__('pipe')],
-      ['#', trans.__('hash')]
-    ];
+  /**
+   * Create the node for a CSV toolbar select.
+   */
+  export function createNode(options: ICreateNodeOptions): HTMLElement {
+    const {
+      selected,
+      label,
+      labelClassName,
+      dropdownClassName,
+      translator,
+      values
+    } = options;
+    const trans = (translator || nullTranslator).load('jupyterlab');
 
     const div = document.createElement('div');
-    const label = document.createElement('span');
+    const labelNode = document.createElement('span');
     const select = document.createElement('select');
-    label.textContent = trans.__('Delimiter: ');
-    label.className = CSV_DELIMITER_LABEL_CLASS;
-    for (const [delimiter, label] of delimiters) {
+    labelNode.textContent = trans.__(label);
+    labelNode.className = labelClassName;
+    for (const [value, optionLabel] of values) {
       const option = document.createElement('option');
-      option.value = delimiter;
-      option.textContent = label;
-      if (delimiter === selected) {
+      option.value = value;
+      option.textContent = trans.__(optionLabel);
+      if (value === selected) {
         option.selected = true;
       }
       select.appendChild(option);
     }
-    div.appendChild(label);
+    div.appendChild(labelNode);
     const node = Styling.wrapSelect(select);
-    node.classList.add(CSV_DELIMITER_DROPDOWN_CLASS);
+    node.classList.add(dropdownClassName);
     div.appendChild(node);
     return div;
   }

--- a/packages/csvviewer/src/toolbar.ts
+++ b/packages/csvviewer/src/toolbar.ts
@@ -45,8 +45,7 @@ export class CSVDelimiter extends Widget {
           [',', ','],
           [';', ';'],
           ['\t', 'tab'],
-          ['|', 'pipe'],
-          ['#', 'hash']
+          ['|', 'pipe']
         ]
       })
     });

--- a/packages/csvviewer/src/toolbar.ts
+++ b/packages/csvviewer/src/toolbar.ts
@@ -45,7 +45,8 @@ export class CSVDelimiter extends Widget {
           [',', ','],
           [';', ';'],
           ['\t', 'tab'],
-          ['|', 'pipe']
+          ['|', 'pipe'],
+          ['#', '#']
         ]
       })
     });

--- a/packages/csvviewer/src/widget.ts
+++ b/packages/csvviewer/src/widget.ts
@@ -14,7 +14,7 @@ import type { ISignal } from '@lumino/signaling';
 import { Signal } from '@lumino/signaling';
 import { PanelLayout, Widget } from '@lumino/widgets';
 import type * as DSVModelModule from './model';
-import { CSVDelimiter } from './toolbar';
+import { CSVComment, CSVDelimiter } from './toolbar';
 
 /**
  * The class name added to a CSV viewer.
@@ -322,6 +322,20 @@ export class CSVViewer extends Widget {
   }
 
   /**
+   * The optional comment character for the file.
+   */
+  get comment(): string | null {
+    return this._comment;
+  }
+  set comment(value: string | null) {
+    if (value === this._comment) {
+      return;
+    }
+    this._comment = value;
+    void this._updateGrid();
+  }
+
+  /**
    * The style used by the data grid.
    */
   get style(): DataGridModule.DataGrid.Style {
@@ -382,7 +396,8 @@ export class CSVViewer extends Widget {
     const oldModel = this._grid.dataModel as DSVModelModule.DSVModel;
     const dataModel = (this._grid.dataModel = new DSVModel({
       data,
-      delimiter
+      delimiter,
+      comment: this._comment ?? undefined
     }));
     this._grid.selectionModel = new BasicSelectionModel({ dataModel });
     if (oldModel) {
@@ -421,6 +436,7 @@ export class CSVViewer extends Widget {
   private _monitor: ActivityMonitor<DocumentRegistry.IModel, void> | null =
     null;
   private _delimiter = ',';
+  private _comment: string | null = null;
   private _revealed = new PromiseDelegate<void>();
   private _baseRenderer: TextRenderConfig | null = null;
   private _ready: Promise<void>;
@@ -521,6 +537,13 @@ export class CSVViewerFactory extends ABCWidgetFactory<
       {
         name: 'delimiter',
         widget: new CSVDelimiter({
+          widget: widget.content,
+          translator: this.translator
+        })
+      },
+      {
+        name: 'comment',
+        widget: new CSVComment({
           widget: widget.content,
           translator: this.translator
         })

--- a/packages/csvviewer/style/base.css
+++ b/packages/csvviewer/style/base.css
@@ -13,7 +13,8 @@
   font-size: var(--jp-ui-font-size1);
 }
 
-.jp-CSVDelimiter {
+.jp-CSVDelimiter,
+.jp-CSVComment {
   display: flex;
   flex: 0 0 auto;
   flex-direction: row;
@@ -23,14 +24,16 @@
   z-index: 1;
 }
 
-.jp-CSVDelimiter .jp-CSVDelimiter-label {
+.jp-CSVDelimiter .jp-CSVDelimiter-label,
+.jp-CSVComment .jp-CSVComment-label {
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size1);
   padding-left: 8px;
   padding-right: 8px;
 }
 
-.jp-CSVDelimiter .jp-CSVDelimiter-dropdown {
+.jp-CSVDelimiter .jp-CSVDelimiter-dropdown,
+.jp-CSVComment .jp-CSVComment-dropdown {
   flex: 0 0 auto;
   vertical-align: middle;
   border-radius: 0;
@@ -40,7 +43,8 @@
   margin-bottom: 2px;
 }
 
-.jp-CSVDelimiter .jp-CSVDelimiter-dropdown select.jp-mod-styled {
+.jp-CSVDelimiter .jp-CSVDelimiter-dropdown select.jp-mod-styled,
+.jp-CSVComment .jp-CSVComment-dropdown select.jp-mod-styled {
   color: var(--jp-ui-font-color1);
   background: var(--jp-layout-color1);
   font-size: var(--jp-ui-font-size1);

--- a/packages/csvviewer/test/model.spec.ts
+++ b/packages/csvviewer/test/model.spec.ts
@@ -297,6 +297,40 @@ describe('csvviewer/model', () => {
       expect([0, 1, 2].map(i => d.data('body', 1, i))).toEqual(['g', 'h', '']);
     });
 
+    it('ignores leading comment rows when determining headers and columns', () => {
+      const d = new DSVModel({
+        data: `# metadata\n# units,date,lon,lat,value\ndate,lon,lat,value\n2020-01-01,-97.0,40,5.00\n`,
+        delimiter: ',',
+        comment: '#'
+      });
+      expect(d.rowCount('body')).toBe(3);
+      expect(d.columnCount('body')).toBe(4);
+      expect([0, 1, 2, 3].map(i => d.data('column-header', 0, i))).toEqual([
+        'date',
+        'lon',
+        'lat',
+        'value'
+      ]);
+      expect([0, 1, 2, 3].map(i => d.data('body', 0, i))).toEqual([
+        '# metadata',
+        '',
+        '',
+        ''
+      ]);
+      expect([0, 1, 2, 3].map(i => d.data('body', 1, i))).toEqual([
+        '# units',
+        'date',
+        'lon',
+        'lat,value'
+      ]);
+      expect([0, 1, 2, 3].map(i => d.data('body', 2, i))).toEqual([
+        '2020-01-01',
+        '-97.0',
+        '40',
+        '5.00'
+      ]);
+    });
+
     it('handles delayed parsing of rows past the initial rows', async () => {
       const d = new DSVModel({
         data: `a,b,c\nc,d,e\nf,g,h\ni,j,k`,

--- a/packages/csvviewer/test/toolbar.spec.ts
+++ b/packages/csvviewer/test/toolbar.spec.ts
@@ -4,20 +4,24 @@
 import { Widget } from '@lumino/widgets';
 import { simulate } from 'simulate-event';
 import type { CSVViewer } from '../src';
-import { CSVDelimiter } from '../src';
+import { CSVComment, CSVDelimiter } from '../src';
 
 const DELIMITERS = [',', ';', '\t'];
+const COMMENTS = ['', '#'];
 
 describe('csvviewer/toolbar', () => {
   let delimiter = DELIMITERS[0];
+  let comment = COMMENTS[0];
   const mockViewer: jest.Mock<CSVViewer> = jest.fn().mockImplementation(() => {
     return {
-      delimiter
+      delimiter,
+      comment: comment || null
     };
   });
 
   beforeEach(() => {
     delimiter = DELIMITERS[0];
+    comment = COMMENTS[0];
   });
 
   describe('CSVDelimiter', () => {
@@ -87,6 +91,48 @@ describe('csvviewer/toolbar', () => {
         widget.dispose();
         widget.dispose();
         expect(widget.isDisposed).toBe(true);
+      });
+    });
+  });
+
+  describe('CSVComment', () => {
+    describe('#constructor()', () => {
+      it('should instantiate a `CSVComment` toolbar widget', () => {
+        const widget = new CSVComment({ widget: mockViewer() });
+        expect(widget).toBeInstanceOf(CSVComment);
+        expect(Array.from(widget.node.classList)).toEqual(
+          expect.arrayContaining(['jp-CSVComment'])
+        );
+        widget.dispose();
+      });
+
+      it('should allow pre-selecting the comment character', () => {
+        comment = COMMENTS[COMMENTS.length - 1];
+        const widget = new CSVComment({ widget: mockViewer() });
+        expect(widget.selectNode.value).toBe(comment);
+        widget.dispose();
+      });
+    });
+
+    describe('#handleEvent', () => {
+      it('should change the comment character', () => {
+        const viewer = mockViewer();
+        const widget = new CSVComment({ widget: viewer });
+        const wanted = COMMENTS[1];
+        widget.selectNode.value = wanted;
+        widget.handleEvent({ type: 'change' } as any);
+        expect(viewer.comment).toBe(wanted);
+        widget.dispose();
+      });
+
+      it('should clear the comment character', () => {
+        comment = COMMENTS[1];
+        const viewer = mockViewer();
+        const widget = new CSVComment({ widget: viewer });
+        widget.selectNode.value = COMMENTS[0];
+        widget.handleEvent({ type: 'change' } as any);
+        expect(viewer.comment).toBeNull();
+        widget.dispose();
       });
     });
   });


### PR DESCRIPTION
## References

- Closes #11902
- roughly same as https://github.com/jupyterlab/jupyterlab/pull/18387

## Code changes

- added a separate comment-character toolbar control in the CSV viewer alongside the delimiter selector
- updated the CSV data model to ignore leading comment rows when choosing the header row and inferred column count while still rendering those rows in the grid
- added csvviewer model and toolbar tests covering the new comment-character behavior

## User-facing changes

- CSV files can now be parsed with an optional comment character in the CSV viewer toolbar
- leading comment rows no longer become the header row or determine the inferred column count
- comment rows are still shown in the grid

## Backwards-incompatible changes

- None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Codex (GPT-5)
