### PR TITLE
Wait for cell toolbar before snapshot in markdown tests

### DIFF
--- a/galata/test/jupyterlab/notebook-markdown.test.ts
+++ b/galata/test/jupyterlab/notebook-markdown.test.ts
@@ -34,7 +34,7 @@ async function enterEditingModeForScreenshot(
   await cell!.evaluate(element => {
     element.scrollIntoView({ block: 'center', inline: 'nearest' });
   });
-  await cell!.locator('.jp-cell-toolbar').waitFor();
+  await page.waitForTimeout(50);
 }
 
 test.describe('Notebook Markdown', () => {
@@ -79,6 +79,7 @@ test.describe('Notebook Markdown', () => {
     const imageName = 'do-not-highlight-standalone-dollar.png';
     await enterEditingModeForScreenshot(page, 2);
     const cell = await page.notebook.getCellLocator(2);
+    await cell!.locator('.jp-cell-toolbar').waitFor();
 
     expect(await cell!.locator('.jp-Editor').screenshot()).toMatchSnapshot(
       imageName

--- a/galata/test/jupyterlab/notebook-markdown.test.ts
+++ b/galata/test/jupyterlab/notebook-markdown.test.ts
@@ -34,7 +34,7 @@ async function enterEditingModeForScreenshot(
   await cell!.evaluate(element => {
     element.scrollIntoView({ block: 'center', inline: 'nearest' });
   });
-  await page.waitForTimeout(50);
+  await cell!.locator('.jp-cell-toolbar').waitFor();
 }
 
 test.describe('Notebook Markdown', () => {


### PR DESCRIPTION
## References

Fixes #18920

## Code changes

Replace fixed timeout (which should never be used really) with an explicit wait for cell toolbar

| Before | After |
|--|--|
| <img width="344" height="438" alt="Screenshot From 2026-05-21 12-08-58" src="https://github.com/user-attachments/assets/93e688e4-275d-48d1-9132-1ba70e8050e6" /> | <img width="344" height="438" alt="Screenshot From 2026-05-21 12-09-23" src="https://github.com/user-attachments/assets/29fbfcc2-98dc-4d31-9862-c559782255a6" /> | 
| [8/10 flaky](https://github.com/jupyterlab/jupyterlab/actions/runs/26222268473) | [0/10 flaky](https://github.com/krassowski/jupyterlab/actions/runs/26222291449)|



## User-facing changes

None

## Backwards-incompatible changes

None
