### PR TITLE
Short-circuit command button re-render if it has not changed

### DIFF
--- a/galata/test/benchmark/toolbar-tab-switch.spec.ts
+++ b/galata/test/benchmark/toolbar-tab-switch.spec.ts
@@ -1,0 +1,198 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { expect, test } from '@playwright/test';
+import { benchmark, galata } from '@jupyterlab/galata';
+
+/**
+ * Benchmark for the cost of re-rendering notebook toolbars when switching tabs.
+ *
+ * Switching the active tab notifies (almost) every notebook command, which in
+ * turn asks each `CommandToolbarButton` - across *all* open notebooks, including
+ * the hidden ones whose React roots stay mounted - to re-render. This benchmark
+ * opens several notebooks and measures the time it takes React to flush the
+ * toolbar re-renders triggered by cycling the active tab.
+ */
+
+const tmpPath = 'test-performance-toolbar';
+
+// Number of notebooks to open simultaneously. More notebooks means more mounted
+// toolbars (hence more buttons to re-render on every tab switch).
+const N_NOTEBOOKS = 8;
+
+// Number of tab activations to perform inside a single measurement. Cycling
+// through distinct notebooks guarantees the current-widget actually changes
+// (and therefore that the command notifications fire) on every iteration. A
+// large number amplifies the toolbar re-render cost above the background noise.
+const N_ROUNDS = 100;
+
+const notebookNames = Array.from(
+  { length: N_NOTEBOOKS },
+  (_, i) => `toolbar_bench_${i}.ipynb`
+);
+
+const parameters: number[] = new Array<number>(benchmark.nSamples)
+  .fill(0)
+  .map((_, i) => i);
+
+test.describe('Benchmark - Toolbar tab switch', () => {
+  test.beforeAll(async ({ request }) => {
+    const content = galata.newContentsHelper(request);
+    // Tiny notebooks: we want the toolbars to dominate the cost, not the cells.
+    const nb = galata.Notebook.generateNotebook(1, 'code', ['']);
+    for (const name of notebookNames) {
+      await content.uploadContent(
+        JSON.stringify(nb),
+        'text',
+        `${tmpPath}/${name}`
+      );
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await galata.Mock.mockSettings(page, [], galata.DEFAULT_SETTINGS);
+  });
+
+  test.afterAll(async ({ request }) => {
+    const content = galata.newContentsHelper(request);
+    await content.deleteDirectory(tmpPath);
+  });
+
+  for (const sample of parameters) {
+    test(`measure tab switch with ${N_NOTEBOOKS} notebooks - ${
+      sample + 1
+    }`, async ({ baseURL, browserName, page }, testInfo) => {
+      test.setTimeout(300_000);
+
+      const attachmentCommon = {
+        nSamples: benchmark.nSamples,
+        browser: browserName,
+        file: `toolbar-tab-switch-${N_NOTEBOOKS}-notebooks`,
+        project: testInfo.project.name
+      };
+
+      await page.goto(baseURL + '?reset');
+
+      // Wait for the JupyterLab application to be ready.
+      await page.waitForFunction(
+        () => !!(window as any).jupyterapp?.commands,
+        undefined,
+        { timeout: 60_000 }
+      );
+      await page.evaluate(() => (window as any).jupyterapp.restored);
+
+      // Open all the notebooks as tabs in the main area.
+      await page.evaluate(
+        async ([paths]) => {
+          const app = (window as any).jupyterapp;
+          for (const path of paths) {
+            await app.commands.execute('docmanager:open', {
+              path,
+              factory: 'Notebook'
+            });
+          }
+        },
+        [notebookNames.map(name => `${tmpPath}/${name}`)]
+      );
+
+      // Wait for all the notebook panels to be mounted.
+      await expect(page.locator('[role="main"] .jp-NotebookPanel')).toHaveCount(
+        N_NOTEBOOKS
+      );
+      await page
+        .locator('[role="main"] >> .jp-SpinnerContent')
+        .waitFor({ state: 'hidden' });
+
+      // Shut the kernels down so that kernel status changes do not add noise to
+      // the measurement (the command notifications we want to measure are
+      // triggered by the tab switch, not by the kernels).
+      await page.evaluate(async () => {
+        const app = (window as any).jupyterapp;
+        await app.serviceManager.sessions.shutdownAll();
+      });
+
+      // Let the UI (and any asynchronous kernel-shutdown work) settle before
+      // measuring, so it does not leak into the measurement window.
+      await page.waitForTimeout(2500);
+
+      // The toolbar re-renders triggered by a tab switch reconcile the button
+      // subtrees but usually produce *no* DOM change (the rendered output is
+      // identical) - so the cost is pure JS CPU time. We therefore measure the
+      // cumulative script execution time (via the Chrome DevTools Protocol)
+      // rather than wall-clock, which would be dominated by the shell's own
+      // per-activation work and by scheduling/frame timing.
+      const client = await page.context().newCDPSession(page);
+      await client.send('Performance.enable');
+      const scriptDuration = async (): Promise<number> => {
+        const { metrics } = await client.send('Performance.getMetrics');
+        return metrics.find(m => m.name === 'ScriptDuration')!.value;
+      };
+
+      // Run `rounds` iterations of: optionally switch the active tab, then flush
+      // React. When `activate` is false this is an idle baseline of the exact
+      // same shape, used to cancel out the constant background JS (pollers etc.)
+      // that runs regardless of tab switches.
+      const runLoop = (rounds: number, activate: boolean) =>
+        page.evaluate(
+          async ([nRounds, doActivate]) => {
+            const app = (window as any).jupyterapp;
+            const shell = app.shell;
+            const ids = (Array.from(shell.widgets('main')) as any[])
+              .filter(widget =>
+                widget.node.classList.contains('jp-NotebookPanel')
+              )
+              .map(widget => widget.id);
+
+            // Wait for two animation frames so that React reliably commits the
+            // renders scheduled by the command notifications before the next
+            // iteration. The idle time spent waiting for frames is NOT counted
+            // by ScriptDuration (which only measures JS execution), so - unlike
+            // a wall-clock measurement - this does not introduce a frame-budget
+            // floor; it only guarantees the renders land inside the window.
+            const tick = () =>
+              new Promise<void>(resolve =>
+                requestAnimationFrame(() => resolve())
+              );
+            const flush = async () => {
+              await tick();
+              await tick();
+            };
+
+            await flush();
+            for (let i = 0; i < (nRounds as number); i++) {
+              if (doActivate) {
+                // Cycle through the notebooks so the current widget changes.
+                shell.activateById(ids[i % ids.length]);
+              }
+              await flush();
+            }
+          },
+          [rounds, activate] as [number, boolean]
+        );
+
+      // Idle baseline (no tab switches).
+      const idleStart = await scriptDuration();
+      await runLoop(N_ROUNDS, false);
+      const idleScript = (await scriptDuration()) - idleStart;
+
+      // Tab switches.
+      const switchStart = await scriptDuration();
+      await runLoop(N_ROUNDS, true);
+      const switchScript = (await scriptDuration()) - switchStart;
+
+      await client.detach();
+
+      // Script time attributable to the tab switches (ScriptDuration is in
+      // seconds). Clamp at 0 to guard against baseline noise.
+      const switchScriptTime = Math.max(0, (switchScript - idleScript) * 1000);
+
+      testInfo.attachments.push(
+        benchmark.addAttachment({
+          ...attachmentCommon,
+          test: 'tab-switch',
+          time: switchScriptTime
+        })
+      );
+    });
+  }
+});

--- a/galata/test/benchmark/toolbar-tab-switch.spec.ts
+++ b/galata/test/benchmark/toolbar-tab-switch.spec.ts
@@ -115,17 +115,30 @@ test.describe('Benchmark - Toolbar tab switch', () => {
       // measuring, so it does not leak into the measurement window.
       await page.waitForTimeout(2500);
 
-      // The toolbar re-renders triggered by a tab switch reconcile the button
-      // subtrees but usually produce *no* DOM change (the rendered output is
-      // identical) - so the cost is pure JS CPU time. We therefore measure the
-      // cumulative script execution time (via the Chrome DevTools Protocol)
-      // rather than wall-clock, which would be dominated by the shell's own
-      // per-activation work and by scheduling/frame timing.
+      // A tab switch reconciles the button subtrees but usually produces *no*
+      // DOM change (the rendered output is identical). The cost is therefore
+      // not just JS - re-rendering the button also re-runs the web-component
+      // property setters, which can trigger style recalculation independently
+      // of any DOM mutation. We thus capture, via the Chrome DevTools Protocol,
+      // the main-thread breakdown (script, style recalc, layout) rather than
+      // wall-clock, which would be dominated by the shell's per-activation work.
+      const METRICS = [
+        'TaskDuration',
+        'ScriptDuration',
+        'RecalcStyleDuration',
+        'LayoutDuration',
+        'RecalcStyleCount',
+        'LayoutCount'
+      ];
       const client = await page.context().newCDPSession(page);
       await client.send('Performance.enable');
-      const scriptDuration = async (): Promise<number> => {
+      const snapshot = async (): Promise<Record<string, number>> => {
         const { metrics } = await client.send('Performance.getMetrics');
-        return metrics.find(m => m.name === 'ScriptDuration')!.value;
+        const result: Record<string, number> = {};
+        for (const name of METRICS) {
+          result[name] = metrics.find(m => m.name === name)?.value ?? 0;
+        }
+        return result;
       };
 
       // Run `rounds` iterations of: optionally switch the active tab, then flush
@@ -170,27 +183,38 @@ test.describe('Benchmark - Toolbar tab switch', () => {
           [rounds, activate] as [number, boolean]
         );
 
-      // Idle baseline (no tab switches).
-      const idleStart = await scriptDuration();
+      // Idle baseline (no tab switches) of the exact same shape, to cancel the
+      // constant background work (pollers etc.).
+      const idle0 = await snapshot();
       await runLoop(N_ROUNDS, false);
-      const idleScript = (await scriptDuration()) - idleStart;
+      const idle1 = await snapshot();
 
       // Tab switches.
-      const switchStart = await scriptDuration();
+      const switch0 = await snapshot();
       await runLoop(N_ROUNDS, true);
-      const switchScript = (await scriptDuration()) - switchStart;
+      const switch1 = await snapshot();
 
       await client.detach();
 
-      // Script time attributable to the tab switches (ScriptDuration is in
-      // seconds). Clamp at 0 to guard against baseline noise.
-      const switchScriptTime = Math.max(0, (switchScript - idleScript) * 1000);
+      // Per-metric delta attributable to the tab switches (idle-subtracted).
+      const delta: Record<string, number> = {};
+      for (const name of METRICS) {
+        const idleDelta = idle1[name] - idle0[name];
+        const switchDelta = switch1[name] - switch0[name];
+        // Durations are in seconds; convert to ms. Counts stay as-is.
+        const scale = name.endsWith('Count') ? 1 : 1000;
+        delta[name] = (switchDelta - idleDelta) * scale;
+      }
 
+      console.log(`TAB_SWITCH_METRICS=${JSON.stringify(delta)}`);
+
+      // Record total main-thread time (script + style + layout + everything
+      // else on the thread) attributable to the switches as the headline metric.
       testInfo.attachments.push(
         benchmark.addAttachment({
           ...attachmentCommon,
           test: 'tab-switch',
-          time: switchScriptTime
+          time: Math.max(0, delta.TaskDuration)
         })
       );
     });

--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -1075,7 +1075,14 @@ export function CommandToolbarButtonComponent(
     >
       {() =>
         props.commands.listCommands().includes(props.id) ? (
-          <ToolbarButtonComponent {...Private.propsFromCommand(props)} />
+          // Use a memoized component so that signal emissions which do not
+          // actually change the rendered output (e.g. the bulk command
+          // notifications fired when switching tabs) do not trigger a costly
+          // re-render of the button subtree. See `Private.arePropsEqual`.
+          <Private.MemoizedToolbarButtonComponent
+            {...Private.propsFromCommand(props)}
+            commandArgs={props.args}
+          />
         ) : null
       }
     </UseSignal>
@@ -1417,6 +1424,110 @@ namespace Private {
       'aria-controls': ariaControls
     };
   }
+
+  /**
+   * Props of the memoized toolbar button.
+   *
+   * It carries the command `args` (`commandArgs`) in addition to the rendered
+   * button props so that a change of arguments - which only affects the click
+   * handler and not the visual props - still re-renders the button. This field
+   * is not forwarded to the underlying `ToolbarButtonComponent`.
+   */
+  interface IMemoizedButtonProps extends ToolbarButtonComponent.IProps {
+    commandArgs?: ReadonlyJSONObject;
+  }
+
+  /**
+   * Props which are recreated on every call to `propsFromCommand` and therefore
+   * cannot be compared by identity:
+   * - `onClick` is a fresh closure but is semantically stable - what it
+   *   dispatches depends only on the command id and `args` (the latter compared
+   *   through `commandArgs`) - so it is skipped entirely.
+   * - `dataset` is a fresh object and is compared by value instead.
+   */
+  const NON_IDENTITY_PROPS: {
+    [key in keyof IMemoizedButtonProps]?: 'skip' | 'dataset';
+  } = {
+    onClick: 'skip',
+    dataset: 'dataset'
+  };
+
+  /**
+   * Compare two sets of toolbar button props for rendering equality.
+   *
+   * Used as the equality function of a `React.memo` wrapper so that command
+   * change notifications which do not affect the button (the common case when
+   * switching tabs, where every notebook command is notified but most buttons
+   * are unaffected) do not re-render the button.
+   *
+   * #### Notes
+   * This compares *every* prop generically (rather than an explicit allow-list)
+   * so that the optimization stays correct when a new prop is added to
+   * `ToolbarButtonComponent.IProps`: an unhandled prop is compared by identity,
+   * which at worst forces a re-render but can never leave the button stale.
+   * Only the props that are recreated on every render
+   * (see {@link NON_IDENTITY_PROPS}) need explicit handling here.
+   *
+   * `propsFromCommand` always returns the same set of keys, so iterating the
+   * keys of `a` is sufficient. We use `for...in` rather than `Object.keys`/a
+   * `Set` to avoid allocating on every call: this runs for every toolbar button
+   * on every command notification, so the per-call cost must stay minimal.
+   */
+  export function arePropsEqual(
+    a: IMemoizedButtonProps,
+    b: IMemoizedButtonProps
+  ): boolean {
+    const aRecord = a as Record<string, unknown>;
+    const bRecord = b as Record<string, unknown>;
+    for (const key in aRecord) {
+      const handling = NON_IDENTITY_PROPS[key as keyof IMemoizedButtonProps];
+      if (handling === 'skip') {
+        continue;
+      }
+      if (handling === 'dataset') {
+        if (!shallowEqualDataset(a.dataset, b.dataset)) {
+          return false;
+        }
+        continue;
+      }
+      if (aRecord[key] !== bRecord[key]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Shallow comparison of two `dataset` objects (key/value equality).
+   */
+  function shallowEqualDataset(a?: DOMStringMap, b?: DOMStringMap): boolean {
+    if (a === b) {
+      return true;
+    }
+    if (!a || !b) {
+      return false;
+    }
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    if (aKeys.length !== bKeys.length) {
+      return false;
+    }
+    return aKeys.every(key => a[key] === b[key]);
+  }
+
+  /**
+   * A memoized version of `ToolbarButtonComponent` which skips re-rendering
+   * when the derived props are unchanged (see `arePropsEqual`).
+   */
+  export const MemoizedToolbarButtonComponent = React.memo(
+    (props: IMemoizedButtonProps): JSX.Element => {
+      // `commandArgs` is only used by `arePropsEqual`; the remaining fields are
+      // the actual button props (the extra field is ignored by the button).
+      const buttonProps: ToolbarButtonComponent.IProps = props;
+      return <ToolbarButtonComponent {...buttonProps} />;
+    },
+    arePropsEqual
+  );
 
   /**
    * An attached property for the name of a toolbar item.

--- a/packages/ui-components/test/toolbar.spec.ts
+++ b/packages/ui-components/test/toolbar.spec.ts
@@ -6,16 +6,23 @@ import {
   bugDotIcon,
   bugIcon,
   CommandToolbarButton,
+  CommandToolbarButtonComponent,
   jupyterIcon,
+  LabIcon,
   ReactiveToolbar,
+  ReactWidget,
   Toolbar,
   ToolbarButton
 } from '@jupyterlab/ui-components';
 import { framePromise, JupyterServer } from '@jupyterlab/testing';
 import { CommandRegistry } from '@lumino/commands';
-import type { ReadonlyPartialJSONObject } from '@lumino/coreutils';
+import type {
+  ReadonlyJSONObject,
+  ReadonlyPartialJSONObject
+} from '@lumino/coreutils';
 import type { PanelLayout } from '@lumino/widgets';
 import { Widget } from '@lumino/widgets';
+import * as React from 'react';
 import { simulate } from 'simulate-event';
 
 const server = new JupyterServer();
@@ -441,6 +448,118 @@ describe('@jupyterlab/ui-components', () => {
 
           button.dispose();
         });
+      });
+    });
+
+    describe('re-render optimization', () => {
+      let commands: CommandRegistry;
+      const id = 'test:rerender';
+      let enabled = true;
+      let iconClassValue = 'initial-icon-class';
+
+      async function render(button: CommandToolbarButton) {
+        button.update();
+        await framePromise();
+        await button.renderPromise;
+      }
+
+      beforeEach(() => {
+        commands = new CommandRegistry();
+        enabled = true;
+        iconClassValue = 'initial-icon-class';
+        commands.addCommand(id, {
+          execute: () => undefined,
+          label: 'Re-render test',
+          icon: blankIcon,
+          iconClass: () => iconClassValue,
+          isEnabled: () => enabled
+        });
+      });
+
+      it('should not re-render the button when an unrelated command change is notified', async () => {
+        const button = new CommandToolbarButton({ commands, id });
+        await render(button);
+
+        // Spy is installed after the initial render so its call count starts
+        // at zero; `resolveReact` is only invoked while rendering the button
+        // subtree, so it is a proxy for "the button re-rendered".
+        const resolveReact = jest.spyOn(LabIcon, 'resolveReact');
+        try {
+          // A `changed` notification with no underlying state change (the
+          // common case when switching tabs) must not re-render the button.
+          commands.notifyCommandChanged(id);
+          await framePromise();
+          expect(resolveReact).not.toHaveBeenCalled();
+
+          // A `many-changed` notification (also emitted on tab switch) must
+          // likewise be a no-op when nothing relevant changed.
+          commands.notifyCommandChanged();
+          await framePromise();
+          expect(resolveReact).not.toHaveBeenCalled();
+        } finally {
+          resolveReact.mockRestore();
+        }
+        button.dispose();
+      });
+
+      it('should re-render the button when the command state changes', async () => {
+        const button = new CommandToolbarButton({ commands, id });
+        await render(button);
+
+        const resolveReact = jest.spyOn(LabIcon, 'resolveReact');
+        try {
+          enabled = false;
+          commands.notifyCommandChanged(id);
+          await framePromise();
+          expect(resolveReact).toHaveBeenCalled();
+        } finally {
+          resolveReact.mockRestore();
+        }
+        button.dispose();
+      });
+
+      it('should not execute the command with stale arguments after args change', async () => {
+        // Regression test: when only the command arguments change (the visual
+        // props stay identical), the memoized button must still re-render so
+        // that its click handler dispatches the command with the new args.
+        const execute = jest.fn();
+        const argsId = 'test:rerender-args';
+        commands.addCommand(argsId, {
+          execute,
+          label: 'Args test',
+          icon: blankIcon
+        });
+
+        class Wrapper extends ReactWidget {
+          args: ReadonlyJSONObject = { value: 1 };
+          render(): React.ReactElement {
+            return React.createElement(CommandToolbarButtonComponent, {
+              commands,
+              id: argsId,
+              args: this.args
+            });
+          }
+        }
+
+        const wrapper = new Wrapper();
+        Widget.attach(wrapper, document.body);
+        await framePromise();
+        await wrapper.renderPromise;
+
+        simulate(wrapper.node.firstElementChild!, 'click');
+        expect(execute).toHaveBeenLastCalledWith({ value: 1 });
+
+        // Change the args (new reference and content); the rendered output of
+        // the button is unchanged, but the handler must pick up the new args.
+        wrapper.args = { value: 2 };
+        wrapper.update();
+        await framePromise();
+        await wrapper.renderPromise;
+
+        simulate(wrapper.node.firstElementChild!, 'click');
+        expect(execute).toHaveBeenLastCalledWith({ value: 2 });
+
+        wrapper.dispose();
       });
     });
   });


### PR DESCRIPTION

## References

- https://github.com/jupyterlab/jupyterlab/issues/13683

## Code changes

Check if props changed instead of triggering re-render

## User-facing changes

There is a negligible performance improvement in the playwright test measuring individual profile components.

|Metric | Before | After |
|--|--|--|
| ScriptDuration | 303 ms | 292 ms|
|RecalcStyleDuration | 566 ms | 554 ms|
|LayoutDuration| 157 ms | 155 ms|
| RecalcStyleCount | 1151 | 1150|
| LayoutCount | 738 | 738 |
|TaskDuration (total) | 1740 ms | 1657 ms|

There is a negligible performance improvement in UI Profiler, "Switch Tab Focus" scenario, 500 repeats between two empty notebooks and a side notebook with 5000 div, span and svg elements

| | IQM | mean | min |
|--|--|--|--|
| Before | 78.5 [67.5 – 89.8] ms | 81.2 ms | 51.9 ms |
| After | 77.6 [67.8 – 87.9] ms | 79.6 ms | 49 ms |

With additional 5000 button elements

| | IQM | mean | min |
|--|--|--|--|
| Before |106.5 [99.9 – 114.9] ms | 108.6 ms | 78.4 ms|
| After | 95.2 [88.9 – 103.4] ms | 97.5 ms | 67.8 ms|



## Backwards-incompatible changes

None

## AI usage

- **Yes**: Some or all of the content of this PR was generated by AI.
- **Yes**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Clause