### PR TITLE
Fix read-only indicator

### DIFF
--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -631,7 +631,6 @@ export class DocumentWidget<
     if (args.name === 'dirty') {
       this._handleDirtyState();
     }
-    this._handleReadOnlyState();
   }
 
   /**
@@ -651,17 +650,15 @@ export class DocumentWidget<
    * Handle the read-only state of the context model.
    */
   private _handleReadOnlyState(): void {
-    if (!this.context.model.dirty) {
-      if (this.context.contentsModel?.writable === false) {
-        const readOnlyIndicator = createReadonlyLabel(this);
-        let roi = this.toolbar.insertBefore(
-          'kernelName',
-          'read-only-indicator',
-          readOnlyIndicator
-        );
-        if (!roi) {
-          this.toolbar.addItem('read-only-indicator', readOnlyIndicator);
-        }
+    if (this.context.contentsModel?.writable === false) {
+      const readOnlyIndicator = createReadonlyLabel(this);
+      let roi = this.toolbar.insertBefore(
+        'kernelName',
+        'read-only-indicator',
+        readOnlyIndicator
+      );
+      if (!roi) {
+        this.toolbar.addItem('read-only-indicator', readOnlyIndicator);
       }
     }
   }

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -568,6 +568,7 @@ export class DocumentWidget<
     this.context.model.stateChanged.connect(this._onModelStateChanged, this);
     void this.context.ready.then(() => {
       this._handleDirtyState();
+      this._handleReadOnlyState();
     });
 
     // listen for changes to the title object
@@ -630,19 +631,7 @@ export class DocumentWidget<
     if (args.name === 'dirty') {
       this._handleDirtyState();
     }
-    if (!this.context.model.dirty) {
-      if (this.context.contentsModel?.writable === false) {
-        const readOnlyIndicator = createReadonlyLabel(this);
-        let roi = this.toolbar.insertBefore(
-          'kernelName',
-          'read-only-indicator',
-          readOnlyIndicator
-        );
-        if (!roi) {
-          this.toolbar.addItem('read-only-indicator', readOnlyIndicator);
-        }
-      }
-    }
+    this._handleReadOnlyState();
   }
 
   /**
@@ -655,6 +644,25 @@ export class DocumentWidget<
       }
     } else {
       this.title.className = this.title.className.replace(DIRTY_CLASS, '');
+    }
+  }
+
+  /**
+   * Handle the read-only state of the context model.
+   */
+  private _handleReadOnlyState(): void {
+    if (!this.context.model.dirty) {
+      if (this.context.contentsModel?.writable === false) {
+        const readOnlyIndicator = createReadonlyLabel(this);
+        let roi = this.toolbar.insertBefore(
+          'kernelName',
+          'read-only-indicator',
+          readOnlyIndicator
+        );
+        if (!roi) {
+          this.toolbar.addItem('read-only-indicator', readOnlyIndicator);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Closes #18739.
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
The read-only state is now handled in the `DocumentWidget` constructor. Previously it was handled when the dirty state transitioned from `true` to `false`.
## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: DeepSeek V4 Flash
