### PR TITLE
Fix `HTMLSelect` dropdown icon misalignment in toolbar popup

### DIFF
--- a/packages/ui-components/src/components/htmlselect.tsx
+++ b/packages/ui-components/src/components/htmlselect.tsx
@@ -97,7 +97,7 @@ export class HTMLSelect extends React.Component<IHTMLSelectProps> {
             tag: 'span',
             stylesheet: 'select',
             right: '4px',
-            top: '8px',
+            top: '4px',
             ...iconProps
           }}
         />

--- a/packages/ui-components/style/base.css
+++ b/packages/ui-components/style/base.css
@@ -172,6 +172,11 @@
   padding: 6px;
 }
 
+.jp-HTMLSelect {
+  position: relative;
+  width: fit-content;
+}
+
 .jp-HTMLSelect.jp-DefaultStyle {
   /* Leave space for the focus outline */
   padding: 0 2px;

--- a/packages/ui-components/style/base.css
+++ b/packages/ui-components/style/base.css
@@ -174,7 +174,6 @@
 
 .jp-HTMLSelect {
   position: relative;
-  width: fit-content;
 }
 
 .jp-HTMLSelect.jp-DefaultStyle {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes #18956

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Two root causes were identified and fixed:

**1. Horizontal misalignment** (`packages/ui-components/style/base.css`)

Added `position: relative` to `.jp-HTMLSelect`. Without it, the caret SVG (`position: absolute; right: 4px`) had no positioned ancestor on the `.jp-HTMLSelect` container, so its containing block became the nearest positioned ancestor in the DOM — the toolbar popup element itself. This caused the caret to anchor to the popup's top-right corner instead of the right edge of the `<select>`.

This generalizes the scoped workaround that already existed in `packages/shortcuts-extension/style/base.css`.

**2. Vertical misalignment** (`packages/ui-components/src/components/htmlselect.tsx`)

Changed `top: '8px'` → `top: '4px'` for the caret icon. The select element is 24px tall and the SVG icon is 16px. The correct centered offset is `(24 - 16) / 2 = 4px`. The previous value of `8px` placed the icon flush with the bottom of the container.

## User-facing changes

The dropdown caret icon in `HTMLSelect` components is now correctly positioned when the toolbar overflows into the `...` (ellipsis) popup:

- **Before**: caret floated to the top-right corner of the popup, detached from the `<select>` element

<img width="415" height="259" alt="Screenshot 2026-06-06 at 9 52 02 PM" src="https://github.com/user-attachments/assets/2209a4f9-ee6a-454a-b38e-7915988e9b7b" />

- **After**: caret sits at the right edge of the `<select>`, vertically centered, in both the normal toolbar and the popup

<img width="449" height="280" alt="Screenshot 2026-06-06 at 9 43 33 PM" src="https://github.com/user-attachments/assets/f4b27373-a0f8-4534-a10e-7246628ecc5a" />

Affected components: notebook cell-type toolbar, debugger scope switcher, log console log-level dropdown, shortcuts-extension command selector.

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

> **Note (Safari):** There is a pre-existing issue in Safari where the toolbar second row renders incorrectly at narrow viewport widths (items rom both toolbar rows mix together). This exists on `main` before this fix and is unrelated to the changes here. Screenshots attached below for visibility — this will be tracked separately.

<img width="412" height="272" alt="Screenshot 2026-06-06 at 9 52 43 PM" src="https://github.com/user-attachments/assets/aca266df-1b42-4d90-8c8f-adc7cc6c69dd" />

## Backwards-incompatible changes

None. `position: relative` on `.jp-HTMLSelect` only affects its own absolutely-positioned child (the caret SVG). No public API changes.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude Sonnet 4.6 via Claude Code Pro
