### PR TITLE
Enhancement: reopen menus after changes in Theme submenu

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -284,7 +284,7 @@ Would you like to clear the workspace or keep waiting?`),
 
             splash.classList.add('splash-fade');
             window.setTimeout(() => {
-              document.body.removeChild(splash);
+              splash.parentNode?.removeChild(splash);
             }, 200);
           }
         });

--- a/packages/apputils-extension/src/themesplugins.ts
+++ b/packages/apputils-extension/src/themesplugins.ts
@@ -16,6 +16,7 @@ import { IMainMenu } from '@jupyterlab/mainmenu';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { ITranslator } from '@jupyterlab/translation';
 
+import type { Menu } from '@lumino/widgets';
 import scrollbarStyleText from '../style/scrollbar.raw.css';
 
 namespace CommandIDs {
@@ -417,7 +418,7 @@ export const themesPaletteMenuPlugin: JupyterFrontEndPlugin<void> = {
     if (mainMenu) {
       void app.restored.then(() => {
         const isPalette = false;
-
+        const settingsMenu = mainMenu.settingsMenu as unknown as Menu;
         const themeMenu = mainMenu.settingsMenu.items.find(
           item =>
             item.type === 'submenu' &&
@@ -433,6 +434,16 @@ export const themesPaletteMenuPlugin: JupyterFrontEndPlugin<void> = {
             });
           });
         }
+        manager.themeChanged.connect(() => {
+          setTimeout(() => {
+            void app.commands.execute('settingsmenu:open').then(() => {
+              settingsMenu.activeItem =
+                settingsMenu.items.find(item => item.submenu === themeMenu) ??
+                null;
+              settingsMenu.triggerActiveItem();
+            });
+          }, 50);
+        });
       });
     }
 

--- a/packages/apputils-extension/src/themesplugins.ts
+++ b/packages/apputils-extension/src/themesplugins.ts
@@ -434,15 +434,27 @@ export const themesPaletteMenuPlugin: JupyterFrontEndPlugin<void> = {
             });
           });
         }
+
+        let lastActiveThemeIndex = -1;
+        let restoring = false;
+
+        // capture last item
+        themeMenu!.node.addEventListener('mouseup', () => {
+          const idx = (themeMenu as any)._activeIndex;
+          if (idx !== -1) lastActiveThemeIndex = idx;
+        });
+
+        // re-open theme submenu after each execution
         manager.themeChanged.connect(() => {
-          setTimeout(() => {
-            void app.commands.execute('settingsmenu:open').then(() => {
-              settingsMenu.activeItem =
-                settingsMenu.items.find(item => item.submenu === themeMenu) ??
-                null;
-              settingsMenu.triggerActiveItem();
-            });
-          }, 50);
+          if (restoring) return;
+          restoring = true;
+          void app.commands.execute('settingsmenu:open').then(() => {
+            settingsMenu.triggerActiveItem();
+            setTimeout(() => {
+              themeMenu!.activeIndex = lastActiveThemeIndex;
+              restoring = false;
+            }, 0);
+          });
         });
       });
     }


### PR DESCRIPTION
fixes #18746

## Code changes

Two files modified:

**`packages/apputils-extension/src/themeplugin.ts`**
- Track the last active index in the Theme submenu via a `mouseup` listener on `themeMenu.node`
- On `manager.themeChanged`, re-execute `settingsmenu:open`, trigger the Theme submenu, and restore the last active index, guarded by a `restoring` flag to prevent re-entrancy

**`packages/apputils/src/splash/index.ts`**
- Replace [`document.body.removeChild(splash)`](https://github.com/jupyterlab/jupyterlab/blob/6d21961ff350d56640ea146d42f8354d760fdd33/packages/apputils-extension/src/index.ts#L287) with `splash.parentNode?.removeChild(splash)` to safely no-op if splash has already been removed during rapid theme switching. Fixes the `NotFoundError` that was seen when switching themes quickly.

## User-facing changes

When changing theme or adjusting font/UI sizes from Settings > Theme, the submenu now reopens automatically after the splash screen transition. Users can make multiple adjustments (e.g. incrementing font size repeatedly) without having to navigate back through Settings > Theme each time.

**Before:** Settings > Theme submenu closes after every change, requiring the user to reopen it manually each time.
**After:** Settings > Theme submenu is restored automatically after the splash screen is dismissed.

<!-- Add before/after GIF or video here -->

## Backwards-incompatible changes

None.

## AI usage
- None