### PR TITLE
Backport PR #18992: Fix hidden cells after moving collapsed headings

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -437,24 +437,27 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
     this.model!.sharedModel.moveCells(from, boundedTo, n);
 
     for (let i = 0; i < n; i++) {
-      const newCell = this.widgets[to + i];
+      const newIndex = from > boundedTo ? boundedTo + i : boundedTo - n + 1 + i;
+      const newCell = this.widgets[newIndex];
       const view = viewModel[i];
       for (const state in view) {
         // @ts-expect-error Cell has no index signature
         newCell[state] = view[state];
       }
 
-      if (from > to) {
-        if (this.widgets[to + i].model.type === 'code') {
-          (this.widgets[to + i].model as CodeCellModel).isDirty = dirtyState[i];
+      if (from > boundedTo) {
+        if (this.widgets[boundedTo + i].model.type === 'code') {
+          (this.widgets[boundedTo + i].model as CodeCellModel).isDirty =
+            dirtyState[i];
         }
       } else {
-        if (this.widgets[to + i - n + 1].model.type === 'code') {
-          (this.widgets[to + i - n + 1].model as CodeCellModel).isDirty =
+        if (this.widgets[boundedTo + i - n + 1].model.type === 'code') {
+          (this.widgets[boundedTo + i - n + 1].model as CodeCellModel).isDirty =
             dirtyState[i];
         }
       }
     }
+    this._refreshCollapsedHeadingVisibility();
   }
 
   /**
@@ -887,6 +890,35 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
       .catch(error => {
         console.warn('Failed to resolve headings: ', error);
       });
+  }
+
+  /**
+   * Recompute hidden cells from the current collapsed heading structure.
+   */
+  private _refreshCollapsedHeadingVisibility(): void {
+    for (const cell of this.widgets) {
+      cell.setHidden(false);
+    }
+
+    for (const cell of this.widgets) {
+      if (!(cell instanceof MarkdownCell) || !cell.headingCollapsed) {
+        continue;
+      }
+      if (cell.headingsResolved) {
+        NotebookActions.setHeadingCollapse(cell, true, this);
+        continue;
+      }
+      cell
+        .getHeadings()
+        .then(() => {
+          if (!cell.isDisposed && cell.headingCollapsed) {
+            this._refreshCollapsedHeadingVisibility();
+          }
+        })
+        .catch(error => {
+          console.warn('Failed to resolve headings: ', error);
+        });
+    }
   }
 
   /**

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -14,6 +14,7 @@ import {
 import {
   INotebookModel,
   Notebook,
+  NotebookActions,
   NotebookModel,
   StaticNotebook
 } from '@jupyterlab/notebook';
@@ -30,6 +31,10 @@ import { Widget } from '@lumino/widgets';
 import { generate, simulate } from 'simulate-event';
 import * as utils from './utils';
 import { CodeMirrorEditor } from '@jupyterlab/codemirror';
+import type {
+  IMarkdownHeadingToken,
+  IMarkdownParser
+} from '@jupyterlab/rendermime';
 import { yUndoManagerFacet } from '@jupyterlab/codemirror/lib/extensions/yundomanager';
 
 const server = new JupyterServer();
@@ -658,6 +663,112 @@ describe('@jupyter/notebook', () => {
     });
 
     describe('#moveCell()', () => {
+      it('should refresh hidden cells after moving a collapsed heading down', async () => {
+        const getMarkdownHeading = (
+          content: string
+        ): { level: number; text: string } | null => {
+          let level = 0;
+          while (
+            level < content.length &&
+            level < 6 &&
+            content[level] === '#'
+          ) {
+            level++;
+          }
+          if (level === 0 || ![' ', '\t'].includes(content[level])) {
+            return null;
+          }
+          return { level, text: content.slice(level).trim() };
+        };
+        const headingParser: IMarkdownParser = {
+          render: async (content: string) => {
+            const heading = getMarkdownHeading(content);
+            if (!heading) {
+              return content;
+            }
+            return `<h${heading.level}>${heading.text}</h${heading.level}>`;
+          },
+          getHeadingTokens: async (
+            content: string
+          ): Promise<IMarkdownHeadingToken[]> => {
+            return content
+              .split('\n')
+              .map((line, lineNumber) => ({ line: lineNumber, raw: line }))
+              .filter(token => getMarkdownHeading(token.raw) !== null);
+          }
+        };
+        const widget = new LogStaticNotebook({
+          ...options,
+          rendermime: rendermime.clone({ markdownParser: headingParser })
+        });
+        widget.model = new NotebookModel();
+        widget.model!.fromJSON({
+          cells: [
+            {
+              cell_type: 'markdown',
+              source: '# Title',
+              metadata: {}
+            },
+            {
+              cell_type: 'markdown',
+              source: '## First section',
+              metadata: {}
+            },
+            {
+              cell_type: 'code',
+              source: 'first = 1',
+              metadata: {},
+              outputs: [],
+              execution_count: null
+            },
+            {
+              cell_type: 'code',
+              source: 'second = 2',
+              metadata: {},
+              outputs: [],
+              execution_count: null
+            },
+            {
+              cell_type: 'markdown',
+              source: '## Second section',
+              metadata: {}
+            }
+          ],
+          metadata: {},
+          nbformat: 4,
+          nbformat_minor: 5
+        });
+
+        const firstHeading = widget.widgets[1] as MarkdownCell;
+        await Promise.all(
+          widget.widgets
+            .filter(
+              (cell): cell is MarkdownCell => cell instanceof MarkdownCell
+            )
+            .map(cell => cell.getHeadings())
+        );
+        NotebookActions.setHeadingCollapse(firstHeading, true, widget);
+
+        expect(widget.widgets[2].isHidden).toBe(true);
+        expect(widget.widgets[3].isHidden).toBe(true);
+
+        widget.moveCell(1, 3);
+
+        expect(
+          widget.widgets.map(cell => cell.model.sharedModel.getSource())
+        ).toEqual([
+          '# Title',
+          'first = 1',
+          'second = 2',
+          '## First section',
+          '## Second section'
+        ]);
+        expect(widget.widgets[1].isHidden).toBe(false);
+        expect(widget.widgets[2].isHidden).toBe(false);
+        expect(widget.widgets[3].isHidden).toBe(false);
+        expect((widget.widgets[3] as MarkdownCell).headingCollapsed).toBe(true);
+      });
+
       it('should preserve isDirty state after moving a code cell', () => {
         const widget = createWidget();
         widget.model!.sharedModel.insertCells(0, [


### PR DESCRIPTION
Backport PR #18992: Fix hidden cells after moving collapsed headings