### PR TITLE
Make rendered HTML tables follow the content font size

### DIFF
--- a/packages/rendermime/style/base.css
+++ b/packages/rendermime/style/base.css
@@ -428,7 +428,7 @@
   border-spacing: 0;
   border: none;
   color: var(--jp-ui-font-color1);
-  font-size: var(--jp-ui-font-size1);
+  font-size: var(--jp-content-font-size1);
   table-layout: fixed;
   margin-left: auto;
   margin-bottom: 1em;


### PR DESCRIPTION
Rendered HTML tables used `--jp-ui-font-size1`, so their font size didn't follow the content font size the way the rest of rendered Markdown does (for example *Increase Content Font Size*, themes, and presentation mode). This switches the `.jp-RenderedHTMLCommon table` rule to `--jp-content-font-size1`.

Refs #7569
