### PR TITLE
Add comment character parameter to CSV parser

### DIFF
--- a/packages/csvviewer/src/model.ts
+++ b/packages/csvviewer/src/model.ts
@@ -49,13 +49,15 @@ export class DSVModel extends DataModel implements IDisposable {
       quote = '"',
       quoteParser = undefined,
       header = true,
-      initialRows = 500
+      initialRows = 500,
+      comment
     } = options;
     this._rawData = data;
     this._delimiter = delimiter;
     this._quote = quote;
     this._quoteEscaped = new RegExp(quote + quote, 'g');
     this._initialRows = initialRows;
+    this._comment = comment;
 
     // Guess the row delimiter if it was not supplied. This will be fooled if a
     // different line delimiter possibility appears in the first row.
@@ -303,7 +305,8 @@ export class DSVModel extends DataModel implements IDisposable {
         columnOffsets: true,
         maxRows: maxRows,
         ncols: ncols,
-        startIndex: this._rowOffsets[row]
+        startIndex: this._rowOffsets[row],
+        comment: this._comment
       });
 
       // Copy results to the cache.
@@ -417,7 +420,8 @@ export class DSVModel extends DataModel implements IDisposable {
         rowDelimiter: this._rowDelimiter,
         quote: this._quote,
         columnOffsets: true,
-        maxRows: 1
+        maxRows: 1,
+        comment: this._comment
       }).ncols;
     }
 
@@ -433,7 +437,8 @@ export class DSVModel extends DataModel implements IDisposable {
       rowDelimiter: this._rowDelimiter,
       quote: this._quote,
       columnOffsets: false,
-      maxRows: endRow - this._rowCount! + reparse
+      maxRows: endRow - this._rowCount! + reparse,
+      comment: this._comment
     });
 
     // If we have already set up our initial bookkeeping, return early if we
@@ -632,6 +637,7 @@ export class DSVModel extends DataModel implements IDisposable {
   private _quoteEscaped: RegExp;
   private _parser: 'quotes' | 'noquotes';
   private _rowDelimiter: string;
+  private _comment: string | undefined;
 
   // Data values
   private _rawData: string;
@@ -737,5 +743,14 @@ export namespace DSVModel {
      * full parse of the data. This should be greater than 0.
      */
     initialRows?: number;
+
+    /**
+     * The comment character to ignore lines.
+     *
+     * #### Notes
+     * If defined, lines that start with this character are treated as comments
+     * and skipped.
+     */
+    comment?: string;
   }
 }

