### PR TITLE
Add `zizmor` GitHub Actions security linter

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run zizmor 🌈
         run: uvx zizmor --format=sarif . > results.sarif
         # Note: we are not passing GitHub token here, so it runs in offline mode;
-        # online mode is known to exhaust iGutHub rate limits due to extensive
+        # online mode is known to exhaust Github rate limits due to extensive
         # GitHub API calls, see https://github.com/zizmorcore/zizmor/issues/278 and
         # https://grafana.com/blog/how-to-detect-vulnerable-github-actions-at-scale-with-zizmor/
         # This means that some checks like imposter-commits and ref-confusion will not run.

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,39 @@
+# Performs static analysis in GitHub actions with https://github.com/zizmorcore/zizmor
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor latest via PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+
+      - name: Run zizmor 🌈
+        run: uvx zizmor --format=sarif . > results.sarif
+        # Note: we are not passing GitHub token here, so it runs in offline mode;
+        # online mode is known to exhaust iGutHub rate limits due to extensive
+        # GitHub API calls, see https://github.com/zizmorcore/zizmor/issues/278 and
+        # https://grafana.com/blog/how-to-detect-vulnerable-github-actions-at-scale-with-zizmor/
+        # This means that some checks like imposter-commits and ref-confusion will not run.
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        with:
+          sarif_file: results.sarif
+          category: zizmor


### PR DESCRIPTION
## References

- Mirrors https://github.com/jupyter/notebook/pull/7880 but uses newer versions
- https://docs.zizmor.sh/integrations/#manual-integration
- https://github.com/jupyterlab/jupyterlab/pull/18896
- https://github.com/jupyterlab/jupyterlab/security/advisories/GHSA-vp3m-r27r-92x4

## Code changes

Added zizmor workflow (manual integration)

## Developer-facing changes

Advanced security logs will include any vulnerable patterns in future workflow changes

## Backwards-incompatible changes

None

## AI usage

None
