### PR TITLE
docs: add custom keyboard shortcut example

### DIFF
--- a/docs/source/user/interface.md
+++ b/docs/source/user/interface.md
@@ -226,6 +226,24 @@ Keyboard Shortcuts in the Settings tab.
 </div>
 ```
 
+Custom shortcuts are stored in the Keyboard Shortcuts user preferences as a
+list of shortcut definitions. Each definition includes the command identifier,
+the key combination, and a CSS selector that determines when the shortcut is
+active. For example, to create a shortcut for **New Console for Notebook**, add
+an entry for the `notebook:create-console` command:
+
+```json
+{
+  "shortcuts": [
+    {
+      "command": "notebook:create-console",
+      "keys": ["Accel ."],
+      "selector": ".jp-Notebook:focus"
+    }
+  ]
+}
+```
+
 To define a custom keyboard shortcut which runs more than one command, add a keyboard shortcut
 for `apputils:run-all-enabled` command in Keyboard Shortcuts advanced settings. The commands you
 wish to run are passed in the `args` argument as a list of strings:

--- a/docs/source/user/interface.md
+++ b/docs/source/user/interface.md
@@ -217,8 +217,11 @@ The browser’s native context menu can be accessed by holding down
 
 As in the classic Notebook, you can navigate the user interface through keyboard
 shortcuts. You can find and customize the current list of keyboard shortcuts by
-selecting the Advanced Settings Editor item in the Settings menu, then selecting
-Keyboard Shortcuts in the Settings tab.
+selecting Settings Editor in the Settings menu, then selecting Keyboard Shortcuts.
+The Keyboard Shortcuts settings editor lets you search for commands, use **Add**
+to assign a shortcut to an existing command, or use the **+** button to create a
+shortcut for another command. For advanced edits, you can also open the JSON
+settings editor and update the Keyboard Shortcuts user preferences directly.
 
 ```{raw} html
 <div class="jp-youtube-video">


### PR DESCRIPTION
## References

Fixes #7049.

## Code changes

Adds a Keyboard Shortcuts documentation example showing how to define a custom shortcut for `notebook:create-console`, including the command identifier, key binding, and selector fields.

## User-facing changes

Users can more easily discover how to add a shortcut for **New Console for Notebook** through Advanced Settings.

## Backwards-incompatible changes

N/A.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **NO**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: OpenAI Codex GPT-5.5 via OpenClaw
