### PR TITLE
Only download the merged blobs on re-runs

### DIFF
--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -201,6 +201,7 @@ jobs:
           echo "version=$PW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Download aggregate blob artifact
+        if: ${{ github.run_attempt > 1 }}
         continue-on-error: true
         uses: actions/download-artifact@v7
         with:


### PR DESCRIPTION
## References

While working on https://github.com/jupyterlab/jupyterlab/pull/18800 I noticed that the first run of the UI tests workflow logs an error because the merged blobs archive (which we only pull on re-runs) is not yet available (which is expected)

<img width="1799" height="239" alt="image" src="https://github.com/user-attachments/assets/d4c0b662-75aa-4e6f-9f96-9faae8539c56" />

This is a follow-up to #18742.

## Code changes

Only run it on second attempt and so forth.

```diff
+ if: ${{ github.run_attempt > 1 }}
```

## Developer-facing changes

The error is no more

## Backwards-incompatible changes

None
