### PR TITLE
Add tests for the readonly indicator

### DIFF
--- a/galata/test/jupyterlab/readonly.test.ts
+++ b/galata/test/jupyterlab/readonly.test.ts
@@ -24,8 +24,8 @@ test.describe('test readonly status', () => {
     await page.notebook.close();
     await page.notebook.open('notebook.ipynb');
 
-    // The read-only indicator should be shown in the toolbar as soon as a
-    // read-only document is opened (regression check for #18739).
+    // The read-only indicator should show in the toolbar when a read-only
+    // document is opened (regression check for #18739).
     const readOnlyIndicator = page
       .getByRole('main')
       .locator('[data-jp-item-name="read-only-indicator"]');

--- a/galata/test/jupyterlab/readonly.test.ts
+++ b/galata/test/jupyterlab/readonly.test.ts
@@ -24,6 +24,14 @@ test.describe('test readonly status', () => {
     await page.notebook.close();
     await page.notebook.open('notebook.ipynb');
 
+    // The read-only indicator should be shown in the toolbar as soon as a
+    // read-only document is opened (regression check for #18739).
+    const readOnlyIndicator = page
+      .getByRole('main')
+      .locator('[data-jp-item-name="read-only-indicator"]');
+    await expect(readOnlyIndicator).toBeVisible();
+    await expect(readOnlyIndicator).toContainText('read-only');
+
     await page.keyboard.press('Control+s');
 
     const imageName = 'readonly.png';

--- a/galata/test/jupyterlab/readonly.test.ts
+++ b/galata/test/jupyterlab/readonly.test.ts
@@ -25,7 +25,7 @@ test.describe('test readonly status', () => {
     await page.notebook.open('notebook.ipynb');
 
     // The read-only indicator should show in the toolbar when a read-only
-    // document is opened (regression check for #18739).
+    // document is opened.
     const readOnlyIndicator = page
       .getByRole('main')
       .locator('[data-jp-item-name="read-only-indicator"]');

--- a/packages/docregistry/test/default.spec.ts
+++ b/packages/docregistry/test/default.spec.ts
@@ -626,8 +626,7 @@ describe('docregistry/default', () => {
           get: () => ({ ...baseModel!, writable: false })
         });
 
-        // The read-only state is handled once the context is ready, so a
-        // fresh widget is needed to exercise the constructor path.
+        // The read-only state is handled once the context is ready.
         const readOnlyWidget = new DocumentWidget({
           context,
           content: new Widget()

--- a/packages/docregistry/test/default.spec.ts
+++ b/packages/docregistry/test/default.spec.ts
@@ -16,7 +16,7 @@ import {
 import { createFileContextWithMockedServices } from '@jupyterlab/docregistry/lib/testutils';
 import type { ServiceManager } from '@jupyterlab/services';
 import { ServiceManagerMock } from '@jupyterlab/services/lib/testutils';
-import { sleep } from '@jupyterlab/testing';
+import { framePromise, sleep } from '@jupyterlab/testing';
 import { UUID } from '@lumino/coreutils';
 import { Widget } from '@lumino/widgets';
 
@@ -616,6 +616,30 @@ describe('docregistry/default', () => {
         expect(widget.title.className).toContain('jp-mod-dirty');
         context.model.dirty = false;
         expect(widget.title.className).not.toContain('jp-mod-dirty');
+      });
+
+      it('should add the read-only indicator when the file is not writable', async () => {
+        // Force the contents model to report the document as read-only.
+        const baseModel = context.contentsModel;
+        Object.defineProperty(context, 'contentsModel', {
+          configurable: true,
+          get: () => ({ ...baseModel!, writable: false })
+        });
+
+        // The read-only state is handled once the context is ready, so a
+        // fresh widget is needed to exercise the constructor path.
+        const readOnlyWidget = new DocumentWidget({
+          context,
+          content: new Widget()
+        });
+        await context.ready;
+        await framePromise();
+
+        expect(Array.from(readOnlyWidget.toolbar.names())).toContain(
+          'read-only-indicator'
+        );
+
+        readOnlyWidget.dispose();
       });
 
       it('should store the context', () => {


### PR DESCRIPTION

## References

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/18960

This may help avoid future regressions as noticed downstream in https://github.com/jupyterlite/jupyterlite/pull/1964

## Code changes

- [x] Add test for the readonly indicator

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Opus 4.8 & GPT 5.5
