### PR TITLE
Fix flaky example UI snapshot test by disabling cursor blinking

### DIFF
--- a/examples/example.spec.ts
+++ b/examples/example.spec.ts
@@ -35,6 +35,13 @@ test('should load the example', async ({ page }) => {
   page.on('console', handleMessage);
 
   await page.goto(URL);
+  await page.addStyleTag({
+    content: `
+      .cm-cursor {
+        visibility: hidden !important;
+      }
+    `
+  });
 
   await expect.soft(page.locator('#jupyter-config-data')).toHaveCount(1);
 


### PR DESCRIPTION
<!-- 
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes flaky visual snapshot differences in `examples/example.spec.ts` caused by cursor rendering during screenshot capture.

Related: #18921

## Code changes

This PR adds a minimal style override in `examples/example.spec.ts` before taking screenshots to disable cursor rendering.

This ensures deterministic visual snapshots in Playwright example tests by preventing cursor blinking from affecting screenshot comparisons.

The change is intentionally scoped only to the example test file and does not modify application or editor configuration.

## User-facing changes

No user-facing changes.

This only affects test execution for visual snapshot stability in example Playwright tests.

## Backwards-incompatible changes

None.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code.
- AI tools and models used: ChatGPT