### PR TITLE
Handle invalid file browser drag target

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -2157,6 +2157,10 @@ export class DirListing extends Widget {
       dropTarget.classList.remove(DROP_TARGET_CLASS);
     }
     const index = Private.hitTestNodes(this._items, event);
+    if (index === -1 || index >= this._items.length) {
+      event.dropAction = 'none';
+      return;
+    }
     this._items[index].classList.add(DROP_TARGET_CLASS);
   }
 


### PR DESCRIPTION
## References

Fixes #19115.

This PR fixes a console error when dragging a tab over the File Browser after moving the File Browser to the main area.

`evtDragOver` assumed that `Private.hitTestNodes()` always returned a valid file browser item index. When the drag event occurred outside a valid item row, the index could be invalid, causing `this._items[index]` to be `undefined` and throwing when accessing `classList`.

## Code changes

Adds a guard in `DirListing.evtDragOver` to handle invalid drag targets.

If `Private.hitTestNodes()` does not return a valid file browser item index, the drag action is set to `none` and the handler returns early. Valid drag targets continue to use the existing behavior.

## User-facing changes

Users should no longer see the following console error when dragging a tab over the File Browser after moving it to the main area:

```text
Cannot read properties of undefined (reading 'classList')
```
## Backwards-incompatible changes

None.

## Testing
Reproduced the issue by moving File Browser to the main area and dragging another tab over it.
Verified that the console no longer shows Cannot read properties of undefined (reading 'classList').

```
Ran git diff --check.
Ran jlpm prettier:check packages/filebrowser/src/listing.ts.
Ran jlpm build.
Pre-commit hooks passed, including prettier and eslint.
```
## AI usage
YES: Some or all of the content of this PR was generated by AI.
YES: The human author has carefully reviewed this PR and run this code.
AI tools and models used: ChatGPT