### PR TITLE
Backport PR #18652 on branch 4.5.x (Video and Audio Content Providers: Fix JupyterLite support)

### DIFF
--- a/packages/audio-extension/src/index.ts
+++ b/packages/audio-extension/src/index.ts
@@ -21,8 +21,8 @@ import {
 } from '@jupyterlab/docregistry';
 import {
   Contents,
-  IDefaultDrive,
-  RestContentProvider
+  IContentProvider,
+  IDefaultDrive
 } from '@jupyterlab/services';
 import { ITranslator } from '@jupyterlab/translation';
 import { Widget } from '@lumino/widgets';
@@ -216,16 +216,16 @@ export namespace AudioViewerFactory {
  *
  * This overrides the default behavior of the RestContentProvider to not include the file content.
  */
-class AudioContentProvider extends RestContentProvider {
-  constructor(options: RestContentProvider.IOptions) {
-    super(options);
+class AudioContentProvider implements IContentProvider {
+  constructor(options: { drive: Contents.IDrive }) {
+    this._drive = options.drive;
   }
 
   /**
    * Get a file or directory.
    *
    * @param localPath - The path to the file.
-   * @param options - The options used to fetch the file.
+   * @param options - The options used to get the file.
    *
    * @returns A promise which resolves with the file content.
    */
@@ -233,8 +233,32 @@ class AudioContentProvider extends RestContentProvider {
     localPath: string,
     options?: Contents.IFetchOptions
   ): Promise<Contents.IModel> {
-    return super.get(localPath, { ...options, content: false });
+    return this._drive.get(localPath, {
+      ...options,
+      contentProviderId: undefined,
+      content: false
+    });
   }
+
+  /**
+   * Save a file.
+   *
+   * @param localPath - The path to the file.
+   * @param options - The options used to save the file.
+   *
+   * @returns A promise which resolves with the file content.
+   */
+  async save(
+    localPath: string,
+    options: Partial<Contents.IModel> & Contents.IContentProvisionOptions = {}
+  ): Promise<Contents.IModel> {
+    return this._drive.save(localPath, {
+      ...options,
+      contentProviderId: undefined
+    });
+  }
+
+  private _drive: Contents.IDrive;
 }
 
 /**
@@ -254,7 +278,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
   ): void => {
     const trans = translator.load('jupyterlab');
 
-    const { contents, serverSettings } = app.serviceManager;
+    const { contents } = app.serviceManager;
 
     // Get audio file types from the document registry
     const audioFileTypes = getAudioFileTypes(app.docRegistry);
@@ -263,8 +287,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     const registry = defaultDrive.contentProviderRegistry;
     if (registry) {
       const audioContentProvider = new AudioContentProvider({
-        apiEndpoint: '/api/contents',
-        serverSettings
+        drive: defaultDrive
       });
       registry.register(AUDIO_CONTENT_PROVIDER_ID, audioContentProvider);
     }

--- a/packages/video-extension/src/index.ts
+++ b/packages/video-extension/src/index.ts
@@ -21,8 +21,8 @@ import {
 } from '@jupyterlab/docregistry';
 import {
   Contents,
-  IDefaultDrive,
-  RestContentProvider
+  IContentProvider,
+  IDefaultDrive
 } from '@jupyterlab/services';
 import { ITranslator } from '@jupyterlab/translation';
 import { Widget } from '@lumino/widgets';
@@ -213,16 +213,16 @@ export namespace VideoViewerFactory {
  *
  * This overrides the default behavior of the RestContentProvider to not include the file content.
  */
-class VideoContentProvider extends RestContentProvider {
-  constructor(options: RestContentProvider.IOptions) {
-    super(options);
+class VideoContentProvider implements IContentProvider {
+  constructor(options: { drive: Contents.IDrive }) {
+    this._drive = options.drive;
   }
 
   /**
    * Get a file or directory.
    *
    * @param localPath - The path to the file.
-   * @param options - The options used to fetch the file.
+   * @param options - The options used to get the file.
    *
    * @returns A promise which resolves with the file content.
    */
@@ -230,8 +230,32 @@ class VideoContentProvider extends RestContentProvider {
     localPath: string,
     options?: Contents.IFetchOptions
   ): Promise<Contents.IModel> {
-    return super.get(localPath, { ...options, content: false });
+    return this._drive.get(localPath, {
+      ...options,
+      contentProviderId: undefined,
+      content: false
+    });
   }
+
+  /**
+   * Save a file.
+   *
+   * @param localPath - The path to the file.
+   * @param options - The options used to save the file.
+   *
+   * @returns A promise which resolves with the file content.
+   */
+  async save(
+    localPath: string,
+    options: Partial<Contents.IModel> & Contents.IContentProvisionOptions = {}
+  ): Promise<Contents.IModel> {
+    return this._drive.save(localPath, {
+      ...options,
+      contentProviderId: undefined
+    });
+  }
+
+  private _drive: Contents.IDrive;
 }
 
 /**
@@ -250,7 +274,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     restorer: ILayoutRestorer | null
   ): void => {
     const trans = translator.load('jupyterlab');
-    const { contents, serverSettings } = app.serviceManager;
+    const { contents } = app.serviceManager;
 
     // Get video file types from the document registry
     const videoFileTypes = getVideoFileTypes(app.docRegistry);
@@ -259,8 +283,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     const registry = defaultDrive.contentProviderRegistry;
     if (registry) {
       const videoContentProvider = new VideoContentProvider({
-        apiEndpoint: '/api/contents',
-        serverSettings
+        drive: defaultDrive
       });
       registry.register(VIDEO_CONTENT_PROVIDER_ID, videoContentProvider);
     }


### PR DESCRIPTION

## References

Manual backport of https://github.com/jupyterlab/jupyterlab/pull/18652

## Code changes

See https://github.com/jupyterlab/jupyterlab/pull/18652

## User-facing changes

Audio / video support in jupyterlite.

## Backwards-incompatible changes

None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude Opus 4.7
