### PR TITLE
Some linting improvements from the Scientific Python style guide

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,13 +18,15 @@ repos:
       - id: check-executables-have-shebangs
       - id: requirements-txt-fixer
       - id: check-added-large-files
-      - id: check-case-conflict
       - id: check-toml
       - id: check-yaml
       - id: debug-statements
       - id: check-builtin-literals
       - id: trailing-whitespace
         exclude: .bumpversion.cfg
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: mixed-line-ending
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.37.2

--- a/docs/source/_ext/shellcheck_builder.py
+++ b/docs/source/_ext/shellcheck_builder.py
@@ -11,13 +11,16 @@ import subprocess
 import textwrap
 from pathlib import Path
 from shutil import which
+from typing import TYPE_CHECKING
 
 from docutils import nodes
-from sphinx.application import Sphinx
 from sphinx.builders import Builder
 from sphinx.errors import SphinxError
 from sphinx.locale import __
 from sphinx.util import logging
+
+if TYPE_CHECKING:
+    from sphinx.application import Sphinx
 
 LOGGER = logging.getLogger(__name__)
 
@@ -147,7 +150,7 @@ class ShellcheckBuilder(Builder):
                 stripped = line.lstrip()
                 if stripped.startswith(self._prompt):
                     command = stripped[len(self._prompt) :]
-                    script_lines.append(command[1:] if command.startswith(" ") else command)
+                    script_lines.append(command.removeprefix(" "))
                 else:
                     script_lines.append("# output")
             return "\n".join(script_lines) + "\n"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -260,8 +260,7 @@ def _format_command_arguments(args_schema: dict) -> str:
 
 def _format_scope_name(scope: str) -> str:
     """Format scope name for display."""
-    if scope.endswith("-extension"):
-        scope = scope[: -len("-extension")]
+    scope = scope.removesuffix("-extension")
 
     compound_suffixes = ["browser", "manager", "menu", "editor", "console", "viewer", "search"]
     for suffix in compound_suffixes:
