### PR TITLE
Tell dependabot to ignore updates to `staging` directory as that is updated on release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,8 @@ updates:
       # in some of the Galata snapshots
       - dependency-name: "ipython"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+  - package-ecosystem: "npm"
+    directory: "/staging"
+    ignore:
+      # Ignore updates to staging directory as that is updated on release
+      - dependency-name: "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,9 @@ updates:
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
   - package-ecosystem: "npm"
     directory: "/jupyterlab/staging"
+    schedule:
+      # Just becasue it is required
+      interval: "monthly"
     ignore:
       # Ignore updates to staging directory as that is updated on release
       - dependency-name: "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,7 @@ updates:
       - dependency-name: "ipython"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
   - package-ecosystem: "npm"
-    directory: "/staging"
+    directory: "jupyterlab/staging"
     ignore:
       # Ignore updates to staging directory as that is updated on release
       - dependency-name: "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,7 @@ updates:
       - dependency-name: "ipython"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
   - package-ecosystem: "npm"
-    directory: "jupyterlab/staging"
+    directory: "/jupyterlab/staging"
     ignore:
       # Ignore updates to staging directory as that is updated on release
       - dependency-name: "*"


### PR DESCRIPTION

## References

Hopefully will reduce maintenance burn on closing duplicate dependabot alerts:

<img width="910" height="1160" alt="image" src="https://github.com/user-attachments/assets/4c0a2628-9208-4518-9034-5b0a4e8173ef" />
