### PR TITLE
Expose link to UI tests report in comment with Binder link

### DIFF
--- a/.github/workflows/galata-pr-comment.yml
+++ b/.github/workflows/galata-pr-comment.yml
@@ -1,0 +1,89 @@
+name: Update PR comment with UI test report
+
+on:
+  workflow_run:
+    workflows: ["UI Tests"]
+    types: [completed]
+
+jobs:
+  update-preview-comment:
+    name: Add report link to preview comment
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download PR comment data
+        uses: actions/download-artifact@v4
+        with:
+          name: galata-pr-comment-data
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Update binder preview comment
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const { prNumber, reportUrl, failing, flaky } = JSON.parse(
+              fs.readFileSync('pr-comment-data.json', 'utf8')
+            );
+
+            if (!prNumber || !reportUrl) {
+              console.warn('Missing PR number or report URL; skipping preview comment update.');
+              return;
+            }
+
+            const reportLinePrefix = 'View the integration tests report in browser: ';
+
+            let badgeStatus;
+            let badgeColor;
+            let badgeTitle;
+            if (failing > 0) {
+              badgeStatus = `${failing}_failing`;
+              badgeColor = 'red';
+              badgeTitle = `${failing} failing UI tests`;
+            } else if (flaky > 0) {
+              badgeStatus = `${flaky}_flaky`;
+              badgeColor = 'orange';
+              badgeTitle = `${flaky} flaky UI tests`;
+            } else {
+              badgeStatus = 'All_passing';
+              badgeColor = 'success';
+              badgeTitle = 'All tests UI tests passed';
+            }
+
+            const badgeUrl = `https://img.shields.io/badge/UI_tests-${badgeStatus}-${badgeColor}`;
+            const reportBadge = `[![UI tests report](${badgeUrl} '${badgeTitle}')](${reportUrl})`;
+            const reportLine = `${reportLinePrefix}${reportBadge}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber
+            });
+            const binderComment = comments
+              .slice()
+              .reverse()
+              .find(comment => comment.body.includes("![Binder]("));
+            if (!binderComment) {
+              return;
+            }
+
+            const existingReportLine = binderComment.body
+              .split('\n')
+              .find(line => line.startsWith(reportLinePrefix));
+            const updatedBody =
+              existingReportLine === undefined
+                ? `${binderComment.body.trimEnd()}\n\n${reportLine}`
+                : binderComment.body.replace(existingReportLine, reportLine);
+
+            if (binderComment.body.trim() !== updatedBody.trim()) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: binderComment.id,
+                body: updatedBody
+              });
+            }

--- a/.github/workflows/galata-pr-comment.yml
+++ b/.github/workflows/galata-pr-comment.yml
@@ -35,7 +35,7 @@ jobs:
               return;
             }
 
-            const reportLinePrefix = 'View the integration tests report in browser: ';
+            const reportLinePrefix = 'View the integration tests report in the browser: ';
 
             let badgeStatus;
             let badgeColor;

--- a/.github/workflows/galata-pr-comment.yml
+++ b/.github/workflows/galata-pr-comment.yml
@@ -54,8 +54,14 @@ jobs:
               badgeTitle = 'All tests UI tests passed';
             }
 
+            const reportUrlWithFilter = failing > 0
+              ? `${reportUrl}#?q=s%3Afailed`
+              : flaky > 0
+              ? `${reportUrl}#?q=s%3Aflaky`
+              : reportUrl;
+
             const badgeUrl = `https://img.shields.io/badge/UI_tests-${badgeStatus}-${badgeColor}`;
