### PR TITLE
Enable nullable-number strict boolean linting

### DIFF
--- a/eslint.config.typecheck.mjs
+++ b/eslint.config.typecheck.mjs
@@ -6,6 +6,33 @@
 import baseConfig from './eslint.config.mjs';
 import tseslint from 'typescript-eslint';
 
+const strictBooleanExpressionsRule =
+  tseslint.plugin.rules['strict-boolean-expressions'];
+
+// The upstream rule cannot be configured to report only nullable numbers: even
+// with every allow* option enabled, it still reports always-truthy objects and
+// other non-number conditions. Filter its reports for the staged rollout.
+const strictBooleanNullableNumberRule = {
+  ...strictBooleanExpressionsRule,
+  create(context) {
+    const filteredContext = Object.create(context);
+    Object.defineProperty(filteredContext, 'report', {
+      value: (...args) => {
+        const descriptor = args[0];
+        if (
+          descriptor &&
+          typeof descriptor === 'object' &&
+          descriptor.messageId === 'conditionErrorNullableNumber'
+        ) {
+          return context.report(...args);
+        }
+      }
+    });
+
+    return strictBooleanExpressionsRule.create(filteredContext);
+  }
+};
+
 export default [
   ...baseConfig,
   {
@@ -14,12 +41,30 @@ export default [
       parser: tseslint.parser
     },
     plugins: {
-      '@typescript-eslint': tseslint.plugin
+      '@typescript-eslint': tseslint.plugin,
+      jupyterlab: {
+        rules: {
+          'strict-boolean-nullable-number': strictBooleanNullableNumberRule
+        }
+      }
     },
     rules: {
       '@typescript-eslint/no-floating-promises': [
         'error',
         { ignoreVoid: true }
+      ],
+      'jupyterlab/strict-boolean-nullable-number': [
+        'warn',
+        {
+          allowAny: true,
+          allowNullableBoolean: true,
+          allowNullableEnum: true,
+          allowNullableNumber: false,
+          allowNullableObject: true,
+          allowNullableString: true,
+          allowNumber: true,
+          allowString: true
+        }
       ],
       'jest/no-done-callback': 'off'
     }

--- a/galata/extension/src/global.ts
+++ b/galata/extension/src/global.ts
@@ -216,7 +216,7 @@ export class GalataInpage implements IGalataInpage {
       const check = async () => {
         checkTimer = null;
         if (await Promise.resolve(fn())) {
-          if (timeoutTimer) {
+          if (timeoutTimer !== null) {
             clearTimeout(timeoutTimer);
           }
           resolve();
@@ -227,10 +227,10 @@ export class GalataInpage implements IGalataInpage {
 
       void check();
 
-      if (timeout) {
+      if (timeout !== undefined && timeout !== 0) {
         timeoutTimer = window.setTimeout(() => {
           timeoutTimer = null;
-          if (checkTimer) {
+          if (checkTimer !== null) {
             clearTimeout(checkTimer);
           }
           reject(new Error('Timed out waiting for condition to be fulfilled.'));

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -1323,7 +1323,9 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     // Rehydrate the down area
     if (downArea) {
       const { currentWidget, widgets, size } = downArea;
-      const collapsed = downArea.collapsed ?? !size;
+      const collapsed =
+        downArea.collapsed ??
+        (size === undefined || size === null || size === 0);
 
       const widgetIds = widgets?.map(widget => widget.id) ?? [];
       const otherAreaWidgetIds = new Set<string>();
@@ -1390,12 +1392,18 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
         }
       }
 
-      if (!collapsed && widgets?.length && size && size > 0.0) {
+      if (
+        !collapsed &&
+        (widgets?.length ?? 0) > 0 &&
+        size !== undefined &&
+        size !== null &&
+        size > 0.0
+      ) {
         this._showDownPanel(size);
         this._downPanel.currentWidget?.activate();
       } else {
         this._hideDownPanel();
-        if (size && size > 0.0) {
+        if (size !== undefined && size !== null && size > 0.0) {
           // Remember the saved size so a later expand restores the user's
           // previous height. `_hideDownPanel` seeds `_lastDownAreaSize`
           // from the current splitter, which at cold startup reflects the

--- a/packages/apputils/src/clipboard.ts
+++ b/packages/apputils/src/clipboard.ts
@@ -75,7 +75,7 @@ export namespace Clipboard {
 
     // Save the current selection.
     const savedRanges: any[] = [];
-    for (let i = 0, len = sel?.rangeCount || 0; i < len; ++i) {
+    for (let i = 0, len = sel?.rangeCount ?? 0; i < len; ++i) {
       savedRanges[i] = sel!.getRangeAt(i).cloneRange();
     }
 

--- a/packages/apputils/src/inputdialog.ts
+++ b/packages/apputils/src/inputdialog.ts
@@ -381,7 +381,8 @@ class InputNumberDialog extends InputDialogBase<number> {
     super(options);
 
     this._input.type = 'number';
-    this._input.value = options.value ? options.value.toString() : '0';
+    this._input.value =
+      options.value !== undefined ? options.value.toString() : '0';
   }
 
   /**

--- a/packages/apputils/src/licenses.tsx
+++ b/packages/apputils/src/licenses.tsx
@@ -372,7 +372,7 @@ export namespace Licenses {
       if (options.packageFilter) {
         this._packageFilter = options.packageFilter;
       }
-      if (options.currentPackageIndex) {
+      if (options.currentPackageIndex !== undefined) {
         this._currentPackageIndex = options.currentPackageIndex;
       }
     }

--- a/packages/cell-toolbar/src/celltoolbartracker.ts
+++ b/packages/cell-toolbar/src/celltoolbartracker.ts
@@ -476,7 +476,7 @@ export class CellToolbarTracker implements IDisposable {
   }
 
   private _cellToolbarLeft(activeCell: Cell<ICellModel>): number | null {
-    return this._cellToolbarRect(activeCell)?.left || null;
+    return this._cellToolbarRect(activeCell)?.left ?? null;
   }
 
   private _enabled: boolean;

--- a/packages/cells/src/celldragutils.ts
+++ b/packages/cells/src/celldragutils.ts
@@ -146,7 +146,7 @@ export namespace CellDragUtils {
       const executionCount = (activeCell.model as ICodeCellModel)
         .executionCount;
       promptNumber = ' ';
-      if (executionCount) {
+      if (executionCount !== null) {
         promptNumber = executionCount.toString();
       }
     } else {

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -659,10 +659,10 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
    * The execution count of the cell.
    */
   get executionCount(): nbformat.ExecutionCount {
-    return this.sharedModel.execution_count || null;
+    return this.sharedModel.execution_count ?? null;
   }
   set executionCount(newValue: nbformat.ExecutionCount) {
-    this.sharedModel.execution_count = newValue || null;
+    this.sharedModel.execution_count = newValue ?? null;
   }
 
   /**

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1695,7 +1695,7 @@ export class CodeCell extends Cell<ICodeCellModel> {
     if (this.model.executionState == 'running') {
       prompt = '*';
     } else {
-      prompt = `${this.model.executionCount || ''}`;
+      prompt = `${this.model.executionCount ?? ''}`;
     }
     this._setPrompt(prompt);
   }

--- a/packages/codemirror/src/extensions/customStyle.ts
+++ b/packages/codemirror/src/extensions/customStyle.ts
@@ -53,13 +53,13 @@ function setEditorStyle(view: EditorView): Record<string, string> | null {
     view.state.facet(customThemeConfig);
 
   let style = '';
-  if (fontSize) {
+  if (fontSize !== null) {
     style += `font-size: ${fontSize}px !important;`;
   }
   if (fontFamily) {
     style += `font-family: ${fontFamily} !important;`;
   }
-  if (lineHeight) {
+  if (lineHeight !== null && lineHeight !== 0) {
     style += `line-height: ${lineHeight.toString()} !important`;
   }
 

--- a/packages/codemirror/src/searchprovider.ts
+++ b/packages/codemirror/src/searchprovider.ts
@@ -364,7 +364,7 @@ export abstract class EditorSearchProvider<
                 match!.position + insertText.length;
               let nextMatchFound = false;
               for (
-                let matchIdx = this.currentIndex || 0;
+                let matchIdx = this.currentIndex ?? 0;
                 matchIdx < allMatches.length;
                 matchIdx++
               ) {

--- a/packages/completer/src/ghost.ts
+++ b/packages/completer/src/ghost.ts
@@ -246,7 +246,10 @@ class GhostTextWidget extends WidgetType {
       content = content.substring(0, content.length - addition.length);
     }
 
-    const maxLines = this.options.maxLines || Infinity;
+    const maxLines =
+      this.options.maxLines === undefined || this.options.maxLines === 0
+        ? Infinity
+        : this.options.maxLines;
     if (maxLines !== Infinity) {
       // Split into content to show immediately and the hidden part
       const lines = content.split('\n');

--- a/packages/completer/src/inline.ts
+++ b/packages/completer/src/inline.ts
@@ -811,7 +811,7 @@ export namespace InlineCompleter {
           }
           completions.items = items;
         } else {
-          if (!change.retain) {
+          if (change.retain === undefined || change.retain === 0) {
             this._completions = null;
           }
         }

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -1253,7 +1253,7 @@ export namespace Completer {
       // Get the label text without HTML markup (`<mark>` is the only markup
       // that is allowed in processed items, everything else gets escaped).
       const labelText = item.label.replace(/<\/?mark>/g, '');
-      return labelText.length + (item.type?.length || 0);
+      return labelText.length + (item.type?.length ?? 0);
     }
 
     /**

--- a/packages/coreutils/src/activitymonitor.ts
+++ b/packages/coreutils/src/activitymonitor.ts
@@ -13,7 +13,10 @@ export class ActivityMonitor<Sender, Args> implements IDisposable {
    */
   constructor(options: ActivityMonitor.IOptions<Sender, Args>) {
     options.signal.connect(this._onSignalFired, this);
-    this._timeout = options.timeout || 1000;
+    this._timeout =
+      options.timeout === undefined || options.timeout === 0
+        ? 1000
+        : options.timeout;
   }
 
   /**

--- a/packages/coreutils/src/lru.ts
+++ b/packages/coreutils/src/lru.ts
@@ -9,7 +9,14 @@ export class LruCache<T, U> {
   protected _maxSize: number;
 
   constructor(options: LruCache.IOptions = {}) {
-    this._maxSize = options?.maxSize || DEFAULT_MAX_SIZE;
+    const maxSize = options.maxSize;
+    this._maxSize =
+      maxSize === undefined ||
+      maxSize === null ||
+      maxSize === 0 ||
+      Number.isNaN(maxSize)
+        ? DEFAULT_MAX_SIZE
+        : maxSize;
     if (this._maxSize < 1) {
       throw new Error('maxSize must be at least 1');
     }

--- a/packages/coreutils/test/activitymonitor.spec.ts
+++ b/packages/coreutils/test/activitymonitor.spec.ts
@@ -34,6 +34,14 @@ describe('@jupyterlab/coreutils', () => {
         });
         expect(monitor).toBeInstanceOf(ActivityMonitor);
       });
+
+      it('should treat timeout 0 as the default', () => {
+        const monitor = new ActivityMonitor<TestObject, number>({
+          signal,
+          timeout: 0
+        });
+        expect(monitor.timeout).toBe(1000);
+      });
     });
 
     describe('#activityStopped', () => {

--- a/packages/coreutils/test/lru.spec.ts
+++ b/packages/coreutils/test/lru.spec.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { LruCache } from '@jupyterlab/coreutils';
+
+describe('@jupyterlab/coreutils', () => {
+  describe('LruCache()', () => {
+    describe('#constructor()', () => {
+      it('should treat maxSize 0 as the default', () => {
+        const cache = new LruCache<number, number>({ maxSize: 0 });
+
+        for (let i = 0; i < 129; i++) {
+          cache.set(i, i);
+        }
+
+        expect(cache.size).toBe(128);
+        expect(cache.get(0)).toBeNull();
+        expect(cache.get(1)).toBe(1);
+      });
+
+      it('should reject negative maxSize values', () => {
+        expect(() => new LruCache({ maxSize: -1 })).toThrow(
+          'maxSize must be at least 1'
+        );
+      });
+    });
+  });
+});

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -598,7 +598,7 @@ const variables: JupyterFrontEndPlugin<void> = {
           name?: string;
         };
 
-        if (!variableReference) {
+        if (variableReference === undefined) {
           variableReference =
             service.model.variables.selectedVariable?.variablesReference;
         }
@@ -609,7 +609,8 @@ const variables: JupyterFrontEndPlugin<void> = {
         const id = `jp-debugger-variable-${name}`;
         if (
           !name ||
-          !variableReference ||
+          variableReference === undefined ||
+          variableReference <= 0 ||
           tracker.find(widget => widget.id === id)
         ) {
           return;
@@ -680,7 +681,7 @@ const variables: JupyterFrontEndPlugin<void> = {
         if (!name) {
           name = service.model.variables.selectedVariable?.name;
         }
-        if (!frameId) {
+        if (frameId === undefined) {
           frameId = service.model.callstack.frame?.id;
         }
 
@@ -701,7 +702,7 @@ const variables: JupyterFrontEndPlugin<void> = {
         if (
           !name || // Name is mandatory
           trackerMime.find(widget => widget.id === id) || // Widget already exists
-          (!frameId && service.hasStoppedThreads()) // frame id missing on breakpoint
+          (frameId === undefined && service.hasStoppedThreads()) // frame id missing on breakpoint
         ) {
           return;
         }

--- a/packages/docmanager-extension/src/index.tsx
+++ b/packages/docmanager-extension/src/index.tsx
@@ -279,12 +279,15 @@ const docManagerPlugin: JupyterFrontEndPlugin<void> = {
       const autosaveInterval = settings.get('autosaveInterval').composite as
         | number
         | null;
-      docManager.autosaveInterval = autosaveInterval || 120;
+      docManager.autosaveInterval =
+        autosaveInterval === null || autosaveInterval === 0
+          ? 120
+          : autosaveInterval;
 
       // Handle last modified timestamp check margin
       const lastModifiedCheckMargin = settings.get('lastModifiedCheckMargin')
         .composite as number | null;
-      docManager.lastModifiedCheckMargin = lastModifiedCheckMargin || 500;
+      docManager.lastModifiedCheckMargin = lastModifiedCheckMargin ?? 500;
 
       const renameUntitledFile = settings.get('renameUntitledFileOnSave')
         .composite as boolean;

--- a/packages/docmanager/src/savehandler.ts
+++ b/packages/docmanager/src/savehandler.ts
@@ -18,7 +18,10 @@ export class SaveHandler implements IDisposable {
   constructor(options: SaveHandler.IOptions) {
     this._context = options.context;
     this._isConnectedCallback = options.isConnectedCallback || (() => true);
-    const interval = options.saveInterval || 120;
+    const interval =
+      options.saveInterval === undefined || options.saveInterval === 0
+        ? 120
+        : options.saveInterval;
     this._minInterval = interval * 1000;
     this._interval = this._minInterval;
     // Restart the timer when the contents model is updated.

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -53,7 +53,7 @@ export class Context<
       new SessionContextDialogs({ translator: options.translator });
     this._opener = options.opener || Private.noOp;
     this._path = this._manager.contents.normalize(options.path);
-    this._lastModifiedCheckMargin = options.lastModifiedCheckMargin || 500;
+    this._lastModifiedCheckMargin = options.lastModifiedCheckMargin ?? 500;
     const localPath = this._manager.contents.localPath(this._path);
     const lang = this._factory.preferredLanguage(PathExt.basename(localPath));
 

--- a/packages/docregistry/src/mimedocument.ts
+++ b/packages/docregistry/src/mimedocument.ts
@@ -269,7 +269,10 @@ export class MimeDocumentFactory extends ABCWidgetFactory<MimeDocument> {
   constructor(options: MimeDocumentFactory.IOptions<MimeDocument>) {
     super(Private.createRegistryOptions(options));
     this._rendermime = options.rendermime;
-    this._renderTimeout = options.renderTimeout || 1000;
+    this._renderTimeout =
+      options.renderTimeout === undefined || options.renderTimeout === 0
+        ? 1000
+        : options.renderTimeout;
     this._dataType = options.dataType || 'string';
     this._fileType = options.primaryFileType;
     this._factory = options.factory;
@@ -280,9 +283,11 @@ export class MimeDocumentFactory extends ABCWidgetFactory<MimeDocument> {
    */
   protected createNewWidget(context: DocumentRegistry.Context): MimeDocument {
     const ft = this._fileType;
-    const mimeType = ft?.mimeTypes.length
-      ? ft.mimeTypes[0]
-      : IEditorMimeTypeService.defaultMimeType;
+    const mimeTypes = ft?.mimeTypes ?? [];
+    const mimeType =
+      mimeTypes.length > 0
+        ? mimeTypes[0]
+        : IEditorMimeTypeService.defaultMimeType;
 
     const rendermime = this._rendermime.clone({
       resolver: context.urlResolver

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -1221,7 +1221,8 @@ const notifyUploadPlugin: JupyterFrontEndPlugin<void> = {
           const file = models[0];
           if (
             autoOpen &&
-            file.size &&
+            file.size !== null &&
+            file.size !== undefined &&
             file.size <= maxSize &&
             isAllowedFileType
           ) {
@@ -1237,7 +1238,9 @@ const notifyUploadPlugin: JupyterFrontEndPlugin<void> = {
               trans.__(
                 'Uploaded %1%2',
                 file.name,
-                file.size ? ` (${formatFileSize(file.size, 1, 1024)})` : ''
+                file.size !== null && file.size !== undefined
+                  ? ` (${formatFileSize(file.size, 1, 1024)})`
+                  : ''
               ),
               'info',
               {

--- a/packages/filebrowser/src/crumbs.ts
+++ b/packages/filebrowser/src/crumbs.ts
@@ -728,7 +728,7 @@ export class BreadCrumbs extends Widget {
     this._cachedWidths = {
       home: (home.getBoundingClientRect().width || 22) + 4,
       ellipsis: (ellipsis.getBoundingClientRect().width || 28) + 4,
-      separator: separator?.getBoundingClientRect().width || 4,
+      separator: (separator?.getBoundingClientRect().width ?? 0) || 4,
       preferred: this._hasPreferred
         ? (preferred.getBoundingClientRect().width || 22) + 4
         : 0,

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1016,7 +1016,7 @@ export class DirListing extends Widget {
   }
 
   private _computeContentWidth(width: number | null = null) {
-    if (!width) {
+    if (width === null || width === 0) {
       width = this.node.getBoundingClientRect().width;
     }
 
@@ -1382,7 +1382,7 @@ export class DirListing extends Widget {
       }
       // restrict the minimum and maximum width
       size = Math.max(size, column.minWidth);
-      if (this._width) {
+      if (this._width !== null && this._width > 0) {
         let reservedForOtherColumns = 0;
         for (const other of visibleColumns) {
           if (other.id === column.id) {
@@ -1397,7 +1397,7 @@ export class DirListing extends Widget {
     }
 
     // Ensure that total fits
-    if (this._width) {
+    if (this._width !== null && this._width > 0) {
       // Distribute the excess/shortfall over the columns which should stretch.
       const excess = this._width - total;
       let growAllowed = doNotGrowBeforeInclusive === null;
@@ -1430,7 +1430,7 @@ export class DirListing extends Widget {
     for (const column of visibleColumns) {
       let size = this._columnSizes[column.id];
 
-      if (Private.isResizable(column) && size) {
+      if (Private.isResizable(column) && size !== null && size !== 0) {
         size -=
           (this._handleWidth * resizeHandles.length) / resizableColumns.length;
         // if this is first resizable or last resizable column
@@ -1466,7 +1466,7 @@ export class DirListing extends Widget {
     size: number | null
   ): void {
     const previousSize = this._columnSizes[name];
-    if (previousSize && size && size > previousSize) {
+    if (previousSize !== null && size !== null && size > previousSize) {
       // check if we can resize up
       let total = 0;
       let before = true;
@@ -1488,7 +1488,7 @@ export class DirListing extends Widget {
           total += column.minWidth;
         }
       }
-      if (this._width && total > this._width) {
+      if (this._width !== null && this._width > 0 && total > this._width) {
         // up sizing is no longer possible
         return;
       }

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -76,7 +76,10 @@ export class FileBrowserModel implements IDisposable {
       format: 'text'
     };
     this._state = options.state || null;
-    const refreshInterval = options.refreshInterval || DEFAULT_REFRESH_INTERVAL;
+    const refreshInterval =
+      options.refreshInterval === undefined || options.refreshInterval === 0
+        ? DEFAULT_REFRESH_INTERVAL
+        : options.refreshInterval;
 
     const { services } = options.manager;
     services.contents.fileChanged.connect(this.onFileChanged, this);

--- a/packages/lsp/src/manager.ts
+++ b/packages/lsp/src/manager.ts
@@ -28,8 +28,8 @@ export class LanguageServerManager implements ILanguageServerManager {
   constructor(options: ILanguageServerManager.IOptions) {
     this._settings = options.settings || ServerConnection.makeSettings();
     this._baseUrlOverride = options.baseUrl;
-    this._retries = options.retries || 2;
-    this._retriesInterval = options.retriesInterval || 10000;
+    this._retries = options.retries ?? 2;
+    this._retriesInterval = options.retriesInterval ?? 10000;
     this._statusCode = -1;
     this._configuration = {};
 

--- a/packages/lsp/src/virtual/document.ts
+++ b/packages/lsp/src/virtual/document.ts
@@ -643,8 +643,8 @@ export class VirtualDocument implements IDisposable {
       this.sourceLines.set(this.lastSourceLine + i, {
         editorLine: i,
         editorShift: {
-          line: editorShift.line - (virtualShift?.line || 0),
-          column: i === 0 ? editorShift.column - (virtualShift?.column || 0) : 0
+          line: editorShift.line - (virtualShift?.line ?? 0),
+          column: i === 0 ? editorShift.column - (virtualShift?.column ?? 0) : 0
         },
         // TODO: move those to a new abstraction layer (DocumentBlock class)
         editor: ceEditor,

--- a/packages/mermaid/src/manager.ts
+++ b/packages/mermaid/src/manager.ts
@@ -211,8 +211,9 @@ export class MermaidManager implements IMermaidManager {
     );
 
     // add dimension information
-    if (info.width !== undefined) {
-      img.width = info.width;
+    const { width } = info;
+    if (width !== undefined && width !== null && width !== 0) {
+      img.width = width;
     }
 
     // add accessible alt title

--- a/packages/mermaid/src/manager.ts
+++ b/packages/mermaid/src/manager.ts
@@ -29,7 +29,7 @@ export class MermaidManager implements IMermaidManager {
   protected _themes: IThemeManager | null;
 
   constructor(options: MermaidManager.IOptions = {}) {
-    this._diagrams = new LruCache({ maxSize: options.maxCacheSize || null });
+    this._diagrams = new LruCache({ maxSize: options.maxCacheSize ?? null });
 
     // handle reacting to themes
     if (options.themes) {
@@ -211,7 +211,7 @@ export class MermaidManager implements IMermaidManager {
     );
 
     // add dimension information
-    if (info.width) {
+    if (info.width !== undefined) {
       img.width = info.width;
     }
 

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -2273,8 +2273,12 @@ function activateNotebookHandler(
             value: settings.get('sideBySideOutputRatio').composite as number
           })
             .then(result => {
-              setSideBySideOutputRatio(result.value!);
-              if (result.value) {
+              if (
+                result.value !== null &&
+                Number.isFinite(result.value) &&
+                result.value >= 0
+              ) {
+                setSideBySideOutputRatio(result.value);
                 void settings.set('sideBySideOutputRatio', result.value);
               }
             })

--- a/packages/notebook/src/searchprovider.ts
+++ b/packages/notebook/src/searchprovider.ts
@@ -794,7 +794,7 @@ export class NotebookSearchProvider extends SearchProvider<NotebookPanel> {
         return;
       }
       const currentMatch = searchEngine.getCurrentMatch();
-      if (!currentMatch && this.matchesCount) {
+      if (!currentMatch && this.matchesCount > 0) {
         // Select a match as current by highlighting next (with looping) from
         // the selection start, to prevent "current" match from jumping around.
         await this.highlightNext(true, {

--- a/packages/notebook/src/searchprovider.ts
+++ b/packages/notebook/src/searchprovider.ts
@@ -794,7 +794,8 @@ export class NotebookSearchProvider extends SearchProvider<NotebookPanel> {
         return;
       }
       const currentMatch = searchEngine.getCurrentMatch();
-      if (!currentMatch && this.matchesCount > 0) {
+      const matchesCount = this.matchesCount;
+      if (!currentMatch && matchesCount !== null && matchesCount > 0) {
         // Select a match as current by highlighting next (with looping) from
         // the selection start, to prevent "current" match from jumping around.
         await this.highlightNext(true, {

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -970,7 +970,7 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
 
   private _scheduleCellRenderOnIdle() {
     if (this.notebookConfig.windowingMode !== 'none' && !this.isDisposed) {
-      if (!this._idleCallBack) {
+      if (this._idleCallBack === null) {
         this._idleCallBack = requestIdleCallback(
           (deadline: IdleDeadline) => {
             this._idleCallBack = null;
@@ -1073,7 +1073,7 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
         this._scheduleCellRenderOnIdle();
       }
     } else {
-      if (this._idleCallBack) {
+      if (this._idleCallBack !== null) {
         window.cancelIdleCallback(this._idleCallBack);
         this._idleCallBack = null;
       }
@@ -1678,7 +1678,7 @@ class ScrollbarItem implements WindowedList.IRenderer.IScrollbarItem {
       state = 'error';
     } else if (model.executionState == 'running') {
       content = '[*]';
-    } else if (model.executionCount) {
+    } else if (model.executionCount !== null) {
       content = `[${model.executionCount}]`;
     } else {
       content = '[ ]';
@@ -3470,7 +3470,7 @@ export class Notebook extends StaticNotebook {
       const executionCount = (activeCell.model as ICodeCellModel)
         .executionCount;
       countString = ' ';
-      if (executionCount) {
+      if (executionCount !== null) {
         countString = executionCount.toString();
       }
     } else {

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -486,7 +486,7 @@ export class OutputArea extends Widget {
     change: number | void
   ): void {
     const outputLength = Math.min(this.model.length, this._maxNumberOutputs);
-    if (change) {
+    if (change !== undefined) {
       if (change >= this._maxNumberOutputs) {
         // Bail early
         return;
@@ -532,7 +532,7 @@ export class OutputArea extends Widget {
     // to prevent this jitter.
     const rect = this.node.getBoundingClientRect();
     this.node.style.minHeight = `${rect.height}px`;
-    if (this._minHeightTimeout) {
+    if (this._minHeightTimeout !== null) {
       window.clearTimeout(this._minHeightTimeout);
     }
     this._minHeightTimeout = window.setTimeout(() => {

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -727,7 +727,7 @@ function* nodeIter<T extends Node>(
   let start = 0;
   let end;
   for (let node of nodes) {
-    end = start + (node.textContent?.length || 0);
+    end = start + (node.textContent?.length ?? 0);
     yield {
       node,
       start,

--- a/packages/running/src/index.tsx
+++ b/packages/running/src/index.tsx
@@ -229,7 +229,7 @@ function Item(props: {
   const children = runningItem.children;
 
   // Manage collapsed state. Use the shutdown flag in lieu of `stopPropagation`.
-  const collapsible = !!children?.length;
+  const collapsible = (children?.length ?? 0) > 0;
   const onClick = useCallback(
     (event: React.MouseEvent) => {
       if (shuttingDown.current) {

--- a/packages/services/src/kernel/serialize.ts
+++ b/packages/services/src/kernel/serialize.ts
@@ -203,7 +203,7 @@ namespace Private {
     msg: KernelMessage.IMessage
   ): string | ArrayBuffer {
     let value: string | ArrayBuffer;
-    if (msg.buffers?.length) {
+    if ((msg.buffers?.length ?? 0) > 0) {
       value = serializeBinary(msg);
     } else {
       value = JSON.stringify(msg);

--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -714,7 +714,7 @@ function addCommands(
     label: trans.__('Increase Terminal Font Size'),
     execute: async () => {
       const { fontSize } = options;
-      if (fontSize && fontSize < 72) {
+      if (fontSize !== undefined && fontSize < 72) {
         try {
           await settingRegistry.set(plugin.id, 'fontSize', fontSize + 1);
         } catch (err) {
@@ -734,7 +734,7 @@ function addCommands(
     label: trans.__('Decrease Terminal Font Size'),
     execute: async () => {
       const { fontSize } = options;
-      if (fontSize && fontSize > 9) {
+      if (fontSize !== undefined && fontSize > 9) {
         try {
           await settingRegistry.set(plugin.id, 'fontSize', fontSize - 1);
         } catch (err) {

--- a/packages/tooltip-extension/src/index.ts
+++ b/packages/tooltip-extension/src/index.ts
@@ -348,7 +348,7 @@ namespace Private {
     const contents: KernelMessage.IInspectRequestMsg['content'] = {
       code,
       cursor_pos: offset,
-      detail_level: detail || 0
+      detail_level: detail ?? 0
     };
     const current = ++pending;
 

--- a/packages/ui-components/src/components/form.tsx
+++ b/packages/ui-components/src/components/form.tsx
@@ -515,7 +515,7 @@ const CustomTemplateFactory = (options: FormComponent.ILabCustomizerProps) =>
           }`}
         >
           {!hasCustomField &&
-            (rawErrors?.length ? (
+            ((rawErrors?.length ?? 0) > 0 ? (
               // Shows a red indicator for fields that have validation errors
               <div className="jp-modifiedIndicator jp-errorIndicator" />
             ) : (

--- a/packages/ui-components/src/components/menu.ts
+++ b/packages/ui-components/src/components/menu.ts
@@ -188,7 +188,7 @@ export class RankedMenu extends Menu implements IRankedMenu {
   addItem(options: IRankedMenu.IItemOptions): IDisposableMenuItem {
     let insertIndex = -1;
 
-    if (options.rank) {
+    if (options.rank !== undefined) {
       insertIndex = this._ranks.findIndex(rank => options.rank! < rank);
     }
     if (insertIndex < 0) {

--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -588,7 +588,7 @@ export class ReactiveToolbar extends Toolbar<Widget> {
           // Get the saved position of the widget to insert.
           const widget = widgetsToRemove.pop()!;
           const name = Private.nameProperty.get(widget);
-          width -= this._widgetWidths.get(name) || 0;
+          width -= this._widgetWidths.get(name) ?? 0;
           const position = this._widgetPositions.get(name) ?? 0;
 
           // Get the saved position of the first item in the popup toolbar.
@@ -724,7 +724,7 @@ export class ReactiveToolbar extends Toolbar<Widget> {
 
   private _getWidgetWidth(widget: Widget): number {
     const widgetName = Private.nameProperty.get(widget);
-    return this._widgetWidths.get(widgetName) || 0;
+    return this._widgetWidths.get(widgetName) ?? 0;
   }
 
   protected readonly popupOpener: ToolbarPopupOpener = new ToolbarPopupOpener();

--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -1328,7 +1328,7 @@ export class WindowedList<
           this._viewport.dataset.isScrolling = 'true';
         }
 
-        if (this._timerToClearScrollStatus) {
+        if (this._timerToClearScrollStatus !== null) {
           window.clearTimeout(this._timerToClearScrollStatus);
         }
         // TODO: remove once `scrollend` event is supported by Safari
@@ -1694,11 +1694,11 @@ export class WindowedList<
    * Clear any outstanding timeout and enqueue scrolling to a new item.
    */
   private _resetScrollToItem(): void {
-    if (this._resetScrollToItemTimeout) {
+    if (this._resetScrollToItemTimeout !== null) {
       clearTimeout(this._resetScrollToItemTimeout);
     }
 
-    if (this._programmaticScrollTimeout) {
+    if (this._programmaticScrollTimeout !== null) {
       clearTimeout(this._programmaticScrollTimeout);
     }
 
@@ -1841,7 +1841,7 @@ export class WindowedList<
    * Handle `scrollend` events on the scroller.
    */
   private _onScrollEnd() {
-    if (this._timerToClearScrollStatus) {
+    if (this._timerToClearScrollStatus !== null) {
       window.clearTimeout(this._timerToClearScrollStatus);
     }
     this._viewport.dataset.isScrolling = 'false';

--- a/packages/ui-components/src/hoverbox.ts
+++ b/packages/ui-components/src/hoverbox.ts
@@ -214,23 +214,15 @@ export namespace HoverBox {
     const initialHeight = options.size
       ? options.size.height
       : node.getBoundingClientRect().height;
-    const offsetAbove =
-      (options.offset &&
-        options.offset.vertical &&
-        options.offset.vertical.above) ||
-      0;
-    const offsetBelow =
-      (options.offset &&
-        options.offset.vertical &&
-        options.offset.vertical.below) ||
-      0;
+    const offsetAbove = options.offset?.vertical?.above ?? 0;
+    const offsetBelow = options.offset?.vertical?.below ?? 0;
     let top = renderBelow
       ? hostRect.bottom - spaceBelow + offsetBelow
       : hostRect.top + spaceAbove - initialHeight + offsetAbove;
     node.style.top = `${Math.floor(top)}px`;
 
     // Position the box horizontally.
-    const offsetHorizontal = (options.offset && options.offset.horizontal) || 0;
+    const offsetHorizontal = options.offset?.horizontal ?? 0;
     let left = anchor.left + offsetHorizontal;
 
     node.style.left = `${Math.ceil(left)}px`;

--- a/packages/workspaces/src/model.ts
+++ b/packages/workspaces/src/model.ts
@@ -20,7 +20,10 @@ const DEFAULT_REFRESH_INTERVAL = 10000;
 export class WorkspacesModel implements IWorkspacesModel {
   constructor(options: WorkspacesModel.IOptions) {
     this._manager = options.manager;
-    const refreshInterval = options.refreshInterval || DEFAULT_REFRESH_INTERVAL;
+    const refreshInterval =
+      options.refreshInterval === undefined || options.refreshInterval === 0
+        ? DEFAULT_REFRESH_INTERVAL
+        : options.refreshInterval;
     this._poll = new Poll({
       auto: options.auto ?? true,
       name: '@jupyterlab/workspaces:Model',


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
Refs; #19129

## Code changes

This adds a focused typed ESLint check for nullable-number boolean expressions. The upstream rule is useful for this class of bug, but cannot be configured as nullable-number-only. Even with all other `allow*` options enabled, the full rule still reports 667 unrelated non-number warnings. To make the first rollout practical, this PR adds a local typed-lint wrapper that delegates to the upstream rule but only reports nullable-number diagnostics.

- Adds `jupyterlab/strict-boolean-nullable-number` as a warning-level typed lint rule.
- Fixes all 76 nullable-number warnings with explicit checks for `null`, `undefined`, `0`, `NaN`, and positive counts where appropriate.
- Preserves existing behavior for public defaults such as `timeout: 0`, `maxSize: 0`, render timeouts, and editor line height.
- Guards notebook side-by-side ratio input against `NaN`, negative values, and `null`.
- Adds regression tests for `ActivityMonitor timeout: 0` and `LruCache maxSize: 0`.

## User-facing changes
None

## Backwards-incompatible changes
None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: ChatGPT 5.5
