### PR TITLE
Remove dead `.jp-VariableRenderer-TrustButton` CSS rule

### DIFF
--- a/packages/debugger/style/variables.css
+++ b/packages/debugger/style/variables.css
@@ -100,16 +100,6 @@
   height: 100%;
 }
 
-.jp-VariableRenderer-TrustButton[aria-pressed='true'] {
-  box-shadow: inset 0 var(--jp-border-width) 4px
-    rgba(
-      var(--jp-shadow-base-lightness),
-      var(--jp-shadow-base-lightness),
-      var(--jp-shadow-base-lightness),
-      0.6
-    );
-}
-
 .jp-DebuggerRichVariable div[data-mime-type='text/plain'] > pre {
   white-space: normal;
 }


### PR DESCRIPTION
Introduce by #11171, which originally had a trust button, but the trust button was removed in reviews and iteration; the css rule was just never cleaned.


## References

See also https://github.com/jupyterlab/jupyterlab/pull/18759

## Code changes

Remove dead css rule

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

No