-            const reportBadge = `[![UI tests report](${badgeUrl} '${badgeTitle}')](${reportUrl})`;
+            const reportBadge = `[![UI tests report](${badgeUrl} '${badgeTitle}')](${reportUrlWithFilter})`;
             const reportLine = `${reportLinePrefix}${reportBadge}`;
 
             const { data: comments } = await github.rest.issues.listComments({

--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -243,8 +243,10 @@ jobs:
           echo "Prepared $COUNT blob report chunks for Playwright merge."
 
       - name: Merge Playwright reports
+        env:
+          PLAYWRIGHT_JSON_OUTPUT_NAME: merged-report.json
         run: |
-          npx playwright@${{ steps.pw-version.outputs.version }} merge-reports --reporter html,github ./artifacts/final/
+          npx playwright@${{ steps.pw-version.outputs.version }} merge-reports --reporter html,json,github ./artifacts/final/
 
       - name: Upload merged reports
         uses: actions/upload-artifact@v6
@@ -268,6 +270,79 @@ jobs:
       - name: Add report link to job summary
         run: |
           echo "**[View Visual Regression Report](${{ steps.upload-report.outputs.artifact-url }})**" >> $GITHUB_STEP_SUMMARY
+
+      - name: Add report link to preview comment
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            if (!context.issue.number) {
+              return;
+            }
+
+            const fs = require('fs');
+            const reportUrl = '${{ steps.upload-report.outputs.artifact-url }}';
+            let failing = 0;
+            let flaky = 0;
+            try {
+              const report = JSON.parse(fs.readFileSync('merged-report.json', 'utf8'));
+              failing = Number(report?.stats?.unexpected ?? 0);
+              flaky = Number(report?.stats?.flaky ?? 0);
+            } catch (error) {
+              console.warn(`Could not read merged-report.json for test counts: ${error.message}`);
+            }
+            const reportLinePrefix = 'View the integration tests report in browser: ';
+
+            let badgeStatus;
+            let badgeColor;
+            let badgeTitle;
+            if (failing > 0) {
+              badgeStatus = `${failing}_failing`;
+              badgeColor = 'red';
+              badgeTitle = `${failing} failing UI tests`;
+            } else if (flaky > 0) {
+              badgeStatus = `${flaky}_flaky`;
+              badgeColor = 'orange';
+              badgeTitle = `${flaky} flaky UI tests`;
+            } else {
+              badgeStatus = 'All_passing';
+              badgeColor = 'success';
+              badgeTitle = 'All tests UI tests passed';
+            }
+
+            const badgeUrl = `https://img.shields.io/badge/UI_tests-${badgeStatus}-${badgeColor}`;
+            const reportBadge = `[![UI tests report](${badgeUrl} '${badgeTitle}')](${reportUrl})`;
+            const reportLine = `${reportLinePrefix}${reportBadge}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            const binderComment = comments
+              .slice()
+              .reverse()
+              .find(comment => comment.body.includes("![Binder]("));
+            if (!binderComment) {
+              return;
+            }
+
+            const existingReportLine = binderComment.body
+              .split('\n')
+              .find(line => line.startsWith(reportLinePrefix));
+            const updatedBody =
+              existingReportLine === undefined
+                ? `${binderComment.body.trimEnd()}\n\n${reportLine}`
+                : binderComment.body.replace(existingReportLine, reportLine);
+
+            if (binderComment.body.trim() !== updatedBody.trim()) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: binderComment.id,
+                body: updatedBody
+              });
+            }
 
       - name: Merge and upload test results
         if: ${{ !cancelled() }}

--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -185,10 +185,6 @@ jobs:
     if: ${{ !cancelled() }}
     needs: test
     runs-on: ubuntu-22.04
-    outputs:
-      report-url: ${{ steps.upload-report.outputs.artifact-url }}
-      failing: ${{ steps.test-counts.outputs.failing }}
-      flaky: ${{ steps.test-counts.outputs.flaky }}
     permissions:
       contents: read
     steps:
@@ -289,6 +285,27 @@ jobs:
         run: |
           echo "**[View Visual Regression Report](${{ steps.upload-report.outputs.artifact-url }})**" >> $GITHUB_STEP_SUMMARY
 
+      - name: Save PR comment data
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            fs.writeFileSync('pr-comment-data.json', JSON.stringify({
+              prNumber: context.payload.pull_request.number,
+              reportUrl: '${{ steps.upload-report.outputs.artifact-url }}',
+              failing: ${{ steps.test-counts.outputs.failing || 0 }},
+              flaky: ${{ steps.test-counts.outputs.flaky || 0 }},
+            }));
+
+      - name: Upload PR comment data
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: galata-pr-comment-data
+          path: pr-comment-data.json
+          retention-days: 1
+
       - name: Merge and upload test results
         if: ${{ !cancelled() }}
         continue-on-error: true
@@ -309,82 +326,3 @@ jobs:
           delete-merged: true
           retention-days: 1
           compression-level: 1
-
-  update-preview-comment:
-    name: Add report link to preview comment
-    if: ${{ !cancelled() && github.event_name == 'pull_request' }}
-    needs: merge-reports
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Update binder preview comment
-        uses: actions/github-script@v8
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            if (!context.issue.number) {
-              return;
-            }
-
-            const reportUrl = '${{ needs.merge-reports.outputs.report-url }}';
-            if (!reportUrl) {
-              console.warn('Missing report URL from merge-reports job output; skipping preview comment update.');
-              return;
-            }
-
-            const failing = Number('${{ needs.merge-reports.outputs.failing }}');
-            const flaky = Number('${{ needs.merge-reports.outputs.flaky }}');
-            const reportLinePrefix = 'View the integration tests report in browser: ';
-
-            let badgeStatus;
-            let badgeColor;
-            let badgeTitle;
-            if (failing > 0) {
-              badgeStatus = `${failing}_failing`;
-              badgeColor = 'red';
-              badgeTitle = `${failing} failing UI tests`;
-            } else if (flaky > 0) {
-              badgeStatus = `${flaky}_flaky`;
-              badgeColor = 'orange';
-              badgeTitle = `${flaky} flaky UI tests`;
-            } else {
-              badgeStatus = 'All_passing';
-              badgeColor = 'success';
-              badgeTitle = 'All tests UI tests passed';
-            }
-
-            const badgeUrl = `https://img.shields.io/badge/UI_tests-${badgeStatus}-${badgeColor}`;
-            const reportBadge = `[![UI tests report](${badgeUrl} '${badgeTitle}')](${reportUrl})`;
-            const reportLine = `${reportLinePrefix}${reportBadge}`;
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number
-            });
-            const binderComment = comments
-              .slice()
-              .reverse()
-              .find(comment => comment.body.includes("![Binder]("));
-            if (!binderComment) {
-              return;
-            }
-
-            const existingReportLine = binderComment.body
-              .split('\n')
-              .find(line => line.startsWith(reportLinePrefix));
-            const updatedBody =
-              existingReportLine === undefined
-                ? `${binderComment.body.trimEnd()}\n\n${reportLine}`
-                : binderComment.body.replace(existingReportLine, reportLine);
-
-            if (binderComment.body.trim() !== updatedBody.trim()) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: binderComment.id,
-                body: updatedBody
-              });
-            }

