### PR TITLE
Add OS-level external file change detection

### DIFF
--- a/jupyterlab/handlers/file_watch_handler.py
+++ b/jupyterlab/handlers/file_watch_handler.py
@@ -1,0 +1,232 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""WebSocket handler for OS-level filesystem notifications."""
+
+import asyncio
+import json
+import os
+from pathlib import Path
+
+from jupyter_server.base.handlers import JupyterHandler
+from tornado import web
+from tornado.websocket import WebSocketHandler
+
+try:
+    from watchdog.events import FileSystemEvent, FileSystemEventHandler
+    from watchdog.observers import Observer
+
+    WATCHDOG_AVAILABLE = True
+except ImportError:
+    WATCHDOG_AVAILABLE = False
+
+
+class _BridgeEventHandler(FileSystemEventHandler if WATCHDOG_AVAILABLE else object):
+    """Bridges watchdog's background thread into Tornado's IOLoop."""
+
+    def __init__(
+        self,
+        abs_path: str,
+        rel_path: str,
+        callback,
+        loop: asyncio.AbstractEventLoop,
+    ):
+        if WATCHDOG_AVAILABLE:
+            super().__init__()
+        self._abs_path = abs_path
+        self._rel_path = rel_path
+        self._callback = callback
+        self._loop = loop
+
+    def _emit(self, event_type: str) -> None:
+        self._loop.call_soon_threadsafe(self._callback, self._rel_path, event_type)
+
+    def on_modified(self, event: "FileSystemEvent") -> None:
+        if not event.is_directory and event.src_path == self._abs_path:
+            self._emit("modified")
+
+    def on_deleted(self, event: "FileSystemEvent") -> None:
+        if not event.is_directory and event.src_path == self._abs_path:
+            self._emit("deleted")
+
+    def on_created(self, event: "FileSystemEvent") -> None:
+        # Reappearance after a delete (e.g. `rm` + `echo > file`) — treat as modified.
+        if not event.is_directory and event.src_path == self._abs_path:
+            self._emit("modified")
+
+    def on_moved(self, event: "FileSystemEvent") -> None:
+        if event.is_directory:
+            return
+        # Watched file was renamed away (rare, but record it).
+        if event.src_path == self._abs_path:
+            self._emit("moved")
+            return
+        # Atomic-save pattern (vim, JetBrains, many GUI editors): a temp file
+        # is renamed onto the watched path. From the user's point of view the
+        # file content changed, so surface it as a "modified" event.
+        if getattr(event, "dest_path", None) == self._abs_path:
+            self._emit("modified")
+
+
+class FileWatchHandler(JupyterHandler, WebSocketHandler):
+    """
+    WebSocket handler that watches specific files for OS-level changes.
+
+    URL: /lab/api/filewatch
+
+    Protocol:
+      Client → Server:
+        {"msgType": "subscribe",   "path": "relative/path"}
+        {"msgType": "unsubscribe", "path": "relative/path"}
+
+      Server → Client:
+        {"msgType": "changed",     "path": "...", "eventType": "modified|deleted|moved"}
+        {"msgType": "unavailable", "reason": "..."}
+        {"msgType": "error",       "message": "..."}
+    """
+
+    def initialize(self) -> None:
+        super().initialize()
+        # Map from relative path -> (Observer, _BridgeEventHandler)
+        self._watches: dict[str, tuple] = {}
+        # Strong refs to background subscribe tasks. asyncio only keeps
+        # weak references to tasks, so without this set a task could be
+        # garbage-collected mid-execution.
+        self._subscribe_tasks: set = set()
+
+    @web.authenticated
+    async def get(self, *args, **kwargs):
+        await super().get(*args, **kwargs)
+
+    def open(self) -> None:
+        if not WATCHDOG_AVAILABLE:
+            self._send({"msgType": "unavailable", "reason": "watchdog is not installed"})
+            return
+        self.log.debug("FileWatchHandler: WebSocket opened")
+
+    def on_message(self, raw: str) -> None:
+        try:
+            msg = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return
+        msg_type = msg.get("msgType")
+        path = msg.get("path", "")
+        if not isinstance(path, str):
+            return
+        if msg_type == "subscribe":
+            # Run as a task so the brief setup-window check inside _subscribe
+            # does not block other incoming messages (e.g. concurrent subscribes
+            # when multiple files are opened back-to-back).
+            task = asyncio.create_task(self._subscribe(path))
+            self._subscribe_tasks.add(task)
+            task.add_done_callback(self._subscribe_tasks.discard)
+        elif msg_type == "unsubscribe":
+            self._unsubscribe(path)
+
+    def on_close(self) -> None:
+        for rel_path in list(self._watches):
+            self._unsubscribe(rel_path)
+        self.log.debug("FileWatchHandler: WebSocket closed")
+
+    # ------------------------------------------------------------------ #
+    # Private helpers
+    # ------------------------------------------------------------------ #
+
+    def _resolve_and_validate(self, rel_path: str) -> "str | None":
+        """Resolve rel_path against server root; return abs path or None."""
+        root = Path(self.settings.get("server_root_dir", os.getcwd())).expanduser().resolve()
+        try:
+            abs_path = (root / rel_path).resolve()
+            abs_path.relative_to(root)  # raises ValueError if outside root
+        except ValueError:
+            self._send({"msgType": "error", "message": "Path is outside the root directory"})
+            return None
+        except OSError as exc:
+            self._send({"msgType": "error", "message": f"Cannot resolve path: {exc}"})
+            return None
+        return str(abs_path)
+
+    # FSEvents (macOS) / inotify (Linux) need a brief moment between
+    # `observer.start()` and the watch being effectively armed at the OS
+    # level. Without a catch-up step here, external changes that happen
+    # within this window are silently missed — the symptom users see is
+    # "auto-reload does not work on first open, but works after a reload".
+    SETUP_GRACE_SECONDS = 0.2
+
+    async def _subscribe(self, rel_path: str) -> None:
+        if not WATCHDOG_AVAILABLE or rel_path in self._watches:
+            return
+        abs_path = self._resolve_and_validate(rel_path)
+        if abs_path is None:
+            return
+
+        loop = asyncio.get_running_loop()
+
+        def _on_event(path: str, event_type: str) -> None:
+            if not self.ws_connection:
+                return
+            try:
+                self.write_message(
+                    json.dumps({"msgType": "changed", "path": path, "eventType": event_type})
+                )
+            except Exception:
+                self.log.debug("FileWatchHandler: write_message failed", exc_info=True)
+
+        handler = _BridgeEventHandler(abs_path, rel_path, _on_event, loop)
+        observer = Observer()
+        observer.schedule(handler, path=os.path.dirname(abs_path), recursive=False)
+
+        # Snapshot mtime BEFORE start so we can detect any change that lands
+        # during the OS watch's setup window.
+        try:
+            initial_mtime = os.path.getmtime(abs_path)
+        except OSError:
+            initial_mtime = None
+
+        observer.start()
+        self._watches[rel_path] = (observer, handler)
+        self.log.debug("FileWatchHandler: subscribed to %s", rel_path)
+
+        await self._catch_up_changes(rel_path, abs_path, initial_mtime, _on_event)
+
+    async def _catch_up_changes(
+        self,
+        rel_path: str,
+        abs_path: str,
+        initial_mtime: "float | None",
+        on_event,
+    ) -> None:
+        """Sleep through the OS-watcher setup window and replay any change.
+
+        FSEvents/inotify need a brief moment after observer.start() to fully
+        arm the watch. Changes during that window would otherwise be lost.
+        """
+        await asyncio.sleep(self.SETUP_GRACE_SECONDS)
+        if rel_path not in self._watches:
+            # Unsubscribed during the grace window — nothing more to do.
+            return
+        try:
+            current_mtime = os.path.getmtime(abs_path)
+        except OSError:
+            if initial_mtime is not None:
+                on_event(rel_path, "deleted")
+            return
+        if initial_mtime is not None and current_mtime != initial_mtime:
+            on_event(rel_path, "modified")
+
+    def _unsubscribe(self, rel_path: str) -> None:
+        entry = self._watches.pop(rel_path, None)
+        if entry is None:
+            return
+        observer, _ = entry
+        observer.stop()
+        observer.join(timeout=2)
+        self.log.debug("FileWatchHandler: unsubscribed from %s", rel_path)
+
+    def _send(self, msg: dict) -> None:
+        try:
+            self.write_message(json.dumps(msg))
+        except Exception:
+            self.log.debug("FileWatchHandler: _send failed", exc_info=True)
+
+
+file_watch_handler_path = r"/lab/api/filewatch"

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -57,6 +57,7 @@ from .handlers.announcements import (
 from .handlers.build_handler import Builder, BuildHandler, build_path
 from .handlers.error_handler import ErrorHandler
 from .handlers.extension_manager_handler import ExtensionHandler, extensions_handler_path
+from .handlers.file_watch_handler import FileWatchHandler, file_watch_handler_path
 from .handlers.plugin_manager_handler import PluginHandler, plugins_handler_path
 
 DEV_NOTE = """You're running JupyterLab from source.
