### PR TITLE
cells: expose data-jp-cell-id and data-jp-tags on cell DOM nodes

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -193,6 +193,10 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
     this.addClass(CELL_CLASS);
     const model = (this._model = options.model);
 
+    // Surface the cell id on the DOM node so that tests and automation can
+    // target a specific cell unambiguously (#8298).
+    this.node.dataset.jpCellId = model.id;
+
     this.contentFactory = options.contentFactory;
     this.layout = options.layout ?? new PanelLayout();
     // Set up translator for aria labels
@@ -207,6 +211,9 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
     this.placeholder = options.placeholder ?? true;
 
     model.metadataChanged.connect(this.onMetadataChanged, this);
+
+    // Reflect any tags already present on the model onto the DOM (#8298).
+    this._syncTags();
   }
 
   /**
@@ -716,8 +723,29 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
           this.loadEditableState();
         }
         break;
+      case 'tags':
+        this._syncTags();
+        break;
       default:
         break;
+    }
+  }
+
+  /**
+   * Reflect the cell `tags` metadata onto the DOM as a `data-jp-tags`
+   * attribute, so that tests and CSS selectors can target tagged cells.
+   *
+   * #### Notes
+   * The attribute is removed entirely when the cell has no tags, rather than
+   * left empty, to match the convention used by other `data-jp-*` attributes
+   * and to keep `[data-jp-tags]` selectors meaningful.
+   */
+  private _syncTags(): void {
+    const tags = this._model.getMetadata('tags') as string[] | undefined;
+    if (tags && tags.length > 0) {
+      this.node.dataset.jpTags = tags.join(' ');
+    } else {
+      delete this.node.dataset.jpTags;
     }
   }
 

--- a/packages/cells/test/widget.spec.ts
+++ b/packages/cells/test/widget.spec.ts
@@ -484,6 +484,92 @@ describe('cells/widget', () => {
       });
     });
 
+    describe('#dataset attributes (#8298)', () => {
+      it('should expose the cell id on the DOM node', () => {
+        const cellModel = new CodeCellModel({
+          sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
+        });
+        const widget = new Cell({
+          contentFactory: NBTestUtils.createBaseCellFactory(),
+          model: cellModel
+        }).initializeState();
+
+        expect(widget.node.dataset.jpCellId).toBe(cellModel.id);
+      });
+
+      it('should not set a tags attribute when the cell has no tags', () => {
+        const cellModel = new CodeCellModel({
+          sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
+        });
+        const widget = new Cell({
+          contentFactory: NBTestUtils.createBaseCellFactory(),
+          model: cellModel
+        }).initializeState();
+
+        expect(widget.node.dataset.jpTags).toBeUndefined();
+      });
+
+      it('should reflect tags onto the DOM when set through metadata', () => {
+        const cellModel = new CodeCellModel({
+          sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
+        });
+        const widget = new Cell({
+          contentFactory: NBTestUtils.createBaseCellFactory(),
+          model: cellModel
+        }).initializeState();
+
+        cellModel.setMetadata('tags', ['parameters', 'hide-input']);
+
+        expect(widget.node.dataset.jpTags).toBe('parameters hide-input');
+      });
+
+      it('should update the tags attribute when tags change', () => {
+        const cellModel = new CodeCellModel({
+          sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
+        });
+        const widget = new Cell({
+          contentFactory: NBTestUtils.createBaseCellFactory(),
+          model: cellModel
+        }).initializeState();
+
+        cellModel.setMetadata('tags', ['a']);
+        expect(widget.node.dataset.jpTags).toBe('a');
+
+        cellModel.setMetadata('tags', ['a', 'b', 'c']);
+        expect(widget.node.dataset.jpTags).toBe('a b c');
+      });
+
+      it('should remove the tags attribute when tags are cleared', () => {
+        const cellModel = new CodeCellModel({
+          sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
+        });
+        const widget = new Cell({
+          contentFactory: NBTestUtils.createBaseCellFactory(),
+          model: cellModel
+        }).initializeState();
+
+        cellModel.setMetadata('tags', ['a']);
+        expect(widget.node.dataset.jpTags).toBe('a');
+
+        cellModel.setMetadata('tags', []);
+        expect(widget.node.dataset.jpTags).toBeUndefined();
+      });
+
+      it('should reflect tags present at construction time', () => {
+        const sharedModel = createStandaloneCell({
+          cell_type: 'code'
+        }) as YCodeCell;
+        sharedModel.setMetadata('tags', ['pre-existing']);
+        const cellModel = new CodeCellModel({ sharedModel });
+        const widget = new Cell({
+          contentFactory: NBTestUtils.createBaseCellFactory(),
+          model: cellModel
+        }).initializeState();
+
+        expect(widget.node.dataset.jpTags).toBe('pre-existing');
+      });
+    });
+
     describe('.ContentFactory', () => {
       describe('#constructor', () => {
         it('should create a ContentFactory', () => {


### PR DESCRIPTION
## Summary

`Cell` now reflects two pieces of cell state into DOM data attributes so that extensions, themes, and
end-to-end tests can target cells unambiguously:

- `data-jp-cell-id` — the cell model's `id`, set once in the constructor.
- `data-jp-tags` — the cell model's `tags` metadata, kept in sync on `onMetadataChanged('tags')` and at
  construction time.

Datasets are written via `this.node.dataset.jpCellId` / `this.node.dataset.jpTags`, which the DOM serialises
to the `data-jp-cell-id` / `data-jp-tags` attributes you see on the rendered cell. The `data-jp-tags`
attribute is removed (not set to `""`) when the cell has no tags, so `[data-jp-tags]` selectors remain
meaningful.

### Files

- `packages/cells/src/widget.ts` — `Cell` constructor + `onMetadataChanged` switch + `_syncTags()` (+28 lines).
- `packages/cells/test/widget.spec.ts` — new `describe('#dataset attributes (#8298)')` block with 6 cases
  (+86 lines).

## Verified

- `jest packages/cells/test/widget.spec.ts -t dataset --config=packages/cells/jest.config.js` passes **6 / 6**:

  - `should expose the cell id on the DOM node`
  - `should not set a tags attribute when the cell has no tags`
  - `should reflect tags onto the DOM when set through metadata`
  - `should update the tags attribute when tags change`
  - `should remove the tags attribute when tags are cleared`
  - `should reflect tags present at construction time`

  (67 unrelated cases in the same file are correctly skipped under `-t dataset`.)

- `tsc -b packages/cells --noEmit` is clean for the changed files.

## Not verified

- A full run of `packages/cells/test/widget.spec.ts` (73 cases) was not completed in this verification
  environment due to a per-suite timeout, but every touched code path is covered by the dataset-test
  block above, and the file is widely exercised on maintainer CI on Linux.

Closes #8298
