### PR TITLE
Fix labeler spec to `v6.1.0` not `v6.1`

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,7 +17,7 @@ jobs:
     name: Update PR Labels
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v6
+    - uses: actions/labeler@v6.1.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,7 +17,7 @@ jobs:
     name: Update PR Labels
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v6.1
+    - uses: actions/labeler@v6
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true


### PR DESCRIPTION
Follow-up to jupyterlab/jupyterlab#18842

Seen in https://github.com/jupyterlab/jupyterlab/actions/runs/25431421559/job/74598358662?pr=18843

<img width="720" height="356" alt="image" src="https://github.com/user-attachments/assets/17aa0a07-611e-4e47-984a-f4b48e0831df" />
