### PR TITLE
Harden type checks by removing `any` (remove `no-explicit-any` suppressions)

### DIFF
--- a/buildutils/src/bump-js-major.ts
+++ b/buildutils/src/bump-js-major.ts
@@ -2,12 +2,15 @@
 | Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { program as commander } from 'commander';
 import semver from 'semver';
 import path from 'path';
 import * as utils from './utils';
+
+interface IBumpJSOptions {
+  force?: boolean;
+  dryRun?: boolean;
+}
 
 /**
  * Get the packages that depend on a given package, recursively.
@@ -36,7 +39,7 @@ commander
   .arguments('<package> [others...]')
   .option('--force', 'Force the upgrade')
   .option('--dry-run', 'Show what would be executed')
-  .action((pkg: string, others: Array<string>, options: any) => {
+  .action((pkg: string, others: Array<string>, options: IBumpJSOptions) => {
     utils.exitOnUncaughtException();
     others.push(pkg);
     const toBump: Set<string> = new Set();

--- a/buildutils/src/bumpversion.ts
+++ b/buildutils/src/bumpversion.ts
@@ -2,10 +2,14 @@
 | Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { program as commander } from 'commander';
 import * as utils from './utils';
+
+interface IBumpVersionOptions {
+  dryRun?: boolean;
+  force?: boolean;
+  skipCommit?: boolean;
+}
 
 // Specify the program signature.
 commander
@@ -14,7 +18,7 @@ commander
   .option('--force', 'Force the upgrade')
   .option('--skip-commit', 'Whether to skip commit changes')
   .arguments('<spec>')
-  .action((spec: any, opts: any) => {
+  .action((spec: string, opts: IBumpVersionOptions) => {
     utils.exitOnUncaughtException();
 
     // Get the previous version.

--- a/buildutils/src/patch-release.ts
+++ b/buildutils/src/patch-release.ts
@@ -2,10 +2,14 @@
 | Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { program as commander } from 'commander';
 import * as utils from './utils';
+
+interface IPatchReleaseOptions {
+  all?: boolean;
+  force?: boolean;
+  skipCommit?: boolean;
+}
 
 // Specify the program signature.
 commander
@@ -13,7 +17,7 @@ commander
   .option('--force', 'Force the upgrade')
   .option('--all', 'Patch all JS packages instead of the changed ones')
   .option('--skip-commit', 'Whether to skip commit changes')
-  .action((options: any) => {
+  .action((options: IPatchReleaseOptions) => {
     utils.exitOnUncaughtException();
 
     // Make sure we can patch release.

--- a/buildutils/src/prepare-python-release.ts
+++ b/buildutils/src/prepare-python-release.ts
@@ -2,8 +2,6 @@
 | Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { program as commander } from 'commander';
 import * as crypto from 'crypto';
 import * as fs from 'fs-extra';
@@ -13,7 +11,7 @@ import * as utils from './utils';
 // Specify the program signature.
 commander
   .description('Prepare the Python package for release')
-  .action(async (options: any) => {
+  .action(async () => {
     utils.exitOnUncaughtException();
 
     const distDir = './dist';

--- a/buildutils/src/publish.ts
+++ b/buildutils/src/publish.ts
@@ -2,13 +2,19 @@
 | Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { program as commander } from 'commander';
 import * as path from 'path';
 import * as os from 'os';
 import { handlePackage } from './update-dist-tag';
 import * as utils from './utils';
+
+interface IPublishOptions {
+  skipBuild?: boolean;
+  skipPublish?: boolean;
+  skipTags?: boolean;
+  yes?: boolean;
+  dryRun?: boolean;
+}
 
 /**
  * Sleep for a specified period.
@@ -30,7 +36,7 @@ commander
   .option('--skip-tags', 'publish assets but do not handle tags')
   .option('--yes', 'Publish without confirmation')
   .option('--dry-run', 'Do not actually push any assets')
-  .action(async (options: any) => {
+  .action(async (options: IPublishOptions) => {
     utils.exitOnUncaughtException();
 
     // No-op if we're in release helper dry run

--- a/buildutils/src/update-core-mode.ts
+++ b/buildutils/src/update-core-mode.ts
@@ -2,13 +2,15 @@
 | Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { program as commander } from 'commander';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as utils from './utils';
 import { upgradeLock } from './update-staging-lock';
+
+interface IUpdateCoreModeOptions {
+  skipAssets?: boolean;
+}
 
 commander
   .description('Update the core mode package.json and staging assets')
@@ -16,7 +18,7 @@ commander
     '--skip-assets',
     'Skip the staging build - only update core.package.json metadata'
   )
-  .action((options: any) => {
+  .action((options: IUpdateCoreModeOptions) => {
     updateCoreMode(options.skipAssets);
   });
 

--- a/packages/apputils/src/mainareawidget.ts
+++ b/packages/apputils/src/mainareawidget.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import type { ITranslator } from '@jupyterlab/translation';
 import { nullTranslator } from '@jupyterlab/translation';
 import type { Toolbar } from '@jupyterlab/ui-components';
@@ -329,7 +327,7 @@ export namespace MainAreaWidget {
     /**
      * An optional promise for when the content is ready to be revealed.
      */
