### PR TITLE
docs(contributing): mention `--extensions-in-dev-mode` next to `--dev-mode`

### DIFF
--- a/docs/source/developer/contributing.md
+++ b/docs/source/developer/contributing.md
@@ -504,6 +504,21 @@ dev mode, extensions will not be activated by default - refer
 When running in dev mode, a red stripe will appear at the top of the
 page; this is to indicate running an unreleased version.
 
+```{important}
+`--dev-mode` only loads the **core** packages from source. If you are
+changing code under `jupyterlab/packages/` that is shipped as a
+*prebuilt extension* (for example `@jupyterlab/cell-toolbar-extension`
+or `@jupyterlab/debugger-extension`), you also need
+`--extensions-in-dev-mode` for your changes to be picked up:
+
+```bash
+jupyter lab --dev-mode --extensions-in-dev-mode
+```
+
+See {ref}`prebuilt-dev-workflow` for the full prebuilt-extension
+development workflow.
+```
+
 If you want to change the TypeScript code and rebuild on the fly
 (needs page refresh after each rebuild):
 


### PR DESCRIPTION
## References

Closes #17420.

## Code changes

None. Docs-only.

## User-facing changes

Adds a short `{important}` admonition in `docs/source/developer/contributing.md`, right after the `Run JupyterLab` section, that:

- States that `--dev-mode` alone loads only the **core** packages from source.
- Tells contributors who modify prebuilt-extension packages in `jupyterlab/packages/` (e.g. `@jupyterlab/cell-toolbar-extension`, `@jupyterlab/debugger-extension`) to also pass `--extensions-in-dev-mode` for their changes to be picked up.
- Links to the existing {ref}`prebuilt-dev-workflow` section in `docs/source/extension/extension_dev.md` rather than duplicating its content.

This addresses the specific pain point in #17420: the existing mention of `--extensions-in-dev-mode` lives in the extension-dev page, but contributors following the Contributing → Installing JupyterLab → Run JupyterLab path don't necessarily land there, and end up debugging \"why isn't my packages/ change showing up?\".

I kept the admonition short on purpose so the developer-onboarding flow stays linear; happy to expand or relocate it if maintainers prefer a different spot.

## Backwards-incompatible changes

None.

---

> Authored and verified by an AI agent (Claude Opus 4.7 via Cursor) operating **unattended** as a personal token-burn initiative by @adv0r. **Not human-reviewed before submission.** Tone and placement modeled on the existing `{ref}` cross-link a few lines above; please flag if the admonition style doesn't match house style.

Made with [Cursor](https://cursor.com)