### PR TITLE
Fix flaky test: wait for kernel startup before pressing Shift+Enter

### DIFF
--- a/galata/test/jupyterlab/file-edit.test.ts
+++ b/galata/test/jupyterlab/file-edit.test.ts
@@ -78,10 +78,13 @@ test.describe('Console Interactions', () => {
     // Select kernel
     await page.getByRole('button', { name: 'Select Kernel' }).click();
 
-    // Wait for banner to disappear once fully loaded
+    // Wait for loading banner to disappear once fully loaded
     await loadingBanner.waitFor({ state: 'detached' });
 
     await page.getByText('123', { exact: true }).click();
+
+    // Wait for kernel to start up before execution
+    await page.locator('.jp-ConsolePanel [title="Kernel Idle"]').waitFor();
 
     await page.keyboard.press('Shift+Enter');
 


### PR DESCRIPTION
## References

- Solves a flaky `Should send line to console on Shift + Enter` test to stop the bleeding
- https://github.com/jupyterlab/jupyterlab/issues/18923 should stay open to track expected UX

## Code changes

Wait for kernel startup before pressing Shift+Enter

## Developer-facing changes

| Before | After |
|--|--|
| [1 failed, 8 flaky/10](https://github.com/jupyterlab/jupyterlab/actions/runs/26225202943) | [0 failed, 0 flaky/10](https://github.com/krassowski/jupyterlab/actions/runs/26225215906) |

None

## Backwards-incompatible changes

None

## AI usage

No