### PR TITLE
Fix file editor tab trap

### DIFF
--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -37,6 +37,7 @@ export class FileEditor extends Widget {
   constructor(options: FileEditor.IOptions) {
     super();
     this.addClass('jp-FileEditor');
+    this.node.tabIndex = 0;
 
     const context = (this._context = options.context);
     this._mimeTypeService = options.mimeTypeService;
@@ -99,6 +100,9 @@ export class FileEditor extends Widget {
       return;
     }
     switch (event.type) {
+      case 'keydown':
+        this._evtKeyDown(event as KeyboardEvent);
+        break;
       case 'mousedown':
         this._ensureFocus();
         break;
@@ -113,6 +117,7 @@ export class FileEditor extends Widget {
   protected onAfterAttach(msg: Message): void {
     super.onAfterAttach(msg);
     const node = this.node;
+    node.addEventListener('keydown', this, true);
     node.addEventListener('mousedown', this);
   }
 
@@ -121,7 +126,31 @@ export class FileEditor extends Widget {
    */
   protected onBeforeDetach(msg: Message): void {
     const node = this.node;
+    node.removeEventListener('keydown', this, true);
     node.removeEventListener('mousedown', this);
+  }
+
+  /**
+   * Handle the `'keydown'` event for the widget.
+   */
+  private _evtKeyDown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' && !this.editor.hasFocus()) {
+      event.preventDefault();
+      this.node.tabIndex = -1;
+      this.editor.setOption('tabFocusable', true);
+      this.editor.focus();
+      return;
+    }
+
+    if (event.key !== 'Escape' || !this.editor.hasFocus()) {
+      return;
+    }
+    // Set to command mode.
+    event.preventDefault();
+    event.stopPropagation();
+    this.editor.setOption('tabFocusable', false);
+    this.node.tabIndex = 0;
+    this.node.focus();
   }
 
   /**
@@ -136,6 +165,8 @@ export class FileEditor extends Widget {
    */
   private _ensureFocus(): void {
     if (!this.editor.hasFocus()) {
+      this.node.tabIndex = -1;
+      this.editor.setOption('tabFocusable', true);
       this.editor.focus();
     }
   }

--- a/packages/fileeditor/style/base.css
+++ b/packages/fileeditor/style/base.css
@@ -19,6 +19,13 @@
   height: 100%;
 }
 
+.jp-FileEditor:focus-visible::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border: 2px solid var(--jp-brand-color1);
+}
+
 /* Add extra space at the bottom when scrollPastEnd is enabled */
 .jp-FileEditor.jp-mod-scrollPastEnd .cm-content {
   padding-bottom: var(--jp-editor-scroll-padding);

--- a/packages/fileeditor/test/widget.spec.ts
+++ b/packages/fileeditor/test/widget.spec.ts
@@ -141,6 +141,26 @@ describe('fileeditorcodewrapper', () => {
           expect(widget.editor.hasFocus()).toBe(true);
         });
       });
+
+      describe('keydown', () => {
+        it('should escape editor focus on Escape', () => {
+          widget.editor.focus();
+          expect(widget.editor.hasFocus()).toBe(true);
+          simulate(widget.node, 'keydown', { key: 'Escape' });
+          expect(widget.events).toContain('keydown');
+          expect(widget.editor.hasFocus()).toBe(false);
+          expect(widget.node.tabIndex).toBe(0);
+        });
+
+        it('should re-focus editor on Enter from command mode', () => {
+          widget.editor.focus();
+          simulate(widget.node, 'keydown', { key: 'Escape' });
+          expect(widget.editor.hasFocus()).toBe(false);
+          simulate(widget.node, 'keydown', { key: 'Enter' });
+          expect(widget.editor.hasFocus()).toBe(true);
+          expect(widget.node.tabIndex).toBe(-1);
+        });
+      });
     });
 
     describe('#onAfterAttach()', () => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

- Fixes #18815 

<!-- Note any other pull requests that address this issue and how this pull request is different. -->


## Code changes

<!-- Describe the code changes and how they address the issue. -->

- Add event handling to intercept `Esc` and `Enter` key presses when using the file editor.
- Add styling to make the file editor focus ring visible.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

- Pressing `Esc` moves focus to the editor widget (exiting input area), and then editor can be `Tab` navigated with the other elements.
- Pressing `Enter` when the editor widget is in focus, enters the input area.

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

<img width="988" height="667" alt="escaping file editor with Esc key" src="https://github.com/user-attachments/assets/83cdefcc-ec7f-4e9d-a5b5-d4c4c1a01d19" />


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

None

## AI usage

- YES: Some or all of the content of this PR was generated by AI.
- YES: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Codex 5.3
