### PR TITLE
Fixes keyboard navigation of plugin list in Settings Editor

### DIFF
--- a/packages/settingeditor/package.json
+++ b/packages/settingeditor/package.json
@@ -54,6 +54,7 @@
     "@lumino/commands": "^2.3.3",
     "@lumino/coreutils": "^2.2.2",
     "@lumino/disposable": "^2.1.5",
+    "@lumino/domutils": "^2.0.4",
     "@lumino/messaging": "^2.0.4",
     "@lumino/polling": "^2.1.5",
     "@lumino/signaling": "^2.1.5",

--- a/packages/settingeditor/src/pluginlist.tsx
+++ b/packages/settingeditor/src/pluginlist.tsx
@@ -671,9 +671,7 @@ export class PluginList extends ReactWidget {
     const matchesId = hasMatchDetails
       ? `jp-PluginList-matches-${encodeURIComponent(id)}`
       : undefined;
-    const ariaLabel = this._errors[id]
-      ? trans.__('%1 (error)', title)
-      : title;
+    const ariaLabel = this._errors[id] ? trans.__('%1 (error)', title) : title;
 
     return (
       <li role="presentation" key={id}>
@@ -752,7 +750,11 @@ export class PluginList extends ReactWidget {
             <h1 className="jp-PluginList-header" id={MODIFIED_HEADER_ID}>
               {trans.__('Modified')}
             </h1>
-            <ul role="tablist" aria-labelledby={MODIFIED_HEADER_ID} aria-orientation="vertical">
+            <ul
+              role="tablist"
+              aria-labelledby={MODIFIED_HEADER_ID}
+              aria-orientation="vertical"
+            >
               {modifiedItems}
             </ul>
           </div>
@@ -762,7 +764,11 @@ export class PluginList extends ReactWidget {
             <h1 className="jp-PluginList-header" id={SETTINGS_HEADER_ID}>
               {trans.__('Settings')}
             </h1>
-            <ul role="tablist" aria-labelledby={SETTINGS_HEADER_ID} aria-orientation="vertical">
+            <ul
+              role="tablist"
+              aria-labelledby={SETTINGS_HEADER_ID}
+              aria-orientation="vertical"
+            >
               {otherItems}
             </ul>
           </div>

--- a/packages/settingeditor/src/pluginlist.tsx
+++ b/packages/settingeditor/src/pluginlist.tsx
@@ -666,12 +666,22 @@ export class PluginList extends ReactWidget {
           return <li key={`${id}-${fieldValue}`}> {highlighted} </li>;
         })
       : undefined;
+    const hasMatchDetails =
+      filteredProperties !== undefined && filteredProperties.length > 0;
+    const matchesId = hasMatchDetails
+      ? `jp-PluginList-matches-${encodeURIComponent(id)}`
+      : undefined;
+    const ariaLabel = this._errors[id]
+      ? trans.__('%1 (error)', title)
+      : title;
 
     return (
       <li role="presentation" key={id}>
         <div
           role="tab"
           aria-selected={id === this.selection}
+          aria-label={ariaLabel}
+          aria-describedby={matchesId}
           tabIndex={id === this._focusedId ? 0 : -1}
           onClick={this._evtClick}
           className={classes(
@@ -695,7 +705,7 @@ export class PluginList extends ReactWidget {
               {hightlightedTitle}
             </span>
           </div>
-          <ul>{filteredProperties}</ul>
+          <ul id={matchesId}>{filteredProperties}</ul>
         </div>
       </li>
     );

--- a/packages/settingeditor/src/pluginlist.tsx
+++ b/packages/settingeditor/src/pluginlist.tsx
@@ -21,6 +21,7 @@ import {
 import { StringExt } from '@lumino/algorithm';
 import type { PartialJSONObject } from '@lumino/coreutils';
 import { PromiseDelegate } from '@lumino/coreutils';
+import { ElementExt } from '@lumino/domutils';
 import type { Message } from '@lumino/messaging';
 import type { ISignal } from '@lumino/signaling';
 import { Signal } from '@lumino/signaling';
@@ -44,6 +45,17 @@ const ICON_CLASS_KEY = 'jupyter.lab.setting-icon-class';
  * icon label of a plugin.
  */
 const ICON_LABEL_KEY = 'jupyter.lab.setting-icon-label';
+
+/**
+ * DOM ids for plugin list section headers (used by aria-labelledby).
+ */
+const MODIFIED_HEADER_ID = 'jp-PluginList-modified-header';
+const SETTINGS_HEADER_ID = 'jp-PluginList-settings-header';
+
+/**
+ * The class name for a plugin list entry.
+ */
+const ENTRY_CLASS = 'jp-PluginList-entry';
 
 /**
  * A list of plugins with editable settings.
@@ -123,6 +135,9 @@ export class PluginList extends ReactWidget {
   }
   set selection(selection: string) {
     this._selection = selection;
+    if (selection) {
+      this._focusedId = selection;
+    }
     this.update();
   }
 
@@ -138,12 +153,52 @@ export class PluginList extends ReactWidget {
   }
 
   /**
+   * Handle the DOM events for the plugin list.
+   */
+  handleEvent(event: Event): void {
+    switch (event.type) {
+      case 'keydown':
+        this._evtKeyDown(event as KeyboardEvent);
+        break;
+      case 'focusin':
+        this._evtFocusIn(event as FocusEvent);
+        break;
+    }
+  }
+
+  /**
+   * A message handler invoked on an `'after-attach'` message.
+   */
+  protected onAfterAttach(msg: Message): void {
+    super.onAfterAttach(msg);
+    this.node.addEventListener('keydown', this);
+    this.node.addEventListener('focusin', this);
+  }
+
+  /**
+   * A message handler invoked on a `'before-detach'` message.
+   */
+  protected onBeforeDetach(msg: Message): void {
+    this.node.removeEventListener('keydown', this);
+    this.node.removeEventListener('focusin', this);
+    super.onBeforeDetach(msg);
+  }
+
+  /**
    * Handle `'update-request'` messages.
    */
   protected onUpdateRequest(msg: Message): void {
     const ul = this.node.querySelector('ul');
     if (ul && this._scrollTop !== undefined) {
       ul.scrollTop = this._scrollTop;
+    }
+    if (this._pendingEntryFocus) {
+      const id = this._pendingEntryFocus;
+      this._pendingEntryFocus = null;
+      const entry = this._getEntryById(id);
+      if (entry) {
+        this._focusEntryElement(entry);
+      }
     }
     super.onUpdateRequest(msg);
   }
@@ -154,30 +209,262 @@ export class PluginList extends ReactWidget {
    * @param event - The DOM event sent to the widget
    */
   private _evtMousedown(event: React.MouseEvent<HTMLDivElement>): void {
-    const target = event.currentTarget;
-    const id = target.getAttribute('data-id');
+    const id = event.currentTarget.getAttribute('data-id');
+    if (id) {
+      this._selectPlugin(id);
+    }
+  }
 
+  /**
+   * Select a plugin in the list and notify listeners.
+   *
+   * @param id - The plugin id to select
+   */
+  private _selectPlugin(id: string): void {
+    if (this._confirm) {
+      this._confirm(id)
+        .then(() => {
+          this._applySelection(id);
+        })
+        .catch(() => {
+          this._pendingEntryFocus = null;
+        });
+    } else {
+      this._scrollTop = this.scrollTop;
+      this._applySelection(id);
+    }
+  }
+
+  /**
+   * Apply the current selection and focus state without confirmation.
+   *
+   * @param id - The plugin id to select
+   */
+  private _applySelection(id: string): void {
+    this._selection = id;
+    this._focusedId = id;
+    this._pendingEntryFocus = id;
+    this._handleSelectSignal.emit(id);
+    this._changed.emit(undefined);
+    this.update();
+  }
+
+  /**
+   * Resolve the plugin id that should hold the roving tab stop.
+   */
+  private _getTabStopId(visiblePluginIds: string[]): string {
+    if (this._focusedId && visiblePluginIds.includes(this._focusedId)) {
+      return this._focusedId;
+    }
+    if (this._selection && visiblePluginIds.includes(this._selection)) {
+      return this._selection;
+    }
+    return visiblePluginIds[0] ?? '';
+  }
+
+  /**
+   * Keep focus state aligned with the currently visible plugin entries.
+   */
+  private _syncFocusedId(visiblePluginIds: string[]): void {
+    const tabStopId = this._getTabStopId(visiblePluginIds);
+    if (tabStopId !== this._focusedId) {
+      this._focusedId = tabStopId;
+    }
+  }
+
+  /**
+   * Return plugin entries in DOM order across all visible lists.
+   */
+  private _getEntryElements(): HTMLElement[] {
+    return Array.from(
+      this.node.querySelectorAll(`.${ENTRY_CLASS}`)
+    ) as HTMLElement[];
+  }
+
+  /**
+   * Return a plugin entry element by plugin id.
+   */
+  private _getEntryById(id: string): HTMLElement | null {
+    return this.node.querySelector(
+      `.${ENTRY_CLASS}[data-id="${CSS.escape(id)}"]`
+    );
+  }
+
+  /**
+   * Return the scrollable container for plugin list entries.
+   */
+  private _getScrollElement(): HTMLElement {
+    return (
+      (this.node.querySelector('.jp-PluginList-wrapper') as HTMLElement) ??
+      this.node
+    );
+  }
+
+  /**
+   * Focus an entry element and sync the roving tab stop in the DOM.
+   *
+   * Used when keyboard navigation updates focus without a React re-render.
+   */
+  private _focusEntryElement(entry: HTMLElement): void {
+    const id = entry.getAttribute('data-id');
+    if (id) {
+      this._focusedId = id;
+    }
+    for (const item of this._getEntryElements()) {
+      item.tabIndex = item === entry ? 0 : -1;
+    }
+    entry.focus();
+    ElementExt.scrollIntoViewIfNeeded(this._getScrollElement(), entry);
+  }
+
+  /**
+   * Walk from an event target to the nearest plugin entry, if any.
+   */
+  private _resolveEntryFromEventTarget(
+    target: EventTarget | null
+  ): HTMLElement | null {
+    let node = target as HTMLElement | null;
+    while (node && node !== this.node) {
+      if (node.classList.contains(ENTRY_CLASS)) {
+        return node;
+      }
+      node = node.parentElement;
+    }
+    return null;
+  }
+
+  /**
+   * Whether the event target is inside the settings search input.
+   */
+  private _isFilterInputTarget(target: EventTarget | null): boolean {
+    let node = target as HTMLElement | null;
+    while (node && node !== this.node) {
+      const tag = node.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'JP-SEARCH') {
+        return true;
+      }
+      node = node.parentElement;
+    }
+    return false;
+  }
+
+  /**
+   * Index of the currently focused entry, falling back to the first entry.
+   */
+  private _getFocusedEntryIndex(entries: HTMLElement[]): number {
+    const index = entries.findIndex(
+      entry => entry.getAttribute('data-id') === this._focusedId
+    );
+    return index === -1 ? 0 : index;
+  }
+
+  /**
+   * Move keyboard focus to a plugin entry without changing the selection.
+   */
+  private _focusEntry(id: string): boolean {
+    if (!id || id === this._focusedId) {
+      return false;
+    }
+
+    const entry = this._getEntryById(id);
+    if (!entry) {
+      return false;
+    }
+
+    this._focusEntryElement(entry);
+    return true;
+  }
+
+  /**
+   * Move focus to the entry at the given index.
+   */
+  private _focusEntryAtIndex(index: number): boolean {
+    const entries = this._getEntryElements();
+    if (entries.length === 0) {
+      return false;
+    }
+
+    const nextIndex = Math.min(Math.max(index, 0), entries.length - 1);
+    const nextId = entries[nextIndex].getAttribute('data-id');
+    return nextId ? this._focusEntry(nextId) : false;
+  }
+
+  /**
+   * Move focus to another visible entry by index offset.
+   */
+  private _moveFocusByDelta(delta: number): boolean {
+    const entries = this._getEntryElements();
+    if (entries.length === 0) {
+      return false;
+    }
+
+    const nextIndex = this._getFocusedEntryIndex(entries) + delta;
+    if (nextIndex < 0 || nextIndex >= entries.length) {
+      return false;
+    }
+
+    return this._focusEntryAtIndex(nextIndex);
+  }
+
+  /**
+   * Handle the `'keydown'` event for the plugin list.
+   */
+  private _evtKeyDown(event: KeyboardEvent): void {
+    if (this._isFilterInputTarget(event.target)) {
+      return;
+    }
+
+    const entry = this._resolveEntryFromEventTarget(event.target);
+    if (!entry) {
+      return;
+    }
+
+    const id = entry.getAttribute('data-id');
     if (!id) {
       return;
     }
 
-    if (this._confirm) {
-      this._confirm(id)
-        .then(() => {
-          this.selection = id!;
-          this._changed.emit(undefined);
-          this.update();
-        })
-        .catch(() => {
-          /* no op */
-        });
-    } else {
-      this._scrollTop = this.scrollTop;
-      this._selection = id!;
-      this._handleSelectSignal.emit(id!);
-      this._changed.emit(undefined);
-      this.update();
+    let handled = false;
+    switch (event.key) {
+      case 'ArrowDown':
+        handled = this._moveFocusByDelta(1);
+        break;
+      case 'ArrowUp':
+        handled = this._moveFocusByDelta(-1);
+        break;
+      case 'Home':
+        handled = this._focusEntryAtIndex(0);
+        break;
+      case 'End':
+        handled = this._focusEntryAtIndex(this._getEntryElements().length - 1);
+        break;
+      case 'Enter':
+      case ' ':
+        if (id !== this._selection) {
+          this._selectPlugin(id);
+        }
+        handled = true;
+        break;
+      default:
+        return;
     }
+
+    if (handled) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }
+
+  /**
+   * Keep roving tabindex aligned when focus moves between entries via Tab.
+   */
+  private _evtFocusIn(event: FocusEvent): void {
+    const entry = this._resolveEntryFromEventTarget(event.target);
+    if (!entry || entry.getAttribute('data-id') === this._focusedId) {
+      return;
+    }
+
+    this._focusEntryElement(entry);
   }
 
   /**
@@ -381,32 +668,36 @@ export class PluginList extends ReactWidget {
       : undefined;
 
     return (
-      <div
-        onClick={this._evtMousedown}
-        className={`${
-          id === this.selection
-            ? 'jp-mod-selected jp-PluginList-entry'
-            : 'jp-PluginList-entry'
-        } ${this._errors[id] ? 'jp-ErrorPlugin' : ''}`}
-        data-id={id}
-        key={id}
-        title={itemTitle}
-      >
-        <div className="jp-PluginList-entry-label" role="tab">
-          <div className="jp-SelectedIndicator" />
-          <LabIcon.resolveReact
-            icon={icon || (iconClass ? undefined : settingsIcon)}
-            iconClass={classes(iconClass, 'jp-Icon')}
-            title={iconTitle}
-            tag="span"
-            stylesheet="settingsEditor"
-          />
-          <span className="jp-PluginList-entry-label-text">
-            {hightlightedTitle}
-          </span>
+      <li role="presentation" key={id}>
+        <div
+          role="tab"
+          aria-selected={id === this.selection}
+          tabIndex={id === this._focusedId ? 0 : -1}
+          onClick={this._evtMousedown}
+          className={classes(
+            ENTRY_CLASS,
+            id === this.selection ? 'jp-mod-selected' : '',
+            this._errors[id] ? 'jp-ErrorPlugin' : ''
+          )}
+          data-id={id}
+          title={itemTitle}
+        >
+          <div className="jp-PluginList-entry-label">
+            <div className="jp-SelectedIndicator" />
+            <LabIcon.resolveReact
+              icon={icon || (iconClass ? undefined : settingsIcon)}
+              iconClass={classes(iconClass, 'jp-Icon')}
+              title={iconTitle}
+              tag="span"
+              stylesheet="settingsEditor"
+            />
+            <span className="jp-PluginList-entry-label-text">
+              {hightlightedTitle}
+            </span>
+          </div>
+          <ul>{filteredProperties}</ul>
         </div>
-        <ul>{filteredProperties}</ul>
-      </div>
+      </li>
     );
   }
 
@@ -424,12 +715,17 @@ export class PluginList extends ReactWidget {
     const modifiedPlugins = allPlugins.filter(plugin => {
       return this._model.settings[plugin.id]?.isModified;
     });
+    const otherPlugins = allPlugins.filter(plugin => {
+      return !modifiedPlugins.includes(plugin);
+    });
+    const visiblePluginIds = [
+      ...modifiedPlugins.map(plugin => plugin.id),
+      ...otherPlugins.map(plugin => plugin.id)
+    ];
+    this._syncFocusedId(visiblePluginIds);
+
     const modifiedItems = modifiedPlugins.map(this.mapPlugins);
-    const otherItems = allPlugins
-      .filter(plugin => {
-        return !modifiedPlugins.includes(plugin);
-      })
-      .map(this.mapPlugins);
+    const otherItems = otherPlugins.map(this.mapPlugins);
 
     return (
       <div className="jp-PluginList-wrapper">
@@ -443,14 +739,22 @@ export class PluginList extends ReactWidget {
         />
         {modifiedItems.length > 0 && (
           <div>
-            <h1 className="jp-PluginList-header">{trans.__('Modified')}</h1>
-            <ul>{modifiedItems}</ul>
+            <h1 className="jp-PluginList-header" id={MODIFIED_HEADER_ID}>
+              {trans.__('Modified')}
+            </h1>
+            <ul role="tablist" aria-labelledby={MODIFIED_HEADER_ID}>
+              {modifiedItems}
+            </ul>
           </div>
         )}
         {otherItems.length > 0 && (
           <div>
-            <h1 className="jp-PluginList-header">{trans.__('Settings')}</h1>
-            <ul>{otherItems}</ul>
+            <h1 className="jp-PluginList-header" id={SETTINGS_HEADER_ID}>
+              {trans.__('Settings')}
+            </h1>
+            <ul role="tablist" aria-labelledby={SETTINGS_HEADER_ID}>
+              {otherItems}
+            </ul>
           </div>
         )}
         {modifiedItems.length === 0 && otherItems.length === 0 && (
@@ -476,6 +780,8 @@ export class PluginList extends ReactWidget {
   private _confirm?: (id: string) => Promise<void>;
   private _scrollTop: number | undefined = 0;
   private _selection = '';
+  private _focusedId = '';
+  private _pendingEntryFocus: string | null = null;
 }
 
 /**

--- a/packages/settingeditor/src/pluginlist.tsx
+++ b/packages/settingeditor/src/pluginlist.tsx
@@ -742,7 +742,7 @@ export class PluginList extends ReactWidget {
             <h1 className="jp-PluginList-header" id={MODIFIED_HEADER_ID}>
               {trans.__('Modified')}
             </h1>
-            <ul role="tablist" aria-labelledby={MODIFIED_HEADER_ID}>
+            <ul role="tablist" aria-labelledby={MODIFIED_HEADER_ID} aria-orientation="vertical">
               {modifiedItems}
             </ul>
           </div>
@@ -752,7 +752,7 @@ export class PluginList extends ReactWidget {
             <h1 className="jp-PluginList-header" id={SETTINGS_HEADER_ID}>
               {trans.__('Settings')}
             </h1>
-            <ul role="tablist" aria-labelledby={SETTINGS_HEADER_ID}>
+            <ul role="tablist" aria-labelledby={SETTINGS_HEADER_ID} aria-orientation="vertical">
               {otherItems}
             </ul>
           </div>

--- a/packages/settingeditor/src/pluginlist.tsx
+++ b/packages/settingeditor/src/pluginlist.tsx
@@ -58,6 +58,18 @@ const SETTINGS_HEADER_ID = 'jp-PluginList-settings-header';
 const ENTRY_CLASS = 'jp-PluginList-entry';
 
 /**
+ * The class name for a plugin list entry search-match list.
+ */
+const MATCHES_CLASS = 'jp-PluginList-matches';
+
+/**
+ * Element with ARIA element reference properties.
+ */
+interface IElementAriaDescriptions {
+  ariaDescribedByElements: HTMLElement[];
+}
+
+/**
  * A list of plugins with editable settings.
  */
 export class PluginList extends ReactWidget {
@@ -200,7 +212,41 @@ export class PluginList extends ReactWidget {
         this._focusEntryElement(entry);
       }
     }
+    this._syncEntryAccessibleDescriptions();
     super.onUpdateRequest(msg);
+  }
+
+  /**
+   * Link plugin entry tabs to their search-match lists for screen readers.
+   */
+  private _syncEntryAccessibleDescriptions(): void {
+    const supportsElementReferences =
+      'ariaDescribedByElements' in HTMLElement.prototype;
+
+    for (const entry of this._getEntryElements()) {
+      const matchesList = entry.querySelector(
+        `:scope > ul.${MATCHES_CLASS}`
+      ) as HTMLUListElement | null;
+
+      if (supportsElementReferences) {
+        const entryWithAria = entry as HTMLElement & IElementAriaDescriptions;
+        entryWithAria.ariaDescribedByElements = matchesList
+          ? [matchesList]
+          : [];
+        continue;
+      }
+
+      if (matchesList) {
+        const pluginId = entry.getAttribute('data-id') ?? '';
+        const matchesId = `jp-PluginList-matches-${encodeURIComponent(pluginId)}`;
+        if (!matchesList.id) {
+          matchesList.id = matchesId;
+        }
+        entry.setAttribute('aria-describedby', matchesList.id);
+      } else {
+        entry.removeAttribute('aria-describedby');
+      }
+    }
   }
 
   /**
@@ -668,9 +714,6 @@ export class PluginList extends ReactWidget {
       : undefined;
     const hasMatchDetails =
       filteredProperties !== undefined && filteredProperties.length > 0;
-    const matchesId = hasMatchDetails
-      ? `jp-PluginList-matches-${encodeURIComponent(id)}`
-      : undefined;
     const ariaLabel = this._errors[id] ? trans.__('%1 (error)', title) : title;
 
     return (
@@ -679,7 +722,6 @@ export class PluginList extends ReactWidget {
           role="tab"
           aria-selected={id === this.selection}
           aria-label={ariaLabel}
-          aria-describedby={matchesId}
           tabIndex={id === this._focusedId ? 0 : -1}
           onClick={this._evtClick}
           className={classes(
@@ -703,7 +745,9 @@ export class PluginList extends ReactWidget {
               {hightlightedTitle}
             </span>
           </div>
-          <ul id={matchesId}>{filteredProperties}</ul>
+          <ul className={hasMatchDetails ? MATCHES_CLASS : undefined}>
+            {filteredProperties}
+          </ul>
         </div>
       </li>
     );

--- a/packages/settingeditor/src/pluginlist.tsx
+++ b/packages/settingeditor/src/pluginlist.tsx
@@ -87,7 +87,7 @@ export class PluginList extends ReactWidget {
       options.query ? updateFilterFunction(options.query, false, false) : null
     );
     this.setError = this.setError.bind(this);
-    this._evtMousedown = this._evtMousedown.bind(this);
+    this._evtClick = this._evtClick.bind(this);
     this._query = options.query ?? '';
 
     this._errors = {};
@@ -204,11 +204,11 @@ export class PluginList extends ReactWidget {
   }
 
   /**
-   * Handle the `'mousedown'` event for the plugin list.
+   * Handle the `'click'` event for the plugin list.
    *
    * @param event - The DOM event sent to the widget
    */
-  private _evtMousedown(event: React.MouseEvent<HTMLDivElement>): void {
+  private _evtClick(event: React.MouseEvent<HTMLDivElement>): void {
     const id = event.currentTarget.getAttribute('data-id');
     if (id) {
       this._selectPlugin(id);
@@ -673,7 +673,7 @@ export class PluginList extends ReactWidget {
           role="tab"
           aria-selected={id === this.selection}
           tabIndex={id === this._focusedId ? 0 : -1}
-          onClick={this._evtMousedown}
+          onClick={this._evtClick}
           className={classes(
             ENTRY_CLASS,
             id === this.selection ? 'jp-mod-selected' : '',

--- a/packages/settingeditor/src/pluginlist.tsx
+++ b/packages/settingeditor/src/pluginlist.tsx
@@ -58,18 +58,6 @@ const SETTINGS_HEADER_ID = 'jp-PluginList-settings-header';
 const ENTRY_CLASS = 'jp-PluginList-entry';
 
 /**
- * The class name for a plugin list entry search-match list.
- */
-const MATCHES_CLASS = 'jp-PluginList-matches';
-
-/**
- * Element with ARIA element reference properties.
- */
-interface IElementAriaDescriptions {
-  ariaDescribedByElements: HTMLElement[];
-}
-
-/**
  * A list of plugins with editable settings.
  */
 export class PluginList extends ReactWidget {
@@ -212,41 +200,7 @@ export class PluginList extends ReactWidget {
         this._focusEntryElement(entry);
       }
     }
-    this._syncEntryAccessibleDescriptions();
     super.onUpdateRequest(msg);
-  }
-
-  /**
-   * Link plugin entry tabs to their search-match lists for screen readers.
-   */
-  private _syncEntryAccessibleDescriptions(): void {
-    const supportsElementReferences =
-      'ariaDescribedByElements' in HTMLElement.prototype;
-
-    for (const entry of this._getEntryElements()) {
-      const matchesList = entry.querySelector(
-        `:scope > ul.${MATCHES_CLASS}`
-      ) as HTMLUListElement | null;
-
-      if (supportsElementReferences) {
-        const entryWithAria = entry as HTMLElement & IElementAriaDescriptions;
-        entryWithAria.ariaDescribedByElements = matchesList
-          ? [matchesList]
-          : [];
-        continue;
-      }
-
-      if (matchesList) {
-        const pluginId = entry.getAttribute('data-id') ?? '';
-        const matchesId = `jp-PluginList-matches-${encodeURIComponent(pluginId)}`;
-        if (!matchesList.id) {
-          matchesList.id = matchesId;
-        }
-        entry.setAttribute('aria-describedby', matchesList.id);
-      } else {
-        entry.removeAttribute('aria-describedby');
-      }
-    }
   }
 
   /**
@@ -714,6 +668,9 @@ export class PluginList extends ReactWidget {
       : undefined;
     const hasMatchDetails =
       filteredProperties !== undefined && filteredProperties.length > 0;
+    const matchesId = hasMatchDetails
+      ? `jp-PluginList-matches-${encodeURIComponent(id)}`
+      : undefined;
     const ariaLabel = this._errors[id] ? trans.__('%1 (error)', title) : title;
 
     return (
@@ -722,6 +679,7 @@ export class PluginList extends ReactWidget {
           role="tab"
           aria-selected={id === this.selection}
           aria-label={ariaLabel}
+          aria-describedby={matchesId}
           tabIndex={id === this._focusedId ? 0 : -1}
           onClick={this._evtClick}
           className={classes(
@@ -745,9 +703,7 @@ export class PluginList extends ReactWidget {
               {hightlightedTitle}
             </span>
           </div>
-          <ul className={hasMatchDetails ? MATCHES_CLASS : undefined}>
-            {filteredProperties}
-          </ul>
+          <ul id={matchesId}>{filteredProperties}</ul>
         </div>
       </li>
     );

--- a/packages/settingeditor/style/base.css
+++ b/packages/settingeditor/style/base.css
@@ -136,6 +136,13 @@
   background: var(--jp-layout-color2);
 }
 
+.jp-PluginList-entry:focus-visible {
+  outline-width: var(--jp-focus-outline-width);
+  outline-color: var(--jp-focus-outline-color);
+  outline-style: solid;
+  outline-offset: calc(var(--jp-focus-outline-width) * -1);
+}
+
 .jp-PluginList-entry li {
   margin-left: 27px;
   margin-top: 5px;
@@ -265,6 +272,13 @@
   background-color: var(--jp-warn-color-normal);
   border: 0;
   color: var(--jp-ui-inverse-font-color0);
+}
+
+.jp-SettingsHeader-buttonbar > .jp-RestoreButton:focus-visible {
+  outline-width: var(--jp-focus-outline-width);
+  outline-color: var(--jp-warn-color-normal);
+  outline-style: solid;
+  outline-offset: 2px;
 }
 
 .jp-PluginEditor {

--- a/packages/settingeditor/test/pluginlist.spec.tsx
+++ b/packages/settingeditor/test/pluginlist.spec.tsx
@@ -2,8 +2,39 @@
 // Distributed under the terms of the Modified BSD License.
 import { PluginList } from '../src/pluginlist';
 import { signalToPromise } from '@jupyterlab/coreutils';
+import { framePromise, simulate } from '@jupyterlab/testing';
 import type { ISettingRegistry } from '@jupyterlab/settingregistry';
+import { updateFilterFunction } from '@jupyterlab/ui-components';
+import { MessageLoop } from '@lumino/messaging';
+import { Widget } from '@lumino/widgets';
 import { TestConnector, TestRegistry } from './utils';
+
+const ENTRY_QUERY = '.jp-PluginList-entry';
+
+function tabStop(list: PluginList): HTMLElement {
+  return list.node.querySelector(`${ENTRY_QUERY}[tabindex="0"]`) as HTMLElement;
+}
+
+function key(target: EventTarget, keyName: string): void {
+  simulate(target, 'keydown', { key: keyName, bubbles: true });
+}
+
+async function setupList(
+  registry: TestRegistry,
+  selection?: string
+): Promise<PluginList> {
+  const model = new PluginList.Model({ registry });
+  await model.ready;
+  const list = new PluginList({ registry, model });
+  if (selection) {
+    list.selection = selection;
+  }
+  Widget.attach(list, document.body);
+  list.setFilter(updateFilterFunction('', false, false), '');
+  MessageLoop.sendMessage(list, Widget.Msg.UpdateRequest);
+  await framePromise();
+  return list;
+}
 
 describe('@jupyterlab/settingeditor', () => {
   describe('PluginList.Model', () => {
@@ -200,6 +231,70 @@ describe('@jupyterlab/settingeditor', () => {
         expect(Object.keys(model.settings)).toHaveLength(1);
         expect(model.settings[id].schema.transformed).toBe(true);
       });
+    });
+  });
+
+  describe('PluginList', () => {
+    let connector: TestConnector;
+    let registry: TestRegistry;
+    let list: PluginList;
+
+    const IDS = ['plugin-alpha', 'plugin-beta', 'plugin-gamma'];
+    const mkSchema = (title: string): ISettingRegistry.ISchema => ({
+      type: 'object',
+      title,
+      properties: { value: { type: 'string', default: 'x' } }
+    });
+
+    beforeAll(() => {
+      connector = new TestConnector();
+    });
+
+    beforeEach(async () => {
+      registry = new TestRegistry({ connector });
+      connector.schemas = {
+        [IDS[0]]: mkSchema('Alpha'),
+        [IDS[1]]: mkSchema('Beta'),
+        [IDS[2]]: mkSchema('Gamma')
+      };
+      await Promise.all(IDS.map(id => registry.load(id)));
+    });
+
+    afterEach(async () => {
+      list?.dispose();
+      if (list?.node.isConnected) {
+        Widget.detach(list);
+      }
+      connector.schemas = {};
+      await connector.clear();
+    });
+
+    it('should rove tabindex and move focus with arrows without selecting', async () => {
+      list = await setupList(registry, IDS[0]);
+      tabStop(list).focus();
+      key(document.activeElement!, 'ArrowDown');
+
+      expect(document.activeElement?.getAttribute('data-id')).toBe(IDS[1]);
+      expect(list.selection).toBe(IDS[0]);
+      expect(list.node.querySelectorAll(`${ENTRY_QUERY}[tabindex="0"]`)).toHaveLength(1);
+
+      let emitted = false;
+      list.handleSelectSignal.connect(() => {
+        emitted = true;
+      });
+      key(document.activeElement!, 'ArrowDown');
+      expect(emitted).toBe(false);
+    });
+
+    it('should select the focused entry on Enter', async () => {
+      list = await setupList(registry, IDS[0]);
+      tabStop(list).focus();
+      key(document.activeElement!, 'ArrowDown');
+
+      const selected = signalToPromise(list.handleSelectSignal);
+      key(document.activeElement!, 'Enter');
+      await expect(selected).resolves.toBe(IDS[1]);
+      expect(list.selection).toBe(IDS[1]);
     });
   });
 });

--- a/packages/settingeditor/test/pluginlist.spec.tsx
+++ b/packages/settingeditor/test/pluginlist.spec.tsx
@@ -11,8 +11,13 @@ import { TestConnector, TestRegistry } from './utils';
 
 const ENTRY_QUERY = '.jp-PluginList-entry';
 
+function entries(list: PluginList): HTMLElement[] {
+  return Array.from(list.node.querySelectorAll(ENTRY_QUERY));
+}
+
 function tabStop(list: PluginList): HTMLElement {
-  return list.node.querySelector(`${ENTRY_QUERY}[tabindex="0"]`) as HTMLElement;
+  const items = entries(list);
+  return items.find(entry => entry.tabIndex === 0) ?? items[0];
 }
 
 function key(target: EventTarget, keyName: string): void {
@@ -26,13 +31,15 @@ async function setupList(
   const model = new PluginList.Model({ registry });
   await model.ready;
   const list = new PluginList({ registry, model });
+  Widget.attach(list, document.body);
+  list.setFilter(updateFilterFunction('', false, false), '');
   if (selection) {
     list.selection = selection;
   }
-  Widget.attach(list, document.body);
-  list.setFilter(updateFilterFunction('', false, false), '');
   MessageLoop.sendMessage(list, Widget.Msg.UpdateRequest);
-  await framePromise();
+  for (let i = 0; i < 10 && entries(list).length === 0; i++) {
+    await framePromise();
+  }
   return list;
 }
 
@@ -271,14 +278,17 @@ describe('@jupyterlab/settingeditor', () => {
 
     it('should rove tabindex and move focus with arrows without selecting', async () => {
       list = await setupList(registry, IDS[0]);
-      tabStop(list).focus();
-      key(document.activeElement!, 'ArrowDown');
+      expect(entries(list).length).toBe(3);
+
+      const focused = tabStop(list);
+      focused.focus();
+      key(focused, 'ArrowDown');
 
       expect(document.activeElement?.getAttribute('data-id')).toBe(IDS[1]);
       expect(list.selection).toBe(IDS[0]);
-      expect(
-        list.node.querySelectorAll(`${ENTRY_QUERY}[tabindex="0"]`)
-      ).toHaveLength(1);
+      expect(entries(list).filter(entry => entry.tabIndex === 0)).toHaveLength(
+        1
+      );
 
       let emitted = false;
       list.handleSelectSignal.connect(() => {
@@ -290,8 +300,9 @@ describe('@jupyterlab/settingeditor', () => {
 
     it('should select the focused entry on Enter', async () => {
       list = await setupList(registry, IDS[0]);
-      tabStop(list).focus();
-      key(document.activeElement!, 'ArrowDown');
+      const focused = tabStop(list);
+      focused.focus();
+      key(focused, 'ArrowDown');
 
       const selected = signalToPromise(list.handleSelectSignal);
       key(document.activeElement!, 'Enter');

--- a/packages/settingeditor/test/pluginlist.spec.tsx
+++ b/packages/settingeditor/test/pluginlist.spec.tsx
@@ -276,7 +276,9 @@ describe('@jupyterlab/settingeditor', () => {
 
       expect(document.activeElement?.getAttribute('data-id')).toBe(IDS[1]);
       expect(list.selection).toBe(IDS[0]);
-      expect(list.node.querySelectorAll(`${ENTRY_QUERY}[tabindex="0"]`)).toHaveLength(1);
+      expect(
+        list.node.querySelectorAll(`${ENTRY_QUERY}[tabindex="0"]`)
+      ).toHaveLength(1);
 
       let emitted = false;
       list.handleSelectSignal.connect(() => {

--- a/packages/settingeditor/test/pluginlist.spec.tsx
+++ b/packages/settingeditor/test/pluginlist.spec.tsx
@@ -295,7 +295,8 @@ describe('@jupyterlab/settingeditor', () => {
 
       const selected = signalToPromise(list.handleSelectSignal);
       key(document.activeElement!, 'Enter');
-      await expect(selected).resolves.toBe(IDS[1]);
+      const [, pluginId] = await selected;
+      expect(pluginId).toBe(IDS[1]);
       expect(list.selection).toBe(IDS[1]);
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4854,6 +4854,7 @@ __metadata:
     "@lumino/commands": ^2.3.3
     "@lumino/coreutils": ^2.2.2
     "@lumino/disposable": ^2.1.5
+    "@lumino/domutils": ^2.0.4
     "@lumino/messaging": ^2.0.4
     "@lumino/polling": ^2.1.5
     "@lumino/signaling": ^2.1.5


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

- Fixes #19027

## Code changes

<!-- Describe the code changes and how they address the issue. -->
- Make plugin entries keyboard focusable with a roving tab index
- Restore focus to the active tab after the panel updates
- Add consistent styling for focus outlines
- Improve markup and ARIA

```html
<!-- Before: no list items -->
<ul>
    <div class="jp-PluginList-entry"></div>
</ul>

<!-- After -->
<ul role="tablist" aria-labelledby="jp-PluginList-modified-header">
    <li role="presentation">
        <div role="tab" class="jp-PluginList-entry"></div>
    </li>
</ul>
```

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

- Users can now reach the plugin list when navigating with `Tab` / `Shift` + `Tab`.
- Pressing `Enter` or `Space` when one of the list entries is in focus activates the tab.
- Pressing `Home` / `End` moves focus to the first or last entry respectively.

[settings_editor_nav.webm](https://github.com/user-attachments/assets/0c1eaa9e-639c-41e6-b887-7175fbb49e5f)


**NOTE**: I also attempted to not use `Enter` / `Space` to activate each tab, meaning that the tab would be activated automatically when moving the focus with the arrow keys. However, some tabs such as the Keyboard Shortcuts take too long to load which makes the navigation feel sticky. Therefore, requiring `Enter` / `Space` to activate the tab felt like a better solution.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None

## AI usage

- YES: Some or all of the content of this PR was generated by AI.
- YES: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Cursor
