### PR TITLE
Remove unused Extension Manager CSS rules, add regression test

### DIFF
--- a/galata/test/documentation/extension_manager.test.ts
+++ b/galata/test/documentation/extension_manager.test.ts
@@ -120,6 +120,197 @@ test.describe('Extension Manager', () => {
     await page.getByRole('button', { name: 'Update to 3.2.1' }).click();
     await waitRequest;
   });
+
+  test('Has no unused style rules', async ({ page }) => {
+    // Layer a test-specific mock on top of the describe-level one so a
+    // single test can walk through every DOM state the extension-manager
+    // rules apply to:
+    //   - the first installed entry carries both the error status and the
+    //     disallowed flag, so the error/should-be-uninstalled rules match;
+    //   - the search endpoint returns real paginated chunks built from
+    //     250 fake geojson clones (30 per page → 9 pages), so the full
+    //     pagination UI renders including the `...` break node;
+    //   - a `query=geojson` request returns an empty array, so the search
+    //     section renders the "No entries" listview-message;
+    //   - an `install` POST replies with `status: 'error'`, so clicking
+    //     Install opens the install-error dialog; every other action
+    //     fails with HTTP 500, so `model.actionError` is set and the
+    //     header renders an ErrorMessage wrapping a <pre>.
+    const installed = JSONExt.deepCopy(extensionsList);
+    installed[0]['status'] = 'error';
+    installed[0]['is_allowed'] = false;
+
+    const fakeExtensions = Array.from({ length: 250 }, (_, i) => ({
+      ...extensionsList[0],
+      name: `@jupyterlab/geojson-extension-${i + 1}`,
+      description: `Fake extension ${i + 1}`,
+      installed: false,
+      installed_version: ''
+    }));
+
+    const paginate = (
+      url: string,
+      entries: ReadonlyArray<unknown>
+    ): { headers: Record<string, string>; chunk: ReadonlyArray<unknown> } => {
+      const params = new URL(url).searchParams;
+      const requestedPage = parseInt(params.get('page') ?? '1', 10);
+      const perPage = parseInt(params.get('per_page') ?? '30', 10);
+      const lastPage = Math.max(1, Math.ceil(entries.length / perPage));
+      const start = (requestedPage - 1) * perPage;
+      const chunk = entries.slice(start, start + perPage);
+      const lastUrl = new URL(url);
+      lastUrl.searchParams.set('page', String(lastPage));
+      return {
+        headers: { Link: `<${lastUrl.toString()}>; rel="last"` },
+        chunk
+      };
+    };
+
+    await page.route(galata.Routes.extensions, async (route, request) => {
+      const url = request.url();
+      if (request.method() === 'GET') {
+        if (!url.includes('query')) {
+          return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(installed)
+          });
+        }
+        if (url.includes('query=geojson')) {
+          const { headers } = paginate(url, []);
+          return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            headers,
+            body: JSON.stringify([])
+          });
+        }
+        const { headers, chunk } = paginate(url, fakeExtensions);
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          headers,
+          body: JSON.stringify(chunk)
+        });
+      }
+      if (request.method() === 'POST') {
+        const body = JSON.parse(request.postData() ?? '{}');
+        if (body.cmd === 'install') {
+          return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              status: 'error',
+              message: 'forced test failure'
+            })
+          });
+        }
+        // uninstall / enable / disable fail with a transport error so the
+        // action-error path in the model is triggered.
+        return route.fulfill({
+          status: 500,
+          contentType: 'text/plain',
+          body: 'forced server error'
+        });
+      }
+      return route.continue();
+    });
+
+    await page.goto();
+    await openExtensionSidebar(page);
+
+    // Expand every accordion section so that rules scoped under the warning,
+    // installed and discover panels can be matched.
+    for (const section of await page
+      .locator(
+        '.jp-extensionmanager-view >> .jp-AccordionPanel-title[aria-expanded="false"]'
+      )
+      .all()) {
+      await section.click();
+    }
+
+    const options = {
+      fragments: ['jp-extensionmanager'],
+      exclude: []
+    };
+
+    // --- State A ---------------------------------------------------------
+    // Installed has an entry flagged as both error and disallowed, the
+    // search list is paginated with entries, and the install-error dialog
+    // is open on top (triggered by clicking Install).
+    await page
+      .locator(
+        '.jp-extensionmanager-entry.jp-extensionmanager-entry-error.jp-extensionmanager-entry-should-be-uninstalled'
+      )
+      .waitFor();
+    await page.locator('.jp-extensionmanager-pagination ul').waitFor();
+    // Wait for the `...` break node so `.pagination .break > a` matches.
+    await page.locator('.jp-extensionmanager-pagination .break').waitFor();
+    await page
+      .locator('.jp-extensionmanager-searchresults')
+      .getByRole('button', { name: 'Install', exact: true })
+      .first()
+      .click();
+    await page.locator('.jp-Dialog .jp-extensionmanager-dialog').waitFor();
+    const unusedA = await page.style.findUnusedStyleRules(options);
+    await page
+      .locator('.jp-Dialog')
+      .getByRole('button', { name: 'Ok' })
+      .click();
+    await page.locator('.jp-Dialog').waitFor({ state: 'detached' });
+
+    // --- State B ---------------------------------------------------------
+    // Search `geojson` so the installed section keeps rendering the
+    // flagged entry (its name matches the query) while the search
+    // section renders the "No entries" listview-message next to the
+    // pagination UI.
+    await page
+      .locator('.jp-extensionmanager-view')
+      .getByRole('searchbox')
+      .fill('geojson');
+    await page.evaluate(() => {
+      (document.activeElement as HTMLElement).blur();
+    });
+    await page
+      .locator(
+        '.jp-extensionmanager-searchresults .jp-extensionmanager-listview-message',
+        { hasText: 'No entries' }
+      )
+      .waitFor();
+    const unusedB = await page.style.findUnusedStyleRules(options);
+
+    // --- State C ---------------------------------------------------------
+    // Withdraw the disclaimer so the "Yes" (disclaimer-enable) button is
+    // rendered. The previously loaded lists stay in the DOM because the
+    // model does not clear them on un-disclaim.
+    await page.locator('.jp-extensionmanager-disclaimer-disable').click();
+    await page.locator('.jp-extensionmanager-disclaimer-enable').waitFor();
+    const unusedC = await page.style.findUnusedStyleRules(options);
+
+    // --- State D ---------------------------------------------------------
+    // Re-disclaim, then click Uninstall on the flagged installed entry.
+    // The POST fails with HTTP 500, which rejects the action request and
+    // sets `model.actionError`. The header then renders an ErrorMessage
+    // wrapping a <pre>, exercising `.jp-extensionmanager-error pre`.
+    await page.locator('.jp-extensionmanager-disclaimer-enable').click();
+    const uninstallBtn = page
+      .locator('.jp-extensionmanager-installedlist')
+      .getByRole('button', { name: 'Uninstall', exact: true });
+    await uninstallBtn.click();
+    await page
+      .locator('.jp-extensionmanager-header .jp-extensionmanager-error pre')
+      .waitFor();
+    const unusedD = await page.style.findUnusedStyleRules(options);
+
+    // A rule is only truly unused if it failed to match in every state.
+    const unused = unusedA.filter(
+      rule =>
+        unusedB.includes(rule) &&
+        unusedC.includes(rule) &&
+        unusedD.includes(rule)
+    );
+    expect(unused).toEqual([]);
+  });
 });
 
 test.describe('Filtered Extension Manager', () => {

--- a/packages/extensionmanager/style/base.css
+++ b/packages/extensionmanager/style/base.css
@@ -91,13 +91,6 @@
   List view pagination styling
 */
 
-.jp-extensionmanager-view ul.pagination {
-  display: flex;
-  justify-content: center;
-  padding-left: 0;
-  padding-right: 0;
-}
-
 .jp-extensionmanager-pagination li {
   display: inline-block;
 }

--- a/packages/extensionmanager/style/base.css
+++ b/packages/extensionmanager/style/base.css
@@ -80,16 +80,6 @@
 }
 
 /*
-  Section headers
-*/
-
-.jp-extensionmanager-view .jp-SidePanel-header .jp-extensionmanager-error {
-  text-transform: none;
-  font-size: var(--jp-ui-font-size1);
-  font-weight: 400;
-}
-
-/*
   Error messages
 */
 
@@ -166,11 +156,6 @@
 }
 
 /* Precedence order update/error/warning matters! */
