### PR TITLE
Workaround flaky test for scrolling on page down in windowed notebook

### DIFF
--- a/galata/test/jupyterlab/windowed-notebook.test.ts
+++ b/galata/test/jupyterlab/windowed-notebook.test.ts
@@ -289,6 +289,19 @@ test.describe('Scrolling on keyboard interaction when active editor is above the
       for (let i = 0; i < testCase.times; i++) {
         await page.keyboard.press(testCase.key);
         // Allow for small delay between pressing keys
+        if (i === 0 && testCase.key === 'PageDown' && testCase.times === 10) {
+          // TODO: for some reason the notebook scrolls back to the selected cell after a few seconds.
+          // The exact mechanism is not clear but it is easily reproducible with the test case
+          // "Show neither cell on pressing PageDown 10 times" by commenting out the timeout below,
+          // and decreasing the timeout for each iteration (say down to 10ms).
+          // It might be unrelated to this test, but instead a different bug in the windowing
+          // logic where some stale request remains beyond its intended lifetime
+          // (i.e. when user requested a different scroll).
+          // This could be related related to the scrollback logic; PR #18973 demonstrated
+          // a potential fix, however it made the scrollback test for full windowing flaky
+          // ("should keep active cell when a cell above generates a lot of output").
+          await page.waitForTimeout(3000);
+        }
         await page.waitForTimeout(100);
       }
 


### PR DESCRIPTION
## References

- Replaces https://github.com/jupyterlab/jupyterlab/pull/18973 for now
- Tracking issue itself in #19005

## Code changes

Adds an explicit timeout as a workaround for some yet to be solved bug in the scrolling logic

| Before | After |
|--|--|
| [8 failed, 12 flaky](https://github.com/jupyterlab/jupyterlab/actions/runs/27208685539) | [20/20 passed](https://github.com/krassowski/jupyterlab/actions/runs/27208475733) |

Note above I used "Show neither cell" for grepping which included another test too, hence it shows total ot 40.

Makes "Show neither cell on pressing PageDown 10 times" no longer flaky.

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

None