### PR TITLE
Ask if the user wants to sanitize HTML export and send param to jupyter server

### DIFF
--- a/docs/source/user/export.md
+++ b/docs/source/user/export.md
@@ -25,6 +25,9 @@ To access these options, while a notebook is open, browse the File menu:
 :class: jp-screenshot
 ```
 
+When exporting to HTML, a dialog will prompt you to choose whether to sanitize
+the HTML output, i.e. escape tags. This sends a `sanitize_html` param to nbconvert.
+
 Note: The exporting options depend on your nbconvert configuration. For more
 information visit the
 [official nbconvert documentation](https://nbconvert.readthedocs.io/en/latest/).

--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -333,3 +333,18 @@ export namespace PageConfig {
     }
   }
 }
+
+/**
+ * Compare two version tuples element-by-element.
+ */
+export function compareVersions(
+  a: [number, number, number],
+  b: [number, number, number]
+): number {
+  for (let index = 0; index < 3; index++) {
+    if (a[index] !== b[index]) {
+      return a[index] - b[index];
+    }
+  }
+  return 0;
+}

--- a/packages/coreutils/test/pageconfig.spec.ts
+++ b/packages/coreutils/test/pageconfig.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { PageConfig } from '@jupyterlab/coreutils';
+import { compareVersions, PageConfig } from '@jupyterlab/coreutils';
 
 describe('@jupyterlab/coreutils', () => {
   describe('PageConfig', () => {
@@ -98,6 +98,14 @@ describe('@jupyterlab/coreutils', () => {
           expect(url).toEqual(`${shareUrl}/lab/tree${path}`);
         });
       });
+    });
+  });
+
+  describe('compareVersions', () => {
+    it('should correctly order versions', () => {
+      expect(compareVersions([3, 99, 0], [4, 0, 0])).toBeLessThan(0);
+      expect(compareVersions([4, 0, 0], [4, 0, 0])).toBe(0);
+      expect(compareVersions([5, 10, 1], [5, 9, 99])).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -3,7 +3,7 @@
 
 import { Dialog, showDialog } from '@jupyterlab/apputils';
 import type { IChangedArgs } from '@jupyterlab/coreutils';
-import { PageConfig, PathExt } from '@jupyterlab/coreutils';
+import { compareVersions, PageConfig, PathExt } from '@jupyterlab/coreutils';
 import type { IDocumentManager } from '@jupyterlab/docmanager';
 import { shouldOverwrite } from '@jupyterlab/docmanager';
 import type { Contents, KernelSpec, Session } from '@jupyterlab/services';
@@ -443,8 +443,9 @@ export class FileBrowserModel implements IDisposable {
     // instead of Jupyter Notebook.
     const serverVersion = PageConfig.getNotebookVersion();
     const supportsChunked =
-      serverVersion < [4, 0, 0] /* Jupyter Server */ ||
-      serverVersion >= [5, 1, 0]; /* Jupyter Notebook >= 5.1.0 */
+      compareVersions(serverVersion, [4, 0, 0]) < 0 /* Jupyter Server */ ||
+      compareVersions(serverVersion, [5, 1, 0]) >=
+        0; /* Jupyter Notebook >= 5.1.0 */
     const largeFile = file.size > LARGE_FILE_SIZE;
 
     if (largeFile && !supportsChunked) {

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -617,11 +617,25 @@ export const exportPlugin: JupyterFrontEndPlugin<void> = {
 
         const { context } = current;
 
+        let sanitizeHtml = false;
+        if (args['format'] === 'html') {
+          const result = await InputDialog.getBoolean({
+            title: trans.__('Export as HTML'),
+            label: trans.__('Sanitize HTML output'),
+            value: true
+          });
+          if (!result.button.accept) {
+            return;
+          }
+          sanitizeHtml = result.value ?? false;
+        }
+
         const exportOptions: NbConvert.IExportOptions = {
           format: args['format'] as string,
           path: current.context.path,
           exporterOptions: {
-            download: true
+            download: true,
+            sanitizeHtml
           }
         };
 

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -617,8 +617,14 @@ export const exportPlugin: JupyterFrontEndPlugin<void> = {
 
         const { context } = current;
 
+        const serverVersion = PageConfig.getNotebookVersion();
+        const supportsHTMLSanitizationOption =
+          serverVersion < [4, 0, 0] /* Jupyter Server only */ &&
+          serverVersion >= [2, 99, 0]; // TODO update this when the flag is supported on a release
+
         let sanitizeHtml = false;
-        if (args['format'] === 'html') {
+
+        if (args['format'] === 'html' && supportsHTMLSanitizationOption) {
           const result = await InputDialog.getBoolean({
             title: trans.__('Export as HTML'),
             label: trans.__('Sanitize HTML output'),

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -35,7 +35,7 @@ import { MarkdownCell } from '@jupyterlab/cells';
 import type { CodeEditor } from '@jupyterlab/codeeditor';
 import { IEditorServices, IPositionModel } from '@jupyterlab/codeeditor';
 import type { IChangedArgs } from '@jupyterlab/coreutils';
-import { PageConfig } from '@jupyterlab/coreutils';
+import { PageConfig, compareVersions } from '@jupyterlab/coreutils';
 
 import {
   IEditorExtensionRegistry,
@@ -666,8 +666,9 @@ export const exportPlugin: JupyterFrontEndPlugin<void> = {
 
         const serverVersion = PageConfig.getNotebookVersion();
         const supportsHTMLSanitizationOption =
-          serverVersion < [4, 0, 0] /* Jupyter Server only */ &&
-          serverVersion >= [2, 99, 0]; // TODO update this when the flag is supported on a release
+          compareVersions(serverVersion, [4, 0, 0]) <
+            0 /* Jupyter Server only */ &&
+          compareVersions(serverVersion, [2, 99, 0]) >= 0; // TODO update this when the flag is supported on a release
 
         let sanitizeHtml = false;
 

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -35,7 +35,7 @@ import { MarkdownCell } from '@jupyterlab/cells';
 import type { CodeEditor } from '@jupyterlab/codeeditor';
 import { IEditorServices, IPositionModel } from '@jupyterlab/codeeditor';
 import type { IChangedArgs } from '@jupyterlab/coreutils';
-import { PageConfig, compareVersions } from '@jupyterlab/coreutils';
+import { compareVersions, PageConfig } from '@jupyterlab/coreutils';
 
 import {
   IEditorExtensionRegistry,
@@ -668,7 +668,7 @@ export const exportPlugin: JupyterFrontEndPlugin<void> = {
         const supportsHTMLSanitizationOption =
           compareVersions(serverVersion, [4, 0, 0]) <
             0 /* Jupyter Server only */ &&
-          compareVersions(serverVersion, [2, 99, 0]) >= 0; // TODO update this when the flag is supported on a release
+          compareVersions(serverVersion, [2, 18, 0]) >= 0;
 
         let sanitizeHtml = false;
 

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -664,11 +664,25 @@ export const exportPlugin: JupyterFrontEndPlugin<void> = {
 
         const { context } = current;
 
+        let sanitizeHtml = false;
+        if (args['format'] === 'html') {
+          const result = await InputDialog.getBoolean({
+            title: trans.__('Export as HTML'),
+            label: trans.__('Sanitize HTML output'),
+            value: true
+          });
+          if (!result.button.accept) {
+            return;
+          }
+          sanitizeHtml = result.value ?? false;
+        }
+
         const exportOptions: NbConvert.IExportOptions = {
           format: args['format'] as string,
           path: current.context.path,
           exporterOptions: {
-            download: true
+            download: true,
+            sanitizeHtml
           }
         };
 

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -664,8 +664,14 @@ export const exportPlugin: JupyterFrontEndPlugin<void> = {
 
         const { context } = current;
 
+        const serverVersion = PageConfig.getNotebookVersion();
+        const supportsHTMLSanitizationOption =
+          serverVersion < [4, 0, 0] /* Jupyter Server only */ &&
+          serverVersion >= [2, 99, 0]; // TODO update this when the flag is supported on a release
+
         let sanitizeHtml = false;
-        if (args['format'] === 'html') {
+
+        if (args['format'] === 'html' && supportsHTMLSanitizationOption) {
           const result = await InputDialog.getBoolean({
             title: trans.__('Export as HTML'),
             label: trans.__('Sanitize HTML output'),

--- a/packages/services/src/nbconvert/index.ts
+++ b/packages/services/src/nbconvert/index.ts
@@ -88,16 +88,27 @@ export class NbConvertManager implements NbConvert.IManager {
    * @param options.format - The export format (e.g., 'html', 'pdf').
    * @param options.path - The path to the notebook to export.
    * @param options.exporterOptions.download - Whether to download the file or open it in a new tab. Defaults to false.
+   * @param options.exporterOptions.sanitizeHtml - Whether to sanitize HTML in the output. Defaults to false.
    */
   async exportAs(options: NbConvert.IExportOptions): Promise<void> {
     const { format, path } = options;
-    const { download = false } = options.exporterOptions || {};
+    const { download = false, sanitizeHtml = false } =
+      options.exporterOptions || {};
 
     const baseUrl = this.serverSettings.baseUrl;
     const notebookPath = URLExt.encodeParts(path);
     let url = URLExt.join(baseUrl, NBCONVERT_EXPORT_URL, format, notebookPath);
+
+    const params = new URLSearchParams();
     if (download) {
-      url += '?download=true';
+      params.set('download', 'true');
+    }
+    if (sanitizeHtml) {
+      params.set('sanitize_html', 'true');
+    }
+    const query = params.toString();
+    if (query) {
+      url += `?${query}`;
     }
 
     // Open the URL in a new tab if in a browser environment.
@@ -187,7 +198,8 @@ export namespace NbConvert {
      * @param options - The export options.
      * @param options.format - The export format (e.g., 'html', 'pdf').
      * @param options.path - The path to the notebook to export.
-     * @param exporterOptions.download - Whether to download the file or open it in a new tab. Defaults to false.
+     * @param options.exporterOptions.download - Whether to download the file or open it in a new tab. Defaults to false.
+     * @param options.exporterOptions.sanitizeHtml - Whether to sanitize HTML in the output. Defaults to false.
      */
     exportAs?(options: NbConvert.IExportOptions): Promise<void>;
   }

--- a/packages/services/test/nbconvert/index.spec.ts
+++ b/packages/services/test/nbconvert/index.spec.ts
@@ -1,0 +1,90 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { NbConvertManager } from '../../src/nbconvert';
+import { ServerConnection } from '../../src/serverconnection';
+
+describe('NbConvertManager', () => {
+  let manager: NbConvertManager;
+  let openSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    manager = new NbConvertManager({
+      serverSettings: ServerConnection.makeSettings({
+        baseUrl: 'http://localhost:8888/'
+      })
+    });
+    openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    openSpy.mockRestore();
+  });
+
+  describe('.exportAs()', () => {
+    it('should open the export URL with no query params by default', async () => {
+      await manager.exportAs({ format: 'pdf', path: 'notebook.ipynb' });
+
+      expect(openSpy).toHaveBeenCalledTimes(1);
+      const url = new URL(openSpy.mock.calls[0][0]);
+      expect(url.searchParams.toString()).toBe('');
+    });
+
+    it('should append download=true when download is set', async () => {
+      await manager.exportAs({
+        format: 'pdf',
+        path: 'notebook.ipynb',
+        exporterOptions: { download: true }
+      });
+
+      const url = new URL(openSpy.mock.calls[0][0]);
+      expect(url.searchParams.get('download')).toBe('true');
+      expect(url.searchParams.get('sanitize_html')).toBeNull();
+    });
+
+    it('should append sanitize_html=true when sanitizeHtml is set', async () => {
+      await manager.exportAs({
+        format: 'html',
+        path: 'notebook.ipynb',
+        exporterOptions: { sanitizeHtml: true }
+      });
+
+      const url = new URL(openSpy.mock.calls[0][0]);
+      expect(url.searchParams.get('sanitize_html')).toBe('true');
+      expect(url.searchParams.get('download')).toBeNull();
+    });
+
+    it('should combine download and sanitize_html params', async () => {
+      await manager.exportAs({
+        format: 'html',
+        path: 'notebook.ipynb',
+        exporterOptions: { download: true, sanitizeHtml: true }
+      });
+
+      const url = new URL(openSpy.mock.calls[0][0]);
+      expect(url.searchParams.get('download')).toBe('true');
+      expect(url.searchParams.get('sanitize_html')).toBe('true');
+    });
+
+    it('should not append sanitize_html when false', async () => {
+      await manager.exportAs({
+        format: 'html',
+        path: 'notebook.ipynb',
+        exporterOptions: { sanitizeHtml: false }
+      });
+
+      const url = new URL(openSpy.mock.calls[0][0]);
+      expect(url.searchParams.get('sanitize_html')).toBeNull();
+    });
+
+    it('should encode the notebook path in the URL', async () => {
+      await manager.exportAs({
+        format: 'html',
+        path: 'my folder/notebook.ipynb'
+      });
+
+      const url = openSpy.mock.calls[0][0] as string;
+      expect(url).toContain('my%20folder/notebook.ipynb');
+    });
+  });
+});


### PR DESCRIPTION
TODO 
- [x] guard with a jupyter_server version check
- [x] tests

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

First step for #17994, see also #7612

Backend PR : https://github.com/jupyter-server/jupyter_server/pull/1618

## Code changes

When exporting a notebook as HTML, from the palette or File menu, a new modal asks if the user wishes to sanitize HTML. This then sends an extra query param to jupyter_server's `/nbconvert/download` endpoint (see Breaking Changes)

## User-facing changes

Modal when selecting export to HTML from the File menu or the Palette.

<img width="510" height="62" alt="image" src="https://github.com/user-attachments/assets/8f9572c9-7dfe-4e6b-b584-ac3dade68e8f" />

or

<img width="362" height="78" alt="image" src="https://github.com/user-attachments/assets/3edffb8e-d647-4764-86ce-2b656a0c60b3" />


v

<img width="350" height="230" alt="image" src="https://github.com/user-attachments/assets/db1aa229-df90-4897-8546-06e00a7633ca" />


<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

-`jupyter_server` should be updated to consume `sanitize_html` and forward it to `nbconvert`. Hence [a version guard](https://github.com/jupyterlab/jupyterlab/pull/18765/changes#diff-9bfcf1dd55d0d858225f19d220d93e635e9f83f14bd735a3958156a244345d24R622-R623).

<img width="270" height="203" alt="image" src="https://github.com/user-attachments/assets/a97809c9-0fb2-43c6-a3bd-b09d77001944" />


## AI usage

- YES: Some or all of the content of this PR was generated by AI.
- YES : The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude Code