-
-.jp-extensionmanager-entry.jp-extensionmanager-entry-update {
-  border-left: solid 8px var(--jp-brand-color2);
-  padding-left: 4px;
-}
 
 .jp-extensionmanager-entry.jp-extensionmanager-entry-error {
   border-left: solid 8px var(--jp-error-color2);
@@ -295,28 +280,6 @@
   flex-direction: row;
   padding-block-start: 4px;
   justify-content: flex-end;
-}
-
-/*
-  Rebuild prompt dialog
-*/
-
-.jp-extensionmanager-buildprompt {
-  background-color: var(--jp-brand-color1);
-  color: var(--jp-ui-inverse-font-color1);
-  padding: 4px 8px;
-  font-size: var(--jp-ui-font-size1);
-  font-weight: 400;
-}
-
-.jp-extensionmanager-buildprompt button {
-  border: none;
-  background-color: transparent;
-  color: var(--jp-ui-inverse-font-color1);
-  font-size: var(--jp-ui-font-size1);
-  font-weight: 600;
-  float: right;
-  margin: 4px;
 }
 
 /*


### PR DESCRIPTION
Test that the extension manager has no unused CSS rules

Opens the extension manager, disclaims the warning, expands every
accordion section and asserts that every `.jp-extensionmanager-*`
rule matches at least one element on the page — so orphaned rules
cannot be re-introduced unnoticed.

Remove orphaned jp-extensionmanager-buildprompt CSS rules

The rebuild-prompt UI was removed in PR #12866 (commit c6d57dc2) when
the extension manager was rewritten, but the matching CSS rules were
left behind. No source references `jp-extensionmanager-buildprompt`.

Remove more orphan rules

packages/extensionmanager/src/widget.tsx:48-50

```
if (entry.status && ['ok', 'warning', 'error'].indexOf(entry.status) !== -1) {
    flagClasses.push(`jp-extensionmanager-entry-${entry.status}`);
    }
```

thus `.jp-extensionmanager-entry-update` cannot exist anymore.

'.jp-SidePanel-header .jp-extensionmanager-error', and '.jp-extensionmanager-error pre'

According to Claude:
> orphaned from the pre-#12866 layout: the ErrorMessage component is
> rendered inside the list body, never inside the side panel header
> or wrapped around a pre block

I can't reason as well as claude, but I indeed can't see those rules
used when trying locally and killing the server to see the error
message.

This also extend the test and create a number of fake extension to test
the pagination css rules


## References

Related to: 

 - https://github.com/jupyterlab/jupyterlab/issues/9757#issuecomment-1264484484
 - jupyterlab/jupyterlab#14167
 - Quansight/deshaw#251 (private)


## Code changes

Removed orphaned css rules since jupyterlab/jupyterlab#12866 (commit c6d57dc28dd566aa60fe95a7548640143fb443ee), and a few others.

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

- **Yes**: Some or all of the content of this PR was generated by AI: Tests were added by Opus 4.7
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Opus 4.7
