### PR TITLE
Allow providing a custom extension manager model

### DIFF
--- a/galata/test/documentation/plugins.test.ts-snapshots/tokens-documentation-linux.json
+++ b/galata/test/documentation/plugins.test.ts-snapshots/tokens-documentation-linux.json
@@ -45,6 +45,7 @@
   "@jupyterlab/docmanager:IDocumentWidgetOpener": "A service to open a widget.",
   "@jupyterlab/docmanager:IRecentsManager": "A service providing information about recently opened and closed documents",
   "@jupyterlab/documentsearch:ISearchProviderRegistry": "A service for a registry of search\n  providers for the application. Plugins can register their UI elements with this registry\n  to provide find/replace support.",
+  "@jupyterlab/extensionmanager:IExtensionManagerModel": "A service providing the model backing the extension manager. Provide it to list extensions from a custom source.",
   "@jupyterlab/filebrowser:IDefaultFileBrowser": "A service for the default file browser.",
   "@jupyterlab/filebrowser:IDefaultFileBrowserRenderer": "A service for overriding the default file browser directory listing renderer.",
   "@jupyterlab/filebrowser:IFileBrowserCommands": "A token to ensure file browser commands are loaded.",

--- a/packages/extensionmanager-extension/src/index.ts
+++ b/packages/extensionmanager-extension/src/index.ts
@@ -11,7 +11,11 @@ import type {
 } from '@jupyterlab/application';
 import { ILayoutRestorer } from '@jupyterlab/application';
 import { Dialog, ICommandPalette, showDialog } from '@jupyterlab/apputils';