@@ -915,6 +916,9 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
 
         # Update Jupyter Server's webapp settings with jupyterlab settings.
         self.serverapp.web_app.settings["page_config_data"] = page_config
+
+        # Add filesystem notification handler (requires watchdog; degrades gracefully otherwise)
+        handlers.append((file_watch_handler_path, FileWatchHandler))
 
         # Extend Server handlers with jupyterlab handlers.
         self.handlers.extend(handlers)

--- a/jupyterlab/tests/test_file_watch_handler.py
+++ b/jupyterlab/tests/test_file_watch_handler.py
@@ -1,0 +1,344 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""Tests for the FileWatchHandler WebSocket endpoint."""
+
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from jupyterlab.handlers.file_watch_handler import (
+    FileWatchHandler,
+    _BridgeEventHandler,
+    file_watch_handler_path,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture — register the handler with the test server
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def file_watch_app(jp_serverapp, make_labserver_extension_app):
+    app = make_labserver_extension_app()
+    app._link_jupyter_server_extension(jp_serverapp)
+    app.handlers.extend([(file_watch_handler_path, FileWatchHandler)])
+    app.initialize()
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Unit tests (all Observer / watchdog interactions are mocked)
+# ---------------------------------------------------------------------------
+
+
+async def test_unavailable_when_watchdog_missing(file_watch_app, jp_ws_fetch):
+    """Handler sends 'unavailable' when watchdog is not installed."""
+    with patch("jupyterlab.handlers.file_watch_handler.WATCHDOG_AVAILABLE", False):
+        ws = await jp_ws_fetch("lab", "api", "filewatch")
+        raw = await ws.read_message()
+        msg = json.loads(raw)
+        assert msg["msgType"] == "unavailable"
+        assert "watchdog" in msg["reason"].lower()
+        ws.close()
+
+
+async def test_subscribe_starts_observer(file_watch_app, jp_ws_fetch, jp_root_dir):
+    """Subscribe message creates and starts a watchdog Observer."""
+    (jp_root_dir / "watch_test.txt").write_text("hello")
+
+    mock_observer = MagicMock()
+
+    with (
+        patch("jupyterlab.handlers.file_watch_handler.WATCHDOG_AVAILABLE", True),
+        patch(
+            "jupyterlab.handlers.file_watch_handler.Observer",
+            return_value=mock_observer,
+            create=True,
+        ),
+    ):
+        ws = await jp_ws_fetch("lab", "api", "filewatch")
+        await ws.write_message(json.dumps({"msgType": "subscribe", "path": "watch_test.txt"}))
+        await asyncio.sleep(0.05)
+
+        assert mock_observer.start.called
+        ws.close()
+
+
+async def test_unsubscribe_stops_observer(file_watch_app, jp_ws_fetch, jp_root_dir):
+    """Unsubscribe message stops and joins the Observer."""
+    (jp_root_dir / "watch_test2.txt").write_text("hello")
+
+    mock_observer = MagicMock()
+
+    with (
+        patch("jupyterlab.handlers.file_watch_handler.WATCHDOG_AVAILABLE", True),
+        patch(
+            "jupyterlab.handlers.file_watch_handler.Observer",
+            return_value=mock_observer,
+            create=True,
+        ),
+    ):
+        ws = await jp_ws_fetch("lab", "api", "filewatch")
+        await ws.write_message(json.dumps({"msgType": "subscribe", "path": "watch_test2.txt"}))
+        await asyncio.sleep(0.05)
+        await ws.write_message(json.dumps({"msgType": "unsubscribe", "path": "watch_test2.txt"}))
+        await asyncio.sleep(0.05)
+
+        assert mock_observer.stop.called
+        ws.close()
+
+
+async def test_path_traversal_rejected(file_watch_app, jp_ws_fetch):
+    """Paths that escape the server root are rejected with an error message."""
+    with (
+        patch("jupyterlab.handlers.file_watch_handler.WATCHDOG_AVAILABLE", True),
+        patch("jupyterlab.handlers.file_watch_handler.Observer", create=True),
+    ):
+        ws = await jp_ws_fetch("lab", "api", "filewatch")
+        await ws.write_message(json.dumps({"msgType": "subscribe", "path": "../../../etc/passwd"}))
+        raw = await ws.read_message()
+        msg = json.loads(raw)
+        assert msg["msgType"] == "error"
+        ws.close()
+
+
+async def test_changed_message_forwarded(file_watch_app, jp_ws_fetch, jp_root_dir):
+    """When watchdog fires an event the handler forwards a 'changed' WS message."""
+    (jp_root_dir / "notify_test.txt").write_text("v1")
+
+    mock_observer = MagicMock()
+    captured: dict = {}
+
+    def fake_bridge(abs_p, rel_p, callback, loop):
+        captured["callback"] = callback
+        return MagicMock()
+
+    with (
+        patch("jupyterlab.handlers.file_watch_handler.WATCHDOG_AVAILABLE", True),
+        patch(
+            "jupyterlab.handlers.file_watch_handler.Observer",
+            return_value=mock_observer,
+            create=True,
+        ),
+        patch(
+            "jupyterlab.handlers.file_watch_handler._BridgeEventHandler",
+            side_effect=fake_bridge,
+        ),
+    ):
+        ws = await jp_ws_fetch("lab", "api", "filewatch")
+        await ws.write_message(json.dumps({"msgType": "subscribe", "path": "notify_test.txt"}))
+        await asyncio.sleep(0.05)
+
+        assert "callback" in captured, "BridgeEventHandler callback was not captured"
+
+        # Simulate an OS-level modified event from the watchdog thread
+        captured["callback"]("notify_test.txt", "modified")
+        await asyncio.sleep(0.05)
+
+        raw = await ws.read_message()
+        msg = json.loads(raw)
+        assert msg["msgType"] == "changed"
+        assert msg["path"] == "notify_test.txt"
+        assert msg["eventType"] == "modified"
+        ws.close()
+
+
+async def test_subscribe_twice_does_not_create_two_observers(
+    file_watch_app, jp_ws_fetch, jp_root_dir
+):
+    """Subscribing the same path twice only starts one Observer."""
+    (jp_root_dir / "dup.txt").write_text("x")
+
+    observers: list = []
+
+    def make_observer():
+        obs = MagicMock()
+        observers.append(obs)
+        return obs
+
+    with (
+        patch("jupyterlab.handlers.file_watch_handler.WATCHDOG_AVAILABLE", True),
+        patch(
+            "jupyterlab.handlers.file_watch_handler.Observer",
+            side_effect=make_observer,
+            create=True,
+        ),
+    ):
+        ws = await jp_ws_fetch("lab", "api", "filewatch")
+        await ws.write_message(json.dumps({"msgType": "subscribe", "path": "dup.txt"}))
+        await ws.write_message(json.dumps({"msgType": "subscribe", "path": "dup.txt"}))
+        await asyncio.sleep(0.05)
+
+        assert len(observers) == 1
+        ws.close()
+
+
+async def test_malformed_message_is_ignored(file_watch_app, jp_ws_fetch, jp_root_dir):
+    """Non-JSON or invalid messages are silently dropped — connection stays open."""
+    (jp_root_dir / "ok.txt").write_text("x")
+
+    with (
+        patch("jupyterlab.handlers.file_watch_handler.WATCHDOG_AVAILABLE", True),
+        patch(
+            "jupyterlab.handlers.file_watch_handler.Observer",
+            return_value=MagicMock(),
+            create=True,
+        ),
+    ):
+        ws = await jp_ws_fetch("lab", "api", "filewatch")
+        # Garbage payload
+        await ws.write_message("not json at all")
+        # Path is not a string
+        await ws.write_message(json.dumps({"msgType": "subscribe", "path": 42}))
+        # Unknown msgType — silently ignored
+        await ws.write_message(json.dumps({"msgType": "bogus", "path": "ok.txt"}))
+        # A legitimate subscribe must still go through after the garbage.
+        await ws.write_message(json.dumps({"msgType": "subscribe", "path": "ok.txt"}))
+        await asyncio.sleep(0.05)
+        ws.close()
+
+
+async def test_atomic_rename_is_reported_as_modified(file_watch_app, jp_ws_fetch, jp_root_dir):
+    """A tmp file renamed onto the watched path (vim, JetBrains save) → modified event."""
+    target = jp_root_dir / "atomic.txt"
+    target.write_text("v1")
+
+    mock_observer = MagicMock()
+    captured_handler: dict = {}
+
+    def fake_bridge(abs_p, rel_p, callback, loop):
+        # Use the real (already-imported) handler so we exercise on_moved.
+        h = _BridgeEventHandler(abs_p, rel_p, callback, loop)
+        captured_handler["handler"] = h
+        captured_handler["abs_path"] = abs_p
+        return h
+
+    with (
+        patch("jupyterlab.handlers.file_watch_handler.WATCHDOG_AVAILABLE", True),
+        patch(
+            "jupyterlab.handlers.file_watch_handler.Observer",
+            return_value=mock_observer,
+            create=True,
+        ),
+        patch(
+            "jupyterlab.handlers.file_watch_handler._BridgeEventHandler",
+            side_effect=fake_bridge,
+        ),
+    ):
+        ws = await jp_ws_fetch("lab", "api", "filewatch")
+        await ws.write_message(json.dumps({"msgType": "subscribe", "path": "atomic.txt"}))
+        await asyncio.sleep(0.05)
+
+        # Simulate the atomic-save move: tmp file renamed onto the watched path.
+        abs_path = captured_handler["abs_path"]
+        fake_event = MagicMock()
+        fake_event.is_directory = False
+        fake_event.src_path = abs_path + ".tmp"
+        fake_event.dest_path = abs_path
+        captured_handler["handler"].on_moved(fake_event)
+        await asyncio.sleep(0.05)
+
+        raw = await ws.read_message()
+        msg = json.loads(raw)
+        assert msg["msgType"] == "changed"
+        assert msg["path"] == "atomic.txt"
+        assert msg["eventType"] == "modified"
+        ws.close()
+
+
+async def test_catch_up_emits_synthetic_modified_event(file_watch_app, jp_ws_fetch, jp_root_dir):
+    """If the file changes during the OS-watcher setup window, fire a synthetic modified event."""
+    target = jp_root_dir / "race.txt"
+    target.write_text("v1")
+
+    mock_observer = MagicMock()
+
+    with (
+        patch("jupyterlab.handlers.file_watch_handler.WATCHDOG_AVAILABLE", True),
+        patch(
+            "jupyterlab.handlers.file_watch_handler.Observer",
+            return_value=mock_observer,
+            create=True,
+        ),
+        patch.object(FileWatchHandler, "SETUP_GRACE_SECONDS", 0.1),
+    ):
+        ws = await jp_ws_fetch("lab", "api", "filewatch")
+        await ws.write_message(json.dumps({"msgType": "subscribe", "path": "race.txt"}))
+        # Modify the file DURING the setup-grace window.
+        await asyncio.sleep(0.02)
+        target.write_text("v2")
+
+        # The catch-up step inside _subscribe should produce a synthetic
+        # 'modified' message after the grace window elapses.
+        raw = await asyncio.wait_for(ws.read_message(), timeout=2.0)
+        msg = json.loads(raw)
+        assert msg["msgType"] == "changed"
+        assert msg["path"] == "race.txt"
+        assert msg["eventType"] == "modified"
+        ws.close()
+
+
+async def test_close_stops_all_observers(file_watch_app, jp_ws_fetch, jp_root_dir):
+    """Closing the WebSocket stops all active observers."""
+    (jp_root_dir / "file_a.txt").write_text("a")
+    (jp_root_dir / "file_b.txt").write_text("b")
+
+    observers: list = []
+
+    def make_observer():
+        obs = MagicMock()
+        observers.append(obs)
+        return obs
+
+    with (
+        patch("jupyterlab.handlers.file_watch_handler.WATCHDOG_AVAILABLE", True),
+        patch(
+            "jupyterlab.handlers.file_watch_handler.Observer",
+            side_effect=make_observer,
+            create=True,
+        ),
+    ):
+        ws = await jp_ws_fetch("lab", "api", "filewatch")
+        await ws.write_message(json.dumps({"msgType": "subscribe", "path": "file_a.txt"}))
+        await ws.write_message(json.dumps({"msgType": "subscribe", "path": "file_b.txt"}))
+        await asyncio.sleep(0.05)
+
+        ws.close()
+        await asyncio.sleep(0.05)
+
+        assert len(observers) == 2
+        for obs in observers:
+            assert obs.stop.called
+
+
+# ---------------------------------------------------------------------------
+# Integration test — requires watchdog installed, skipped otherwise
+# ---------------------------------------------------------------------------
+
+
+async def test_real_file_change_detected(file_watch_app, jp_ws_fetch, jp_root_dir):
+    """End-to-end: modifying a real file triggers a 'changed' WebSocket message."""
+    pytest.importorskip("watchdog", reason="watchdog not installed")
+    target = jp_root_dir / "real_watch.txt"
+    target.write_text("version1")
+
+    ws = await jp_ws_fetch("lab", "api", "filewatch")
+    await ws.write_message(json.dumps({"msgType": "subscribe", "path": "real_watch.txt"}))
+    # Give watchdog time to set up the OS watch
+    await asyncio.sleep(0.5)
+
+    target.write_text("version2")
+
+    # Wait up to 3 s for the notification
+    try:
+        raw = await asyncio.wait_for(ws.read_message(), timeout=3.0)
+    except asyncio.TimeoutError:  # pragma: no cover
+        pytest.fail("No 'changed' message received within 3 seconds")
+
+    msg = json.loads(raw)
+    assert msg["msgType"] == "changed"
+    assert msg["path"] == "real_watch.txt"
+    assert msg["eventType"] == "modified"
+    ws.close()

--- a/packages/docmanager-extension/schema/plugin.json
+++ b/packages/docmanager-extension/schema/plugin.json
@@ -156,6 +156,18 @@
       "description": "Number of recently opened/closed files and directories to remember.",
       "default": 10,
       "minimum": 0
+    },
+    "watchForExternalChanges": {
+      "type": "boolean",
+      "title": "Watch for External File Changes",
+      "description": "Use OS-level filesystem notifications to detect when open files are modified externally. Requires the Python 'watchdog' package.",
+      "default": true
+    },
+    "externalChangeAutoReload": {
+      "type": "boolean",
+      "title": "Auto-Reload on External Change",
+      "description": "Automatically reload files changed externally when they have no unsaved edits. When false, always shows a notification instead.",
+      "default": true
     }
   },
   "additionalProperties": false,

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -31,9 +31,12 @@ import { PathExt, Time } from '@jupyterlab/coreutils';
 import {
   DocumentManager,
   DocumentManagerDialogs,
+  FileWatchController,
+  FileWatcherService,
   IDocumentManager,
   IDocumentManagerDialogs,
   IDocumentWidgetOpener,
+  IFileWatcherService,
   IRecentsManager,
   PathStatus,
   SavingStatus
@@ -601,6 +604,91 @@ export const openBrowserTabPlugin: JupyterFrontEndPlugin<void> = {
 };
 
 /**
+ * A plugin that detects external file changes via OS-level filesystem
+ * notifications and either auto-reloads or notifies the user.
+ */
+const fileWatcherPlugin: JupyterFrontEndPlugin<IFileWatcherService> = {
+  id: '@jupyterlab/docmanager-extension:file-watcher',
+  description:
+    'Detects external file changes via OS-level filesystem notifications.',
+  autoStart: true,
+  provides: IFileWatcherService,
+  requires: [IDocumentManager, IDocumentWidgetOpener, ISettingRegistry],
+  optional: [ITranslator, ILabShell],
+  activate: (
+    app: JupyterFrontEnd,
+    docManager: IDocumentManager,
+    widgetOpener: IDocumentWidgetOpener,
+    settingRegistry: ISettingRegistry,
+    translator: ITranslator | null,
+    labShell: ILabShell | null
+  ): IFileWatcherService => {
+    const trans = (translator ?? nullTranslator).load('jupyterlab');
+
+    const service = new FileWatcherService({
+      serverSettings: app.serviceManager.serverSettings
+    });
+
+    // Settings — read up-front so the controller always has a snapshot.
+    let watchEnabled = true;
+    let autoReload = true;
+    void settingRegistry
+      .load(docManagerPluginId)
+      .then(settings => {
+        const applySettings = () => {
+          watchEnabled = settings.get('watchForExternalChanges')
+            .composite as boolean;
+          autoReload = settings.get('externalChangeAutoReload')
+            .composite as boolean;
+        };
+        applySettings();
+        settings.changed.connect(applySettings);
+      })
+      .catch(console.error);
+
+    const controller = new FileWatchController({
+      service,
+      getSettings: () => ({ watchEnabled, autoReload }),
+      notifyDeleted: path => {
+        Notification.warning(trans.__('"%1" was deleted on disk.', path), {
+          autoClose: false
+        });
+      },
+      notifyChanged: (path, reload) => {
+        Notification.info(trans.__('"%1" was changed on disk.', path), {
+          autoClose: 8000,
+          actions: [{ label: trans.__('Reload'), callback: reload }]
+        });
+      }
+    });
+
+    widgetOpener.opened.connect((_, widget) => {
+      const context = docManager.contextForWidget(widget);
+      if (context) {
+        controller.track(context);
+      }
+    });
+
+    // When JupyterLab restores the previous session, widgets are opened
+    // before this plugin activates and the opened signal is missed.
+    // Iterate existing widgets after restore to catch them.
+    void app.restored.then(() => {
+      if (!labShell) {
+        return;
+      }
+      for (const widget of labShell.widgets('main')) {
+        const context = docManager.contextForWidget(widget);
+        if (context) {
+          controller.track(context);
+        }
+      }
+    });
+
+    return service;
+  }
+};
+
+/**
  * A plugin that provides the default dialogs for three document management operations:
  * Rename, Confirm Close, and Save Before Close.
  *
@@ -630,6 +718,7 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   openBrowserTabPlugin,
   openerPlugin,
   recentsManagerPlugin,
+  fileWatcherPlugin,
   dialogsPlugin
 ];
 export default plugins;

--- a/packages/docmanager/src/filewatcher.ts
+++ b/packages/docmanager/src/filewatcher.ts
@@ -1,0 +1,450 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { URLExt } from '@jupyterlab/coreutils';
+import type { DocumentRegistry } from '@jupyterlab/docregistry';
+import type { ServerConnection } from '@jupyterlab/services';
+import type { IDisposable } from '@lumino/disposable';
+import type { ISignal } from '@lumino/signaling';
+import { Signal } from '@lumino/signaling';
+
+import type { IFileWatcherService } from './tokens';
+
+const FILE_WATCH_URL = 'lab/api/filewatch';
+
+/**
+ * Namespace for FileWatcher types.
+ */
+export namespace FileWatcher {
+  /**
+   * Arguments emitted when a watched file changes on disk.
+   */
+  export interface IChangedArgs {
+    /** Relative path as supplied to subscribe(). */
+    path: string;
+    /** 'modified' | 'deleted' | 'moved' */
+    eventType: string;
+  }
+
+  /**
+   * Options for constructing a FileWatcherService.
+   */
+  export interface IOptions {
+    serverSettings: ServerConnection.ISettings;
+  }
+}
+
+/**
+ * A service that connects to the backend WebSocket endpoint and notifies
+ * subscribers when watched files change on disk via OS-level notifications
+ * (inotify on Linux, FSEvents on macOS).
+ */
+export class FileWatcherService implements IDisposable {
+  constructor(options: FileWatcher.IOptions) {
+    this._serverSettings = options.serverSettings;
+    this._connect();
+  }
+
+  /**
+   * Whether the service has been disposed.
+   */
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
+  /**
+   * Whether the backend watchdog library is available.
+   * False if the server sent an 'unavailable' message.
+   */
+  get isAvailable(): boolean {
+    return this._isAvailable;
+  }
+
+  /**
+   * Signal emitted when a subscribed file changes externally.
+   */
+  get fileChanged(): ISignal<this, FileWatcher.IChangedArgs> {
+    return this._fileChanged;
+  }
+
+  /**
+   * Subscribe to change events for a specific relative path.
+   */
+  subscribe(path: string): void {
+    if (this._isDisposed || !this._isAvailable) {
+      return;
+    }
+    this._subscriptions.add(path);
+    this._sendIfOpen({ msgType: 'subscribe', path });
+  }
+
+  /**
+   * Unsubscribe from change events for a specific relative path.
+   */
+  unsubscribe(path: string): void {
+    if (this._isDisposed) {
+      return;
+    }
+    this._subscriptions.delete(path);
+    this._sendIfOpen({ msgType: 'unsubscribe', path });
+  }
+
+  /**
+   * Dispose of the service and close the WebSocket.
+   */
+  dispose(): void {
+    if (this._isDisposed) {
+      return;
+    }
+    this._isDisposed = true;
+    clearTimeout(this._reconnectTimer);
+    if (this._socket) {
+      this._socket.onclose = null;
+      this._socket.close();
+      this._socket = null;
+    }
+    Signal.clearData(this);
+  }
+
+  // ------------------------------------------------------------------ //
+  // Private
+  // ------------------------------------------------------------------ //
+
+  private _connect(): void {
+    if (this._isDisposed || !this._isAvailable) {
+      return;
+    }
+
+    const { appendToken, token, WebSocket: WS, wsUrl } = this._serverSettings;
+    let url = URLExt.join(wsUrl, FILE_WATCH_URL);
+    if (appendToken && token !== '') {
+      url += `?token=${encodeURIComponent(token)}`;
+    }
+
+    const socket = (this._socket = new WS(url));
+
+    socket.onopen = () => {
+      // Reset back-off so a future disconnect retries quickly again.
+      this._reconnectDelay = 1000;
+      // Replay all subscriptions after (re)connect.
+      for (const path of this._subscriptions) {
+        this._sendIfOpen({ msgType: 'subscribe', path });
+      }
+    };
+
+    socket.onmessage = (evt: MessageEvent) => {
+      this._onMessage(evt.data as string);
+    };
+
+    socket.onclose = () => {
+      this._socket = null;
+      if (!this._isDisposed && this._isAvailable) {
+        this._scheduleReconnect();
+      }
+    };
+
+    socket.onerror = () => {
+      // onclose will fire after onerror; reconnect logic lives there.
+    };
+  }
+
+  private _onMessage(raw: string): void {
+    let msg: Record<string, string>;
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      return;
+    }
+
+    switch (msg['msgType']) {
+      case 'changed':
+        this._fileChanged.emit({
+          path: msg['path'],
+          eventType: msg['eventType']
+        });
+        break;
+
+      case 'unavailable':
+        this._isAvailable = false;
+        console.info(
+          '[JupyterLab] File watch unavailable: watchdog is not installed on the server. ' +
+            'Install it with: pip install watchdog'
+        );
+        break;
+
+      case 'error':
+        console.warn('[JupyterLab] FileWatchHandler error:', msg['message']);
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  private _scheduleReconnect(): void {
+    clearTimeout(this._reconnectTimer);
+    this._reconnectTimer = window.setTimeout(() => {
+      if (!this._isDisposed && this._isAvailable) {
+        this._connect();
+      }
+    }, this._reconnectDelay);
+    // Exponential back-off capped at 30 s.
+    this._reconnectDelay = Math.min(this._reconnectDelay * 2, 30_000);
+  }
+
+  private _sendIfOpen(msg: Record<string, string>): void {
+    if (this._socket && this._socket.readyState === WebSocket.OPEN) {
+      this._socket.send(JSON.stringify(msg));
+    }
+  }
+
+  private readonly _serverSettings: ServerConnection.ISettings;
+  private readonly _fileChanged = new Signal<this, FileWatcher.IChangedArgs>(
+    this
+  );
+  private _socket: WebSocket | null = null;
+  private _subscriptions = new Set<string>();
+  private _isAvailable = true;
+  private _isDisposed = false;
+  private _reconnectDelay = 1000;
+  private _reconnectTimer = -1;
+}
+
+/**
+ * Orchestrates the response to OS-level file change events for documents
+ * that are open in the application.
+ *
+ * Responsibilities:
+ *   - Subscribe and unsubscribe paths on the {@link IFileWatcherService}
+ *     as document contexts are tracked or disposed.
+ *   - Decide what to do on an external change: silent revert (clean +
+ *     autoReload), inform the user (clean + !autoReload), or trigger the
+ *     existing save-conflict modal (dirty).
+ *   - Suppress watchdog echoes that follow a context-initiated save.
+ */
+export class FileWatchController implements IDisposable {
+  constructor(options: FileWatchController.IOptions) {
+    this._service = options.service;
+    this._getSettings = options.getSettings;
+    this._notifyDeleted = options.notifyDeleted;
+    this._notifyChanged = options.notifyChanged;
+
+    this._service.fileChanged.connect(this._onFileChanged, this);
+  }
+
+  /**
+   * Whether the controller has been disposed.
+   */
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
+  /**
+   * Start tracking a document context: subscribes the path on the file
+   * watcher service and hooks into the context's lifecycle so that future
+   * external changes drive the appropriate UI flow.
+   *
+   * Safe to call multiple times with the same context.
+   */
+  track(context: DocumentRegistry.Context): void {
+    if (this._isDisposed) {
+      return;
+    }
+    const path = context.path;
+    const existing = this._contextsByPath.get(path) ?? [];
+    if (existing.includes(context)) {
+      return;
+    }
+    existing.push(context);
+    this._contextsByPath.set(path, existing);
+    this._service.subscribe(path);
+
+    context.disposed.connect(this._onContextDisposed, this);
+    context.saveState.connect(this._onSaveState, this);
+    context.pathChanged.connect(this._onPathChanged, this);
+  }
+
+  /**
+   * Dispose of the controller; unsubscribes all paths and detaches listeners.
+   */
+  dispose(): void {
+    if (this._isDisposed) {
+      return;
+    }
+    this._isDisposed = true;
+    this._service.fileChanged.disconnect(this._onFileChanged, this);
+    for (const [path, contexts] of this._contextsByPath) {
+      this._service.unsubscribe(path);
+      for (const context of contexts) {
+        context.disposed.disconnect(this._onContextDisposed, this);
+        context.saveState.disconnect(this._onSaveState, this);
+        context.pathChanged.disconnect(this._onPathChanged, this);
+      }
+    }
+    this._contextsByPath.clear();
+    this._suppressUntil.clear();
+  }
+
+  // ------------------------------------------------------------------ //
+  // Private
+  // ------------------------------------------------------------------ //
+
+  private _onFileChanged(
+    _: IFileWatcherService,
+    args: FileWatcher.IChangedArgs
+  ): void {
+    const { path, eventType } = args;
+    const { watchEnabled, autoReload } = this._getSettings();
+    if (!watchEnabled) {
+      return;
+    }
+    const until = this._suppressUntil.get(path);
+    if (until !== undefined) {
+      if (Date.now() < until) {
+        return;
+      }
+      this._suppressUntil.delete(path);
+    }
+    const contexts = this._contextsByPath.get(path) ?? [];
+    for (const context of contexts) {
+      if (eventType === 'deleted') {
+        this._notifyDeleted(path);
+        continue;
+      }
+      if (context.model.dirty) {
+        // Open the suppression window now to absorb any multi-event burst
+        // from this single external change while the conflict modal is open.
+        this._suppressUntil.set(
+          path,
+          Date.now() + FileWatchController.SUPPRESS_WINDOW_MS
+        );
+        // Trigger the existing _maybeSave -> _raiseConflict flow:
+        // the Cancel/Revert/Overwrite modal handles the user decision.
+        // ModalCancelError / ModalDuplicateError are expected here.
+        void context.save().catch(() => {
+          /* user cancelled or modal already open — nothing to do */
+        });
+      } else if (autoReload) {
+        void context.revert();
+      } else {
+        this._notifyChanged(path, () => void context.revert());
+      }
+    }
+  }
+
+  private _onContextDisposed(context: DocumentRegistry.Context): void {
+    const path = context.path;
+    const remaining = (this._contextsByPath.get(path) ?? []).filter(
+      c => c !== context
+    );
+    if (remaining.length === 0) {
+      this._contextsByPath.delete(path);
+      this._service.unsubscribe(path);
+      this._suppressUntil.delete(path);
+    } else {
+      this._contextsByPath.set(path, remaining);
+    }
+  }
+
+  private _onPathChanged(
+    context: DocumentRegistry.Context,
+    newPath: string
+  ): void {
+    // Find the path the context was tracked under (the OLD path).
+    let oldPath: string | undefined;
+    for (const [path, contexts] of this._contextsByPath) {
+      if (contexts.includes(context)) {
+        oldPath = path;
+        break;
+      }
+    }
+    if (oldPath === undefined || oldPath === newPath) {
+      return;
+    }
+    // Remove from the old bucket; unsubscribe if it becomes empty.
+    const oldRemaining = (this._contextsByPath.get(oldPath) ?? []).filter(
+      c => c !== context
+    );
+    if (oldRemaining.length === 0) {
+      this._contextsByPath.delete(oldPath);
+      this._service.unsubscribe(oldPath);
+      this._suppressUntil.delete(oldPath);
+    } else {
+      this._contextsByPath.set(oldPath, oldRemaining);
+    }
+    // Add to the new bucket; subscribe if the path is fresh.
+    const newBucket = this._contextsByPath.get(newPath) ?? [];
+    if (!newBucket.includes(context)) {
+      const fresh = newBucket.length === 0;
+      newBucket.push(context);
+      this._contextsByPath.set(newPath, newBucket);
+      if (fresh) {
+        this._service.subscribe(newPath);
+      }
+    }
+  }
+
+  private _onSaveState(
+    context: DocumentRegistry.Context,
+    state: DocumentRegistry.SaveState
+  ): void {
+    // revert() does not emit saveState, so a genuine external change
+    // following a revert is not falsely suppressed.
+    if (state === 'completed') {
+      this._suppressUntil.set(
+        context.path,
+        Date.now() + FileWatchController.SUPPRESS_WINDOW_MS
+      );
+    }
+  }
+
+  private readonly _service: IFileWatcherService;
+  private readonly _getSettings: () => FileWatchController.ISettings;
+  private readonly _notifyDeleted: (path: string) => void;
+  private readonly _notifyChanged: (path: string, reload: () => void) => void;
+  private readonly _contextsByPath = new Map<
+    string,
+    DocumentRegistry.Context[]
+  >();
+  private readonly _suppressUntil = new Map<string, number>();
+  private _isDisposed = false;
+}
+
+/**
+ * Namespace for FileWatchController types.
+ */
+export namespace FileWatchController {
+  /**
+   * Echo-suppression window in milliseconds. Absorbs the watchdog echo
+   * that follows a context-initiated save and the multi-event burst many
+   * editors emit per write.
+   */
+  export const SUPPRESS_WINDOW_MS = 1000;
+
+  /**
+   * Plugin-provided settings snapshot, read once per event.
+   */
+  export interface ISettings {
+    /** Master switch; if false, no reaction happens to file change events. */
+    watchEnabled: boolean;
+    /** If true, clean files revert silently; if false, the user is notified. */
+    autoReload: boolean;
+  }
+
+  /**
+   * Constructor options.
+   */
+  export interface IOptions {
+    /** The file watcher service to listen to. */
+    service: IFileWatcherService;
+    /** Called on every event to retrieve the current settings. */
+    getSettings(): ISettings;
+    /** Display a "file was deleted on disk" notification. */
+    notifyDeleted(path: string): void;
+    /**
+     * Display a "file changed on disk; reload?" notification. The reload
+     * callback should perform the actual context.revert().
+     */
+    notifyChanged(path: string, reload: () => void): void;
+  }
+}

--- a/packages/docmanager/src/index.ts
+++ b/packages/docmanager/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 export * from './dialogs';
+export * from './filewatcher';
 export * from './manager';
 export * from './pathstatus';
 export * from './savehandler';

--- a/packages/docmanager/src/tokens.ts
+++ b/packages/docmanager/src/tokens.ts
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { ISessionContext } from '@jupyterlab/apputils';
+import type { FileWatcher } from './filewatcher';
 import type { IChangedArgs } from '@jupyterlab/coreutils';
 import type {
   DocumentRegistry,
@@ -460,3 +461,36 @@ export type RecentDocument = {
    */
   factory?: string;
 };
+
+/**
+ * The file watcher service token.
+ */
+export const IFileWatcherService = new Token<IFileWatcherService>(
+  '@jupyterlab/docmanager:IFileWatcherService',
+  'A service that detects external file changes via OS-level filesystem notifications.'
+);
+
+/**
+ * The interface for the file watcher service.
+ */
+export interface IFileWatcherService extends IDisposable {
+  /**
+   * Whether the backend watchdog library is available.
+   */
+  readonly isAvailable: boolean;
+
+  /**
+   * Signal emitted when a subscribed file changes on disk.
+   */
+  readonly fileChanged: ISignal<this, FileWatcher.IChangedArgs>;
+
+  /**
+   * Subscribe to change events for a file path.
+   */
+  subscribe(path: string): void;
+
+  /**
+   * Unsubscribe from change events for a file path.
+   */
+  unsubscribe(path: string): void;
+}

--- a/packages/docmanager/test/filewatcher.spec.ts
+++ b/packages/docmanager/test/filewatcher.spec.ts
@@ -1,0 +1,643 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { ServerConnection } from '@jupyterlab/services';
+import { signalToPromise } from '@jupyterlab/testing';
+import { Signal } from '@lumino/signaling';
+import type { FileWatcher, IFileWatcherService } from '../src';
+import { FileWatchController, FileWatcherService } from '../src';
+
+// ---------------------------------------------------------------------------
+// MockWebSocket — replaces the real WebSocket in serverSettings
+// ---------------------------------------------------------------------------
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  readyState = WebSocket.OPEN;
+  onopen: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  sentMessages: string[] = [];
+
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this);
+    // Trigger onopen on the next microtask (mirrors real WebSocket behaviour)
+    void Promise.resolve().then(() => this.onopen?.());
+  }
+
+  send(data: string): void {
+    this.sentMessages.push(data);
+  }
+
+  close(): void {
+    this.onclose?.();
+  }
+
+  /** Simulate a server → client push message. */
+  push(payload: Record<string, string>): void {
+    this.onmessage?.({ data: JSON.stringify(payload) });
+  }
+}
+
+function makeSettings(): ServerConnection.ISettings {
+  return ServerConnection.makeSettings({
+    WebSocket: MockWebSocket as unknown as typeof WebSocket
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('FileWatcherService', () => {
+  let service: FileWatcherService;
+
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    service?.dispose();
+    jest.useRealTimers();
+  });
+
+  // ---- construction -------------------------------------------------------
+
+  describe('#constructor()', () => {
+    it('should connect to the correct URL', async () => {
+      service = new FileWatcherService({ serverSettings: makeSettings() });
+      await Promise.resolve(); // flush onopen microtask
+      expect(MockWebSocket.instances).toHaveLength(1);
+      expect(MockWebSocket.instances[0].url).toContain('lab/api/filewatch');
+    });
+
+    it('should start with isAvailable=true', () => {
+      service = new FileWatcherService({ serverSettings: makeSettings() });
+      expect(service.isAvailable).toBe(true);
+    });
+
+    it('should start with isDisposed=false', () => {
+      service = new FileWatcherService({ serverSettings: makeSettings() });
+      expect(service.isDisposed).toBe(false);
+    });
+  });
+
+  // ---- subscribe / unsubscribe --------------------------------------------
+
+  describe('#subscribe()', () => {
+    it('should send a subscribe message', async () => {
+      service = new FileWatcherService({ serverSettings: makeSettings() });
+      await Promise.resolve();
+      service.subscribe('notebooks/analysis.ipynb');
+      const parsed = MockWebSocket.instances[0].sentMessages.map(m =>
+        JSON.parse(m)
+      );
+      expect(parsed).toContainEqual({
+        msgType: 'subscribe',
+        path: 'notebooks/analysis.ipynb'
+      });
+    });
+  });
+
+  describe('#unsubscribe()', () => {
+    it('should send an unsubscribe message', async () => {
+      service = new FileWatcherService({ serverSettings: makeSettings() });
+      await Promise.resolve();
+      service.subscribe('test.ipynb');
+      service.unsubscribe('test.ipynb');
+      const parsed = MockWebSocket.instances[0].sentMessages.map(m =>
+        JSON.parse(m)
+      );
+      expect(parsed).toContainEqual({
+        msgType: 'unsubscribe',
+        path: 'test.ipynb'
+      });
+    });
+  });
+
+  // ---- incoming messages --------------------------------------------------
+
+  describe('#fileChanged signal', () => {
+    it('should emit on a changed message', async () => {
+      service = new FileWatcherService({ serverSettings: makeSettings() });
+      await Promise.resolve();
+      service.subscribe('notebook.ipynb');
+
+      const promise = signalToPromise(service.fileChanged);
+      MockWebSocket.instances[0].push({
+        msgType: 'changed',
+        path: 'notebook.ipynb',
+        eventType: 'modified'
+      });
+
+      const [, args] = await promise;
+      expect(args.path).toBe('notebook.ipynb');
+      expect(args.eventType).toBe('modified');
+    });
+
+    it('should emit with eventType=deleted for deleted files', async () => {
+      service = new FileWatcherService({ serverSettings: makeSettings() });
+      await Promise.resolve();
+      service.subscribe('gone.txt');
+
+      const promise = signalToPromise(service.fileChanged);
+      MockWebSocket.instances[0].push({
+        msgType: 'changed',
+        path: 'gone.txt',
+        eventType: 'deleted'
+      });
+
+      const [, args] = await promise;
+      expect(args.eventType).toBe('deleted');
+    });
+  });
+
+  // ---- unavailable --------------------------------------------------------
+
+  describe('unavailable message', () => {
+    it('should set isAvailable=false', async () => {
+      service = new FileWatcherService({ serverSettings: makeSettings() });
+      await Promise.resolve();
+      MockWebSocket.instances[0].push({
+        msgType: 'unavailable',
+        reason: 'watchdog is not installed'
+      });
+      expect(service.isAvailable).toBe(false);
+    });
+
+    it('should not reconnect after unavailable', async () => {
+      service = new FileWatcherService({ serverSettings: makeSettings() });
+      await Promise.resolve();
+      MockWebSocket.instances[0].push({
+        msgType: 'unavailable',
+        reason: 'watchdog is not installed'
+      });
+      // Simulate socket close after unavailable
+      MockWebSocket.instances[0].close();
+      jest.advanceTimersByTime(60_000);
+      // No new WebSocket should have been created
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+  });
+
+  // ---- reconnect ----------------------------------------------------------
+
+  describe('reconnection', () => {
+    it('should reconnect after socket closes', async () => {
+      service = new FileWatcherService({ serverSettings: makeSettings() });
+      await Promise.resolve();
+
+      MockWebSocket.instances[0].close(); // triggers scheduleReconnect
+      jest.advanceTimersByTime(1100); // past 1 s initial delay
+      await Promise.resolve(); // flush onopen
+
+      expect(MockWebSocket.instances).toHaveLength(2);
+    });
+
+    it('should replay subscriptions on reconnect', async () => {
+      service = new FileWatcherService({ serverSettings: makeSettings() });
+      await Promise.resolve();
+      service.subscribe('a.ipynb');
+      service.subscribe('b.ipynb');
+
+      MockWebSocket.instances[0].close();
+      jest.advanceTimersByTime(1100);
+      await Promise.resolve();
+
+      const ws2 = MockWebSocket.instances[1];
+      const msgs = ws2.sentMessages.map(
+        m => JSON.parse(m) as Record<string, string>
+      );
+      const subscribed = msgs
+        .filter(m => m['msgType'] === 'subscribe')
+        .map(m => m['path']);
+      expect(subscribed).toContain('a.ipynb');
+      expect(subscribed).toContain('b.ipynb');
+    });
+
+    it('should reset back-off after a successful reconnect', async () => {
+      service = new FileWatcherService({ serverSettings: makeSettings() });
+      await Promise.resolve();
+
+      // First close → reconnect after 1 s (initial delay)
+      MockWebSocket.instances[0].close();
+      jest.advanceTimersByTime(1001);
+      await Promise.resolve(); // flush onopen → resets delay
+      expect(MockWebSocket.instances).toHaveLength(2);
+
+      // Second close → since delay was reset on onopen, reconnect again at 1 s
+      MockWebSocket.instances[1].close();
+      jest.advanceTimersByTime(999);
+      expect(MockWebSocket.instances).toHaveLength(2); // not yet
+
+      jest.advanceTimersByTime(2);
+      await Promise.resolve();
+      expect(MockWebSocket.instances).toHaveLength(3);
+    });
+  });
+
+  // ---- dispose ------------------------------------------------------------
+
+  describe('#dispose()', () => {
+    it('should set isDisposed=true', () => {
+      service = new FileWatcherService({ serverSettings: makeSettings() });
+      service.dispose();
+      expect(service.isDisposed).toBe(true);
+    });
+
+    it('should not reconnect after dispose', async () => {
+      service = new FileWatcherService({ serverSettings: makeSettings() });
+      await Promise.resolve();
+      service.dispose();
+      jest.advanceTimersByTime(60_000);
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+
+    it('should be idempotent', () => {
+      service = new FileWatcherService({ serverSettings: makeSettings() });
+      expect(() => {
+        service.dispose();
+        service.dispose();
+      }).not.toThrow();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FileWatchController tests
+// ---------------------------------------------------------------------------
+
+/** Minimal service double that lets us drive fileChanged from tests. */
+class FakeService implements IFileWatcherService {
+  readonly fileChanged = new Signal<this, FileWatcher.IChangedArgs>(this);
+  readonly isAvailable = true;
+  isDisposed = false;
+  subscribed: string[] = [];
+  unsubscribed: string[] = [];
+
+  subscribe(path: string): void {
+    this.subscribed.push(path);
+  }
+  unsubscribe(path: string): void {
+    this.unsubscribed.push(path);
+  }
+  dispose(): void {
+    this.isDisposed = true;
+    Signal.clearData(this);
+  }
+  /** Helper to push a change event to the controller. */
+  emit(args: FileWatcher.IChangedArgs): void {
+    this.fileChanged.emit(args);
+  }
+}
+
+/** Minimal DocumentRegistry.Context double exposing only what the controller uses. */
+class FakeContext {
+  readonly disposed = new Signal<this, void>(this);
+  readonly saveState = new Signal<this, string>(this);
+  readonly pathChanged = new Signal<this, string>(this);
+  model = { dirty: false };
+  save = jest.fn(() => Promise.resolve());
+  revert = jest.fn(() => Promise.resolve());
+
+  constructor(public path: string) {}
+
+  dispose(): void {
+    this.disposed.emit();
+  }
+  /** Simulate a rename — updates the path and emits pathChanged. */
+  rename(newPath: string): void {
+    this.path = newPath;
+    this.pathChanged.emit(newPath);
+  }
+  /** Trigger a saveState transition (only 'completed' matters to the controller). */
+  emitSaveState(state: string): void {
+    this.saveState.emit(state);
+  }
+}
+
+function makeController(opts: {
+  service: FakeService;
+  watchEnabled?: boolean;
+  autoReload?: boolean;
+}): {
+  controller: FileWatchController;
+  notifyDeleted: jest.Mock;
+  notifyChanged: jest.Mock;
+} {
+  const notifyDeleted = jest.fn();
+  const notifyChanged = jest.fn();
+  const controller = new FileWatchController({
+    service: opts.service,
+    getSettings: () => ({
+      watchEnabled: opts.watchEnabled ?? true,
+      autoReload: opts.autoReload ?? true
+    }),
+    notifyDeleted,
+    notifyChanged
+  });
+  return { controller, notifyDeleted, notifyChanged };
+}
+
+describe('FileWatchController', () => {
+  let service: FakeService;
+
+  beforeEach(() => {
+    service = new FakeService();
+    jest.useFakeTimers().setSystemTime(new Date('2025-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // ---- track() ------------------------------------------------------------
+
+  describe('#track()', () => {
+    it('should subscribe the path on the service', () => {
+      const { controller } = makeController({ service });
+      controller.track(new FakeContext('a.txt') as any);
+      expect(service.subscribed).toEqual(['a.txt']);
+    });
+
+    it('should be a no-op if the same context is tracked twice', () => {
+      const { controller } = makeController({ service });
+      const ctx = new FakeContext('a.txt');
+      controller.track(ctx as any);
+      controller.track(ctx as any);
+      expect(service.subscribed).toEqual(['a.txt']);
+    });
+
+    it('should unsubscribe when the only context for a path is disposed', () => {
+      const { controller } = makeController({ service });
+      const ctx = new FakeContext('a.txt');
+      controller.track(ctx as any);
+      ctx.dispose();
+      expect(service.unsubscribed).toEqual(['a.txt']);
+    });
+
+    it('should keep the subscription when a second context for the same path is open', () => {
+      const { controller } = makeController({ service });
+      const ctx1 = new FakeContext('a.txt');
+      const ctx2 = new FakeContext('a.txt');
+      controller.track(ctx1 as any);
+      controller.track(ctx2 as any);
+      ctx1.dispose();
+      expect(service.unsubscribed).toEqual([]);
+      ctx2.dispose();
+      expect(service.unsubscribed).toEqual(['a.txt']);
+    });
+  });
+
+  // ---- clean files -------------------------------------------------------
+
+  describe('clean file reaction', () => {
+    it('should silently revert when autoReload=true', () => {
+      const { controller } = makeController({ service, autoReload: true });
+      const ctx = new FakeContext('a.txt');
+      controller.track(ctx as any);
+      service.emit({ path: 'a.txt', eventType: 'modified' });
+      expect(ctx.revert).toHaveBeenCalledTimes(1);
+      expect(ctx.save).not.toHaveBeenCalled();
+    });
+
+    it('should notify with a reload callback when autoReload=false', () => {
+      const { controller, notifyChanged } = makeController({
+        service,
+        autoReload: false
+      });
+      const ctx = new FakeContext('a.txt');
+      controller.track(ctx as any);
+      service.emit({ path: 'a.txt', eventType: 'modified' });
+      expect(notifyChanged).toHaveBeenCalledTimes(1);
+      expect(notifyChanged).toHaveBeenCalledWith('a.txt', expect.any(Function));
+      expect(ctx.revert).not.toHaveBeenCalled();
+
+      // The reload callback should call context.revert().
+      const reloadCb = notifyChanged.mock.calls[0][1];
+      reloadCb();
+      expect(ctx.revert).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---- dirty files -------------------------------------------------------
+
+  describe('dirty file reaction', () => {
+    it('should call context.save() to trigger the conflict modal', () => {
+      const { controller } = makeController({ service });
+      const ctx = new FakeContext('a.txt');
+      ctx.model.dirty = true;
+      controller.track(ctx as any);
+      service.emit({ path: 'a.txt', eventType: 'modified' });
+      expect(ctx.save).toHaveBeenCalledTimes(1);
+      expect(ctx.revert).not.toHaveBeenCalled();
+    });
+
+    it('should swallow rejected save() (user cancelled / modal already open)', async () => {
+      const { controller } = makeController({ service });
+      const ctx = new FakeContext('a.txt');
+      ctx.model.dirty = true;
+      ctx.save.mockRejectedValueOnce(new Error('ModalCancelError'));
+      controller.track(ctx as any);
+      expect(() =>
+        service.emit({ path: 'a.txt', eventType: 'modified' })
+      ).not.toThrow();
+      // Wait for the .catch() to run.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  });
+
+  // ---- rename ------------------------------------------------------------
+
+  describe('rename reaction', () => {
+    it('should unsubscribe the old path and subscribe the new one', () => {
+      const { controller } = makeController({ service });
+      const ctx = new FakeContext('untitled.txt');
+      controller.track(ctx as any);
+      expect(service.subscribed).toEqual(['untitled.txt']);
+
+      ctx.rename('notes.txt');
+      expect(service.unsubscribed).toEqual(['untitled.txt']);
+      expect(service.subscribed).toEqual(['untitled.txt', 'notes.txt']);
+    });
+
+    it('should react to external changes at the new path after rename', () => {
+      const { controller } = makeController({ service });
+      const ctx = new FakeContext('untitled.txt');
+      controller.track(ctx as any);
+      ctx.rename('notes.txt');
+
+      // An event at the OLD path must NOT trigger anything.
+      service.emit({ path: 'untitled.txt', eventType: 'modified' });
+      expect(ctx.revert).not.toHaveBeenCalled();
+
+      // An event at the NEW path must trigger the revert.
+      service.emit({ path: 'notes.txt', eventType: 'modified' });
+      expect(ctx.revert).toHaveBeenCalledTimes(1);
+    });
+
+    it('should be a no-op when rename emits the same path', () => {
+      const { controller } = makeController({ service });
+      const ctx = new FakeContext('a.txt');
+      controller.track(ctx as any);
+      ctx.rename('a.txt');
+      expect(service.unsubscribed).toEqual([]);
+      expect(service.subscribed).toEqual(['a.txt']);
+    });
+  });
+
+  // ---- moved -------------------------------------------------------------
+
+  describe('moved reaction', () => {
+    it('should treat a clean moved file the same as modified (revert when autoReload=true)', () => {
+      const { controller } = makeController({ service, autoReload: true });
+      const ctx = new FakeContext('a.txt');
+      controller.track(ctx as any);
+      service.emit({ path: 'a.txt', eventType: 'moved' });
+      expect(ctx.revert).toHaveBeenCalledTimes(1);
+    });
+
+    it('should treat a dirty moved file the same as modified (trigger save)', () => {
+      const { controller } = makeController({ service });
+      const ctx = new FakeContext('a.txt');
+      ctx.model.dirty = true;
+      controller.track(ctx as any);
+      service.emit({ path: 'a.txt', eventType: 'moved' });
+      expect(ctx.save).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---- deleted -----------------------------------------------------------
+
+  describe('deleted reaction', () => {
+    it('should call notifyDeleted and not touch save/revert', () => {
+      const { controller, notifyDeleted } = makeController({ service });
+      const ctx = new FakeContext('a.txt');
+      controller.track(ctx as any);
+      service.emit({ path: 'a.txt', eventType: 'deleted' });
+      expect(notifyDeleted).toHaveBeenCalledWith('a.txt');
+      expect(ctx.save).not.toHaveBeenCalled();
+      expect(ctx.revert).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---- settings ----------------------------------------------------------
+
+  describe('settings', () => {
+    it('should ignore events when watchEnabled=false', () => {
+      const { controller, notifyDeleted } = makeController({
+        service,
+        watchEnabled: false
+      });
+      const ctx = new FakeContext('a.txt');
+      controller.track(ctx as any);
+      service.emit({ path: 'a.txt', eventType: 'modified' });
+      service.emit({ path: 'a.txt', eventType: 'deleted' });
+      expect(ctx.revert).not.toHaveBeenCalled();
+      expect(notifyDeleted).not.toHaveBeenCalled();
+    });
+
+    it('should re-read settings on every event (dynamic toggle)', () => {
+      let watchEnabled = false;
+      const ctx = new FakeContext('a.txt');
+      const controller = new FileWatchController({
+        service,
+        getSettings: () => ({ watchEnabled, autoReload: true }),
+        notifyDeleted: jest.fn(),
+        notifyChanged: jest.fn()
+      });
+      controller.track(ctx as any);
+
+      service.emit({ path: 'a.txt', eventType: 'modified' });
+      expect(ctx.revert).not.toHaveBeenCalled();
+
+      watchEnabled = true;
+      service.emit({ path: 'a.txt', eventType: 'modified' });
+      expect(ctx.revert).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---- echo suppression --------------------------------------------------
+
+  describe('echo suppression', () => {
+    it('should suppress events that arrive within the window after a completed save', () => {
+      const { controller } = makeController({ service });
+      const ctx = new FakeContext('a.txt');
+      controller.track(ctx as any);
+
+      // Simulate Ctrl+S → context emits saveState 'completed'.
+      ctx.emitSaveState('completed');
+
+      // The watchdog echo that follows must be suppressed.
+      service.emit({ path: 'a.txt', eventType: 'modified' });
+      expect(ctx.revert).not.toHaveBeenCalled();
+    });
+
+    it('should release suppression after the window elapses', () => {
+      const { controller } = makeController({ service });
+      const ctx = new FakeContext('a.txt');
+      controller.track(ctx as any);
+
+      ctx.emitSaveState('completed');
+      jest.advanceTimersByTime(FileWatchController.SUPPRESS_WINDOW_MS + 50);
+      service.emit({ path: 'a.txt', eventType: 'modified' });
+      expect(ctx.revert).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT suppress when saveState is not "completed"', () => {
+      const { controller } = makeController({ service });
+      const ctx = new FakeContext('a.txt');
+      controller.track(ctx as any);
+
+      ctx.emitSaveState('started');
+      service.emit({ path: 'a.txt', eventType: 'modified' });
+      expect(ctx.revert).toHaveBeenCalledTimes(1);
+    });
+
+    it('should collapse a multi-event burst on a dirty file into one modal', () => {
+      const { controller } = makeController({ service });
+      const ctx = new FakeContext('a.txt');
+      ctx.model.dirty = true;
+      controller.track(ctx as any);
+
+      service.emit({ path: 'a.txt', eventType: 'modified' });
+      service.emit({ path: 'a.txt', eventType: 'modified' });
+      service.emit({ path: 'a.txt', eventType: 'modified' });
+      expect(ctx.save).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---- dispose -----------------------------------------------------------
+
+  describe('#dispose()', () => {
+    it('should be idempotent', () => {
+      const { controller } = makeController({ service });
+      expect(() => {
+        controller.dispose();
+        controller.dispose();
+      }).not.toThrow();
+      expect(controller.isDisposed).toBe(true);
+    });
+
+    it('should unsubscribe all tracked paths', () => {
+      const { controller } = makeController({ service });
+      controller.track(new FakeContext('a.txt') as any);
+      controller.track(new FakeContext('b.txt') as any);
+      controller.dispose();
+      expect(service.unsubscribed).toEqual(['a.txt', 'b.txt']);
+    });
+
+    it('should stop reacting to file change events', () => {
+      const { controller } = makeController({ service });
+      const ctx = new FakeContext('a.txt');
+      controller.track(ctx as any);
+      controller.dispose();
+      service.emit({ path: 'a.txt', eventType: 'modified' });
+      expect(ctx.revert).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,9 @@ Zulip = "https://jupyter.zulipchat.com/#narrow/channel/469762-jupyterlab"
 Pypi = "https://pypi.org/project/jupyterlab"
 
 [project.optional-dependencies]
+filewatcher = [
+    "watchdog>=3.0.0",
+]
 docs = [
     "sphinx>=1.8,<8.2.0",
     "sphinx-copybutton",


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Closes #18699 

## Code changes

 - Adds new Jupyter Server handler `/lab/api/file-watch` (`jupyterlab/handlers/file_watch_handler.py`)
  using a WebSocket and the optional `watchdog` package to deliver OS-level filesystem notifications.
  Degrades gracefully when `watchdog` is not installed.
  - Registers the handler in `jupyterlab/labapp.py`.
  - Adds `watchdog>=3.0.0` as a new `filewatcher` optional dependency in `pyproject.toml`.
  - New `FileWatcherService` and `FileWatchController` in `packages/docmanager/src/filewatcher.ts`,
  exposed via the `IFileWatcherService` token in `packages/docmanager/src/tokens.ts`.
  - New `fileWatcherPlugin` in `packages/docmanager-extension/src/index.tsx` that wires the service to
  opened document contexts (including widgets restored from a previous session) and shows reload
  notifications.
  - Two new user settings in `packages/docmanager-extension/schema/plugin.json`:
    - `watchForExternalChanges` (default `true`)
    - `externalChangeAutoReload` (default `true`)
  - Backend tests: `jupyterlab/tests/test_file_watch_handler.py`.
  - Frontend tests: `packages/docmanager/test/filewatcher.spec.ts`.
 
## User-facing changes

- Open files modified by another process are detected via OS filesystem events (no polling).
- If the buffer has no unsaved edits and `externalChangeAutoReload` is on, the file is auto-reloaded
  silently.
- Otherwise a notification is shown with a "Reload" action. Deleted files surface a persistent warning.
- Two new toggles under Document Manager settings: "Watch for External File Changes" and "Auto-Reload
  on External Change".

https://github.com/user-attachments/assets/1aacfb56-aee2-4ae3-a275-22befcf340f8

## Backwards-incompatible changes

 None. Feature is additive; `watchdog` is an optional dependency and the feature degrades gracefully
  when absent.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude Code (Claude Opus 4.7)
