### PR TITLE
Fix `jupyter labextension build` crash on `webpack ≥ 5.107`

### DIFF
--- a/builder/src/webpack-plugins.ts
+++ b/builder/src/webpack-plugins.ts
@@ -9,6 +9,7 @@ import * as webpack from 'webpack';
 import { LicenseWebpackPlugin } from 'license-webpack-plugin';
 import { LicenseIdentifiedModule } from 'license-webpack-plugin/dist/LicenseIdentifiedModule';
 import { PluginOptions } from 'license-webpack-plugin/dist/PluginOptions';
+import { WebpackInnerModuleIterator } from 'license-webpack-plugin/dist/WebpackInnerModuleIterator';
 
 // From
 // https://github.com/webpack/webpack/blob/95120bdf98a01649740b104bebc426b0123651ce/lib/WatchIgnorePlugin.js
@@ -218,6 +219,26 @@ export namespace WPPlugin {
    * be concatenated.
    */
   export const DEFAULT_LICENSE_REPORT_FILENAME = 'third-party-licenses.json';
+
+  /**
+   * Teach `license-webpack-plugin` to read webpack >= 5.107 shared-module
+   * identifiers, which use `|` instead of `=`.
+   */
+  const _getActualFilename =
+    WebpackInnerModuleIterator.prototype.getActualFilename;
+  WebpackInnerModuleIterator.prototype.getActualFilename = function (
+    filename: string | null | undefined
+  ): string | null {
+    if (
+      typeof filename === 'string' &&
+      filename.indexOf('provide module') === 0 &&
+      filename.indexOf('=') === -1 &&
+      filename.indexOf('|') > -1
+    ) {
+      return filename.slice(filename.indexOf('|') + 1).trim();
+    }
+    return _getActualFilename.call(this, filename);
+  };
 
   /**
    * a plugin that creates a predictable, machine-readable report of licenses for


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References https://github.com/jupyterlab/jupyterlab/pull/19001#issuecomment-4658758160

Webpack 5.107 changed the shared-module identifier format from `name@version = path` to `name@version|path`

`license-webpack-plugin` still parses the identifier using:

```js
split('=')[1].trim()
```

As a result, the path becomes `undefined`, causing extension builds to fail with:

```text
Cannot read properties of undefined (reading 'trim')
```

Version `4.0.2` is the latest release of the plugin, so there is nothing to upgrade to. This patch wraps its `getActualFilename` implementation to also understand the new `|` separator while falling back to the original behavior for older formats.


## AI usage
- No
