### PR TITLE
Deduplicate concurrent LSP document connects by URI

### DIFF
--- a/packages/lsp/src/connection_manager.ts
+++ b/packages/lsp/src/connection_manager.ts
@@ -26,7 +26,7 @@ import { expandDottedPaths, sleep, untilReady } from './utils';
 import type { VirtualDocument } from './virtual/document';
 
 import type * as protocol from 'vscode-languageserver-protocol';
-import type { ReadonlyJSONObject } from '@lumino/coreutils';
+import { PromiseDelegate, type ReadonlyJSONObject } from '@lumino/coreutils';
 
 /**
  * Each Widget with a document (whether file or a notebook) has the same DocumentConnectionManager
@@ -377,44 +377,77 @@ export class DocumentConnectionManager implements ILSPDocumentConnectionManager 
     firstTimeoutSeconds = 30,
     secondTimeoutMinutes = 5
   ): Promise<ILSPConnection | undefined> {
-    let connection = await this._connectSocket(options);
-    let { virtualDocument } = options;
-    if (!connection) {
-      return;
+    const { virtualDocument } = options;
+    const { uri } = virtualDocument;
+    const existingConnection = this.connections.get(uri);
+
+    if (existingConnection) {
+      return existingConnection;
     }
-    if (!connection.isReady) {
+
+    const pendingConnection = this._pendingConnections.get(uri);
+    if (pendingConnection) {
+      return pendingConnection;
+    }
+
+    const pendingConnectDelegate = new PromiseDelegate<
+      ILSPConnection | undefined
+    >();
+    const pendingConnectionPromise = pendingConnectDelegate.promise;
+    this._pendingConnections.set(uri, pendingConnectionPromise);
+
+    void (async () => {
       try {
-        // user feedback hinted that 40 seconds was too short and some users are willing to wait more;
-        // to make the best of both worlds we first check frequently (6.6 times a second) for the first
-        // 30 seconds, and show the warning early in case if something is wrong; we then continue retrying
-        // for another 5 minutes, but only once per second.
-        await untilReady(
-          () => connection!.isReady,
-          Math.round((firstTimeoutSeconds * 1000) / 150),
-          150
-        );
-      } catch {
-        console.log(
-          `Connection to ${virtualDocument.uri} timed out after ${firstTimeoutSeconds} seconds, will continue retrying for another ${secondTimeoutMinutes} minutes`
-        );
-        try {
-          await untilReady(
-            () => connection!.isReady,
-            60 * secondTimeoutMinutes,
-            1000
-          );
-        } catch {
-          console.log(
-            `Connection to ${virtualDocument.uri} timed out again after ${secondTimeoutMinutes} minutes, giving up`
-          );
+        let connection = await this._connectSocket(options);
+        if (!connection) {
+          pendingConnectDelegate.resolve(undefined);
           return;
         }
+        if (!connection.isReady) {
+          try {
+            // user feedback hinted that 40 seconds was too short and some users are willing to wait more;
+            // to make the best of both worlds we first check frequently (6.6 times a second) for the first
+            // 30 seconds, and show the warning early in case if something is wrong; we then continue retrying
+            // for another 5 minutes, but only once per second.
+            await untilReady(
+              () => connection!.isReady,
+              Math.round((firstTimeoutSeconds * 1000) / 150),
+              150
+            );
+          } catch {
+            console.log(
+              `Connection to ${virtualDocument.uri} timed out after ${firstTimeoutSeconds} seconds, will continue retrying for another ${secondTimeoutMinutes} minutes`
+            );
+            try {
+              await untilReady(
+                () => connection!.isReady,
+                60 * secondTimeoutMinutes,
+                1000
+              );
+            } catch {
+              console.log(
+                `Connection to ${virtualDocument.uri} timed out again after ${secondTimeoutMinutes} minutes, giving up`
+              );
+              pendingConnectDelegate.resolve(undefined);
+              return;
+            }
+          }
+        }
+
+        this._connected.emit({ connection, virtualDocument });
+        pendingConnectDelegate.resolve(connection);
+      } catch (error) {
+        pendingConnectDelegate.reject(error);
+      }
+    })();
+
+    try {
+      return await pendingConnectionPromise;
+    } finally {
+      if (this._pendingConnections.get(uri) === pendingConnectionPromise) {
+        this._pendingConnections.delete(uri);
       }
     }
-
-    this._connected.emit({ connection, virtualDocument });
-
-    return connection;
   }
 
   /**
@@ -541,6 +574,14 @@ export class DocumentConnectionManager implements ILSPDocumentConnectionManager 
    * Set of ignored languages
    */
   private _ignoredLanguages: Set<string>;
