### PR TITLE
Fix #13795: Unable to install extension if same name dir/file exists

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -2170,8 +2170,13 @@ def _ensure_logger(logger=None):
 def _normalize_path(extension):
     """Normalize a given extension if it is a path."""
     extension = osp.expanduser(extension)
-    if osp.exists(extension):
-        extension = osp.abspath(extension)
+
+    if osp.exists(extension) and (
+        (osp.isfile(extension) and extension.endswith(".tgz"))
+        or (osp.isdir(extension) and osp.exists(osp.join(extension, "package.json")))
+    ):
+        return osp.abspath(extension)
+
     return extension
 
 


### PR DESCRIPTION
The `jupyter labextension install` command fails with a `ValueError` if an empty directory or unrelated file matching the extension name exists in the current working directory, because it mistakenly attempts to install from the local path instead of fetching from npm.

Modified `_normalize_path` in `jupyterlab/commands.py` to only resolve absolute paths if the local path is actually a valid npm package. Added checks to ensure the local path is either a file ending in `.tgz` or a directory containing a `package.json`.

Users can now successfully install extensions from the npm registry even if a local file or folder with the exact same name exists in their current working directory.

## References

- Fixes #13795
- The `jupyter labextension install` command incorrectly resolves a local file or directory matching the extension name as an absolute path, causing a `ValueError` instead of fetching the package from npm.

## Code changes

- Modified `_normalize_path` in `jupyterlab/commands.py` to only resolve absolute paths if the local path is actually a valid npm package (a `.tgz` file or a directory containing `package.json`).
- Previously, any existing file or directory matching the extension name was resolved to an absolute path, which caused `npm pack` to fail.

## User-facing changes

- Users can now successfully run `jupyter labextension install <extension>` even if a local file or folder with the same name as the extension exists in the current working directory.
- No visual changes.

## Backwards-incompatible changes

No backwards-incompatible changes.

## AI usage

- **YES**: Some of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code.
- AI tools and models used: Google Gemini, GitHub Copilot