--- a/packages/csvviewer/src/parse.ts
+++ b/packages/csvviewer/src/parse.ts
@@ -92,6 +92,15 @@ export namespace IParser {
      * first row.
      */
     ncols?: number;
+
+    /**
+     * The comment character to ignore lines.
+     *
+     * #### Notes
+     * If defined, lines that start with this character are treated as comments
+     * and skipped.
+     */
+    comment?: string;
   }
 
   /**
@@ -161,7 +170,8 @@ export function parseDSV(options: IParser.IOptions): IParser.IResults {
     startIndex = 0,
     maxRows = 0xffffffff,
     rowDelimiter = '\r\n',
-    quote = '"'
+    quote = '"',
+    comment
   } = options;
 
   // ncols will be set automatically if it is undefined.
@@ -219,6 +229,18 @@ export function parseDSV(options: IParser.IOptions): IParser.IResults {
       // Start a new row and reset the column counter.
       offsets.push(i);
       col = 1;
+
+      // If we have a comment character and this line starts with it,
+      // skip to the next line.
+      if (comment !== undefined && data.charCodeAt(i) === comment.charCodeAt(0)) {
+        offsets.pop();
+        const delimIndex = data.indexOf(rowDelimiter, i);
+        if (delimIndex < 0) {
+          break;
+        }
+        i = delimIndex + rowDelimiterLength;
+        continue;
+      }
     }
 
     // Below, we handle this character, modify the parser state and increment the index to be consistent.
@@ -494,7 +516,8 @@ export function parseDSVNoQuotes(options: IParser.IOptions): IParser.IResults {
     delimiter = ',',
     rowDelimiter = '\r\n',
     startIndex = 0,
-    maxRows = 0xffffffff
+    maxRows = 0xffffffff,
+    comment
   } = options;
 
   // ncols will be set automatically if it is undefined.
@@ -521,6 +544,16 @@ export function parseDSVNoQuotes(options: IParser.IOptions): IParser.IResults {
 
   // Loop through rows until we run out of data or we've reached maxRows.
   while (nextRow !== -1 && nrows < maxRows && currRow < len) {
+    // If this line starts with the comment character, skip it.
+    if (comment !== undefined && data.charCodeAt(currRow) === comment.charCodeAt(0)) {
+      nextRow = data.indexOf(rowDelimiter, currRow);
+      if (nextRow === -1) {
+        break;
+      }
+      currRow = nextRow + rowDelimiterLength;
+      continue;
+    }
+
     // Store the offset for the beginning of the row and increment the rows.
     offsets.push(currRow);
     nrows++;

--- a/packages/csvviewer/src/widget.ts
+++ b/packages/csvviewer/src/widget.ts
@@ -322,6 +322,20 @@ export class CSVViewer extends Widget {
   }
 
   /**
+   * The comment character for the file.
+   */
+  get comment(): string | undefined {
+    return this._comment;
+  }
+  set comment(value: string | undefined) {
+    if (value === this._comment) {
+      return;
+    }
+    this._comment = value;
+    void this._updateGrid();
+  }
+
+  /**
    * The style used by the data grid.
    */
   get style(): DataGridModule.DataGrid.Style {
@@ -382,7 +396,8 @@ export class CSVViewer extends Widget {
     const oldModel = this._grid.dataModel as DSVModelModule.DSVModel;
     const dataModel = (this._grid.dataModel = new DSVModel({
       data,
-      delimiter
+      delimiter,
+      comment: this._comment
     }));
     this._grid.selectionModel = new BasicSelectionModel({ dataModel });
     if (oldModel) {
@@ -421,6 +436,7 @@ export class CSVViewer extends Widget {
   private _monitor: ActivityMonitor<DocumentRegistry.IModel, void> | null =
     null;
   private _delimiter = ',';
+  private _comment: string | undefined;
   private _revealed = new PromiseDelegate<void>();
   private _baseRenderer: TextRenderConfig | null = null;
   private _ready: Promise<void>;
@@ -446,13 +462,16 @@ export namespace CSVViewer {
  */
 export class CSVDocumentWidget extends DocumentWidget<CSVViewer> {
   constructor(options: CSVDocumentWidget.IOptions) {
-    let { content, context, delimiter, reveal, ...other } = options;
+    let { content, context, delimiter, comment, reveal, ...other } = options;
     content = content || Private.createContent(context);
     reveal = Promise.all([reveal, content.revealed]);
     super({ content, context, reveal, ...other });
 
     if (delimiter) {
       content.delimiter = delimiter;
+    }
+    if (comment) {
+      content.comment = comment;
     }
   }
 
@@ -492,6 +511,11 @@ export namespace CSVDocumentWidget {
      * Data delimiter character
      */
     delimiter?: string;
+
+    /**
+     * Comment character to skip lines
+     */
+    comment?: string;
   }
 }
 


### PR DESCRIPTION
## Description

Adds a comment character parameter to the CSV parser in JupyterLab's CSV viewer. Lines starting with the specified comment character are skipped during parsing. This implements feature request #11902.

## Changes

### packages/csvviewer/src/parse.ts
- Added optional `comment` field to `IParser.IOptions` interface
- `parseDSV`: skips lines starting with the comment character at row start
- `parseDSVNoQuotes`: skips lines starting with the comment character

### packages/csvviewer/src/model.ts
- Added optional `comment` field to `DSVModel.IOptions` interface
- Added `_comment` private field
- Passes `comment` through to all parser calls (`_computeRowOffsets`, `getOffsetIndex`)

### packages/csvviewer/src/widget.ts
- Added `comment` getter/setter to `CSVViewer`, triggering re-render on change
- Passes `comment` to `DSVModel` on grid update
- Added `comment` option to `CSVDocumentWidget.IOptions` and constructor

## Usage

```ts
// Skip lines starting with '#'
const model = new DSVModel({ data, delimiter: ',', comment: '#' });
```

Closes #11902