### PR TITLE
Harden GitHub actions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           # Need to fetch enough nodes to get the common ancestor - but don't want to fetch everything
           fetch-depth: 100
+          persist-credentials: false
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
@@ -207,6 +208,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1

--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,6 +39,7 @@ jobs:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
         fetch-depth: 2
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Build the image
         run: |

--- a/.github/workflows/galata-update-v2.yml
+++ b/.github/workflows/galata-update-v2.yml
@@ -170,6 +170,7 @@ jobs:
           sparse-checkout: scripts/unpack_snapshots.py
           sparse-checkout-cone-mode: false
           path: tools
+          persist-credentials: false
 
       - name: Process JSON reports and unpack snapshots
         run: |
@@ -261,6 +262,7 @@ jobs:
           repository: galata-snapshots-bot/${{ github.event.repository.name }}
           fetch-depth: 1
           token: ${{ secrets.BOT_USER_PAT }}
+          persist-credentials: false
 
       - name: Open Pull Request
         id: open-pr

--- a/.github/workflows/galata-update-v2.yml
+++ b/.github/workflows/galata-update-v2.yml
@@ -150,10 +150,12 @@ jobs:
           path: repo
 
       - name: Download test results
-        run: |
-          gh run download ${{ needs.get-snapshot-updates.outputs.assets-run-id }} --repo ${{ github.repository }} --name galata-test-assets-merged --dir ./test-assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ASSETS_RUN_ID: ${{ needs.get-snapshot-updates.outputs.assets-run-id }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          gh run download "$ASSETS_RUN_ID" --repo "$REPOSITORY" --name galata-test-assets-merged --dir ./test-assets
 
       - name: List tests assets
         run: |
@@ -226,17 +228,20 @@ jobs:
 
       - name: Ensure fork exists
         if: steps.check-changes.outputs.has-changes == 'true'
-        run: |
-          gh repo fork --default-branch-only
-          git remote add bot https://@github.com/galata-snapshots-bot/${{ github.event.repository.name }}.git
-        working-directory: repo
         env:
           GH_TOKEN: ${{ secrets.BOT_USER_PAT }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          gh repo fork --default-branch-only
+          git remote add bot "https://@github.com/galata-snapshots-bot/${REPO_NAME}.git"
+        working-directory: repo
 
       - name: Push to bot fork
         if: steps.check-changes.outputs.has-changes == 'true'
+        env:
+          BRANCH_NAME: ${{ steps.create-branch.outputs.branch-name }}
         run: |
-          git push bot ${{ steps.create-branch.outputs.branch-name }} --force
+          git push bot "$BRANCH_NAME" --force
         working-directory: repo
 
   open-pr:
@@ -319,16 +324,22 @@ jobs:
         env:
           SNAPSHOT_PR_URL: ${{ needs.open-pr.outputs.pr-url }}
           SNAPSHOT_PR_ACTION: ${{ needs.open-pr.outputs.pr-action }}
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          ASSETS_RUN_ID: ${{ needs.get-snapshot-updates.outputs.assets-run-id }}
+          CREATE_BRANCH_RESULT: ${{ needs.create-branch.result }}
+          HAS_CHANGES: ${{ needs.create-branch.outputs.has-changes }}
+          OPEN_PR_RESULT: ${{ needs.open-pr.result }}
         run: |
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          ASSETS_RUN_ID="${{ needs.get-snapshot-updates.outputs.assets-run-id }}"
-          ASSETS_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${ASSETS_RUN_ID}"
+          RUN_URL="${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}"
+          ASSETS_RUN_URL="${SERVER_URL}/${REPOSITORY}/actions/runs/${ASSETS_RUN_ID}"
 
-          if [ "${{ needs.create-branch.result }}" != "success" ]; then
+          if [ "$CREATE_BRANCH_RESULT" != "success" ]; then
             BODY="I failed to update snapshots while preparing/pushing the update branch. [Workflow run](${RUN_URL})"
-          elif [ "${{ needs.create-branch.outputs.has-changes }}" = "false" ]; then
+          elif [ "$HAS_CHANGES" = "false" ]; then
             BODY="I did not detect any snapshot changes. [Workflow run](${RUN_URL})"
-          elif [ "${{ needs.open-pr.result }}" != "success" ]; then
+          elif [ "$OPEN_PR_RESULT" != "success" ]; then
             BODY="I prepared snapshot changes, but opening the snapshot update PR failed. [Workflow run](${RUN_URL})"
           elif [ "$SNAPSHOT_PR_ACTION" = "updated" ]; then
             BODY="I updated the PR ${SNAPSHOT_PR_URL} with the latest snapshots from [run ${ASSETS_RUN_ID}](${ASSETS_RUN_URL})."
@@ -342,7 +353,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.BOT_USER_PAT }}
           COMMENT_BODY: ${{ steps.compose-message.outputs.body }}
+          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          PR_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
-          gh api repos/${{ github.repository }}/issues/${PR_NUMBER}/comments \
+          gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
             --raw-field "body=$COMMENT_BODY"

--- a/.github/workflows/galata-update.yml
+++ b/.github/workflows/galata-update.yml
@@ -77,6 +77,7 @@ jobs:
           repository: jupyterlab/jupyterlab-demo
           ref: master
           path: demo
+          persist-credentials: false
 
       - name: Get demo folder
         run: |

--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -69,6 +69,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: core
+          persist-credentials: false
 
       - name: Checkout demo project
         if: ${{ matrix.project == 'documentation' }}
@@ -77,6 +78,7 @@ jobs:
           repository: jupyterlab/jupyterlab-demo
           ref: master
           path: demo
+          persist-credentials: false
 
       - name: Get demo folder
         if: ${{ matrix.project == 'documentation' }}
