### PR TITLE
Update minimum mermaid to 11.15.0 and marked 17.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@types/react": "^18.0.26",
     "lodash": "^4.17.23",
     "lodash-es": "^4.18.1",
-    "marked": "^17.0.4",
+    "marked": "^17.0.6",
     "prettier": "^3.8.1",
     "react": "^18.2.0",
     "type-fest": "^4.30.0",

--- a/packages/markedparser-extension/package.json
+++ b/packages/markedparser-extension/package.json
@@ -41,9 +41,9 @@
     "@jupyterlab/mermaid": "^4.6.0-beta.0",
     "@jupyterlab/rendermime": "^4.6.0-beta.0",
     "@lumino/coreutils": "^2.2.2",
-    "marked": "^17.0.4",
-    "marked-gfm-heading-id": "^4.1.3",
-    "marked-mangle": "^1.1.12"
+    "marked": "^17.0.6",
+    "marked-gfm-heading-id": "^4.1.4",
+    "marked-mangle": "^1.1.13"
   },
   "devDependencies": {
     "@types/d3": "^7.4.0",

--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -47,7 +47,7 @@
     "@lumino/coreutils": "^2.2.2",
     "@lumino/widgets": "^2.8.0",
     "@mermaid-js/layout-elk": "^0.2.1",
-    "mermaid": "^11.13.0"
+    "mermaid": "^11.15.0"
   },
   "devDependencies": {
     "@types/jest": "^29.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4148,9 +4148,9 @@ __metadata:
     "@jupyterlab/rendermime": ^4.6.0-beta.0
     "@lumino/coreutils": ^2.2.2
     "@types/d3": ^7.4.0
-    marked: ^17.0.4
-    marked-gfm-heading-id: ^4.1.3
-    marked-mangle: ^1.1.12
+    marked: ^17.0.6
+    marked-gfm-heading-id: ^4.1.4
+    marked-mangle: ^1.1.13
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -15965,32 +15965,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"marked-gfm-heading-id@npm:^4.1.3":
-  version: 4.1.3
-  resolution: "marked-gfm-heading-id@npm:4.1.3"
+"marked-gfm-heading-id@npm:^4.1.4":
+  version: 4.1.4
+  resolution: "marked-gfm-heading-id@npm:4.1.4"
   dependencies:
     github-slugger: ^2.0.0
   peerDependencies:
-    marked: ">=13 <18"
-  checksum: 61cccce4b5d8a75c9d5c4c1c9b6ee4896fa9c34747dd7efe37bb3ff100f0cb8bd93cc0f93eed4ead1c2e6b0d546b4886455e4655ada3c6f1051d122a456c507a
+    marked: ">=13 <19"
+  checksum: a389ac34bdbc5425cb0420268585853d71b6951f7b12773e0a3e4bda76328554c3f1d528d83b6228efa4463675960bc069d85ddcbf80c2a900ecc421c87d1079
   languageName: node
   linkType: hard
 
-"marked-mangle@npm:^1.1.12":
-  version: 1.1.12
-  resolution: "marked-mangle@npm:1.1.12"
+"marked-mangle@npm:^1.1.13":
+  version: 1.1.13
+  resolution: "marked-mangle@npm:1.1.13"
   peerDependencies:
-    marked: ">=4 <18"
-  checksum: 3340af16fb4247142a6cb803e89a8e1650f2f4878da0d05344dd80780abd575288015e3f9ff831e075a0b09cc5947fce39fd68bcdce2fc8ed2f727a603d78ada
+    marked: ">=4 <19"
+  checksum: c7cb122458f1b9615e8e19ca60fe508ff6a2d2a4915d210058dd5b0a0a476f08c836ace39b19e7beabe255dfb68578082b250ed7854f9cc699cd3a453b6f594c
   languageName: node
   linkType: hard
 
-"marked@npm:^17.0.4":
-  version: 17.0.4
-  resolution: "marked@npm:17.0.4"
+"marked@npm:^17.0.6":
+  version: 17.0.6
+  resolution: "marked@npm:17.0.6"
   bin:
     marked: bin/marked.js
-  checksum: d633d9b11f6ab3f3ff24dd2a37e46fe770d2af9fb4bc522711720c1ba2ed3d4d3e99f2d057278bde38e5d8b41d5318288290e88d86d1eea9edf6789fa732b9b9
+  checksum: 0143f449ba253053bc27f48a1a2ab3a0619f3c1b527f5cd9eb6af9d879ab97c93d5d2b2c4ab81e8c42106f7f1731173c1f3aebfd176c66f1f2cd728aa9966cbf
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4199,7 +4199,7 @@ __metadata:
     "@mermaid-js/layout-elk": ^0.2.1
     "@types/jest": ^29.2.0
     jest: ^29.2.0
-    mermaid: ^11.13.0
+    mermaid: ^11.15.0
     rimraf: ~5.0.5
     typescript: ~5.9.3
   languageName: unknown
@@ -16109,7 +16109,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mermaid@npm:^11.13.0":
+"mermaid@npm:^11.15.0":
   version: 11.15.0
   resolution: "mermaid@npm:11.15.0"
   dependencies:


### PR DESCRIPTION
## References

- continues #18872 

## Code changes

- [x] update the bottom pin for `mermaid` so downstreams don't have to
- [x] update `marked` to latest `17.x`, plugins
-   > for some ReDoS fixes in [17.0.5](https://github.com/markedjs/marked/releases/tag/v17.0.5) and async behavior in [17.0.6](https://github.com/markedjs/marked/releases/tag/v17.0.5)
  - > may want to consider bumping to `marked ^18.x` now that it has settled down a bit (some _new_ infinite loops in the early releases)

## User-facing changes

- fewer hangs in some markdown cases
- the next releases of downstreams which do not relock will 

## Backwards-incompatible changes

- n/a

## AI usage

- NO: Some or all of the content of this PR was generated by AI.
- **<!-- YES or NO -->**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: <!-- FILL IN -->
