### PR TITLE
Fix `PageConfig.getUrl` to honor explicit workspace option

### DIFF
--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -148,7 +148,7 @@ export namespace PageConfig {
       path = URLExt.join(
         path,
         'workspaces',
-        encodeURIComponent(getOption('workspace') ?? defaultWorkspace)
+        encodeURIComponent(workspace)
       );
     }
     const treePath = options.treePath ?? getOption('treePath');

--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -145,11 +145,7 @@ export namespace PageConfig {
     const labOrDoc = mode === 'single-document' ? 'doc' : 'lab';
     path = URLExt.join(path, labOrDoc);
     if (workspace !== defaultWorkspace) {
-      path = URLExt.join(
-        path,
-        'workspaces',
-        encodeURIComponent(workspace)
-      );
+      path = URLExt.join(path, 'workspaces', encodeURIComponent(workspace));
     }
     const treePath = options.treePath ?? getOption('treePath');
     if (treePath) {

--- a/packages/coreutils/test/pageconfig.spec.ts
+++ b/packages/coreutils/test/pageconfig.spec.ts
@@ -81,6 +81,25 @@ describe('@jupyterlab/coreutils', () => {
         expect(url).toEqual(`http://localhost/lab/tree${path}`);
       });
 
+      it('should honor an explicit workspace option over the page config value', () => {
+        PageConfig.setOption('workspace', 'config-ws');
+        const url = PageConfig.getUrl({ workspace: 'options-ws' });
+        expect(url).toEqual('http://localhost/lab/workspaces/options-ws');
+      });
+
+      it('should fall back to the page config workspace when option is absent', () => {
+        PageConfig.setOption('workspace', 'config-ws');
+        const url = PageConfig.getUrl({});
+        expect(url).toEqual('http://localhost/lab/workspaces/config-ws');
+      });
+
+      it('should URL-encode a workspace name that contains special characters', () => {
+        const url = PageConfig.getUrl({ workspace: 'my ws/with spaces' });
+        expect(url).toEqual(
+          'http://localhost/lab/workspaces/my%20ws%2Fwith%20spaces'
+        );
+      });
+
       describe('hub environment', () => {
         const shareUrl = 'http://hub.host.lab/hub/user-redirect';
 


### PR DESCRIPTION
```
## References

N/A — spotted via code review. `IGetUrlOptions.workspace` has been a public export of `@jupyterlab/coreutils` since the option was added in commit `7f28037209` (2020-07-25, "Add workspace to getUrl"), and the current broken shape has been shipping since commit `f786d539a` (2021-09-06, PR #11011 "Restore Copy shareable link use of shareUrl") — five years. I couldn't find an existing issue tracking this; the closest related items are `#11011` (the commit that introduced the bug) and `#8715` (an older single-document mode cleanup). If maintainers want me to open a companion issue first I'm happy to, but the fix is self-contained and the docstring/sibling evidence in this PR is already sufficient to justify the change on review alone.

Discovered while auditing the `@jupyterlab/coreutils` public surface for extension authors — not encountered in production by me personally, but the bug is reachable from any extension call that passes a non-default `workspace` option, so any extension author relying on that argument (as documented) silently gets the wrong URL.

## Code changes

`PageConfig.getUrl` captures `workspace = options.workspace ?? getOption('workspace')` on line 144 and correctly uses it in the `workspace !== defaultWorkspace` gate on line 147 — but the URL segment itself on line 148 was built from `getOption('workspace') ?? defaultWorkspace`, silently ignoring any `workspace` the caller passed in. Replace that expression with the captured `workspace` local so the option is actually honored. Matches the sibling `mode` and `treePath` option handling in the same function.

Also pin the behaviour with three new test cases in `packages/coreutils/test/pageconfig.spec.ts`:

- `should honor an explicit workspace option over the page config value`
- `should fall back to the page config workspace when option is absent`
- `should URL-encode a workspace name that contains special characters` (verifies `/` and space are percent-encoded — needed for workspace names containing path-like characters)

The existing tests only exercised `workspace: PageConfig.defaultWorkspace`, which opts out of the URL segment entirely via the `!==` check — so the broken path was never covered.

## User-facing changes

None visible in the JupyterLab UI directly. The fix only affects programmatic callers of `PageConfig.getUrl({ workspace: ... })` — typically third-party JupyterLab extensions and custom launchers — who will now receive the URL they actually asked for instead of the page config's stored workspace.

## Backwards-incompatible changes

None. Every call site inside the JupyterLab monorepo (`application-extension/src/index.tsx:999,1029,1043` and `filebrowser-extension/src/index.ts:777,895`) passes only `mode` / `treePath` / `toShare`; none pass an explicit `workspace` option, so none change behaviour. The fix only affects callers that previously hit the buggy branch — those now receive the documented behaviour. The public API shape of `IGetUrlOptions` is unchanged.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude (Anthropic, Claude Opus 4.7) via the Claude Code CLI, used to scan `@jupyterlab/coreutils` for mechanical bugs and to draft the test cases. The human author reviewed the fix line-by-line against the docstring and sibling option handling in the same function, simulated the behaviour against five input shapes in Node before committing, and verified `prettier --check` passes on both modified files.
```

**Note on the "encountered in practice" question:** answered honestly in the `References` section — this was a code-review find, not a production incident. The docstring-vs-code contradiction + five-year-old typo + two in-file sibling patterns + closed test-coverage gap still make it a defensible fix on its own merits; happy to open a companion issue if that's the project norm.

### Update 2 — maintainer feedback on 2026-04-26 (upstream PR #18791, second round)

Maintainer `@krassowski` left two follow-ups after the prettier fix landed:
1. *"the template is still not being followed correctly and that everything was wrapped in code backticks"*
2. *"Can you also confirm if this is an issue that is impacting you downstream, or just something that you found when scanning the codebase? It will help me decide if this needs backporting."*

**Root cause of the formatting issue:** when I drafted the previous PR body in PRList.md, I wrapped the entire revised description inside a triple-backtick fenced block for visual clarity in the chat reply. When pasted to GitHub, the outer fences turned the whole body into one giant code block, so the `## References` / `## Code changes` / etc. headings rendered as plain text inside backticks instead of as real markdown headings. The template was technically correct *content* but visually illegible.

**Fix to apply on GitHub:** paste the description as **raw markdown without any outer triple-backtick fences**. The new body lives below in this PRList entry verbatim — copy from the heading `## References` to the end of the AI-usage block.

**Revised PR description (paste as-is, NO outer code fences):**

## References

This was found via a code-review audit of the `@jupyterlab/coreutils` public surface — see the "Did this impact you downstream?" comment thread below for the full context. There is no existing issue tracking it; the closest related items are #11011 (the commit that introduced the regression) and #8715 (an older single-document mode cleanup). Happy to open a companion issue first if maintainers prefer.

## Code changes

`PageConfig.getUrl` captures `workspace = options.workspace ?? getOption('workspace')` on line 144 and correctly uses that captured local in the `workspace !== defaultWorkspace` gate on line 147 — but the URL segment itself on line 148 was built from `getOption('workspace') ?? defaultWorkspace`, silently ignoring any explicit `workspace` option the caller passed in. Replace that expression with the captured `workspace` local so the option is actually honored.

This matches the sibling option handling in the same function: `mode` (line 145) and `treePath` (line 154) both correctly reuse their captured local variables.

Three new test cases in `packages/coreutils/test/pageconfig.spec.ts` pin the behaviour:

- `should honor an explicit workspace option over the page config value`
- `should fall back to the page config workspace when option is absent`
- `should URL-encode a workspace name that contains special characters` (verifies `/` and space are percent-encoded — needed for workspace names containing path-like characters)

The existing tests only exercised `workspace: PageConfig.defaultWorkspace`, which opts out of the URL segment entirely via the `!==` check — so the broken path was never covered.

## User-facing changes

None visible directly in the JupyterLab UI. The fix only affects programmatic callers of `PageConfig.getUrl({ workspace: ... })` — typically third-party JupyterLab extensions and custom launchers — who will now receive the URL they actually asked for instead of the page config's stored workspace.

## Backwards-incompatible changes

None. Every call site inside the JupyterLab monorepo passes only `mode` / `treePath` / `toShare`:

- `packages/application-extension/src/index.tsx:999, 1029, 1043`
- `packages/filebrowser-extension/src/index.ts:777, 895`

None pass an explicit `workspace` option, so none change behaviour. The fix only affects callers that previously hit the buggy branch — those now receive the documented behaviour. The public API shape of `IGetUrlOptions` is unchanged.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude (Anthropic, Claude Opus 4.7) via the Claude Code CLI, used to scan `@jupyterlab/coreutils` for mechanical bugs and to draft the test cases. The human author reviewed the fix line-by-line against the docstring and sibling option handling in the same function, simulated the behaviour against five input shapes in Node before committing, and verified `prettier --check` passes on both modified files.

**Reply to post as a PR comment** (answers the downstream / backport question honestly):

> Thanks for the patience! I've updated the description so the template renders as actual headings (the previous version was wrapped in a single code block by mistake on my paste).
>
> On the downstream question: this was **not encountered in practice** — I found it while auditing the `@jupyterlab/coreutils` public surface for mechanical bugs against the docstring contract. So I don't think a backport is required from my side — the fix can land on `main` only. That said, I checked the in-repo callers and none of them pass an explicit `workspace` option today (`grep -rn "PageConfig.getUrl"` → only `treePath`/`mode`/`toShare` in `application-extension` and `filebrowser-extension`), so the bug is reachable only through third-party extensions or external scripts. If you know of any extension authors who depend on this option, the backport call is yours.

**Why answer honestly "no downstream impact":**
- It's the truth — I told the user this was a code-review find from day one
- Maintainers ask the question to decide on backport scope; lying inflates work
- The fix is still defensible on merit (docstring-vs-code contradiction + sibling pattern + test-coverage gap) without needing a fake production-impact story
- Saying "I scanned the codebase" honestly is the standard accepted practice for jupyterlab and most large OSS projects — the kind of contribution they call out positively in their CONTRIBUTING.md

**Action items for the user:**
1. Edit the PR body on GitHub: copy the markdown block above (starting at `## References`, ending at the AI-usage block), paste into the PR body **without wrapping in triple backticks**
2. Post the reply quote above as a new comment on the PR
3. No code change, no new commit, no push needed

**Memory.md update** — add this scenario as precedent to section 1: when a jupyterlab PR gets prettier CI feedback, the fix pattern is "install pinned prettier in a temp venv with `npm install --silent prettier@<version>`, run `--check` then `--write`, new commit (never `--amend`), push." Will add this in a separate edit if the user wants it codified.

---