--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -185,6 +185,12 @@ jobs:
     if: ${{ !cancelled() }}
     needs: test
     runs-on: ubuntu-22.04
+    outputs:
+      report-url: ${{ steps.upload-report.outputs.artifact-url }}
+      failing: ${{ steps.test-counts.outputs.failing }}
+      flaky: ${{ steps.test-counts.outputs.flaky }}
+    permissions:
+      contents: read
     steps:
       - name: Checkout lockfile
         uses: actions/checkout@v6
@@ -248,6 +254,18 @@ jobs:
         run: |
           npx playwright@${{ steps.pw-version.outputs.version }} merge-reports --reporter html,json,github ./artifacts/final/
 
+      - name: Extract failing and flaky counts
+        id: test-counts
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const report = JSON.parse(fs.readFileSync('merged-report.json', 'utf8'));
+            const failing = Number(report?.stats?.unexpected ?? 0);
+            const flaky = Number(report?.stats?.flaky ?? 0);
+            core.setOutput('failing', String(failing));
+            core.setOutput('flaky', String(flaky));
+
       - name: Upload merged reports
         uses: actions/upload-artifact@v6
         with:
@@ -271,7 +289,37 @@ jobs:
         run: |
           echo "**[View Visual Regression Report](${{ steps.upload-report.outputs.artifact-url }})**" >> $GITHUB_STEP_SUMMARY
 
