### PR TITLE
fix: support ?reset=1 for proxy-compatible workspace reset

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -160,7 +160,8 @@ const resolver: JupyterFrontEndPlugin<IWindowResolver> = {
         path = rest ? URLExt.join(path, URLExt.encodeParts(rest)) : path;
 
         // Reset the workspace on load.
-        query['reset'] = '';
+        // Use a non-empty value so that auth proxies do not strip the parameter.
+        query['reset'] = '1';
 
         const url = path + URLExt.objectToQueryString(query) + (hash || '');
         router.navigate(url, { hard: true });
@@ -651,7 +652,7 @@ const state: JupyterFrontEndPlugin<IStateDB> = {
 
     router.register({
       command: CommandIDs.resetOnLoad,
-      pattern: /(\?reset|\&reset)($|&)/,
+      pattern: /(\?reset|\&reset)(=[^&]*)?($|&)/,
       rank: 20 // High priority: 20:100.
     });
 


### PR DESCRIPTION
## Summary

- Some auth proxies strip bare query parameters (e.g. `?reset` with no value), silently breaking workspace reset
- Generate `?reset=1` instead of `?reset` when redirecting to a reset URL
- Update the router registration pattern to match both bare (`?reset`) and valued (`?reset=1`, `?reset=true`) forms — fully backward-compatible

## Changes

`packages/apputils-extension/src/index.ts`:
- `query['reset'] = ''` → `query['reset'] = '1'`: `objectToQueryString` omits `=` when value is empty string, producing a bare `?reset` that some proxies drop. A non-empty value produces `?reset=1`.
- Router pattern `/(\?reset|\&reset)($|&)/` → `/(\?reset|\&reset)(=[^&]*)?($|&)/`: adds optional `(=[^&]*)?` to also match `?reset=1`, `?reset=true`, etc.

`queryStringToObject` already handles `?reset=1` correctly (splits on `=`, checks `'reset' in query`), so no changes needed there.

## Test plan

- [ ] Workspace reset via `?reset` still works (backward-compatible)
- [ ] Workspace reset via `?reset=1` now works
- [ ] Workspace reset via `?reset=true` now works

Closes #18700