### PR TITLE
Fix inconsistent width measurement for breadcrumbs

### DIFF
--- a/packages/filebrowser/src/crumbs.ts
+++ b/packages/filebrowser/src/crumbs.ts
@@ -596,7 +596,7 @@ export class BreadCrumbs extends Widget {
     // Calculate available space for items
     let fixedOverhead = homeWidth + separatorWidth;
     if (this._hasPreferred) {
-      fixedOverhead += preferredWidth + separatorWidth;
+      fixedOverhead += preferredWidth;
     }
     const availableForItems = containerWidth - fixedOverhead;
 


### PR DESCRIPTION
See comment in https://github.com/jupyterlab/jupyterlab/pull/18571#discussion_r2987815395

There appear to be an inconsistency in construction of the breadcrumb bar (and it's shadow copy used for measurement).

Mostly the addition of a crumb separator between the preferred folder (when present) and the home folder, crum separator that is not present in the final UI.

Another note, the `Home` is a folder-icon, and the `Preferred` is a home-icon ... that confused me for a while; i would have use a bookmark or a star for preferred.

## References

No-ref, too small of a change.

## Code changes

Remove the crumb separator in the `_calculateAdaptiveItems` function

## User-facing changes

None, or if any fix a bug where the crumbs would improperly wrap or elide.

## Backwards-incompatible changes

None

## AI usage

YES, Copilot found the issue (see original comment). Claude Opus seem to agree this is the only place that needs a fix.
