### PR TITLE
Bump `jupyter-builder` to `v1.0.0b1`

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -206,7 +206,7 @@
     "@jupyterlab/workspaces-extension": "~4.6.0-alpha.5"
   },
   "devDependencies": {
-    "@jupyter/builder": "^0.0.8",
+    "@jupyter/builder": "^1.0.0-beta.1",
     "@jupyterlab/buildutils": "^4.6.0-alpha.5",
     "@module-federation/runtime-tools": "^2.0.0",
     "@rsdoctor/rspack-plugin": "^1.3.12",

--- a/examples/app/package.json
+++ b/examples/app/package.json
@@ -7,7 +7,7 @@
     "clean": "rimraf build"
   },
   "dependencies": {
-    "@jupyter/builder": "^0.0.8",
+    "@jupyter/builder": "^1.0.0-beta.1",
     "@jupyterlab/application": "^4.6.0-alpha.5",
     "@jupyterlab/application-extension": "^4.6.0-alpha.5",
     "@jupyterlab/apputils-extension": "^4.6.0-alpha.5",

--- a/examples/federated/core_package/package.json
+++ b/examples/federated/core_package/package.json
@@ -139,7 +139,7 @@
     "@jupyterlab/vega5-extension": "^4.6.0-alpha.5"
   },
   "devDependencies": {
-    "@jupyter/builder": "^0.0.8",
+    "@jupyter/builder": "^1.0.0-beta.1",
     "@rspack/cli": "^2.0.2",
     "copy-webpack-plugin": "^11.0.0",
     "fs-extra": "^10.1.0",

--- a/examples/federated/md_package/package.json
+++ b/examples/federated/md_package/package.json
@@ -14,7 +14,7 @@
     "@lumino/widgets": "^2.7.5"
   },
   "devDependencies": {
-    "@jupyter/builder": "^0.0.8",
+    "@jupyter/builder": "^1.0.0-beta.1",
     "rimraf": "~5.0.5"
   },
   "jupyterlab": {

--- a/examples/federated/middle_package/package.json
+++ b/examples/federated/middle_package/package.json
@@ -10,7 +10,7 @@
     "@lumino/coreutils": "^2.2.2"
   },
   "devDependencies": {
-    "@jupyter/builder": "^0.0.8",
+    "@jupyter/builder": "^1.0.0-beta.1",
     "rimraf": "~5.0.5"
   },
   "publishConfig": {

--- a/galata/extension/package.json
+++ b/galata/extension/package.json
@@ -49,7 +49,7 @@
     "@lumino/signaling": "^2.1.5"
   },
   "devDependencies": {
-    "@jupyter/builder": "^0.0.8",
+    "@jupyter/builder": "^1.0.0-beta.1",
     "rimraf": "~5.0.5",
     "typescript": "~5.9.3"
   },

