### PR TITLE
Fix too eager autocompletion heuristics

### DIFF
--- a/packages/completer/src/default/kernelprovider.ts
+++ b/packages/completer/src/default/kernelprovider.ts
@@ -8,7 +8,7 @@ import type { JSONObject } from '@lumino/coreutils';
 import type { CompletionHandler } from '../handler';
 import type { ICompletionContext, ICompletionProvider } from '../tokens';
 import type { Completer } from '../widget';
-import { isHintableMimeType } from '../utils';
+import { isContinuousHintingChange, isHintableMimeType } from '../utils';
 
 export const KERNEL_PROVIDER_ID = 'CompletionProvider:kernel';
 /**
@@ -122,8 +122,8 @@ export class KernelCompleterProvider implements ICompletionProvider {
   }
 
   /**
-   * Kernel provider will activate the completer in continuous mode after
-   * the `.` character.
+   * Kernel provider will activate the completer in continuous mode after an
+   * identifier character.
    */
   shouldShowContinuousHint(
     visible: boolean,
@@ -135,19 +135,6 @@ export class KernelCompleterProvider implements ICompletionProvider {
       return false;
     }
 
-    const sourceChange = changed.sourceChange;
-    if (sourceChange == null) {
-      return true;
-    }
-
-    if (sourceChange.some(delta => delta.delete != null)) {
-      return false;
-    }
-
-    return sourceChange.some(
-      delta =>
-        delta.insert != null &&
-        (delta.insert === '.' || (!visible && delta.insert.trim().length > 0))
-    );
+    return !visible && isContinuousHintingChange(changed);
   }
 }

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -344,6 +344,8 @@ export class CompletionHandler implements IDisposable {
     if (!editor) {
       return;
     }
+    const position = editor.getCursorPosition();
+    const state = this.getState(editor, position);
     if (
       model &&
       this._autoCompletion &&
@@ -351,12 +353,10 @@ export class CompletionHandler implements IDisposable {
       (await this._reconciliator.shouldShowContinuousHint(
         this.completer.isVisible,
         changed
-      ))
+      )) &&
+      this._isCurrentState(editor, state)
     ) {
-      void this._makeRequest(
-        editor.getCursorPosition(),
-        CompletionTriggerKind.TriggerCharacter
-      );
+      void this._makeRequest(position, CompletionTriggerKind.TriggerCharacter);
     }
 
     const inlineModel = this.inlineCompleter?.model;
@@ -436,6 +436,10 @@ export class CompletionHandler implements IDisposable {
           return;
         }
 
