### PR TITLE
Accept `aborted` status in `IReplyAbortContent`

### DIFF
--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -775,11 +775,18 @@ export interface IReplyErrorContent {
 /**
  * Reply content indicating an aborted request.
  *
- * This is [deprecated](https://jupyter-client.readthedocs.io/en/latest/messaging.html#request-reply)
- * in message spec 5.1. Kernels should send an 'error' reply instead.
+ * For the general request/reply contract, `'abort'` is
+ * [deprecated](https://jupyter-client.readthedocs.io/en/latest/messaging.html#request-reply)
+ * since message spec 5.1 and kernels should send an `'error'` reply instead.
+ *
+ * For `execute_reply` specifically, the
+ * [spec](https://jupyter-client.readthedocs.io/en/latest/messaging.html#execution-results)
+ * defines `'aborted'` as the status sent by kernels (e.g. `ipykernel` emits
+ * `'aborted'` on interrupt). Both spellings are accepted here so the type
+ * matches what kernels actually send on the wire.
  */
 export interface IReplyAbortContent {
-  status: 'abort';
+  status: 'abort' | 'aborted';
 }
 
 /**

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -775,9 +775,11 @@ export interface IReplyErrorContent {
 /**
  * Reply content indicating an aborted request.
  *
- * The status value is `'aborted'`; the `'abort'` spelling that appears in
- * parts of the messaging documentation is a typo, see
+ * The status value emitted by kernels is `'aborted'`; the `'abort'` spelling
+ * that appears in parts of the messaging documentation is a typo, see
  * [jupyter_client#1063](https://github.com/jupyter/jupyter_client/issues/1063#issuecomment-3050583217).
+ * Both spellings are kept in the union so that downstream consumers already
+ * typed against `'abort'` continue to compile.
  *
  * This status is
  * [deprecated](https://jupyter-client.readthedocs.io/en/latest/messaging.html#request-reply)
@@ -786,7 +788,7 @@ export interface IReplyErrorContent {
  * emit it on interrupt.
  */
 export interface IReplyAbortContent {
-  status: 'aborted';
+  status: 'abort' | 'aborted';
 }
 
 /**

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -775,18 +775,18 @@ export interface IReplyErrorContent {
 /**
  * Reply content indicating an aborted request.
  *
- * For the general request/reply contract, `'abort'` is
- * [deprecated](https://jupyter-client.readthedocs.io/en/latest/messaging.html#request-reply)
- * since message spec 5.1 and kernels should send an `'error'` reply instead.
+ * The status value is `'aborted'`; the `'abort'` spelling that appears in
+ * parts of the messaging documentation is a typo, see
+ * [jupyter_client#1063](https://github.com/jupyter/jupyter_client/issues/1063#issuecomment-3050583217).
  *
- * For `execute_reply` specifically, the
- * [spec](https://jupyter-client.readthedocs.io/en/latest/messaging.html#execution-results)
- * defines `'aborted'` as the status sent by kernels (e.g. `ipykernel` emits
- * `'aborted'` on interrupt). Both spellings are accepted here so the type
- * matches what kernels actually send on the wire.
+ * This status is
+ * [deprecated](https://jupyter-client.readthedocs.io/en/latest/messaging.html#request-reply)
+ * since message spec 5.1 — kernels are encouraged to send an `'error'` reply
+ * instead — but it remains valid and some kernels (e.g. `ipykernel`) still
+ * emit it on interrupt.
  */
 export interface IReplyAbortContent {
-  status: 'abort' | 'aborted';
+  status: 'aborted';
 }
 
 /**


### PR DESCRIPTION
## References

Closes #17685.

## Code changes

The Jupyter messaging spec defines `'aborted'` as the status sent by kernels in `execute_reply` on interrupt (e.g. `ipykernel` emits `'aborted'`), whereas the now-deprecated general request/reply contract used `'abort'`.

`IReplyAbortContent.status` was previously typed as `'abort'` only. This widens the union to `'abort' | 'aborted'` so the type matches what kernels actually send on the wire. The doc comment is updated to explain the two spec contexts.

No runtime code paths in `@jupyterlab/services` / `cells` / `notebook` compare against the `'abort'` string literal — the existing runtime branch is `status !== 'ok'`, so real `'aborted'` messages are already handled at runtime; only the type was wrong.

Verified locally with a clean rebuild of `@jupyterlab/services` (`tsc -b`); typecheck passes and the built `lib/kernel/messages.d.ts` reflects the widened union.

## User-facing changes

None.

## Backwards-incompatible changes

None. The change widens the existing union type (adds a permitted literal), so prior code that produced or consumed `IReplyAbortContent` with `status: 'abort'` continues to type-check.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (verified `tsc -b` typechecks cleanly on `packages/services`; the change is type-only with no runtime behavior).
- AI tools and models used: Claude Code (Claude Opus 4.7)