--- a/jupyterlab/tests/mock_packages/extension/package.json
+++ b/jupyterlab/tests/mock_packages/extension/package.json
@@ -6,7 +6,7 @@
     "@jupyterlab/launcher": "^4.6.0-alpha.5"
   },
   "devDependencies": {
-    "@jupyter/builder": "^0.0.8"
+    "@jupyter/builder": "^1.0.0-beta.1"
   },
   "jupyterlab": {
     "extension": true,

--- a/jupyterlab/tests/mock_packages/interop/consumer/package.json
+++ b/jupyterlab/tests/mock_packages/interop/consumer/package.json
@@ -6,7 +6,7 @@
     "@jupyterlab/mock-token": "^4.6.0-alpha.5"
   },
   "devDependencies": {
-    "@jupyter/builder": "^0.0.8"
+    "@jupyter/builder": "^1.0.0-beta.1"
   },
   "jupyterlab": {
     "extension": true,

--- a/jupyterlab/tests/mock_packages/interop/provider/package.json
+++ b/jupyterlab/tests/mock_packages/interop/provider/package.json
@@ -6,7 +6,7 @@
     "@jupyterlab/mock-token": "^4.6.0-alpha.5"
   },
   "devDependencies": {
-    "@jupyter/builder": "^0.0.8"
+    "@jupyter/builder": "^1.0.0-beta.1"
   },
   "jupyterlab": {
     "extension": true

--- a/jupyterlab/tests/mock_packages/service-manager-extension/package.json
+++ b/jupyterlab/tests/mock_packages/service-manager-extension/package.json
@@ -6,7 +6,7 @@
     "@jupyterlab/services": "^7.6.0-alpha.5"
   },
   "devDependencies": {
-    "@jupyter/builder": "^0.0.8"
+    "@jupyter/builder": "^1.0.0-beta.1"
   },
   "jupyterlab": {
     "extension": true,

--- a/jupyterlab/tests/mock_packages/test-hyphens-underscore/package.json
+++ b/jupyterlab/tests/mock_packages/test-hyphens-underscore/package.json
@@ -11,7 +11,7 @@
     "@jupyterlab/launcher": "^4.0.0"
   },
   "devDependencies": {
-    "@jupyter/builder": "^0.0.8",
+    "@jupyter/builder": "^1.0.0-beta.1",
     "rimraf": "^3.0.2"
   },
   "files": [

--- a/jupyterlab/tests/mock_packages/test-hyphens-underscore/pyproject.toml
+++ b/jupyterlab/tests/mock_packages/test-hyphens-underscore/pyproject.toml
@@ -4,7 +4,7 @@
 [build-system]
 requires = [
     "hatchling",
-    "jupyter-builder>=0.0.8",
+    "jupyter-builder>=1.0.0b1",
 ]
 build-backend = "hatchling.build"
 

--- a/jupyterlab/tests/mock_packages/test-hyphens/package.json
+++ b/jupyterlab/tests/mock_packages/test-hyphens/package.json
@@ -14,7 +14,7 @@
     "@jupyterlab/launcher": "^4.0.0-alpha.21"
   },
   "devDependencies": {
-    "@jupyter/builder": "^0.0.8",
+    "@jupyter/builder": "^1.0.0-beta.1",
     "rimraf": "~3.0.0"
   },
   "jupyterlab": {

--- a/jupyterlab/tests/mock_packages/test-hyphens/pyproject.toml
+++ b/jupyterlab/tests/mock_packages/test-hyphens/pyproject.toml
@@ -4,7 +4,7 @@
 [build-system]
 requires = [
     "hatchling",
-    "jupyter-builder>=0.0.8",
+    "jupyter-builder>=1.0.0b1",
 ]
 build-backend = "hatchling.build"
 

--- a/jupyterlab/tests/mock_packages/test_no_hyphens/package.json
+++ b/jupyterlab/tests/mock_packages/test_no_hyphens/package.json
@@ -11,7 +11,7 @@
     "@jupyterlab/launcher": "^4.0.0"
   },
   "devDependencies": {
-    "@jupyter/builder": "^0.0.8",
+    "@jupyter/builder": "^1.0.0-beta.1",
     "rimraf": "^3.0.2"
   },
   "files": [

--- a/jupyterlab/tests/mock_packages/test_no_hyphens/pyproject.toml
+++ b/jupyterlab/tests/mock_packages/test_no_hyphens/pyproject.toml
@@ -4,7 +4,7 @@
 [build-system]
 requires = [
     "hatchling",
-    "jupyter-builder>=0.0.8",
+    "jupyter-builder>=1.0.0b1",
 ]
 build-backend = "hatchling.build"
 

--- a/packages/core-meta/core.package.json
+++ b/packages/core-meta/core.package.json
@@ -206,7 +206,7 @@
     "@jupyterlab/workspaces-extension": "~4.6.0-alpha.5"
   },
   "devDependencies": {
-    "@jupyter/builder": "^0.0.8",
+    "@jupyter/builder": "^1.0.0-beta.1",
     "@jupyterlab/builder": "^4.6.0-alpha.5",
     "@jupyterlab/buildutils": "^4.6.0-alpha.5",
     "@rsdoctor/rspack-plugin": "^1.3.12",

--- a/packages/extensionmanager-extension/examples/listings/package.json
+++ b/packages/extensionmanager-extension/examples/listings/package.json
@@ -42,7 +42,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@jupyter/builder": "^0.0.8",
+    "@jupyter/builder": "^1.0.0-beta.1",
     "@rspack/cli": "^2.0.2",
     "fs-extra": "^10.1.0",
     "glob": "~7.1.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 [build-system]
-requires = ["hatchling>=1.21.1", "jupyter-builder>=0.0.8"]
+requires = ["hatchling>=1.21.1", "jupyter-builder>=1.0.0b1"]
 build-backend = "hatchling.build"
 
 [project]
@@ -35,7 +35,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "jupyter-builder>=0.0.8",
+    "jupyter-builder>=1.0.0b1",
     "async_lru>=1.0.0",
     "httpx>=0.25.0,<1",
     "ipykernel>=6.5.0,!=6.30.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2232,12 +2232,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyter/builder@npm:^0.0.8":
-  version: 0.0.8
-  resolution: "@jupyter/builder@npm:0.0.8"
+"@jupyter/builder@npm:^1.0.0-beta.1":
+  version: 1.0.0-beta.1
+  resolution: "@jupyter/builder@npm:1.0.0-beta.1"
   dependencies:
     "@jupyterlab/core-meta": 4.6.0-alpha.4
-    "@rspack/core": ^1.7.7
+    "@module-federation/runtime-tools": ^2.0.0
+    "@rspack/core": ^2.0.2
     ajv: ^8.12.0
     commander: ^9.4.1
     css-loader: ^6.7.1
@@ -2253,7 +2254,7 @@ __metadata:
     supports-color: ^7.2.0
     webpack-merge: ^5.8.0
     worker-loader: ^3.0.2
-  checksum: 5f80322e4eecd4c643e73996b9f383bc9bc60cc5d52d5909c80e658bfb7c9e8727a219c4330994cfc2df5d5fd900d89e28e2b29bd4d5078a32c142d22d4d9e9f
+  checksum: 70b0900546f11ceed9ce3cebeff3e21eed4b6212a20eb81a75a9aa3f94ba7232c312f8df66ba1c2dd9bc4d720abd64e58a36a423ef583ea48bb1635e918923ac
   languageName: node
   linkType: hard
 
@@ -2331,7 +2332,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/application-top@workspace:dev_mode"
   dependencies:
-    "@jupyter/builder": ^0.0.8
+    "@jupyter/builder": ^1.0.0-beta.1
     "@jupyterlab/application": ~4.6.0-alpha.5
     "@jupyterlab/application-extension": ~4.6.0-alpha.5
     "@jupyterlab/apputils-extension": ~4.6.0-alpha.5
@@ -3180,7 +3181,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/example-app@workspace:examples/app"
   dependencies:
-    "@jupyter/builder": ^0.0.8
+    "@jupyter/builder": ^1.0.0-beta.1
     "@jupyterlab/application": ^4.6.0-alpha.5
     "@jupyterlab/application-extension": ^4.6.0-alpha.5
     "@jupyterlab/apputils-extension": ^4.6.0-alpha.5
@@ -3283,7 +3284,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/example-federated-core@workspace:examples/federated/core_package"
   dependencies:
-    "@jupyter/builder": ^0.0.8
+    "@jupyter/builder": ^1.0.0-beta.1
     "@jupyterlab/application": ^4.6.0-alpha.5
     "@jupyterlab/application-extension": ^4.6.0-alpha.5
     "@jupyterlab/apputils-extension": ^4.6.0-alpha.5
@@ -3340,7 +3341,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/example-federated-md@workspace:examples/federated/md_package"
   dependencies:
-    "@jupyter/builder": ^0.0.8
+    "@jupyter/builder": ^1.0.0-beta.1
     "@jupyterlab/application": ^4.6.0-alpha.5
     "@jupyterlab/example-federated-middle": ^3.5.0-alpha.5
     "@jupyterlab/markdownviewer-extension": ^4.6.0-alpha.5
@@ -3353,7 +3354,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/example-federated-middle@workspace:examples/federated/middle_package"
   dependencies:
-    "@jupyter/builder": ^0.0.8
+    "@jupyter/builder": ^1.0.0-beta.1
     "@lumino/coreutils": ^2.2.2
     rimraf: ~5.0.5
   languageName: unknown
@@ -3671,7 +3672,7 @@ __metadata:
     "@fontsource-variable/noto-sans-sc": ^5.2.10
     "@fontsource/dejavu-mono": ^5.2.5
     "@fontsource/dejavu-sans": ^5.2.5
-    "@jupyter/builder": ^0.0.8
+    "@jupyter/builder": ^1.0.0-beta.1
     "@jupyterlab/application": ^4.6.0-alpha.5
     "@jupyterlab/apputils": ^4.7.0-alpha.5
     "@jupyterlab/cells": ^4.6.0-alpha.5
@@ -4341,7 +4342,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/mock-consumer@workspace:jupyterlab/tests/mock_packages/interop/consumer"
   dependencies:
-    "@jupyter/builder": ^0.0.8
+    "@jupyter/builder": ^1.0.0-beta.1
     "@jupyterlab/mock-token": ^4.6.0-alpha.5
   languageName: unknown
   linkType: soft
@@ -4350,7 +4351,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/mock-extension@workspace:jupyterlab/tests/mock_packages/extension"
   dependencies:
-    "@jupyter/builder": ^0.0.8
+    "@jupyter/builder": ^1.0.0-beta.1
     "@jupyterlab/launcher": ^4.6.0-alpha.5
   languageName: unknown
   linkType: soft
@@ -4359,7 +4360,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/mock-provider@workspace:jupyterlab/tests/mock_packages/interop/provider"
   dependencies:
-    "@jupyter/builder": ^0.0.8
+    "@jupyter/builder": ^1.0.0-beta.1
     "@jupyterlab/mock-token": ^4.6.0-alpha.5
   languageName: unknown
   linkType: soft
@@ -4368,7 +4369,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/mock-service-manager-extension@workspace:jupyterlab/tests/mock_packages/service-manager-extension"
   dependencies:
-    "@jupyter/builder": ^0.0.8
+    "@jupyter/builder": ^1.0.0-beta.1
     "@jupyterlab/services": ^7.6.0-alpha.5
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## References
PyPI release: https://pypi.org/project/jupyter-builder/1.0.0b1/
NPM release: https://www.npmjs.com/package/@jupyter/builder/v/1.0.0-beta.1

## Description

Bumps `jupyter-builder`.

## User-facing changes

None

## Backwards-incompatible changes

`jupyter-builder` now uses `rspack v2.0`. So far, no issues have been observed when building extensions, but additional testing would be beneficial.
## AI usage

- **NO**
