### PR TITLE
Improve scroll overlay icon placement

### DIFF
--- a/packages/cells/style/widget.css
+++ b/packages/cells/style/widget.css
@@ -110,7 +110,16 @@
 }
 
 .jp-CodeCell.jp-mod-outputsScrolled .jp-OutputArea-promptOverlay {
-  left: calc(-1 * var(--jp-private-cell-scrolling-output-offset));
+  position: fixed;
+  top: anchor(top);
+  bottom: anchor(bottom);
+  left: anchor(left);
+  position-anchor: --jp-output-area;
+  height: unset;
+  width: calc(
+    var(--jp-cell-prompt-width) - 1 *
+      var(--jp-private-cell-scrolling-output-offset)
+  );
 }
 
 /*-----------------------------------------------------------------------------

--- a/packages/outputarea/style/base.css
+++ b/packages/outputarea/style/base.css
@@ -10,6 +10,7 @@
 
 .jp-OutputArea {
   overflow-y: auto;
+  anchor-name: --jp-output-area;
   anchor-scope: --jp-output-area;
 }
 
@@ -18,7 +19,6 @@
   flex-direction: row;
   width: 100%;
   overflow: hidden;
-  anchor-name: --jp-output-area;
 }
 
 .jp-OutputPrompt {
@@ -66,8 +66,8 @@
 
 .jp-OutputArea-promptOverlay {
   position: absolute;
-  top: anchor(--jp-output-area top);
-  bottom: anchor(--jp-output-area bottom);
+  top: 0;
+  height: 100%;
   width: var(--jp-cell-prompt-width);
   opacity: 0.5;
   display: flex;


### PR DESCRIPTION

## References

- Follow-up to https://github.com/jupyterlab/jupyterlab/pull/18840
- Closes https://github.com/jupyterlab/jupyterlab/issues/17890

## Code changes

Use anchor positioning to fix the prompt overlay over the collapsed output.

## User-facing changes

The icon is visible (and centered) regardless of the scroll position.

| Before | After |
|--|--|
| <img width="252" height="371" alt="image" src="https://github.com/user-attachments/assets/62477424-2a3e-458e-adf4-98573aeaec81" /> | <img width="252" height="367" alt="image" src="https://github.com/user-attachments/assets/77073474-fd74-4d2b-823f-d69866456cd1" /> |
| <img width="252" height="367" alt="image" src="https://github.com/user-attachments/assets/47fe2b10-af5b-414f-9781-e9ffb28dfa14" /> | <img width="252" height="367" alt="image" src="https://github.com/user-attachments/assets/c2c33ca1-8ee8-466f-9543-5b103e1a993d" />

## Backwards-incompatible changes

None

## AI usage

None