### PR TITLE
package.json: add repository.directory to monorepo packages

### DIFF
--- a/buildutils/src/create-package.ts
+++ b/buildutils/src/create-package.ts
@@ -38,6 +38,10 @@ void import('inquirer')
     }
     data.name = name;
     data.description = description;
+    // Set the repository directory for monorepo npm metadata (#6443).
+    if (data.repository) {
+      data.repository.directory = `packages/${answers.name}`;
+    }
     utils.writePackageData(jsonPath, data);
 
     // Add the launch file to git.

--- a/buildutils/template/package.json
+++ b/buildutils/template/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/PACKAGENAME"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/application-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/application"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/apputils-extension/package.json
+++ b/packages/apputils-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/apputils-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/apputils"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/attachments"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/audio-extension/package.json
+++ b/packages/audio-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/audio-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/cell-toolbar-extension/package.json
+++ b/packages/cell-toolbar-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/cell-toolbar-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/cell-toolbar/package.json
+++ b/packages/cell-toolbar/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/cell-toolbar"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/cells"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/celltags-extension/package.json
+++ b/packages/celltags-extension/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/celltags-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/codeeditor"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/codemirror-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/codemirror"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/completer-extension/package.json
+++ b/packages/completer-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/completer-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/completer"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/console-extension/package.json
+++ b/packages/console-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/console-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/console"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/core-meta/package.json
+++ b/packages/core-meta/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/core-meta"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/coreutils"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/csvviewer-extension/package.json
+++ b/packages/csvviewer-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/csvviewer-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/csvviewer/package.json
+++ b/packages/csvviewer/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/csvviewer"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/debugger-extension/package.json
+++ b/packages/debugger-extension/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/debugger-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/debugger"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/docmanager-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/docmanager/package.json
+++ b/packages/docmanager/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/docmanager"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/docregistry"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/documentsearch-extension/package.json
+++ b/packages/documentsearch-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/documentsearch-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/documentsearch/package.json
+++ b/packages/documentsearch/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/documentsearch"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/extensionmanager-extension/package.json
+++ b/packages/extensionmanager-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/extensionmanager-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/extensionmanager/package.json
+++ b/packages/extensionmanager/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/extensionmanager"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/filebrowser-extension/package.json
+++ b/packages/filebrowser-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/filebrowser-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/filebrowser"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/fileeditor-extension/package.json
+++ b/packages/fileeditor-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/fileeditor-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/fileeditor/package.json
+++ b/packages/fileeditor/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/fileeditor"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/help-extension/package.json
+++ b/packages/help-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/help-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/htmlviewer-extension/package.json
+++ b/packages/htmlviewer-extension/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/htmlviewer-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter Contributors",

