### PR TITLE
Fix toolbar popup row clipping in Safari

### DIFF
--- a/packages/ui-components/style/toolbar.css
+++ b/packages/ui-components/style/toolbar.css
@@ -93,7 +93,6 @@ button.jp-ToolbarButtonComponent .jp-ToolbarButtonComponent-label {
 
 .jp-Toolbar-responsive-popup.jp-ThemedContainer {
   position: absolute;
-  height: fit-content;
   border-bottom: var(--jp-border-width) solid var(--jp-toolbar-border-color);
   box-shadow: var(--jp-toolbar-box-shadow);
   background: var(--jp-toolbar-background);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes #18997

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Removed `height: fit-content` from `.jp-Toolbar-responsive-popup.jp-ThemedContainer` in `packages/ui-components/style/toolbar.css`.

This rule styles the toolbar's `...` overflow-popup container (the `ToolbarPopup` widget in `packages/ui-components/src/components/toolbar.tsx`), which is `position: absolute` with only `top`/`right` set (no `bottom`). Safari/WebKit resolves an explicit `height: fit-content` differently than Chrome/Blink for this case, collapsing/clipping the popup row. Removing the explicit keyword falls back to the default `height: auto`, which already shrink-wraps to the content's natural height consistently across engines — achieving the exact same intended sizing without the cross-browser divergence.

The root cause was confirmed by live-toggling the rule in Safari's Web Inspector: disabling `height: fit-content` immediately fixed the rendering.

This is the same `fit-content`-on-Safari bug class as the `.jp-HTMLSelect` fix in #18956 (different element/property — `width` vs `height` — but the same root pattern), and both trace back to the November 2023 toolbar web-component rewrite (#15021) that originally introduced this popup.

## User-facing changes

In Safari, the toolbar overflow (`...`) popup now renders at full height with all of its content visible, matching Chrome/Firefox/other browsers.

- **Before**: the popup row appeared compressed/cut down in Safari only
<img width="412" height="264" alt="Screenshot 2026-06-08 at 7 26 24 PM" src="https://github.com/user-attachments/assets/55eec69f-9404-4f48-a178-d534b5c7a8c3" />

- **After**: the popup renders identically across browsers

<img width="1465" height="893" alt="Screenshot 2026-06-08 at 8 49 10 PM" src="https://github.com/user-attachments/assets/3c698242-2914-48dd-b562-3f80ec9bd6f3" />
<img width="1465" height="923" alt="Screenshot 2026-06-08 at 8 50 00 PM" src="https://github.com/user-attachments/assets/63e374c7-0b73-4c7c-a492-24e31412e7f7" />

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->
(Before/after screenshots from Chrome, Safari, and Firefox dev tools attached below.)

## Backwards-incompatible changes

None. A single CSS property was removed from one internal widget class (`ToolbarPopup`), used uniformly by every `MainAreaWidget` toolbar across the application — no other selector or component references it, and there are no public API changes.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI. ( primarily the writeup for the Issue and PR)
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude Sonnet 4.6 via Claude Code
