### PR TITLE
Change default setting of read-only Markdown cells to hide source code

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -2584,7 +2584,7 @@ export class MarkdownCell extends AttachmentsCell<IMarkdownCellModel> {
   private _rendermime: IRenderMimeRegistry;
   private _rendered = true;
   private _renderedChanged = new Signal<this, boolean>(this);
-  private _showEditorForReadOnlyMarkdown = true;
+  private _showEditorForReadOnlyMarkdown = false;
   private _cachedHeadingText = '';
   private _headingResolved: boolean = false;
   private _emptyPlaceholder: string;
@@ -2617,7 +2617,7 @@ export namespace MarkdownCell {
   /**
    * Default value for showEditorForReadOnlyMarkdown.
    */
-  export const defaultShowEditorForReadOnlyMarkdown = true;
+  export const defaultShowEditorForReadOnlyMarkdown = false;
 }
 
 /** ****************************************************************************

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -803,7 +803,7 @@
       "title": "Show editor for read-only Markdown cells",
       "description": "Should an editor be shown for read-only markdown",
       "type": "boolean",
-      "default": true
+      "default": false
     },
     "kernelStatus": {
       "title": "Kernel status icon configuration",

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1467,7 +1467,7 @@ export namespace StaticNotebook {
     recordTiming: false,
     inputHistoryScope: 'global',
     maxNumberOutputs: 50,
-    showEditorForReadOnlyMarkdown: true,
+    showEditorForReadOnlyMarkdown: false,
     disableDocumentWideUndoRedo: true,
     autoRenderMarkdownCells: false,
     renderingLayout: 'default',


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

- Closes https://github.com/jupyterlab/jupyterlab/issues/19051

This PR changes the default of the setting `showEditorForReadOnlyMarkdown`, in order to automatically hide the source of read-only Markdown cells. Since the content of the cells it not editable, being able to see their source code is not consistent with the expected behavior of read-only cells and can be confusing for users who accidentally double-click the cell and activate the editor mode. 

As such, changing the default of the setting will better align the behaviour of read-only content with user expectations, improving consistency.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

This PR changes the default of the `showEditorForReadOnlyMarkdown` setting to `false`, including in the Notebook configuration.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

When working with read-only markdown cells, the source code will be automatically hidden. The `showEditorForReadOnlyMarkdown` setting remains available to be activated in the Notebook settings, for those who prefer to see the source code.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes
N/A.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

## AI usage

- NO: Some or all of the content of this PR was generated by AI.
- YES: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: N/A.
