### PR TITLE
Add merge driver for png files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
 jupyterlab/staging/yarn.js binary
 # SCM syntax highlighting
 pixi.lock linguist-language=YAML linguist-generated=true
+# Merge png files to ease regenerating snapshots on conflicts
+# (we always need to "resolve" conflicts and then regenerate
+# the snapshots anyways, so the initial "resolution"
+# does not really matter)
+*.png merge=ours

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,4 +5,5 @@ pixi.lock linguist-language=YAML linguist-generated=true
 # (we always need to "resolve" conflicts and then regenerate
 # the snapshots anyways, so the initial "resolution"
 # does not really matter)
-*.png merge=ours
+galata/**/*.png merge=ours
+examples/**/*.png merge=ours

--- a/docs/source/developer/contributing.md
+++ b/docs/source/developer/contributing.md
@@ -666,6 +666,23 @@ Main reasons for UI test failures are:
 For more information on UI Testing, please read the [UI Testing developer documentation](https://github.com/jupyterlab/jupyterlab/blob/main/galata/README.md)
 and [Playwright documentation](https://playwright.dev/docs/intro).
 
+#### Configure merge driver to reduce snapshot drift friction
+
+If you find yourself frequently resolving merge conflicts due to snapshots being
+updated on both your branch and changing on the `main` branch, you may wish
+to configure git to automatically resolve the `png` conflicts with:
+
+```bash
+git config merge.ours.driver true
+```
+
+Next time when merging the `main` branch you won't be prompted to manually resolve
+the conflicts of the binary files and instead the copy from your branch will be
+used for the merge. This copy will most likely still require regenerating, but
+this setup saves time for manually confirming which copy to use for merge.
+
+This is made possible by the driver rule present in `.gitattributes` file.
+
 ### Good Practices for Integration tests
 
 Here are some good practices to follow when writing integration tests:

--- a/docs/source/developer/contributing.md
+++ b/docs/source/developer/contributing.md
@@ -666,7 +666,7 @@ Main reasons for UI test failures are:
 For more information on UI Testing, please read the [UI Testing developer documentation](https://github.com/jupyterlab/jupyterlab/blob/main/galata/README.md)
 and [Playwright documentation](https://playwright.dev/docs/intro).
 
-#### Configure merge driver to reduce snapshot drift friction
+### Configure merge driver to reduce snapshot drift friction
 
 If you find yourself frequently resolving merge conflicts due to snapshots being
 updated on both your branch and changing on the `main` branch, you may wish


### PR DESCRIPTION
## References

- Closes https://github.com/jupyterlab/jupyterlab/issues/18553

## Code changes

Adds `*.png merge=ours` to `.gitattributes`. It does nothing by default, but if developers choose to configure their git to respect it with `git config merge.ours.driver true` (as documented), their journey of rebasing PRs will be smoother.

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

No