### PR TITLE
Split external link checks and only run if diff includes a URL

### DIFF
--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -2,12 +2,17 @@ name: External Link Audit
 
 on:
   push:
-    branches: [main]
-  release:
-    types: [published]
+    branches:
+      - main
+  pull_request:
+    paths:
+      - 'docs/**'
   workflow_dispatch:
   schedule:
-    - cron: "0 6 * * 1"
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
 
 jobs:
   external_link_audit:
@@ -26,5 +31,5 @@ jobs:
           jlpm docs
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@95d85449e4f3f352e261221f6529f8ed307f5728 # v1
         with:
-          ignore_glob: "docs/api packages/ui-components/docs/source/ui_components.rst images"
+          ignore_glob: 'docs/api packages/ui-components/docs/source/ui_components.rst images'
           ignore_links: ".*/images/[\\w-]+.png https://docs.github.com/en/.* https://jupyterlab.github.io https://mybinder.org/v2/gh/jupyterlab/.* https://github.com/[^/]+/?$ https://blog.jupyter.org/.* https://pypi.org/.* https://code.visualstudio.com/.* https://github.com/.* https://www.npmjs.com.* https://webpack.js.org/.* https://docs.conda.io/* https://conda.io/*"

--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    paths:
-      - 'docs/**'
-      - '**/*.md'
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1'
@@ -16,8 +13,58 @@ permissions:
   contents: read
 
 jobs:
+  should_audit_external_links:
+    name: Check for external link changes
+    runs-on: ubuntu-latest
+    outputs:
+      run_audit: ${{ steps.audit-decision.outputs.run_audit }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        if: github.event_name == 'pull_request'
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - id: audit-decision
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$GITHUB_EVENT_NAME" != "pull_request" ]]; then
+            echo "run_audit=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          base_sha="$BASE_SHA"
+          head_sha="$HEAD_SHA"
+
+          if ! git cat-file -e "${base_sha}^{commit}" || ! git cat-file -e "${head_sha}^{commit}"; then
+            if git cat-file -e "HEAD^1^{commit}" && git cat-file -e "HEAD^2^{commit}"; then
+              base_sha="HEAD^1"
+              head_sha="HEAD^2"
+            else
+              echo "Unable to inspect PR commits; running audit conservatively."
+              echo "run_audit=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          if git diff --quiet --no-ext-diff --diff-filter=ACMRT -G'https?://' "$base_sha" "$head_sha"; then
+            echo "run_audit=false" >> "$GITHUB_OUTPUT"
+          else
+            status=$?
+            if [[ "$status" != "1" ]]; then
+              exit "$status"
+            fi
+            echo "run_audit=true" >> "$GITHUB_OUTPUT"
+          fi
+
   external_link_audit:
     name: Audit external links
+    needs: should_audit_external_links
+    if: needs.should_audit_external_links.outputs.run_audit == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -1,0 +1,30 @@
+name: External Link Audit
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  external_link_audit:
+    name: Audit external links
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@95d85449e4f3f352e261221f6529f8ed307f5728 # v1
+      - run: |
+          pip install -vv --group builder
+          jlpm
+          jlpm build:packages
+          jlpm docs
+      - uses: jupyterlab/maintainer-tools/.github/actions/check-links@95d85449e4f3f352e261221f6529f8ed307f5728 # v1
+        with:
+          ignore_glob: "docs/api packages/ui-components/docs/source/ui_components.rst images"
+          ignore_links: ".*/images/[\\w-]+.png https://docs.github.com/en/.* https://jupyterlab.github.io https://mybinder.org/v2/gh/jupyterlab/.* https://github.com/[^/]+/?$ https://blog.jupyter.org/.* https://pypi.org/.* https://code.visualstudio.com/.* https://github.com/.* https://www.npmjs.com.* https://webpack.js.org/.* https://docs.conda.io/* https://conda.io/*"

--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - 'docs/**'
+      - '**/*.md'
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1'

--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -196,4 +196,4 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@95d85449e4f3f352e261221f6529f8ed307f5728 # v1
         with:
           ignore_glob: "docs/api packages/ui-components/docs/source/ui_components.rst images"
-          ignore_links: ".*/images/[\\w-]+.png https://docs.github.com/en/.* https://jupyterlab.github.io https://mybinder.org/v2/gh/jupyterlab/.* https://github.com/[^/]+/?$ https://blog.jupyter.org/.* https://pypi.org/.* https://code.visualstudio.com/.* https://github.com/.* https://www.npmjs.com.* https://webpack.js.org/.* https://docs.conda.io/* https://conda.io/*"
+          ignore_links: "https?://.* .*/images/[\\w-]+.png"


### PR DESCRIPTION
## References
Part of #16837 

## Code changes
This makes the existing Linux `check_links` job deterministic by checking only internal/relative links during PR CI, avoiding third-party rate limits and transient network failures.

Full external-link auditing is moved to a separate workflow that runs on PRs if any URLs are in the diff range, after merges to main, weekly, and by manual dispatch, preserving coverage without blocking unrelated PRs.

## User-facing changes
None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes
None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: ChatGPT 5.5
