### PR TITLE
Drop serial mode from galata test suite

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -475,9 +475,9 @@ export default defineConfig([
         },
         {
           selector:
-            "CallExpression[callee.object.object.name='test'][callee.object.property.name='describe'][callee.property.name='configure']",
+            "CallExpression[callee.object.object.name='test'][callee.object.property.name='describe'][callee.property.name='configure'] > ObjectExpression > Property[key.name='mode'][value.value='serial']",
           message:
-            "Do not use test.describe.configure({ mode: 'serial' }). Tests should run in parallel for betteer performance and to allow updating all snapshots at once."
+            "Do not use test.describe.configure({ mode: 'serial' }). Tests should run in parallel for better performance and to allow updating all snapshots at once."
         }
       ]
     }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -472,6 +472,12 @@ export default defineConfig([
             "CallExpression[callee.property.name='screenshot'] > ObjectExpression > Property[key.name='path']",
           message:
             "Do not pass 'path' to screenshot(). Save the result of toMatchSnapshot() or use expect() assertions instead."
+        },
+        {
+          selector:
+            "CallExpression[callee.object.object.name='test'][callee.object.property.name='describe'][callee.property.name='configure']",
+          message:
+            "Do not use test.describe.configure({ mode: 'serial' }). Tests should run in parallel for betteer performance and to allow updating all snapshots at once."
         }
       ]
     }

--- a/galata/test/documentation/customization.test.ts
+++ b/galata/test/documentation/customization.test.ts
@@ -10,9 +10,6 @@ test.use({
   viewport: { height: 720, width: 1280 }
 });
 
-// Use serial mode to avoid flaky screenshots
-test.describe.configure({ mode: 'serial' });
-
 test.describe('Default', () => {
   test('should use default layout', async ({ page }) => {
     await galata.Mock.freezeContentLastModified(page, filterContent);

--- a/galata/test/documentation/overview.test.ts
+++ b/galata/test/documentation/overview.test.ts
@@ -11,9 +11,6 @@ test.use({
   viewport: { height: 720, width: 1280 }
 });
 
-// Use serial mode to avoid flaky screenshots
-test.describe.configure({ mode: 'serial' });
-
 test.describe('Overview', () => {
   test('Overview', async ({ page }) => {
     await galata.Mock.freezeContentLastModified(page, filterContent);


### PR DESCRIPTION
## References

- Fixes #18837
 
Playwright documentation itself discourages the serial mode (https://playwright.dev/docs/test-parallel#serial-mode):

> <img width="944" height="231" alt="image" src="https://github.com/user-attachments/assets/6947f986-e9e6-4ff1-9b26-4952f0309653" />


## Code changes

- [x] forbid serial mode configuration via linter ([fails](https://github.com/jupyterlab/jupyterlab/actions/runs/25366259008/job/74377758761?pr=18838#step:8:120) before fixes, as expected)
   <img width="1470" height="182" alt="image" src="https://github.com/user-attachments/assets/5f362995-e445-45d1-8719-981dd5b34127" />
- [x] remove serial mode configuration
- [x] <s>fix tests if needed</s> not needed:
  - no flaky tests in the Overview group
    <img width="433" alt="image" src="https://github.com/user-attachments/assets/ad82da2a-82a7-448b-8c48-a436bb782bb4" />
  - flaky tests in customization group are pre-existing (https://github.com/jupyterlab/jupyterlab/issues/18514), no new flaky tests
    <img width="433" alt="image" src="https://github.com/user-attachments/assets/2a676f74-755b-46ea-8e9c-d6c36442eb87" />


## Developer-facing changes

- all snapshots are updated not only the first one
- all failing snapshots are highlighted in report not only the first one
- tests on CI run slightly faster


| Shard | [Before](https://github.com/jupyterlab/jupyterlab/actions/runs/25158504140/job/73746440256) | [Afer](https://github.com/jupyterlab/jupyterlab/actions/runs/25366676443/job/74379204248?pr=18838) |
|--|--|--|
| 1 | <img width="341" height="38" alt="image" src="https://github.com/user-attachments/assets/6e600dd7-f691-425f-8b49-a55dccfff569" /> | <img width="341" height="38" alt="image" src="https://github.com/user-attachments/assets/dd9fa241-777b-406e-96c9-679e39180be0" />
| 2 | <img width="341" height="38" alt="image" src="https://github.com/user-attachments/assets/d846bde9-e293-458e-a2fb-a9e4c02e965f" /> | <img width="341" height="38" alt="image" src="https://github.com/user-attachments/assets/6b4ec7c7-7862-404d-8b32-f23a5ab47f69" />


## Backwards-incompatible changes

None

## AI usage

Yes