+        if (!this._isCurrentState(editor, state)) {
+          return;
+        }
+
         const model = this._updateModel(state, reply.start, reply.end);
         if (!model) {
           return;
@@ -455,6 +459,19 @@ export class CompletionHandler implements IDisposable {
       .catch(p => {
         /* Fails silently. */
       });
+  }
+
+  private _isCurrentState(
+    editor: CodeEditor.IEditor,
+    state: Completer.ITextState
+  ): boolean {
+    const position = editor.getCursorPosition();
+    return (
+      editor === this.editor &&
+      state.text === editor.model.sharedModel.getSource() &&
+      state.line === position.line &&
+      state.column === position.column
+    );
   }
 
   private async _makeInlineRequest(

--- a/packages/completer/src/reconciliator.ts
+++ b/packages/completer/src/reconciliator.ts
@@ -15,7 +15,7 @@ import type {
 import { InlineCompletionTriggerKind } from './tokens';
 import type { Completer } from './widget';
 import { Signal } from '@lumino/signaling';
-import { isHintableMimeType } from './utils';
+import { isContinuousHintingChange, isHintableMimeType } from './utils';
 
 // Shorthand for readability.
 export type InlineResult =
@@ -320,13 +320,7 @@ export class ProviderReconciliator implements IProviderReconciliator {
       return false;
     }
 
-    return (
-      !completerIsVisible &&
-      (changed.sourceChange == null ||
-        changed.sourceChange.some(
-          delta => delta.insert != null && delta.insert.length > 0
-        ))
-    );
+    return !completerIsVisible && isContinuousHintingChange(changed);
   }
 
   private _resolveFactory = (

--- a/packages/completer/src/utils.ts
+++ b/packages/completer/src/utils.ts
@@ -1,6 +1,28 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import type { SourceChange } from '@jupyter/ydoc';
+
+/**
+ * Whether a source change should trigger continuous completion.
+ *
+ * Continuous completion is limited to a single identifier character so that
+ * punctuation, whitespace, and multi-character edits such as pastes do not
+ * open the completer.
+ */
+export function isContinuousHintingChange(changed: SourceChange): boolean {
+  const sourceChange = changed.sourceChange;
+  if (
+    sourceChange == null ||
+    sourceChange.some(delta => delta.delete != null)
+  ) {
+    return false;
+  }
+
+  const inserted = sourceChange.map(delta => delta.insert ?? '').join('');
+  return /^[\p{L}\p{N}\p{M}_$]$/u.test(inserted);
+}
+
 /**
  * Determines whether the given MIME type is suitable for code completion.
  *

--- a/packages/completer/test/kernelprovider.spec.ts
+++ b/packages/completer/test/kernelprovider.spec.ts
@@ -4,20 +4,29 @@
 import type { KernelMessage } from '@jupyterlab/services';
 import type { ICompletionContext } from '@jupyterlab/completer';
 import { KernelCompleterProvider } from '@jupyterlab/completer';
+import { createEditorWidget } from '@jupyterlab/completer/lib/testutils';
 import {
   KernelMock,
   SessionConnectionMock
 } from '@jupyterlab/services/lib/testutils';
+import type { SourceChange } from '@jupyter/ydoc';
 
 describe('completer/default/kernelprovider', () => {
   describe('KernelCompleterProvider', () => {
     const provider = new KernelCompleterProvider();
     const kernel = new KernelMock({});
     const connection = new SessionConnectionMock({}, kernel);
+    const editorWidget = createEditorWidget();
+    editorWidget.model.mimeType = 'text/x-python';
     const context: ICompletionContext = {
-      widget: null as any,
+      widget: editorWidget,
+      editor: editorWidget.editor,
       session: connection
     };
+
+    afterAll(() => {
+      editorWidget.dispose();
+    });
 
     describe('#fetch()', () => {
       it('should accept results with `_jupyter_types_experimental` metadata', async () => {
@@ -165,6 +174,49 @@ describe('completer/default/kernelprovider', () => {
             { label: 'plot.xy' }
           ]
         });
+      });
+    });
+
+    describe('#shouldShowContinuousHint()', () => {
+      const change = (insert: string): SourceChange => ({
+        sourceChange: [{ insert }]
+      });
+
+      it.each(['a', '1', '_', '$', 'é'])(
+        'should trigger for identifier character %s',
+        insert => {
+          expect(
+            provider.shouldShowContinuousHint(false, change(insert), context)
+          ).toBe(true);
+        }
+      );
+
+      it.each([' ', '.', ')', ':', '\n', 'ab'])(
+        'should not trigger for %j',
+        insert => {
+          expect(
+            provider.shouldShowContinuousHint(false, change(insert), context)
+          ).toBe(false);
+        }
+      );
+
+      it('should not trigger while the completer is visible', () => {
+        expect(
+          provider.shouldShowContinuousHint(true, change('a'), context)
+        ).toBe(false);
+      });
+
+      it('should not trigger on deletions or unknown changes', () => {
+        expect(
+          provider.shouldShowContinuousHint(
+            false,
+            { sourceChange: [{ delete: 1 }] },
+            context
+          )
+        ).toBe(false);
+        expect(provider.shouldShowContinuousHint(false, {}, context)).toBe(
+          false
+        );
       });
     });
   });

--- a/packages/metapackage/test/completer/handler.spec.ts
+++ b/packages/metapackage/test/completer/handler.spec.ts
@@ -435,6 +435,46 @@ describe('@jupyterlab/completer', () => {
         );
         spy.mockRestore();
       });
+
+      it('should ignore stale completion replies', async () => {
+        handler.editor!.model.sharedModel.setSource('foo.');
+        await new Promise(process.nextTick);
+        anchor.editor.setCursorPosition({ line: 0, column: 4 });
+        handler.completer.reset();
+
+        let resolvePending!: (
+          reply: CompletionHandler.ICompletionItemsReply
+        ) => void;
+        const pending = new Promise<CompletionHandler.ICompletionItemsReply>(
+          resolve => {
+            resolvePending = resolve;
+          }
+        );
+        const fetch = jest.spyOn(provider, 'fetch').mockReturnValue(pending);
+        const shouldShow = jest
+          .spyOn(provider, 'shouldShowContinuousHint')
+          .mockReturnValueOnce(true)
+          .mockReturnValue(false);
+        const model = handler.completer.model!;
+
+        handler.editor!.model.sharedModel.updateSource(4, 4, 'a');
+        await new Promise(process.nextTick);
+        expect(fetch).toHaveBeenCalledTimes(1);
+
+        handler.editor!.model.sharedModel.updateSource(5, 5, ':');
+        await new Promise(process.nextTick);
+        resolvePending({
+          start: 0,
+          end: 1,
+          items: [{ label: 'alpha' }]
+        });
+        await new Promise(process.nextTick);
+
+        expect(model.original).toBeNull();
+        expect(model.completionItems()).toHaveLength(0);
+        fetch.mockRestore();
+        shouldShow.mockRestore();
+      });
     });
 
     it('should update cursor position after autocomplete on empty word', () => {

--- a/packages/metapackage/test/completer/reconciliator.spec.ts
+++ b/packages/metapackage/test/completer/reconciliator.spec.ts
@@ -15,6 +15,7 @@ import type { INotebookModel } from '@jupyterlab/notebook';
 import { NotebookModelFactory } from '@jupyterlab/notebook';
 import { ServiceManager } from '@jupyterlab/services';
 import { NBTestUtils } from '@jupyterlab/notebook/lib/testutils';
+import type { SourceChange } from '@jupyter/ydoc';
 
 function contextFactory(): Context<INotebookModel> {
   const serviceManager = new ServiceManager({ standby: 'never' });
@@ -71,9 +72,10 @@ class FooCompletionProvider implements ICompletionProvider {
   async isApplicable(context: ICompletionContext): Promise<boolean> {
     return true;
   }
-  shouldShowContinuousHint(completerIsVisible: boolean, changed: any) {
-    return true;
-  }
+  shouldShowContinuousHint: ICompletionProvider['shouldShowContinuousHint'] = (
+    completerIsVisible: boolean,
+    changed: SourceChange
+  ) => true;
 }
 
 const defaultOptions = {
@@ -298,6 +300,39 @@ describe('completer/reconciliator', () => {
         await reconciliator.shouldShowContinuousHint(true, null as any);
         expect(fooProvider1.shouldShowContinuousHint).toHaveBeenCalledTimes(1);
         expect(fooProvider2.shouldShowContinuousHint).toHaveBeenCalledTimes(0);
+      });
+
+      it('should use the default identifier heuristic', async () => {
+        const provider = new FooCompletionProvider();
+        provider.shouldShowContinuousHint = undefined;
+        const editor = createEditorWidget();
+        editor.model.mimeType = 'text/x-python';
+        const reconciliator = new ProviderReconciliator({
+          ...defaultOptions,
+          context: {
+            ...defaultOptions.context,
+            editor: editor.editor
+          },
+          providers: [provider]
+        });
+        const change = (insert: string): SourceChange => ({
+          sourceChange: [{ insert }]
+        });
+
+        await expect(
+          reconciliator.shouldShowContinuousHint(false, change('a'))
+        ).resolves.toBe(true);
+        await expect(
+          reconciliator.shouldShowContinuousHint(false, change('.'))
+        ).resolves.toBe(false);
+        await expect(
+          reconciliator.shouldShowContinuousHint(false, change('ab'))
+        ).resolves.toBe(false);
+        await expect(
+          reconciliator.shouldShowContinuousHint(true, change('a'))
+        ).resolves.toBe(false);
+
+        editor.dispose();
       });
     });
     describe('#applicableProviders()', () => {


### PR DESCRIPTION
## References
Closes #15013 

## Code changes
This limits automatic completion to single identifier-character edits and ignores stale async completion replies after the editor state changes. This keeps manual Tab completion intact while preventing popups from appearing after punctuation, whitespace, newlines, deletions, or paste edits.


## User-facing changes

https://github.com/user-attachments/assets/1765b21d-eda8-4efb-a585-2710a5ea2695



## Backwards-incompatible changes
None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: 5.5 ChatGPT
