### PR TITLE
Bump license webpack plugin

### DIFF
--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         group: [integrity, integrity2, integrity3, release_test, docs, usage, usage2, splice_source, python, examples, interop, nonode, lint]
         # This will be used by the base setup action
-        python-version: ["3.9", "3.13"]
+        python-version: ["3.10", "3.14"]
         include:
           - group: examples
             upload-output: true
@@ -23,27 +23,27 @@ jobs:
             upload-output: true
         exclude:
           - group: integrity
-            python-version: "3.9"
+            python-version: "3.10"
           - group: integrity2
-            python-version: "3.9"
+            python-version: "3.10"
           - group: integrity3
-            python-version: "3.9"
+            python-version: "3.10"
           - group: release_test
-            python-version: "3.9"
+            python-version: "3.10"
           - group: docs
-            python-version: "3.9"
+            python-version: "3.10"
           - group: usage
-            python-version: "3.9"
+            python-version: "3.10"
           - group: usage2
-            python-version: "3.9"
+            python-version: "3.10"
           - group: nonode
-            python-version: "3.9"
+            python-version: "3.10"
           - group: lint
-            python-version: "3.9"
+            python-version: "3.10"
           - group: examples
-            python-version: "3.9"
+            python-version: "3.10"
           - group: splice_source
-            python-version: "3.9"
+            python-version: "3.10"
       fail-fast: false
     timeout-minutes: 45
     runs-on: ubuntu-22.04

--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         with:
-          python_version: "3.9"
+          python_version: "3.10"
           dependency_type: minimum
       - name: Install dependencies
         run: |

--- a/builder/package.json
+++ b/builder/package.json
@@ -51,7 +51,7 @@
     "duplicate-package-checker-webpack-plugin": "^3.0.0",
     "fs-extra": "^10.1.0",
     "glob": "~7.1.6",
-    "license-webpack-plugin": "^2.3.14",
+    "license-webpack-plugin": "^4.0.2",
     "mini-css-extract-plugin": "^2.7.0",
     "mini-svg-data-uri": "^1.4.4",
     "path-browserify": "^1.0.0",

--- a/builder/package.json
+++ b/builder/package.json
@@ -63,6 +63,7 @@
     "webpack": "^5.76.1",
     "webpack-cli": "^5.0.1",
     "webpack-merge": "^5.8.0",
