### PR TITLE
Filter snapshot artifacts from PR by latest commit

### DIFF
--- a/.github/workflows/galata-update-v2.yml
+++ b/.github/workflows/galata-update-v2.yml
@@ -49,6 +49,7 @@ jobs:
       pull-requests: read  # for getting the PR info
     outputs:
       pr-head-ref: ${{ steps.get-pr-info.outputs.head-ref }}
+      pr-head-sha: ${{ steps.get-pr-info.outputs.head-sha }}
       pr-head-repo: ${{ steps.get-pr-info.outputs.head-repo }}
       assets-run-id: ${{ steps.download.outputs.assets-run-id }}
     steps:
@@ -58,8 +59,10 @@ jobs:
           PR_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
           PR_DATA=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER)
           HEAD_REF=$(echo "$PR_DATA" | jq -r '.head.ref')
+          HEAD_SHA=$(echo "$PR_DATA" | jq -r '.head.sha')
           HEAD_REPO=$(echo "$PR_DATA" | jq -r '.head.repo.full_name')
           echo "head-ref=$HEAD_REF" >> $GITHUB_OUTPUT
+          echo "head-sha=$HEAD_SHA" >> $GITHUB_OUTPUT
           echo "head-repo=$HEAD_REPO" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -69,11 +72,12 @@ jobs:
         run: |
           PR_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
           PR_HEAD_REF=${{ steps.get-pr-info.outputs.head-ref }}
+          PR_HEAD_SHA=${{ steps.get-pr-info.outputs.head-sha }}
           ARTIFACT_NAME="galata-test-assets-merged"
           MAX_WAIT=1800  # 30 minutes
           ELAPSED=0
 
-          echo "Waiting for artifact: $ARTIFACT_NAME from PR #$PR_NUMBER (head ref: $PR_HEAD_REF)"
+          echo "Waiting for artifact: $ARTIFACT_NAME from PR #$PR_NUMBER (head ref: $PR_HEAD_REF, head sha: $PR_HEAD_SHA)"
 
           while [ $ELAPSED -lt $MAX_WAIT ]; do
             echo "Checking for artifact... (elapsed: ${ELAPSED}s)"
@@ -92,23 +96,31 @@ jobs:
               echo "Recent galata.yml runs (up to 20):"
               echo "$RUNS" | jq -r '.[] | "  id=\(.databaseId) event=\(.event) branch=\(.headBranch) sha=\(.headSha) conclusion=\(.conclusion) created=\(.createdAt)"'
 
-              RUN_IDS=$(echo "$RUNS" | jq -r --arg ref "$PR_HEAD_REF" '[.[] | select(.headBranch == $ref) | .databaseId] | .[]')
-              if [ -z "$RUN_IDS" ]; then
-                echo "No runs matched head ref '$PR_HEAD_REF'"
+              LATEST_RUN_ID=$(echo "$RUNS" | jq -r --arg ref "$PR_HEAD_REF" --arg sha "$PR_HEAD_SHA" '
+                [
+                  .[]
+                  | select(.headBranch == $ref and .headSha == $sha)
+                ]
+                | sort_by(.createdAt)
+                | last
+                | .databaseId // empty
+              ')
+              if [ -z "$LATEST_RUN_ID" ]; then
+                echo "No completed runs matched head ref '$PR_HEAD_REF' and head sha '$PR_HEAD_SHA'"
               fi
 
-              for RUN_ID in $RUN_IDS; do
-                echo "Trying artifact download from run $RUN_ID"
+              if [ -n "$LATEST_RUN_ID" ]; then
+                echo "Trying artifact download from latest matching run $LATEST_RUN_ID"
                 rm -rf ./artifact
-                if gh run download "$RUN_ID" \
+                if gh run download "$LATEST_RUN_ID" \
                   --repo ${{ github.repository }} \
                   --name $ARTIFACT_NAME \
                   --dir ./artifact 2>/dev/null; then
-                  echo "Artifact downloaded successfully from run $RUN_ID"
-                  echo "assets-run-id=$RUN_ID" >> $GITHUB_OUTPUT
+                  echo "Artifact downloaded successfully from run $LATEST_RUN_ID"
+                  echo "assets-run-id=$LATEST_RUN_ID" >> $GITHUB_OUTPUT
                   exit 0
                 fi
-              done
+              fi
             fi
 
             # Wait before retrying


### PR DESCRIPTION
## References

Fixes #18623

## Code changes

Added filtering by commit SHA.

## Developer-facing changes

When developer asks for the snapshot updates, the workflow will wait for the run corresponding to the latest commit at time of trigger, rather than using an already completed, potentially stale artifact.

## Backwards-incompatible changes

None

## AI usage

- **Yes**: Some or all of the content of this PR was generated by AI.
- **<!-- YES or NO -->**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Codex 5.3
