### PR TITLE
Move `SettingConnector` to `@jupyterlab/settingregistry` and export it

### DIFF
--- a/packages/apputils-extension/src/settingconnector.ts
+++ b/packages/apputils-extension/src/settingconnector.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+export {
+  /**
+   * @deprecated The setting connector is now in the settingregistry package. Import from '@jupyterlab/settingregistry' instead.
+   * Use: import { SettingConnector } from '@jupyterlab/settingregistry';
+   */
+  SettingConnector
+} from '@jupyterlab/settingregistry';

--- a/packages/apputils-extension/src/settingsplugin.ts
+++ b/packages/apputils-extension/src/settingsplugin.ts
@@ -11,9 +11,9 @@ import { PageConfig } from '@jupyterlab/coreutils';
 import {
   ISettingConnector,
   ISettingRegistry,
+  SettingConnector,
   SettingRegistry
 } from '@jupyterlab/settingregistry';
-import { SettingConnector } from './settingconnector';
 
 /**
  * Provides the settings connector as a separate plugin to allow for alternative

--- a/packages/settingregistry/package.json
+++ b/packages/settingregistry/package.json
@@ -36,11 +36,13 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
+    "@jupyterlab/coreutils": "^6.7.0-alpha.0",
     "@jupyterlab/nbformat": "^4.7.0-alpha.0",
     "@jupyterlab/statedb": "^4.7.0-alpha.0",
     "@lumino/commands": "^2.3.4",
     "@lumino/coreutils": "^2.2.3",
     "@lumino/disposable": "^2.1.6",
+    "@lumino/polling": "^2.1.6",
     "@lumino/signaling": "^2.1.6",
     "@rjsf/utils": "^5.13.4",
     "ajv": "^8.12.0",

--- a/packages/settingregistry/src/index.ts
+++ b/packages/settingregistry/src/index.ts
@@ -7,5 +7,6 @@
  * @module settingregistry
  */
 
+export * from './settingconnector';
 export * from './settingregistry';
 export * from './tokens';

--- a/packages/settingregistry/src/settingconnector.ts
+++ b/packages/settingregistry/src/settingconnector.ts
@@ -4,13 +4,10 @@
  */
 
 import { PageConfig } from '@jupyterlab/coreutils';
-import type {
-  ISettingConnector,
-  ISettingRegistry
-} from '@jupyterlab/settingregistry';
 import type { IDataConnector } from '@jupyterlab/statedb';
 import { DataConnector } from '@jupyterlab/statedb';
 import { Throttler } from '@lumino/polling';
