### PR TITLE
Enable horizontal scrolling for dock tabs with wheel support

### DIFF
--- a/packages/application/style/tabs.css
+++ b/packages/application/style/tabs.css
@@ -45,7 +45,7 @@
 
 .lm-DockPanel-tabBar .lm-TabBar-tab,
 .lm-TabPanel-tabBar .lm-TabBar-tab {
-  flex: 0 1 var(--jp-private-horizontal-tab-width);
+  flex: 0 0 auto;
   align-items: center;
   min-height: calc(
     var(--jp-private-horizontal-tab-height) + 2 * var(--jp-border-width)

--- a/packages/ui-components/src/icon/widgets/tabbarsvg.ts
+++ b/packages/ui-components/src/icon/widgets/tabbarsvg.ts
@@ -3,6 +3,7 @@
 
 import type { ITranslator } from '@jupyterlab/translation';
 import { nullTranslator } from '@jupyterlab/translation';
+import type { Message } from '@lumino/messaging';
 import type { VirtualElement } from '@lumino/virtualdom';
 import { hpass } from '@lumino/virtualdom';
 import type { Widget } from '@lumino/widgets';
@@ -34,6 +35,44 @@ export class TabBarSvg<T> extends TabBar<T> {
       title: trans.__('New Launcher')
     });
   }
+
+  /**
+   * Add wheel listener when widget is attached.
+   */
+  protected onAfterAttach(msg: Message): void {
+    super.onAfterAttach(msg);
+    this.node.addEventListener('wheel', this._onWheel, { passive: false });
+  }
+
+  /**
+   * Remove wheel listener before widget is detached.
+   */
+  protected onBeforeDetach(msg: Message): void {
+    this.node.removeEventListener('wheel', this._onWheel);
+    super.onBeforeDetach(msg);
+  }
+
+  /**
+   * Convert vertical wheel motion into horizontal tab scrolling.
+   */
+  private _onWheel = (event: WheelEvent): void => {
+    const content = this.node.querySelector(
+      '.lm-TabBar-content'
+    ) as HTMLElement | null;
+    if (!content) {
+      return;
+    }
+    const delta =
+      Math.abs(event.deltaX) > Math.abs(event.deltaY)
+        ? event.deltaX
+        : event.deltaY;
+    if (delta === 0) {
+      return;
+    }
+    // Scroll tab strip horizontally with the mouse wheel.
+    content.scrollLeft += delta;
+    event.preventDefault();
+  };
 }
 
 export namespace TabBarSvg {

--- a/packages/ui-components/style/tabbar.css
+++ b/packages/ui-components/style/tabbar.css
@@ -17,13 +17,46 @@
 }
 
 .lm-DockPanel-tabBar .lm-TabBar-tab {
-  width: var(--jp-private-horizontal-tab-width);
+  width: auto;
 }
 
 .lm-DockPanel-tabBar .lm-TabBar-content {
-  flex: unset;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .lm-DockPanel-tabBar[data-orientation='horizontal'] {
   flex: 1 1 auto;
+  overflow: hidden;
+}
+
+.lm-DockPanel-tabBar[data-orientation='horizontal'] > .lm-TabBar-content {
+  overflow-x: auto;
+  overflow-y: hidden;
+  position: relative;
+  z-index: 3;
+}
+
+.lm-TabBar-content::-webkit-scrollbar {
+  height: 2px;
+  background: var(--jp-layout-color1);
+}
+
+.lm-TabBar-content::-webkit-scrollbar-button {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
+.lm-TabBar-content::-webkit-scrollbar-track {
+  background: var(--jp-layout-color1);
+}
+
+.lm-TabBar-content::-webkit-scrollbar-thumb {
+  background: rgba(120, 120, 120, 0.4);
+  border-radius: 999px;
+}
+
+.lm-TabBar-content:hover::-webkit-scrollbar-thumb {
+  background: rgba(160, 160, 160, 0.6);
 }


### PR DESCRIPTION
## References

#18795

## Code changes

Updated dock/tab panel tab sizing in packages/application/style/tabs.css so tabs can size to content (flex: 0 0 auto).
Added wheel-to-horizontal-scroll behavior in packages/ui-components/src/icon/widgets/tabbarsvg.ts:
TabBarSvg now listens for wheel events on attach and removes the listener on detach.
The handler maps wheel delta to .lm-TabBar-content.scrollLeft and prevents default vertical scrolling.
Updated tab bar layout and overflow styling in packages/ui-components/style/tabbar.css:
Tab width changed to auto.
.lm-TabBar-content set to flex: 1 1 auto; min-width: 0.
Horizontal dock tabbar now hides overflow while its content enables overflow-x: auto.
Added subtle WebKit scrollbar styling for the tab strip.

## User-facing changes

Dock area tabs are now horizontally scrollable when many tabs are open.
Mouse wheel interaction over the tab strip scrolls tabs horizontally, improving navigation in crowded tab layouts.
Tab strip now shows a minimal scrollbar style (WebKit browsers) for better discoverability without heavy visual noise.

## Backwards-incompatible changes

None.

## AI usage

YES: Some or all of the content of this PR was generated by AI.
YES: The human author has carefully reviewed this PR and run this code.
AI tools and models used: Cursor Agent (Codex 5.3).

<img width="1138" height="325" alt="image" src="https://github.com/user-attachments/assets/e0ccb8da-2b6d-494e-902e-58411043a7af" />
