### PR TITLE
Remove default shortcuts 1-6 for header cell

### DIFF
--- a/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
+++ b/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
@@ -3823,9 +3823,7 @@
     "id": "notebook:change-cell-to-heading-1",
     "label": "Change to Heading 1",
     "caption": "",
-    "shortcuts": [
-      "1"
-    ],
+    "shortcuts": [],
     "args": {
       "type": "object",
       "properties": {}
@@ -3835,9 +3833,7 @@
     "id": "notebook:change-cell-to-heading-2",
     "label": "Change to Heading 2",
     "caption": "",
-    "shortcuts": [
-      "2"
-    ],
+    "shortcuts": [],
     "args": {
       "type": "object",
       "properties": {}
@@ -3847,9 +3843,7 @@
     "id": "notebook:change-cell-to-heading-3",
     "label": "Change to Heading 3",
     "caption": "",
-    "shortcuts": [
-      "3"
-    ],
+    "shortcuts": [],
     "args": {
       "type": "object",
       "properties": {}
@@ -3859,9 +3853,7 @@
     "id": "notebook:change-cell-to-heading-4",
     "label": "Change to Heading 4",
     "caption": "",
-    "shortcuts": [
-      "4"
-    ],
+    "shortcuts": [],
     "args": {
       "type": "object",
       "properties": {}
@@ -3871,9 +3863,7 @@
     "id": "notebook:change-cell-to-heading-5",
     "label": "Change to Heading 5",
     "caption": "",
-    "shortcuts": [
-      "5"
-    ],
+    "shortcuts": [],
     "args": {
       "type": "object",
       "properties": {}
@@ -3883,9 +3873,7 @@
     "id": "notebook:change-cell-to-heading-6",
     "label": "Change to Heading 6",
     "caption": "",
-    "shortcuts": [
-      "6"
-    ],
+    "shortcuts": [],
     "args": {
       "type": "object",
       "properties": {}

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -378,32 +378,26 @@
     },
     {
       "command": "notebook:change-cell-to-heading-1",
-      "keys": ["1"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-2",
-      "keys": ["2"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-3",
-      "keys": ["3"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-4",
-      "keys": ["4"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-5",
-      "keys": ["5"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {
       "command": "notebook:change-cell-to-heading-6",
-      "keys": ["6"],
       "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     },
     {


### PR DESCRIPTION
This were added in 2018 as a compatibility layer between classic notebook and lab (I am, and was, a bit proponent of keeping the behavior identical whether the shortcut themselves were good or bad).

Those shortcuts date from the time where notebooks had specific header cell with an actual level; now it's only markdown cells, so this is sort of redundant and have been for a while.

This does not remove the command themselves (yet), I would argue that those likely need o be remove in the long run, but this makes it easy for users that _still_ use the shortcut to re-add them, so in the need this only changes the default.

Related to #18637

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Related to #18637, I suppose the issue will be closed once the commands themselves are fixed/

## Code changes

remove the default shortcuts.

## User-facing changes

6 default shortcuts removed.

## Backwards-incompatible changes

6 default shortcuts remove

## AI usage

- **NO**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: <!-- FILL IN -->

## Alternative

Add a pop-up when those shortcuts are pressed that explain how to re-configure them.