-    reveal?: Promise<any>;
+    reveal?: Promise<unknown>;
 
     /**
      * The application language translator.
@@ -362,6 +360,6 @@ export namespace MainAreaWidget {
     /**
      * An optional promise for when the content is ready to be revealed.
      */
-    reveal?: Promise<any>;
+    reveal?: Promise<unknown>;
   }
 }

--- a/packages/codemirror/src/factory.ts
+++ b/packages/codemirror/src/factory.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import type { CodeEditor, IEditorFactoryService } from '@jupyterlab/codeeditor';
 import type { ITranslator } from '@jupyterlab/translation';
 import { nullTranslator } from '@jupyterlab/translation';
@@ -86,6 +84,6 @@ export class CodeMirrorEditorFactory implements IEditorFactoryService {
   protected extensions: IEditorExtensionRegistry;
   protected languages: IEditorLanguageRegistry;
   protected translator: ITranslator;
-  protected inlineCodeMirrorConfig: Record<string, any>;
-  protected documentCodeMirrorConfig: Record<string, any>;
+  protected inlineCodeMirrorConfig: Record<string, unknown>;
+  protected documentCodeMirrorConfig: Record<string, unknown>;
 }

--- a/packages/codemirror/src/typings.d.ts
+++ b/packages/codemirror/src/typings.d.ts
@@ -2,13 +2,11 @@
  * Copyright (c) Jupyter Development Team.
  * Distributed under the terms of the Modified BSD License.
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 declare module '@codemirror/legacy-modes/mode/python' {
   import type { StreamParser } from '@codemirror/language';
 
   export const python: StreamParser<unknown>;
   export const cython: StreamParser<unknown>;
 
-  export function mkPython(parserConf: any): StreamParser<unknown>;
+  export function mkPython(parserConf: unknown): StreamParser<unknown>;
 }

--- a/packages/completer/src/manager.ts
+++ b/packages/completer/src/manager.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import type { ISignal } from '@lumino/signaling';
 import { Signal } from '@lumino/signaling';
 import { Widget } from '@lumino/widgets';