+
+  /**
+   * Map of in-flight connect calls keyed by virtual document URI.
+   */
+  private _pendingConnections: Map<
+    VirtualDocument.uri,
+    Promise<ILSPConnection | undefined>
+  > = new Map();
 }
 
 export namespace DocumentConnectionManager {

--- a/packages/lsp/test/connection_manager.spec.ts
+++ b/packages/lsp/test/connection_manager.spec.ts
@@ -11,6 +11,7 @@ import {
 } from '@jupyterlab/lsp';
 import { LabShell } from '@jupyterlab/application';
 import { ServerConnection } from '@jupyterlab/services';
+import { PromiseDelegate } from '@lumino/coreutils';
 import { LSPConnection } from '../src/connection';
 
 jest.mock('@jupyterlab/notebook');
@@ -110,6 +111,57 @@ describe('@jupyterlab/lsp', () => {
         });
         connection.dispose();
         expect(connection.isDisposed).toBe(true);
+      });
+    });
+    describe('#connect()', () => {
+      it('should deduplicate concurrent connects for the same URI', async () => {
+        const connectPromise = new PromiseDelegate<LSPConnection | undefined>();
+        const connection = { isReady: true } as LSPConnection;
+        const connectSocketSpy = jest
+          .spyOn(manager as any, '_connectSocket')
+          .mockReturnValue(connectPromise.promise);
+
+        const connectedSlot = jest.fn();
+        manager.connected.connect(connectedSlot);
+
+        const options = {
+          capabilities: {},
+          virtualDocument: document,
+          language: document.language,
+          hasLspSupportedFile: document.hasLspSupportedFile
+        };
+
+        const firstConnect = manager.connect(options);
+        const secondConnect = manager.connect(options);
+
+        expect(connectSocketSpy).toHaveBeenCalledTimes(1);
+
+        connectPromise.resolve(connection);
+
+        await expect(firstConnect).resolves.toBe(connection);
+        await expect(secondConnect).resolves.toBe(connection);
+        expect(connectedSlot).toHaveBeenCalledTimes(1);
+      });
+
+      it('should clear pending connect state when a connect fails', async () => {
+        const connection = { isReady: true } as LSPConnection;
+        const connectSocketSpy = jest
+          .spyOn(manager as any, '_connectSocket')
+          .mockRejectedValueOnce(new Error('connect failed'))
+          .mockResolvedValueOnce(connection);
+
+        const options = {
+          capabilities: {},
+          virtualDocument: document,
+          language: document.language,
+          hasLspSupportedFile: document.hasLspSupportedFile
+        };
+
+        await expect(manager.connect(options)).rejects.toThrow(
+          'connect failed'
+        );
+        await expect(manager.connect(options)).resolves.toBe(connection);
+        expect(connectSocketSpy).toHaveBeenCalledTimes(2);
       });
     });
   });


### PR DESCRIPTION
## References
Closes https://github.com/jupyter-lsp/jupyterlab-lsp/issues/1192

## Code changes
This PR fixes a race in `DocumentConnectionManager.connect()` where multiple concurrent calls for the same `virtualDocument.uri` could start duplicate connection flows. We now coalesce in-flight connects using a URI-keyed pending map, return an existing settled connection when available, and always clear pending state after success or failure so retries work correctly.

## User-facing changes
None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: codex 5.3
