### PR TITLE
Allow to run a subset of UI test (once or more) from GitHub Actions UI

### DIFF
--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -178,7 +178,7 @@ jobs:
           mv test-results/report.json test-results/${{ matrix.browser }}-${{ matrix.project }}-${{ matrix.shard }}.json
 
           BENCHMARK_EXIT_CODE=0
-          if [[ "${{ matrix.browser }}" == "chromium" ]] && [[ "${{ matrix.project }}" == "galata" ]] && [[ "${{ matrix.shard }}" == "1" ]]; then
+          if [[ -z "${TEST_PATTERN}" ]] && [[ "${{ matrix.browser }}" == "chromium" ]] && [[ "${{ matrix.project }}" == "galata" ]] && [[ "${{ matrix.shard }}" == "1" ]]; then
             # Run benchmark tests once to ensure they have no regressions
             BENCHMARK_NUMBER_SAMPLES=1 jlpm run test:benchmark
             BENCHMARK_EXIT_CODE=$?

--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -18,8 +18,8 @@ on:
       repeat_each:
         description: Number of times to repeat each matching test (passed to --repeat-each)
         required: false
-        default: '1'
-        type: string
+        default: 1
+        type: number
 
 env:
   PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/pw-browsers
@@ -151,7 +151,7 @@ jobs:
       - name: Test
         env:
           TEST_PATTERN: ${{ github.event.inputs.test_pattern || '' }}
-          REPEAT_EACH: ${{ github.event.inputs.repeat_each || '1' }}
+          REPEAT_EACH: ${{ github.event.inputs.repeat_each || 1 }}
         run: |
           cd core/galata
           set +e  # we want to move the reports even if we fail

--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -155,8 +155,13 @@ jobs:
         run: |
           cd core/galata
           set +e  # we want to move the reports even if we fail
+          MAX_REPEAT_EACH=20
           if ! [[ "${REPEAT_EACH}" =~ ^[1-9][0-9]*$ ]]; then
             echo "Invalid repeat_each: '${REPEAT_EACH}'. Expected a positive integer."
+            exit 1
+          fi
+          if (( REPEAT_EACH > MAX_REPEAT_EACH )); then
+            echo "Invalid repeat_each: '${REPEAT_EACH}'. Maximum allowed value is ${MAX_REPEAT_EACH}."
             exit 1
           fi
 

--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -9,6 +9,17 @@ on:
     # Run every 6 hours to establish a baseline for flaky tests
     - cron: '0 */6 * * *'
   workflow_dispatch:
+    inputs:
+      test_pattern:
+        description: Playwright test name pattern to match (passed to --grep)
+        required: false
+        default: ''
+        type: string
+      repeat_each:
+        description: Number of times to repeat each matching test (passed to --repeat-each)
+        required: false
+        default: '1'
+        type: string
 
 env:
   PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/pw-browsers
@@ -138,10 +149,26 @@ jobs:
         run: timeout 360 bash -c 'until curl -f http://localhost:8888/lab > /dev/null 2>&1; do sleep 1; done'
 
       - name: Test
+        env:
+          TEST_PATTERN: ${{ github.event.inputs.test_pattern || '' }}
+          REPEAT_EACH: ${{ github.event.inputs.repeat_each || '1' }}
         run: |
           cd core/galata
           set +e  # we want to move the reports even if we fail
-          jlpm run test --project ${{ matrix.project }} --shard ${{ matrix.shard }}/${{ matrix.shards }}
+          if ! [[ "${REPEAT_EACH}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Invalid repeat_each: '${REPEAT_EACH}'. Expected a positive integer."
+            exit 1
+          fi
+
+          TEST_ARGS=(--project ${{ matrix.project }} --shard ${{ matrix.shard }}/${{ matrix.shards }})
+          if [[ -n "${TEST_PATTERN}" ]]; then
+            TEST_ARGS+=(--grep "${TEST_PATTERN}")
+          fi
+          if [[ "${REPEAT_EACH}" != "1" ]]; then
+            TEST_ARGS+=(--repeat-each "${REPEAT_EACH}")
+          fi
+
+          jlpm run test "${TEST_ARGS[@]}"
           TEST_EXIT_CODE=$?
           mv test-results/report.json test-results/${{ matrix.browser }}-${{ matrix.project }}-${{ matrix.shard }}.json
 

--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -155,7 +155,7 @@ jobs:
         run: |
           cd core/galata
           set +e  # we want to move the reports even if we fail
-          MAX_REPEAT_EACH=20
+          MAX_REPEAT_EACH=50
           if ! [[ "${REPEAT_EACH}" =~ ^[1-9][0-9]*$ ]]; then
             echo "Invalid repeat_each: '${REPEAT_EACH}'. Expected a positive integer."
             exit 1


### PR DESCRIPTION

## References

Closes #18513

## Code changes

Adds inputs `test_pattern` and `repeat_each` to galata tests workflow.

## Developer-facing changes

<img width="364" height="510" alt="image" src="https://github.com/user-attachments/assets/5bcb598a-bfe0-47c6-8ce8-09235888bd2b" />

Example run: https://github.com/krassowski/jupyterlab/actions/runs/24955942852

## Backwards-incompatible changes

None

## AI usage

- **Yes**: Some or all of the content of this PR was generated by AI.
- **Yes**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Codex 5.3
