### PR TITLE
Remove unused CodeMirror v5 CSS rule

### DIFF
--- a/packages/codemirror/style/base.css
+++ b/packages/codemirror/style/base.css
@@ -101,12 +101,6 @@
   color: var(--jp-search-selected-match-color);
 }
 
-.cm-trailingspace {
-  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAFCAYAAAB4ka1VAAAAsElEQVQIHQGlAFr/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA7+r3zKmT0/+pk9P/7+r3zAAAAAAAAAAABAAAAAAAAAAA6OPzM+/q9wAAAAAA6OPzMwAAAAAAAAAAAgAAAAAAAAAAGR8NiRQaCgAZIA0AGR8NiQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQyoYJ/SY80UAAAAASUVORK5CYII=);
-  background-position: center left;
-  background-repeat: repeat-x;
-}
-
 .jp-CollaboratorCursor-hover {
   position: absolute;
   z-index: 1;


### PR DESCRIPTION
`cm-trailingspace` does not exist in recent codemirror, it is now replaced by an inline css rule `cm-trailingSpace` (different casing), and codemirror now already have options exposed in settings to show whitespaces and trailing space.


## References

 - https://github.com/jupyterlab/jupyterlab/issues/9757#issuecomment-1264484484
 - jupyterlab/jupyterlab#14167
 - Quansight/deshaw#251 (private)

## Code changes

Drop old codemirror css rule

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

- **No**: Some or all of the content of this PR was generated by AI:
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: None
