### PR TITLE
Update user-facing changelog for 4.6.0 RC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 # JupyterLab Changelog
 
-## v4.6 (beta)
+## v4.6 (Release Candidate)
 
 JupyterLab 4.6 includes a number of new features (described below), bug fixes, and enhancements.
 This release is compatible with extensions supporting JupyterLab 4.0.
@@ -92,7 +92,7 @@ A new "Date Created" column has been added to the file browser, showing when fil
 src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/main/docs/source/getting_started/changelog_assets/4.6-date-created.png"
 class="jp-screenshot">
 
-The breadcrumb bar now supports [direct path editing](https://jupyterlab.readthedocs.io/en/latest/user/files.html#editable-breadcrumbs) with tab-completion. Clicking the edit button at the end of the breadcrumbs, or using the Command Palette, opens an editable text field where pressing Tab completes the longest common prefix of matching subdirectories.
+The breadcrumb bar now supports [direct path editing](https://jupyterlab.readthedocs.io/en/latest/user/files.html#editable-breadcrumbs) with tab-completion. Clicking the area behind breadcrumbs (highlighted on hover), or using the Command Palette, opens an editable text field where pressing Tab completes the longest common prefix of matching subdirectories.
 
 <img alt="The file browser showing an editable breadcrumb input field with a completion dropdown listing subdirectory names"
 src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/main/docs/source/getting_started/changelog_assets/4.6-breadcrumbs-editable.png"
@@ -178,6 +178,13 @@ src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/main/docs/source/ge
 class="jp-screenshot">
 
 Ghost text is now also shown for all active cursors in a multi-cursor editing session.
+
+### Miscellaneous
+
+- Tab widths are kept frozen while the mouse pointer hovers over them, making it easier to close multiple tabs with the mouse
+- Autocompletion heuristics were improved; the autocompletion (which remains opt-in) should no longer trigger in unexpected scenarios
+- The output scroll overlay collapse icon is now visible regardless of the output size and scroll state
+- The fonts used across components were standardized and fonts specified by themes or overrides are respected in every component of the application
 
 ## v4.5
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -414,7 +414,7 @@ html_favicon = "_static/logo-icon.png"
 # documentation.
 #
 html_theme_options = {
-    "announcement": '🚀 You can now test JupyterLab 4.6.0 Beta · <a href="https://jupyterlab.rtfd.io/en/latest/getting_started/installation.html">INSTALL</a> · <a href="https://jupyterlab.rtfd.io/en/latest/getting_started/changelog.html#v4-6-beta">RELEASE NOTES</a>',
+    "announcement": '🚀 You can now test JupyterLab 4.6.0 RC · <a href="https://jupyterlab.rtfd.io/en/latest/getting_started/installation.html">INSTALL</a> · <a href="https://jupyterlab.rtfd.io/en/latest/getting_started/changelog.html#v4-6-Release-Candidate">RELEASE NOTES</a>',
     "icon_links": [
         {
             "name": "jupyter.org",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -414,7 +414,7 @@ html_favicon = "_static/logo-icon.png"
 # documentation.
 #
 html_theme_options = {
-    "announcement": '🚀 You can now test JupyterLab 4.6.0 RC · <a href="https://jupyterlab.rtfd.io/en/latest/getting_started/installation.html">INSTALL</a> · <a href="https://jupyterlab.rtfd.io/en/latest/getting_started/changelog.html#v4-6-Release-Candidate">RELEASE NOTES</a>',
+    "announcement": '🚀 You can now test JupyterLab 4.6.0 RC · <a href="https://jupyterlab.rtfd.io/en/latest/getting_started/installation.html">INSTALL</a> · <a href="https://jupyterlab.rtfd.io/en/latest/getting_started/changelog.html#v4-6-release-candidate">RELEASE NOTES</a>',
     "icon_links": [
         {
             "name": "jupyter.org",


### PR DESCRIPTION

## References

Follow-up to #18932 

## Code changes

None

## User-facing changes

- Updates beta → RC references
- In changelog:
  - corrects description of the editable breadcrumbs feature (an earlier iteration used to have a button, but the final thing has click-on-background behaviour)
  - adds Miscellaneous section calling out some smaller improvements and bug fixes merged during the beta cycle or just not listed otherwise.

## Backwards-incompatible changes

No

## AI usage

No