@@ -329,7 +327,7 @@ export class CompletionProviderManager implements ICompletionProviderManager {
     for (const [id, providerSettings] of Object.entries(
       this._inlineCompleterSettings.providers
     )) {
-      if ((providerSettings as any).enabled === true) {
+      if (providerSettings.enabled === true) {
         enabledProviders.push(id);
       }
     }

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * @packageDocumentation
  * @module console-extension
@@ -254,7 +253,7 @@ const completerPlugin: JupyterFrontEndPlugin<void> = {
 /**
  * Export the plugins as the default.
  */
-const plugins: JupyterFrontEndPlugin<any>[] = [
+const plugins: JupyterFrontEndPlugin<unknown>[] = [
   factory,
   tracker,
   foreign,
@@ -1515,7 +1514,10 @@ function activateConsoleCompleterService(
     keys: ['Enter'],
     selector: '.jp-ConsolePanel .jp-mod-completer-active'
   });
-  const updateCompleter = async (_: any, consolePanel: ConsolePanel) => {
+  const updateCompleter = async (
+    _: IConsoleTracker | undefined,
+    consolePanel: ConsolePanel
+  ) => {
     const completerContext = {
       editor: consolePanel.console.promptCell?.editor ?? null,
       session: consolePanel.console.sessionContext.session,

--- a/packages/coreutils/src/testutils.ts
+++ b/packages/coreutils/src/testutils.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 // Test helpers
 
 /**
@@ -11,9 +9,9 @@ export function sleep(milliseconds?: number): Promise<void>;
 export function sleep<T>(milliseconds: number, value: T): Promise<T>;
 export function sleep<T>(
   milliseconds: number = 0,
-  value?: any
-): Promise<T> | Promise<void> {
-  return new Promise<T>((resolve, reject) => {
+  value?: T
+): Promise<T | void> {
+  return new Promise<T | void>(resolve => {
     setTimeout(() => {
       resolve(value);
     }, milliseconds);

--- a/packages/debugger/src/config.ts
+++ b/packages/debugger/src/config.ts
@@ -44,7 +44,9 @@ export class DebuggerConfig implements IDebugger.IConfig {
     }
     switch (method) {
       case 'Murmur2':
-        this._hashMethods.set(kernel, code => murmur2(code, seed).toString());
+        this._hashMethods.set(kernel, code =>
+          murmur2(code, Number(seed ?? 0)).toString()
+        );
         break;
       default:
         throw new Error(`Hash method (${method}) is not supported.`);

--- a/packages/debugger/src/handlers/notebook.ts
+++ b/packages/debugger/src/handlers/notebook.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import type { Cell, CodeCell, ICellModel } from '@jupyterlab/cells';
 import type { NotebookPanel } from '@jupyterlab/notebook';
 import type { IObservableList, IObservableMap } from '@jupyterlab/observables';
@@ -13,6 +11,10 @@ import { EditorHandler } from './editor';
 import type { ITranslator } from '@jupyterlab/translation';
 import { nullTranslator } from '@jupyterlab/translation';
 import { DebuggerPausedOverlay } from './pausedoverlay';
+
+type TNotebookCellList = NonNullable<
+  NotebookPanel['content']['model']
+>['cells'];
 
 /**
  * A handler for notebooks.
@@ -93,7 +95,7 @@ export class NotebookHandler implements IDisposable {
    * Handle a notebook cells changed event.
    */
   private _onCellsChanged(
-    cells?: any,
+    cells?: TNotebookCellList,
     changes?: IObservableList.IChangedArgs<ICellModel>
   ): void {
     this._notebookPanel.content.widgets.forEach(cell =>

--- a/packages/debugger/src/handlers/notebook.ts
+++ b/packages/debugger/src/handlers/notebook.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 import type { Cell, CodeCell, ICellModel } from '@jupyterlab/cells';
-import type { NotebookPanel } from '@jupyterlab/notebook';
+import type { INotebookModel, NotebookPanel } from '@jupyterlab/notebook';
 import type { IObservableList, IObservableMap } from '@jupyterlab/observables';
 import { ObservableMap } from '@jupyterlab/observables';
 import type { IDisposable } from '@lumino/disposable';
@@ -11,10 +11,6 @@ import { EditorHandler } from './editor';
 import type { ITranslator } from '@jupyterlab/translation';
 import { nullTranslator } from '@jupyterlab/translation';
 import { DebuggerPausedOverlay } from './pausedoverlay';
-
-type TNotebookCellList = NonNullable<
-  NotebookPanel['content']['model']
->['cells'];
 
 /**
  * A handler for notebooks.
@@ -95,7 +91,7 @@ export class NotebookHandler implements IDisposable {
    * Handle a notebook cells changed event.
    */
   private _onCellsChanged(
-    cells?: TNotebookCellList,
+    cells?: INotebookModel['cells'],
     changes?: IObservableList.IChangedArgs<ICellModel>
   ): void {
     this._notebookPanel.content.widgets.forEach(cell =>

--- a/packages/debugger/src/tokens.ts
+++ b/packages/debugger/src/tokens.ts
@@ -531,7 +531,7 @@ export namespace IDebugger {
       /**
        * An optional hashing seed provided by the kernel.
        */
-      seed?: string | number;
+      seed?: string;
     };
   }
 
@@ -663,7 +663,7 @@ export namespace IDebugger {
          */
         copyToGlobals?: boolean;
         hashMethod: string;
-        hashSeed: number;
+        hashSeed: string;
         isStarted: boolean;
         /**
          * Whether the kernel supports variable rich rendering or not.

--- a/packages/debugger/src/tokens.ts
+++ b/packages/debugger/src/tokens.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import type { CodeEditor, CodeEditorWrapper } from '@jupyterlab/codeeditor';
 
 import type { KernelMessage, Session } from '@jupyterlab/services';
@@ -533,7 +531,7 @@ export namespace IDebugger {
       /**
        * An optional hashing seed provided by the kernel.
        */
-      seed?: any;
+      seed?: string | number;
     };
   }
 

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { ISessionContext } from '@jupyterlab/apputils';
 import { SessionContextDialogs } from '@jupyterlab/apputils';
@@ -27,6 +26,7 @@ import { SaveHandler } from './savehandler';
 import type {
   IDocumentManager,
   IDocumentManagerDialogs,
+  IDocumentManagerStateChange,
   IDocumentWidgetOpener,
   IRecentsManager
 } from './tokens';
@@ -216,7 +216,7 @@ export class DocumentManager implements IDocumentManager {
   /**
    * Signal triggered when an attribute changes.
    */
-  get stateChanged(): ISignal<IDocumentManager, IChangedArgs<any>> {
+  get stateChanged(): ISignal<IDocumentManager, IDocumentManagerStateChange> {
     return this._stateChanged;
   }
 
@@ -739,7 +739,7 @@ export class DocumentManager implements IDocumentManager {
 
   protected _onWidgetStateChanged(
     sender: DocumentWidgetManager,
-    args: IChangedArgs<any>
+    args: IChangedArgs<boolean, boolean, 'confirmClosingDocument'>
   ): void {
     if (args.name === 'confirmClosingDocument') {
       this._stateChanged.emit(args);
@@ -761,7 +761,10 @@ export class DocumentManager implements IDocumentManager {
   private _urlResolverFactory?: IUrlResolverFactory;
   private _dialogs: ISessionContext.IDialogs;
   private _isConnectedCallback: () => boolean;
-  private _stateChanged = new Signal<DocumentManager, IChangedArgs<any>>(this);
+  private _stateChanged = new Signal<
+    IDocumentManager,
+    IDocumentManagerStateChange
+  >(this);
   private _docManagerDialogs: IDocumentManagerDialogs;
 }
 

--- a/packages/docmanager/src/tokens.ts
+++ b/packages/docmanager/src/tokens.ts
@@ -144,6 +144,21 @@ export interface IDocumentManagerDialogs {
 }
 
 /**
+ * State changes emitted by {@link IDocumentManager.stateChanged}.
+ */
+export type IDocumentManagerStateChange =
+  | IChangedArgs<
+      boolean,
+      boolean,
+      'autosave' | 'confirmClosingDocument' | 'renameUntitledFileOnSave'
+    >
+  | IChangedArgs<
+      number,
+      number,
+      'autosaveInterval' | 'lastModifiedCheckMargin'
+    >;
+
+/**
  * The interface for a document manager.
  */
 export interface IDocumentManager extends IDisposable {
@@ -190,10 +205,7 @@ export interface IDocumentManager extends IDisposable {
   /**
    * Signal triggered when an attribute changes.
    */
-  readonly stateChanged: ISignal<
-    IDocumentManager,
-    IChangedArgs<boolean | number>
-  >;
+  readonly stateChanged: ISignal<IDocumentManager, IDocumentManagerStateChange>;
 
   /**
    * Clone a widget.

--- a/packages/docmanager/src/tokens.ts
+++ b/packages/docmanager/src/tokens.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import type { ISessionContext } from '@jupyterlab/apputils';
 import type { IChangedArgs } from '@jupyterlab/coreutils';
 import type {
@@ -192,7 +190,10 @@ export interface IDocumentManager extends IDisposable {
   /**
    * Signal triggered when an attribute changes.
    */
-  readonly stateChanged: ISignal<IDocumentManager, IChangedArgs<any>>;
+  readonly stateChanged: ISignal<
+    IDocumentManager,
+    IChangedArgs<boolean | number>
+  >;
 
   /**
    * Clone a widget.

--- a/packages/docmanager/src/widgetmanager.ts
+++ b/packages/docmanager/src/widgetmanager.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { IChangedArgs } from '@jupyterlab/coreutils';
 import { Time } from '@jupyterlab/coreutils';
@@ -70,7 +69,10 @@ export class DocumentWidgetManager implements IDisposable {
   /**
    * Signal triggered when an attribute changes.
    */
-  get stateChanged(): ISignal<DocumentWidgetManager, IChangedArgs<any>> {
+  get stateChanged(): ISignal<
+    DocumentWidgetManager,
+    IChangedArgs<boolean, boolean, 'confirmClosingDocument'>
+  > {
     return this._stateChanged;
   }
 
@@ -551,9 +553,10 @@ export class DocumentWidgetManager implements IDisposable {
   private _activateRequested = new Signal<this, string>(this);
   private _confirmClosingTab = false;
   private _isDisposed = false;
-  private _stateChanged = new Signal<DocumentWidgetManager, IChangedArgs<any>>(
-    this
-  );
+  private _stateChanged = new Signal<
+    DocumentWidgetManager,
+    IChangedArgs<boolean, boolean, 'confirmClosingDocument'>
+  >(this);
   private _recentsManager: IRecentsManager | null;
   private _dialogs: IDocumentManagerDialogs | null;
 }

--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import type {
   CodeEditor,
   IEditorMimeTypeService,
@@ -201,7 +199,9 @@ export namespace FileEditor {
   /**
    * File editor default configuration.
    */
-  export const defaultEditorConfig: Record<string, any> = {
+  export const defaultEditorConfig: NonNullable<
+    CodeEditor.IOptions['config']
+  > & { scrollPastEnd: boolean } = {
     lineNumbers: true,
     scrollPastEnd: true
   };

--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * @packageDocumentation
  * @module help-extension
@@ -426,7 +425,7 @@ const resources: JupyterFrontEndPlugin<void> = {
       }
     ];
 
-    resources.sort((a: any, b: any) => {
+    resources.sort((a, b) => {
       return a.text.localeCompare(b.text);
     });
 
@@ -595,7 +594,7 @@ const resources: JupyterFrontEndPlugin<void> = {
   }
 };
 
-const plugins: JupyterFrontEndPlugin<any>[] = [
+const plugins: JupyterFrontEndPlugin<unknown>[] = [
   about,
   jupyterForum,
   licensesCommands,

--- a/packages/inspector/src/inspector.ts
+++ b/packages/inspector/src/inspector.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { Printing } from '@jupyterlab/apputils';
 import type { ITranslator, TranslationBundle } from '@jupyterlab/translation';
 import { nullTranslator } from '@jupyterlab/translation';
@@ -116,7 +114,7 @@ export class InspectorPanel
    * Handle inspector update signals.
    */
   protected onInspectorUpdate(
-    sender: any,
+    sender: IInspector.IInspectable,
     args: IInspector.IInspectorUpdate
   ): void {
     const { content } = args;
@@ -135,7 +133,10 @@ export class InspectorPanel
   /**
    * Handle source disposed signals.
    */
-  protected onSourceDisposed(sender: any, args: void): void {
+  protected onSourceDisposed(
+    sender: IInspector.IInspectable,
+    args: void
+  ): void {
     this.source = null;
   }
 

--- a/packages/inspector/src/tokens.ts
+++ b/packages/inspector/src/tokens.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { Token } from '@lumino/coreutils';
 import type { ISignal } from '@lumino/signaling';
 import type { Widget } from '@lumino/widgets';
@@ -36,17 +34,17 @@ export namespace IInspector {
     /**
      * A signal emitted when the inspector should clear all items.
      */
-    cleared: ISignal<any, void>;
+    cleared: ISignal<IInspectable, void>;
 
     /**
      * A signal emitted when the inspectable is disposed.
      */
-    disposed: ISignal<any, void>;
+    disposed: ISignal<IInspectable, void>;
 
     /**
      * A signal emitted when an inspector value is generated.
      */
-    inspected: ISignal<any, IInspectorUpdate>;
+    inspected: ISignal<IInspectable, IInspectorUpdate>;
 
     /**
      * Test whether the inspectable has been disposed.

--- a/packages/launcher/src/widget.tsx
+++ b/packages/launcher/src/widget.tsx
@@ -1,7 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { showErrorMessage } from '@jupyterlab/apputils';
 import type { ITranslator, TranslationBundle } from '@jupyterlab/translation';
 import { nullTranslator } from '@jupyterlab/translation';
@@ -104,7 +102,7 @@ export class Launcher extends VDomRenderer<ILauncher.IModel> {
   /**
    * Render the launcher to virtual DOM nodes.
    */
-  protected render(): React.ReactElement<any> | null {
+  protected render(): React.ReactElement<unknown> | null {
     // Bail if there is no model.
     if (!this.model) {
       return null;
@@ -134,8 +132,8 @@ export class Launcher extends VDomRenderer<ILauncher.IModel> {
     }
 
     // Variable to help create sections
-    const sections: React.ReactElement<any>[] = [];
-    let section: React.ReactElement<any>;
+    const sections: React.ReactElement<unknown>[] = [];
+    let section: React.ReactElement<unknown>;
 
     // Assemble the final ordered list of categories, beginning with
     // KNOWN_CATEGORIES.
@@ -251,7 +249,7 @@ function Card(
   commands: CommandRegistry,
   trans: TranslationBundle,
   launcherCallback: (widget: Widget) => void
-): React.ReactElement<any> {
+): React.ReactElement<unknown> {
   // Get some properties of the command
   const command = item.command;
   const args = { ...item.args, cwd: launcher.cwd };

--- a/packages/logconsole/src/tokens.ts
+++ b/packages/logconsole/src/tokens.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import type { IChangedArgs } from '@jupyterlab/coreutils';
 import type * as nbformat from '@jupyterlab/nbformat';
 import type { IOutputAreaModel } from '@jupyterlab/outputarea';
@@ -67,7 +65,7 @@ export interface ILogPayloadBase {
   /**
    * Data
    */
-  data: any;
+  data: unknown;
 }
 
 /**

--- a/packages/lsp/src/ws-connection/server-capability-registration.ts
+++ b/packages/lsp/src/ws-connection/server-capability-registration.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Jupyter Development Team.
  * Distributed under the terms of the Modified BSD License.
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 // Disclaimer/acknowledgement: Fragments are based on https://github.com/wylieconlon/lsp-editor-adapter,
 // which is copyright of wylieconlon and contributors and ISC licenced.
 // ISC licence is, quote, "functionally equivalent to the simplified BSD and MIT licenses,
@@ -17,7 +15,7 @@ import type {
 } from 'vscode-languageserver-protocol';
 
 interface IFlexibleServerCapabilities extends ServerCapabilities {
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 /**

--- a/packages/mainmenu/src/mainmenu.ts
+++ b/packages/mainmenu/src/mainmenu.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import type { TranslationBundle } from '@jupyterlab/translation';
 import { IRankedMenu, MenuSvg, RankedMenu } from '@jupyterlab/ui-components';
 import { ArrayExt } from '@lumino/algorithm';
@@ -17,6 +15,8 @@ import { SettingsMenu } from './settings';
 import { TabsMenu } from './tabs';
 import type { IMainMenu } from './tokens';
 import { ViewMenu } from './view';
+
+type TRankedMenu = Menu & { rank?: number };
 
 /**
  * The main menu class.  It is intended to be used as a singleton.
@@ -162,7 +162,7 @@ export class MainMenu extends MenuBar implements IMainMenu {
       'rank' in options
         ? options.rank
         : 'rank' in menu
-          ? (menu as any).rank
+          ? (menu as TRankedMenu).rank
           : IRankedMenu.DEFAULT_RANK;
     const rankItem = { menu, rank };
     const index = ArrayExt.upperBound(this._items, rankItem, Private.itemCmp);

--- a/packages/mainmenu/src/mainmenu.ts
+++ b/packages/mainmenu/src/mainmenu.ts
@@ -16,8 +16,6 @@ import { TabsMenu } from './tabs';
 import type { IMainMenu } from './tokens';
 import { ViewMenu } from './view';
 
-type TRankedMenu = Menu & { rank?: number };
-
 /**
  * The main menu class.  It is intended to be used as a singleton.
  */
@@ -162,7 +160,7 @@ export class MainMenu extends MenuBar implements IMainMenu {
       'rank' in options
         ? options.rank
         : 'rank' in menu
-          ? (menu as TRankedMenu).rank
+          ? (menu as RankedMenu).rank
           : IRankedMenu.DEFAULT_RANK;
     const rankItem = { menu, rank };
     const index = ArrayExt.upperBound(this._items, rankItem, Private.itemCmp);

--- a/packages/metadataform/src/form.tsx
+++ b/packages/metadataform/src/form.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * @packageDocumentation
  * @module metadataform
@@ -42,7 +41,7 @@ export class FormWidget extends ReactWidget {
       <FormComponent
         validator={validatorAjv8}
         schema={this._props.properties as JSONSchema7}
-        formData={this._props.formData as Record<string, any>}
+        formData={this._props.formData}
         formContext={formContext}
         uiSchema={this._props.uiSchema}
         liveValidate

--- a/packages/notebook/src/widgetfactory.ts
+++ b/packages/notebook/src/widgetfactory.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import type { IEditorMimeTypeService } from '@jupyterlab/codeeditor';
 import type { DocumentRegistry } from '@jupyterlab/docregistry';
 import { ABCWidgetFactory } from '@jupyterlab/docregistry';
@@ -12,6 +10,10 @@ import type { INotebookModel } from './model';
 import { NotebookPanel } from './panel';
 import { StaticNotebook } from './widget';
 import { NotebookHistory } from './history';
+
+type TNotebookContext = DocumentRegistry.IContext<INotebookModel> & {
+  translator?: ITranslator;
+};
 
 /**
  * A widget factory for notebook panels.
@@ -82,7 +84,7 @@ export class NotebookWidgetFactory extends ABCWidgetFactory<
     context: DocumentRegistry.IContext<INotebookModel>,
     source?: NotebookPanel
   ): NotebookPanel {
-    const translator = (context as any).translator;
+    const translator = (context as TNotebookContext).translator;
     const kernelHistory = new NotebookHistory({
       sessionContext: context.sessionContext,
       translator: translator

--- a/packages/notebook/src/widgetfactory.ts
+++ b/packages/notebook/src/widgetfactory.ts
@@ -11,10 +11,6 @@ import { NotebookPanel } from './panel';
 import { StaticNotebook } from './widget';
 import { NotebookHistory } from './history';
 
-type TNotebookContext = DocumentRegistry.IContext<INotebookModel> & {
-  translator?: ITranslator;
-};
-
 /**
  * A widget factory for notebook panels.
  */
@@ -84,7 +80,7 @@ export class NotebookWidgetFactory extends ABCWidgetFactory<
     context: DocumentRegistry.IContext<INotebookModel>,
     source?: NotebookPanel
   ): NotebookPanel {
-    const translator = (context as TNotebookContext).translator;
+    const translator = this.translator;
     const kernelHistory = new NotebookHistory({
       sessionContext: context.sessionContext,
       translator: translator

--- a/packages/running/src/index.tsx
+++ b/packages/running/src/index.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * @packageDocumentation
  * @module running
@@ -1242,7 +1241,7 @@ export namespace IRunningSessions {
     /**
      * A signal that should be emitted when the item list has changed.
      */
-    runningChanged: ISignal<any, any>;
+    runningChanged: ISignal<unknown, unknown>;
 
     /**
      * A string used to describe the shutdown action.

--- a/packages/settingeditor/src/plugineditor.ts
+++ b/packages/settingeditor/src/plugineditor.ts
@@ -2,8 +2,6 @@
 | Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { Dialog, showDialog, showErrorMessage } from '@jupyterlab/apputils';
 import type { CodeEditor } from '@jupyterlab/codeeditor';
 import type { IRenderMimeRegistry } from '@jupyterlab/rendermime';
@@ -177,7 +175,7 @@ export class PluginEditor extends Widget {
    * Handle layout state changes that need to be saved.
    */
   private _onStateChanged(): void {
-    (this.stateChanged as Signal<any, void>).emit(undefined);
+    this._stateChanged.emit(undefined);
   }
 
   protected translator: ITranslator;

--- a/packages/shortcuts-extension/src/components/ShortcutInput.tsx
+++ b/packages/shortcuts-extension/src/components/ShortcutInput.tsx
@@ -2,8 +2,6 @@
  * Copyright (c) Jupyter Development Team.
  * Distributed under the terms of the Modified BSD License.
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import * as React from 'react';
 import type { ITranslator } from '@jupyterlab/translation';
 import { JSONExt } from '@lumino/coreutils';
@@ -153,7 +151,7 @@ export class ShortcutInput extends React.Component<
     userInput: string,
     keys: Array<string>,
     currentChain: string
-  ): Array<any> => {
+  ): [string, string[], string] => {
     let key = EN_US.keyForKeydownEvent(event.nativeEvent);
 
     const modKeys = ['Shift', 'Control', 'Alt', 'Meta', 'Ctrl', 'Accel'];

--- a/packages/statusbar/src/tokens.ts
+++ b/packages/statusbar/src/tokens.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { Token } from '@lumino/coreutils';
 import type { IDisposable } from '@lumino/disposable';
 import type { ISignal } from '@lumino/signaling';
@@ -68,6 +66,6 @@ export namespace IStatusBar {
     /**
      * A signal that is fired when the item active state changes.
      */
-    activeStateChanged?: ISignal<any, void>;
+    activeStateChanged?: ISignal<unknown, void>;
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References
 Part of #18854 

## Code changes
Removes file-level `no-explicit-any` suppressions from 30 files.



## User-facing changes
None

## Backwards-incompatible changes
None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: ChatGPT