+import type { ISettingConnector, ISettingRegistry } from './tokens';
 
 /**
  * A data connector for fetching settings.

--- a/packages/settingregistry/test/settingconnector.spec.ts
+++ b/packages/settingregistry/test/settingconnector.spec.ts
@@ -1,0 +1,110 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import type { ISettingRegistry } from '@jupyterlab/settingregistry';
+import { SettingConnector } from '@jupyterlab/settingregistry';
+import { DataConnector } from '@jupyterlab/statedb';
+
+class TestConnector extends DataConnector<ISettingRegistry.IPlugin, string> {
+  fetchCalls: string[] = [];
+  listCalls: (string | undefined)[] = [];
+  saveCalls: [string, string][] = [];
+  plugins: ISettingRegistry.IPlugin[] = [];
+
+  async fetch(id: string): Promise<ISettingRegistry.IPlugin | undefined> {
+    this.fetchCalls.push(id);
+    return this.plugins.find(plugin => plugin.id === id);
+  }
+
+  async list(
+    query?: string
+  ): Promise<{ ids: string[]; values: ISettingRegistry.IPlugin[] }> {
+    this.listCalls.push(query);
+    return {
+      ids: this.plugins.map(plugin => plugin.id),
+      values: this.plugins
+    };
+  }
+
+  async save(id: string, raw: string): Promise<void> {
+    this.saveCalls.push([id, raw]);
+  }
+}
+
+function makePlugin(id: string): ISettingRegistry.IPlugin {
+  return {
+    id,
+    data: { composite: {}, user: {} },
+    raw: '{}',
+    schema: { type: 'object' },
+    version: 'test'
+  };
+}
+
+describe('@jupyterlab/settingregistry', () => {
+  describe('SettingConnector', () => {
+    let testConnector: TestConnector;
+    let connector: SettingConnector;
+
+    beforeEach(() => {
+      testConnector = new TestConnector();
+      testConnector.plugins = [makePlugin('foo:bar'), makePlugin('baz:qux')];
+      connector = new SettingConnector(testConnector);
+    });
+
+    describe('#fetch()', () => {
+      it('should fetch a plugin from the underlying connector', async () => {
+        const plugin = await connector.fetch('foo:bar');
+        expect(plugin?.id).toBe('foo:bar');
+        expect(testConnector.fetchCalls).toEqual(['foo:bar']);
+      });
+
+      it('should return undefined for a missing plugin', async () => {
+        const plugin = await connector.fetch('does-not:exist');
+        expect(plugin).toBeUndefined();
+      });
+
+      it('should throttle concurrent requests for the same plugin', async () => {
+        const plugins = await Promise.all([
+          connector.fetch('foo:bar'),
+          connector.fetch('foo:bar')
+        ]);
+        expect(plugins.map(plugin => plugin?.id)).toEqual([
+          'foo:bar',
+          'foo:bar'
+        ]);
+        expect(testConnector.fetchCalls).toEqual(['foo:bar']);
+      });
+    });
+
+    describe('#list()', () => {
+      it('should list all plugins for the "all" query', async () => {
+        const { ids, values } = await connector.list('all');
+        expect(ids).toEqual(['foo:bar', 'baz:qux']);
+        expect(values.map(plugin => plugin.id)).toEqual(['foo:bar', 'baz:qux']);
+      });
+
+      it('should list only the plugin ids for the "ids" query', async () => {
+        const result = await connector.list('ids');
+        expect(result.ids).toEqual(['foo:bar', 'baz:qux']);
+        expect(result).not.toHaveProperty('values');
+        expect(testConnector.listCalls).toEqual(['ids']);
+      });
+
+      it('should list the active plugins', async () => {
+        const { ids, values } = await connector.list('active');
+        expect(ids).toEqual(['foo:bar', 'baz:qux']);
+        expect(values.map(plugin => plugin.id)).toEqual(['foo:bar', 'baz:qux']);
+      });
+    });
+
+    describe('#save()', () => {
+      it('should delegate to the underlying connector', async () => {
+        await connector.save('foo:bar', '{ "flag": true }');
+        expect(testConnector.saveCalls).toEqual([
+          ['foo:bar', '{ "flag": true }']
+        ]);
+      });
+    });
+  });
+});

--- a/packages/settingregistry/tsconfig.json
+++ b/packages/settingregistry/tsconfig.json
@@ -8,6 +8,9 @@
   "include": ["src/*"],
   "references": [
     {
+      "path": "../coreutils"
+    },
+    {
       "path": "../nbformat"
     },
     {

--- a/packages/settingregistry/tsconfig.test.json
+++ b/packages/settingregistry/tsconfig.test.json
@@ -3,6 +3,9 @@
   "include": ["src/*", "test/*"],
   "references": [
     {
+      "path": "../coreutils"
+    },
+    {
       "path": "../nbformat"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4864,12 +4864,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlab/settingregistry@workspace:packages/settingregistry"
   dependencies:
+    "@jupyterlab/coreutils": ^6.7.0-alpha.0
     "@jupyterlab/nbformat": ^4.7.0-alpha.0
     "@jupyterlab/statedb": ^4.7.0-alpha.0
     "@jupyterlab/testing": ^4.7.0-alpha.0
     "@lumino/commands": ^2.3.4
     "@lumino/coreutils": ^2.2.3
     "@lumino/disposable": ^2.1.6
+    "@lumino/polling": ^2.1.6
     "@lumino/signaling": ^2.1.6
     "@rjsf/utils": ^5.13.4
     "@types/jest": ^29.2.0


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

This should help downstreams like Notebook reuse the JupyterLab implementation more easily.

As noticed in https://github.com/jupyter/notebook/pull/7713#discussion_r3538132236

## Code changes

- [x] Move `SettingConnector` to `@jupyterlab/settingregistry` and export it
- [x] Test

## User-facing changes

None

## Backwards-incompatible changes

None (`SettingConnector` was not "properly" exported from `@jupyterlab/apputils-extension`)

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude
