### PR TITLE
Clarify TypeScript watch builds in documentation

### DIFF
--- a/docs/source/developer/contributing.md
+++ b/docs/source/developer/contributing.md
@@ -496,12 +496,17 @@ dev mode, extensions will not be activated by default - refer
 When running in dev mode, a red stripe will appear at the top of the
 page; this is to indicate running an unreleased version.
 
-If you want to change the TypeScript code and rebuild on the fly
-(needs page refresh after each rebuild):
+If you want to change the TypeScript code in the core packages and
+rebuild on the fly (needs page refresh after each rebuild):
 
 ```bash
 jupyter lab --dev-mode --watch
 ```
+
+The watch mode rebuilds TypeScript sources in the JupyterLab repository.
+When developing a separate extension, run that extension's build or watch
+command as well so its TypeScript changes are compiled before refreshing
+JupyterLab.
 
 ### Build and Run the Tests
 


### PR DESCRIPTION
## References

Fixes #5840.

## Code changes

Clarifies that `jupyter lab --dev-mode --watch` rebuilds TypeScript sources for core JupyterLab packages and that separate extension development still requires the extension's own build or watch command.

## User-facing changes

Documentation-only clarification for contributors working on TypeScript changes.

## Backwards-incompatible changes

N/A.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: OpenAI GPT-5.5 via OpenClaw
