### PR TITLE
docs: mention extensions-in-dev-mode near dev-mode instructions

### DIFF
--- a/docs/source/developer/contributing.md
+++ b/docs/source/developer/contributing.md
@@ -499,9 +499,17 @@ jupyter lab --dev-mode
 ```
 
 Development mode ensures that you are running the JavaScript assets that
-are built in the dev-installed Python package. Note that when running in
-dev mode, extensions will not be activated by default - refer
-{ref}`documentation on extension development <prebuilt-dev-workflow>` to know more.
+are built in the dev-installed Python package. By default, extensions
+from labextension paths are not activated in dev mode. If you are testing
+changes to an extension package in `packages/`, you may need to start
+JupyterLab with:
+
+```bash
+jupyter lab --dev-mode --extensions-in-dev-mode
+```
+
+See {ref}`documentation on extension development <prebuilt-dev-workflow>`
+for more details.
 
 When running in dev mode, a red stripe will appear at the top of the
 page; this is to indicate running an unreleased version.


### PR DESCRIPTION
## References

Closes #17420.

## Code changes

Adds a short note near the contributor `--dev-mode` instructions explaining that labextension-path extensions are not activated by default in dev mode, and points contributors testing extension-package changes in `packages/` to:

```bash
jupyter lab --dev-mode --extensions-in-dev-mode
```

The existing cross-reference to the extension development workflow is kept for details.

## User-facing changes

Documentation-only change for contributors developing JupyterLab from source.

## Backwards-incompatible changes

None.

## Validation

- `git diff --check origin/main...HEAD` passed.
- `python -m pytest --check-links docs/source/developer/contributing.md` passed: 58 passed, 1 warning. A temporary local server was started on port 8000 for existing `http://localhost:8000/` links in the page.
- `docs/make.bat html` was attempted after installing the docs dependencies, but timed out after 10 minutes while building the TypeScript/API docs (`@jupyterlab/metapackage tsc -b`), not while parsing the changed Markdown.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has reviewed this docs-only change.
- AI tools and models used: Codex GPT-5.5. AI assistance was primarily used to smooth the documentation wording for English readability; the change was reviewed locally and kept limited to the documented `--extensions-in-dev-mode` behavior.