### PR TITLE
Set `showFileFilter` in settings change listener

### DIFF
--- a/packages/filebrowser-extension/schema/browser.json
+++ b/packages/filebrowser-extension/schema/browser.json
@@ -308,7 +308,7 @@
         }
       }
     },
-    "showFileFilter": {
+    "showFileFilterByDefault": {
       "type": "boolean",
       "title": "Show Filter Bar by Default",
       "description": "Show the filter bar by default in the file browser.",

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -274,9 +274,6 @@ const browserSettings: JupyterFrontEndPlugin<void> = {
           allowFileUploads: true
         };
 
-        browser.showFileFilter = settings.get('showFileFilter')
-          .composite as boolean;
-
         function onSettingsChanged(settings: ISettingRegistry.ISettings): void {
           let key: keyof typeof defaultFileBrowserConfig;
           for (key in defaultFileBrowserConfig) {
@@ -293,6 +290,8 @@ const browserSettings: JupyterFrontEndPlugin<void> = {
             .composite as boolean;
           browser.model.filterDirectories = filterDirectories;
           browser.model.useFuzzyFilter = useFuzzyFilter;
+          browser.showFileFilter = settings.get('showFileFilter')
+            .composite as boolean;
         }
         settings.changed.connect(onSettingsChanged);
         onSettingsChanged(settings);

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -272,14 +272,20 @@ const browserSettings: JupyterFrontEndPlugin<void> = {
           sortFileNamesNaturally: true,
           showFullPath: false,
           allowFileUploads: true,
-          showFileFilter: false
+          showFileFilterByDefault: false
         };
 
         function onSettingsChanged(settings: ISettingRegistry.ISettings): void {
           let key: keyof typeof defaultFileBrowserConfig;
           for (key in defaultFileBrowserConfig) {
             const value = settings.get(key).composite as boolean;
-            browser[key] = value;
+            if (key === 'showFileFilterByDefault') {
+              if (value !== browser.showFileFilterByDefault) {
+                browser.showFileFilterByDefault = value;
+              }
+            } else {
+              browser[key] = value;
+            }
           }
           const breadcrumbs = settings.get('breadcrumbs')
             .composite as unknown as IBreadcrumbsSettings;

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -271,7 +271,8 @@ const browserSettings: JupyterFrontEndPlugin<void> = {
           sortNotebooksFirst: false,
           sortFileNamesNaturally: true,
           showFullPath: false,
-          allowFileUploads: true
+          allowFileUploads: true,
+          showFileFilter: false
         };
 
         function onSettingsChanged(settings: ISettingRegistry.ISettings): void {
@@ -290,8 +291,6 @@ const browserSettings: JupyterFrontEndPlugin<void> = {
             .composite as boolean;
           browser.model.filterDirectories = filterDirectories;
           browser.model.useFuzzyFilter = useFuzzyFilter;
-          browser.showFileFilter = settings.get('showFileFilter')
-            .composite as boolean;
         }
         settings.changed.connect(onSettingsChanged);
         onSettingsChanged(settings);

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -329,6 +329,20 @@ export class FileBrowser extends SidePanel {
   }
 
   /**
+   * Whether to show the file filter by default when the file browser is opened.
+   */
+  get showFileFilterByDefault(): boolean {
+    return this._showFileFilterByDefault;
+  }
+
+  set showFileFilterByDefault(value: boolean) {
+    this._showFileFilterByDefault = value;
+    if (value) {
+      this.showFileFilter = true;
+    }
+  }
+
+  /**
    * Whether to clear the filter value when navigating to a new directory.
    */
   get clearFilterOnNavigation(): boolean {
@@ -696,6 +710,7 @@ export class FileBrowser extends SidePanel {
   private _allowSingleClick: boolean = false;
   private _showFileCheckboxes: boolean = false;
   private _showFileFilter: boolean = false;
+  private _showFileFilterByDefault: boolean = false;
   private _showDateCreatedColumn: boolean = false;
   private _showFileSizeColumn: boolean = false;
   private _showHiddenFiles: boolean = false;


### PR DESCRIPTION
## References

Fixes #18893 

## Code changes

Moves `showFileFilter` into `onSettingsChanged` listener function.

## User-facing changes

Users will be able to see the file filter without the need to reload the page.

## Backwards-incompatible changes

N/A

## AI usage

No
