### PR TITLE
Remove unused CSS rule forgotten after CodeMirror migration

### DIFF
--- a/packages/debugger/style/editor.css
+++ b/packages/debugger/style/editor.css
@@ -17,10 +17,3 @@ body[data-jp-theme-light='true'] .jp-DebuggerEditor-highlight {
   background-color: var(--md-brown-100, #d7ccc8);
   outline-color: var(--md-brown-300, #a1887f);
 }
-
-.jp-DebuggerEditor-marker {
-  position: absolute;
-  left: -34px;
-  top: -1px;
-  color: var(--jp-error-color1);
-}


### PR DESCRIPTION
Migration from CM6, a9761d380251f5dec9243e533ba001613aaaef44, not a specific class anymore, it is now a direct Dom element that extend GutterMarker.

## References

See also #18759,

## Code changes

Delete css rule

## User-facing changes

No User facing Changes.

## Backwards-incompatible changes

No Backward incompatible change,

## AI usage

No AI