--- a/packages/htmlviewer/package.json
+++ b/packages/htmlviewer/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/htmlviewer"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/hub-extension/package.json
+++ b/packages/hub-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/hub-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/imageviewer-extension/package.json
+++ b/packages/imageviewer-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/imageviewer-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/imageviewer/package.json
+++ b/packages/imageviewer/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/imageviewer"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/inspector-extension/package.json
+++ b/packages/inspector-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/inspector-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/inspector"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/javascript-extension/package.json
+++ b/packages/javascript-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/javascript-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/json-extension/package.json
+++ b/packages/json-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/json-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/launcher-extension/package.json
+++ b/packages/launcher-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/launcher-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/launcher"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/logconsole-extension/package.json
+++ b/packages/logconsole-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/logconsole-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/logconsole/package.json
+++ b/packages/logconsole/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/logconsole"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/lsp-extension/package.json
+++ b/packages/lsp-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/lsp-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/lsp/package.json
+++ b/packages/lsp/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/lsp"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/mainmenu-extension/package.json
+++ b/packages/mainmenu-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/mainmenu-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/mainmenu/package.json
+++ b/packages/mainmenu/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/mainmenu"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/markdownviewer-extension/package.json
+++ b/packages/markdownviewer-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/markdownviewer-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/markdownviewer/package.json
+++ b/packages/markdownviewer/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/markdownviewer"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/markedparser-extension/package.json
+++ b/packages/markedparser-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/markedparser-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/mathjax-extension/package.json
+++ b/packages/mathjax-extension/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/mathjax-extension"
   },
   "license": "BSD-3-Clause",
   "author": {

--- a/packages/mermaid-extension/package.json
+++ b/packages/mermaid-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/mermaid-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/mermaid"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/metadataform-extension/package.json
+++ b/packages/metadataform-extension/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/metadataform-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/metadataform/package.json
+++ b/packages/metadataform/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/metadataform"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/metapackage"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/nbconvert-css/package.json
+++ b/packages/nbconvert-css/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/nbconvert-css"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/nbformat/package.json
+++ b/packages/nbformat/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/nbformat"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/notebook-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/notebook"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/observables/package.json
+++ b/packages/observables/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/observables"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/outputarea/package.json
+++ b/packages/outputarea/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/outputarea"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/pdf-extension/package.json
+++ b/packages/pdf-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/pdf-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/pluginmanager-extension/package.json
+++ b/packages/pluginmanager-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/pluginmanager-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/pluginmanager/package.json
+++ b/packages/pluginmanager/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/pluginmanager"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/property-inspector/package.json
+++ b/packages/property-inspector/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/property-inspector"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/rendermime-extension/package.json
+++ b/packages/rendermime-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/rendermime-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/rendermime-interfaces/package.json
+++ b/packages/rendermime-interfaces/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/rendermime-interfaces"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/rendermime"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/running-extension/package.json
+++ b/packages/running-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/running-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/running/package.json
+++ b/packages/running/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/running"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/services-extension/package.json
+++ b/packages/services-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/services-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab"
+    "url": "https://github.com/jupyterlab/jupyterlab",
+    "directory": "packages/services"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/settingeditor-extension/package.json
+++ b/packages/settingeditor-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/settingeditor-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/settingeditor/package.json
+++ b/packages/settingeditor/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/settingeditor"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/settingregistry/package.json
+++ b/packages/settingregistry/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/settingregistry"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/shortcuts-extension/package.json
+++ b/packages/shortcuts-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/shortcuts-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/statedb/package.json
+++ b/packages/statedb/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/statedb"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/statusbar-extension/package.json
+++ b/packages/statusbar-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/statusbar-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter, Richa Gadgil, Takahiro Shimokobe, Declan Kelly",

--- a/packages/statusbar/package.json
+++ b/packages/statusbar/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/statusbar"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/terminal-extension/package.json
+++ b/packages/terminal-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/terminal-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/terminal"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/testing"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/theme-dark-extension/package.json
+++ b/packages/theme-dark-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/theme-dark-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/theme-dark-high-contrast-extension/package.json
+++ b/packages/theme-dark-high-contrast-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/theme-dark-high-contrast-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/theme-light-extension/package.json
+++ b/packages/theme-light-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/theme-light-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/toc-extension/package.json
+++ b/packages/toc-extension/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/toc-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/toc/package.json
+++ b/packages/toc/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/toc"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/tooltip-extension/package.json
+++ b/packages/tooltip-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/tooltip-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/tooltip"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/translation-extension/package.json
+++ b/packages/translation-extension/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/translation-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/translation/package.json
+++ b/packages/translation/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/translation"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/ui-components-extension/package.json
+++ b/packages/ui-components-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/ui-components-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/ui-components"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/vega5-extension/package.json
+++ b/packages/vega5-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/vega5-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/video-extension/package.json
+++ b/packages/video-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/video-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/workspaces-extension/package.json
+++ b/packages/workspaces-extension/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/workspaces-extension"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/workspaces/package.json
+++ b/packages/workspaces/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
+    "url": "https://github.com/jupyterlab/jupyterlab.git",
+    "directory": "packages/workspaces"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",


### PR DESCRIPTION
## Summary

This PR fills in the [recommended][npm-repo] npm field: `repository.directory` on every `package.json` in
the monorepo. Without it, when someone clicks "View package on npm" or installs-from-tarball links from
`package.json`'s `repository.url`, the browser / tooling cannot resolve from the monorepo root to the
sub-package's source files in `packages/<name>/`.

[npm-repo]: https://docs.npmjs.com/files/package.json#repository

It also teaches `create-package.ts` to set the field at scaffold time so any future `packages/<new>/` will
inherit the correct metadata automatically.

### Files

- `buildutils/src/create-package.ts` — adds `data.repository.directory = `packages/${answers.name}`` after
  the existing `data.name` / `data.description` assignment in the `void import('inquirer')` block (+4 lines).
- `buildutils/template/package.json` — adds the same field, with the literal `packages/PACKAGENAME` placeholder
  (+1 line). `create-package.ts` substitutes `PACKAGENAME` at scaffold time.
- 103 existing `packages/<name>/package.json` files — each gains `"directory": "packages/<name>"`. The
  `repository.url` is preserved verbatim; only the `directory` field is added.

## Verified

- All 104 touched `*.json` files parse cleanly with `json.load`.
- `repository.directory` is set on every `packages/<name>/package.json`; spot checks on `observables`,
  `rendermime-interfaces`, `nbconvert-css`, `notebook-extension`, `services` all confirm
  `{"type": "git", "url": "https://github.com/jupyterlab/jupyterlab(.git)?", "directory": "packages/<name>"}`.
- The `buildutils/template/package.json` field uses the literal `packages/PACKAGENAME` placeholder, which is
  the in-tree convention for the scaffold template and is substituted by `create-package.ts` when a new
  package is added.
- The `create-package.ts` change adds the assignment under an `if (data.repository)` guard, so existing
  templates without a `repository` block continue to work.

## Not verified

- `yarn run integrity` was not run here — it depends on `fs.symlinkSync` for `node_modules/.bin/*` shims, which
  fails on Windows + OneDrive hosts with `EPERM`. This is a host-environment blocker, not a code change; the
  same EPERM also reproduces on a clean checkout of `main`. Maintainers running this on a Linux CI host will
  exercise `ensureRepo()` as part of their normal PR flow; the diff does not touch any of the symlink code.

Closes #6443