-      - name: Add report link to preview comment
+      - name: Merge and upload test results
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: actions/upload-artifact/merge@v6
+        with:
+          # The name matches the pattern so that it is picked again on re-runs
+          name: galata-test-assets-merged
+          pattern: galata-test-assets-*
+          delete-merged: true
+
+      - name: Merge blobs and delete individual shards
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact/merge@v6
+        with:
+          # The name matches the pattern so that it is picked again on re-runs
+          name: galata-blobs-merged
+          pattern: galata-blobs-*
+          delete-merged: true
+          retention-days: 1
+          compression-level: 1
+
+  update-preview-comment:
+    name: Add report link to preview comment
+    if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+    needs: merge-reports
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Update binder preview comment
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -280,17 +328,14 @@ jobs:
               return;
             }
 
-            const fs = require('fs');
-            const reportUrl = '${{ steps.upload-report.outputs.artifact-url }}';
-            let failing = 0;
-            let flaky = 0;
-            try {
-              const report = JSON.parse(fs.readFileSync('merged-report.json', 'utf8'));
-              failing = Number(report?.stats?.unexpected ?? 0);
-              flaky = Number(report?.stats?.flaky ?? 0);
-            } catch (error) {
-              console.warn(`Could not read merged-report.json for test counts: ${error.message}`);
+            const reportUrl = '${{ needs.merge-reports.outputs.report-url }}';
+            if (!reportUrl) {
+              console.warn('Missing report URL from merge-reports job output; skipping preview comment update.');
+              return;
             }
+
+            const failing = Number('${{ needs.merge-reports.outputs.failing }}');
+            const flaky = Number('${{ needs.merge-reports.outputs.flaky }}');
             const reportLinePrefix = 'View the integration tests report in browser: ';
 
             let badgeStatus;
@@ -343,24 +388,3 @@ jobs:
                 body: updatedBody
               });
             }
-
-      - name: Merge and upload test results
-        if: ${{ !cancelled() }}
-        continue-on-error: true
-        uses: actions/upload-artifact/merge@v6
-        with:
-          # The name matches the pattern so that it is picked again on re-runs
-          name: galata-test-assets-merged
-          pattern: galata-test-assets-*
-          delete-merged: true
-
-      - name: Merge blobs and delete individual shards
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact/merge@v6
-        with:
-          # The name matches the pattern so that it is picked again on re-runs
-          name: galata-blobs-merged
-          pattern: galata-blobs-*
-          delete-merged: true
-          retention-days: 1
-          compression-level: 1


### PR DESCRIPTION
## References

- Closes https://github.com/jupyterlab/jupyterlab/issues/10968

Note: the new workflow will only start working after merging this PR so we do not see the badge here.

## Code changes

Adds a script updating Binder comment with link to report. It needs to be a separate workflow with `workflow_run` trigger to allow for secure interaction with PRs from forks.

## Developer-facing changes

The first bot comment will now include the UI tests badge (in addition to Binder badge) leading to the UI tests report (once available) and summarize the status:

<img width="877" height="219" alt="image" src="https://github.com/user-attachments/assets/d779987c-c143-4d62-a946-b9569c403a8c" />

<img width="877" height="219" alt="image" src="https://github.com/user-attachments/assets/ad3bf457-8363-473f-b3ef-997096b6c116" />

When tests get re-run (on new commits push or on manual re-trigger) the badge will be updated.

There is also a green success badge for when all tests pass - hopefully we will see it more often with the work to eliminate flaky tests (and this PR will help with it by exposing the number of flaky tests in a more visible spot).

Tested on https://github.com/test-for-jupyter-PR-bot-testing/jupyterlab/pull/5

## Backwards-incompatible changes

None

## AI usage

- **Yes**: Some or all of the content of this PR was generated by AI.
- **Yes**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: 5.3 Codex