### PR TITLE
Fix opening notebook without a kernel if the kernel already exists by adding `shouldReuse` preference

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -803,7 +803,9 @@ export class SessionContext implements ISessionContext {
    * @returns A promise that resolves with whether to ask the user to select a kernel.
    *
    * #### Notes
-   * If a server session exists on the current path, we will connect to it.
+   * If a server session exists on the current path, we will connect to it
+   * unless opening explicitly without a kernel (`shouldStart === false`
+   * without a preferred kernel `id`).
    * If preferences include disabling `canStart` or `shouldStart`, no
    * server session will be started.
    * If a kernel id is given, we attempt to start a session with that id.
@@ -835,16 +837,22 @@ export class SessionContext implements ISessionContext {
     const manager = this.sessionManager;
     await manager.ready;
     await manager.refreshRunning();
-    const model = find(manager.running(), item => {
-      return item.path === this._path;
-    });
-    if (model) {
-      try {
-        const session = manager.connectTo({ model });
-        this._handleNewSession(session);
-      } catch (err) {
-        void this._handleSessionError(err);
-        return Promise.reject(err);
+    const preference = this.kernelPreference;
+    const shouldConnectToPathSession =
+      preference.shouldStart !== false || !!preference.id;
+
+    if (shouldConnectToPathSession) {
+      const model = find(manager.running(), item => {
+        return item.path === this._path;
+      });
+      if (model) {
+        try {
+          const session = manager.connectTo({ model });
+          this._handleNewSession(session);
+        } catch (err) {
+          void this._handleSessionError(err);
+          return Promise.reject(err);
+        }
       }
     }
 

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -282,6 +282,11 @@ export namespace ISessionContext {
     readonly shouldStart?: boolean;
 
     /**
+     * Reuse an existing session on the current path (default `true`).
+     */
+    readonly shouldReuse?: boolean;
+
+    /**
      * A kernel can be started (default `true`).
      */
     readonly canStart?: boolean;
@@ -804,8 +809,7 @@ export class SessionContext implements ISessionContext {
    *
    * #### Notes
    * If a server session exists on the current path, we will connect to it
-   * unless opening explicitly without a kernel (`shouldStart === false`
-   * without a preferred kernel `id`).
+   * unless `kernelPreference.shouldReuse === false`.
    * If preferences include disabling `canStart` or `shouldStart`, no
    * server session will be started.
    * If a kernel id is given, we attempt to start a session with that id.
@@ -838,8 +842,7 @@ export class SessionContext implements ISessionContext {
     await manager.ready;
     await manager.refreshRunning();
     const preference = this.kernelPreference;
-    const shouldConnectToPathSession =
-      preference.shouldStart !== false || !!preference.id;
+    const shouldConnectToPathSession = preference.shouldReuse !== false;
 
     if (shouldConnectToPathSession) {
       const model = find(manager.running(), item => {

--- a/packages/apputils/test/sessioncontext.spec.ts
+++ b/packages/apputils/test/sessioncontext.spec.ts
@@ -10,6 +10,7 @@ import {
   SessionContext,
   SessionContextDialogs
 } from '@jupyterlab/apputils';
+import type { Session } from '@jupyterlab/services';
 import {
   KernelManager,
   KernelSpecManager,
@@ -299,6 +300,60 @@ describe('@jupyterlab/apputils', () => {
         expect(other.kernel?.id).toBeDefined();
         expect(other.kernel?.id).toBe(sessionContext.session?.kernel?.id);
         await other.shutdown();
+        other.dispose();
+      });
+
+      it('should keep no kernel when shouldStart is false even if a path session exists', async () => {
+        const refreshRunning = jest
+          .spyOn(sessionManager, 'refreshRunning')
+          .mockResolvedValue(undefined);
+        const pathSessionModel: Session.IModel = {
+          id: UUID.uuid4(),
+          path,
+          name: '',
+          type: 'test',
+          kernel: {
+            id: UUID.uuid4(),
+            name: specsManager.specs!.default
+          }
+        };
+        const running = jest
+          .spyOn(sessionManager, 'running')
+          .mockReturnValue([pathSessionModel][Symbol.iterator]());
+        const connectTo = jest.spyOn(sessionManager, 'connectTo');
+        try {
+          sessionContext.kernelPreference = {
+            ...sessionContext.kernelPreference,
+            shouldStart: false
+          };
+
+          const result = await sessionContext.initialize();
+          expect(result).toBe(false);
+          expect(sessionContext.session?.kernel).toBeFalsy();
+          expect(connectTo).not.toHaveBeenCalled();
+        } finally {
+          refreshRunning.mockRestore();
+          running.mockRestore();
+          connectTo.mockRestore();
+        }
+      });
+
+      it('should connect to a path session when shouldStart is false and a kernel id is provided', async () => {
+        const other = await sessionManager.startNew({
+          name: '',
+          path,
+          type: 'test'
+        });
+
+        sessionContext.kernelPreference = {
+          ...sessionContext.kernelPreference,
+          shouldStart: false,
+          id: other.kernel!.id
+        };
+
+        const result = await sessionContext.initialize();
+        expect(result).toBe(false);
+        expect(sessionContext.session?.kernel?.id).toBe(other.kernel?.id);
         other.dispose();
       });
 

--- a/packages/apputils/test/sessioncontext.spec.ts
+++ b/packages/apputils/test/sessioncontext.spec.ts
@@ -303,7 +303,7 @@ describe('@jupyterlab/apputils', () => {
         other.dispose();
       });
 
-      it('should keep no kernel when shouldStart is false even if a path session exists', async () => {
+      it('should keep no kernel when shouldReuse is false even if a path session exists', async () => {
         const refreshRunning = jest
           .spyOn(sessionManager, 'refreshRunning')
           .mockResolvedValue(undefined);
@@ -322,20 +322,41 @@ describe('@jupyterlab/apputils', () => {
           .mockReturnValue([pathSessionModel][Symbol.iterator]());
         const connectTo = jest.spyOn(sessionManager, 'connectTo');
         try {
-          sessionContext.kernelPreference = {
+          const kernelPreference = {
             ...sessionContext.kernelPreference,
-            shouldStart: false
+            shouldStart: false,
+            shouldReuse: false
           };
+          sessionContext.kernelPreference = kernelPreference;
+          expect(sessionContext.kernelPreference.shouldReuse).toBe(false);
 
           const result = await sessionContext.initialize();
           expect(result).toBe(false);
-          expect(sessionContext.session?.kernel).toBeFalsy();
           expect(connectTo).not.toHaveBeenCalled();
+          expect(sessionContext.session?.kernel).toBeFalsy();
         } finally {
           refreshRunning.mockRestore();
           running.mockRestore();
           connectTo.mockRestore();
         }
+      });
+
+      it('should connect to a path session when shouldStart is false', async () => {
+        const other = await sessionManager.startNew({
+          name: '',
+          path,
+          type: 'test'
+        });
+
+        sessionContext.kernelPreference = {
+          ...sessionContext.kernelPreference,
+          shouldStart: false
+        };
+
+        const result = await sessionContext.initialize();
+        expect(result).toBe(false);
+        expect(sessionContext.session?.kernel?.id).toBe(other.kernel?.id);
+        other.dispose();
       });
 
       it('should connect to a path session when shouldStart is false and a kernel id is provided', async () => {

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1231,7 +1231,8 @@ const openWithNoKernelPlugin: JupyterFrontEndPlugin<void> = {
               label: trans.__('Notebook (no kernel)'),
               factory: FACTORY,
               kernelPreference: {
-                shouldStart: false
+                shouldStart: false,
+                shouldReuse: false
               }
             }
           })


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
Fixes #18257 
Refs: https://github.com/jupyterlab/jupyterlab/pull/18813#issuecomment-4351332620

## Code changes
This PR prevents SessionContext from reconnecting to existing path sessions when `shouldReuse: false`. It adds regression tests for both behaviors to lock the fix and compatibility.



<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Codex 5.3
