### PR TITLE
Fix Contextual Help keyboard shortcut reliability and menu Help functionality

### DIFF
--- a/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
+++ b/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
@@ -3450,9 +3450,7 @@
     "id": "inspector:close",
     "label": "Hide Contextual Help",
     "caption": "Live updating code documentation from the active kernel",
-    "shortcuts": [
-      "Ctrl I"
-    ],
+    "shortcuts": [],
     "args": {
       "type": "object",
       "properties": {
@@ -3467,9 +3465,7 @@
     "id": "inspector:open",
     "label": "Show Contextual Help",
     "caption": "Live updating code documentation from the active kernel",
-    "shortcuts": [
-      "Ctrl I"
-    ],
+    "shortcuts": [],
     "args": {
       "type": "object",
       "properties": {
@@ -3492,7 +3488,9 @@
     "id": "inspector:toggle",
     "label": "Show Contextual Help",
     "caption": "Live updating code documentation from the active kernel",
-    "shortcuts": [],
+    "shortcuts": [
+      "Ctrl I"
+    ],
     "args": {
       "type": "object",
       "properties": {

--- a/packages/inspector-extension/schema/consoles.json
+++ b/packages/inspector-extension/schema/consoles.json
@@ -4,7 +4,7 @@
   "jupyter.lab.menus": {
     "context": [
       {
-        "command": "inspector:open",
+        "command": "inspector:toggle",
         "selector": ".jp-CodeConsole-promptCell",
         "rank": 5
       }

--- a/packages/inspector-extension/schema/inspector.json
+++ b/packages/inspector-extension/schema/inspector.json
@@ -11,7 +11,7 @@
             "rank": 0.1
           },
           {
-            "command": "inspector:open",
+            "command": "inspector:toggle",
             "rank": 0.1
           },
           {
@@ -24,14 +24,9 @@
   },
   "jupyter.lab.shortcuts": [
     {
-      "command": "inspector:open",
+      "command": "inspector:toggle",
       "keys": ["Accel I"],
       "selector": "body"
-    },
-    {
-      "command": "inspector:close",
-      "keys": ["Accel I"],
-      "selector": "body[data-jp-inspector='open']"
     }
   ],
   "properties": {},

--- a/packages/inspector-extension/schema/notebooks.json
+++ b/packages/inspector-extension/schema/notebooks.json
@@ -4,7 +4,7 @@
   "jupyter.lab.menus": {
     "context": [
       {
-        "command": "inspector:open",
+        "command": "inspector:toggle",
         "selector": ".jp-Notebook",
         "rank": 50
       }

--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -61,7 +61,6 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
     );
     const openedLabel = trans.__('Contextual Help');
     const namespace = 'inspector';
-    const datasetKey = 'jpInspector';
     const tracker = new WidgetTracker<MainAreaWidget<InspectorPanel>>({
       namespace
     });
@@ -93,12 +92,10 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
         });
       }
       shell.activateById(inspector.id);
-      document.body.dataset[datasetKey] = 'open';
       return inspector;
     }
     function closeInspector(): void {
       inspector.dispose();
-      delete document.body.dataset[datasetKey];
     }
 
     // Add inspector:open command to registry.

--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -61,6 +61,7 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
     );
     const openedLabel = trans.__('Contextual Help');
     const namespace = 'inspector';
+    const datasetKey = 'jpInspector';
     const tracker = new WidgetTracker<MainAreaWidget<InspectorPanel>>({
       namespace
     });
@@ -75,6 +76,9 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
       if (!isInspectorOpen()) {
         inspector = new MainAreaWidget({
           content: new InspectorPanel({ translator })
+        });
+        inspector.disposed.connect(() => {
+          delete document.body.dataset[datasetKey];
         });
         inspector.id = 'jp-inspector';
         inspector.title.label = openedLabel;
@@ -92,6 +96,7 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
         });
       }
       shell.activateById(inspector.id);
+      document.body.dataset[datasetKey] = 'open';
       return inspector;
     }
     function closeInspector(): void {

--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -95,7 +95,9 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
       return inspector;
     }
     function closeInspector(): void {
-      inspector.dispose();
+      if (isInspectorOpen()) {
+        inspector.dispose();
+      }
     }
 
     // Add inspector:open command to registry.


### PR DESCRIPTION
## References

Fixes #12021

## Description

The `Accel+I` shortcut previously used two separate commands
(`inspector:open` + `inspector:close`) with a CSS attribute selector
(`body[data-jp-inspector='open']`) to simulate toggle behaviour.

This approach had a subtle but user-visible bug: closing the inspector
via the **X button** on the panel bypassed `closeInspector()`, so the
`data-jp-inspector` dataset attribute was never cleaned up. The next
`Accel+I` press would then match `body[data-jp-inspector='open']` and
call `inspector:close` on an already-disposed widget — silently
cleaning up the stale attribute but **not reopening the panel**. The
user had to press the shortcut a second time to get anything to happen.

## Changes

- Drop `data-jp-inspector` dataset attribute handling
- Switch the Help menu tem and the `Accel+I` keyboard shortcut from `inspector:open` /
  `inspector:close` to the already-existing `inspector:toggle` command, removing the two-command selector entirely.

The launcher still uses `inspector:open` (open-only, no hide) which is
the correct UX for a launcher button, as noted in the issue thread.

## User-facing changes

`Accel+I` now reliably toggles Contextual Help open and closed on every
press, whether the panel was previously closed via the keyboard or the
X button. The Help menu item gains the `isToggled` checkmark styling
when the panel is open.

## Backwards-incompatible changes

None — `inspector:open`, `inspector:close`, and `inspector:toggle` all
remain registered. Only the default key binding and menu item pointer
changed.
