### PR TITLE
Fix typo in contributing docs

### DIFF
--- a/docs/source/developer/contributing.md
+++ b/docs/source/developer/contributing.md
@@ -635,7 +635,7 @@ Galata generates a user friendly test result report which can be used to inspect
 UI tests. Result report shows the failure reason, call-stack up to the failure and
 detailed information on visual regression issues. For visual regression errors, reference
 image and test capture image, along with diff image generated during comparison are
-provided in the report. You can use these information to debug failing tests. Galata test
+provided in the report. You can use this information to debug failing tests. Galata test
 report can be downloaded from GitHub Actions page for a UI test run. Test artifact is
 named `galata-report` and once you extract it, you can access the report by launching
 a server to serve the files `python -m http.server -d <path-to-extracted-report>`.


### PR DESCRIPTION
## Description

Fixed a grammatical error in `docs/source/developer/contributing.md` where "these information" was used incorrectly. Since "information" is uncountable, it should be "this information".

## Type of change

- [x] Bug fix (typo/grammar fix in documentation)