### PR TITLE
Adopt `eslint-plugin-regexp`

### DIFF
--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -289,6 +289,7 @@ function ensureBranch(): string[] {
   // Handle the github_version in conf.py
   const confPath = 'docs/source/conf.py';
   const oldConfData = fs.readFileSync(confPath, 'utf-8');
+  // eslint-disable-next-line prefer-regex-literals
   const confTest = new RegExp('"github_version": "(.*)"');
   const newConfData = oldConfData.replace(
     confTest,

--- a/buildutils/src/update-dependency.ts
+++ b/buildutils/src/update-dependency.ts
@@ -17,7 +17,8 @@ const versionCache = new Map();
 /**
  * Matches a simple semver range, where the version number could be an npm tag.
  */
-const SEMVER_RANGE = /^([~^=<>]|<=|>=)?([\w\-.]*)$/;
+// eslint-disable-next-line regexp/prefer-character-class
+const SEMVER_RANGE = /^(~|\^|=|<|>|<=|>=)?([\w\-.]*)$/;
 
 /**
  * Get the specifier we should use

--- a/buildutils/src/update-dependency.ts
+++ b/buildutils/src/update-dependency.ts
@@ -17,7 +17,7 @@ const versionCache = new Map();
 /**
  * Matches a simple semver range, where the version number could be an npm tag.
  */
-const SEMVER_RANGE = /^(~|\^|=|<|>|<=|>=)?([\w\-.]*)$/;
+const SEMVER_RANGE = /^([~^=<>]|<=|>=)?([\w\-.]*)$/;
 
 /**
  * Get the specifier we should use

--- a/buildutils/src/utils.ts
+++ b/buildutils/src/utils.ts
@@ -439,7 +439,7 @@ export function stem(pathArg: string): string {
  * @returns the camel case version of the input string.
  */
 export function camelCase(str: string, upper: boolean = false): string {
-  return str.replace(/(?:^\w|[A-Z]|\b\w|\s+|-+|_+)/g, function (match, index) {
+  return str.replace(/^\w|[A-Z]|\b\w|\s+|-+|_+/g, function (match, index) {
     if (+match === 0 || match[0] === '-') {
       return '';
     } else if (index === 0 && !upper) {

--- a/buildutils/src/utils.ts
+++ b/buildutils/src/utils.ts
@@ -291,7 +291,7 @@ export function run(
   }
   return value
     .toString()
-    .replace(/(\r\n|\n)$/, '') // eslint-disable-line regexp/no-unused-capturing-group
+    .replace(/(?:\r\n|\n)$/, '')
     .trim();
 }
 

--- a/buildutils/src/utils.ts
+++ b/buildutils/src/utils.ts
@@ -189,7 +189,7 @@ export function fromTemplate(
       // try to match the indentation level of the {{var}} in the input template.
       templ = templ.split(`{{${key}}}`).reduce((acc, cur) => {
         // Regex: 0 or more non-newline whitespaces followed by end of string
-        const indentRe = acc.match(/([^\S\r\n]*).*$/);
+        const indentRe = acc.match(/([^\S\r\n]*).*$/); // eslint-disable-line regexp/no-super-linear-backtracking
         const indent = indentRe ? indentRe[1] : '';
         return acc + val.split('\n').join('\n' + indent) + cur;
       });
@@ -291,7 +291,7 @@ export function run(
   }
   return value
     .toString()
-    .replace(/(\r\n|\n)$/, '')
+    .replace(/(\r\n|\n)$/, '') // eslint-disable-line regexp/no-unused-capturing-group
     .trim();
 }
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,7 @@ import js from '@eslint/js';
 import globals from 'globals';
 import jestPlugin from 'eslint-plugin-jest';
 import reactPlugin from 'eslint-plugin-react';
+import regexpPlugin from 'eslint-plugin-regexp';
 import prettierPluginRecommended from 'eslint-plugin-prettier/recommended';
 import tseslint from 'typescript-eslint';
 import * as jsoncParser from 'jsonc-eslint-parser';
@@ -196,7 +197,11 @@ export default defineConfig([
   },
   {
     files: ['**/*.ts', '**/*.tsx'],
-    extends: [js.configs.recommended, tseslint.configs.recommended],
+    extends: [
+      js.configs.recommended,
+      tseslint.configs.recommended,
+      regexpPlugin.configs.recommended
+    ],
 
     plugins: {
       '@typescript-eslint': tseslint.plugin,

--- a/galata/src/galata.ts
+++ b/galata/src/galata.ts
@@ -464,8 +464,7 @@ export namespace galata {
      *
      * The id will be prefixed by '/'.
      */
-    // eslint-disable-next-line regexp/strict
-    export const kernels = /.*\/api\/kernels(?!pecs)(?<id>\/[@:-\w]+)?/;
+    export const kernels = /.*\/api\/kernels(?!pecs)(?<id>\/[@:\-\w]+)?/;
 
     /**
      * Sessions API
@@ -474,8 +473,7 @@ export namespace galata {
      *
      * The id will be prefixed by '/'.
      */
-    // eslint-disable-next-line regexp/strict
-    export const sessions = /.*\/api\/sessions(?<id>\/[@:-\w]+)?/;
+    export const sessions = /.*\/api\/sessions(?<id>\/[@:\-\w]+)?/;
 
     /**
      * Settings API
@@ -484,8 +482,7 @@ export namespace galata {
      *
      * The id will be prefixed by '/'.
      */
-    // eslint-disable-next-line regexp/strict
-    export const settings = /.*\/api\/settings(?<id>(\/[@:-\w]+)*)/;
+    export const settings = /.*\/api\/settings(?<id>(\/[@:\-\w]+)*)/;
 
     /**
      * Terminals API
@@ -494,8 +491,7 @@ export namespace galata {
      *
      * The id will be prefixed by '/'.
      */
-    // eslint-disable-next-line regexp/strict
-    export const terminals = /.*\/api\/terminals(?<id>\/[@:-\w]+)?/;
+    export const terminals = /.*\/api\/terminals(?<id>\/[@:\-\w]+)?/;
 
     /**
      * Translations API
@@ -504,8 +500,7 @@ export namespace galata {
      *
      * The id will be prefixed by '/'.
      */
-    // eslint-disable-next-line regexp/strict
-    export const translations = /.*\/api\/translations(?<id>\/[@:-\w]+)?/;
+    export const translations = /.*\/api\/translations(?<id>\/[@:\-\w]+)?/;
 
     /**
      * Workspaces API

--- a/galata/src/galata.ts
+++ b/galata/src/galata.ts
@@ -464,6 +464,7 @@ export namespace galata {
      *
      * The id will be prefixed by '/'.
      */
+    // eslint-disable-next-line regexp/strict
     export const kernels = /.*\/api\/kernels(?!pecs)(?<id>\/[@:-\w]+)?/;
 
     /**
@@ -473,6 +474,7 @@ export namespace galata {
      *
      * The id will be prefixed by '/'.
      */
+    // eslint-disable-next-line regexp/strict
     export const sessions = /.*\/api\/sessions(?<id>\/[@:-\w]+)?/;
 
     /**
@@ -482,6 +484,7 @@ export namespace galata {
      *
      * The id will be prefixed by '/'.
      */
+    // eslint-disable-next-line regexp/strict
     export const settings = /.*\/api\/settings(?<id>(\/[@:-\w]+)*)/;
 
     /**
@@ -491,6 +494,7 @@ export namespace galata {
      *
      * The id will be prefixed by '/'.
      */
+    // eslint-disable-next-line regexp/strict
     export const terminals = /.*\/api\/terminals(?<id>\/[@:-\w]+)?/;
 
     /**
@@ -500,6 +504,7 @@ export namespace galata {
      *
      * The id will be prefixed by '/'.
      */
+    // eslint-disable-next-line regexp/strict
     export const translations = /.*\/api\/translations(?<id>\/[@:-\w]+)?/;
 
     /**

--- a/galata/src/helpers/style.ts
+++ b/galata/src/helpers/style.ts
@@ -64,6 +64,7 @@ export class StyleHelper {
       // so we just check their parents
       .map(selector =>
         selector.replace(
+          // eslint-disable-next-line regexp/no-unused-capturing-group, regexp/no-dupe-disjunctions
           /::?(after|before|backdrop|cue|cue-region|first-letter|first-line|file-selector-button|marker|placeholder|selection)/,
           ''
         )

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "eslint-plugin-jest": "^28.0.0",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.37.0",
+    "eslint-plugin-regexp": "^3.1.0",
     "prettier": "^3.8.1",
     "stylelint": "16.12.0",
     "stylelint-config-recommended": "^14.0.1",

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -1487,6 +1487,7 @@ const tree: JupyterFrontEndPlugin<JupyterFrontEnd.ITreeResolver> = {
     const set = new DisposableSet();
     const delegate = new PromiseDelegate<JupyterFrontEnd.ITreeResolver.Paths>();
 
+    // eslint-disable-next-line prefer-regex-literals
     const treePattern = new RegExp(
       '/(lab|doc)(/workspaces/[\\w-]+)?(/tree/.*)?'
     );

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -1488,7 +1488,7 @@ const tree: JupyterFrontEndPlugin<JupyterFrontEnd.ITreeResolver> = {
     const delegate = new PromiseDelegate<JupyterFrontEnd.ITreeResolver.Paths>();
 
     const treePattern = new RegExp(
-      '/(lab|doc)(/workspaces/[a-zA-Z0-9-_]+)?(/tree/.*)?'
+      '/(lab|doc)(/workspaces/[\\w-]+)?(/tree/.*)?'
     );
 
     set.add(

--- a/packages/apputils-extension/src/announcements.ts
+++ b/packages/apputils-extension/src/announcements.ts
@@ -66,7 +66,7 @@ export const announcements: JupyterFrontEndPlugin<void> = {
     settingRegistry: ISettingRegistry | null,
     translator: ITranslator | null
   ): void => {
-    const CONFIG_SECTION_NAME = announcements.id.replace(/[^\w]/g, '');
+    const CONFIG_SECTION_NAME = announcements.id.replace(/\W/g, '');
 
     void Promise.all([
       app.restored,

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -62,7 +62,7 @@ const SPLASH_RECOVER_TIMEOUT = 12000;
  * Matches bare `?reset`, `?reset=<value>`, and `&reset` variants,
  * including URLs where `reset` is followed by a hash fragment.
  */
-const RESET_QUERY_PATTERN = /(\?reset|\&reset)(=[^&#]*)?($|&|#)/;
+const RESET_QUERY_PATTERN = /(\?reset|&reset)(=[^&#]*)?($|&|#)/;
 
 /**
  * The command IDs used by the apputils plugin.

--- a/packages/apputils/src/thememanager.ts
+++ b/packages/apputils/src/thememanager.ts
@@ -379,7 +379,7 @@ export class ThemeManager implements IThemeManager {
    */
   private _incrFontSize(key: string, add: boolean = true): Promise<void> {
     // get the numeric and unit parts of the current font size
-    const parts = (this.getCSS(key) ?? '13px').split(/([a-zA-Z]+)/);
+    const parts = (this.getCSS(key) ?? '13px').split(/([a-z]+)/i);
 
     // determine the increment
     const incr = (add ? 1 : -1) * (parts[1] === 'em' ? 0.1 : 1);

--- a/packages/apputils/src/windowresolver.ts
+++ b/packages/apputils/src/windowresolver.ts
@@ -134,7 +134,7 @@ namespace Private {
         return;
       }
 
-      const reported = newValue.replace(/\-\d+$/, '');
+      const reported = newValue.replace(/-\d+$/, '');
 
       // Store the reported window name.
       known[reported] = null;

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -2077,7 +2077,7 @@ export abstract class AttachmentsCell<
       if (protocol !== 'data:') {
         return;
       }
-      const dataURIRegex = /([\w+\/\+]+)?(?:;(charset=[\w\d-]*|base64))?,(.*)/;
+      const dataURIRegex = /([\w+/]+)?(?:;(charset=[\w-]*|base64))?,(.*)/;
       const matches = dataURIRegex.exec(href);
       if (!matches || matches.length !== 4) {
         return;

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -1252,7 +1252,7 @@ export namespace Completer {
     itemWidthHeuristic(item: CompletionHandler.ICompletionItem): number {
       // Get the label text without HTML markup (`<mark>` is the only markup
       // that is allowed in processed items, everything else gets escaped).
-      const labelText = item.label.replace(/<(\/)?mark>/g, '');
+      const labelText = item.label.replace(/<(\/)?mark>/g, ''); // eslint-disable-line regexp/no-unused-capturing-group
       return labelText.length + (item.type?.length || 0);
     }
 

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -1252,7 +1252,7 @@ export namespace Completer {
     itemWidthHeuristic(item: CompletionHandler.ICompletionItem): number {
       // Get the label text without HTML markup (`<mark>` is the only markup
       // that is allowed in processed items, everything else gets escaped).
-      const labelText = item.label.replace(/<(\/)?mark>/g, ''); // eslint-disable-line regexp/no-unused-capturing-group
+      const labelText = item.label.replace(/<\/?mark>/g, '');
       return labelText.length + (item.type?.length || 0);
     }
 

--- a/packages/coreutils/src/text.ts
+++ b/packages/coreutils/src/text.ts
@@ -83,7 +83,8 @@ export namespace Text {
    * @returns the camel case version of the input string.
    */
   export function camelCase(str: string, upper: boolean = false): string {
-    return str.replace(/^(\w)|[\s_:-]+(\w)/g, function (match, p1, p2) {
+    // eslint-disable-next-line regexp/strict
+    return str.replace(/^(\w)|[\s-_:]+(\w)/g, function (match, p1, p2) {
       if (p2) {
         return p2.toUpperCase();
       } else {

--- a/packages/coreutils/src/text.ts
+++ b/packages/coreutils/src/text.ts
@@ -83,6 +83,7 @@ export namespace Text {
    * @returns the camel case version of the input string.
    */
   export function camelCase(str: string, upper: boolean = false): string {
+    // eslint-disable-next-line regexp/strict
     return str.replace(/^(\w)|[\s-_:]+(\w)/g, function (match, p1, p2) {
       if (p2) {
         return p2.toUpperCase();

--- a/packages/coreutils/src/text.ts
+++ b/packages/coreutils/src/text.ts
@@ -83,8 +83,7 @@ export namespace Text {
    * @returns the camel case version of the input string.
    */
   export function camelCase(str: string, upper: boolean = false): string {
-    // eslint-disable-next-line regexp/strict
-    return str.replace(/^(\w)|[\s-_:]+(\w)/g, function (match, p1, p2) {
+    return str.replace(/^(\w)|[\s_:-]+(\w)/g, function (match, p1, p2) {
       if (p2) {
         return p2.toUpperCase();
       } else {

--- a/packages/docmanager/src/dialogs.ts
+++ b/packages/docmanager/src/dialogs.ts
@@ -255,7 +255,7 @@ export function shouldOverwrite(
  * Disallows "/", "\", and ":" in file names, as well as names with zero length.
  */
 export function isValidFileName(name: string): boolean {
-  const validNameExp = /[\/\\:]/;
+  const validNameExp = /[/\\:]/;
   return name.length > 0 && !validNameExp.test(name);
 }
 

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -598,7 +598,7 @@ export class DocumentWidget<
    * Handle a title change.
    */
   private async _onTitleChanged(_sender: Title<this>) {
-    const validNameExp = /[\/\\:]/;
+    const validNameExp = /[/\\:]/;
     const name = this.title.label;
     // Use localPath to avoid the drive name
     const filename =

--- a/packages/filebrowser/src/pathnavigator.ts
+++ b/packages/filebrowser/src/pathnavigator.ts
@@ -163,7 +163,7 @@ export class PathNavigator extends Widget {
       normalized = '/' + normalized;
     }
     // Collapse any double slashes that may result from the above transforms.
-    normalized = normalized.replace(/\/\/+/g, '/');
+    normalized = normalized.replace(/\/{2,}/g, '/');
     this._submittedLocalPath = this._model.manager.services.contents.localPath(
       normalized || '/'
     );

--- a/packages/filebrowser/test/openfiledialog.spec.ts
+++ b/packages/filebrowser/test/openfiledialog.spec.ts
@@ -211,7 +211,7 @@ describe('@jupyterlab/filebrowser', () => {
       const files = result.value!;
       expect(files.length).toBe(1);
       expect(files[0].type).toBe('notebook');
-      expect(files[0].name).toEqual(expect.stringMatching(/Untitled.+ipynb/));
+      expect(files[0].name).toEqual(expect.stringMatching(/Untitled.*\.ipynb/));
 
       document.body.removeChild(node);
     });
@@ -259,7 +259,7 @@ describe('@jupyterlab/filebrowser', () => {
       const files = result.value!;
       expect(files.length).toBe(1);
       expect(files[0].type).toBe('notebook');
-      expect(files[0].name).toEqual(expect.stringMatching(/Untitled.+ipynb/));
+      expect(files[0].name).toEqual(expect.stringMatching(/Untitled.*\.ipynb/));
 
       document.body.removeChild(node);
     });
@@ -321,7 +321,7 @@ describe('@jupyterlab/filebrowser', () => {
       const files = result.value!;
       expect(files.length).toBe(1);
       expect(files[0].type).toBe('notebook');
-      expect(files[0].name).toEqual(expect.stringMatching(/Untitled.+ipynb/));
+      expect(files[0].name).toEqual(expect.stringMatching(/Untitled.*\.ipynb/));
 
       const fileDirectory = PathExt.dirname(files[0].path);
       expect(fileDirectory).toEqual(testDirectory);

--- a/packages/filebrowser/test/openfiledialog.spec.ts
+++ b/packages/filebrowser/test/openfiledialog.spec.ts
@@ -211,7 +211,7 @@ describe('@jupyterlab/filebrowser', () => {
       const files = result.value!;
       expect(files.length).toBe(1);
       expect(files[0].type).toBe('notebook');
-      expect(files[0].name).toEqual(expect.stringMatching(/Untitled.*.ipynb/));
+      expect(files[0].name).toEqual(expect.stringMatching(/Untitled.+ipynb/));
 
       document.body.removeChild(node);
     });
@@ -259,7 +259,7 @@ describe('@jupyterlab/filebrowser', () => {
       const files = result.value!;
       expect(files.length).toBe(1);
       expect(files[0].type).toBe('notebook');
-      expect(files[0].name).toEqual(expect.stringMatching(/Untitled.*.ipynb/));
+      expect(files[0].name).toEqual(expect.stringMatching(/Untitled.+ipynb/));
 
       document.body.removeChild(node);
     });
@@ -321,7 +321,7 @@ describe('@jupyterlab/filebrowser', () => {
       const files = result.value!;
       expect(files.length).toBe(1);
       expect(files[0].type).toBe('notebook');
-      expect(files[0].name).toEqual(expect.stringMatching(/Untitled.*.ipynb/));
+      expect(files[0].name).toEqual(expect.stringMatching(/Untitled.+ipynb/));
 
       const fileDirectory = PathExt.dirname(files[0].path);
       expect(fileDirectory).toEqual(testDirectory);

--- a/packages/fileeditor/src/toc/latex.ts
+++ b/packages/fileeditor/src/toc/latex.ts
@@ -35,7 +35,7 @@ const LATEX_LEVELS: { [label: string]: number } = {
 /**
  * Regular expression to create the outline
  */
-const SECTIONS = /^\s*\\(section|subsection|subsubsection){(.+)}/;
+const SECTIONS = /^\s*\\(section|subsection|subsubsection)\{(.+)\}/;
 
 /**
  * Table of content model for LaTeX files.

--- a/packages/fileeditor/src/toc/python.ts
+++ b/packages/fileeditor/src/toc/python.ts
@@ -23,8 +23,10 @@ try {
   // https://github.com/tc39/proposal-regexp-match-indices was accepted
   // in May 2021 (https://github.com/tc39/proposals/blob/main/finished-proposals.md)
   // So we will fallback to the polyfill regexp-match-indices if not available
+  // eslint-disable-next-line prefer-regex-literals
   KEYWORDS = new RegExp('^\\s*(class |def |async def |from |import )', 'd');
 } catch {
+  // eslint-disable-next-line prefer-regex-literals
   KEYWORDS = new RegExp('^\\s*(class |def |async def |from |import )');
 }
 

--- a/packages/imageviewer-extension/src/index.ts
+++ b/packages/imageviewer-extension/src/index.ts
@@ -64,7 +64,7 @@ const TEXT_FILE_TYPES = ['svg', 'xbm'];
 /**
  * The test pattern for text file types in paths.
  */
-const TEXT_FILE_REGEX = new RegExp(`[.](${TEXT_FILE_TYPES.join('|')})$`); // eslint-disable-line regexp/no-unused-capturing-group, regexp/no-useless-character-class
+const TEXT_FILE_REGEX = new RegExp(`\\.(?:${TEXT_FILE_TYPES.join('|')})$`);
 
 /**
  * The image file handler extension.

--- a/packages/imageviewer-extension/src/index.ts
+++ b/packages/imageviewer-extension/src/index.ts
@@ -64,7 +64,7 @@ const TEXT_FILE_TYPES = ['svg', 'xbm'];
 /**
  * The test pattern for text file types in paths.
  */
-const TEXT_FILE_REGEX = new RegExp(`[.](${TEXT_FILE_TYPES.join('|')})$`);
+const TEXT_FILE_REGEX = new RegExp(`[.](${TEXT_FILE_TYPES.join('|')})$`); // eslint-disable-line regexp/no-unused-capturing-group, regexp/no-useless-character-class
 
 /**
  * The image file handler extension.

--- a/packages/markdownviewer/src/widget.ts
+++ b/packages/markdownviewer/src/widget.ts
@@ -375,7 +375,7 @@ namespace Private {
    * Remove YAML front matter from source.
    */
   export function removeFrontMatter(source: string): string {
-    const re = /^---\n[\s\S]*?\n(---|...)\n/;
+    const re = /^---\n[\s\S]*?\n(---|...)\n/; // eslint-disable-line regexp/no-unused-capturing-group, regexp/no-dupe-disjunctions
     const match = source.match(re);
     if (!match) {
       return source;

--- a/packages/markdownviewer/src/widget.ts
+++ b/packages/markdownviewer/src/widget.ts
@@ -375,7 +375,7 @@ namespace Private {
    * Remove YAML front matter from source.
    */
   export function removeFrontMatter(source: string): string {
-    const re = /^---\n[^]*?\n(---|...)\n/;
+    const re = /^---\n[\s\S]*?\n(---|...)\n/;
     const match = source.match(re);
     if (!match) {
       return source;

--- a/packages/markdownviewer/src/widget.ts
+++ b/packages/markdownviewer/src/widget.ts
@@ -375,7 +375,7 @@ namespace Private {
    * Remove YAML front matter from source.
    */
   export function removeFrontMatter(source: string): string {
-    const re = /^---\n[\s\S]*?\n(---|...)\n/; // eslint-disable-line regexp/no-unused-capturing-group, regexp/no-dupe-disjunctions
+    const re = /^---\n[\s\S]*?\n(?:---|...)\n/; // eslint-disable-line regexp/no-dupe-disjunctions
     const match = source.match(re);
     if (!match) {
       return source;

--- a/packages/markdownviewer/src/widget.ts
+++ b/packages/markdownviewer/src/widget.ts
@@ -375,7 +375,7 @@ namespace Private {
    * Remove YAML front matter from source.
    */
   export function removeFrontMatter(source: string): string {
-    const re = /^---\n[\s\S]*?\n(?:---|...)\n/; // eslint-disable-line regexp/no-dupe-disjunctions
+    const re = /^---\n[\s\S]*?\n(?:---|\.\.\.)\n/;
     const match = source.match(re);
     if (!match) {
       return source;

--- a/packages/mermaid/src/manager.ts
+++ b/packages/mermaid/src/manager.ts
@@ -398,7 +398,7 @@ namespace Private {
    * but _any_ "malformed" tag will break the SVG rendering entirely.
    */
   export const RE_VOID_ELEMENT =
-    /<\s*(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)\s*([^>]*?)\s*>/gi;
+    /<\s*(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)\s*([^>]*?)\s*>/gi; // eslint-disable-line regexp/no-super-linear-backtracking
 
   /**
    * Ensure a void element is closed with a slash, preserving any attributes.

--- a/packages/mermaid/src/tokens.ts
+++ b/packages/mermaid/src/tokens.ts
@@ -11,7 +11,7 @@ export const MERMAID_FILE_EXTENSIONS = ['.mmd', '.mermaid'];
 
 // layout sniffing
 export const RE_DEFAULT_RENDERER =
-  /\bdefaultRenderer["']?\s*:\s*(["']?)(\b[^"'\s]+\b)(\1)/gm;
+  /\bdefaultRenderer["']?\s*:\s*(["']?)(\b[^"'\s]+\b)(\1)/g;
 
 // mermaid themes
 export const MERMAID_DEFAULT_THEME: MermaidConfig['theme'] = 'default';

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -3163,7 +3163,7 @@ namespace Private {
    */
   export function setMarkdownHeader(source: string, level: number): string {
     // Remove existing header or leading white space.
-    const regex = /^(#+\s*)|^(\s*)/; // eslint-disable-line regexp/no-unused-capturing-group
+    const regex = /^#+\s*|^\s*/;
     const newHeader = Array(level + 1).join('#') + ' ';
     const matches = regex.exec(source);
 

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -3163,7 +3163,7 @@ namespace Private {
    */
   export function setMarkdownHeader(source: string, level: number): string {
     // Remove existing header or leading white space.
-    const regex = /^(#+\s*)|^(\s*)/;
+    const regex = /^(#+\s*)|^(\s*)/; // eslint-disable-line regexp/no-unused-capturing-group
     const newHeader = Array(level + 1).join('#') + ' ';
     const matches = regex.exec(source);
 

--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -564,6 +564,7 @@ namespace Private {
     let idx0 = index;
     let idx1: number = -1;
     let lastEnd: number = 0;
+    // Matching the backspace (not word boundary) here is intended.
     const regex = /[\n\b\r]/; // eslint-disable-line regexp/no-escape-backspace
 
     while (true) {

--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -564,7 +564,7 @@ namespace Private {
     let idx0 = index;
     let idx1: number = -1;
     let lastEnd: number = 0;
-    const regex = /[\n\b\r]/;
+    const regex = /[\n\b\r]/; // eslint-disable-line regexp/no-escape-backspace
 
     while (true) {
       idx1 = indexOfAny(newText, regex, lastEnd);

--- a/packages/rendermime/src/latex.ts
+++ b/packages/rendermime/src/latex.ts
@@ -14,7 +14,7 @@ const inline = '$'; // the inline math delimiter
 // MATHSPLIT contains the pattern for math delimiters and special symbols
 // needed for searching for math in the text input.
 const MATHSPLIT =
-  /(\$\$?|\\(?:begin|end)\{[a-z]*\*?\}|\\[{}$]|[{}]|(?:\n\s*)+|@@\d+@@|\\\\(?:\(|\)|\[|\]))/i;
+  /(\$\$?|\\(?:begin|end)\{[a-z]*\*?\}|\\[{}$]|[{}]|(?:\n\s*)+|@@\d+@@|\\\\[()[\]])/i;
 
 /**
  *  Break up the text into its component parts and search

--- a/packages/rendermime/src/latex.ts
+++ b/packages/rendermime/src/latex.ts
@@ -44,9 +44,11 @@ export function removeMath(text: string): { text: string; math: string[] } {
       // can be followed by an `info string` but this cannot include backticks,
       // see specification: https://spec.commonmark.org/0.30/#info-string
       .replace(
+        // eslint-disable-next-line regexp/no-unused-capturing-group, regexp/optimal-quantifier-concatenation
         /^(?<fence>`{3,}|(~T){3,})[^`\n]*\n([\s\S]*?)^\k<fence>`*$/gm,
         wholematch => wholematch.replace(/\$/g, '~D')
       )
+      // eslint-disable-next-line regexp/no-unused-capturing-group, regexp/no-super-linear-backtracking
       .replace(/(^|[^\\])(`+)([^\n]*?[^`\n])\2(?!`)/gm, wholematch =>
         wholematch.replace(/\$/g, '~D')
       );

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -571,18 +571,17 @@ namespace ILinker {
       '"]{2,}[^\\s' +
       controlCodes +
       '"\'(){}\\[\\],:;.!?])',
-    'ug'
+    'gu'
   );
   // Taken from Visual Studio Code:
   // https://github.com/microsoft/vscode/blob/3e407526a1e2ff22cacb69c7e353e81a12f41029/extensions/notebook-renderers/src/linkify.ts#L9
-  const winAbsPathRegex = /(?:[a-zA-Z]:(?:(?:\\|\/)[\w\.-]*)+)/;
-  const winRelPathRegex = /(?:(?:\~|\.)(?:(?:\\|\/)[\w\.-]*)+)/;
+  const winAbsPathRegex = /(?:[a-zA-Z]:(?:(?:\\|\/)[\w.-]*)+)/;
+  const winRelPathRegex = /(?:(?:~|\.)(?:(?:\\|\/)[\w.-]*)+)/;
   const winPathRegex = new RegExp(
     `(${winAbsPathRegex.source}|${winRelPathRegex.source})`
   );
-  const posixPathRegex = /((?:\~|\.)?(?:\/[\w\.-]*)+)/;
-  const lineColumnRegex =
-    /(?:(?:\:|", line )(?<line>[\d]+))?(?:\:(?<column>[\d]+))?/;
+  const posixPathRegex = /((?:~|\.)?(?:\/[\w.-]*)+)/;
+  const lineColumnRegex = /(?:(?::|", line )(?<line>\d+))?(?::(?<column>\d+))?/;
   // TODO: this ought to come from kernel (browser may be on a different OS).
   const isWindows = navigator.userAgent.indexOf('Windows') >= 0;
   export const pathLinkRegex = new RegExp(

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -578,6 +578,7 @@ namespace ILinker {
   const winAbsPathRegex = /(?:[a-zA-Z]:(?:(?:\\|\/)[\w.-]*)+)/;
   const winRelPathRegex = /(?:(?:~|\.)(?:(?:\\|\/)[\w.-]*)+)/;
   const winPathRegex = new RegExp(
+    // eslint-disable-next-line regexp/no-useless-non-capturing-group
     `(${winAbsPathRegex.source}|${winRelPathRegex.source})`
   );
   const posixPathRegex = /((?:~|\.)?(?:\/[\w.-]*)+)/;
@@ -1632,7 +1633,7 @@ namespace Private {
    * This is supposed to have the same behavior as nbconvert.filters.ansi2html()
    */
   export function ansiSpan(str: string): string {
-    const ansiRe = /\x1b\[(.*?)([@-~])/g; // eslint-disable-line no-control-regex
+    const ansiRe = /\x1b\[(.*?)([@-~])/g; // eslint-disable-line no-control-regex, regexp/no-obscure-range
     let fg: number | Array<number> = [];
     let bg: number | Array<number> = [];
     let bold = false;

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -1633,6 +1633,7 @@ namespace Private {
    * This is supposed to have the same behavior as nbconvert.filters.ansi2html()
    */
   export function ansiSpan(str: string): string {
+    // Final byte range and control regex are intended here
     const ansiRe = /\x1b\[(.*?)([@-~])/g; // eslint-disable-line no-control-regex, regexp/no-obscure-range
     let fg: number | Array<number> = [];
     let bg: number | Array<number> = [];

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -1446,7 +1446,7 @@ export class KernelConnection implements Kernel.IKernelConnection {
     );
 
     // Strip any authentication from the display string.
-    const display = partialUrl.replace(/^((?:\w+:)?\/\/)(?:[^@\/]+@)/, '$1');
+    const display = partialUrl.replace(/^((?:\w+:)?\/\/)[^@/]+@/, '$1');
     console.debug(`Starting WebSocket: ${display}`);
 
     let url = URLExt.join(

--- a/packages/toc/src/utils/markdown.ts
+++ b/packages/toc/src/utils/markdown.ts
@@ -195,9 +195,8 @@ export function getHeadings(text: string): IMarkdownHeading[] {
 // Returns the length of ``` or ~~~ fences.
 function extractLeadingFences(line: string) {
   let match;
-  if (line.startsWith('`'))
-    match = line.match(/^(`{3,})/); // eslint-disable-line regexp/no-unused-capturing-group
-  else match = line.match(/^(~{3,})/); // eslint-disable-line regexp/no-unused-capturing-group
+  if (line.startsWith('`')) match = line.match(/^`{3,}/);
+  else match = line.match(/^~{3,}/);
   return match ? match[0].length : 0;
 }
 
@@ -350,5 +349,4 @@ function cleanTitle(heading: string): string {
  * Ignore title with html tag with a class name equal to `jp-toc-ignore` or `tocSkip`
  */
 const skipHeading =
-  // eslint-disable-next-line regexp/no-unused-capturing-group
-  /<\w+\s(.*?\s)?class="(.*?\s)?(jp-toc-ignore|tocSkip)(\s.*?)?"(\s.*?)?>/;
+  /<\w+\s(?:.*?\s)?class="(?:.*?\s)?(?:jp-toc-ignore|tocSkip)(?:\s.*?)?"(?:\s.*?)?>/;

--- a/packages/toc/src/utils/markdown.ts
+++ b/packages/toc/src/utils/markdown.ts
@@ -195,8 +195,9 @@ export function getHeadings(text: string): IMarkdownHeading[] {
 // Returns the length of ``` or ~~~ fences.
 function extractLeadingFences(line: string) {
   let match;
-  if (line.startsWith('`')) match = line.match(/^(`{3,})/);
-  else match = line.match(/^(~{3,})/);
+  if (line.startsWith('`'))
+    match = line.match(/^(`{3,})/); // eslint-disable-line regexp/no-unused-capturing-group
+  else match = line.match(/^(~{3,})/); // eslint-disable-line regexp/no-unused-capturing-group
   return match ? match[0].length : 0;
 }
 
@@ -327,7 +328,7 @@ function parseHeading(line: string, nextLine?: string): IHeader | null {
     }
   }
   // Case: HTML heading (WARNING: this is not particularly robust, as HTML headings can span multiple lines)
-  match = line.match(/<h([1-6]).*>(.*)<\/h\1>/i);
+  match = line.match(/<h([1-6]).*>(.*)<\/h\1>/i); // eslint-disable-line regexp/no-super-linear-backtracking
   if (match) {
     return {
       text: match[2],
@@ -349,4 +350,5 @@ function cleanTitle(heading: string): string {
  * Ignore title with html tag with a class name equal to `jp-toc-ignore` or `tocSkip`
  */
 const skipHeading =
+  // eslint-disable-next-line regexp/no-unused-capturing-group
   /<\w+\s(.*?\s)?class="(.*?\s)?(jp-toc-ignore|tocSkip)(\s.*?)?"(\s.*?)?>/;

--- a/packages/toc/src/utils/markdown.ts
+++ b/packages/toc/src/utils/markdown.ts
@@ -305,7 +305,7 @@ interface IHeader {
  */
 function parseHeading(line: string, nextLine?: string): IHeader | null {
   // Case: Markdown heading
-  let match = line.match(/^([#]{1,6}) (.*)/);
+  let match = line.match(/^(#{1,6}) (.*)/);
   if (match) {
     return {
       text: cleanTitle(match[2]),
@@ -316,7 +316,7 @@ function parseHeading(line: string, nextLine?: string): IHeader | null {
   }
   // Case: Markdown heading (alternative style)
   if (nextLine) {
-    match = nextLine.match(/^ {0,3}([=]{2,}|[-]{2,})\s*$/);
+    match = nextLine.match(/^ {0,3}([=]{2,}|-{2,})\s*$/);
     if (match) {
       return {
         text: cleanTitle(line),

--- a/packages/translation/src/gettext.ts
+++ b/packages/translation/src/gettext.ts
@@ -545,7 +545,7 @@ class Gettext {
     // taken from https://github.com/Orange-OpenSource/gettext.js/blob/master/lib.gettext.js
     // plural forms list available here http://localization-guide.readthedocs.org/en/latest/l10n/pluralforms.html
     let pf_re = new RegExp(
-      '^\\s*nplurals\\s*=\\s*[0-9]+\\s*;\\s*plural\\s*=\\s*(?:\\s|[-\\?\\|&=!<>+*/%:;n0-9_()])+'
+      '^\\s*nplurals\\s*=\\s*\\d+\\s*;\\s*plural\\s*=[\\s\\-?|&=!<>+*/%:;n0-9_()]+'
     );
 
     if (!pf_re.test(pluralForm))

--- a/packages/translation/src/gettext.ts
+++ b/packages/translation/src/gettext.ts
@@ -544,6 +544,7 @@ class Gettext {
     // Plural form string regexp
     // taken from https://github.com/Orange-OpenSource/gettext.js/blob/master/lib.gettext.js
     // plural forms list available here http://localization-guide.readthedocs.org/en/latest/l10n/pluralforms.html
+    // eslint-disable-next-line prefer-regex-literals
     let pf_re = new RegExp(
       '^\\s*nplurals\\s*=\\s*\\d+\\s*;\\s*plural\\s*=[\\s\\-?|&=!<>+*/%:;n0-9_()]+'
     );

--- a/packages/ui-components/src/icon/labicon.tsx
+++ b/packages/ui-components/src/icon/labicon.tsx
@@ -903,6 +903,10 @@ namespace Private {
     // then match to raw svg string
     const [, base64, raw] = decodeURIComponent(svgstr)
       .replace(
+        // \s includes \n, so />\s*\n/ is ambiguous and causes super-linear backtracking.
+        // The explicit list is \s minus \n, ensuring only one way to reach the \n.
+        // See: https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-super-linear-backtracking.html
+        // and https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Cheatsheet
         />[\t\v\f\r \xa0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]*\n\s*</g,
         '><'
       )

--- a/packages/ui-components/src/icon/labicon.tsx
+++ b/packages/ui-components/src/icon/labicon.tsx
@@ -902,7 +902,10 @@ namespace Private {
     // decode any uri escaping, condense leading/lagging whitespace,
     // then match to raw svg string
     const [, base64, raw] = decodeURIComponent(svgstr)
-      .replace(/>\s*\n\s*</g, '><')
+      .replace(
+        />[\t\v\f\r \xa0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]*\n\s*</g,
+        '><'
+      )
       .replace(/\s*\n\s*/g, ' ')
       .match(
         strict

--- a/yarn.lock
+++ b/yarn.lock
@@ -1720,7 +1720,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/eslint-utils@npm:^4.8.0, @eslint-community/eslint-utils@npm:^4.9.1":
+"@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.8.0, @eslint-community/eslint-utils@npm:^4.9.1":
   version: 4.9.1
   resolution: "@eslint-community/eslint-utils@npm:4.9.1"
   dependencies:
@@ -1731,7 +1731,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/regexpp@npm:^4.12.1, @eslint-community/regexpp@npm:^4.12.2":
+"@eslint-community/regexpp@npm:^4.11.0, @eslint-community/regexpp@npm:^4.12.1, @eslint-community/regexpp@npm:^4.12.2, @eslint-community/regexpp@npm:^4.8.0":
   version: 4.12.2
   resolution: "@eslint-community/regexpp@npm:4.12.2"
   checksum: 1770bc81f676a72f65c7200b5675ff7a349786521f30e66125faaf767fde1ba1c19c3790e16ba8508a62a3933afcfc806a893858b3b5906faf693d862b9e4120
@@ -4711,6 +4711,7 @@ __metadata:
     eslint-plugin-jest: ^28.0.0
     eslint-plugin-prettier: ^5.0.0
     eslint-plugin-react: ^7.37.0
+    eslint-plugin-regexp: ^3.1.0
     lerna: ^7.1.4
     prettier: ^3.8.1
     stylelint: 16.12.0
@@ -9983,6 +9984,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"comment-parser@npm:^1.4.0":
+  version: 1.4.6
+  resolution: "comment-parser@npm:1.4.6"
+  checksum: 5e3cdff8d958d2725f8f7a10f962c6294c0acd6321e29505c1d90baa666844cf010afba4037127458380cd71556ff24cd89469ca5987190d1baccaa78b978b68
+  languageName: node
+  linkType: hard
+
 "compare-func@npm:^2.0.0":
   version: 2.0.0
   resolution: "compare-func@npm:2.0.0"
@@ -11979,6 +11987,23 @@ __metadata:
   peerDependencies:
     eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
   checksum: 8675e7558e646e3c2fcb04bb60cfe416000b831ef0b363f0117838f5bfc799156113cb06058ad4d4b39fc730903b7360b05038da11093064ca37caf76b7cf2ca
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-regexp@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "eslint-plugin-regexp@npm:3.1.0"
+  dependencies:
+    "@eslint-community/eslint-utils": ^4.2.0
+    "@eslint-community/regexpp": ^4.11.0
+    comment-parser: ^1.4.0
+    jsdoc-type-pratt-parser: ^7.0.0
+    refa: ^0.12.1
+    regexp-ast-analysis: ^0.7.1
+    scslre: ^0.3.0
+  peerDependencies:
+    eslint: ">=9.38.0"
+  checksum: f972323543ea028450a073278a3540d36f85cff5081c7f5c7223c7c318103cc61cfc81b3eaa6abf498f2baf0d12545936b47436498ffdb53ae0d3752990445b7
   languageName: node
   linkType: hard
 
@@ -14922,6 +14947,13 @@ __metadata:
   version: 0.1.1
   resolution: "jsbn@npm:0.1.1"
   checksum: e5ff29c1b8d965017ef3f9c219dacd6e40ad355c664e277d31246c90545a02e6047018c16c60a00f36d561b3647215c41894f5d869ada6908a2e0ce4200c88f2
+  languageName: node
+  linkType: hard
+
+"jsdoc-type-pratt-parser@npm:^7.0.0":
+  version: 7.2.0
+  resolution: "jsdoc-type-pratt-parser@npm:7.2.0"
+  checksum: 750c84a2c5f632164bce60478d3388ee70d419a109d43667c40bca38f475b77eff05e709734aaba1acf7cc637cc62660e658c008c09f00651a24a5b4b7b55051
   languageName: node
   linkType: hard
 
@@ -18339,6 +18371,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"refa@npm:^0.12.0, refa@npm:^0.12.1":
+  version: 0.12.1
+  resolution: "refa@npm:0.12.1"
+  dependencies:
+    "@eslint-community/regexpp": ^4.8.0
+  checksum: 845cef54786884d5f09558dd600cec20ee354ebbcabd206503d5cc5d63d22bb69dee8b66bf8411de622693fc5c2b9d42b9cf1e5e6900c538ee333eefb5cc1b41
+  languageName: node
+  linkType: hard
+
 "reflect.getprototypeof@npm:^1.0.6, reflect.getprototypeof@npm:^1.0.9":
   version: 1.0.10
   resolution: "reflect.getprototypeof@npm:1.0.10"
@@ -18384,6 +18425,16 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.8.4
   checksum: 2d15bdeadbbfb1d12c93f5775493d85874dbe1d405bec323da5c61ec6e701bc9eea36167483e1a5e752de9b2df59ab9a2dfff6bf3784f2b28af2279a673d29a4
+  languageName: node
+  linkType: hard
+
+"regexp-ast-analysis@npm:^0.7.0, regexp-ast-analysis@npm:^0.7.1":
+  version: 0.7.1
+  resolution: "regexp-ast-analysis@npm:0.7.1"
+  dependencies:
+    "@eslint-community/regexpp": ^4.8.0
+    refa: ^0.12.1
+  checksum: c1c47fea637412d8362a9358b1b2952a6ab159daaede2244c05e79c175844960259c88e30072e4f81a06e5ac1c80f590b14038b17bc8cff09293f752cf843b1c
   languageName: node
   linkType: hard
 
@@ -18857,6 +18908,17 @@ __metadata:
     ajv-formats: ^2.1.1
     ajv-keywords: ^5.1.0
   checksum: 4e20404962fd45d5feb5942f7c9ab334a3d3dab94e15001049bd49e2959015f2c59089353953d4976fe664462c79121dea50392968182d4e2c4b75803f822fa3
+  languageName: node
+  linkType: hard
+
+"scslre@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "scslre@npm:0.3.0"
+  dependencies:
+    "@eslint-community/regexpp": ^4.8.0
+    refa: ^0.12.0
+    regexp-ast-analysis: ^0.7.0
+  checksum: a89d4fe5dbf632cae14cc1e53c9d18012924cc88d6615406ad90190d2b9957fc8db16994c2023235af1b6a6c25290b089eb4c26e47d21b05073b933be5ca9d33
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## References

- Closes https://github.com/jupyterlab/jupyterlab/issues/17087
- Supersedes and closes https://github.com/jupyterlab/jupyterlab/pull/17088
- Supersedes and closes https://github.com/jupyterlab/jupyterlab/pull/17089

## Code changes

- Add `eslint-plugin-regexp` plugin
- Apply auto-fixes and custom safe fixes where applicable
- Add ignore comments where necessary

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

Used Claude for final commit 68ef772 and to verify aut-fixes from 9004a96, I asked it to generate example values for each before/after and validate that they pass/fail as expected.
