### PR TITLE
Add a setting to disable the dock panel padding

### DIFF
--- a/packages/application-extension/schema/shell.json
+++ b/packages/application-extension/schema/shell.json
@@ -50,6 +50,12 @@
       },
       "additionalProperties": false
     },
+    "dockPanelPadding": {
+      "type": "boolean",
+      "title": "Dock panel padding",
+      "description": "Whether to show padding around the main dock panel area. Disable for a more compact layout.",
+      "default": true
+    },
     "zoomOnWheel": {
       "type": "boolean",
       "title": "Enable Ctrl+ Scroll Zoom",

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -128,6 +128,13 @@ export namespace ILabShell {
      * `contentVisibility` is only available in Chromium-based browsers.
      */
     hiddenMode: 'display' | 'scale' | 'contentVisibility';
+
+    /**
+     * Whether to show padding around the main dock panel area.
+     *
+     * Set to `false` for a more compact layout.
+     */
+    dockPanelPadding: boolean;
   }
 
   /**
@@ -1373,6 +1380,18 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
           this._dockPanel.hiddenMode = Widget.HiddenMode.ContentVisibility;
           break;
       }
+    }
+
+    if ('dockPanelPadding' in config) {
+      if (config.dockPanelPadding === false) {
+        this._dockPanel.node.style.setProperty(
+          '--jp-dock-panel-padding',
+          '0px'
+        );
+      } else {
+        this._dockPanel.node.style.removeProperty('--jp-dock-panel-padding');
+      }
+      this._dockPanel.fit();
     }
   }
 

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -134,7 +134,7 @@ export namespace ILabShell {
      *
      * Set to `false` for a more compact layout.
      */
-    dockPanelPadding: boolean;
+    dockPanelPadding?: boolean;
   }
 
   /**
@@ -1382,7 +1382,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
       }
     }
 
-    if ('dockPanelPadding' in config) {
+    if (config.dockPanelPadding !== undefined) {
       if (config.dockPanelPadding === false) {
         this._dockPanel.node.style.setProperty(
           '--jp-dock-panel-padding',

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -1385,11 +1385,13 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     if (config.dockPanelPadding !== undefined) {
       if (config.dockPanelPadding === false) {
         this._dockPanel.node.style.setProperty(
-          '--jp-dock-panel-padding',
+          '--jp-private-dock-panel-padding',
           '0px'
         );
       } else {
-        this._dockPanel.node.style.removeProperty('--jp-dock-panel-padding');
+        this._dockPanel.node.style.removeProperty(
+          '--jp-private-dock-panel-padding'
+        );
       }
       this._dockPanel.fit();
     }

--- a/packages/application/style/core.css
+++ b/packages/application/style/core.css
@@ -32,7 +32,7 @@
 }
 
 #jp-main-dock-panel {
-  padding: 5px;
+  padding: var(--jp-dock-panel-padding, 5px);
 }
 
 #jp-main-dock-panel[data-mode='single-document'] {

--- a/packages/application/style/core.css
+++ b/packages/application/style/core.css
@@ -32,7 +32,7 @@
 }
 
 #jp-main-dock-panel {
-  padding: var(--jp-dock-panel-padding, 5px);
+  padding: var(--jp-private-dock-panel-padding, 5px);
 }
 
 #jp-main-dock-panel[data-mode='single-document'] {


### PR DESCRIPTION

## References

Some users would prefer to have a more compact dock panel to save a few pixels here and there.

So this PR proposes to add a new setting to the JupyterLab shell to allow for such control on the dock panel.

## Code changes

- [x] Add a new `--jp-dock-panel-padding` CSS variable so themes can control the value directly, without adding it explicitly to the base themes
- [x] Add a setting so the dock panel padding can be enabled or disabled by users

## User-facing changes

The default stays the same as before.

https://github.com/user-attachments/assets/fe191640-f347-40f1-b4c2-a57a813115ed



## Backwards-incompatible changes

None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Opus 4.6 & GPT 5.4
