### PR TITLE
Ignore links to `docs.conda.io` since it returns 503 often

### DIFF
--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -187,4 +187,4 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
         with:
           ignore_glob: "docs/api packages/ui-components/docs/source/ui_components.rst images"
-          ignore_links: ".*/images/[\\w-]+.png https://docs.github.com/en/.* https://jupyterlab.github.io https://mybinder.org/v2/gh/jupyterlab/.* https://github.com/[^/]+/?$ https://blog.jupyter.org/.* https://pypi.org/.* https://code.visualstudio.com/.* https://github.com/.* https://www.npmjs.com.* https://webpack.js.org/.*"
+          ignore_links: ".*/images/[\\w-]+.png https://docs.github.com/en/.* https://jupyterlab.github.io https://mybinder.org/v2/gh/jupyterlab/.* https://github.com/[^/]+/?$ https://blog.jupyter.org/.* https://pypi.org/.* https://code.visualstudio.com/.* https://github.com/.* https://www.npmjs.com.* https://webpack.js.org/.* https://docs.conda.io/*"


### PR DESCRIPTION
## References

Fixes link check failing randomly in many recent PRs, e.g.:
- https://github.com/jupyterlab/jupyterlab/actions/runs/25917532222/attempts/1?pr=18885
- https://github.com/jupyterlab/jupyterlab/actions/runs/25922149084/job/76193682879 (https://github.com/jupyterlab/jupyterlab/pull/18084) and more

## Code changes

Do not check links to https://docs.conda.io/*

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

No