### PR TITLE
Split PR title spell check into `pull_request` workflow

### DIFF
--- a/.github/workflows/pr-title-spell-check.yml
+++ b/.github/workflows/pr-title-spell-check.yml
@@ -1,0 +1,38 @@
+name: PR Title Spell Check
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  pr-title-spelling:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+          fetch-depth: 1
+          sparse-checkout: .codespellignore
+          sparse-checkout-cone-mode: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.11'
+
+      - name: Check PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          title_file="${RUNNER_TEMP}/pr-title.txt"
+          printf '%s\n' "${PR_TITLE}" > "${title_file}"
+
+          python -m pip install codespell==2.4.1
+          codespell --ignore-words=.codespellignore "${title_file}"

--- a/.github/workflows/pr-title-spell-check.yml
+++ b/.github/workflows/pr-title-spell-check.yml
@@ -11,10 +11,11 @@ jobs:
   pr-title-spelling:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout base repository
+      - name: Checkout spelling configuration
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          repository: jupyterlab/jupyterlab
+          ref: main
           persist-credentials: false
           fetch-depth: 1
           sparse-checkout: .codespellignore

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -13,8 +13,6 @@ on:
       - 'docs/source/spelling_wordlist.txt'
       - 'pyproject.toml'
       - '.github/workflows/spell-check.yml'
-  pull_request_target:
-    types: [opened, edited, reopened, ready_for_review]
 
 permissions:
   contents: read
@@ -95,33 +93,3 @@ jobs:
             done < "${spelling_reports}"
             exit 1
           fi
-
-  pr-title-spelling:
-    if: github.event_name == 'pull_request_target'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout base repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-          persist-credentials: false
-          fetch-depth: 1
-          sparse-checkout: .codespellignore
-          sparse-checkout-cone-mode: false
-
-      - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.11'
-
-      - name: Check PR title
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          set -euo pipefail
-
-          title_file="${RUNNER_TEMP}/pr-title.txt"
-          printf '%s\n' "${PR_TITLE}" > "${title_file}"
-
-          python -m pip install codespell==2.4.1
-          codespell --ignore-words=.codespellignore "${title_file}"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Refs: https://github.com/jupyterlab/jupyterlab/pull/19053#issuecomment-4750989190
## Code changes

Move the PR title spelling check into a separate workflow triggered by `pull_request` instead of `pull_request_target`.

## User-facing changes
None

## Backwards-incompatible changes
None

## AI usage
None
