### PR TITLE
In `OutputArea` move `promptOverlay` to be a child of `panel` rather than a sibling

### DIFF
--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -364,19 +364,6 @@ export class OutputArea extends Widget {
   }
 
   /**
-   * Add overlay allowing to toggle scrolling.
-   */
-  private _createPromptOverlay() {
-    const overlay = document.createElement('div');
-    overlay.className = OUTPUT_PROMPT_OVERLAY;
-    overlay.addEventListener('click', () => {
-      this._toggleScrolling.emit();
-    });
-
-    return overlay;
-  }
-
-  /**
    * Update indices in _displayIdMap in response to element remove from model items
    *
    * @param startIndex - The index of first element removed
@@ -487,8 +474,10 @@ export class OutputArea extends Widget {
     prompt.addClass(OUTPUT_AREA_PROMPT_CLASS);
     panel.addWidget(prompt);
     if (this._promptOverlay) {
-      const promptOverlay = this._createPromptOverlay();
-      panel.addWidget(promptOverlay);
+      const overlay = new PromptOverlay(() => {
+        this._toggleScrolling.emit();
+      });;
+      panel.addWidget(overlay);
     }
 
     // Indicate that input is pending
@@ -809,8 +798,10 @@ export class OutputArea extends Widget {
     panel.addWidget(prompt);
 
     if (this._promptOverlay) {
-      const promptOverlay = this._createPromptOverlay();
-      panel.addWidget(promptOverlay);
+      const overlay = new PromptOverlay(() => {
+        this._toggleScrolling.emit();
+      });
+      panel.addWidget(overlay);
     }
 
     output.addClass(OUTPUT_AREA_OUTPUT_CLASS);
@@ -1052,6 +1043,26 @@ export class OutputPrompt extends Widget implements IOutputPrompt {
   }
 
   private _executionCount: nbformat.ExecutionCount = null;
+}
+
+export class PromptOverlay extends Widget {
+  /*
+   * Create a prompt overlay widget.
+   */
+  constructor(private toggleScrolling: () => void) {
+    super();
+    this.addClass(OUTPUT_PROMPT_OVERLAY);
+    this._setupNode();
+  }
+
+  /**
+   * Set up DOM node behavior.
+   */
+  private _setupNode(): void {
+    this.node.addEventListener('click', () => {
+      this.toggleScrolling();
+    });
+  }
 }
 
 /** ****************************************************************************

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -474,7 +474,7 @@ export class OutputArea extends Widget {
     prompt.addClass(OUTPUT_AREA_PROMPT_CLASS);
     panel.addWidget(prompt);
     if (this._promptOverlay) {
-      const overlay = new PromptOverlay(() => {
+      const overlay = new OutputPromptOverlay(() => {
         this._toggleScrolling.emit();
       });
       panel.addWidget(overlay);
@@ -798,7 +798,7 @@ export class OutputArea extends Widget {
     panel.addWidget(prompt);
 
     if (this._promptOverlay) {
-      const overlay = new PromptOverlay(() => {
+      const overlay = new OutputPromptOverlay(() => {
         this._toggleScrolling.emit();
       });
       panel.addWidget(overlay);
@@ -1045,7 +1045,7 @@ export class OutputPrompt extends Widget implements IOutputPrompt {
   private _executionCount: nbformat.ExecutionCount = null;
 }
 
-export class PromptOverlay extends Widget {
+export class OutputPromptOverlay extends Widget {
   /*
    * Create a prompt overlay widget.
    */

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -828,6 +828,7 @@ export class OutputArea extends Widget {
    * output area.
    */
   private _maxNumberOutputs: number;
+  private _promptOverlay: boolean;
   private _minHeightTimeout: number | null = null;
   private _inputRequested = new Signal<OutputArea, IStdin>(this);
   private _toggleScrolling = new Signal<OutputArea, void>(this);

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -1473,9 +1473,9 @@ namespace Private {
         const body = iframe.contentDocument!.body;
 
         // Adjust the iframe height automatically
-        iframe.style.height = `${body.scrollHeight}px`;
+        iframe.style.height = `${body.getBoundingClientRect().height}px`;
         iframe.heightChangeObserver = new ResizeObserver(() => {
-          iframe.style.height = `${body.scrollHeight}px`;
+          iframe.style.height = `${body.getBoundingClientRect().height}px`;
         });
         iframe.heightChangeObserver.observe(body);
       });

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -109,6 +109,7 @@ export class OutputArea extends Widget {
     this._translator = options.translator ?? nullTranslator;
     this._inputHistoryScope = options.inputHistoryScope ?? 'global';
     this._showInputPlaceholder = options.showInputPlaceholder ?? true;
+    this._promptOverlay = options.promptOverlay;
 
     const model = (this.model = options.model);
     for (
@@ -132,9 +133,9 @@ export class OutputArea extends Widget {
     }
     model.changed.connect(this.onModelChanged, this);
     model.stateChanged.connect(this.onStateChanged, this);
-    if (options.promptOverlay) {
-      this._addPromptOverlay();
-    }
+    requestAnimationFrame(() => {
+      this._initialize.emit();
+    });
   }
 
   /**
@@ -365,17 +366,14 @@ export class OutputArea extends Widget {
   /**
    * Add overlay allowing to toggle scrolling.
    */
-  private _addPromptOverlay() {
+  private _createPromptOverlay() {
     const overlay = document.createElement('div');
     overlay.className = OUTPUT_PROMPT_OVERLAY;
     overlay.addEventListener('click', () => {
       this._toggleScrolling.emit();
     });
-    this.node.appendChild(overlay);
 
-    requestAnimationFrame(() => {
-      this._initialize.emit();
-    });
+    return overlay;
   }
 
   /**
@@ -488,6 +486,10 @@ export class OutputArea extends Widget {
     const prompt = factory.createOutputPrompt();
     prompt.addClass(OUTPUT_AREA_PROMPT_CLASS);
     panel.addWidget(prompt);
+    if (this._promptOverlay) {
+      const promptOverlay = this._createPromptOverlay();
+      panel.addWidget(promptOverlay);
+    }
 
     // Indicate that input is pending
     this._pendingInput = true;
@@ -805,6 +807,11 @@ export class OutputArea extends Widget {
     prompt.executionCount = executionCount;
     prompt.addClass(OUTPUT_AREA_PROMPT_CLASS);
     panel.addWidget(prompt);
+
+    if (this._promptOverlay) {
+      const promptOverlay = this._createPromptOverlay();
+      panel.addWidget(promptOverlay);
+    }
 
     output.addClass(OUTPUT_AREA_OUTPUT_CLASS);
     panel.addWidget(output);

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -476,7 +476,7 @@ export class OutputArea extends Widget {
     if (this._promptOverlay) {
       const overlay = new PromptOverlay(() => {
         this._toggleScrolling.emit();
-      });;
+      });
       panel.addWidget(overlay);
     }
 

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -828,7 +828,7 @@ export class OutputArea extends Widget {
    * output area.
    */
   private _maxNumberOutputs: number;
-  private _promptOverlay: boolean;
+  private _promptOverlay?: boolean;
   private _minHeightTimeout: number | null = null;
   private _inputRequested = new Signal<OutputArea, IStdin>(this);
   private _toggleScrolling = new Signal<OutputArea, void>(this);

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -1472,9 +1472,9 @@ namespace Private {
         const body = iframe.contentDocument!.body;
 
         // Adjust the iframe height automatically
-        iframe.style.height = `${body.getBoundingClientRect().height}px`;
+        iframe.style.height = `${body.scrollHeight}px`;
         iframe.heightChangeObserver = new ResizeObserver(() => {
-          iframe.style.height = `${body.getBoundingClientRect().height}px`;
+          iframe.style.height = `${body.scrollHeight}px`;
         });
         iframe.heightChangeObserver.observe(body);
       });

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -373,26 +373,6 @@ export class OutputArea extends Widget {
     });
     this.node.appendChild(overlay);
 
-    // Update overlay height so it always matches the output panel.
-    // TODO: use CSS anchor positionning level once fully supported in all browsers
-    const resize = () => {
-      const panel = this.node.querySelector(
-        '.jp-OutputArea-child'
-      ) as HTMLElement;
-      if (panel) {
-        overlay.style.height = `${Math.max(
-          panel.getBoundingClientRect().height,
-          this.node.getBoundingClientRect().height
-        )}px`;
-      }
-    };
-    const observer = new ResizeObserver(resize);
-    observer.observe(this.node);
-
-    this.disposed.connect(() => {
-      observer.disconnect();
-    });
-
     requestAnimationFrame(() => {
       this._initialize.emit();
     });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes #18799
Makes #17890 unnecessary.

Also fixes the problem that was addressed in https://github.com/jupyterlab/jupyterlab/pull/17863 without using any code from that pull request

## Code changes

Move `promptOverlay` to be a child of `panel` rather than a sibling as described in #18799 

## User-facing changes

Fixes #18799

https://github.com/user-attachments/assets/8f03b4b7-08d5-4fb1-ab56-ccd570ff28ba

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: ChatGPT for changing `_addPromptOverlay` to `class PromptOverlay`. Everything else is human-written.
