### PR TITLE
Wait for launcher icons before screenshots

### DIFF
--- a/galata/src/fixtures.ts
+++ b/galata/src/fixtures.ts
@@ -369,18 +369,6 @@ export const test: TestType<
       if (!(await helpers.isInSimpleMode())) {
         await helpers.activity.activateTab('Launcher');
       }
-      await page.locator('.jp-LauncherCard').first().waitFor();
-      await helpers.waitForCondition(() =>
-        page.locator('.jp-Launcher-kernelIcon').evaluateAll(images =>
-          images.every(image => {
-            return (
-              image instanceof HTMLImageElement &&
-              image.complete &&
-              image.naturalWidth > 0
-            );
-          })
-        )
-      );
     };
     await use(waitIsReady);
   },

--- a/galata/src/fixtures.ts
+++ b/galata/src/fixtures.ts
@@ -369,6 +369,18 @@ export const test: TestType<
       if (!(await helpers.isInSimpleMode())) {
         await helpers.activity.activateTab('Launcher');
       }
+      await page.locator('.jp-LauncherCard').first().waitFor();
+      await helpers.waitForCondition(() =>
+        page.locator('.jp-Launcher-kernelIcon').evaluateAll(images =>
+          images.every(image => {
+            return (
+              image instanceof HTMLImageElement &&
+              image.complete &&
+              image.naturalWidth > 0
+            );
+          })
+        )
+      );
     };
     await use(waitIsReady);
   },

--- a/galata/test/jupyterlab/general.test.ts
+++ b/galata/test/jupyterlab/general.test.ts
@@ -2,9 +2,11 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { expect, test } from '@jupyterlab/galata';
+import { waitForLauncherIcons } from './utils';
 
 test.describe('General Tests', () => {
   test('Launch Screen', async ({ page }) => {
+    await waitForLauncherIcons(page);
     const imageName = 'launch.png';
     expect(await page.screenshot()).toMatchSnapshot(imageName.toLowerCase());
   });

--- a/galata/test/jupyterlab/launcher.test.ts
+++ b/galata/test/jupyterlab/launcher.test.ts
@@ -2,6 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { expect, galata, test } from '@jupyterlab/galata';
+import { waitForLauncherIcons } from './utils';
 
 test.use({
   autoGoto: false,
@@ -38,6 +39,7 @@ test.describe('Dynamic Text Spacing', () => {
       expect(height).toEqual(expectedValue + 'px');
     }
 
+    await waitForLauncherIcons(page);
     const imageName = 'launcher-card-label-height.png';
     expect(
       await page.locator('.jp-Launcher-content').screenshot()

--- a/galata/test/jupyterlab/utils.ts
+++ b/galata/test/jupyterlab/utils.ts
@@ -7,6 +7,27 @@ const OUTER_SELECTOR = '.jp-WindowedPanel-outer';
 const DRAGGABLE_AREA = '.jp-InputArea-prompt';
 
 /**
+ * Wait for visible launcher card images to load before taking screenshots.
+ */
+export async function waitForLauncherIcons(
+  page: IJupyterLabPageFixture
+): Promise<void> {
+  const launcher = page.locator('.jp-Launcher:visible');
+  await launcher.locator('.jp-LauncherCard').first().waitFor();
+  await page.waitForCondition(() =>
+    launcher.locator('.jp-Launcher-kernelIcon').evaluateAll(images =>
+      images.every(image => {
+        return (
+          image instanceof HTMLImageElement &&
+          image.complete &&
+          image.naturalWidth > 0
+        );
+      })
+    )
+  );
+}
+
+/**
  * Measure how much of the **notebook** viewport does a cell take up.
  */
 export async function notebookViewportRatio(


### PR DESCRIPTION
## References
Closes #19072 

## Code changes

This updates Galata’s application-ready wait to ensure the launcher has rendered cards and all kernel icon images have loaded before tests take launcher screenshots. This prevents flaky visual diffs where the launch screen is captured during the brief icon-loading state

## User-facing changes
None

## Backwards-incompatible changes
None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: 5.5 chatgpt