+    "webpack-sources": "^3.4.1",
     "worker-loader": "^3.0.2"
   },
   "devDependencies": {

--- a/builder/src/webpack-plugins.ts
+++ b/builder/src/webpack-plugins.ts
@@ -242,7 +242,7 @@ export namespace WPPlugin {
       for (const mod of modules) {
         report.packages.push({
           name: mod.name || '',
-          versionInfo: mod.packageJson.version || '',
+          versionInfo: mod.packageJson?.version || '',
           licenseId: mod.licenseId || '',
           extractedText: mod.licenseText || ''
         });

--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -83,6 +83,7 @@ const UNUSED: Dict<string[]> = {
     'style-loader',
     'terser-webpack-plugin',
     'webpack-cli',
+    'webpack-sources',
     'worker-loader',
     'source-map-loader'
   ],

--- a/packages/outputarea/style/base.css
+++ b/packages/outputarea/style/base.css
@@ -10,6 +10,7 @@
 
 .jp-OutputArea {
   overflow-y: auto;
+  /* stylelint-disable-next-line csstree/validator, property-no-unknown */
   anchor-scope: --jp-output-area;
 }
 
@@ -18,6 +19,7 @@
   flex-direction: row;
   width: 100%;
   overflow: hidden;
+  /* stylelint-disable-next-line csstree/validator, property-no-unknown */
   anchor-name: --jp-output-area;
 }
 
@@ -66,8 +68,10 @@
 
 .jp-OutputArea-promptOverlay {
   position: absolute;
+  /* stylelint-disable csstree/validator, function-no-unknown */
   top: anchor(--jp-output-area top);
   bottom: anchor(--jp-output-area bottom);
+  /* stylelint-enable csstree/validator, function-no-unknown */
   width: var(--jp-cell-prompt-width);
   opacity: 0.5;
   display: flex;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2474,6 +2474,7 @@ __metadata:
     webpack: ^5.76.1
     webpack-cli: ^5.0.1
     webpack-merge: ^5.8.0
+    webpack-sources: ^3.4.1
     worker-loader: ^3.0.2
   bin:
     build-labextension: ./lib/build-labextension.js
@@ -21736,6 +21737,13 @@ __metadata:
   version: 3.2.3
   resolution: "webpack-sources@npm:3.2.3"
   checksum: 989e401b9fe3536529e2a99dac8c1bdc50e3a0a2c8669cbafad31271eadd994bc9405f88a3039cd2e29db5e6d9d0926ceb7a1a4e7409ece021fe79c37d9c4607
+  languageName: node
+  linkType: hard
+
+"webpack-sources@npm:^3.4.1":
+  version: 3.4.1
+  resolution: "webpack-sources@npm:3.4.1"
+  checksum: 5b318a9d3ed0ab53ca1e7e6b340eb7d88220a7197977b51b24d9e15ac864615f7ab58486f3233327d152f4a618f23d219877b7dc506f6adb75f3a8dd4d73ab5c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -21733,14 +21733,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-sources@npm:^3.0.0, webpack-sources@npm:^3.2.3":
-  version: 3.2.3
-  resolution: "webpack-sources@npm:3.2.3"
-  checksum: 989e401b9fe3536529e2a99dac8c1bdc50e3a0a2c8669cbafad31271eadd994bc9405f88a3039cd2e29db5e6d9d0926ceb7a1a4e7409ece021fe79c37d9c4607
-  languageName: node
-  linkType: hard
-
-"webpack-sources@npm:^3.4.1":
+"webpack-sources@npm:^3.0.0, webpack-sources@npm:^3.2.3, webpack-sources@npm:^3.4.1":
   version: 3.4.1
   resolution: "webpack-sources@npm:3.4.1"
   checksum: 5b318a9d3ed0ab53ca1e7e6b340eb7d88220a7197977b51b24d9e15ac864615f7ab58486f3233327d152f4a618f23d219877b7dc506f6adb75f3a8dd4d73ab5c

--- a/yarn.lock
+++ b/yarn.lock
@@ -2460,7 +2460,7 @@ __metadata:
     duplicate-package-checker-webpack-plugin: ^3.0.0
     fs-extra: ^10.1.0
     glob: ~7.1.6
-    license-webpack-plugin: ^2.3.14
+    license-webpack-plugin: ^4.0.2
     mini-css-extract-plugin: ^2.7.0
     mini-svg-data-uri: ^1.4.4
     path-browserify: ^1.0.0
@@ -7323,13 +7323,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/source-list-map@npm:*":
-  version: 0.1.2
-  resolution: "@types/source-list-map@npm:0.1.2"
-  checksum: fda8f37537aca9d3ed860d559289ab1dddb6897e642e6f53e909bbd18a7ac3129a8faa2a7d093847c91346cf09c86ef36e350c715406fba1f2271759b449adf6
-  languageName: node
-  linkType: hard
-
 "@types/stack-utils@npm:^2.0.0":
   version: 2.0.1
   resolution: "@types/stack-utils@npm:2.0.1"
@@ -7392,17 +7385,6 @@ __metadata:
   version: 1.18.0
   resolution: "@types/webpack-env@npm:1.18.0"
   checksum: ecf4daa31cb37d474ac0ce058d83a3cadeb9881ca8107ae93c2299eaa9954943aae09b43e143c62ccbe4288a14db00c918c9debd707afe17c3998f873eaabc59
-  languageName: node
-  linkType: hard
-
-"@types/webpack-sources@npm:^0.1.5":
-  version: 0.1.9
-  resolution: "@types/webpack-sources@npm:0.1.9"
-  dependencies:
-    "@types/node": "*"
-    "@types/source-list-map": "*"
-    source-map: ^0.6.1
-  checksum: bc09c584c7047e8aed29801a3981787dee3898e9e7a99891a362df114fcac3879eea5a00932314866a01b25220391839be09fe1487b16d4970ff4a7afd5b9725
   languageName: node
   linkType: hard
 
@@ -15311,19 +15293,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"license-webpack-plugin@npm:^2.3.14":
-  version: 2.3.21
-  resolution: "license-webpack-plugin@npm:2.3.21"
-  dependencies:
-    "@types/webpack-sources": ^0.1.5
-    webpack-sources: ^1.2.0
-  peerDependenciesMeta:
-    webpack:
-      optional: true
-  checksum: 6208bd2060d200fbffbcc89702c929d50c5a4a3f2158b046cf813b3f7f728bbbe4611b9fea2d67843bb5e7d64ad9122cc368a19ac73f5c4ad41765e6283bdc0c
-  languageName: node
-  linkType: hard
-
 "license-webpack-plugin@npm:^4.0.2":
   version: 4.0.2
   resolution: "license-webpack-plugin@npm:4.0.2"
@@ -19355,13 +19324,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-list-map@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "source-list-map@npm:2.0.1"
-  checksum: 806efc6f75e7cd31e4815e7a3aaf75a45c704871ea4075cb2eb49882c6fca28998f44fc5ac91adb6de03b2882ee6fb02f951fdc85e6a22b338c32bfe19557938
-  languageName: node
-  linkType: hard
-
 "source-map-js@npm:^1.0.1, source-map-js@npm:^1.0.2":
   version: 1.0.2
   resolution: "source-map-js@npm:1.0.2"
@@ -21767,16 +21729,6 @@ __metadata:
     clone-deep: ^4.0.1
     wildcard: ^2.0.0
   checksum: 88786ab91013f1bd2a683834ff381be81c245a4b0f63304a5103e90f6653f44dab496a0768287f8531761f8ad957d1f9f3ccb2cb55df0de1bd9ee343e079da26
-  languageName: node
-  linkType: hard
-
-"webpack-sources@npm:^1.2.0":
-  version: 1.4.3
-  resolution: "webpack-sources@npm:1.4.3"
-  dependencies:
-    source-list-map: ^2.0.0
-    source-map: ~0.6.1
-  checksum: 37463dad8d08114930f4bc4882a9602941f07c9f0efa9b6bc78738cd936275b990a596d801ef450d022bb005b109b9f451dd087db2f3c9baf53e8e22cf388f79
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References https://github.com/jupyterlab/jupyter-builder/pull/103

### Description
Building extensions has started failing, as seen in this CI action: https://github.com/jupyterlab/extension-template/actions/runs/26198995338/job/77084621851

This affects both new and existing extensions when they are built after regenerating the lockfile.

For more context, see the discussion in the comments under https://github.com/jupyterlab/jupyter-builder/pull/103

Bumping `"license-webpack-plugin"` effectively resolves the underlying issue.

## User-facing changes

No

## Backwards-incompatible changes

No

## AI usage

No
