### PR TITLE
Fix Font Awesome icon rendering on buttons

### DIFF
--- a/packages/application/style/buttons.css
+++ b/packages/application/style/buttons.css
@@ -17,8 +17,14 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-.jp-ThemedContainer button {
+/* Use :where() so this rule has specificity (0,0,1), lower than Font
+ * Awesome's `.fa` and friends who have (0,1,0), so that `<button class="fa">`
+ * keep their glyph font while plain buttons still get the UI font. */
+:where(.jp-ThemedContainer) button {
   font-family: var(--jp-ui-font-family);
+}
+
+.jp-ThemedContainer button {
   border-radius: var(--jp-border-radius);
 }
 


### PR DESCRIPTION

## References

- Fixes #19089 

## Code changes

Use `:where` to decrease selector specificfity.

## User-facing changes

| `4.6.0` | This PR (and earlier `4.x`) |
|--|--|
| <img width="618" height="97" alt="image" src="https://github.com/user-attachments/assets/ba17c8fe-a733-4fe7-a21c-4b31c7600f91" /> | <img width="618" height="97" alt="image" src="https://github.com/user-attachments/assets/56e442d4-618c-4749-b0a4-714cbe958269" /> |


## Backwards-incompatible changes

None

## AI usage

Used Clause to compare a few ideas like `:not`, `:where` and `:has` and think through performance implications. TLDR: no performance impact with `:where` on selector matching it only changes specificity.