### PR TITLE
Add file open/close

### DIFF
--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { ISessionContext } from '@jupyterlab/apputils';
-import { SessionContextDialogs } from '@jupyterlab/apputils';
+import { SessionContextDialogs, showErrorMessage } from '@jupyterlab/apputils';
 import type { IChangedArgs } from '@jupyterlab/coreutils';
 import { PathExt } from '@jupyterlab/coreutils';
 import type {
@@ -629,6 +629,15 @@ export class DocumentManager implements IDocumentManager {
    */
   private _onContextDisposed(context: Private.IContext): void {
     ArrayExt.removeFirstOf(this._contexts, context);
+
+    // If no more contexts remain for this path, notify the server
+    // that the file is no longer being edited across any client.
+    const remaining = this._contextsForPath(context.path);
+    if (remaining.length === 0) {
+      this.services.contents.close?.(context.path).catch(() => {
+        // Server may not support open/close endpoints.
+      });
+    }
   }
 
   /**
@@ -719,6 +728,10 @@ export class DocumentManager implements IDocumentManager {
     ready.catch(err => {
       console.error(
         `Failed to initialize the context with '${factory.name}' for ${path}`,
+        err
+      );
+      void showErrorMessage(
+        this.translator.load('jupyterlab').__('File Open Error'),
         err
       );
       widget.close();

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -210,6 +210,7 @@ export class Context<
       return;
     }
     this._isDisposed = true;
+    this._stopLeaseHeartbeat();
     this.sessionContext.dispose();
     this._model.dispose();
     // Ensure we dispose the `sharedModel` as it may have been generated in the context
@@ -255,11 +256,23 @@ export class Context<
    * @returns a promise that resolves upon initialization.
    */
   async initialize(isNew: boolean) {
+    const contents = this._manager.contents;
+
     if (isNew) {
       await this._save();
+
+      try {
+        await contents.open?.(this._path, { mode: 'write' });
+        this._startLeaseHeartbeat();
+      } catch {
+        // Server does not support open/close; proceed without heartbeat.
+      }
     } else {
+      await contents.open?.(this._path, { mode: 'write' });
+      this._startLeaseHeartbeat();
       await this._revert();
     }
+
     this.model.sharedModel.clearUndoHistory();
   }
 
@@ -997,6 +1010,14 @@ or load the version on disk (revert)?`,
 
   protected translator: ITranslator;
 
+  /**
+   * Interval at which the lease heartbeat is sent (in milliseconds).
+   *
+   * The server-side TTL for the open lease should be at least 2x this value
+   * to account for network delays and client-side processing time.
+   */
+  private readonly _LEASE_HEARTBEAT_INTERVAL_MS = 30000;
+
   private _isReady = false;
   private _isDisposed = false;
   private _isPopulated = false;
@@ -1026,6 +1047,39 @@ or load the version on disk (revert)?`,
   private _dialogs: ISessionContext.IDialogs;
   private _lastModifiedCheckMargin = 500;
   private _conflictModalIsOpen = false;
+  private _leaseTimer: ReturnType<typeof setInterval> | null = null;
+
+  /**
+   * Start the lease heartbeat timer so the server knows this file is
+   * still being edited. If the server supports open/close, this
+   * periodically renews the lease. On crash, the heartbeat stops and
+   * the server eventually auto-expires the lease.
+   */
+  private _startLeaseHeartbeat(): void {
+    if (this._leaseTimer !== null) {
+      return;
+    }
+    const contents = this._manager.contents;
+    if (!contents.open) {
+      return;
+    }
+    this._leaseTimer = setInterval(() => {
+      contents.open!(this._path).catch(() => {
+        // Server may not support open/close; stop trying.
+        this._stopLeaseHeartbeat();
+      });
+    }, this._LEASE_HEARTBEAT_INTERVAL_MS);
+  }
+
+  /**
+   * Stop the lease heartbeat timer.
+   */
+  private _stopLeaseHeartbeat(): void {
+    if (this._leaseTimer !== null) {
+      clearInterval(this._leaseTimer);
+      this._leaseTimer = null;
+    }
+  }
 }
 
 /**

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -223,6 +223,21 @@ export namespace Contents {
   }
 
   /**
+   * The options used to open a file.
+   */
+  export interface IOpenOptions {
+    /**
+     * The access mode for opening the file.
+     *
+     * - `"write"`: the client intends to edit the file (default).
+     *    The server may deny if another client has it open in write mode.
+     * - `"read"`: the client only intends to view the file.
+     *    Multiple clients may open a file in read mode concurrently.
+     */
+    mode?: 'read' | 'write';
+  }
+
+  /**
    * Checkpoint model.
    */
   export interface ICheckpointModel {
@@ -525,6 +540,37 @@ export namespace Contents {
      * @returns A promise which resolves when the checkpoint is deleted.
      */
     deleteCheckpoint(path: string, checkpointID: string): Promise<void>;
+
+    /**
+     * Open a file and notify the server that it is being actively edited.
+     *
+     * @param path - The path to the file.
+     *
+     * @param options - Optional parameters such as access mode.
+     *
+     * @returns A promise which resolves when the server acknowledges the open.
+     *
+     * #### Notes
+     * This can be used by server-side implementations to track which files
+     * are currently open across clients, to prevent conflicting operations
+     * such as renaming or deleting an open file.
+     * If not implemented, the operation is treated as a no-op.
+     */
+    open?(path: string, options?: Contents.IOpenOptions): Promise<void>;
+
+    /**
+     * Close a file and notify the server that it is no longer being edited.
+     *
+     * @param path - The path to the file.
+     *
+     * @returns A promise which resolves when the server acknowledges the close.
+     *
+     * #### Notes
+     * This is the counterpart to `open`. It should be called when the client
+     * is done editing a file.
+     * If not implemented, the operation is treated as a no-op.
+     */
+    close?(path: string): Promise<void>;
   }
 
   /**
@@ -681,6 +727,37 @@ export namespace Contents {
      * @returns A promise which resolves when the checkpoint is deleted.
      */
     deleteCheckpoint(localPath: string, checkpointID: string): Promise<void>;
+
+    /**
+     * Open a file and notify the server that it is being actively edited.
+     *
+     * @param localPath - The path to the file.
+     *
+     * @param options - Optional parameters such as access mode.
+     *
+     * @returns A promise which resolves when the server acknowledges the open.
+     *
+     * #### Notes
+     * This can be used by server-side implementations to track which files
+     * are currently open across clients, to prevent conflicting operations
+     * such as renaming or deleting an open file.
+     * If not implemented, the operation is treated as a no-op.
+     */
+    open?(localPath: string, options?: IOpenOptions): Promise<void>;
+
+    /**
+     * Close a file and notify the server that it is no longer being edited.
+     *
+     * @param localPath - The path to the file.
+     *
+     * @returns A promise which resolves when the server acknowledges the close.
+     *
+     * #### Notes
+     * This is the counterpart to `open`. It should be called when the client
+     * is done editing a file.
+     * If not implemented, the operation is treated as a no-op.
+     */
+    close?(localPath: string): Promise<void>;
   }
 }
 
