### PR TITLE
fix: handle isApplicable() rejection in completion provider reconciliator

### DIFF
--- a/packages/completer/src/reconciliator.ts
+++ b/packages/completer/src/reconciliator.ts
@@ -45,8 +45,18 @@ export class ProviderReconciliator implements IProviderReconciliator {
     const isApplicablePromises = this._providers.map(p =>
       p.isApplicable(this._context)
     );
-    const applicableProviders = await Promise.all(isApplicablePromises);
-    return this._providers.filter((_, idx) => applicableProviders[idx]);
+    const results = await Promise.allSettled(isApplicablePromises);
+    return this._providers.filter((_, idx) => {
+      const result = results[idx];
+      if (result.status === 'rejected') {
+        console.warn(
+          `Completion provider "${this._providers[idx].identifier}" isApplicable() rejected:`,
+          result.reason
+        );
+        return false;
+      }
+      return result.value;
+    });
   }
 
   fetchInline(

--- a/packages/metapackage/test/completer/reconciliator.spec.ts
+++ b/packages/metapackage/test/completer/reconciliator.spec.ts
@@ -319,6 +319,28 @@ describe('completer/reconciliator', () => {
         spy1.mockRestore();
         spy2.mockRestore();
       });
+
+      it('should handle provider isApplicable rejection gracefully', async () => {
+        const fooProvider1 = new FooCompletionProvider();
+        const fooProvider2 = new FooCompletionProvider();
+        // Make provider1's isApplicable reject
+        jest
+          .spyOn(fooProvider1, 'isApplicable')
+          .mockRejectedValue(new Error('provider error'));
+        const spy2 = jest.spyOn(fooProvider2, 'isApplicable');
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+        const reconciliator = new ProviderReconciliator({
+          ...defaultOptions,
+          providers: [fooProvider1, fooProvider2]
+        });
+        const applicableProviders =
+          await reconciliator['applicableProviders']();
+        // Provider1 rejected, so only provider2 should be returned
+        expect(applicableProviders).toEqual([fooProvider2]);
+        expect(spy2).toHaveBeenCalledTimes(1);
+        expect(warnSpy).toHaveBeenCalled();
+        warnSpy.mockRestore();
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #15441

When a completion provider's `isApplicable()` rejects or throws, `Promise.all()` never resolves, silently breaking all completions for the entire session. This means a single broken provider can disable completions from all providers.

## Changes

**`packages/completer/src/reconciliator.ts`**:
- Replace `Promise.all(isApplicablePromises)` with `Promise.allSettled(...)` 
- Filter out rejected providers with a console warning
- Other providers continue to work normally

**`packages/metapackage/test/completer/reconciliator.spec.ts`**:
- Add test verifying that a rejecting provider is excluded from the applicable list without affecting others

## Notes

PR #18384 attempted this fix but has been stale since Feb 13. This PR addresses the review feedback from @krassowski: uses `Promise.allSettled` and includes a unit test.