### PR TITLE
Add return type annotations for some command utility functions

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -278,7 +278,7 @@ def ensure_app(app_dir) -> list[str] | None:
     If it does not exist, return a list of messages to prompt the user.
     """
     if osp.exists(pjoin(app_dir, "static", "index.html")):
-        return
+        return None
 
     msgs = [
         f'JupyterLab application assets not found in "{app_dir}"',

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -138,21 +138,21 @@ def pjoin(*args):
     return osp.abspath(osp.join(*args))
 
 
-def get_user_settings_dir():
+def get_user_settings_dir() -> str:
     """Get the configured JupyterLab user settings directory."""
     settings_dir = os.environ.get("JUPYTERLAB_SETTINGS_DIR")
     settings_dir = settings_dir or pjoin(jupyter_config_dir(), "lab", "user-settings")
     return osp.abspath(settings_dir)
 
 
-def get_workspaces_dir():
+def get_workspaces_dir() -> str:
     """Get the configured JupyterLab workspaces directory."""
     workspaces_dir = os.environ.get("JUPYTERLAB_WORKSPACES_DIR")
     workspaces_dir = workspaces_dir or pjoin(jupyter_config_dir(), "lab", "workspaces")
     return osp.abspath(workspaces_dir)
 
 
-def get_app_dir():
+def get_app_dir() -> str:
     """Get the configured JupyterLab app directory."""
     # Default to the override environment variable.
     if os.environ.get("JUPYTERLAB_DIR"):
@@ -228,7 +228,7 @@ def dedupe_yarn(path, logger=None):
         yarn_proc.wait()
 
 
-def ensure_node_modules(cwd, logger=None):
+def ensure_node_modules(cwd, logger=None) -> bool:
     """Ensure that node_modules is up to date.
 
     Returns true if the node_modules was updated.
@@ -248,7 +248,7 @@ def ensure_node_modules(cwd, logger=None):
     return ret != 0
 
 
-def ensure_dev(logger=None):
+def ensure_dev(logger=None) -> None:
     """Ensure that the dev assets are available."""
     logger = _ensure_logger(logger)
     target = pjoin(DEV_DIR, "static")
@@ -259,7 +259,7 @@ def ensure_dev(logger=None):
         yarn_proc.wait()
 
 
-def ensure_core(logger=None):
+def ensure_core(logger=None) -> None:
     """Ensure that the core assets are available."""
     staging = pjoin(HERE, "staging")
     logger = _ensure_logger(logger)
@@ -272,7 +272,7 @@ def ensure_core(logger=None):
         yarn_proc.wait()
 
 
-def ensure_app(app_dir):
+def ensure_app(app_dir) -> list[str] | None:
     """Ensure that an application directory is available.
 
     If it does not exist, return a list of messages to prompt the user.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Part of #19057

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Added return type annotations to utility functions in jupyterlab/commands.py:

get_user_settings_dir() -> str
get_workspaces_dir() -> str
get_app_dir() -> str
ensure_node_modules(...) -> bool
ensure_dev(...) -> None
ensure_core(...) -> None
ensure_app(...) -> list[str] | None

These changes improve type information without modifying runtime behavior.
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None.
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

## AI usage

- **<!-- YES or NO -->YES**: Some or all of the content of this PR was generated by AI.
- **<!-- YES or NO -->YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: ChatGPT (OpenAI)<!-- FILL IN -->
