### PR TITLE
docs(settings): clarify what "preferred kernel" means

### DIFF
--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -718,7 +718,7 @@
     },
     "autoStartDefaultKernel": {
       "title": "Automatically Start Preferred Kernel",
-      "description": "Whether to automatically start the preferred kernel.",
+      "description": "If true, opening a notebook for which a 'preferred' kernel is known will start that kernel automatically, without showing the 'Select Kernel' dialog. The 'preferred' kernel is the one matching the notebook's stored kernel metadata (the kernel that was used when the notebook was last saved) and, as a fallback, the kernel whose language matches the notebook. This setting only controls whether the dialog is auto-confirmed; the kernel selection itself is not stored here.",
       "type": "boolean",
       "default": false
     },


### PR DESCRIPTION
## References

Refs #16340.

## Code changes

None at runtime. Only the user-visible **description** of the `autoStartDefaultKernel` setting in `packages/notebook-extension/schema/tracker.json` is updated. The setting's title, default value, and the dialog UI strings are unchanged.

## User-facing changes

In **Settings → Notebook**, the entry currently shown as:

> **Automatically Start Preferred Kernel** — \"Whether to automatically start the preferred kernel.\"

now reads (description only):

> If true, opening a notebook for which a 'preferred' kernel is known will start that kernel automatically, without showing the 'Select Kernel' dialog. The 'preferred' kernel is the one matching the notebook's stored kernel metadata (the kernel that was used when the notebook was last saved) and, as a fallback, the kernel whose language matches the notebook. This setting only controls whether the dialog is auto-confirmed; the kernel selection itself is not stored here.

This directly addresses the \"The setting description should explain the behaviour in more detail\" bullet of #16340.

## What this PR intentionally does *not* do

#16340 also asks to revisit the dialog **label/caption** (`Always start the preferred kernel` / `Remember my choice…`). I left those strings untouched on purpose, because:

1. They are `trans.__(…)` strings — changing them invalidates existing translation entries.
2. The maintainers have not yet picked between the suggested rewordings (\"selected kernel\" vs \"for the duration of this session\" etc.), so I didn't want to pre-empt that decision.

Happy to add a follow-up commit (or follow-up PR) once a wording is chosen.

## Backwards-incompatible changes

None.

---

> Authored and verified by an AI agent (Claude Opus 4.7 via Cursor) operating **unattended** as a personal token-burn initiative by @adv0r. **Not human-reviewed before submission.** I verified the \"preferred kernel = metadata match, language fallback\" claim against the current `Private.getDefaultKernel` / `IKernelPreference` logic in `sessioncontext.tsx`; please double-check the wording matches how maintainers think about it.

Made with [Cursor](https://cursor.com)