@@ -414,7 +413,7 @@ html_theme_options = {
     "switcher": {
         # Trick to get the documentation version switcher to always points to the latest version without being corrected by the integrity check;
         # otherwise older versions won't list newer versions
-        "json_url": "/".join(
+        "json_url": "/".join(  # noqa: FLY002
             ("https://jupyterlab.readthedocs.io/en", "latest", "_static/switcher.json")
         ),
         "version_match": os.environ.get("READTHEDOCS_VERSION", "latest"),

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -57,7 +57,7 @@ def main():
                     runner = osp.join(here, "example_check.py")
                     subprocess.check_call([sys.executable, runner, path], cwd=cwd)  # noqa S603
                     count += 1
-        except subprocess.CalledProcessError:
+        except subprocess.CalledProcessError:  # noqa: PERF203
             failed.append(path)
 
     if failed:

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1004,7 +1004,7 @@ class _AppHandler:
         Returns `True` if a rebuild is recommended, `False` otherwise
         """
         should_rebuild = False
-        for extname, _ in self.info["extensions"].items():
+        for extname in self.info["extensions"]:
             uninstalled = self.uninstall_extension(extname)
             should_rebuild = should_rebuild or uninstalled
         return should_rebuild
@@ -1015,7 +1015,7 @@ class _AppHandler:
         Returns `True` if a rebuild is recommended, `False` otherwise.
         """
         should_rebuild = False
-        for extname, _ in self.info["extensions"].items():
+        for extname in self.info["extensions"]:
             if extname in self.info["local_extensions"]:
                 continue
             updated = self._update_extension(extname)
@@ -1340,10 +1340,7 @@ class _AppHandler:
             locked = dict.fromkeys(locked, True)
         info["locked"] = locked
 
-        disabled_core = []
-        for key in info["core_extensions"]:
-            if key in info["disabled"]:
-                disabled_core.append(key)
+        disabled_core = [key for key in info["core_extensions"] if key in info["disabled"]]
 
         info["disabled_core"] = disabled_core
 

--- a/jupyterlab/coreconfig.py
+++ b/jupyterlab/coreconfig.py
@@ -102,10 +102,7 @@ class CoreConfig:
             data["jupyterlab"]["mimeExtensions"],
         )
         for m in maps:
-            try:
-                del m[name]
-            except KeyError:
-                pass
+            m.pop(name, None)
 
         data["jupyterlab"]["singletonPackages"].remove(name)
 

--- a/jupyterlab/extensions/manager.py
+++ b/jupyterlab/extensions/manager.py
@@ -361,7 +361,7 @@ class ExtensionManager(PluginManager):
     @property
     def metadata(self) -> ExtensionManagerMetadata:
         """Extension manager metadata."""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     async def get_latest_version(self, extension: str) -> str | None:
         """Return the latest available version for a given extension.
@@ -371,7 +371,7 @@ class ExtensionManager(PluginManager):
         Returns:
             The latest available version
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     async def list_packages(
         self, query: str, page: int, per_page: int
@@ -386,7 +386,7 @@ class ExtensionManager(PluginManager):
             The available extensions in a mapping {name: metadata}
             The results last page; None if the manager does not support pagination
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     async def install(self, extension: str, version: str | None = None) -> ActionResult:
         """Install the required extension.
@@ -402,7 +402,7 @@ class ExtensionManager(PluginManager):
         Returns:
             The action result
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     async def uninstall(self, extension: str) -> ActionResult:
         """Uninstall the required extension.
@@ -417,7 +417,7 @@ class ExtensionManager(PluginManager):
         Returns:
             The action result
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     @staticmethod
     def get_semver_version(version: str) -> str:

--- a/jupyterlab/handlers/announcements.py
+++ b/jupyterlab/handlers/announcements.py
@@ -255,9 +255,7 @@ class NewsHandler(APIHandler):
                         link_node = links[0] if len(links) == 1 else None
                     entry_link = link_node.get("href") if link_node is not None else None
 
-                    message = (
-                        "\n".join([entry_title, entry_summary]) if entry_summary else entry_title
-                    )
+                    message = f"{entry_title}\n{entry_summary}" if entry_summary else entry_title
                     modified_at = format_datetime(entry_updated)
                     created_at = format_datetime(entry_published)
                     notification = Notification(

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -803,7 +803,7 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
             entry_point = EXT_MANAGERS.get(provider)
             if entry_point is None:
                 self.log.error(f"Extension Manager: No manager defined for provider '{provider}'.")
-                raise NotImplementedError()
+                raise NotImplementedError
             else:
                 self.log.info(f"Extension Manager is '{provider}'.")
             manager_factory = entry_point.load()

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -718,7 +718,7 @@ class TestExtension(AppHandlerTest):
         def _mock_install(self, name, *args, **kwargs):
             assert name in ("mockextension", "mockextension@1.1.0")
             if name == "mockextension@1.1.0":
-                raise Success()
+                raise Success
             return orig_install(self, name, *args, **kwargs)
 
         p1 = patch.object(commands, "_fetch_package_metadata", _mock_metadata)

--- a/jupyterlab/utils.py
+++ b/jupyterlab/utils.py
@@ -10,8 +10,6 @@ class jupyterlab_deprecation(Warning):  # noqa
     silences deprecations by default.
     """
 
-    pass
-
 
 class deprecated:  # noqa
     """Decorator to mark deprecated functions with warning.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,9 +261,9 @@ exclude = ["*.ipynb"]
 target-version = "py310"
 line-length = 100
 lint.select = [
-  "A", "B", "C", "DTZ", "E", "EM", "F", "FBT", "I", "ICN", "N",
-  "PLC", "PLE", "PLR", "PLW", "Q", "RUF", "S", "SIM", "T", "TID", "UP",
-  "W", "YTT",
+  "A", "B", "C", "C4", "DTZ", "E", "EM", "F", "FBT", "FLY", "FURB", "I",
+  "ICN", "LOG", "N", "PERF", "PIE", "PLC", "PLE", "PLR", "PLW", "Q", "RSE",
+  "RUF", "S", "SIM", "SLOT", "T", "TC", "TID", "UP", "W", "YTT",
 ]
 lint.ignore = [
 # FBT001 Boolean positional arg in function definition


### PR DESCRIPTION
### Description

Some low-risk Linting improvements from [Scientific Python style guide](https://learn.scientific-python.org/development/guides/style/)

#### Pre-commit hooks
- Added:
  - `check-merge-conflict`
  - `check-symlinks`
  - `mixed-line-ending`
- Removed duplicate `check-case-conflict` entry

#### Ruff rules
- Enabled selected rule sets from the Scientific Python style guide:
  - C4
  - FLY
  - FURB
  - LOG
  - PERF
  - PIE
  - RSE
  - SLOT
  - TC

- Fixed ~18 newly surfaced violations (mostly auto-fixes)
 
## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude Code
