### PR TITLE
Fix multiple dropdown settings not rendering in the Setting Editor

### DIFF
--- a/packages/application-extension/schema/shell.json
+++ b/packages/application-extension/schema/shell.json
@@ -24,6 +24,7 @@
       "default": "display"
     },
     "startMode": {
+      "type": "string",
       "oneOf": [
         { "const": "", "title": "Default" },
         { "const": "single", "title": "Single" },
@@ -98,6 +99,7 @@
           "type": "object",
           "properties": {
             "area": {
+              "type": "string",
               "oneOf": [
                 { "const": "main", "title": "Main" },
                 { "const": "left", "title": "Left" },

--- a/packages/lsp-extension/schema/plugin.json
+++ b/packages/lsp-extension/schema/plugin.json
@@ -39,6 +39,7 @@
     "activate": {
       "title": "Activate",
       "description": "Enable or disable the language server services.",
+      "type": "string",
       "oneOf": [
         { "const": "off", "title": "Off" },
         { "const": "on", "title": "On" }
@@ -58,6 +59,7 @@
     },
     "setTrace": {
       "title": "Ask servers to send trace notifications",
+      "type": "string",
       "oneOf": [
         { "const": "off", "title": "Off" },
         { "const": "messages", "title": "Messages" },

--- a/packages/lsp/src/plugin.ts
+++ b/packages/lsp/src/plugin.ts
@@ -11,7 +11,7 @@
 /**
  * Enable or disable the language server services.
  */
-export type Activate = Off | On;
+export type Activate = (Off | On) & string;
 export type Off = 'off';
 export type On = 'on';
 /**
@@ -21,7 +21,8 @@ export type RankOfTheServer = number;
 /**
  * Whether to ask server to send logs with execution trace (for debugging). Accepted values are: "off", "messages", "verbose". Servers are allowed to ignore this request.
  */
-export type AskServersToSendTraceNotifications = Off1 | Messages | Verbose;
+export type AskServersToSendTraceNotifications = (Off1 | Messages | Verbose) &
+  string;
 export type Off1 = 'off';
 export type Messages = 'messages';
 export type Verbose = 'verbose';

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -830,6 +830,7 @@
     "renderingLayout": {
       "title": "Rendering Layout",
       "description": "Global setting to define the rendering layout in notebooks. 'default' or 'side-by-side' are supported.",
+      "type": "string",
       "oneOf": [
         { "const": "default", "title": "Default" },
         { "const": "side-by-side", "title": "Side by side" }
@@ -858,6 +859,7 @@
     "windowingMode": {
       "title": "Windowing mode",
       "description": "- 'defer': Improve loading time - Wait for idle CPU cycles to attach out of viewport cells\n- 'full': Best performance with side effects - Attach to the DOM only cells in viewport\n- 'none': Worst performance without side effects - Attach all cells to the viewport\n- 'contentVisibility': Browser-optimized rendering - Use content-visibility to skip offscreen cells",
+      "type": "string",
       "oneOf": [
         { "const": "defer", "title": "Defer" },
         { "const": "full", "title": "Full" },

--- a/packages/settingeditor-extension/schema/form-ui.json
+++ b/packages/settingeditor-extension/schema/form-ui.json
@@ -5,6 +5,7 @@
     "settingEditorType": {
       "title": "Type of editor for the setting.",
       "description": "Set the type of editor to use while editing your settings.",
+      "type": "string",
       "oneOf": [
         { "const": "json", "title": "JSON" },
         { "const": "ui", "title": "UI" }

--- a/packages/terminal-extension/schema/plugin.json
+++ b/packages/terminal-extension/schema/plugin.json
@@ -41,6 +41,7 @@
       "minimum": 1.0
     },
     "theme": {
+      "type": "string",
       "oneOf": [
         { "const": "dark", "title": "Dark" },
         { "const": "light", "title": "Light" },


### PR DESCRIPTION


## References

- Fixes #19086 

## Code changes

Add missing `type` to all settings conveted to `oneOf` from `enum`

## User-facing changes

| Before | After |
|--|--|
| <img width="859" height="263" alt="image" src="https://github.com/user-attachments/assets/7f358c42-86ea-458b-a9af-5cbede4b855e" /> | <img width="859" height="263" alt="image" src="https://github.com/user-attachments/assets/cb277fa8-34ac-44e7-9b63-1a1d2ff5e931" /> |

## Backwards-incompatible changes

None

## AI usage

- **Yes**: Some or all of the content of this PR was generated by AI.
- **Yes**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude for narrowing down the cuplrit