### PR TITLE
Update documentation snapshot docs and document new CI trigger

### DIFF
--- a/.github/workflows/galata-update-v2.yml
+++ b/.github/workflows/galata-update-v2.yml
@@ -21,7 +21,9 @@ jobs:
       (github.event.issue.pull_request || github.event.pull_request) &&
       (
         contains(github.event.comment.body || github.event.review.body || '', 'would you be so kind as to update galata snapshots please') ||
-        contains(github.event.comment.body || github.event.review.body || '', 'would you be so kind as to update snapshots please')
+        contains(github.event.comment.body || github.event.review.body || '', 'would you be so kind as to update snapshots please') ||
+        contains(github.event.comment.body || github.event.review.body || '', 'please open PR to update galata snapshots') ||
+        contains(github.event.comment.body || github.event.review.body || '', 'please open PR to update snapshots')
       )
     runs-on: ubuntu-slim
     environment: update-snapshots

--- a/docs/source/developer/contributing.md
+++ b/docs/source/developer/contributing.md
@@ -651,17 +651,20 @@ Main reasons for UI test failures are:
 2. **An intended update to user interface**:
 
    If your code change is introducing an update to UI which causes existing UI Tests to
-   fail, then you will need to update reference image(s) for the failing tests. In order
-   to do that, you can post a comment on your PR with the following content:
-   - `please update galata snapshots`: A bot will push a new commit to your PR updating galata
-     test snapshots.
-   - `please update documentation snapshots`: A bot will push a new commit to your PR updating
-     documentation test snapshots.
+   fail, then you will need to update reference image(s) (and/or JSON snapshots) for the failing tests.
+   In order to do that, you can post a comment on your PR with the following content:
+   - `bot please open PR to update snapshots` - A bot will open a PR updating snapshots
+     generated in the most recent run of CI from your branch.
+
+   Maintainers can also use the following commands:
+   - `please update galata snapshots`: A bot will regenerate galata snapshots
+     and push a new commit to your PR branch.
+   - `please update documentation snapshots`: A bot will regenerate documentation
+     snapshots and push a new commit to your PR branch.
    - `please update snapshots`: Combine the two previous comments effects.
 
    > The bot will react with +1 emoji to indicate that the run started and then comment
-   > back once it concluded. This feature is restricted to a subset of users with higher
-   > privileges due to security concerns.
+   > back once it concluded.
 
 For more information on UI Testing, please read the [UI Testing developer documentation](https://github.com/jupyterlab/jupyterlab/blob/main/galata/README.md)
 and [Playwright documentation](https://playwright.dev/docs/intro).
@@ -670,8 +673,15 @@ and [Playwright documentation](https://playwright.dev/docs/intro).
 
 Here are some good practices to follow when writing integration tests:
 
-- Don't compare multiple screenshots in the same test; if the first comparison breaks,
-  it will require running multiple times the CI workflow to fix all tests.
+- Don't compare multiple screenshots in the same test, unless using `expect.soft`;
+  if the first comparison breaks, it will require multiple re-runs of CI workflow to update all snapshots.
+- Don't include more UI elements than necessary, as that increases review burden when elements other than
+  the one tested change - reviewing hundreds of unrelated snapshots is exhausting and error-prone.
+- When cropping snapshots, prefer retrieving the required dimensions programmatically over hard-coding them.
+- Always use `toMatchSnapshot()` for comparing snapshots; do not implement custom logic reading/writing snapshots.
+- Do not use `waitForTimeout()` as this slows down tests and makes them flaky when CI runs slower than expected.
+- If your change introduces subpixel change to dozens of snapshots, consider if it is necessary;
+  such a change often requires many extensions to update their snapshots too, leading to significant cost downstream.
 
 ## Contributing to the debugger front-end
 

--- a/docs/source/developer/contributing.md
+++ b/docs/source/developer/contributing.md
@@ -653,7 +653,7 @@ Main reasons for UI test failures are:
    If your code change is introducing an update to UI which causes existing UI Tests to
    fail, then you will need to update reference image(s) (and/or JSON snapshots) for the failing tests.
    In order to do that, you can post a comment on your PR with the following content:
-   - `bot please open PR to update snapshots` - A bot will open a PR updating snapshots
+   - (bot) `please open PR to update snapshots` - A bot will open a PR updating all snapshots
      generated in the most recent run of CI from your branch.
 
    Maintainers can also use the following commands:


### PR DESCRIPTION

## References

Follow-up to:
- https://github.com/jupyterlab/jupyterlab/pull/17336
- https://github.com/jupyterlab/jupyterlab/pull/18559

## Code changes

- Adds shorter `please open PR to update snapshots` command (keeps `would you be so kind as to update snapshots please` for now) for the new workflow.
- Documents the new snapshot update workflow
- Adds more good practices for visual regression tests

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

No