### PR TITLE
Add an optional widget ID to 'application:split-tab' command

### DIFF
--- a/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
+++ b/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
@@ -212,6 +212,10 @@
             "bottom"
           ],
           "description": "The direction to split the tab"
+        },
+        "id": {
+          "type": "string",
+          "description": "The widget ID to split. Defaults to the context menu target."
         }
       },
       "required": [

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -837,7 +837,7 @@ const mainCommands: JupyterFrontEndPlugin<void> = {
         return find(labShell.widgets('main'), w => w.id === id) ?? null;
       };
 
-      commands.addCommand('application:split-tab', {
+      commands.addCommand(CommandIDs.splitTab, {
         label: args => {
           const direction = args?.['direction'] as
             | 'left'
@@ -869,6 +869,12 @@ const mainCommands: JupyterFrontEndPlugin<void> = {
                 type: 'string',
                 enum: ['left', 'right', 'top', 'bottom'],
                 description: trans.__('The direction to split the tab')
+              },
+              id: {
+                type: 'string',
+                description: trans.__(
+                  'The widget ID to split. Defaults to the context menu target.'
+                )
               }
             },
             required: ['direction']
@@ -899,7 +905,16 @@ const mainCommands: JupyterFrontEndPlugin<void> = {
             | 'top'
             | 'bottom';
 
-          const widget = contextMenuTabWidget();
+          // Get the widget from its id if provided.
+          let widget = args?.['id']
+            ? find(labShell.widgets('main'), value => value.id === args?.['id'])
+            : null;
+
+          // Get the widget from the context menu hit test.
+          if (!widget) {
+            widget = contextMenuTabWidget();
+          }
+
           if (widget && direction) {
             labShell.moveTab(widget, direction);
           }


### PR DESCRIPTION
## References

Fix #19069

## Code changes

Adds an optional `id` arg to the command 'application:split-tab', to allow using this command without using the context menu.

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

- **NO**: Some or all of the content of this PR was generated by AI.

