### PR TITLE
Forward port CodeMirror DOM compatibility patch

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -83,6 +83,12 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
       ],
       model.sharedModel.source
     );
+    // For backward-compatibility with older CodeMirror
+    const content = host.querySelector('.cm-content')!;
+    (content as any).cmView = {
+      view: this._editor,
+      dom: content
+    };
 
     const scroller = host.querySelector('.cm-scroller') as HTMLElement | null;
     if (scroller) {

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -83,12 +83,23 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
       ],
       model.sharedModel.source
     );
-    // For backward-compatibility with older CodeMirror
-    const content = host.querySelector('.cm-content')!;
-    (content as any).cmView = {
-      view: this._editor,
-      dom: content
-    };
+    // For backward-compatibility with consumers of older CodeMirror private API.
+    const content = host.querySelector('.cm-content');
+    if (content) {
+      const legacyCmView = {
+        view: this._editor,
+        dom: content
+      };
+      Object.defineProperty(content, 'cmView', {
+        configurable: true,
+        get: () => {
+          console.warn(
+            'Accessing cmView is deprecated. Use the public API EditorView.findFromDOM() instead.'
+          );
+          return legacyCmView;
+        }
+      });
+    }
 
     const scroller = host.querySelector('.cm-scroller') as HTMLElement | null;
     if (scroller) {

--- a/packages/codemirror/test/editor.spec.ts
+++ b/packages/codemirror/test/editor.spec.ts
@@ -134,6 +134,21 @@ describe('CodeMirrorEditor', () => {
       const cm = editor.editor;
       expect(cm.state.doc).toBe(editor.doc);
     });
+
+    it('should warn when accessing the legacy cmView shim', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const content = editor.editor.contentDOM as HTMLElement & {
+        cmView?: { view: typeof editor.editor; dom: HTMLElement };
+      };
+
+      expect(content.cmView?.view).toBe(editor.editor);
+      expect(content.cmView?.dom).toBe(content);
+      expect(warn).toHaveBeenCalledWith(
+        'Accessing cmView is deprecated. Use the public API EditorView.findFromDOM() instead.'
+      );
+
+      warn.mockRestore();
+    });
   });
 
   describe('#lineCount', () => {


### PR DESCRIPTION
## References

- Closes #18373

## Code changes

- [x] adds unit test
- [x] adds shim
- [x] adds warning

## User-facing changes

Extensions (spellchecker, older versions of LSP) will continue to work in JupyterLab 4.6 as they did in older versions.

## Backwards-incompatible changes

None

## AI usage

- **Yes**: Some or all of the content of this PR was generated by AI.
- **Yes**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude
