### PR TITLE
Enable non-nullable type assertion style lint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -265,6 +265,7 @@ export default defineConfig([
 
       '@typescript-eslint/no-use-before-define': 'off',
       '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/non-nullable-type-assertion-style': 'error',
       '@typescript-eslint/no-non-null-assertion': 'off',
       '@typescript-eslint/no-namespace': 'off',
       '@typescript-eslint/interface-name-prefix': 'off',
@@ -467,7 +468,8 @@ export default defineConfig([
     ],
 
     rules: {
-      '@typescript-eslint/no-explicit-any': 'off'
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/non-nullable-type-assertion-style': 'off'
     }
   },
   {

--- a/galata/src/benchmarkReporter.ts
+++ b/galata/src/benchmarkReporter.ts
@@ -544,17 +544,13 @@ class BenchmarkReporter implements Reporter {
     });
 
     // If the reference | project lists has two items, the intervals will be compared.
-    if (!groups.values().next().value) {
+    const firstTestGroup = groups.values().next().value;
+    if (!firstTestGroup) {
       return ['## Benchmark report\n\nNot enough data', reportExtension];
     }
 
-    const compare =
-      (
-        groups.values().next().value?.values().next().value as Map<
-          string,
-          Map<string, number[]>
-        >
-      ).size === 2;
+    const firstBrowserGroup = firstTestGroup.values().next().value!;
+    const compare = firstBrowserGroup.size === 2;
 
     // - Create report
     const reportContent = new Array<string>(
@@ -576,8 +572,6 @@ class BenchmarkReporter implements Reporter {
     let header = '| Test file |';
     let nFiles = 0;
     // groups is non-empty (checked above), so all nested maps have at least one entry
-    const firstTestGroup = groups.values().next().value!;
-    const firstBrowserGroup = firstTestGroup.values().next().value!;
     const firstFileGroup = firstBrowserGroup.values().next().value!;
     for (const [file] of firstFileGroup) {
       header += ` ${file} |`;

--- a/galata/src/galata.ts
+++ b/galata/src/galata.ts
@@ -797,8 +797,7 @@ export namespace galata {
       config: Record<string, JSONObject>
     ): Promise<void> {
       await page.route(Routes.config, (route, request) => {
-        const section = Routes.config.exec(request.url())?.groups
-          ?.section as string;
+        const { section } = Routes.config.exec(request.url())!.groups!;
         switch (request.method()) {
           case 'GET':
             return route.fulfill({

--- a/galata/src/helpers/statusbar.ts
+++ b/galata/src/helpers/statusbar.ts
@@ -20,9 +20,8 @@ export class StatusBarHelper {
    */
   async isVisible(): Promise<boolean> {
     return await this.page.evaluate(() => {
-      const statusBar = document.querySelector(
-        '#jp-main-statusbar'
-      ) as HTMLElement;
+      const statusBar =
+        document.querySelector<HTMLElement>('#jp-main-statusbar')!;
       return window.galata.isElementVisible(statusBar);
     });
   }

--- a/galata/src/helpers/theme.ts
+++ b/galata/src/helpers/theme.ts
@@ -37,7 +37,7 @@ export class ThemeHelper {
    */
   async getTheme(): Promise<string> {
     return await this.page.evaluate(() => {
-      return document.body.dataset.jpThemeName as string;
+      return document.body.dataset.jpThemeName!;
     });
   }
 

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -278,7 +278,7 @@ const mainCommands: JupyterFrontEndPlugin<void> = {
     function getZoomTarget(widget: Widget): HTMLElement {
       const node = widget.node;
 
-      let target = node.querySelector('.jp-zoom-target') as HTMLElement;
+      const target = node.querySelector<HTMLElement>('.jp-zoom-target');
       if (target) return target;
 
       node.classList.add('jp-zoom-target');
@@ -944,7 +944,7 @@ const mainCommands: JupyterFrontEndPlugin<void> = {
       if (!target) return null;
 
       // closest lumino widget node
-      const node = target.closest('.lm-Widget') as HTMLElement;
+      const node = target.closest<HTMLElement>('.lm-Widget');
       if (!node) return null;
 
       for (const widget of shell.widgets('main')) {
@@ -1593,15 +1593,15 @@ const busy: JupyterFrontEndPlugin<void> = {
   requires: [ILabStatus],
   activate: async (_: JupyterFrontEnd, status: ILabStatus) => {
     status.busySignal.connect((_, isBusy) => {
-      const favicon = document.querySelector(
+      const favicon = document.querySelector<HTMLLinkElement>(
         `link[rel="icon"]${isBusy ? '.idle.favicon' : '.busy.favicon'}`
-      ) as HTMLLinkElement;
+      );
       if (!favicon) {
         return;
       }
-      const newFavicon = document.querySelector(
+      const newFavicon = document.querySelector<HTMLLinkElement>(
         `link${isBusy ? '.busy.favicon' : '.idle.favicon'}`
-      ) as HTMLLinkElement;
+      );
       if (!newFavicon) {
         return;
       }

--- a/packages/apputils/src/domutils.ts
+++ b/packages/apputils/src/domutils.ts
@@ -30,7 +30,7 @@ export namespace DOMUtils {
     parent: HTMLElement,
     className: string
   ): HTMLElement {
-    return parent.querySelector(`.${className}`) as HTMLElement;
+    return parent.querySelector<HTMLElement>(`.${className}`)!;
   }
 
   /**

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -1851,7 +1851,7 @@ namespace Private {
      * Get the value of the kernel selector widget.
      */
     getValue(): Kernel.IModel {
-      const selector = this.node.querySelector('select') as HTMLSelectElement;
+      const selector = this.node.querySelector<HTMLSelectElement>('select')!;
       return JSON.parse(selector.value) as Kernel.IModel;
     }
   }

--- a/packages/codemirror/src/extension.ts
+++ b/packages/codemirror/src/extension.ts
@@ -748,7 +748,7 @@ export namespace EditorExtensionRegistry {
               'Alt-A',
               'Escape',
               'Enter'
-            ].includes(binding.key as string);
+            ].includes(binding.key!);
           }),
           {
             key: 'Tab',

--- a/packages/completer/src/inline.ts
+++ b/packages/completer/src/inline.ts
@@ -535,7 +535,7 @@ export class InlineCompleter extends Widget {
     }
 
     const host =
-      (editor.host.closest('.jp-MainAreaWidget > .lm-Widget') as HTMLElement) ||
+      editor.host.closest<HTMLElement>('.jp-MainAreaWidget > .lm-Widget') ??
       editor.host;
 
     let anchor: DOMRect;

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -247,12 +247,12 @@ export class Completer extends Widget {
    * Emit the selected signal for the current active item and reset.
    */
   selectActive(): void {
-    const active = this.node.querySelector(`.${ACTIVE_CLASS}`) as HTMLElement;
+    const active = this.node.querySelector<HTMLElement>(`.${ACTIVE_CLASS}`);
     if (!active) {
       this.reset();
       return;
     }
-    this._selected.emit(active.getAttribute('data-value') as string);
+    this._selected.emit(active.getAttribute('data-value')!);
     this.reset();
   }
 
@@ -548,10 +548,10 @@ export class Completer extends Widget {
    * to the first item, subsequent `ArrowUp` cycles will cycle to the last index.
    */
   private _cycle(direction: Private.scrollType): void {
-    const items = this.node.querySelectorAll(`.${ITEM_CLASS}`);
+    const items = this.node.querySelectorAll<HTMLElement>(`.${ITEM_CLASS}`);
     const index = this._activeIndex;
     const last = items.length - 1;
-    let active = this.node.querySelector(`.${ACTIVE_CLASS}`) as HTMLElement;
+    let active = this.node.querySelector<HTMLElement>(`.${ACTIVE_CLASS}`)!;
     active.classList.remove(ACTIVE_CLASS);
 
     switch (direction) {
@@ -573,9 +573,9 @@ export class Completer extends Widget {
       }
     }
 
-    active = items[this._activeIndex] as HTMLElement;
+    active = items[this._activeIndex]!;
     active.classList.add(ACTIVE_CLASS);
-    let completionList = this.node.querySelector(`.${LIST_CLASS}`) as Element;
+    const completionList = this.node.querySelector(`.${LIST_CLASS}`)!;
     ElementExt.scrollIntoViewIfNeeded(completionList, active);
     this._indexChanged.emit(this._activeIndex);
     const visibleCompletionItems = this.model?.completionItems();
@@ -677,7 +677,7 @@ export class Completer extends Widget {
         event.preventDefault();
         event.stopPropagation();
         event.stopImmediatePropagation();
-        this._selected.emit(target.getAttribute('data-value') as string);
+        this._selected.emit(target.getAttribute('data-value')!);
         this.reset();
         return;
       }
@@ -690,7 +690,7 @@ export class Completer extends Widget {
         return;
       }
 
-      target = target.parentElement as HTMLElement;
+      target = target.parentElement!;
     }
     this.reset();
   }
@@ -762,7 +762,7 @@ export class Completer extends Widget {
     }
 
     const start = model.cursor.start;
-    const position = editor.getPositionAt(start) as CodeEditor.IPosition;
+    const position = editor.getPositionAt(start)!;
     const anchor = editor.getCoordinateForPosition(position);
 
     if (!anchor) {
@@ -779,7 +779,7 @@ export class Completer extends Widget {
     // and editor is preferred. The difference is negligible in File Editor, but
     // substantial for Notebooks.
     const host =
-      (editor.host.closest('.jp-MainAreaWidget > .lm-Widget') as HTMLElement) ||
+      editor.host.closest<HTMLElement>('.jp-MainAreaWidget > .lm-Widget') ??
       editor.host;
 
     const items = model.completionItems();

--- a/packages/debugger/src/panels/breakpoints/pauseonexceptions.tsx
+++ b/packages/debugger/src/panels/breakpoints/pauseonexceptions.tsx
@@ -109,7 +109,7 @@ export class PauseOnExceptionsMenu extends MenuSvg {
         command: this._command,
         args: {
           filter: filter.filter,
-          description: filter.description as string
+          description: filter.description!
         }
       });
     });

--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -411,7 +411,7 @@ export class DebuggerService implements IDebugger, IDisposable {
     const modules = await this.session.sendRequest('modules', {});
     this._pendingKernelSources = modules.body.modules.map(module => ({
       name: module.name as string,
-      path: module.path as string
+      path: module.path!
     }));
 
     void this._displayModulesDebouncer.invoke();

--- a/packages/filebrowser/src/crumbs.ts
+++ b/packages/filebrowser/src/crumbs.ts
@@ -520,7 +520,7 @@ export class BreadCrumbs extends Widget {
         event.stopPropagation();
         return;
       }
-      node = node.parentElement as HTMLElement;
+      node = node.parentElement!;
     }
 
     // Click landed on the breadcrumb background (including separators
@@ -542,7 +542,7 @@ export class BreadCrumbs extends Widget {
         if (index !== -1) {
           break;
         }
-        target = target.parentElement as HTMLElement;
+        target = target.parentElement!;
       }
       if (index !== -1) {
         const hitElement = breadcrumbElements[index];
@@ -590,7 +590,7 @@ export class BreadCrumbs extends Widget {
       if (index !== -1) {
         break;
       }
-      target = target.parentElement as HTMLElement;
+      target = target.parentElement!;
     }
     if (index !== -1) {
       breadcrumbElements[index].classList.add(DROP_TARGET_CLASS);

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -3943,7 +3943,7 @@ namespace Private {
     edit: HTMLInputElement,
     original: string
   ): Promise<string> {
-    const parent = text.parentElement as HTMLElement;
+    const parent = text.parentElement!;
     parent.replaceChild(edit, text);
     edit.focus();
     const index = edit.value.lastIndexOf('.');

--- a/packages/filebrowser/src/pathnavigator.ts
+++ b/packages/filebrowser/src/pathnavigator.ts
@@ -331,7 +331,7 @@ export class PathNavigator extends Widget {
         }
         return;
       }
-      target = target.parentElement as HTMLElement;
+      target = target.parentElement!;
     }
   }
 

--- a/packages/json-extension/src/component.tsx
+++ b/packages/json-extension/src/component.tsx
@@ -52,7 +52,7 @@ export class Component extends React.Component<IProps, IState> {
   timer: number = 0;
 
   componentDidMount(): void {
-    StyleModule.mount(document, jupyterHighlightStyle.module as StyleModule);
+    StyleModule.mount(document, jupyterHighlightStyle.module!);
   }
 
   handleChange = (event: React.ChangeEvent<HTMLInputElement>): void => {

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -2958,9 +2958,9 @@ export class Notebook extends StaticNotebook {
             (this.rendermime.sanitizer.allowNamedProperties ?? false)
               ? 'id'
               : 'data-jupyter-id';
-          const element = this.node.querySelector(
+          const element = this.node.querySelector<HTMLElement>(
             `h${heading.level}[${attribute}="${CSS.escape(id)}"]`
-          ) as HTMLElement;
+          )!;
 
           return {
             cell,

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -709,9 +709,9 @@ function splitShallowNode<T extends Node>(
   at: number
 ): { pre: T; post: T } {
   const pre = node.cloneNode() as T;
-  pre.textContent = node.textContent?.slice(0, at) as string;
+  pre.textContent = (node.textContent ?? '').slice(0, at);
   const post = node.cloneNode() as T;
-  post.textContent = node.textContent?.slice(at) as string;
+  post.textContent = (node.textContent ?? '').slice(at);
   return {
     pre,
     post
@@ -780,9 +780,9 @@ function* alignedNodes<T extends Node, U extends Node>(
         let { pre, post } = splitShallowNode(A.node, B.end - A.start);
         if (B.start < A.start) {
           // this node should not be yielded anywhere else, so ok to modify in-place
-          B.node.textContent = B.node.textContent?.slice(
+          B.node.textContent = (B.node.textContent ?? '').slice(
             A.start - B.start
-          ) as string;
+          );
         }
         yield [pre, B.node];
         // Modify iteration result in-place:
@@ -793,9 +793,9 @@ function* alignedNodes<T extends Node, U extends Node>(
         let { pre, post } = splitShallowNode(B.node, A.end - B.start);
         if (A.start < B.start) {
           // this node should not be yielded anywhere else, so ok to modify in-place
-          A.node.textContent = A.node.textContent?.slice(
+          A.node.textContent = (A.node.textContent ?? '').slice(
             B.start - A.start
-          ) as string;
+          );
         }
         yield [A.node, pre];
         // Modify iteration result in-place:

--- a/packages/settingeditor-extension/src/index.ts
+++ b/packages/settingeditor-extension/src/index.ts
@@ -172,7 +172,7 @@ function activate(
         toSkip,
         translator,
         status,
-        query: args.query as string
+        query: args.query!
       })
     });
 

--- a/packages/settingeditor/src/pluginlist.tsx
+++ b/packages/settingeditor/src/pluginlist.tsx
@@ -273,8 +273,9 @@ export class PluginList extends ReactWidget {
       // If this is the base case, check for matching title / description
       const subProps = props[value] as PartialJSONObject;
       if (!subProps) {
-        if (filter((props.title as string) ?? '')) {
-          return props.title;
+        const title = props.title;
+        if (typeof title === 'string' && filter(title)) {
+          return title;
         }
         if (filter(value)) {
           return value;

--- a/packages/settingeditor/src/pluginlist.tsx
+++ b/packages/settingeditor/src/pluginlist.tsx
@@ -295,7 +295,7 @@ export class PluginList extends ReactWidget {
    */
   private _getScrollElement(): HTMLElement {
     return (
-      (this.node.querySelector('.jp-PluginList-wrapper') as HTMLElement) ??
+      this.node.querySelector<HTMLElement>('.jp-PluginList-wrapper') ??
       this.node
     );
   }

--- a/packages/tooltip/src/widget.ts
+++ b/packages/tooltip/src/widget.ts
@@ -228,7 +228,7 @@ export class Tooltip extends Widget {
     const paddingLeft = parseInt(style.paddingLeft!, 10) || 0;
 
     const host =
-      (editor.host.closest('.jp-MainAreaWidget > .lm-Widget') as HTMLElement) ||
+      editor.host.closest<HTMLElement>('.jp-MainAreaWidget > .lm-Widget') ??
       editor.host;
 
     // Calculate the geometry of the tooltip.

--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -586,7 +586,7 @@ export class ReactiveToolbar extends Toolbar<Widget> {
           // to the saved position of the first item of the popup toolbar.
 
           // Get the saved position of the widget to insert.
-          const widget = widgetsToRemove.pop() as Widget;
+          const widget = widgetsToRemove.pop()!;
           const name = Private.nameProperty.get(widget);
           width -= this._widgetWidths.get(name) || 0;
           const position = this._widgetPositions.get(name) ?? 0;


### PR DESCRIPTION
## References
Closes #18853

## Code changes
This enables `@typescript-eslint/non-nullable-type-assertion-style` for non-test TypeScript code and fixes the current source violations with type-preserving querySelector/closest generics, non-null assertions, and null-safe string handling. No user-facing changes.

## User-facing changes
None

## Backwards-incompatible changes
None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: ChatGPT 5.5
