### PR TITLE
Fix XSS in extension manager's `homepage_url`

### DIFF
--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -44,7 +44,7 @@ function isProtocolAllowed(url: string): boolean {
   try {
     const parsed = new URL(url, window.location.href);
     const protocol = parsed.protocol.toLowerCase();
-    return ['http:', 'https:', 'mailto:'].includes(protocol);
+    return ['http:', 'https:'].includes(protocol);
   } catch {
     return false;
   }

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -40,6 +40,16 @@ function getExtensionGitHubUser(entry: IEntry) {
   return null;
 }
 
+function isProtocolAllowed(url: string): boolean {
+  try {
+    const parsed = new URL(url, window.location.href);
+    const protocol = parsed.protocol.toLowerCase();
+    return ['http:', 'https:', 'mailto:'].includes(protocol);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * VDOM for visualizing an extension entry.
  */
@@ -75,7 +85,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
       <div className="jp-extensionmanager-entry-description">
         <div className="jp-extensionmanager-entry-title">
           <div className="jp-extensionmanager-entry-name">
-            {entry.homepage_url ? (
+            {entry.homepage_url && isProtocolAllowed(entry.homepage_url) ? (
               <a
                 href={entry.homepage_url}
                 target="_blank"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

https://github.com/jupyterlab/jupyterlab/security/advisories/GHSA-vmhf-c436-hxj4

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Restrict protocols in <a href to avoid `javascript:` leading to XSS

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

Nothing visible

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

## AI usage

- **NO**: Some or all of the content of this PR was generated by AI.
- **NO**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: <!-- FILL IN -->


Security note: opening this as a regular PR on purpose as the vuln is minor and GHSAs are a pain to work with: no CI, easy to miss private forks when releasing a new version.