### PR TITLE
Fix typo in a shell test description

### DIFF
--- a/packages/application/test/shell.spec.ts
+++ b/packages/application/test/shell.spec.ts
@@ -1025,7 +1025,7 @@ describe('LabShell', () => {
       expect(bottomPanel?.getAttribute('role')).toEqual('contentinfo');
     });
 
-    it('left handler should have a role of compelementary and aria label of main sidebar', () => {
+    it('left handler should have a role of complementary and aria label of main sidebar', () => {
       const widget = new Widget();
       widget.id = 'foo';
       shell.add(widget, 'left');

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -683,7 +683,7 @@
         "showJumpToRecentExecutionButton": {
           "type": "boolean",
           "title": "Show jump to most recently executed/executing cell button",
-          "description": "If enabled, displays a button that scrolls to the currently executing cell or, if none, the most recently executed cell. scrolls to the currently executing cell or, if none, the most recently executed cell. The button shows when hovering over the kernel execution indicator. Enabling this option automatically enables recording of execution timing metadata.",
+          "description": "If enabled, displays a button that scrolls to the currently executing cell or, if none, the most recently executed cell. The button shows when hovering over the kernel execution indicator. Enabling this option automatically enables recording of execution timing metadata.",
           "default": false
         }
       }


### PR DESCRIPTION
Fix a typo in the test description in `packages/application/test/shell.spec.ts`: `compelementary` -> `complementary`.