-import { ExtensionsPanel, ListModel } from '@jupyterlab/extensionmanager';
+import {
+  ExtensionsPanel,
+  IExtensionManagerModel,
+  ListModel
+} from '@jupyterlab/extensionmanager';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import type { TranslationBundle } from '@jupyterlab/translation';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
@@ -35,19 +39,27 @@ const plugin: JupyterFrontEndPlugin<void> = {
   description: 'Adds the extension manager plugin.',
   autoStart: true,
   requires: [ISettingRegistry],
-  optional: [ITranslator, ILayoutRestorer, ICommandPalette],
+  optional: [
+    ITranslator,
+    ILayoutRestorer,
+    ICommandPalette,
+    IExtensionManagerModel
+  ],
   activate: async (
     app: JupyterFrontEnd,
     registry: ISettingRegistry,
     translator: ITranslator | null,
     restorer: ILayoutRestorer | null,
-    palette: ICommandPalette | null
+    palette: ICommandPalette | null,
+    extensionManagerModel: IExtensionManagerModel | null
   ) => {
     const { commands, shell, serviceManager } = app;
     translator = translator ?? nullTranslator;
     const trans = translator.load('jupyterlab');
 
-    const model = new ListModel(serviceManager, translator);
+    // Use the model provided by the distribution, if any, else the default.
+    const model =
+      extensionManagerModel ?? new ListModel(serviceManager, translator);
 
     const createView = () => {
       const v = new ExtensionsPanel({ model, translator: translator! });
@@ -71,12 +83,16 @@ const plugin: JupyterFrontEndPlugin<void> = {
     // Create a view by default, so it can be restored when loading the workspace.
     let view: ExtensionsPanel | null = createView();
 
+    if (!model.canInstall) {
+      // A read-only manager cannot be toggled off; keep the panel enabled.
+      model.isEnabled = true;
+    }
+
     // If the extension is enabled or disabled,
     // add or remove it from the left area.
     Promise.all([app.restored, registry.load(PLUGIN_ID)])
       .then(([, settings]) => {
         model.isDisclaimed = settings.get('disclaimed').composite as boolean;
-        model.isEnabled = settings.get('enabled').composite as boolean;
         model.stateChanged.connect(() => {
           if (
             model.isDisclaimed !==
@@ -87,6 +103,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
             });
           }
           if (
+            model.canInstall &&
             model.isEnabled !== (settings.get('enabled').composite as boolean)
           ) {
             settings.set('enabled', model.isEnabled).catch(reason => {
@@ -95,15 +112,12 @@ const plugin: JupyterFrontEndPlugin<void> = {
           }
         });
 
-        if (model.isEnabled) {
-          view = view ?? createView();
-        } else {
-          view?.dispose();
-          view = null;
-        }
-
         settings.changed.connect(async () => {
           model.isDisclaimed = settings.get('disclaimed').composite as boolean;
+          // Only an installable manager exposes the enable/disable toggle.
+          if (!model.canInstall) {
+            return;
+          }
           model.isEnabled = settings.get('enabled').composite as boolean;
           app.commands.notifyCommandChanged(CommandIDs.toggle);
 
@@ -121,6 +135,19 @@ const plugin: JupyterFrontEndPlugin<void> = {
             view = null;
           }
         });
+
+        // The rest wires the enable/disable lifecycle of an installable manager.
+        if (!model.canInstall) {
+          return;
+        }
+
+        model.isEnabled = settings.get('enabled').composite as boolean;
+        if (model.isEnabled) {
+          view = view ?? createView();
+        } else {
+          view?.dispose();
+          view = null;
+        }
       })
       .catch(reason => {
         console.error(
@@ -162,6 +189,8 @@ const plugin: JupyterFrontEndPlugin<void> = {
         }
       },
       isToggled: () => model.isEnabled,
+      // Read-only managers are always enabled and cannot be disabled.
+      isVisible: () => model.canInstall,
       describedBy: {
         args: {
           type: 'object',

--- a/packages/extensionmanager/babel.config.js
+++ b/packages/extensionmanager/babel.config.js
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+module.exports = require('@jupyterlab/testing/lib/babel-config');

--- a/packages/extensionmanager/jest.config.js
+++ b/packages/extensionmanager/jest.config.js
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+const func = require('@jupyterlab/testing/lib/jest-config');
+module.exports = func(__dirname);

--- a/packages/extensionmanager/package.json
+++ b/packages/extensionmanager/package.json
@@ -32,7 +32,13 @@
   ],
   "scripts": {
     "build": "tsc -b",
+    "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
+    "test": "jest",
+    "test:cov": "jest --collect-coverage",
+    "test:debug": "node --inspect-brk ../../node_modules/.bin/jest --runInBand",
+    "test:debug:watch": "node --inspect-brk ../../node_modules/.bin/jest --runInBand --watch",
+    "test:watch": "jest --runInBand --watch",
     "watch": "tsc -b --watch"
   },
   "dependencies": {
@@ -41,6 +47,7 @@
     "@jupyterlab/services": "^7.7.0-alpha.1",
     "@jupyterlab/translation": "^4.7.0-alpha.1",
     "@jupyterlab/ui-components": "^4.7.0-alpha.1",
+    "@lumino/coreutils": "^2.2.3",
     "@lumino/messaging": "^2.0.5",
     "@lumino/polling": "^2.1.6",
     "@lumino/widgets": "^2.9.0",
@@ -49,6 +56,8 @@
     "semver": "^7.5.2"
   },
   "devDependencies": {
+    "@jupyterlab/testing": "^4.7.0-alpha.1",
+    "@types/jest": "^29.2.0",
     "@types/react": "^18.0.26",
     "@types/react-paginate": "^6.2.1",
     "@types/semver": "^7.5.2",

--- a/packages/extensionmanager/src/index.ts
+++ b/packages/extensionmanager/src/index.ts
@@ -6,4 +6,5 @@
  */
 
 export * from './model';
+export * from './tokens';
 export * from './widget';

--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -158,15 +158,19 @@ interface IExtensionManagerMetadata {
   /**
    * Extension manager name.
    */
-  name: string;
+  name?: string;
   /**
    * Whether the extension manager can un-/install extensions.
    */
-  can_install: boolean;
+  can_install?: boolean;
   /**
    * Extensions installation path.
    */
-  install_path: string | null;
+  install_path?: string | null;
+  /**
+   * Whether the extension manager can enable/disable extensions (default true).
+   */
+  can_manage?: boolean;
 }
 
 /**
@@ -207,10 +211,12 @@ export class ListModel extends VDomModel {
       PageConfig.getOption('extensionManager') || '{}'
     ) as IExtensionManagerMetadata;
 
-    this.name = metadata.name;
-    this.canInstall = metadata.can_install;
-    this.installPath = metadata.install_path;
     this.translator = translator || nullTranslator;
+    const trans = this.translator.load('jupyterlab');
+    this.name = metadata.name ?? trans.__('Extension');
+    this.canInstall = metadata.can_install ?? false;
+    this.canManage = metadata.can_manage ?? true;
+    this.installPath = metadata.install_path ?? null;
     this._installed = [];
     this._lastSearchResult = [];
     this.serviceManager = serviceManager;
@@ -223,9 +229,22 @@ export class ListModel extends VDomModel {
   readonly name: string;
 
   /**
-   * Whether the extension manager support installation methods or not.
+   * Whether the extension manager supports installing extensions.
+   *
+   * When `false`, extensions are listed read-only: there is no registry to
+   * search and no un-/installation. They can still be enabled or disabled
+   * when {@link canManage} is `true`.
    */
   readonly canInstall: boolean;
+
+  /**
+   * Whether the extension manager supports enabling and disabling extensions.
+   *
+   * It is independent of {@link canInstall}, so a read-only manager still
+   * exposes enable and disable actions by default. Set it to `false` for a
+   * pure listing with no actions at all.
+   */
+  readonly canManage: boolean;
 
   /**
    * Extensions installation path.
@@ -251,6 +270,30 @@ export class ListModel extends VDomModel {
       this.stateChanged.emit();
       void this._debouncedSearch.invoke();
     }
+  }
+
+  /**
+   * Whether the model may fetch data from external web services, such as
+   * extension author avatars.
+   *
+   * #### Notes
+   * Fetching requires the user to have accepted the disclaimer (see
+   * {@link isDisclaimed}); this holds for a read-only manager too.
+   */
+  get canFetch(): boolean {
+    return this.isDisclaimed;
+  }
+
+  /**
+   * Whether actions may currently be performed on installed extensions.
+   *
+   * #### Notes
+   * Requires {@link canManage}. An installable manager additionally requires
+   * the disclaimer, as its actions may contact external services; a read-only
+   * manager only toggles extensions locally.
+   */
+  get canPerformActions(): boolean {
+    return this.canManage && (!this.canInstall || this.isDisclaimed);
   }
 
   /**
@@ -422,9 +465,7 @@ export class ListModel extends VDomModel {
     this._isLoadingInstalledExtensions = true;
     this.stateChanged.emit();
     try {
-      const [extensions] = await Private.requestAPI<IEntry[]>({
-        refresh: force ? 1 : 0
-      });
+      const extensions = await this.fetchInstalled(force);
       this._installed = extensions.sort(Private.installedComparator);
     } catch (reason) {
       this.installedError = reason.toString();
@@ -435,6 +476,22 @@ export class ListModel extends VDomModel {
   }
 
   /**
+   * Fetch the list of installed extensions.
+   *
+   * @param force Force refreshing the list of installed packages
+   *
+   * #### Notes
+   * This is the data source backing {@link refreshInstalled}; override it to
+   * list extensions from a source other than the default server API.
+   */
+  protected async fetchInstalled(force: boolean): Promise<IEntry[]> {
+    const [extensions] = await Private.requestAPI<IEntry[]>({
+      refresh: force ? 1 : 0
+    });
+    return extensions;
+  }
+
+  /**
    * Search with current query.
    *
    * Sets searchError and totalEntries as appropriate.
@@ -442,6 +499,11 @@ export class ListModel extends VDomModel {
    * @returns The extensions matching the current query.
    */
   protected async search(force = false): Promise<void> {
+    if (!this.canInstall) {
+      // No registry to search; re-render so the query filters the list locally.
+      this.stateChanged.emit();
+      return;
+    }
     if (!this.isDisclaimed) {
       return Promise.reject('Installation warning is not disclaimed.');
     }

--- a/packages/extensionmanager/src/tokens.ts
+++ b/packages/extensionmanager/src/tokens.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { Token } from '@lumino/coreutils';
+import type { ListModel } from './model';
+
+/**
+ * The extension manager model interface.
+ */
+export interface IExtensionManagerModel extends ListModel {}
+
+/**
+ * The extension manager model token.
+ *
+ * #### Notes
+ * Provide this token to replace the default {@link ListModel} — typically
+ * with a subclass overriding {@link ListModel.fetchInstalled} to list
+ * extensions from a source other than the default server API.
+ */
+export const IExtensionManagerModel = new Token<IExtensionManagerModel>(
+  '@jupyterlab/extensionmanager:IExtensionManagerModel',
+  'A service providing the model backing the extension manager. Provide it to list extensions from a custom source.'
+);

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -378,7 +378,8 @@ class Header extends ReactWidget {
         <FilterBox
           initialQuery={this.model.query || undefined}
           placeholder={this.trans.__('Search extensions')}
-          disabled={!this.model.isDisclaimed}
+          // A read-only manager only filters locally, so no disclaimer is needed.
+          disabled={this.model.canInstall && !this.model.isDisclaimed}
           updateFilter={(fn, query) => {
             this.model.query = query ?? '';
           }}
@@ -414,16 +415,21 @@ class Warning extends ReactWidget {
   }
 
   render(): JSX.Element {
+    const canInstall = this.model.canInstall;
     return (
       <>
         <p>
-          {this.trans
-            .__(`The JupyterLab development team is excited to have a robust
+          {canInstall
+            ? this.trans
+                .__(`The JupyterLab development team is excited to have a robust
 third-party extension community. However, we do not review
 third-party extensions, and some extensions may introduce security
 risks or contain malicious code that runs on your machine. Moreover in order
 to work, this panel needs to fetch data from web services. Do you agree to
-activate this feature?`)}
+activate this feature?`)
+            : this.trans
+                .__(`To display extension author avatars, this panel fetches images
+from external web services. Do you want to allow these external requests?`)}
           <br />
           <a
             href="https://jupyterlab.readthedocs.io/en/latest/privacy_policies.html"
@@ -453,17 +459,19 @@ activate this feature?`)}
             >
               {this.trans.__('Yes')}
             </Button>
-            <Button
-              className="jp-extensionmanager-disclaimer-disable"
-              onClick={() => {
-                this.model.isEnabled = false;
-              }}
-              title={this.trans.__(
-                'This will disable the extension manager panel; including the listing of installed extension.'
-              )}
-            >
-              {this.trans.__('No, disable')}
-            </Button>
+            {canInstall && (
+              <Button
+                className="jp-extensionmanager-disclaimer-disable"
+                onClick={() => {
+                  this.model.isEnabled = false;
+                }}
+                title={this.trans.__(
+                  'This will disable the extension manager panel, including the listing of installed extensions.'
+                )}
+              >
+                {this.trans.__('No, disable')}
+              </Button>
+            )}
           </div>
         )}
       </>
@@ -495,7 +503,7 @@ class InstalledList extends ReactWidget {
           </div>
         ) : (
           <ListView
-            canFetch={this.model.isDisclaimed}
+            canFetch={this.model.canFetch}
             entries={this.model.installed.filter(pkg =>
               new RegExp(this.model.query.toLowerCase()).test(pkg.name)
             )}
@@ -505,7 +513,9 @@ class InstalledList extends ReactWidget {
               /* no-op */
             }}
             performAction={
-              this.model.isDisclaimed ? this.onAction.bind(this) : undefined
+              this.model.canPerformActions
+                ? this.onAction.bind(this)
+                : undefined
             }
             supportInstallation={
               this.model.canInstall && this.model.isDisclaimed
@@ -602,7 +612,7 @@ class SearchResult extends ReactWidget {
           </div>
         ) : (
           <ListView
-            canFetch={this.model.isDisclaimed}
+            canFetch={this.model.canFetch}
             entries={this.model.searchResult}
             initialPage={this.model.page}
             numPages={this.model.lastPage}
@@ -610,7 +620,9 @@ class SearchResult extends ReactWidget {
               this.onPage(value);
             }}
             performAction={
-              this.model.isDisclaimed ? this.onAction.bind(this) : undefined
+              this.model.canPerformActions
+                ? this.onAction.bind(this)
+                : undefined
             }
             supportInstallation={
               this.model.canInstall && this.model.isDisclaimed
@@ -650,8 +662,9 @@ export class ExtensionsPanel extends SidePanel {
     this.header.addWidget(new Header(model, this.trans, this._searchInputRef));
 
     const warning = new Warning(model, this.trans);
-    warning.title.label = this.trans.__('Warning');
-
+    warning.title.label = model.canInstall
+      ? this.trans.__('Warning')
+      : this.trans.__('Author avatars');
     this.addWidget(warning);
 
     const installed = new PanelWithToolbar();
@@ -688,14 +701,19 @@ export class ExtensionsPanel extends SidePanel {
     }
 
     this._wasDisclaimed = this.model.isDisclaimed;
-    if (this.model.isDisclaimed) {
-      (this.content as AccordionPanel).collapse(0);
-      (this.content.layout as AccordionLayout).setRelativeSizes([0, 1, 1]);
+    if (this.model.canInstall) {
+      if (this.model.isDisclaimed) {
+        (this.content as AccordionPanel).collapse(0);
+        (this.content.layout as AccordionLayout).setRelativeSizes([0, 1, 1]);
+      } else {
+        // If warning is not disclaimed expand only the warning panel
+        (this.content as AccordionPanel).expand(0);
+        (this.content as AccordionPanel).collapse(1);
+        (this.content as AccordionPanel).collapse(2);
+      }
     } else {
-      // If warning is not disclaimed expand only the warning panel
-      (this.content as AccordionPanel).expand(0);
-      (this.content as AccordionPanel).collapse(1);
-      (this.content as AccordionPanel).collapse(2);
+      // Read-only: start with the avatar opt-in panel collapsed.
+      (this.content as AccordionPanel).collapse(0);
     }
 
     this.model.stateChanged.connect(this._onStateChanged, this);
@@ -802,7 +820,10 @@ export class ExtensionsPanel extends SidePanel {
     if (!this._wasDisclaimed && this.model.isDisclaimed) {
       (this.content as AccordionPanel).collapse(0);
       (this.content as AccordionPanel).expand(1);
-      (this.content as AccordionPanel).expand(2);
+      if (this.model.canInstall) {
+        // Only an installable manager has a search results panel.
+        (this.content as AccordionPanel).expand(2);
+      }
     }
     this._wasDisclaimed = this.model.isDisclaimed;
   }

--- a/packages/extensionmanager/test/model.spec.ts
+++ b/packages/extensionmanager/test/model.spec.ts
@@ -1,0 +1,221 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+// The extension entries mirror the snake_case JSON returned by the server.
+/* eslint-disable camelcase */
+
+import { PageConfig } from '@jupyterlab/coreutils';
+import type { ServiceManager } from '@jupyterlab/services';
+import { ServiceManagerMock } from '@jupyterlab/services/lib/testutils';
+import { ListModel } from '@jupyterlab/extensionmanager';
+import type { IEntry } from '@jupyterlab/extensionmanager';
+
+/**
+ * Create a minimal installed extension entry for testing.
+ */
+function createEntry(name: string): IEntry {
+  return {
+    name,
+    description: `Description of ${name}`,
+    homepage_url: `https://example.com/${name}`,
+    installed: true,
+    allowed: true,
+    approved: false,
+    enabled: true,
+    latest_version: '1.0.0',
+    installed_version: '1.0.0',
+    status: 'ok',
+    pkg_type: 'prebuilt'
+  };
+}
+
+/**
+ * A `ListModel` subclass serving installed extensions from an in-memory
+ * source, as a downstream `IExtensionManagerModel` provider would.
+ */
+class TestModel extends ListModel {
+  /**
+   * The installed extensions returned by the overridden `fetchInstalled`.
+   */
+  customInstalled: IEntry[] = [];
+
+  /**
+   * The number of times `fetchInstalled` has been called.
+   */
+  fetchInstalledCount = 0;
+
+  /**
+   * Expose the protected `search` method for testing.
+   */
+  search(force = false): Promise<void> {
+    return super.search(force);
+  }
+
+  protected async fetchInstalled(force: boolean): Promise<IEntry[]> {
+    this.fetchInstalledCount++;
+    return this.customInstalled;
+  }
+}
+
+describe('@jupyterlab/extensionmanager', () => {
+  describe('ListModel', () => {
+    let serviceManager: ServiceManager.IManager;
+    const models: ListModel[] = [];
+
+    /**
+     * Create a test model after setting the extension manager metadata that
+     * the model reads from the page config at construction time.
+     */
+    function createModel(metadata?: Record<string, unknown>): TestModel {
+      PageConfig.setOption('extensionManager', JSON.stringify(metadata ?? {}));
+      const model = new TestModel(serviceManager);
+      models.push(model);
+      return model;
+    }
+
+    beforeEach(() => {
+      serviceManager = new ServiceManagerMock();
+    });
+
+    afterEach(() => {
+      while (models.length) {
+        models.pop()!.dispose();
+      }
+      PageConfig.setOption('extensionManager', '{}');
+    });
+
+    describe('#canInstall', () => {
+      it('should default to false when no metadata is provided', () => {
+        const model = createModel();
+        expect(model.canInstall).toBe(false);
+      });
+
+      it('should reflect the can_install metadata flag', () => {
+        const model = createModel({ can_install: true });
+        expect(model.canInstall).toBe(true);
+      });
+    });
+
+    describe('#canManage', () => {
+      it('should default to true when no metadata is provided', () => {
+        const model = createModel();
+        expect(model.canManage).toBe(true);
+      });
+
+      it('should reflect the can_manage metadata flag', () => {
+        const model = createModel({ can_manage: false });
+        expect(model.canManage).toBe(false);
+      });
+
+      it('should be independent of can_install so actions stay available', () => {
+        const model = createModel({ can_install: false });
+        expect(model.canInstall).toBe(false);
+        expect(model.canManage).toBe(true);
+      });
+    });
+
+    describe('#name', () => {
+      it('should fall back to a default when metadata omits the name', () => {
+        const model = createModel();
+        expect(model.name).toBe('Extension');
+      });
+    });
+
+    describe('#isDisclaimed', () => {
+      it('should default to false whether or not the manager can install', () => {
+        expect(createModel({ can_install: false }).isDisclaimed).toBe(false);
+        expect(createModel({ can_install: true }).isDisclaimed).toBe(false);
+      });
+    });
+
+    describe('#canFetch', () => {
+      it('should require an accepted disclaimer when it can install', () => {
+        const model = createModel({ can_install: true });
+        expect(model.canFetch).toBe(false);
+        model.isDisclaimed = true;
+        expect(model.canFetch).toBe(true);
+      });
+
+      it('should require consent for a read-only manager too', () => {
+        const model = createModel({ can_install: false });
+        expect(model.canFetch).toBe(false);
+        model.isDisclaimed = true;
+        expect(model.canFetch).toBe(true);
+      });
+
+      it('should not depend on canManage', () => {
+        const model = createModel({ can_install: true, can_manage: false });
+        model.isDisclaimed = true;
+        expect(model.canFetch).toBe(true);
+      });
+    });
+
+    describe('#canPerformActions', () => {
+      it('should be available without the disclaimer for a read-only manager', () => {
+        const model = createModel({ can_install: false });
+        expect(model.isDisclaimed).toBe(false);
+        expect(model.canPerformActions).toBe(true);
+      });
+
+      it('should require the disclaimer for an installable manager', () => {
+        const model = createModel({ can_install: true });
+        expect(model.canPerformActions).toBe(false);
+        model.isDisclaimed = true;
+        expect(model.canPerformActions).toBe(true);
+      });
+
+      it('should be false when the manager cannot manage extensions', () => {
+        const listing = createModel({ can_install: false, can_manage: false });
+        expect(listing.canPerformActions).toBe(false);
+      });
+    });
+
+    describe('#search()', () => {
+      it('should be a no-op re-render when it cannot install', async () => {
+        const model = createModel({ can_install: false });
+        let changed = 0;
+        model.stateChanged.connect(() => {
+          changed++;
+        });
+        // Re-render once so the query filters the local list, without
+        // reaching the server.
+        await expect(model.search()).resolves.toBeUndefined();
+        expect(changed).toBe(1);
+      });
+
+      it('should reject when installable but not disclaimed', async () => {
+        const model = createModel({ can_install: true });
+        expect(model.isDisclaimed).toBe(false);
+        await expect(model.search()).rejects.toBe(
+          'Installation warning is not disclaimed.'
+        );
+      });
+    });
+
+    describe('#fetchInstalled()', () => {
+      it('should back refreshInstalled and sort the result by name', async () => {
+        const model = createModel({ can_install: false });
+        model.customInstalled = [
+          createEntry('b-extension'),
+          createEntry('a-extension')
+        ];
+        await model.refreshInstalled();
+        expect(model.fetchInstalledCount).toBe(1);
+        expect(model.installed.map(entry => entry.name)).toEqual([
+          'a-extension',
+          'b-extension'
+        ]);
+      });
+
+      it('should be the override point for an installable manager too', async () => {
+        const model = createModel({ can_install: true });
+        model.customInstalled = [createEntry('an-extension')];
+        await model.refreshInstalled();
+        expect(model.fetchInstalledCount).toBe(1);
+        expect(model.installed.map(entry => entry.name)).toEqual([
+          'an-extension'
+        ]);
+      });
+    });
+  });
+});

--- a/packages/extensionmanager/tsconfig.test.json
+++ b/packages/extensionmanager/tsconfig.test.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../tsconfigbase.test",
+  "include": ["src/*", "test/*"],
+  "references": [
+    {
+      "path": "../apputils"
+    },
+    {
+      "path": "../coreutils"
+    },
+    {
+      "path": "../services"
+    },
+    {
+      "path": "../translation"
+    },
+    {
+      "path": "../ui-components"
+    },
+    {
+      "path": "."
+    },
+    {
+      "path": "../testing"
+    }
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3545,11 +3545,14 @@ __metadata:
     "@jupyterlab/apputils": ^4.8.0-alpha.1
     "@jupyterlab/coreutils": ^6.7.0-alpha.1
     "@jupyterlab/services": ^7.7.0-alpha.1
+    "@jupyterlab/testing": ^4.7.0-alpha.1
     "@jupyterlab/translation": ^4.7.0-alpha.1
     "@jupyterlab/ui-components": ^4.7.0-alpha.1
+    "@lumino/coreutils": ^2.2.3
     "@lumino/messaging": ^2.0.5
     "@lumino/polling": ^2.1.6
     "@lumino/widgets": ^2.9.0
+    "@types/jest": ^29.2.0
     "@types/react": ^18.0.26
     "@types/react-paginate": ^6.2.1
     "@types/semver": ^7.5.2


### PR DESCRIPTION

## References

Looking into making the extension manager more extensible for downstream usage.

For now the main motivation would be displaying available extensions in JupyterLite: https://github.com/jupyterlite/jupyterlite/pull/1987. But this could also apply to other use cases.


## Code changes

- [x] Make the extension manager more easily reusable downstream (for instance JupyterLite)
- [x] Test

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Opus 4.8