### PR TITLE
Mention JupyterLab 4.6.0 beta in installation guide and via a banner

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -376,7 +376,7 @@ html_favicon = "_static/logo-icon.png"
 # documentation.
 #
 html_theme_options = {
-    "announcement": '🚀 You can now test JupyterLab 4.6.0 Beta · <a href="https://jupyterlab.rtfd.io/en/latest/getting_started/installation.html">INSTALL</a> · <a href="https://jupyterlab.rtfd.io/en/latest/getting_started/changelog.html#v4-6">RELEASE NOTES</a>',
+    "announcement": '🚀 You can now test JupyterLab 4.6.0 Beta · <a href="https://jupyterlab.rtfd.io/en/latest/getting_started/installation.html">INSTALL</a> · <a href="https://jupyterlab.rtfd.io/en/latest/getting_started/changelog.html#v4-6-beta">RELEASE NOTES</a>',
     "icon_links": [
         {
             "name": "jupyter.org",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -376,6 +376,7 @@ html_favicon = "_static/logo-icon.png"
 # documentation.
 #
 html_theme_options = {
+    "announcement": '🚀 You can now test JupyterLab 4.6.0 Beta · <a href="https://jupyterlab.rtfd.io/en/latest/getting_started/installation.html">INSTALL</a> · <a href="https://jupyterlab.rtfd.io/en/latest/getting_started/changelog.html#v4-6">RELEASE NOTES</a>',
     "icon_links": [
         {
             "name": "jupyter.org",

--- a/docs/source/getting_started/installation.md
+++ b/docs/source/getting_started/installation.md
@@ -6,6 +6,20 @@
 
 # Installation
 
+:::{hint}
+JupyterLab 4.6 Beta is now available and includes new layout customization options,
+navigation between recently edited cells, revamped keyboard shortcuts UI, editable
+breadcrumbs in file browser and debugger enhancements.
+If you are an experienced user, or just would like to test out the latest
+improvements, please consider installing the pre-release, for example with:
+
+```bash
+pip install --pre --upgrade jupyterlab==4.6.0b0
+```
+
+For the full release notes please see the [Release Notes](https://jupyterlab.readthedocs.io/en/latest/getting_started/changelog.html#v4-6)
+:::
+
 JupyterLab can be installed as a terminal-launched application accessible via a web browser (default), or as a desktop application which is running in its own window and can be opened by clicking on a desktop shortcut ([JupyterLab Desktop](https://github.com/jupyterlab/jupyterlab-desktop)). This page describes installation of the default (terminal-launched) JupyterLab application using `conda`, `mamba`, `pip`, `pipenv` or `docker` and assumes basic knowledge of the terminal. For JupyterLab Desktop instructions see the [Installation section](https://github.com/jupyterlab/jupyterlab-desktop#installation) in the JupyterLab Desktop repository.
 
 :::{warning}

--- a/docs/source/getting_started/installation.md
+++ b/docs/source/getting_started/installation.md
@@ -17,7 +17,7 @@ improvements, please consider installing the pre-release, for example with:
 pip install --pre --upgrade jupyterlab==4.6.0b0
 ```
 
-For the full release notes please see the [Release Notes](https://jupyterlab.readthedocs.io/en/latest/getting_started/changelog.html#v4-6)
+For the full release notes please see the [Release Notes](https://jupyterlab.readthedocs.io/en/latest/getting_started/changelog.html#v4-6-beta)
 :::
 
 JupyterLab can be installed as a terminal-launched application accessible via a web browser (default), or as a desktop application which is running in its own window and can be opened by clicking on a desktop shortcut ([JupyterLab Desktop](https://github.com/jupyterlab/jupyterlab-desktop)). This page describes installation of the default (terminal-launched) JupyterLab application using `conda`, `mamba`, `pip`, `pipenv` or `docker` and assumes basic knowledge of the terminal. For JupyterLab Desktop instructions see the [Installation section](https://github.com/jupyterlab/jupyterlab-desktop#installation) in the JupyterLab Desktop repository.


### PR DESCRIPTION
## References

Similar to previous:
- https://github.com/jupyterlab/jupyterlab/pull/18061
- https://github.com/jupyterlab/jupyterlab/pull/18074

## Code changes

Mention the 4.6 release in docs install page and via an announcement banner

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

None