@@ -1094,6 +1171,32 @@ export class ContentsManager implements Contents.IManager {
   deleteCheckpoint(path: string, checkpointID: string): Promise<void> {
     const [drive, localPath] = this._driveForPath(path);
     return drive.deleteCheckpoint(localPath, checkpointID);
+  }
+
+  /**
+   * Open a file and notify the server that it is being actively edited.
+   *
+   * @param path - The path to the file.
+   *
+   * @param options - Optional parameters such as access mode.
+   *
+   * @returns A promise which resolves when the server acknowledges the open.
+   */
+  open(path: string, options?: Contents.IOpenOptions): Promise<void> {
+    const [drive, localPath] = this._driveForPath(path);
+    return drive.open?.(localPath, options) ?? Promise.resolve();
+  }
+
+  /**
+   * Close a file and notify the server that it is no longer being edited.
+   *
+   * @param path - The path to the file.
+   *
+   * @returns A promise which resolves when the server acknowledges the close.
+   */
+  close(path: string): Promise<void> {
+    const [drive, localPath] = this._driveForPath(path);
+    return drive.close?.(localPath) ?? Promise.resolve();
   }
 
   /**
@@ -1611,6 +1714,47 @@ export class Drive implements Contents.IDrive {
   }
 
   /**
+   * Open a file and notify the server that it is being actively edited.
+   *
+   * @param localPath - The path to the file.
+   *
+   * @param options - Optional parameters such as access mode.
+   *
+   * @returns A promise which resolves when the server acknowledges the open.
+   *
+   * #### Notes
+   * Delegates to the REST content provider.
+   */
+  async open(
+    localPath: string,
+    options?: Contents.IOpenOptions
+  ): Promise<void> {
+    const contentProvider = this.contentProviderRegistry.getProvider(undefined);
+    if (contentProvider?.open) {
+      return contentProvider.open(localPath, options);
+    }
+    return this._restContentProvider.open(localPath, options);
+  }
+
+  /**
+   * Close a file and notify the server that it is no longer being edited.
+   *
+   * @param localPath - The path to the file.
+   *
+   * @returns A promise which resolves when the server acknowledges the close.
+   *
+   * #### Notes
+   * Delegates to the REST content provider.
+   */
+  async close(localPath: string): Promise<void> {
+    const contentProvider = this.contentProviderRegistry.getProvider(undefined);
+    if (contentProvider?.close) {
+      return contentProvider.close(localPath);
+    }
+    return this._restContentProvider.close(localPath);
+  }
+
+  /**
    * Get a REST url for a file given a path.
    */
   private _getUrl(...args: string[]): string {
@@ -1879,6 +2023,70 @@ export class RestContentProvider implements IContentProvider {
   }
 
   /**
+   * Open a file and notify the server that it is being actively edited.
+   *
+   * @param localPath - The path to the file.
+   *
+   * @returns A promise which resolves when the server acknowledges the open.
+   */
+  async open(
+    localPath: string,
+    options?: Contents.IOpenOptions
+  ): Promise<void> {
+    if (!this._openCloseSupported) {
+      return;
+    }
+    const settings = this._options.serverSettings;
+    const url = this._getUrl(localPath);
+    const body = JSON.stringify({
+      operation: 'open',
+      clientId: this._clientId,
+      mode: options?.mode ?? 'write'
+    });
+    const init = { method: 'POST', body };
+    const response = await ServerConnection.makeRequest(url, init, settings);
+    if (response.status === 200 || response.status === 201) {
+      this._openCloseSupported = true;
+      return;
+    }
+    if (response.status === 409) {
+      // Conflict — file is locked by another client.
+      const err = await ServerConnection.ResponseError.create(response);
+      this._openCloseSupported = false;
+      throw err;
+    }
+    // Any other status means the server does not support open/close;
+    // degrade gracefully.
+    this._openCloseSupported = false;
+  }
+
+  /**
+   * Close a file and notify the server that it is no longer being edited.
+   *
+   * @param localPath - The path to the file.
+   *
+   * @returns A promise which resolves when the server acknowledges the close.
+   */
+  async close(localPath: string): Promise<void> {
+    if (!this._openCloseSupported) {
+      return;
+    }
+    const settings = this._options.serverSettings;
+    const url = this._getUrl(localPath);
+    const body = JSON.stringify({
+      operation: 'close',
+      clientId: this._clientId
+    });
+    const init = { method: 'POST', body };
+    const response = await ServerConnection.makeRequest(url, init, settings);
+    if (response.status === 200 || response.status === 204) {
+      this._openCloseSupported = true;
+      return;
+    }
+    this._openCloseSupported = false;
+  }
+
+  /**
    * Get a REST url for a file given a path.
    */
   private _getUrl(...args: string[]): string {
@@ -1888,6 +2096,8 @@ export class RestContentProvider implements IContentProvider {
   }
 
   private _options: RestContentProvider.IOptions;
+  private _clientId = UUID.uuid4();
+  private _openCloseSupported = true;
 }
 
 /**
@@ -1966,4 +2176,28 @@ export interface IContentProvider extends Pick<
    * may emit this signal to communicate a change in the file contents.
    */
   readonly fileChanged?: ISignal<IContentProvider, Contents.IChangedArgs>;
+
+  /**
+   * Open a file and notify the server that it is being actively edited.
+   *
+   * @param localPath - The path to the file.
+   *
+   * @param options - Optional parameters such as access mode.
+   *
+   * @returns A promise which resolves when the server acknowledges the open.
+   *
+   * #### Notes
+   * If not implemented, the drive will handle open/close via the default
+   * REST content provider.
+   */
+  open?(localPath: string, options?: Contents.IOpenOptions): Promise<void>;
+
+  /**
+   * Close a file and notify the server that it is no longer being edited.
+   *
+   * @param localPath - The path to the file.
+   *
+   * @returns A promise which resolves when the server acknowledges the close.
+   */
+  close?(localPath: string): Promise<void>;
 }


### PR DESCRIPTION
## References

Closes #19080.

## Code changes

Add `open(path)` and `close(path)` methods to contents manager and drive. For the REST content provider, this is implemented as `POST /api/contents/{path}` requests with a body of `{"cliendId": "...", "operation": "open"/"close", "mode": "read"/"write"}`, and a heartbeat mechanism so that the server knows the file has been closed if the client doesn't do it gracefully.

## User-facing changes

None.
This may enable future features such as disabling file delete/rename if it is opened by other clients, or opening a file in read-only mode if it is already opened in write mode by another client.

## Backwards-incompatible changes

None.
This is a no-op if the server doesn't support the new REST API.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: DeepSeek
