### PR TITLE
Clarify error message to mention npm alongside nodejs

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -2109,7 +2109,7 @@ def _node_check(logger):
     except Exception:
         data = CoreConfig()._data
         ver = data["engines"]["node"]
-        msg = f"Please install nodejs {ver} before continuing. nodejs may be installed using conda or directly from the nodejs website."
+        msg = f"Please install nodejs {ver} and npm before continuing. nodejs and npm may be installed using conda or directly from the nodejs website."
         raise ValueError(msg) from None
 
 


### PR DESCRIPTION
Closes #8459

Updates the Node.js version check error message to also mention npm, since installing just nodejs (e.g. via `apt install nodejs`) is insufficient — npm is also required for extension installation.

**Change:** `Please install nodejs {ver} before continuing...` → `Please install nodejs {ver} and npm before continuing...`