### PR TITLE
Bump required labeler action to `v6.1`

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,7 +17,7 @@ jobs:
     name: Update PR Labels
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v6
+    - uses: actions/labeler@v6.1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true


### PR DESCRIPTION
## References

- Fixes https://github.com/jupyterlab/jupyterlab/issues/18410
- https://github.com/actions/labeler/releases/tag/v6.1.0 

## Code changes

```diff
- - uses: actions/labeler@v6
+ - uses: actions/labeler@v6.1
```

## Developer-facing changes

Labeller should no longer fight us when we add/remove labels manually

## Backwards-incompatible changes

None

## AI usage

No