### PR TITLE
Fix focusing input element when opening a dialog from Command Palette

### DIFF
--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -471,7 +471,7 @@ export class Dialog<T> extends Widget {
     const target = event.target as HTMLElement;
     if (!this.node.contains(target as HTMLElement)) {
       event.stopPropagation();
-      this._buttonNodes[this._defaultButton]?.focus();
+      (this._primary ?? this._buttonNodes[this._defaultButton])?.focus();
     }
   }
 

--- a/packages/apputils/test/dialog.spec.tsx
+++ b/packages/apputils/test/dialog.spec.tsx
@@ -318,6 +318,49 @@ describe('@jupyterlab/apputils', () => {
           await prompt;
           dialog.dispose();
         });
+
+        it('should focus the primary element when focus leaves the dialog', async () => {
+          // Reproduces the case where a dialog with an input (e.g.
+          // "Open from Path…") is opened from the Command Palette: the palette
+          // steals focus back, and the dialog must redirect focus to the input,
+          // not the default accept button.
+          const host = document.createElement('div');
+          const target = document.createElement('div');
+          target.tabIndex = 0;
+          const body = (
+            <div>
+              <input type={'text'} />
+            </div>
+          );
+          const dialog = new TestDialog({
+            host,
+            body,
+            focusNodeSelector: 'input'
+          });
+
+          document.body.appendChild(target);
+          document.body.appendChild(host);
+          target.focus();
+          expect(document.activeElement).toBe(target);
+
+          const prompt = dialog.launch();
+
+          await waitForDialog();
+          await dialog.ready;
+          expect(document.activeElement!.localName).toBe('input');
+
+          simulate(target, 'focus');
+          expect(document.activeElement).not.toBe(target);
+          expect(document.activeElement!.localName).toBe('input');
+          expect(document.activeElement!.className).not.toContain(
+            'jp-mod-accept'
+          );
+          dialog.resolve();
+          await prompt;
+          dialog.dispose();
+          document.body.removeChild(target);
+          document.body.removeChild(host);
+        });
       });
     });
 


### PR DESCRIPTION
Minor UX detail, when using "Open from Path...", or "Open from URL..."
with the command palette the focused elment is nnot the correct one; it
is the confirmation button instead of the input field (both those
dialog requires the user to type something),

The behavior is correct when used via the mouse and file menu.

I think the `?? this._buttonNodes[this._defaultButton])` is even
unnecessary as this._primary is set in the constructor, to
`this._buttonNodes[this._defaultButton]`, but I'm unsure of the
consequences.

This will likely affect other dialogs

## References

None, I just directly fixed the issue when I saw it.

## Code changes

Dialogs now focus `this._primary` if set.

## User-facing changes

Dialog should now have the same focus logic when opened from the Menus and Command Palette.

## Backwards-incompatible changes

None.

## AI usage

- **YES**: Claude Opus found the code location and suggested the fix + add test
- **YES**: The human author has carefully reviewed this PR and run this code 
- AI tools and models used: Opus 4.6/4.7
