### PR TITLE
Remove 4.5.0 announcement from docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -375,7 +375,6 @@ html_favicon = "_static/logo-icon.png"
 # documentation.
 #
 html_theme_options = {
-    "announcement": '🚀 JupyterLab 4.5.0 is now available · <a href="https://jupyterlab.rtfd.io/en/latest/getting_started/installation.html">INSTALL</a> · <a href="https://jupyterlab.rtfd.io/en/latest/getting_started/changelog.html#v4-5">RELEASE NOTES</a>',
     "icon_links": [
         {
             "name": "jupyter.org",


### PR DESCRIPTION
## References

- Follow-up to https://github.com/jupyterlab/jupyterlab/pull/18125

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

No