### PR TITLE
Fix flaky 'Switch back and forth to reference page' test

### DIFF
--- a/galata/test/jupyterlab/help.test.ts
+++ b/galata/test/jupyterlab/help.test.ts
@@ -33,7 +33,12 @@ test('Switch back and forth to reference page', async ({ page }) => {
   // Workaround for https://github.com/jupyterlab/jupyterlab/issues/18457
   await page.getByText('Python 3 (ipykernel) | Idle').waitFor();
 
-  await page.menu.clickMenuItem('Help>Jupyter Reference');
+  await page.evaluate(async () => {
+    await window.jupyterapp.commands.execute('help:open', {
+      url: 'https://jupyter.org/documentation',
+      text: 'Jupyter Reference'
+    });
+  });
 
   await expect(
     page

--- a/galata/test/jupyterlab/help.test.ts
+++ b/galata/test/jupyterlab/help.test.ts
@@ -22,7 +22,7 @@ const licenseFormats = [
   { name: 'JSON', extension: 'json', validation: isValidJSON }
 ];
 
-test('Switch back and forth to reference page', async ({ page }) => {
+test('Switch back and forth to an iframe', async ({ page }) => {
   // The goal is to test switching back and forth with a tab containing an iframe
   const notebookFilename = 'test-switch-doc-notebook';
   const cellContent = '# First cell';
@@ -33,19 +33,20 @@ test('Switch back and forth to reference page', async ({ page }) => {
   // Workaround for https://github.com/jupyterlab/jupyterlab/issues/18457
   await page.getByText('Python 3 (ipykernel) | Idle').waitFor();
 
+  // Open a local page (the unauthenticated Jupyter Server `/api` version
+  // endpoint) in an in-app iframe tab, avoiding a dependency on an external
+  // website which would make this test flaky.
   await page.evaluate(async () => {
+    const { baseUrl } = window.jupyterapp.serviceManager.serverSettings;
     await window.jupyterapp.commands.execute('help:open', {
-      url: 'https://jupyter.org/documentation',
-      text: 'Jupyter Reference'
+      url: `${baseUrl}api`,
+      text: 'Server API version'
     });
   });
 
   await expect(
-    page
-      .frameLocator('iframe[src="https://jupyter.org/documentation"]')
-      .locator('h1')
-      .first()
-  ).toHaveText('Project Jupyter Documentation#');
+    page.frameLocator('iframe[src$="/api"]').locator('body')
+  ).toContainText('version');
 
   await page.activity.activateTab(notebookFilename);
 


### PR DESCRIPTION
## References

Workarounds issue described in https://github.com/jupyterlab/jupyterlab/issues/18457 for the `Switch back and forth to reference page` test (does not solve the underlying issue, but this test is not about it)

## Code changes

- a) Use command directly to open the help page rather than clicking on menu (which takes longer anyways) - flaky due to #18457
- b) Open `/api` page of jupyter-server instead of the `jupyter.org/documentation` which depends on internet access - flaky due to website availability/rate limiting/Internet availability at the runner

## Developer-facing changes

| Before | After |
|--|--|
| [40 passed (6.8m)](https://github.com/jupyterlab/jupyterlab/actions/runs/27688237913) | [40 passed (1.1m)](https://github.com/krassowski/jupyterlab/actions/runs/27693534921) |

The runtime at 40 repeats was reduced by each change by:
- a) ~1 minute 54 seconds
- b) additional ~3 minute 49 seconds

## Backwards-incompatible changes

None

## AI usage

None