### PR TITLE
Remove unused progress bar CSS rule in execution indicator

### DIFF
--- a/packages/notebook/style/executionindicator.css
+++ b/packages/notebook/style/executionindicator.css
@@ -61,12 +61,6 @@
   display: block;
 }
 
-.jp-Notebook-ExecutionIndicator-progress-bar {
-  display: flex;
-  justify-content: center;
-  height: 100%;
-}
-
 .jp-Notebook-ExecutionIndicator-jumpButton {
   margin-top: 4px;
   margin-bottom: 3px;


### PR DESCRIPTION
This was never used on the main branch, it was just a forgotten cleanup in the original PR that used it at some point during review but now use it's own component with a different name.



## References

- introduced in https://github.com/jupyterlab/jupyterlab/pull/10730
- https://github.com/jupyterlab/jupyterlab/issues/9757#issuecomment-1264484484 (some css rules make JupyterLab slow)

Quansight/deshaw#251 (private)

## Code changes

Remove unused css rule

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

- **NO**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: None.
