### PR TITLE
Add loading animation for file browser refresh action

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -1610,13 +1610,21 @@ function addCommands(
   });
 
   commands.addCommand(CommandIDs.refresh, {
-    execute: args => {
+    execute: async () => {
       const widget = tracker.currentWidget;
 
-      if (widget) {
-        return widget.model.refresh();
+      if (!widget) {
+        return;
+      }
+
+      widget.node.classList.add('jp-mod-refreshing');
+      try {
+        await widget.model.refresh();
+      } finally {
+        widget.node.classList.remove('jp-mod-refreshing');
       }
     },
+
     icon: refreshIcon.bindprops({ stylesheet: 'menuItem' }),
     caption: trans.__('Refresh the file browser.'),
     label: trans.__('Refresh File List'),

--- a/packages/filebrowser-extension/style/base.css
+++ b/packages/filebrowser-extension/style/base.css
@@ -11,3 +11,19 @@
   padding: 0;
   flex: 0 0 auto;
 }
+
+.jp-mod-refreshing
+  .jp-ToolbarButtonComponent[data-command='filebrowser:refresh']
+  svg {
+  animation: jp-refresh-spin 1s linear infinite;
+}
+
+@keyframes jp-refresh-spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/filebrowser-extension/style/base.css
+++ b/packages/filebrowser-extension/style/base.css
@@ -16,6 +16,8 @@
   .jp-ToolbarButtonComponent[data-command='filebrowser:refresh']
   svg {
   animation: jp-refresh-spin 1s linear infinite;
+  transform-origin: 50% 50%;
+  display: block;
 }
 
 @keyframes jp-refresh-spin {

--- a/packages/filebrowser-extension/style/base.css
+++ b/packages/filebrowser-extension/style/base.css
@@ -14,7 +14,7 @@
 
 .jp-mod-refreshing
   .jp-ToolbarButtonComponent[data-command='filebrowser:refresh']
-  svg {
+  > svg {
   animation: jp-refresh-spin 1s linear infinite;
   transform-origin: 50% 50%;
   display: block;


### PR DESCRIPTION
## References

Fixes #18852 

Related discussion:
https://github.com/jupyter/notebook/issues/7904

## Code changes

* Added a temporary `jp-mod-refreshing` state during file browser refresh
* Updated the refresh command to apply the state while awaiting `widget.model.refresh()`
* Added a CSS animation for the refresh toolbar button icon during refresh

## User-facing changes

The refresh button in the file browser now provides visual feedback by spinning while the refresh request is in progress.

This makes the refresh action more visible without blocking user interaction.

## Backwards-incompatible changes

None.

## AI usage

None
