### PR TITLE
Move `jest-environment-jsdom` to dev dependencies section in `filebrowser` package

### DIFF
--- a/packages/filebrowser/jest.config.js
+++ b/packages/filebrowser/jest.config.js
@@ -5,5 +5,5 @@
 
 const func = require('@jupyterlab/testing/lib/jest-config');
 const config = func(__dirname);
-config['testEnvironment'] = './lib/jest-env.js';
+config['testEnvironment'] = './test/jest-env.js';
 module.exports = config;

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -60,13 +60,13 @@
     "@lumino/signaling": "^2.1.5",
     "@lumino/virtualdom": "^2.0.4",
     "@lumino/widgets": "^2.8.0",
-    "jest-environment-jsdom": "^29.3.0",
     "react": "^18.2.0"
   },
   "devDependencies": {
     "@jupyterlab/testing": "^4.6.0",
     "@types/jest": "^29.2.0",
     "jest": "^29.2.0",
+    "jest-environment-jsdom": "^29.3.0",
     "rimraf": "~5.0.5",
     "typescript": "~5.9.3"
   },

--- a/packages/filebrowser/test/jest-env.js
+++ b/packages/filebrowser/test/jest-env.js
@@ -10,7 +10,7 @@
 import JSDOMEnvironment from 'jest-environment-jsdom';
 
 export default class FixJSDOMEnvironment extends JSDOMEnvironment {
-  constructor(...args: ConstructorParameters<typeof JSDOMEnvironment>) {
+  constructor(...args) {
     super(...args);
 
     this.global.fetch = fetch;


### PR DESCRIPTION
## References

I noticed in multiple places that `jest` was now being pulled. This seems due to a new dependency in filebrowser that should probably have been made a dev dependency. 

## Code changes

Make the jest package a dev dependency