### PR TITLE
Use anchor positioning for search box placement

### DIFF
--- a/packages/documentsearch-extension/src/index.ts
+++ b/packages/documentsearch-extension/src/index.ts
@@ -31,6 +31,11 @@ const SEARCHABLE_CLASS = 'jp-mod-searchable';
  * Class added to widgets with open search view (not necessarily focused).
  */
 const SEARCH_ACTIVE_CLASS = 'jp-mod-search-active';
+/**
+ * CSS anchor name used to position the search overlay below the content header
+ * of a `MainAreaWidget`.
+ */
+const CONTENT_HEADER_ANCHOR = '--jp-documentsearch-content-header';
 
 namespace CommandIDs {
   /**
@@ -308,12 +313,20 @@ const extension: JupyterFrontEndPlugin<ISearchProviderRegistry> = {
         Widget.attach(searchView, widget.node);
         widget.addClass(SEARCH_ACTIVE_CLASS);
         if (widget instanceof MainAreaWidget) {
-          // Offset the position of the search widget to not cover the toolbar nor the content header.
-          // TODO this does not update once the search widget is displayed.
-          searchView.node.style.top = `${
-            widget.toolbar.node.getBoundingClientRect().height +
-            widget.contentHeader.node.getBoundingClientRect().height
-          }px`;
+          // Offset the search overlay so it does not cover the toolbar nor the
+          // content header. The content header sits directly below the toolbar
+          // in the widget's box layout, so anchoring the overlay's top to the
+          // content header's bottom edge reproduces "toolbar + header height"
+          // and tracks their size automatically (e.g. when toolbar gets
+          // populated after the search box was already opened).
+          widget.contentHeader.node.style.setProperty(
+            'anchor-name',
+            CONTENT_HEADER_ANCHOR
+          );
+          // Scope the anchor name to this widget so that concurrently open
+          // documents do not resolve one another's anchors.
+          widget.node.style.setProperty('anchor-scope', CONTENT_HEADER_ANCHOR);
+          searchView.node.style.top = `anchor(${CONTENT_HEADER_ANCHOR} bottom)`;
         }
         if (searchView.model.searchExpression) {
           searchView.model.refresh();


### PR DESCRIPTION
## References

- #18862 

## Code changes

Replace two layout reads for manual positioning with an anchor.

## User-facing changes

When toolbar items are populated added after the search box opens the search box is no longer hidden under the toolbar.

While the reproducer below demonstrates a reliable path for this glitch, it also happened from time to time (but very rarely) when triggering search while the notebook was being open.

### Before

https://github.com/user-attachments/assets/7efdb3d8-4761-4c80-8157-5633006fc1de

### After

https://github.com/user-attachments/assets/191c4802-c4f4-45a0-91ab-a0d2f46994b6

Performance: one layout instead of two, ~30ms gain on 20x slowdown in text file with no heavy content in the shell. Likely a larger gain for busy workspace with multiple heavy notebooks open.

| Before | After |
|--|--|
| <img width="1016" height="360" alt="image" src="https://github.com/user-attachments/assets/c5261178-e8d6-42e6-917b-7f7a44762a12" /> | <img width="977" height="360" alt="image" src="https://github.com/user-attachments/assets/54c11b9d-46de-41fa-8690-30bd7af02411" /> |


## Backwards-incompatible changes

None

## AI usage

- **Yes**: Some or all of the content of this PR was generated by AI.
- **Yes**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude