### PR TITLE
Add IPagePayloadRegistry to OutputArea

### DIFF
--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -106,6 +106,7 @@ export class OutputArea extends Widget {
     this.contentFactory =
       options.contentFactory ?? OutputArea.defaultContentFactory;
     this.rendermime = options.rendermime;
+    this._pagePayloadRegistry = options.pagePayloadRegistry;
     this._maxNumberOutputs = options.maxNumberOutputs ?? Infinity;
     this._translator = options.translator ?? nullTranslator;
     this._inputHistoryScope = options.inputHistoryScope ?? 'global';
@@ -831,9 +832,13 @@ export class OutputArea extends Widget {
       return;
     }
     const page = JSON.parse(JSON.stringify(pages[0]));
+    const data = (page as any).data as nbformat.IMimeBundle;
+    if (this._pagePayloadRegistry?.handle({ data })) {
+      return;
+    }
     const output: nbformat.IOutput = {
       output_type: 'display_data',
-      data: (page as any).data as nbformat.IMimeBundle,
+      data,
       metadata: {}
     };
     model.add(output);
@@ -877,6 +882,7 @@ export class OutputArea extends Widget {
   private _inputRequested = new Signal<OutputArea, IStdin>(this);
   private _toggleScrolling = new Signal<OutputArea, void>(this);
   private _initialize = new Signal<OutputArea, void>(this);
+  private _pagePayloadRegistry: OutputArea.IPagePayloadRegistry | undefined;
   private _outputTracker = new WidgetTracker<Widget>({
     namespace: UUID.uuid4()
   });
@@ -940,6 +946,15 @@ export namespace OutputArea {
     rendermime: IRenderMimeRegistry;
 
     /**
+     * Optional registry for handling kernel `page` payloads.
+     *
+     * If set, the registry is consulted before the default inline render of
+     * a page payload. If a registered handler returns `true`, the inline
+     * render is skipped.
+     */
+    pagePayloadRegistry?: IPagePayloadRegistry;
+
+    /**
      * The maximum number of output items to display on top and bottom of cell output.
      */
     maxNumberOutputs?: number;
@@ -963,6 +978,50 @@ export namespace OutputArea {
      * Whether to show placeholder text in standard input
      */
     showInputPlaceholder?: boolean;
+  }
+
+  /**
+   * A handler for kernel `page` payloads.
+   */
+  export interface IPagePayloadHandler {
+    /**
+     * Handle a page payload.
+     *
+     * @param payload - The page payload to handle.
+     * @returns `true` if the payload was claimed (suppressing the default
+     *   inline render); `false` to fall through to the next handler.
+     */
+    handle(payload: IPagePayload): boolean;
+  }
+
+  /**
+   * A page payload from a kernel `execute_reply`.
+   */
+  export interface IPagePayload {
+    /**
+     * The MIME bundle of the payload.
+     */
+    data: nbformat.IMimeBundle;
+  }
+
+  /**
+   * A registry of `page` payload handlers.
+   *
+   * Mirrors the registry pattern used by `DebuggerDisplayRegistry`: handlers
+   * are tried in registration order, and the first one to return `true` from
+   * `handle` claims the payload.
+   */
+  export interface IPagePayloadRegistry {
+    /**
+     * Register a handler.
+     */
+    register(handler: IPagePayloadHandler): void;
+
+    /**
+     * Try each registered handler in turn. Returns `true` if any handler
+     * claimed the payload, otherwise `false`.
+     */
+    handle(payload: IPagePayload): boolean;
   }
 
   /**

--- a/packages/outputarea/test/widget.spec.ts
+++ b/packages/outputarea/test/widget.spec.ts
@@ -9,7 +9,8 @@ import {
   OutputAreaModel,
   SimplifiedOutputArea
 } from '@jupyterlab/outputarea';
-import type { Kernel } from '@jupyterlab/services';
+import type * as nbformat from '@jupyterlab/nbformat';
+import type { Kernel, KernelMessage } from '@jupyterlab/services';
 import { KernelManager } from '@jupyterlab/services';
 import { JupyterServer, signalToPromise } from '@jupyterlab/testing';
 import {
@@ -300,6 +301,73 @@ describe('outputarea/widget', () => {
         widget.future = future;
         const reply = await future.done;
         expect(reply!.content.execution_count).toBeTruthy();
+        expect(model.length).toBe(1);
+      });
+    });
+
+    describe('#pagePayloadRegistry', () => {
+      const replyWithPage = (data: nbformat.IMimeBundle) =>
+        ({
+          channel: 'shell',
+          content: {
+            status: 'ok',
+            execution_count: 1,
+            user_expressions: {},
+            payload: [{ source: 'page', data, start: 0 }]
+          }
+        }) as unknown as KernelMessage.IExecuteReplyMsg;
+
+      it('should inline a `page` payload by default', () => {
+        widget.model.clear();
+        const reply = replyWithPage({ 'text/plain': 'docs for math.pi' });
+        // The OutputArea wires `_onExecuteReply` to `value.onReply` when a
+        // future is set; for unit testing we invoke the same code path
+        // directly via the typed test seam below.
+        (widget as any)._onExecuteReply(reply);
+        expect(model.length).toBe(1);
+        expect(model.toJSON()[0].data).toEqual({
+          'text/plain': 'docs for math.pi'
+        });
+      });
+
+      it('should skip the inline render when a registered handler claims the payload', () => {
+        widget.dispose();
+        const claimed: OutputArea.IPagePayload[] = [];
+        const registry: OutputArea.IPagePayloadRegistry = {
+          register: () => undefined,
+          handle: payload => {
+            claimed.push(payload);
+            return true;
+          }
+        };
+        widget = new LogOutputArea({
+          rendermime,
+          model,
+          pagePayloadRegistry: registry
+        });
+        widget.model.clear();
+        const data = { 'text/plain': 'docs for math.pi' };
+        (widget as any)._onExecuteReply(replyWithPage(data));
+        expect(claimed.length).toBe(1);
+        expect(claimed[0].data).toEqual(data);
+        expect(model.length).toBe(0);
+      });
+
+      it('should fall through to inline render when the handler returns false', () => {
+        widget.dispose();
+        const registry: OutputArea.IPagePayloadRegistry = {
+          register: () => undefined,
+          handle: () => false
+        };
+        widget = new LogOutputArea({
+          rendermime,
+          model,
+          pagePayloadRegistry: registry
+        });
+        widget.model.clear();
+        (widget as any)._onExecuteReply(
+          replyWithPage({ 'text/plain': 'docs' })
+        );
         expect(model.length).toBe(1);
       });
     });


### PR DESCRIPTION
Right now `OutputArea._onExecuteReply` inlines `page` payloads (the `?math.pi`-style help content) as `display_data`, hardcoded. There's no way for a consumer to claim that payload and render it elsewhere.

This adds an optional `IPagePayloadRegistry` on `OutputArea.IOptions` — same shape as `DebuggerDisplayRegistry`. If a registered handler returns `true`, the inline render is skipped. No registry → behavior unchanged.

Two follow-ups this unblocks:

- The Contextual Help panel could finally pick up `?` introspection (today it only listens to `inspect_request`).
- Notebook 7 could route page payloads to its `down` panel — see `jupyter/notebook#6692`.

Went with a registry rather than a signal because `patterns.md` says signals shouldn't gate default behavior.