@@ -225,6 +227,7 @@ jobs:
         with:
           sparse-checkout: yarn.lock
           sparse-checkout-cone-mode: false
+          persist-credentials: false
 
       - name: Find out Playwright version
         id: pw-version

--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -280,8 +280,9 @@ jobs:
       - name: Merge Playwright reports
         env:
           PLAYWRIGHT_JSON_OUTPUT_NAME: merged-report.json
+          PW_VERSION: ${{ steps.pw-version.outputs.version }}
         run: |
-          npx playwright@${{ steps.pw-version.outputs.version }} merge-reports --reporter html,json,github ./artifacts/final/
+          npx "playwright@${PW_VERSION}" merge-reports --reporter html,json,github ./artifacts/final/
 
       - name: Extract failing and flaky counts
         id: test-counts
@@ -315,20 +316,26 @@ jobs:
           path: playwright-report/output.html
 
       - name: Add report link to job summary
+        env:
+          ARTIFACT_URL: ${{ steps.upload-report.outputs.artifact-url }}
         run: |
-          echo "**[View Visual Regression Report](${{ steps.upload-report.outputs.artifact-url }})**" >> $GITHUB_STEP_SUMMARY
+          echo "**[View Visual Regression Report](${ARTIFACT_URL})**" >> $GITHUB_STEP_SUMMARY
 
       - name: Save PR comment data
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/github-script@v8
+        env:
+          REPORT_URL: ${{ steps.upload-report.outputs.artifact-url }}
+          FAILING: ${{ steps.test-counts.outputs.failing || 0 }}
+          FLAKY: ${{ steps.test-counts.outputs.flaky || 0 }}
         with:
           script: |
             const fs = require('fs');
             fs.writeFileSync('pr-comment-data.json', JSON.stringify({
               prNumber: context.payload.pull_request.number,
-              reportUrl: '${{ steps.upload-report.outputs.artifact-url }}',
-              failing: ${{ steps.test-counts.outputs.failing || 0 }},
-              flaky: ${{ steps.test-counts.outputs.flaky || 0 }},
+              reportUrl: process.env.REPORT_URL,
+              failing: Number(process.env.FAILING),
+              flaky: Number(process.env.FLAKY),
             }));
 
       - name: Upload PR comment data

--- a/.github/workflows/license-header.yml
+++ b/.github/workflows/license-header.yml
@@ -48,6 +48,12 @@ jobs:
 
           git diff
 
+      - name: Setup git credentials
+        if: steps.files-changed.outputs.N_CHANGES != '0'
+        run: gh auth setup-git
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Commit any changes
         if: steps.files-changed.outputs.N_CHANGES != '0'
         shell: bash -l {0}

--- a/.github/workflows/license-header.yml
+++ b/.github/workflows/license-header.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Configure git to use https
         run: git config --global hub.protocol https

--- a/.github/workflows/linuxjs-tests.yml
+++ b/.github/workflows/linuxjs-tests.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set matrix
         id: set-matrix
@@ -50,6 +52,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1

--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -57,6 +57,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
@@ -114,6 +116,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         with:
@@ -132,6 +136,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         with:
@@ -179,6 +185,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - run: |
           node ./jupyterlab/staging/yarn.js install

--- a/.github/workflows/macostests.yml
+++ b/.github/workflows/macostests.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -45,5 +45,7 @@ jobs:
           since_last_stable: ${{ github.event.inputs.since_last_stable }}
 
       - name: "** Next Step **"
+        env:
+          RELEASE_URL: ${{ steps.prep-release.outputs.release_url }}
         run: |
-          echo "Optional): Review Draft Release: ${{ steps.prep-release.outputs.release_url }}"
+          echo "Optional): Review Draft Release: ${RELEASE_URL}"

--- a/.github/workflows/publish-changelog.yml
+++ b/.github/workflows/publish-changelog.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Publish changelog
         id: publish-changelog

--- a/.github/workflows/publish-changelog.yml
+++ b/.github/workflows/publish-changelog.yml
@@ -30,5 +30,7 @@ jobs:
           branch: ${{ github.event.inputs.branch }}
 
       - name: "** Next Step **"
+        env:
+          PR_URL: ${{ steps.publish-changelog.outputs.pr_url }}
         run: |
-          echo "Merge the changelog update PR: ${{ steps.publish-changelog.outputs.pr_url }}"
+          echo "Merge the changelog update PR: ${PR_URL}"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -47,12 +47,16 @@ jobs:
 
       - name: "** Next Step **"
         if: ${{ success() }}
+        env:
+          RELEASE_URL: ${{ steps.finalize-release.outputs.release_url }}
         run: |
           echo "Verify the final release"
-          echo ${{ steps.finalize-release.outputs.release_url }}
+          echo "$RELEASE_URL"
 
       - name: "** Failure Message **"
         if: ${{ failure() }}
+        env:
+          RELEASE_URL: ${{ steps.populate-release.outputs.release_url }}
         run: |
           echo "Failed to Publish the Draft Release Url:"
-          echo ${{ steps.populate-release.outputs.release_url }}
+          echo "$RELEASE_URL"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Populate Release
         id: populate-release

--- a/.github/workflows/reject-staging-checks.yml
+++ b/.github/workflows/reject-staging-checks.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Fail if files in staging are modified (excluding allowed files)
         shell: bash

--- a/.github/workflows/windowstests.yml
+++ b/.github/workflows/windowstests.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1


### PR DESCRIPTION
## References

Follow-up to #18896 

## Code changes

Resolves some more zizmor warnings

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

Used `zizmor --fix=all` (which includes `unsafe` as in potentially breaking fixes) to generate fixes and iterated with Claude to drop changes where the fixes could break something.