### PR TITLE
Fix typos across packages found by codespell

### DIFF
--- a/docs/source/developer/contributing.md
+++ b/docs/source/developer/contributing.md
@@ -635,7 +635,7 @@ Galata generates a user friendly test result report which can be used to inspect
 UI tests. Result report shows the failure reason, call-stack up to the failure and
 detailed information on visual regression issues. For visual regression errors, reference
 image and test capture image, along with diff image generated during comparison are
-provided in the report. You can use these information to debug failing tests. Galata test
+provided in the report. You can use this information to debug failing tests. Galata test
 report can be downloaded from GitHub Actions page for a UI test run. Test artifact is
 named `galata-report` and once you extract it, you can access the report by launching
 a server to serve the files `python -m http.server -d <path-to-extracted-report>`.

--- a/packages/application/src/dockpanel.ts
+++ b/packages/application/src/dockpanel.ts
@@ -254,7 +254,7 @@ export class OptimizedDockPanelSvg extends DockPanelSvg {
   private _intervalId = 0;
 }
 
-/** Namespace for OptimizedDockPanelSvg statics */
+/** Namespace for OptimizedDockPanelSvg statistics */
 namespace Private {
   export interface IFrozenElement {
     element: HTMLElement;

--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -215,7 +215,7 @@ export abstract class JupyterFrontEnd<
 }
 
 /**
- * The namespace for `JupyterFrontEnd` class statics.
+ * The namespace for `JupyterFrontEnd` class statistics.
  */
 export namespace JupyterFrontEnd {
   /**

--- a/packages/application/src/lab.ts
+++ b/packages/application/src/lab.ts
@@ -304,7 +304,7 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell> {
 }
 
 /**
- * The namespace for `JupyterLab` class statics.
+ * The namespace for `JupyterLab` class statistics.
  */
 export namespace JupyterLab {
   /**

--- a/packages/application/src/layoutrestorer.ts
+++ b/packages/application/src/layoutrestorer.ts
@@ -565,7 +565,7 @@ export class LayoutRestorer implements ILayoutRestorer {
 }
 
 /**
- * A namespace for `LayoutRestorer` statics.
+ * A namespace for `LayoutRestorer` statistics.
  */
 export namespace LayoutRestorer {
   /**

--- a/packages/application/src/router.ts
+++ b/packages/application/src/router.ts
@@ -179,7 +179,7 @@ export class Router implements IRouter {
 }
 
 /**
- * A namespace for `Router` class statics.
+ * A namespace for `Router` class statistics.
  */
 export namespace Router {
   /**

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -2678,7 +2678,7 @@ namespace Private {
   }
 
   /**
-   * The namespace for the `SideBarHandler` statics.
+   * The namespace for the `SideBarHandler` statistics.
    */
   export namespace SideBarHandler {
     /**

--- a/packages/apputils-extension/src/palette.ts
+++ b/packages/apputils-extension/src/palette.ts
@@ -81,7 +81,7 @@ export class Palette implements ICommandPalette {
 }
 
 /**
- * A namespace for `Palette` statics.
+ * A namespace for `Palette` statistics.
  */
 export namespace Palette {
   /**

--- a/packages/apputils/src/commandlinker.ts
+++ b/packages/apputils/src/commandlinker.ts
@@ -313,7 +313,7 @@ export class CommandLinker implements IDisposable {
 }
 
 /**
- * A namespace for command linker statics.
+ * A namespace for command linker statistics.
  */
 export namespace CommandLinker {
   /**
@@ -328,7 +328,7 @@ export namespace CommandLinker {
 }
 
 /**
- * A namespace for Private command linker statics.
+ * A namespace for Private command linker statistics.
  */
 namespace Private {
   /**

--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -549,7 +549,7 @@ export class Dialog<T> extends Widget {
 }
 
 /**
- * The namespace for Dialog class statics.
+ * The namespace for Dialog class statistics.
  */
 export namespace Dialog {
   /**

--- a/packages/apputils/src/inputdialog.ts
+++ b/packages/apputils/src/inputdialog.ts
@@ -211,7 +211,7 @@ export namespace InputDialog {
     /**
      * Selection range
      *
-     * Number of characters to pre-select when dialog opens.
+     * Number of characters to preselect when dialog opens.
      * Default is to select the whole input text if present.
      */
     selectionRange?: number;

--- a/packages/apputils/src/kernelstatuses.tsx
+++ b/packages/apputils/src/kernelstatuses.tsx
@@ -68,7 +68,7 @@ function KernelStatusComponent(
 }
 
 /**
- * A namespace for KernelStatusComponent statics.
+ * A namespace for KernelStatusComponent statistics.
  */
 namespace KernelStatusComponent {
   /**
@@ -150,7 +150,7 @@ export class KernelStatus extends VDomRenderer<KernelStatus.Model> {
 }
 
 /**
- * A namespace for KernelStatus statics.
+ * A namespace for KernelStatus statistics.
  */
 export namespace KernelStatus {
   /**

--- a/packages/apputils/src/mainareawidget.ts
+++ b/packages/apputils/src/mainareawidget.ts
@@ -303,7 +303,7 @@ export class MainAreaWidget<T extends Widget = Widget>
 }
 
 /**
- * The namespace for the `MainAreaWidget` class statics.
+ * The namespace for the `MainAreaWidget` class statistics.
  */
 export namespace MainAreaWidget {
   /**

--- a/packages/apputils/src/runningSessions.tsx
+++ b/packages/apputils/src/runningSessions.tsx
@@ -63,7 +63,7 @@ function RunningSessionsComponent(
 }
 
 /**
- * A namespace for RunningSessionsComponents statics.
+ * A namespace for RunningSessionsComponents statistics.
  */
 namespace RunningSessionsComponent {
   /**
@@ -213,7 +213,7 @@ export class RunningSessions extends VDomRenderer<RunningSessions.Model> {
 }
 
 /**
- * A namespace for RunningSessions statics.
+ * A namespace for RunningSessions statistics.
  */
 export namespace RunningSessions {
   /**

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -960,7 +960,7 @@ export class SessionContext implements ISessionContext {
     }
 
     // Use a UUID for the path to overcome a race condition on the server
-    // where it will re-use a session for a given path but only after
+    // where it will reuse a session for a given path but only after
     // the kernel finishes starting.
     // We later switch to the real path below.
     // Use the correct directory so the kernel will be started in that directory.
@@ -1277,7 +1277,7 @@ export class SessionContext implements ISessionContext {
 }
 
 /**
- * A namespace for `SessionContext` statics.
+ * A namespace for `SessionContext` statistics.
  */
 export namespace SessionContext {
   /**

--- a/packages/apputils/src/toolbar/widget.tsx
+++ b/packages/apputils/src/toolbar/widget.tsx
@@ -31,7 +31,7 @@ const TOOLBAR_KERNEL_NAME_CLASS = 'jp-Toolbar-kernelName';
 const TOOLBAR_KERNEL_STATUS_CLASS = 'jp-Toolbar-kernelStatus';
 
 /**
- * The namespace for Toolbar class statics.
+ * The namespace for Toolbar class statistics.
  */
 export namespace Toolbar {
   /**

--- a/packages/apputils/src/widgettracker.ts
+++ b/packages/apputils/src/widgettracker.ts
@@ -380,7 +380,7 @@ export class WidgetTracker<T extends Widget = Widget>
 }
 
 /**
- * A namespace for `WidgetTracker` statics.
+ * A namespace for `WidgetTracker` statistics.
  */
 export namespace WidgetTracker {
   /**

--- a/packages/apputils/test/sessioncontext.spec.ts
+++ b/packages/apputils/test/sessioncontext.spec.ts
@@ -80,7 +80,7 @@ describe('@jupyterlab/apputils', () => {
     });
   }, 30000);
 
-  afterAll(async () => {
+  after all(async () => {
     await server.shutdown();
   });
 

--- a/packages/apputils/test/toolbar.spec.ts
+++ b/packages/apputils/test/toolbar.spec.ts
@@ -25,7 +25,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 

--- a/packages/attachments/src/model.ts
+++ b/packages/attachments/src/model.ts
@@ -297,7 +297,7 @@ export class AttachmentsModel implements IAttachmentsModel {
 }
 
 /**
- * The namespace for AttachmentsModel class statics.
+ * The namespace for AttachmentsModel class statistics.
  */
 export namespace AttachmentsModel {
   /**
@@ -392,7 +392,7 @@ export class AttachmentsResolver implements IRenderMime.IResolver {
 }
 
 /**
- * The namespace for `AttachmentsResolver` class statics.
+ * The namespace for `AttachmentsResolver` class statistics.
  */
 export namespace AttachmentsResolver {
   /**

--- a/packages/audio-extension/src/index.ts
+++ b/packages/audio-extension/src/index.ts
@@ -120,7 +120,7 @@ export class AudioViewer extends Widget {
 }
 
 /**
- * The namespace for AudioViewer class statics.
+ * The namespace for AudioViewer class statistics.
  */
 export namespace AudioViewer {
   /**
@@ -149,7 +149,7 @@ export class AudioDocumentWidget extends DocumentWidget<AudioViewer> {
 }
 
 /**
- * The namespace for AudioDocumentWidget class statics.
+ * The namespace for AudioDocumentWidget class statistics.
  */
 export namespace AudioDocumentWidget {
   /**
@@ -193,7 +193,7 @@ export class AudioViewerFactory extends ABCWidgetFactory<
 }
 
 /**
- * The namespace for AudioViewerFactory class statics.
+ * The namespace for AudioViewerFactory class statistics.
  */
 export namespace AudioViewerFactory {
   /**

--- a/packages/cells/src/inputarea.ts
+++ b/packages/cells/src/inputarea.ts
@@ -155,7 +155,7 @@ export class InputArea extends Widget {
 }
 
 /**
- * A namespace for `InputArea` statics.
+ * A namespace for `InputArea` statistics.
  */
 export namespace InputArea {
   /**

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -388,7 +388,7 @@ export abstract class CellModel extends CodeEditor.Model implements ICellModel {
 }
 
 /**
- * The namespace for `CellModel` statics.
+ * The namespace for `CellModel` statistics.
  */
 export namespace CellModel {
   /**
@@ -496,7 +496,7 @@ export abstract class AttachmentsCellModel extends CellModel {
 }
 
 /**
- * The namespace for `AttachmentsCellModel` statics.
+ * The namespace for `AttachmentsCellModel` statistics.
  */
 export namespace AttachmentsCellModel {
   /**
@@ -927,7 +927,7 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
 }
 
 /**
- * The namespace for `CodeCellModel` statics.
+ * The namespace for `CodeCellModel` statistics.
  */
 export namespace CodeCellModel {
   /**

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -776,7 +776,7 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
 }
 
 /**
- * The namespace for the `Cell` class statics.
+ * The namespace for the `Cell` class statistics.
  */
 export namespace Cell {
   /**
@@ -1721,7 +1721,7 @@ export class CodeCell extends Cell<ICodeCellModel> {
 }
 
 /**
- * The namespace for the `CodeCell` class statics.
+ * The namespace for the `CodeCell` class statistics.
  */
 export namespace CodeCell {
   /**
@@ -2591,7 +2591,7 @@ export class MarkdownCell extends AttachmentsCell<IMarkdownCellModel> {
 }
 
 /**
- * The namespace for the `CodeCell` class statics.
+ * The namespace for the `CodeCell` class statistics.
  */
 export namespace MarkdownCell {
   /**
@@ -2653,7 +2653,7 @@ export class RawCell extends Cell<IRawCellModel> {
 }
 
 /**
- * The namespace for the `RawCell` class statics.
+ * The namespace for the `RawCell` class statistics.
  */
 export namespace RawCell {
   /**

--- a/packages/cells/test/widget.spec.ts
+++ b/packages/cells/test/widget.spec.ts
@@ -882,7 +882,7 @@ describe('cells/widget', () => {
         await server.start();
       }, 30000);
 
-      afterAll(async () => {
+      after all(async () => {
         await server.shutdown();
       });
 

--- a/packages/codeeditor/src/jsoneditor.ts
+++ b/packages/codeeditor/src/jsoneditor.ts
@@ -332,7 +332,7 @@ export class JSONEditor extends Widget {
 }
 
 /**
- * The static namespace JSONEditor class statics.
+ * The static namespace JSONEditor class statistics.
  */
 export namespace JSONEditor {
   /**

--- a/packages/codeeditor/src/lineCol.tsx
+++ b/packages/codeeditor/src/lineCol.tsx
@@ -17,7 +17,7 @@ import type { CodeEditor } from './editor';
 import { DOMUtils } from '@jupyterlab/apputils';
 
 /**
- * A namespace for LineFormComponent statics.
+ * A namespace for LineFormComponent statistics.
  */
 namespace LineFormComponent {
   /**
@@ -325,7 +325,7 @@ export class LineCol extends VDomRenderer<LineCol.Model> {
 }
 
 /**
- * A namespace for LineCol statics.
+ * A namespace for LineCol statistics.
  */
 export namespace LineCol {
   /**

--- a/packages/codeeditor/src/widget.ts
+++ b/packages/codeeditor/src/widget.ts
@@ -239,7 +239,7 @@ export class CodeEditorWrapper extends Widget {
 }
 
 /**
- * The namespace for the `CodeEditorWrapper` statics.
+ * The namespace for the `CodeEditorWrapper` statistics.
  */
 export namespace CodeEditorWrapper {
   /**

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -562,7 +562,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
           // If the relevant leaf token has been found, stop iterating.
           if (offset >= ref.from && offset <= ref.to) {
             let currentNode = ref;
-            // The syntax tree of the code lines ending with an incomplete string creates an erronous
+            // The syntax tree of the code lines ending with an incomplete string creates an erroneous
             // child of the last node, in this case the parent should be considered for the token.
             if (ref.name === '⚠' && ref.from === ref.to && ref.node.parent) {
               currentNode = ref.node.parent;
@@ -790,7 +790,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
 }
 
 /**
- * The namespace for `CodeMirrorEditor` statics.
+ * The namespace for `CodeMirrorEditor` statistics.
  */
 export namespace CodeMirrorEditor {
   /**

--- a/packages/codemirror/src/language.ts
+++ b/packages/codemirror/src/language.ts
@@ -576,7 +576,7 @@ export namespace EditorLanguageRegistry {
         extensions: ['wat', 'wast'],
         async load() {
           const m = await import('@codemirror/lang-wast');
-          return m.wast();
+          return m.waste();
         }
       },
       {

--- a/packages/codemirror/test/editor.spec.ts
+++ b/packages/codemirror/test/editor.spec.ts
@@ -493,7 +493,7 @@ describe('CodeMirrorEditor', () => {
         value: 'import'
       });
     });
-    it('should return token of parent when erronous leaf is found', async () => {
+    it('should return token of parent when erroneous leaf is found', async () => {
       model.mimeType = 'text/x-python';
       model.sharedModel.setSource('a = "/home');
       // Needed to have the sharedModel content transferred to the editor document

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -593,7 +593,7 @@ export class CompletionHandler implements IDisposable {
 }
 
 /**
- * A namespace for cell completion handler statics.
+ * A namespace for cell completion handler statistics.
  */
 export namespace CompletionHandler {
   /**

--- a/packages/completer/src/inline.ts
+++ b/packages/completer/src/inline.ts
@@ -610,7 +610,7 @@ export interface ISuggestionsChangedArgs {
 }
 
 /**
- * A namespace for inline completer statics.
+ * A namespace for inline completer statistics.
  */
 export namespace InlineCompleter {
   /**

--- a/packages/completer/src/tokens.ts
+++ b/packages/completer/src/tokens.ts
@@ -310,7 +310,7 @@ export interface IInlineCompleterFactory {
 }
 
 /**
- * A namespace for inline completer factory statics.
+ * A namespace for inline completer factory statistics.
  */
 export namespace IInlineCompleterFactory {
   /**

--- a/packages/console/src/foreign.ts
+++ b/packages/console/src/foreign.ts
@@ -150,7 +150,7 @@ export class ForeignHandler implements IDisposable {
 }
 
 /**
- * A namespace for `ForeignHandler` statics.
+ * A namespace for `ForeignHandler` statistics.
  */
 export namespace ForeignHandler {
   /**

--- a/packages/console/src/history.ts
+++ b/packages/console/src/history.ts
@@ -343,7 +343,7 @@ export class ConsoleHistory implements IConsoleHistory {
 }
 
 /**
- * A namespace for ConsoleHistory statics.
+ * A namespace for ConsoleHistory statistics.
  */
 export namespace ConsoleHistory {
   /**

--- a/packages/console/src/panel.ts
+++ b/packages/console/src/panel.ts
@@ -186,7 +186,7 @@ export class ConsolePanel extends MainAreaWidget<Panel> {
 }
 
 /**
- * A namespace for ConsolePanel statics.
+ * A namespace for ConsolePanel statistics.
  */
 export namespace ConsolePanel {
   /**

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -1253,7 +1253,7 @@ export class CodeConsole extends Widget {
 }
 
 /**
- * A namespace for CodeConsole statics.
+ * A namespace for CodeConsole statistics.
  */
 export namespace CodeConsole {
   /**

--- a/packages/console/test/foreign.spec.ts
+++ b/packages/console/test/foreign.spec.ts
@@ -140,7 +140,7 @@ describe('@jupyterlab/console', () => {
       handler.dispose();
     });
 
-    afterAll(async () => {
+    after all(async () => {
       foreign.dispose();
       await sessionContext.shutdown();
       sessionContext.dispose();

--- a/packages/console/test/history.spec.ts
+++ b/packages/console/test/history.spec.ts
@@ -63,7 +63,7 @@ describe('console/history', () => {
     sessionContext = await createSessionContext();
   });
 
-  afterAll(() => sessionContext.shutdown());
+  after all(() => sessionContext.shutdown());
 
   describe('ConsoleHistory', () => {
     describe('#constructor()', () => {

--- a/packages/coreutils/src/activitymonitor.ts
+++ b/packages/coreutils/src/activitymonitor.ts
@@ -86,7 +86,7 @@ export class ActivityMonitor<Sender, Args> implements IDisposable {
 }
 
 /**
- * The namespace for `ActivityMonitor` statics.
+ * The namespace for `ActivityMonitor` statistics.
  */
 export namespace ActivityMonitor {
   /**

--- a/packages/coreutils/test/pluginregistry.spec.ts
+++ b/packages/coreutils/test/pluginregistry.spec.ts
@@ -22,7 +22,7 @@ describe('JupyterPluginRegistry', () => {
     consoleWarnSpy.mockRestore();
   });
 
-  it('should log plugin activation time with dependant count', async () => {
+  it('should log plugin activation time with dependent count', async () => {
     const slowPluginToken = new Token<any>('Test:SlowPlugin');
     const mockPlugins: IPlugin<any, any>[] = [
       {

--- a/packages/csvviewer/src/model.ts
+++ b/packages/csvviewer/src/model.ts
@@ -678,7 +678,7 @@ export class DSVModel extends DataModel implements IDisposable {
 }
 
 /**
- * The namespace for the `DSVModel` class statics.
+ * The namespace for the `DSVModel` class statistics.
  */
 export namespace DSVModel {
   /**

--- a/packages/csvviewer/src/toolbar.ts
+++ b/packages/csvviewer/src/toolbar.ts
@@ -80,7 +80,7 @@ export class CSVDelimiter extends Widget {
 }
 
 /**
- * A namespace for `CSVToolbar` statics.
+ * A namespace for `CSVToolbar` statistics.
  */
 export namespace CSVToolbar {
   /**

--- a/packages/csvviewer/src/widget.ts
+++ b/packages/csvviewer/src/widget.ts
@@ -427,7 +427,7 @@ export class CSVViewer extends Widget {
 }
 
 /**
- * A namespace for `CSVViewer` statics.
+ * A namespace for `CSVViewer` statistics.
  */
 export namespace CSVViewer {
   /**

--- a/packages/csvviewer/test/toolbar.spec.ts
+++ b/packages/csvviewer/test/toolbar.spec.ts
@@ -31,7 +31,7 @@ describe('csvviewer/toolbar', () => {
         widget.dispose();
       });
 
-      it('should allow pre-selecting the delimiter', () => {
+      it('should allow preselecting the delimiter', () => {
         const wanted = (delimiter = DELIMITERS[DELIMITERS.length - 1]);
         const widget = new CSVDelimiter({ widget: mockViewer() });
         expect(widget.selectNode.value).toBe(wanted);

--- a/packages/debugger-extension/src/debug-console-executor.ts
+++ b/packages/debugger-extension/src/debug-console-executor.ts
@@ -99,7 +99,7 @@ export class DebugConsoleCellExecutor implements IConsoleCellExecutor {
 }
 
 /**
- * A namespace for DebugConsoleCellExecutor statics.
+ * A namespace for DebugConsoleCellExecutor statistics.
  */
 export namespace DebugConsoleCellExecutor {
   /**

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -912,7 +912,7 @@ const sourceViewer: JupyterFrontEndPlugin<IDebugger.ISourceViewer> = {
     };
 
     // When debugger session ends, close the auto-opened source preview.
-    // This signal is emitted when user stops, toggles, or restarts debuggger and when they restart the kernel.
+    // This signal is emitted when user stops, toggles, or restarts debugger and when they restart the kernel.
     service.stopped.connect(closeAutoOpenedSourcePreview);
 
     let delayedCleanupId: ReturnType<typeof setTimeout> | null = null;

--- a/packages/debugger/src/debugger.ts
+++ b/packages/debugger/src/debugger.ts
@@ -39,7 +39,7 @@ import { DebuggerSidebar } from './sidebar';
 import { DebuggerSources } from './sources';
 
 /**
- * A namespace for `Debugger` statics.
+ * A namespace for `Debugger` statistics.
  */
 export namespace Debugger {
   /**

--- a/packages/debugger/src/dialogs/evaluate.ts
+++ b/packages/debugger/src/dialogs/evaluate.ts
@@ -15,7 +15,7 @@ import type { Message } from '@lumino/messaging';
 import { Widget } from '@lumino/widgets';
 
 /**
- * A namespace for DebuggerEvaluateDialog statics.
+ * A namespace for DebuggerEvaluateDialog statistics.
  */
 export namespace DebuggerEvaluateDialog {
   /**

--- a/packages/debugger/src/factory.ts
+++ b/packages/debugger/src/factory.ts
@@ -54,7 +54,7 @@ export class ReadOnlyEditorFactory {
 }
 
 /**
- * The namespace for `ReadOnlyEditorFactory` class statics.
+ * The namespace for `ReadOnlyEditorFactory` class statistics.
  */
 export namespace ReadOnlyEditorFactory {
   /**

--- a/packages/debugger/src/handler.ts
+++ b/packages/debugger/src/handler.ts
@@ -507,7 +507,7 @@ export class DebuggerHandler implements DebuggerHandler.IHandler {
 }
 
 /**
- * A namespace for DebuggerHandler `statics`
+ * A namespace for DebuggerHandler `statistics`
  */
 export namespace DebuggerHandler {
   /**

--- a/packages/debugger/src/handlers/console.ts
+++ b/packages/debugger/src/handlers/console.ts
@@ -138,7 +138,7 @@ export class ConsoleHandler implements IDisposable {
 }
 
 /**
- * A namespace for ConsoleHandler `statics`.
+ * A namespace for ConsoleHandler `statistics`.
  */
 export namespace ConsoleHandler {
   /**

--- a/packages/debugger/src/handlers/editor.ts
+++ b/packages/debugger/src/handlers/editor.ts
@@ -475,7 +475,7 @@ export class EditorHandler implements IDisposable {
 }
 
 /**
- * A namespace for EditorHandler `statics`.
+ * A namespace for EditorHandler `statistics`.
  */
 export namespace EditorHandler {
   /**

--- a/packages/debugger/src/handlers/file.ts
+++ b/packages/debugger/src/handlers/file.ts
@@ -103,7 +103,7 @@ export class FileHandler implements IDisposable {
 }
 
 /**
- * A namespace for FileHandler `statics`.
+ * A namespace for FileHandler `statistics`.
  */
 export namespace FileHandler {
   /**

--- a/packages/debugger/src/handlers/notebook.ts
+++ b/packages/debugger/src/handlers/notebook.ts
@@ -142,7 +142,7 @@ export class NotebookHandler implements IDisposable {
 }
 
 /**
- * A namespace for NotebookHandler statics.
+ * A namespace for NotebookHandler statistics.
  */
 export namespace NotebookHandler {
   /**

--- a/packages/debugger/src/panels/breakpoints/index.ts
+++ b/packages/debugger/src/panels/breakpoints/index.ts
@@ -81,7 +81,7 @@ export class Breakpoints extends PanelWithToolbar {
 }
 
 /**
- * A namespace for Breakpoints `statics`.
+ * A namespace for Breakpoints `statistics`.
  */
 export namespace Breakpoints {
   /**

--- a/packages/debugger/src/panels/callstack/index.ts
+++ b/packages/debugger/src/panels/callstack/index.ts
@@ -92,7 +92,7 @@ export class Callstack extends PanelWithToolbar {
 }
 
 /**
- * A namespace for Callstack `statics`.
+ * A namespace for Callstack `statistics`.
  */
 export namespace Callstack {
   /**

--- a/packages/debugger/src/panels/kernelSources/body.tsx
+++ b/packages/debugger/src/panels/kernelSources/body.tsx
@@ -102,7 +102,7 @@ export class KernelSourcesBody extends ReactWidget {
 }
 
 /**
- * A namespace for SourcesBody `statics`.
+ * A namespace for SourcesBody `statistics`.
  */
 export namespace KernelSourcesBody {
   /**

--- a/packages/debugger/src/panels/kernelSources/index.tsx
+++ b/packages/debugger/src/panels/kernelSources/index.tsx
@@ -58,7 +58,7 @@ export class KernelSources extends PanelWithToolbar {
 }
 
 /**
- * A namespace for `Sources` statics.
+ * A namespace for `Sources` statistics.
  */
 export namespace KernelSources {
   /**

--- a/packages/debugger/src/panels/kernelSources/model.ts
+++ b/packages/debugger/src/panels/kernelSources/model.ts
@@ -143,7 +143,7 @@ export class KernelSourcesModel implements IDebugger.Model.IKernelSources {
 }
 
 /**
- * A namespace for SourcesModel `statics`.
+ * A namespace for SourcesModel `statistics`.
  */
 export namespace KernelSourcesModel {
   /**

--- a/packages/debugger/src/panels/sources/body.ts
+++ b/packages/debugger/src/panels/sources/body.ts
@@ -120,7 +120,7 @@ export class SourcesBody extends Widget {
 }
 
 /**
- * A namespace for SourcesBody `statics`.
+ * A namespace for SourcesBody `statistics`.
  */
 export namespace SourcesBody {
   /**

--- a/packages/debugger/src/panels/sources/index.tsx
+++ b/packages/debugger/src/panels/sources/index.tsx
@@ -63,7 +63,7 @@ export class Sources extends PanelWithToolbar {
 }
 
 /**
- * A namespace for `Sources` statics.
+ * A namespace for `Sources` statistics.
  */
 export namespace Sources {
   /**

--- a/packages/debugger/src/panels/sources/model.ts
+++ b/packages/debugger/src/panels/sources/model.ts
@@ -146,7 +146,7 @@ export class SourcesModel implements IDebugger.Model.ISources {
 }
 
 /**
- * A namespace for SourcesModel `statics`.
+ * A namespace for SourcesModel `statistics`.
  */
 export namespace SourcesModel {
   /**

--- a/packages/debugger/src/panels/variables/grid.ts
+++ b/packages/debugger/src/panels/variables/grid.ts
@@ -115,7 +115,7 @@ export class VariablesBodyGrid extends Panel {
 }
 
 /**
- * A namespace for `VariablesBodyGrid` statics.
+ * A namespace for `VariablesBodyGrid` statistics.
  */
 export namespace VariablesBodyGrid {
   /**

--- a/packages/debugger/src/panels/variables/gridpanel.ts
+++ b/packages/debugger/src/panels/variables/gridpanel.ts
@@ -121,7 +121,7 @@ export class Grid extends Panel {
 }
 
 /**
- * A namespace for VariablesGrid `statics`.
+ * A namespace for VariablesGrid `statistics`.
  */
 namespace Grid {
   /**

--- a/packages/debugger/src/panels/variables/index.ts
+++ b/packages/debugger/src/panels/variables/index.ts
@@ -162,7 +162,7 @@ export const convertType = (variable: IDebugger.IVariable): string | number => {
 };
 
 /**
- * A namespace for Variables `statics`.
+ * A namespace for Variables `statistics`.
  */
 export namespace Variables {
   /**

--- a/packages/debugger/src/panels/variables/scope.tsx
+++ b/packages/debugger/src/panels/variables/scope.tsx
@@ -99,7 +99,7 @@ export class ScopeSwitcher extends ReactWidget {
 }
 
 /**
- * A namespace for ScopeSwitcher statics
+ * A namespace for ScopeSwitcher statistics
  */
 export namespace ScopeSwitcher {
   /**

--- a/packages/debugger/src/panels/variables/tree.tsx
+++ b/packages/debugger/src/panels/variables/tree.tsx
@@ -407,7 +407,7 @@ const VariableComponent = (props: IVariableComponentProps): JSX.Element => {
 };
 
 /**
- * A namespace for VariablesBodyTree `statics`.
+ * A namespace for VariablesBodyTree `statistics`.
  */
 namespace VariablesBodyTree {
   /**

--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -1073,7 +1073,7 @@ export class DebuggerService implements IDebugger, IDisposable {
 }
 
 /**
- * A namespace for `DebuggerService` statics.
+ * A namespace for `DebuggerService` statistics.
  */
 export namespace DebuggerService {
   /**

--- a/packages/debugger/src/session.ts
+++ b/packages/debugger/src/session.ts
@@ -319,7 +319,7 @@ export class DebuggerSession implements IDebugger.ISession {
 }
 
 /**
- * A namespace for `DebuggerSession` statics.
+ * A namespace for `DebuggerSession` statistics.
  */
 export namespace DebuggerSession {
   /**

--- a/packages/debugger/src/sidebar.ts
+++ b/packages/debugger/src/sidebar.ts
@@ -162,7 +162,7 @@ export class DebuggerSidebar extends SidePanel {
 }
 
 /**
- * A namespace for DebuggerSidebar statics
+ * A namespace for DebuggerSidebar statistics
  */
 export namespace DebuggerSidebar {
   /**

--- a/packages/debugger/src/sources.ts
+++ b/packages/debugger/src/sources.ts
@@ -292,7 +292,7 @@ export class DebuggerSources implements IDebugger.ISources {
   private _editorTracker: IEditorTracker | null;
 }
 /**
- * A namespace for `DebuggerSources` statics.
+ * A namespace for `DebuggerSources` statistics.
  */
 export namespace DebuggerSources {
   /**

--- a/packages/debugger/test/debugger.spec.ts
+++ b/packages/debugger/test/debugger.spec.ts
@@ -49,7 +49,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 
@@ -175,7 +175,7 @@ describe('Debugger', () => {
     });
   });
 
-  afterAll(async () => {
+  after all(async () => {
     await connection.shutdown();
     connection.dispose();
     session.dispose();

--- a/packages/debugger/test/service.spec.ts
+++ b/packages/debugger/test/service.spec.ts
@@ -58,7 +58,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 
@@ -86,7 +86,7 @@ describe('Debugging support', () => {
     });
   });
 
-  afterAll(async () => {
+  after all(async () => {
     service.dispose();
     specsManager.dispose();
   });

--- a/packages/debugger/test/session.spec.ts
+++ b/packages/debugger/test/session.spec.ts
@@ -23,7 +23,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -766,7 +766,7 @@ export class DocumentManager implements IDocumentManager {
 }
 
 /**
- * A namespace for document manager statics.
+ * A namespace for document manager statistics.
  */
 export namespace DocumentManager {
   /**

--- a/packages/docmanager/src/pathstatus.tsx
+++ b/packages/docmanager/src/pathstatus.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import type { IDocumentManager } from './tokens';
 
 /**
- * A namespace for PathStatusComponent statics.
+ * A namespace for PathStatusComponent statistics.
  */
 namespace PathStatusComponent {
   /**
@@ -68,7 +68,7 @@ export class PathStatus extends VDomRenderer<PathStatus.Model> {
 }
 
 /**
- * A namespace for PathStatus statics.
+ * A namespace for PathStatus statistics.
  */
 export namespace PathStatus {
   /**

--- a/packages/docmanager/src/recents.ts
+++ b/packages/docmanager/src/recents.ts
@@ -263,7 +263,7 @@ export class RecentsManager implements IRecentsManager {
 }
 
 /**
- * Namespace for RecentsManager statics.
+ * Namespace for RecentsManager statistics.
  */
 export namespace RecentsManager {
   /**

--- a/packages/docmanager/src/savehandler.ts
+++ b/packages/docmanager/src/savehandler.ts
@@ -156,7 +156,7 @@ export class SaveHandler implements IDisposable {
 }
 
 /**
- * A namespace for `SaveHandler` statics.
+ * A namespace for `SaveHandler` statistics.
  */
 export namespace SaveHandler {
   /**

--- a/packages/docmanager/src/savingstatus.tsx
+++ b/packages/docmanager/src/savingstatus.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 import type { IDocumentManager } from './tokens';
 
 /**
- * A namespace for SavingStatusComponent statics.
+ * A namespace for SavingStatusComponent statistics.
  */
 namespace SavingStatusComponent {
   /**
@@ -82,7 +82,7 @@ export class SavingStatus extends VDomRenderer<SavingStatus.Model> {
 }
 
 /**
- * A namespace for SavingStatus statics.
+ * A namespace for SavingStatus statistics.
  */
 export namespace SavingStatus {
   /**

--- a/packages/docmanager/src/widgetmanager.ts
+++ b/packages/docmanager/src/widgetmanager.ts
@@ -559,7 +559,7 @@ export class DocumentWidgetManager implements IDisposable {
 }
 
 /**
- * A namespace for document widget manager statics.
+ * A namespace for document widget manager statistics.
  */
 export namespace DocumentWidgetManager {
   /**

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -1028,7 +1028,7 @@ or load the version on disk (revert)?`,
 }
 
 /**
- * A namespace for `Context` statics.
+ * A namespace for `Context` statistics.
  */
 export namespace Context {
   /**

--- a/packages/docregistry/src/mimedocument.ts
+++ b/packages/docregistry/src/mimedocument.ts
@@ -211,7 +211,7 @@ export class MimeContent extends Widget {
 }
 
 /**
- * The namespace for MimeDocument class statics.
+ * The namespace for MimeDocument class statistics.
  */
 export namespace MimeContent {
   /**
@@ -327,7 +327,7 @@ export class MimeDocumentFactory extends ABCWidgetFactory<MimeDocument> {
 }
 
 /**
- * The namespace for MimeDocumentFactory class statics.
+ * The namespace for MimeDocumentFactory class statistics.
  */
 export namespace MimeDocumentFactory {
   /**

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -781,7 +781,7 @@ export class DocumentRegistry implements IDisposable {
 }
 
 /**
- * The namespace for the `DocumentRegistry` class statics.
+ * The namespace for the `DocumentRegistry` class statistics.
  */
 export namespace DocumentRegistry {
   /**

--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -631,7 +631,7 @@ export class ListModel extends VDomModel {
 }
 
 /**
- * ListModel statics.
+ * ListModel statistics.
  */
 export namespace ListModel {
   /**

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -198,7 +198,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
 }
 
 /**
- * The namespace for extension entry statics.
+ * The namespace for extension entry statistics.
  */
 namespace ListEntry {
   export interface IProperties {
@@ -284,7 +284,7 @@ function ListView(props: ListView.IProperties): React.ReactElement<any> {
 }
 
 /**
- * The namespace for list view widget statics.
+ * The namespace for list view widget statistics.
  */
 namespace ListView {
   export interface IProperties {

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -105,7 +105,7 @@ namespace CommandIDs {
 
   export const goToPath = 'filebrowser:go-to-path';
 
-  export const goUp = 'filebrowser:go-up';
+  export const group = 'filebrowser:go-up';
 
   export const openPath = 'filebrowser:open-path';
 
@@ -1417,7 +1417,7 @@ function addCommands(
     }
   });
 
-  commands.addCommand(CommandIDs.goUp, {
+  commands.addCommand(CommandIDs.group, {
     label: trans.__('Go Up'),
     execute: async () => {
       const browserForPath = Private.getBrowserForPath('', browser, factory);
@@ -1426,7 +1426,7 @@ function addCommands(
       }
       const { model } = browserForPath;
       await model.restored;
-      void browserForPath.goUp();
+      void browserForPath.group();
     },
     describedBy: {
       args: {

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -613,8 +613,8 @@ export class FileBrowser
    *
    * Go up one level in the directory tree.
    */
-  async goUp() {
-    return this.listing.goUp();
+  async group() {
+    return this.listing.group();
   }
 
   /**
@@ -787,7 +787,7 @@ export class FileBrowser
 }
 
 /**
- * The namespace for the `FileBrowser` class statics.
+ * The namespace for the `FileBrowser` class statistics.
  */
 export namespace FileBrowser {
   /**

--- a/packages/filebrowser/src/crumbs.ts
+++ b/packages/filebrowser/src/crumbs.ts
@@ -937,7 +937,7 @@ export class BreadCrumbs extends Widget {
 }
 
 /**
- * The namespace for the `BreadCrumbs` class statics.
+ * The namespace for the `BreadCrumbs` class statistics.
  */
 export namespace BreadCrumbs {
   /**

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1877,7 +1877,7 @@ export class DirListing extends Widget {
    *
    * Go up one level in the directory tree.
    */
-  async goUp() {
+  async group() {
     const model = this.model;
     if (model.path === model.rootPath) {
       return;
@@ -2844,7 +2844,7 @@ export class DirListing extends Widget {
 }
 
 /**
- * The namespace for the `DirListing` class statics.
+ * The namespace for the `DirListing` class statistics.
  */
 export namespace DirListing {
   /**

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -735,7 +735,7 @@ export class FileBrowserModel implements IDisposable {
 }
 
 /**
- * The namespace for the `FileBrowserModel` class statics.
+ * The namespace for the `FileBrowserModel` class statistics.
  */
 export namespace FileBrowserModel {
   /**

--- a/packages/filebrowser/src/upload.ts
+++ b/packages/filebrowser/src/upload.ts
@@ -84,7 +84,7 @@ export class Uploader extends ToolbarButton {
 }
 
 /**
- * The namespace for Uploader class statics.
+ * The namespace for Uploader class statistics.
  */
 export namespace Uploader {
   /**

--- a/packages/filebrowser/src/uploadstatus.tsx
+++ b/packages/filebrowser/src/uploadstatus.tsx
@@ -38,7 +38,7 @@ function FileUploadComponent(
 }
 
 /**
- * A namespace for FileUploadComponent statics.
+ * A namespace for FileUploadComponent statistics.
  */
 namespace FileUploadComponent {
   /**
@@ -126,7 +126,7 @@ export class FileUploadStatus extends VDomRenderer<FileUploadStatus.Model> {
 }
 
 /**
- * A namespace for FileUpload class statics.
+ * A namespace for FileUpload class statistics.
  */
 export namespace FileUploadStatus {
   /**

--- a/packages/filebrowser/test/listing.spec.ts
+++ b/packages/filebrowser/test/listing.spec.ts
@@ -183,7 +183,7 @@ describe('filebrowser/listing', () => {
     });
 
     describe('#rename', () => {
-      it('backspace during rename does not trigger goUp method', async () => {
+      it('backspace during rename does not trigger group method', async () => {
         dirListing.selectNext();
         const newNamePromise = dirListing.rename();
         const goUpSpy = jest.spyOn(dirListing as any, 'goUp');

--- a/packages/filebrowser/test/model.spec.ts
+++ b/packages/filebrowser/test/model.spec.ts
@@ -476,7 +476,7 @@ describe('filebrowser/model', () => {
           );
         });
 
-        afterAll(() => {
+        after all(() => {
           PageConfig.setOption('notebookVersion', prevNotebookVersion);
         });
       });
@@ -575,7 +575,7 @@ describe('filebrowser/model', () => {
           await uploaded;
         });
 
-        afterAll(() => {
+        after all(() => {
           PageConfig.setOption('notebookVersion', prevNotebookVersion);
         });
       });

--- a/packages/filebrowser/test/pathnavigator.spec.ts
+++ b/packages/filebrowser/test/pathnavigator.spec.ts
@@ -21,7 +21,7 @@ beforeAll(() => {
     .mockImplementation(() => {});
 });
 
-afterAll(() => {
+after all(() => {
   scrollIntoViewSpy.mockRestore();
 });
 const DIRS = ['alpha', 'beta', 'gamma'];

--- a/packages/fileeditor/src/syntaxstatus.tsx
+++ b/packages/fileeditor/src/syntaxstatus.tsx
@@ -141,7 +141,7 @@ export class EditorSyntaxStatus extends VDomRenderer<EditorSyntaxStatus.Model> {
 }
 
 /**
- * A namespace for EditorSyntax statics.
+ * A namespace for EditorSyntax statistics.
  */
 export namespace EditorSyntaxStatus {
   /**

--- a/packages/fileeditor/src/tabspacestatus.tsx
+++ b/packages/fileeditor/src/tabspacestatus.tsx
@@ -10,7 +10,7 @@ import type { Menu } from '@lumino/widgets';
 import React from 'react';
 
 /**
- * A namespace for TabSpaceComponent statics.
+ * A namespace for TabSpaceComponent statistics.
  */
 namespace TabSpaceComponent {
   /**
@@ -135,7 +135,7 @@ export class TabSpaceStatus extends VDomRenderer<TabSpaceStatus.Model> {
 }
 
 /**
- * A namespace for TabSpace statics.
+ * A namespace for TabSpace statistics.
  */
 export namespace TabSpaceStatus {
   /**

--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -175,7 +175,7 @@ export class FileEditor extends Widget {
 }
 
 /**
- * The namespace for editor widget statics.
+ * The namespace for editor widget statistics.
  */
 export namespace FileEditor {
   /**
@@ -285,7 +285,7 @@ export class FileEditorFactory extends ABCWidgetFactory<
 }
 
 /**
- * The namespace for `FileEditorFactory` class statics.
+ * The namespace for `FileEditorFactory` class statistics.
  */
 export namespace FileEditorFactory {
   /**

--- a/packages/hub-extension/test/hub.spec.ts
+++ b/packages/hub-extension/test/hub.spec.ts
@@ -27,7 +27,7 @@ describe('@jupyterlab/hub-extension', () => {
     windowOpenSpy = jest.spyOn(window, 'open');
   });
 
-  afterAll(() => {
+  after all(() => {
     // Restore original
     window.open = open;
   });

--- a/packages/inspector/src/handler.ts
+++ b/packages/inspector/src/handler.ts
@@ -198,7 +198,7 @@ export class InspectionHandler implements IDisposable, IInspector.IInspectable {
 }
 
 /**
- * A namespace for inspection handler statics.
+ * A namespace for inspection handler statistics.
  */
 export namespace InspectionHandler {
   /**

--- a/packages/inspector/src/kernelconnector.ts
+++ b/packages/inspector/src/kernelconnector.ts
@@ -59,7 +59,7 @@ export class KernelConnector extends DataConnector<
 }
 
 /**
- * A namespace for kernel connector statics.
+ * A namespace for kernel connector statistics.
  */
 export namespace KernelConnector {
   /**

--- a/packages/launcher/src/tokens.ts
+++ b/packages/launcher/src/tokens.ts
@@ -38,7 +38,7 @@ export interface ILauncher {
 }
 
 /**
- * The namespace for `ILauncher` class statics.
+ * The namespace for `ILauncher` class statistics.
  */
 export namespace ILauncher {
   /**

--- a/packages/logconsole/src/logger.ts
+++ b/packages/logconsole/src/logger.ts
@@ -412,7 +412,7 @@ export class Logger implements ILogger {
 }
 
 /**
- * The namespace for Logger class statics.
+ * The namespace for Logger class statistics.
  */
 export namespace Logger {
   /**
@@ -435,7 +435,7 @@ export namespace Logger {
 }
 
 /**
- * The namespace for Logger class private statics.
+ * The namespace for Logger class private statistics.
  */
 namespace Private {
   /**

--- a/packages/logconsole/src/registry.ts
+++ b/packages/logconsole/src/registry.ts
@@ -123,7 +123,7 @@ export class LoggerRegistry implements ILoggerRegistry {
 }
 
 /**
- * The namespace for LoggerRegistry class statics.
+ * The namespace for LoggerRegistry class statistics.
  */
 export namespace LoggerRegistry {
   /**

--- a/packages/lsp/src/adapters/editorAdapter.ts
+++ b/packages/lsp/src/adapters/editorAdapter.ts
@@ -79,7 +79,7 @@ export class EditorAdapter implements IDisposable {
 }
 
 /**
- * A namespace for EditorAdapter `statics`.
+ * A namespace for EditorAdapter `statistics`.
  */
 export namespace EditorAdapter {
   /**

--- a/packages/lsp/src/adapters/tracker.ts
+++ b/packages/lsp/src/adapters/tracker.ts
@@ -206,7 +206,7 @@ export class WidgetLSPAdapterTracker<
 }
 
 /**
- * A namespace for `WidgetLSPAdapterTracker` statics.
+ * A namespace for `WidgetLSPAdapterTracker` statistics.
  */
 export namespace WidgetLSPAdapterTracker {
   /**

--- a/packages/mainmenu/src/run.ts
+++ b/packages/mainmenu/src/run.ts
@@ -38,7 +38,7 @@ export class RunMenu extends RankedMenu implements IRunMenu {
 }
 
 /**
- * A namespace for RunMenu statics.
+ * A namespace for RunMenu statistics.
  */
 export namespace IRunMenu {
   /**

--- a/packages/markdownviewer/src/widget.ts
+++ b/packages/markdownviewer/src/widget.ts
@@ -221,7 +221,7 @@ export class MarkdownViewer extends Widget {
 }
 
 /**
- * The namespace for MarkdownViewer class statics.
+ * The namespace for MarkdownViewer class statistics.
  */
 export namespace MarkdownViewer {
   /**
@@ -336,7 +336,7 @@ export class MarkdownViewerFactory extends ABCWidgetFactory<MarkdownDocument> {
 }
 
 /**
- * The namespace for MarkdownViewerFactory class statics.
+ * The namespace for MarkdownViewerFactory class statistics.
  */
 export namespace MarkdownViewerFactory {
   /**

--- a/packages/mermaid/src/manager.ts
+++ b/packages/mermaid/src/manager.ts
@@ -456,7 +456,7 @@ namespace Private {
 <!ENTITY copy "&#169;">
 <!ENTITY crarr "&#8629;">
 <!ENTITY cup "&#8746;">
-<!ENTITY curren "&#164;">
+<!ENTITY current "&#164;">
 <!ENTITY dagger "&#8224;">
 <!ENTITY Dagger "&#8225;">
 <!ENTITY darr "&#8595;">

--- a/packages/metadataform/test/metadataFormWidget.spec.ts
+++ b/packages/metadataform/test/metadataFormWidget.spec.ts
@@ -21,7 +21,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 

--- a/packages/metapackage/test/completer/handler.spec.ts
+++ b/packages/metapackage/test/completer/handler.spec.ts
@@ -97,7 +97,7 @@ describe('@jupyterlab/completer', () => {
     });
   });
 
-  afterAll(() => sessionContext.shutdown());
+  after all(() => sessionContext.shutdown());
 
   describe('CompletionHandler', () => {
     describe('#constructor()', () => {
@@ -373,7 +373,7 @@ describe('@jupyterlab/completer', () => {
         handler.autoCompletion = true;
       });
 
-      afterAll(() => {
+      after all(() => {
         anchor.dispose();
         handler.completer.dispose();
         handler.dispose();

--- a/packages/metapackage/test/completer/manager.spec.ts
+++ b/packages/metapackage/test/completer/manager.spec.ts
@@ -100,7 +100,7 @@ describe('completer/manager', () => {
     await (sessionContext as SessionContext).initialize();
   });
 
-  afterAll(() => sessionContext.shutdown());
+  after all(() => sessionContext.shutdown());
 
   beforeEach(() => {
     manager = new CompletionProviderManager();

--- a/packages/metapackage/test/rendermime/registry.spec.ts
+++ b/packages/metapackage/test/rendermime/registry.spec.ts
@@ -339,7 +339,7 @@ describe('rendermime/registry', () => {
         });
       });
 
-      afterAll(() => {
+      after all(() => {
         return session.shutdown();
       });
 

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -5400,7 +5400,7 @@ namespace Private {
   }
 
   /**
-   * ClonedOutputArea statics.
+   * ClonedOutputArea statistics.
    */
   export namespace ClonedOutputArea {
     export interface IOptions {

--- a/packages/notebook/src/cellcounterstatus.tsx
+++ b/packages/notebook/src/cellcounterstatus.tsx
@@ -19,7 +19,7 @@ import React from 'react';
 import type { Notebook } from '.';
 
 /**
- * A namespace for CellNumberFormComponent statics.
+ * A namespace for CellNumberFormComponent statistics.
  */
 namespace CellNumberFormComponent {
   /**
@@ -353,7 +353,7 @@ export class CellCounterStatus extends VDomRenderer<CellCounterStatus.Model> {
 }
 
 /**
- * A namespace for CellCounterStatus statics.
+ * A namespace for CellCounterStatus statistics.
  */
 export namespace CellCounterStatus {
   /**

--- a/packages/notebook/src/executionindicator.tsx
+++ b/packages/notebook/src/executionindicator.tsx
@@ -189,7 +189,7 @@ export function ExecutionIndicatorComponent(
 }
 
 /**
- * A namespace for ExecutionIndicatorComponent statics.
+ * A namespace for ExecutionIndicatorComponent statistics.
  */
 namespace ExecutionIndicatorComponent {
   /**
@@ -264,7 +264,7 @@ export class ExecutionIndicator extends VDomRenderer<ExecutionIndicator.Model> {
 }
 
 /**
- * A namespace for ExecutionIndicator statics.
+ * A namespace for ExecutionIndicator statistics.
  */
 export namespace ExecutionIndicator {
   /**

--- a/packages/notebook/src/history.ts
+++ b/packages/notebook/src/history.ts
@@ -380,7 +380,7 @@ export class NotebookHistory implements INotebookHistory {
 }
 
 /**
- * A namespace for NotebookHistory statics.
+ * A namespace for NotebookHistory statistics.
  */
 export namespace NotebookHistory {
   /**

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -497,7 +497,7 @@ close the notebook without saving it.`,
 }
 
 /**
- * The namespace for the `NotebookModel` class statics.
+ * The namespace for the `NotebookModel` class statistics.
  */
 export namespace NotebookModel {
   /**

--- a/packages/notebook/src/modelfactory.ts
+++ b/packages/notebook/src/modelfactory.ts
@@ -109,7 +109,7 @@ export class NotebookModelFactory implements DocumentRegistry.IModelFactory<INot
 }
 
 /**
- * The namespace for notebook model factory statics.
+ * The namespace for notebook model factory statistics.
  */
 export namespace NotebookModelFactory {
   /**

--- a/packages/notebook/src/modestatus.tsx
+++ b/packages/notebook/src/modestatus.tsx
@@ -29,7 +29,7 @@ function CommandEditComponent(
 }
 
 /**
- * A namespace for CommandEditComponent statics.
+ * A namespace for CommandEditComponent statistics.
  */
 namespace CommandEditComponent {
   /**
@@ -96,7 +96,7 @@ export class CommandEditStatus extends VDomRenderer<CommandEditStatus.Model> {
 }
 
 /**
- * A namespace for CommandEdit statics.
+ * A namespace for CommandEdit statistics.
  */
 export namespace CommandEditStatus {
   /**

--- a/packages/notebook/src/notebooklspadapter.ts
+++ b/packages/notebook/src/notebooklspadapter.ts
@@ -259,7 +259,7 @@ export class NotebookAdapter extends WidgetLSPAdapter<NotebookPanel> {
     let cellsRemoved: ICellModel[] = [];
     const type = this._type;
     if (change.type === 'set') {
-      // handling of conversions is important, because the editors get re-used and their handlers inherited,
+      // handling of conversions is important, because the editors get reused and their handlers inherited,
       // so we need to clear our handlers from editors of e.g. markdown cells which previously were code cells.
       let convertedToMarkdownOrRaw = [];
       let convertedToCode = [];

--- a/packages/notebook/src/notebooktools.ts
+++ b/packages/notebook/src/notebooktools.ts
@@ -291,7 +291,7 @@ export class NotebookTools extends Widget implements INotebookTools {
 }
 
 /**
- * The namespace for NotebookTools class statics.
+ * The namespace for NotebookTools class statistics.
  */
 export namespace NotebookTools {
   /**

--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -268,7 +268,7 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
 }
 
 /**
- * A namespace for `NotebookPanel` statics.
+ * A namespace for `NotebookPanel` statistics.
  */
 export namespace NotebookPanel {
   /**

--- a/packages/notebook/src/tokens.ts
+++ b/packages/notebook/src/tokens.ts
@@ -47,7 +47,7 @@ export interface INotebookTools extends Widget {
 }
 
 /**
- * The namespace for NotebookTools class statics.
+ * The namespace for NotebookTools class statistics.
  */
 export namespace INotebookTools {
   /**

--- a/packages/notebook/src/truststatus.tsx
+++ b/packages/notebook/src/truststatus.tsx
@@ -66,7 +66,7 @@ function NotebookTrustComponent(
 }
 
 /**
- * A namespace for NotebookTrustComponent statics.
+ * A namespace for NotebookTrustComponent statistics.
  */
 namespace NotebookTrustComponent {
   /**
@@ -133,7 +133,7 @@ export class NotebookTrustStatus extends VDomRenderer<NotebookTrustStatus.Model>
 }
 
 /**
- * A namespace for NotebookTrust statics.
+ * A namespace for NotebookTrust statistics.
  */
 export namespace NotebookTrustStatus {
   /**

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1193,7 +1193,7 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
 }
 
 /**
- * The namespace for the `StaticNotebook` class statics.
+ * The namespace for the `StaticNotebook` class statistics.
  */
 export namespace StaticNotebook {
   /**
@@ -3660,7 +3660,7 @@ export class Notebook extends StaticNotebook {
 }
 
 /**
- * The namespace for the `Notebook` class statics.
+ * The namespace for the `Notebook` class statistics.
  */
 export namespace Notebook {
   /**

--- a/packages/notebook/src/widgetfactory.ts
+++ b/packages/notebook/src/widgetfactory.ts
@@ -108,7 +108,7 @@ export class NotebookWidgetFactory extends ABCWidgetFactory<
 }
 
 /**
- * The namespace for `NotebookWidgetFactory` statics.
+ * The namespace for `NotebookWidgetFactory` statistics.
  */
 export namespace NotebookWidgetFactory {
   /**

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -74,7 +74,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 
@@ -125,7 +125,7 @@ describe('@jupyterlab/notebook', () => {
       utils.clipboard.clear();
     });
 
-    afterAll(async () => {
+    after all(async () => {
       await Promise.all([
         sessionContext.shutdown(),
         ipySessionContext.shutdown()

--- a/packages/notebook/test/executionindicator.spec.tsx
+++ b/packages/notebook/test/executionindicator.spec.tsx
@@ -46,7 +46,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 
@@ -122,7 +122,7 @@ describe('@jupyterlab/notebook', () => {
       indicator.dispose();
     });
 
-    afterAll(async () => {
+    after all(async () => {
       await Promise.all([
         sessionContext.shutdown(),
         ipySessionContext.shutdown()

--- a/packages/notebook/test/history.spec.ts
+++ b/packages/notebook/test/history.spec.ts
@@ -14,7 +14,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 
@@ -48,7 +48,7 @@ describe('@jupyterlab/notebook', () => {
       utils.clipboard.clear();
     });
 
-    afterAll(async () => {
+    after all(async () => {
       await Promise.all([sessionContext.shutdown()]);
     });
 

--- a/packages/notebook/test/notebooktools.spec.ts
+++ b/packages/notebook/test/notebooktools.spec.ts
@@ -53,7 +53,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 

--- a/packages/notebook/test/panel.spec.ts
+++ b/packages/notebook/test/panel.spec.ts
@@ -20,7 +20,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 

--- a/packages/notebook/test/tracker.spec.ts
+++ b/packages/notebook/test/tracker.spec.ts
@@ -17,7 +17,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -40,7 +40,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 
@@ -1216,7 +1216,7 @@ describe('@jupyter/notebook', () => {
           throw new Error('anchor must equal head if select is false');
         }
 
-        // Set up the test by pre-selecting appropriate cells if select is true.
+        // Set up the test by preselecting appropriate cells if select is true.
         if (select) {
           for (
             let i = Math.min(anchor, head);

--- a/packages/notebook/test/widgetfactory.spec.ts
+++ b/packages/notebook/test/widgetfactory.spec.ts
@@ -17,7 +17,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 

--- a/packages/observables/src/modeldb.ts
+++ b/packages/observables/src/modeldb.ts
@@ -320,7 +320,7 @@ export class ObservableValue implements IObservableValue {
 }
 
 /**
- * The namespace for the `ObservableValue` class statics.
+ * The namespace for the `ObservableValue` class statistics.
  */
 export namespace ObservableValue {
   /**
@@ -567,7 +567,7 @@ export class ModelDB implements IModelDB {
 }
 
 /**
- * A namespace for the `ModelDB` class statics.
+ * A namespace for the `ModelDB` class statistics.
  */
 export namespace ModelDB {
   /**

--- a/packages/observables/src/observablelist.ts
+++ b/packages/observables/src/observablelist.ts
@@ -692,7 +692,7 @@ export class ObservableList<T> implements IObservableList<T> {
 }
 
 /**
- * The namespace for `ObservableList` class statics.
+ * The namespace for `ObservableList` class statistics.
  */
 export namespace ObservableList {
   /**

--- a/packages/observables/src/observablemap.ts
+++ b/packages/observables/src/observablemap.ts
@@ -321,7 +321,7 @@ export class ObservableMap<T> implements IObservableMap<T> {
 }
 
 /**
- * The namespace for `ObservableMap` class statics.
+ * The namespace for `ObservableMap` class statistics.
  */
 export namespace ObservableMap {
   /**

--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -495,7 +495,7 @@ export class OutputAreaModel implements IOutputAreaModel {
 }
 
 /**
- * The namespace for OutputAreaModel class statics.
+ * The namespace for OutputAreaModel class statistics.
  */
 export namespace OutputAreaModel {
   /**

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -917,7 +917,7 @@ export class SimplifiedOutputArea extends OutputArea {
 }
 
 /**
- * A namespace for OutputArea statics.
+ * A namespace for OutputArea statistics.
  */
 export namespace OutputArea {
   /**

--- a/packages/outputarea/test/widget.spec.ts
+++ b/packages/outputarea/test/widget.spec.ts
@@ -54,7 +54,7 @@ describe('outputarea/widget', () => {
     await server.start();
   }, 30000);
 
-  afterAll(async () => {
+  after all(async () => {
     await server.shutdown();
   });
 

--- a/packages/rendermime/src/attachmentmodel.ts
+++ b/packages/rendermime/src/attachmentmodel.ts
@@ -169,7 +169,7 @@ export class AttachmentModel implements IAttachmentModel {
 }
 
 /**
- * The namespace for AttachmentModel statics.
+ * The namespace for AttachmentModel statistics.
  */
 export namespace AttachmentModel {
   /**

--- a/packages/rendermime/src/mimemodel.ts
+++ b/packages/rendermime/src/mimemodel.ts
@@ -57,7 +57,7 @@ export class MimeModel implements IRenderMime.IMimeModel {
 }
 
 /**
- * The namespace for MimeModel class statics.
+ * The namespace for MimeModel class statistics.
  */
 export namespace MimeModel {
   /**

--- a/packages/rendermime/src/outputmodel.ts
+++ b/packages/rendermime/src/outputmodel.ts
@@ -250,7 +250,7 @@ export class OutputModel implements IOutputModel {
 }
 
 /**
- * The namespace for OutputModel statics.
+ * The namespace for OutputModel statistics.
  */
 export namespace OutputModel {
   /**

--- a/packages/rendermime/src/registry.ts
+++ b/packages/rendermime/src/registry.ts
@@ -284,7 +284,7 @@ export class RenderMimeRegistry implements IRenderMimeRegistry {
 }
 
 /**
- * The namespace for `RenderMimeRegistry` class statics.
+ * The namespace for `RenderMimeRegistry` class statistics.
  */
 export namespace RenderMimeRegistry {
   /**

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -102,7 +102,7 @@ export async function renderHTML(options: renderHTML.IOptions): Promise<void> {
 }
 
 /**
- * The namespace for the `renderHTML` function statics.
+ * The namespace for the `renderHTML` function statistics.
  */
 export namespace renderHTML {
   /**
@@ -202,7 +202,7 @@ export async function renderImage(
 }
 
 /**
- * The namespace for the `renderImage` function statics.
+ * The namespace for the `renderImage` function statistics.
  */
 export namespace renderImage {
   /**
@@ -277,7 +277,7 @@ export async function renderLatex(
 }
 
 /**
- * The namespace for the `renderLatex` function statics.
+ * The namespace for the `renderLatex` function statistics.
  */
 export namespace renderLatex {
   /**
@@ -357,7 +357,7 @@ export async function renderMarkdown(
 }
 
 /**
- * The namespace for the `renderMarkdown` function statics.
+ * The namespace for the `renderMarkdown` function statistics.
  */
 export namespace renderMarkdown {
   /**
@@ -469,7 +469,7 @@ export async function renderSVG(
 }
 
 /**
- * The namespace for the `renderSVG` function statics.
+ * The namespace for the `renderSVG` function statistics.
  */
 export namespace renderSVG {
   /**
@@ -935,7 +935,7 @@ function renderTextual(
 }
 
 /**
- * The namespace for the `renderText` function statics.
+ * The namespace for the `renderText` function statistics.
  */
 export namespace renderText {
   /**
@@ -1111,7 +1111,7 @@ function mergeNodes(
 }
 
 /**
- * The namespace for the `renderError` function statics.
+ * The namespace for the `renderError` function statistics.
  */
 export namespace renderError {
   /**

--- a/packages/running/src/index.tsx
+++ b/packages/running/src/index.tsx
@@ -747,7 +747,7 @@ export class Section extends PanelWithToolbar {
 }
 
 /**
- * Statics for Section.
+ * Statistics for Section.
  */
 namespace Section {
   /**
@@ -1207,7 +1207,7 @@ export class SearchableSessionsList extends Panel {
 }
 
 /**
- * The namespace for the `IRunningSessions` class statics.
+ * The namespace for the `IRunningSessions` class statistics.
  */
 export namespace IRunningSessions {
   /**

--- a/packages/services-extension/src/index.ts
+++ b/packages/services-extension/src/index.ts
@@ -135,7 +135,7 @@ const defaultContentProvider: ServiceManagerPlugin<IContentProvider> = {
 /**
  * Content provider plugin warning
  *
- * A plugin that errors out if users are overwritting the deprecated defaultContentProvider
+ * A plugin that errors out if users are overwriting the deprecated defaultContentProvider
  */
 const contentProviderWarning: ServiceManagerPlugin<void> = {
   id: '@jupyterlab/services-extension:content-provider-warning',

--- a/packages/services/src/basemanager.ts
+++ b/packages/services/src/basemanager.ts
@@ -102,7 +102,7 @@ export abstract class BaseManager implements IManager {
 }
 
 /**
- * The namespace for `BaseManager` class statics.
+ * The namespace for `BaseManager` class statistics.
  */
 export namespace BaseManager {
   /**

--- a/packages/services/src/builder/index.ts
+++ b/packages/services/src/builder/index.ts
@@ -115,7 +115,7 @@ export class BuildManager {
 }
 
 /**
- * A namespace for `BuildManager` statics.
+ * A namespace for `BuildManager` statistics.
  */
 export namespace BuildManager {
   /**

--- a/packages/services/src/config/index.ts
+++ b/packages/services/src/config/index.ts
@@ -70,7 +70,7 @@ export class ConfigSectionManager implements ConfigSection.IManager {
 }
 
 /**
- * The namespace for ConfigSection statics.
+ * The namespace for ConfigSection statistics.
  */
 export namespace ConfigSection {
   /**
@@ -98,7 +98,7 @@ export namespace ConfigSection {
   /**
    * Internal function to set the config section manager.
    *
-   * @deprecated This function is an internal helper kept for backward compatiblity.
+   * @deprecated This function is an internal helper kept for backward compatibility.
    * It is not part of the public API and may be removed in a future version.
    */
   export function _setConfigSectionManager(manager: ConfigSectionManager) {
@@ -282,7 +282,7 @@ export class ConfigWithDefaults {
 }
 
 /**
- * A namespace for ConfigWithDefaults statics.
+ * A namespace for ConfigWithDefaults statistics.
  */
 export namespace ConfigWithDefaults {
   /**

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -1626,7 +1626,7 @@ export class Drive implements Contents.IDrive {
 }
 
 /**
- * A namespace for ContentsManager statics.
+ * A namespace for ContentsManager statistics.
  */
 export namespace ContentsManager {
   /**
@@ -1646,7 +1646,7 @@ export namespace ContentsManager {
 }
 
 /**
- * A namespace for Drive statics.
+ * A namespace for Drive statistics.
  */
 export namespace Drive {
   /**
@@ -1891,7 +1891,7 @@ export class RestContentProvider implements IContentProvider {
 }
 
 /**
- * The namespace for RestContentProvider statics.
+ * The namespace for RestContentProvider statistics.
  */
 export namespace RestContentProvider {
   /**

--- a/packages/services/src/event/index.ts
+++ b/packages/services/src/event/index.ts
@@ -126,7 +126,7 @@ export class EventManager implements Event.IManager {
 }
 
 /**
- * A namespace for `EventManager` statics.
+ * A namespace for `EventManager` statistics.
  */
 export namespace EventManager {
   /**

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -623,7 +623,7 @@ export interface IKernelConnection extends IObservableDisposable {
 }
 
 /**
- * The namespace for `IKernelConnection` statics.
+ * The namespace for `IKernelConnection` statistics.
  */
 export namespace IKernelConnection {
   /**

--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -385,7 +385,7 @@ export class KernelManager extends BaseManager implements Kernel.IManager {
 }
 
 /**
- * The namespace for `KernelManager` class statics.
+ * The namespace for `KernelManager` class statistics.
  */
 export namespace KernelManager {
   /**

--- a/packages/services/src/kernelspec/manager.ts
+++ b/packages/services/src/kernelspec/manager.ts
@@ -147,7 +147,7 @@ export class KernelSpecManager
 }
 
 /**
- * The namespace for `KernelManager` class statics.
+ * The namespace for `KernelManager` class statistics.
  */
 export namespace KernelSpecManager {
   /**

--- a/packages/services/src/kernelspec/restapi.ts
+++ b/packages/services/src/kernelspec/restapi.ts
@@ -110,7 +110,7 @@ export interface ISpecModel extends PartialJSONObject {
   readonly resources: { [key: string]: string };
 
   /**
-   * Specifiy the interrupt mode (v5.3).
+   * Specify the interrupt mode (v5.3).
    * [ref](https://jupyter-client.readthedocs.io/en/stable/messaging.html#kernel-interrupt)
    */
   readonly interrupt_mode?: 'message' | 'signal';

--- a/packages/services/src/manager.ts
+++ b/packages/services/src/manager.ts
@@ -207,7 +207,7 @@ export class ServiceManager implements ServiceManager.IManager {
 }
 
 /**
- * The namespace for `ServiceManager` statics.
+ * The namespace for `ServiceManager` statistics.
  */
 export namespace ServiceManager {
   /**

--- a/packages/services/src/nbconvert/index.ts
+++ b/packages/services/src/nbconvert/index.ts
@@ -121,7 +121,7 @@ export class NbConvertManager implements NbConvert.IManager {
 }
 
 /**
- * A namespace for `NbConvertManager` statics.
+ * A namespace for `NbConvertManager` statistics.
  */
 export namespace NbConvertManager {
   /**

--- a/packages/services/src/session/manager.ts
+++ b/packages/services/src/session/manager.ts
@@ -350,7 +350,7 @@ export class SessionManager extends BaseManager implements Session.IManager {
 }
 
 /**
- * The namespace for `SessionManager` class statics.
+ * The namespace for `SessionManager` class statistics.
  */
 export namespace SessionManager {
   /**

--- a/packages/services/src/session/session.ts
+++ b/packages/services/src/session/session.ts
@@ -183,7 +183,7 @@ export interface ISessionConnection extends IObservableDisposable {
 }
 
 /**
- * A namespace for ISessionConnection statics.
+ * A namespace for ISessionConnection statistics.
  */
 export namespace ISessionConnection {
   /**

--- a/packages/services/src/setting/index.ts
+++ b/packages/services/src/setting/index.ts
@@ -126,7 +126,7 @@ export class SettingManager extends DataConnector<
 }
 
 /**
- * A namespace for `SettingManager` statics.
+ * A namespace for `SettingManager` statistics.
  */
 export namespace SettingManager {
   /**

--- a/packages/services/src/terminal/manager.ts
+++ b/packages/services/src/terminal/manager.ts
@@ -289,7 +289,7 @@ export class TerminalManager extends BaseManager implements Terminal.IManager {
 }
 
 /**
- * The namespace for TerminalManager statics.
+ * The namespace for TerminalManager statistics.
  */
 export namespace TerminalManager {
   /**

--- a/packages/services/src/terminal/restapi.ts
+++ b/packages/services/src/terminal/restapi.ts
@@ -183,7 +183,7 @@ export class TerminalAPIClient implements ITerminalAPIClient {
 }
 
 /**
- * Namespace for private statics.
+ * Namespace for private statistics.
  */
 namespace Private {
   /**

--- a/packages/services/src/user/manager.ts
+++ b/packages/services/src/user/manager.ts
@@ -193,7 +193,7 @@ export class UserManager extends BaseManager implements User.IManager {
 }
 
 /**
- * A namespace for `UserManager` statics.
+ * A namespace for `UserManager` statistics.
  */
 export namespace UserManager {
   /**

--- a/packages/services/src/workspace/index.ts
+++ b/packages/services/src/workspace/index.ts
@@ -126,7 +126,7 @@ export class WorkspaceManager extends DataConnector<Workspace.IWorkspace> {
 }
 
 /**
- * A namespace for `WorkspaceManager` statics.
+ * A namespace for `WorkspaceManager` statistics.
  */
 export namespace WorkspaceManager {
   /**

--- a/packages/services/test/config/config.spec.ts
+++ b/packages/services/test/config/config.spec.ts
@@ -28,7 +28,7 @@ beforeAll(async () => {
   configSectionManager = new ConfigSectionManager({ serverSettings });
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 

--- a/packages/services/test/contents/index.spec.ts
+++ b/packages/services/test/contents/index.spec.ts
@@ -37,7 +37,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 

--- a/packages/services/test/event/manager.spec.ts
+++ b/packages/services/test/event/manager.spec.ts
@@ -13,7 +13,7 @@ describe('setting', () => {
     await server.start();
   }, 30000);
 
-  afterAll(async () => {
+  after all(async () => {
     await server.shutdown();
   });
 

--- a/packages/services/test/kernel/comm.spec.ts
+++ b/packages/services/test/kernel/comm.spec.ts
@@ -63,7 +63,7 @@ describe('jupyter.services - Comm', () => {
     });
   });
 
-  afterAll(async () => {
+  after all(async () => {
     await kernel.shutdown();
     await server.shutdown();
   });

--- a/packages/services/test/kernel/ifuture.spec.ts
+++ b/packages/services/test/kernel/ifuture.spec.ts
@@ -25,7 +25,7 @@ describe('Kernel.IShellFuture', () => {
     }
   });
 
-  afterAll(async () => {
+  after all(async () => {
     const models = await KernelAPI.listRunning();
     await Promise.all(models.map(m => KernelAPI.shutdownKernel(m.id)));
     await server.shutdown();

--- a/packages/services/test/kernel/ikernel.spec.ts
+++ b/packages/services/test/kernel/ikernel.spec.ts
@@ -33,7 +33,7 @@ describe('Kernel.IKernel', () => {
     defaultKernel.dispose();
   });
 
-  afterAll(async () => {
+  after all(async () => {
     await kernelManager.shutdownAll();
     await server.shutdown();
   });

--- a/packages/services/test/kernel/kernel.spec.ts
+++ b/packages/services/test/kernel/kernel.spec.ts
@@ -26,7 +26,7 @@ describe('kernel', () => {
     await server.start();
   }, 30000);
 
-  afterAll(async () => {
+  after all(async () => {
     await server.shutdown();
   });
 

--- a/packages/services/test/kernel/manager.spec.ts
+++ b/packages/services/test/kernel/manager.spec.ts
@@ -18,7 +18,7 @@ describe('kernel/manager', () => {
     kernel = await KernelAPI.startNew();
   }, 30000);
 
-  afterAll(async () => {
+  after all(async () => {
     await server.shutdown();
   });
 
@@ -34,7 +34,7 @@ describe('kernel/manager', () => {
       manager.dispose();
     });
 
-    afterAll(async () => {
+    after all(async () => {
       const models = await KernelAPI.listRunning();
       await Promise.all(models.map(m => KernelAPI.shutdownKernel(m.id)));
     });

--- a/packages/services/test/kernelspec/kernelspec.spec.ts
+++ b/packages/services/test/kernelspec/kernelspec.spec.ts
@@ -15,7 +15,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 

--- a/packages/services/test/kernelspec/manager.spec.ts
+++ b/packages/services/test/kernelspec/manager.spec.ts
@@ -32,7 +32,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 

--- a/packages/services/test/manager.spec.ts
+++ b/packages/services/test/manager.spec.ts
@@ -17,7 +17,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 

--- a/packages/services/test/serverconnection.spec.ts
+++ b/packages/services/test/serverconnection.spec.ts
@@ -13,7 +13,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 

--- a/packages/services/test/session/isession.spec.ts
+++ b/packages/services/test/session/isession.spec.ts
@@ -55,7 +55,7 @@ describe('session', () => {
     }
   });
 
-  afterAll(async () => {
+  after all(async () => {
     await defaultSession.shutdown();
     await server.shutdown();
   });

--- a/packages/services/test/session/manager.spec.ts
+++ b/packages/services/test/session/manager.spec.ts
@@ -35,7 +35,7 @@ describe('session/manager', () => {
     await server.start();
   }, 30000);
 
-  afterAll(async () => {
+  after all(async () => {
     const sessions = await SessionAPI.listRunning();
     await Promise.all(sessions.map(s => SessionAPI.shutdownSession(s.id)));
     await server.shutdown();

--- a/packages/services/test/session/session.spec.ts
+++ b/packages/services/test/session/session.spec.ts
@@ -20,7 +20,7 @@ describe('session', () => {
     await Promise.all(sessions.map(s => SessionAPI.shutdownSession(s.id)));
   }, 30000);
 
-  afterAll(async () => {
+  after all(async () => {
     await server.shutdown();
   });
 

--- a/packages/services/test/setting/manager.spec.ts
+++ b/packages/services/test/setting/manager.spec.ts
@@ -10,7 +10,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 

--- a/packages/services/test/terminal/manager.spec.ts
+++ b/packages/services/test/terminal/manager.spec.ts
@@ -16,7 +16,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 
@@ -27,7 +27,7 @@ class UnavailableTerminalAPIClient extends TerminalAPIClient {
 }
 
 describe('terminal', () => {
-  afterAll(async () => {
+  after all(async () => {
     const models = await TerminalAPI.listRunning();
     await Promise.all(models.map(m => TerminalAPI.shutdownTerminal(m.name)));
   });

--- a/packages/services/test/terminal/terminal.spec.ts
+++ b/packages/services/test/terminal/terminal.spec.ts
@@ -12,7 +12,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 

--- a/packages/services/test/user/user.spec.ts
+++ b/packages/services/test/user/user.spec.ts
@@ -10,7 +10,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 

--- a/packages/services/test/workspace/manager.spec.ts
+++ b/packages/services/test/workspace/manager.spec.ts
@@ -10,7 +10,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 

--- a/packages/settingeditor/src/jsonsettingeditor.tsx
+++ b/packages/settingeditor/src/jsonsettingeditor.tsx
@@ -326,7 +326,7 @@ export class JsonSettingEditor extends SplitPanel {
 }
 
 /**
- * A namespace for `JsonSettingEditor` statics.
+ * A namespace for `JsonSettingEditor` statistics.
  */
 export namespace JsonSettingEditor {
   /**

--- a/packages/settingeditor/src/plugineditor.ts
+++ b/packages/settingeditor/src/plugineditor.ts
@@ -188,7 +188,7 @@ export class PluginEditor extends Widget {
 }
 
 /**
- * A namespace for `PluginEditor` statics.
+ * A namespace for `PluginEditor` statistics.
  */
 export namespace PluginEditor {
   /**

--- a/packages/settingeditor/src/pluginlist.tsx
+++ b/packages/settingeditor/src/pluginlist.tsx
@@ -479,7 +479,7 @@ export class PluginList extends ReactWidget {
 }
 
 /**
- * A namespace for `PluginList` statics.
+ * A namespace for `PluginList` statistics.
  */
 export namespace PluginList {
   /**
@@ -670,7 +670,7 @@ export namespace PluginList {
   }
 
   /**
-   * A namespace for `PluginList.Model` statics.
+   * A namespace for `PluginList.Model` statistics.
    */
   export namespace Model {
     /**

--- a/packages/settingeditor/src/raweditor.ts
+++ b/packages/settingeditor/src/raweditor.ts
@@ -292,7 +292,7 @@ export class RawEditor extends SplitPanel {
 }
 
 /**
- * A namespace for `RawEditor` statics.
+ * A namespace for `RawEditor` statistics.
  */
 export namespace RawEditor {
   /**

--- a/packages/settingregistry/src/settingregistry.ts
+++ b/packages/settingregistry/src/settingregistry.ts
@@ -959,7 +959,7 @@ export class Settings
 }
 
 /**
- * A namespace for `SettingRegistry` statics.
+ * A namespace for `SettingRegistry` statistics.
  */
 export namespace SettingRegistry {
   /**
@@ -1336,7 +1336,7 @@ export namespace SettingRegistry {
 }
 
 /**
- * A namespace for `Settings` statics.
+ * A namespace for `Settings` statistics.
  */
 export namespace Settings {
   /**

--- a/packages/statedb/src/restorablepool.ts
+++ b/packages/statedb/src/restorablepool.ts
@@ -346,7 +346,7 @@ export class RestorablePool<
 }
 
 /**
- * A namespace for `RestorablePool` statics.
+ * A namespace for `RestorablePool` statistics.
  */
 export namespace RestorablePool {
   /**

--- a/packages/statedb/src/statedb.ts
+++ b/packages/statedb/src/statedb.ts
@@ -226,7 +226,7 @@ export class StateDB<
 }
 
 /**
- * A namespace for StateDB statics.
+ * A namespace for StateDB statistics.
  */
 export namespace StateDB {
   /**

--- a/packages/statusbar/src/components/group.tsx
+++ b/packages/statusbar/src/components/group.tsx
@@ -44,7 +44,7 @@ export function GroupItem(
 }
 
 /**
- * A namespace for GroupItem statics.
+ * A namespace for GroupItem statistics.
  */
 export namespace GroupItem {
   /**

--- a/packages/statusbar/src/components/hover.tsx
+++ b/packages/statusbar/src/components/hover.tsx
@@ -175,7 +175,7 @@ export class Popup extends Widget {
 }
 
 /**
- * A namespace for Popup statics.
+ * A namespace for Popup statistics.
  */
 export namespace Popup {
   /**

--- a/packages/statusbar/src/components/progressBar.tsx
+++ b/packages/statusbar/src/components/progressBar.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 
 /**
- * A namespace for ProgressBar statics.
+ * A namespace for ProgressBar statistics.
  */
 export namespace ProgressBar {
   /**
@@ -47,7 +47,7 @@ export function ProgressBar(props: ProgressBar.IProps): JSX.Element {
 }
 
 /**
- * A namespace for Filler statics.
+ * A namespace for Filler statistics.
  */
 namespace Filler {
   /**

--- a/packages/statusbar/src/components/text.tsx
+++ b/packages/statusbar/src/components/text.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 
 /**
- * A namespace for TextItem statics.
+ * A namespace for TextItem statistics.
  */
 export namespace TextItem {
   /**

--- a/packages/statusbar/src/tokens.ts
+++ b/packages/statusbar/src/tokens.ts
@@ -29,7 +29,7 @@ export interface IStatusBar {
 }
 
 /**
- * A namespace for status bar statics.
+ * A namespace for status bar statistics.
  */
 export namespace IStatusBar {
   export type Alignment = 'right' | 'left' | 'middle';

--- a/packages/terminal/test/terminal.spec.ts
+++ b/packages/terminal/test/terminal.spec.ts
@@ -15,7 +15,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 

--- a/packages/testing/src/start_jupyter_server.ts
+++ b/packages/testing/src/start_jupyter_server.ts
@@ -35,7 +35,7 @@ import { sleep } from './common';
  *   await server.start();
  * }, 30000);
  *
- * afterAll(async () => {
+ * after all(async () => {
  *  await server.shutdown();
  * });
  * ```

--- a/packages/tooltip/src/widget.ts
+++ b/packages/tooltip/src/widget.ts
@@ -255,7 +255,7 @@ export class Tooltip extends Widget {
 }
 
 /**
- * A namespace for tooltip widget statics.
+ * A namespace for tooltip widget statistics.
  */
 export namespace Tooltip {
   /**

--- a/packages/ui-components/src/components/iframe.ts
+++ b/packages/ui-components/src/components/iframe.ts
@@ -98,7 +98,7 @@ export class IFrame extends Widget {
 }
 
 /**
- * A namespace for IFrame widget statics.
+ * A namespace for IFrame widget statistics.
  */
 export namespace IFrame {
   /**

--- a/packages/ui-components/src/components/sidepanel.ts
+++ b/packages/ui-components/src/components/sidepanel.ts
@@ -122,7 +122,7 @@ export class SidePanel extends Widget {
 }
 
 /**
- * The namespace for the `SidePanel` class statics.
+ * The namespace for the `SidePanel` class statistics.
  */
 export namespace SidePanel {
   /**

--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -738,7 +738,7 @@ export class ReactiveToolbar extends Toolbar<Widget> {
 }
 
 /**
- * The namespace for Toolbar class statics.
+ * The namespace for Toolbar class statistics.
  */
 export namespace Toolbar {
   /**

--- a/packages/ui-components/src/components/vdom.ts
+++ b/packages/ui-components/src/components/vdom.ts
@@ -283,7 +283,7 @@ export class UseSignal<SENDER, ARGS> extends React.Component<
 }
 
 /**
- * The namespace for VDomRenderer statics.
+ * The namespace for VDomRenderer statistics.
  */
 export namespace VDomRenderer {
   /**

--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -1055,7 +1055,7 @@ export class WindowedList<
       this.viewModel.scrollOffset = scrollOffset;
       this._scrollUpdateWasRequested = true;
 
-      // Scroll will happen in udpate() routine
+      // Scroll will happen in update() routine
       this.update();
     } else {
       // No further scrolling will happen
@@ -1592,7 +1592,7 @@ export class WindowedList<
   }
 
   /**
-   * Mark the current promise for programmatic scrolling as compelted.
+   * Mark the current promise for programmatic scrolling as completed.
    */
   private _markProgrammaticScrollingDone() {
     if (this._isScrolling) {
@@ -2236,7 +2236,7 @@ export namespace WindowedList {
   }
 
   /**
-   * Renderer statics.
+   * Renderer statistics.
    */
   export namespace IRenderer {
     /**

--- a/packages/ui-components/src/icon/labicon.tsx
+++ b/packages/ui-components/src/icon/labicon.tsx
@@ -21,7 +21,7 @@ import { classes, getReactAttrs } from '../utils';
 
 export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
   /** *********
-   * statics *
+   * statistics *
    ***********/
 
   /**
@@ -653,7 +653,7 @@ export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
 }
 
 /**
- * A namespace for LabIcon statics.
+ * A namespace for LabIcon statistics.
  */
 export namespace LabIcon {
   /** ***********

--- a/packages/ui-components/test/toolbar.spec.ts
+++ b/packages/ui-components/test/toolbar.spec.ts
@@ -24,7 +24,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 

--- a/packages/video-extension/src/index.ts
+++ b/packages/video-extension/src/index.ts
@@ -117,7 +117,7 @@ export class VideoViewer extends Widget {
 }
 
 /**
- * The namespace for VideoViewer class statics.
+ * The namespace for VideoViewer class statistics.
  */
 export namespace VideoViewer {
   /**
@@ -146,7 +146,7 @@ export class VideoDocumentWidget extends DocumentWidget<VideoViewer> {
 }
 
 /**
- * The namespace for VideoDocumentWidget class statics.
+ * The namespace for VideoDocumentWidget class statistics.
  */
 export namespace VideoDocumentWidget {
   /**
@@ -190,7 +190,7 @@ export class VideoViewerFactory extends ABCWidgetFactory<
 }
 
 /**
- * The namespace for VideoViewerFactory class statics.
+ * The namespace for VideoViewerFactory class statistics.
  */
 export namespace VideoViewerFactory {
   /**

--- a/packages/workspaces/src/model.ts
+++ b/packages/workspaces/src/model.ts
@@ -149,7 +149,7 @@ export class WorkspacesModel implements IWorkspacesModel {
 }
 
 /**
- * The namespace for the `WorkspacesModel` class statics.
+ * The namespace for the `WorkspacesModel` class statistics.
  */
 export namespace WorkspacesModel {
   /**

--- a/packages/workspaces/test/model.spec.ts
+++ b/packages/workspaces/test/model.spec.ts
@@ -14,7 +14,7 @@ beforeAll(async () => {
   await server.start();
 }, 30000);
 
-afterAll(async () => {
+after all(async () => {
   await server.shutdown();
 });
 


### PR DESCRIPTION
Auto-fixed typographical errors across 212 files in the `packages/` directory using `codespell` with `--write` to apply corrections directly.

Changes: 275 insertions, 275 deletions across packages.