### PR TITLE
Fix syntax for Python 3.9 on `4.5.x` branch

### DIFF
--- a/jupyterlab/extensions/manager.py
+++ b/jupyterlab/extensions/manager.py
@@ -550,7 +550,7 @@ class ExtensionManager(PluginManager):
         else:
             return normalized in normalized_cache
 
-    async def is_install_allowed(self, name: str, _version: str | None = None) -> bool:
+    async def is_install_allowed(self, name: str, _version: Union[str, None] = None) -> bool:
         return await self._is_allowed_by_listing(name)
 
     async def _get_installed_extensions(

--- a/jupyterlab/extensions/pypi.py
+++ b/jupyterlab/extensions/pypi.py
@@ -19,7 +19,7 @@ from os import environ
 from pathlib import Path
 from subprocess import CalledProcessError, run
 from tarfile import TarFile
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Union
 from urllib.parse import urlparse
 from zipfile import ZipFile
 
@@ -171,7 +171,7 @@ class PyPIExtensionManager(ExtensionManager):
         """Extension manager metadata."""
         return ExtensionManagerMetadata("PyPI", True, sys.prefix)
 
-    async def is_install_allowed(self, name: str, version: str | None = None) -> bool:
+    async def is_install_allowed(self, name: str, version: Union[str, None] = None) -> bool:
         try:
             canonicalize_name(name, validate=True)
             if version is not None:
@@ -188,7 +188,7 @@ class PyPIExtensionManager(ExtensionManager):
             self.log.warning(f"Installation denied by allowlist/blocklist for {name}")
         return allowed
 
-    async def get_latest_version(self, pkg: str) -> str | None:
+    async def get_latest_version(self, pkg: str) -> Union[str, None]:
         """Return the latest available version for a given extension.
 
         Args:

--- a/jupyterlab/extensions/readonly.py
+++ b/jupyterlab/extensions/readonly.py
@@ -4,7 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import sys
-from typing import Optional
+from typing import Optional, Union
 
 from jupyterlab_server.translation_utils import translator
 
@@ -81,5 +81,5 @@ class ReadOnlyExtensionManager(ExtensionManager):
             status="error", message=trans.gettext("Extension removal not supported.")
         )
 
-    async def is_install_allowed(self, name: str, version: str | None = None) -> bool:
+    async def is_install_allowed(self, name: str, version: Union[str, None] = None) -> bool:
         return False


### PR DESCRIPTION
## References

Fixes CI failure on `4.5.x` branch as seen in https://github.com/jupyterlab/jupyterlab/actions/runs/25115297336/job/73600444796

## Code changes

```diff
- str | None
+ Union[str, None]
```

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

No