### PR TITLE
Fix completer test failures on CI

### DIFF
--- a/galata/test/jupyterlab/completer.test.ts
+++ b/galata/test/jupyterlab/completer.test.ts
@@ -13,6 +13,15 @@ const COMPLETER_SELECTOR = '.jp-Completer';
 const COMPLETER_TIMEOUT = 15000;
 
 test.describe('Completer', () => {
+  test.use({
+    mockSettings: {
+      ...galata.DEFAULT_SETTINGS,
+      '@jupyterlab/completer-extension:manager': {
+        providerTimeout: 60000
+      }
+    }
+  });
+
   test.describe('Notebook', () => {
     test.beforeEach(async ({ page }) => {
       await page.notebook.createNew(fileName);
@@ -43,6 +52,10 @@ test.describe('Completer', () => {
       await page.waitForTimeout(50);
 
       await expect(completer).toBeHidden();
+      // Ensure the completer is still bound to the editor before pressing Tab
+      // again; this guards against a brief window after Escape where the editor
+      // state hasn't settled yet.
+      await expect(editor).toHaveClass(/jp-mod-completer-enabled/);
       await page.keyboard.press('Tab');
       completer = page.locator(COMPLETER_SELECTOR);
       await completer.waitFor({ timeout: COMPLETER_TIMEOUT });

--- a/galata/test/jupyterlab/debugger-console.test.ts
+++ b/galata/test/jupyterlab/debugger-console.test.ts
@@ -53,6 +53,16 @@ async function setupDebuggerConsole(
 
 test.describe('Debugger Console', () => {
   test.use({ tmpPath: 'test-debugger-console' });
+  test.use({
+    mockSettings: {
+      ...galata.DEFAULT_SETTINGS,
+      // Raise the provider timeout so the two evaluate() calls in
+      // DebuggerCompletionProvider.fetch() complete well within the budget.
+      '@jupyterlab/completer-extension:manager': {
+        providerTimeout: 60000
+      }
+    }
+  });
 
   test.beforeAll(async ({ tmpPath, request }) => {
     const contents = galata.newContentsHelper(request);


### PR DESCRIPTION
## References

- Fixes #18943 

## Code changes

- Increase timeout
- Wait for completer to be enabled

## User-facing changes

None

## Backwards-incompatible changes

None

