### PR TITLE
Expose generic LSP request API

### DIFF
--- a/packages/lsp/src/connection.ts
+++ b/packages/lsp/src/connection.ts
@@ -30,6 +30,7 @@ import { LspWsConnection } from './ws-connection/ws-connection';
 
 import type * as lsp from 'vscode-languageserver-protocol';
 
+import { CancellationTokenSource } from 'vscode-jsonrpc';
 import type { MessageConnection } from 'vscode-ws-jsonrpc';
 
 /**
@@ -149,12 +150,6 @@ type AnyMethodType =
   | typeof Method.ClientNotification
   | typeof Method.ClientRequest
   | typeof Method.ServerRequest;
-type AnyMethod =
-  | Method.ServerNotification
-  | Method.ClientNotification
-  | Method.ClientRequest
-  | Method.ServerRequest;
-
 /**
  * Create a map between the request method and its handler
  */
@@ -178,9 +173,9 @@ enum MessageKind {
   responseForServer
 }
 
-interface IMessageLog<T extends AnyMethod = AnyMethod> {
-  method: T;
-  message: any;
+interface IMessageLog {
+  method: string;
+  message: unknown;
 }
 
 export class LSPConnection extends LspWsConnection implements ILSPConnection {
@@ -322,6 +317,63 @@ export class LSPConnection extends LspWsConnection implements ILSPConnection {
    */
   provides(capability: keyof lsp.ServerCapabilities): boolean {
     return !!(this.serverCapabilities && this.serverCapabilities[capability]);
+  }
+
+  /**
+   * Send a request to the language server.
+   */
+  async request<T = unknown>(
+    method: string,
+    params: lsp.LSPObject,
+    options: ILSPConnection.IRequestOptions = {}
+  ): Promise<T> {
+    if (this.isDisposed) {
+      throw new Error('Cannot send an LSP request on a disposed connection.');
+    }
+    if (!this.isReady) {
+      throw new Error(
+        'Cannot send an LSP request before the connection is ready.'
+      );
+    }
+
+    const { signal } = options;
+    if (signal?.aborted) {
+      throw (
+        signal.reason ??
+        new DOMException('The request was aborted.', 'AbortError')
+      );
+    }
+
+    const cancellation = signal ? new CancellationTokenSource() : undefined;
+    let rejectOnAbort: ((reason?: unknown) => void) | undefined;
+    const aborted = signal
+      ? new Promise<never>((_, reject) => {
+          rejectOnAbort = reject;
+        })
+      : undefined;
+    const cancel = () => {
+      cancellation?.cancel();
+      rejectOnAbort?.(
+        signal?.reason ??
+          new DOMException('The request was aborted.', 'AbortError')
+      );
+    };
+    signal?.addEventListener('abort', cancel, { once: true });
+
+    this.log(MessageKind.clientRequested, { method, message: params });
+    try {
+      const response = cancellation
+        ? this.connection.sendRequest<T>(method, params, cancellation.token)
+        : this.connection.sendRequest<T>(method, params);
+      const result = aborted
+        ? await Promise.race([response, aborted])
+        : await response;
+      this.log(MessageKind.resultForClient, { method, message: result });
+      return result;
+    } finally {
+      signal?.removeEventListener('abort', cancel);
+      cancellation?.dispose();
+    }
   }
 
   /**

--- a/packages/lsp/src/connection.ts
+++ b/packages/lsp/src/connection.ts
@@ -363,11 +363,11 @@ export class LSPConnection extends LspWsConnection implements ILSPConnection {
   /**
    * Send a request to the language server.
    */
-  async request<T = unknown>(
-    method: Method.ClientRequest,
-    params: lsp.LSPObject,
+  async request<M extends Method.ClientRequest>(
+    method: M,
+    params: IClientRequestParams[M],
     options: ILSPConnection.IRequestOptions = {}
-  ): Promise<T> {
+  ): Promise<IClientResult[M]> {
     if (this.isDisposed) {
       throw new Error('Cannot send an LSP request on a disposed connection.');
     }
@@ -405,8 +405,12 @@ export class LSPConnection extends LspWsConnection implements ILSPConnection {
     this.log(MessageKind.clientRequested, { method, message: params });
     try {
       const response = cancellation
-        ? this.connection.sendRequest<T>(method, params, cancellation)
-        : this.connection.sendRequest<T>(method, params);
+        ? this.connection.sendRequest<IClientResult[M]>(
+            method,
+            params,
+            cancellation
+          )
+        : this.connection.sendRequest<IClientResult[M]>(method, params);
       const result = aborted
         ? await Promise.race([response, aborted])
         : await response;

--- a/packages/lsp/src/connection.ts
+++ b/packages/lsp/src/connection.ts
@@ -149,6 +149,12 @@ type AnyMethodType =
   | typeof Method.ClientNotification
   | typeof Method.ClientRequest
   | typeof Method.ServerRequest;
+type AnyMethod =
+  | Method.ServerNotification
+  | Method.ClientNotification
+  | Method.ClientRequest
+  | Method.ServerRequest;
+
 /**
  * Create a map between the request method and its handler
  */
@@ -172,9 +178,9 @@ enum MessageKind {
   responseForServer
 }
 
-interface IMessageLog {
-  method: string;
-  message: unknown;
+interface IMessageLog<T extends AnyMethod = AnyMethod> {
+  method: T;
+  message: any;
 }
 
 interface ICancellationDisposable {
@@ -358,7 +364,7 @@ export class LSPConnection extends LspWsConnection implements ILSPConnection {
    * Send a request to the language server.
    */
   async request<T = unknown>(
-    method: string,
+    method: Method.ClientRequest,
     params: lsp.LSPObject,
     options: ILSPConnection.IRequestOptions = {}
   ): Promise<T> {

--- a/packages/lsp/src/connection.ts
+++ b/packages/lsp/src/connection.ts
@@ -30,7 +30,6 @@ import { LspWsConnection } from './ws-connection/ws-connection';
 
 import type * as lsp from 'vscode-languageserver-protocol';
 
-import { CancellationTokenSource } from 'vscode-jsonrpc';
 import type { MessageConnection } from 'vscode-ws-jsonrpc';
 
 /**
@@ -176,6 +175,42 @@ enum MessageKind {
 interface IMessageLog {
   method: string;
   message: unknown;
+}
+
+interface ICancellationDisposable {
+  dispose(): void;
+}
+
+interface ISignalCancellationToken {
+  readonly isCancellationRequested: boolean;
+  onCancellationRequested(
+    listener: (event: unknown) => void,
+    thisArgs?: unknown,
+    disposables?: ICancellationDisposable[]
+  ): ICancellationDisposable;
+}
+
+function cancellationTokenFromSignal(
+  signal: AbortSignal
+): ISignalCancellationToken {
+  return {
+    get isCancellationRequested(): boolean {
+      return signal.aborted;
+    },
+    onCancellationRequested: (listener, thisArgs, disposables) => {
+      const onAbort = () => {
+        listener.call(thisArgs, undefined);
+      };
+      signal.addEventListener('abort', onAbort, { once: true });
+      const disposable = {
+        dispose: () => {
+          signal.removeEventListener('abort', onAbort);
+        }
+      };
+      disposables?.push(disposable);
+      return disposable;
+    }
+  };
 }
 
 export class LSPConnection extends LspWsConnection implements ILSPConnection {
@@ -344,7 +379,9 @@ export class LSPConnection extends LspWsConnection implements ILSPConnection {
       );
     }
 
-    const cancellation = signal ? new CancellationTokenSource() : undefined;
+    const cancellation = signal
+      ? cancellationTokenFromSignal(signal)
+      : undefined;
     let rejectOnAbort: ((reason?: unknown) => void) | undefined;
     const aborted = signal
       ? new Promise<never>((_, reject) => {
@@ -352,7 +389,6 @@ export class LSPConnection extends LspWsConnection implements ILSPConnection {
         })
       : undefined;
     const cancel = () => {
-      cancellation?.cancel();
       rejectOnAbort?.(
         signal?.reason ??
           new DOMException('The request was aborted.', 'AbortError')
@@ -363,7 +399,7 @@ export class LSPConnection extends LspWsConnection implements ILSPConnection {
     this.log(MessageKind.clientRequested, { method, message: params });
     try {
       const response = cancellation
-        ? this.connection.sendRequest<T>(method, params, cancellation.token)
+        ? this.connection.sendRequest<T>(method, params, cancellation)
         : this.connection.sendRequest<T>(method, params);
       const result = aborted
         ? await Promise.race([response, aborted])
@@ -372,7 +408,6 @@ export class LSPConnection extends LspWsConnection implements ILSPConnection {
       return result;
     } finally {
       signal?.removeEventListener('abort', cancel);
-      cancellation?.dispose();
     }
   }
 

--- a/packages/lsp/src/tokens.ts
+++ b/packages/lsp/src/tokens.ts
@@ -844,6 +844,7 @@ export interface IClientRequestParams {
   [Method.ClientRequest.RENAME]: lsp.RenameParams;
   [Method.ClientRequest.SIGNATURE_HELP]: lsp.TextDocumentPositionParams;
   [Method.ClientRequest.TYPE_DEFINITION]: lsp.TextDocumentPositionParams;
+  [Method.ClientRequest.LINKED_EDITING_RANGE]: lsp.LinkedEditingRangeParams;
   [Method.ClientRequest.INLINE_VALUE]: lsp.InlineValueParams;
   [Method.ClientRequest.INLAY_HINT]: lsp.InlayHintParams;
   [Method.ClientRequest.WORKSPACE_SYMBOL]: lsp.WorkspaceSymbolParams;
@@ -871,6 +872,7 @@ export interface IClientResult {
   [Method.ClientRequest.RENAME]: lsp.WorkspaceEdit;
   [Method.ClientRequest.SIGNATURE_HELP]: lsp.SignatureHelp;
   [Method.ClientRequest.TYPE_DEFINITION]: AnyLocation;
+  [Method.ClientRequest.LINKED_EDITING_RANGE]: lsp.LinkedEditingRanges | null;
   [Method.ClientRequest.INLINE_VALUE]: lsp.InlineValue[] | null;
   [Method.ClientRequest.INLAY_HINT]: lsp.InlayHint[] | null;
   [Method.ClientRequest.WORKSPACE_SYMBOL]:
@@ -1035,11 +1037,11 @@ export interface ILSPConnection extends ILspConnection, IObservableDisposable {
    * @param options - Options for the request.
    * @returns The response from the language server.
    */
-  request<T = unknown>(
-    method: Method.ClientRequest,
-    params: lsp.LSPObject,
+  request<M extends Method.ClientRequest>(
+    method: M,
+    params: IClientRequestParams[M],
     options?: ILSPConnection.IRequestOptions
-  ): Promise<T>;
+  ): Promise<IClientResult[M]>;
 
   /**
    * @alpha

--- a/packages/lsp/src/tokens.ts
+++ b/packages/lsp/src/tokens.ts
@@ -94,6 +94,13 @@ export interface ILanguageServerManager extends IDisposable {
   /**
    * @alpha
    *
+   * The known language server specifications.
+   */
+  readonly specs: TSpecsMap;
+
+  /**
+   * @alpha
+   *
    * Get server connection settings.
    */
   readonly settings: ServerConnection.ISettings;
@@ -1018,6 +1025,22 @@ export interface ILSPConnection extends ILspConnection, IObservableDisposable {
   /**
    * @alpha
    *
+   * Send a request to the language server.
+   *
+   * @param method - The LSP method to request.
+   * @param params - The parameters for the request.
+   * @param options - Options for the request.
+   * @returns The response from the language server.
+   */
+  request<T = unknown>(
+    method: string,
+    params: lsp.LSPObject,
+    options?: ILSPConnection.IRequestOptions
+  ): Promise<T>;
+
+  /**
+   * @alpha
+   *
    * Lists server capabilities.
    */
   serverCapabilities: lsp.ServerCapabilities;
@@ -1043,4 +1066,16 @@ export interface ILSPConnection extends ILspConnection, IObservableDisposable {
    * Send all changes to the server.
    */
   sendFullTextChange(text: string, documentInfo: IDocumentInfo): void;
+}
+
+export namespace ILSPConnection {
+  /**
+   * Options for an LSP request.
+   */
+  export interface IRequestOptions {
+    /**
+     * A signal used to cancel the request.
+     */
+    signal?: AbortSignal;
+  }
 }

--- a/packages/lsp/src/tokens.ts
+++ b/packages/lsp/src/tokens.ts
@@ -761,6 +761,7 @@ export namespace Method {
     COMPLETION = 'textDocument/completion',
     COMPLETION_ITEM_RESOLVE = 'completionItem/resolve',
     DEFINITION = 'textDocument/definition',
+    DIAGNOSTIC = 'textDocument/diagnostic',
     DOCUMENT_COLOR = 'textDocument/documentColor',
     DOCUMENT_HIGHLIGHT = 'textDocument/documentHighlight',
     DOCUMENT_SYMBOL = 'textDocument/documentSymbol',
@@ -832,6 +833,7 @@ export interface IClientRequestParams {
   [Method.ClientRequest.COMPLETION_ITEM_RESOLVE]: lsp.CompletionItem;
   [Method.ClientRequest.COMPLETION]: lsp.CompletionParams;
   [Method.ClientRequest.DEFINITION]: lsp.TextDocumentPositionParams;
+  [Method.ClientRequest.DIAGNOSTIC]: lsp.DocumentDiagnosticParams;
   [Method.ClientRequest.DOCUMENT_COLOR]: lsp.DocumentColorParams;
   [Method.ClientRequest.DOCUMENT_HIGHLIGHT]: lsp.TextDocumentPositionParams;
   [Method.ClientRequest.DOCUMENT_SYMBOL]: lsp.DocumentSymbolParams;
@@ -858,6 +860,7 @@ export interface IClientResult {
   [Method.ClientRequest.COMPLETION_ITEM_RESOLVE]: lsp.CompletionItem;
   [Method.ClientRequest.COMPLETION]: AnyCompletion;
   [Method.ClientRequest.DEFINITION]: AnyLocation;
+  [Method.ClientRequest.DIAGNOSTIC]: lsp.DocumentDiagnosticReport;
   [Method.ClientRequest.DOCUMENT_COLOR]: lsp.ColorInformation[];
   [Method.ClientRequest.DOCUMENT_HIGHLIGHT]: lsp.DocumentHighlight[];
   [Method.ClientRequest.DOCUMENT_SYMBOL]: lsp.DocumentSymbol[];
@@ -1025,7 +1028,7 @@ export interface ILSPConnection extends ILspConnection, IObservableDisposable {
   /**
    * @alpha
    *
-   * Send a request to the language server.
+   * Send a client request to the language server.
    *
    * @param method - The LSP method to request.
    * @param params - The parameters for the request.
@@ -1033,7 +1036,7 @@ export interface ILSPConnection extends ILspConnection, IObservableDisposable {
    * @returns The response from the language server.
    */
   request<T = unknown>(
-    method: string,
+    method: Method.ClientRequest,
     params: lsp.LSPObject,
     options?: ILSPConnection.IRequestOptions
   ): Promise<T>;

--- a/packages/lsp/test/connection.spec.ts
+++ b/packages/lsp/test/connection.spec.ts
@@ -8,6 +8,7 @@ import { PromiseDelegate } from '@lumino/coreutils';
 import type { MessageConnection } from 'vscode-ws-jsonrpc';
 
 import { LSPConnection } from '../src/connection';
+import { Method } from '../src/tokens';
 
 class TestLSPConnection extends LSPConnection {
   initialize(connection: MessageConnection): void {
@@ -30,16 +31,22 @@ function createConnection(sendRequest: jest.Mock): TestLSPConnection {
 
 describe('LSPConnection', () => {
   describe('#request()', () => {
-    it('should forward an arbitrary request and return its result', async () => {
+    it('should forward a client request and return its result', async () => {
       const expected = { contents: 'result' };
       const sendRequest = jest.fn().mockResolvedValue(expected);
       const connection = createConnection(sendRequest);
       const params = { textDocument: { uri: 'file:///test.py' } };
 
-      const result = await connection.request('custom/request', params);
+      const result = await connection.request(
+        Method.ClientRequest.HOVER,
+        params
+      );
 
       expect(result).toBe(expected);
-      expect(sendRequest).toHaveBeenCalledWith('custom/request', params);
+      expect(sendRequest).toHaveBeenCalledWith(
+        Method.ClientRequest.HOVER,
+        params
+      );
     });
 
     it('should propagate request errors', async () => {
@@ -48,9 +55,9 @@ describe('LSPConnection', () => {
         jest.fn().mockRejectedValue(expected)
       );
 
-      await expect(connection.request('custom/request', {})).rejects.toBe(
-        expected
-      );
+      await expect(
+        connection.request(Method.ClientRequest.HOVER, {})
+      ).rejects.toBe(expected);
     });
 
     it('should reject requests before the connection is ready', async () => {
@@ -61,7 +68,9 @@ describe('LSPConnection', () => {
         serverUri: ''
       });
 
-      await expect(connection.request('custom/request', {})).rejects.toThrow(
+      await expect(
+        connection.request(Method.ClientRequest.HOVER, {})
+      ).rejects.toThrow(
         'Cannot send an LSP request before the connection is ready.'
       );
     });
@@ -75,9 +84,9 @@ describe('LSPConnection', () => {
       });
       connection.dispose();
 
-      await expect(connection.request('custom/request', {})).rejects.toThrow(
-        'Cannot send an LSP request on a disposed connection.'
-      );
+      await expect(
+        connection.request(Method.ClientRequest.HOVER, {})
+      ).rejects.toThrow('Cannot send an LSP request on a disposed connection.');
     });
 
     it('should cancel a request with the provided signal', async () => {
@@ -88,7 +97,7 @@ describe('LSPConnection', () => {
       const reason = new Error('Timed out');
 
       const request = connection.request(
-        'custom/request',
+        Method.ClientRequest.HOVER,
         {},
         {
           signal: controller.signal
@@ -117,7 +126,13 @@ describe('LSPConnection', () => {
       controller.abort();
 
       await expect(
-        connection.request('custom/request', {}, { signal: controller.signal })
+        connection.request(
+          Method.ClientRequest.HOVER,
+          {},
+          {
+            signal: controller.signal
+          }
+        )
       ).rejects.toMatchObject({ name: 'AbortError' });
       expect(sendRequest).not.toHaveBeenCalled();
     });

--- a/packages/lsp/test/connection.spec.ts
+++ b/packages/lsp/test/connection.spec.ts
@@ -95,12 +95,18 @@ describe('LSPConnection', () => {
         }
       );
       const cancellationToken = sendRequest.mock.calls[0][2];
+      const onCancellationRequested = jest.fn();
+      const disposable = cancellationToken.onCancellationRequested(
+        onCancellationRequested
+      );
       expect(cancellationToken.isCancellationRequested).toBe(false);
 
       controller.abort(reason);
 
       expect(cancellationToken.isCancellationRequested).toBe(true);
+      expect(onCancellationRequested).toHaveBeenCalledTimes(1);
       await expect(request).rejects.toBe(reason);
+      disposable.dispose();
       response.resolve(undefined);
     });
 

--- a/packages/lsp/test/connection.spec.ts
+++ b/packages/lsp/test/connection.spec.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { PromiseDelegate } from '@lumino/coreutils';
+
+import type { MessageConnection } from 'vscode-ws-jsonrpc';
+
+import { LSPConnection } from '../src/connection';
+
+class TestLSPConnection extends LSPConnection {
+  initialize(connection: MessageConnection): void {
+    this.connection = connection;
+    this._isConnected = true;
+    this._isInitialized = true;
+  }
+}
+
+function createConnection(sendRequest: jest.Mock): TestLSPConnection {
+  const connection = new TestLSPConnection({
+    capabilities: {},
+    languageId: '',
+    rootUri: '',
+    serverUri: ''
+  });
+  connection.initialize({ sendRequest } as unknown as MessageConnection);
+  return connection;
+}
+
+describe('LSPConnection', () => {
+  describe('#request()', () => {
+    it('should forward an arbitrary request and return its result', async () => {
+      const expected = { contents: 'result' };
+      const sendRequest = jest.fn().mockResolvedValue(expected);
+      const connection = createConnection(sendRequest);
+      const params = { textDocument: { uri: 'file:///test.py' } };
+
+      const result = await connection.request('custom/request', params);
+
+      expect(result).toBe(expected);
+      expect(sendRequest).toHaveBeenCalledWith('custom/request', params);
+    });
+
+    it('should propagate request errors', async () => {
+      const expected = new Error('Request failed');
+      const connection = createConnection(
+        jest.fn().mockRejectedValue(expected)
+      );
+
+      await expect(connection.request('custom/request', {})).rejects.toBe(
+        expected
+      );
+    });
+
+    it('should reject requests before the connection is ready', async () => {
+      const connection = new LSPConnection({
+        capabilities: {},
+        languageId: '',
+        rootUri: '',
+        serverUri: ''
+      });
+
+      await expect(connection.request('custom/request', {})).rejects.toThrow(
+        'Cannot send an LSP request before the connection is ready.'
+      );
+    });
+
+    it('should reject requests after the connection is disposed', async () => {
+      const connection = new LSPConnection({
+        capabilities: {},
+        languageId: '',
+        rootUri: '',
+        serverUri: ''
+      });
+      connection.dispose();
+
+      await expect(connection.request('custom/request', {})).rejects.toThrow(
+        'Cannot send an LSP request on a disposed connection.'
+      );
+    });
+
+    it('should cancel a request with the provided signal', async () => {
+      const response = new PromiseDelegate<unknown>();
+      const sendRequest = jest.fn().mockReturnValue(response.promise);
+      const connection = createConnection(sendRequest);
+      const controller = new AbortController();
+      const reason = new Error('Timed out');
+
+      const request = connection.request(
+        'custom/request',
+        {},
+        {
+          signal: controller.signal
+        }
+      );
+      const cancellationToken = sendRequest.mock.calls[0][2];
+      expect(cancellationToken.isCancellationRequested).toBe(false);
+
+      controller.abort(reason);
+
+      expect(cancellationToken.isCancellationRequested).toBe(true);
+      await expect(request).rejects.toBe(reason);
+      response.resolve(undefined);
+    });
+
+    it('should not send a request with an already aborted signal', async () => {
+      const sendRequest = jest.fn();
+      const connection = createConnection(sendRequest);
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(
+        connection.request('custom/request', {}, { signal: controller.signal })
+      ).rejects.toMatchObject({ name: 'AbortError' });
+      expect(sendRequest).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/lsp/test/connection.spec.ts
+++ b/packages/lsp/test/connection.spec.ts
@@ -29,13 +29,20 @@ function createConnection(sendRequest: jest.Mock): TestLSPConnection {
   return connection;
 }
 
+function createHoverParams() {
+  return {
+    textDocument: { uri: 'file:///test.py' },
+    position: { line: 0, character: 0 }
+  };
+}
+
 describe('LSPConnection', () => {
   describe('#request()', () => {
     it('should forward a client request and return its result', async () => {
       const expected = { contents: 'result' };
       const sendRequest = jest.fn().mockResolvedValue(expected);
       const connection = createConnection(sendRequest);
-      const params = { textDocument: { uri: 'file:///test.py' } };
+      const params = createHoverParams();
 
       const result = await connection.request(
         Method.ClientRequest.HOVER,
@@ -56,7 +63,7 @@ describe('LSPConnection', () => {
       );
 
       await expect(
-        connection.request(Method.ClientRequest.HOVER, {})
+        connection.request(Method.ClientRequest.HOVER, createHoverParams())
       ).rejects.toBe(expected);
     });
 
@@ -69,7 +76,7 @@ describe('LSPConnection', () => {
       });
 
       await expect(
-        connection.request(Method.ClientRequest.HOVER, {})
+        connection.request(Method.ClientRequest.HOVER, createHoverParams())
       ).rejects.toThrow(
         'Cannot send an LSP request before the connection is ready.'
       );
@@ -85,7 +92,7 @@ describe('LSPConnection', () => {
       connection.dispose();
 
       await expect(
-        connection.request(Method.ClientRequest.HOVER, {})
+        connection.request(Method.ClientRequest.HOVER, createHoverParams())
       ).rejects.toThrow('Cannot send an LSP request on a disposed connection.');
     });
 
@@ -98,7 +105,7 @@ describe('LSPConnection', () => {
 
       const request = connection.request(
         Method.ClientRequest.HOVER,
-        {},
+        createHoverParams(),
         {
           signal: controller.signal
         }
@@ -126,13 +133,9 @@ describe('LSPConnection', () => {
       controller.abort();
 
       await expect(
-        connection.request(
-          Method.ClientRequest.HOVER,
-          {},
-          {
-            signal: controller.signal
-          }
-        )
+        connection.request(Method.ClientRequest.HOVER, createHoverParams(), {
+          signal: controller.signal
+        })
       ).rejects.toMatchObject({ name: 'AbortError' });
       expect(sendRequest).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## References
Ref: https://github.com/jupyter-lsp/jupyterlab-lsp/issues/1184

## Code changes

Adds a public, cancellable request API to shared LSP connections and exposes known server specifications through `ILanguageServerManager`. Includes deterministic abort handling and focused lifecycle, error, and cancellation tests.

## User-facing changes
None

## Backwards-incompatible changes
None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: ChatGPT 5.5
