### PR TITLE
Fix name of option for extension manager implementation in docs

### DIFF
--- a/docs/source/user/extensions.md
+++ b/docs/source/user/extensions.md
@@ -202,11 +202,11 @@ By default, there are two extension managers provided by JupyterLab:
 - `pypi`: [default] Allow to un-/install extensions from PyPI.org
 - `readonly`: Display installed extensions (with the ability to dis-/en-able them)
 
-You can specify the manager with the command line option `--LabApp.extension-manager`;
+You can specify the manager with the command line option `--LabApp.extension_manager`;
 e.g. to use the _read-only_ manager:
 
 ```sh
-jupyter lab --LabApp.extension-manager=readonly
+jupyter lab --LabApp.extension_manager=readonly
 ```
 
 #### PyPI Manager settings


### PR DESCRIPTION
## References

- Follow-up to https://github.com/jupyterlab/jupyterlab/pull/18044 - it was correct prior to conversion to Markdown:

https://github.com/jupyterlab/jupyterlab/blob/850c95d773b89357d837aa0f17ed4b52f1570ec3/docs/source/user/extensions.rst?plain=1#L201-L206

It was likely the only affected place:

<img width="479" height="330" alt="image" src="https://github.com/user-attachments/assets/496ff7ac-af14-4ba1-92cd-dc20f9927114" />


## Code changes

```diff
- jupyter lab --LabApp.extension-manager=readonly
+ jupyter lab --LabApp.extension_manager=readonly
```

## User-facing changes

Correct traitlet name is displayed in docs

## Backwards-incompatible changes

None

## AI usage

None