### PR TITLE
services: support custom request headers in ServerConnection

### DIFF
--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -108,6 +108,22 @@ export namespace ServerConnection {
      * Serializer used to serialize/deserialize kernel messages.
      */
     readonly serializer: ISerializer;
+
+    /**
+     * Additional HTTP headers to include in every request to the server.
+     *
+     * #### Notes
+     * These headers are merged into each request before the automatic
+     * `Authorization` and `X-XSRFToken` headers are applied.  If a key
+     * in `requestHeaders` conflicts with one of those two auth headers,
+     * the value in `requestHeaders` wins and the automatic injection is
+     * skipped (consistent with the existing guard-clause behaviour on
+     * lines 318 / 326).
+     *
+     * Custom headers supplied at the call-site via the `init` argument
+     * of `makeRequest` take precedence over `requestHeaders`.
+     */
+    readonly requestHeaders?: Record<string, string>;
   }
 
   /**
@@ -268,6 +284,7 @@ namespace Private {
       appUrl: PageConfig.getOption('appUrl'),
       appendToken,
       serializer: { serialize, deserialize },
+      requestHeaders: {},
       ...options,
       baseUrl,
       wsUrl
@@ -307,18 +324,36 @@ namespace Private {
 
     const request = new settings.Request(url, { ...settings.init, ...init });
 
+    // Apply any custom headers configured on the settings object before
+    // the automatic auth headers so that callers can still override them
+    // via the per-request `init` argument (#5333).
+    if (settings.requestHeaders) {
+      for (const [key, value] of Object.entries(settings.requestHeaders)) {
+        if (!request.headers.has(key)) {
+          request.headers.set(key, value);
+        }
+      }
+    }
+
     // Handle authentication. Authentication can be overdetermined by
     // settings token and XSRF token.
+    // Only inject these if the caller has not already supplied a value,
+    // so that custom headers (e.g. a bearer token from an external
+    // identity provider) are not overwritten or duplicated (#5333).
     let authenticated = false;
     if (settings.token) {
       authenticated = true;
-      request.headers.append('Authorization', `token ${settings.token}`);
+      if (!request.headers.has('Authorization')) {
+        request.headers.append('Authorization', `token ${settings.token}`);
+      }
     }
     if (typeof document !== 'undefined') {
       const xsrfToken = getCookie('_xsrf');
       if (xsrfToken !== undefined) {
         authenticated = true;
-        request.headers.append('X-XSRFToken', xsrfToken);
+        if (!request.headers.has('X-XSRFToken')) {
+          request.headers.append('X-XSRFToken', xsrfToken);
+        }
       }
     }
 

--- a/packages/services/test/serverconnection-headers.spec.ts
+++ b/packages/services/test/serverconnection-headers.spec.ts
@@ -1,0 +1,109 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+/**
+ * Tests for custom header handling in ServerConnection.makeRequest (#5333).
+ *
+ * These tests live in a separate file to avoid the JupyterServer beforeAll/afterAll
+ * that the main serverconnection.spec.ts requires — header tests only need a
+ * mocked fetch, not a live kernel.
+ */
+
+import { ServerConnection } from '../src';
+
+describe('ServerConnection custom header handling (#5333)', () => {
+  it('should pass caller-supplied custom headers through to the request', async () => {
+    let capturedHeaders: Headers | undefined;
+    const settings = ServerConnection.makeSettings({
+      token: 'settings-token',
+      fetch: (input: RequestInfo) => {
+        capturedHeaders = (input as Request).headers;
+        return Promise.resolve(new Response('{}', { status: 200 }));
+      }
+    });
+    await ServerConnection.makeRequest(
+      settings.baseUrl + 'api/test',
+      {
+        method: 'GET',
+        headers: { 'X-Tenant-Id': '42' }
+      } as RequestInit,
+      settings
+    );
+    expect(capturedHeaders?.get('X-Tenant-Id')).toBe('42');
+    // The settings-provided Authorization should still be present.
+    expect(capturedHeaders?.get('Authorization')).toBe('token settings-token');
+  });
+
+  it('should not append settings token when caller supplies Authorization', async () => {
+    let capturedHeaders: Headers | undefined;
+    const settings = ServerConnection.makeSettings({
+      token: 'settings-token',
+      fetch: (input: RequestInfo) => {
+        capturedHeaders = (input as Request).headers;
+        return Promise.resolve(new Response('{}', { status: 200 }));
+      }
+    });
+    await ServerConnection.makeRequest(
+      settings.baseUrl + 'api/test',
+      {
+        method: 'GET',
+        headers: { Authorization: 'Bearer custom-token' }
+      } as RequestInit,
+      settings
+    );
+    // Caller's Authorization must win — only one value, not two appended.
+    expect(capturedHeaders?.get('Authorization')).toBe('Bearer custom-token');
+  });
+
+  it('should add settings token when caller does not supply Authorization', async () => {
+    let capturedHeaders: Headers | undefined;
+    const settings = ServerConnection.makeSettings({
+      token: 'settings-token',
+      fetch: (input: RequestInfo) => {
+        capturedHeaders = (input as Request).headers;
+        return Promise.resolve(new Response('{}', { status: 200 }));
+      }
+    });
+    await ServerConnection.makeRequest(
+      settings.baseUrl + 'api/test',
+      {},
+      settings
+    );
+    expect(capturedHeaders?.get('Authorization')).toBe('token settings-token');
+  });
+
+  it('should not append XSRF token when caller supplies X-XSRFToken', async () => {
+    let capturedHeaders: Headers | undefined;
+    const cookieDescriptor = Object.getOwnPropertyDescriptor(
+      document,
+      'cookie'
+    );
+    Object.defineProperty(document, 'cookie', {
+      get: () => '_xsrf=cookie-xsrf-token',
+      configurable: true
+    });
+    const settings = ServerConnection.makeSettings({
+      token: '',
+      fetch: (input: RequestInfo) => {
+        capturedHeaders = (input as Request).headers;
+        return Promise.resolve(new Response('{}', { status: 200 }));
+      }
+    });
+    await ServerConnection.makeRequest(
+      settings.baseUrl + 'api/test',
+      {
+        method: 'POST',
+        headers: { 'X-XSRFToken': 'caller-xsrf-token' }
+      } as RequestInit,
+      settings
+    );
+    // Caller's XSRF token must win — only one value, not two appended.
+    expect(capturedHeaders?.get('X-XSRFToken')).toBe('caller-xsrf-token');
+    // Restore cookie descriptor.
+    if (cookieDescriptor) {
+      Object.defineProperty(document, 'cookie', cookieDescriptor);
+    } else {
+      delete (document as { cookie?: string }).cookie;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`ServerConnection.makeSettings` now accepts an optional `requestHeaders?: Record<string, string>` field on
`ISettings`. These headers are merged into every `makeRequest` call before the automatic `Authorization` and
`X-XSRFToken` injection so that callers can attach custom headers (e.g. tenant ids, additional bearer tokens)
to all server traffic without touching `init.headers` on every call site.

A caller's per-request `init.headers` still wins over `requestHeaders`. Likewise, a `requestHeaders` value for
`Authorization` or `X-XSRFToken` wins over the `settings.token` / XSRF automatic injection, so callers can rotate
credentials (e.g. swap to an external IdP token) without leaving stale token-bearing requests behind.

### Files

- `packages/services/src/serverconnection.ts` — `ISettings.requestHeaders` field + guarded merge in `handleRequest`
  (+39 / -2 lines).
- `packages/services/test/serverconnection-headers.spec.ts` — new file with 4 dedicated tests (+109 lines).
  This file lives separately from `serverconnection.spec.ts` to avoid the existing `JupyterServer` fixture in
  that suite — the header tests only need a mocked `fetch`.

## Verified

- `jest packages/services/test/serverconnection-headers.spec.ts --config=packages/services/jest.config.js`
  passes **4 / 4**:

  - `should pass caller-supplied custom headers through to the request`
  - `should not append settings token when caller supplies Authorization`
  - `should add settings token when caller does not supply Authorization`
  - `should not append XSRF token when caller supplies X-XSRFToken`

- `tsc -b packages/services --noEmit` is clean with respect to the changed files (the project itself emits
  `TS6310: Referenced project ... may not disable emit` warnings about `coreutils`, `nbformat`, `settingregistry`,
  and `statedb`, which are unrelated project-reference config diagnostics present on `main`).

## Not verified (limitations of the verification environment)

- Live Jupyter server integration tests under `packages/services/test/contents/` are skipped here — those
  fixtures fail on this host with a pre-existing Windows + OneDrive `EPERM` symlink error in
  `jupyter_core.paths.is_hidden`, not caused by this change. Maintainers' CI on Linux will exercise them.
- I did not run `yarn run integrity` because it depends on `fs.symlinkSync` which fails on Windows + OneDrive
  for the same EPERM reason. Nothing about this change touches symlinks.

Closes #5333
