### PR TITLE
Use home icon for home preferred directory

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -11,6 +11,7 @@ import sys
 from jupyter_core.application import JupyterApp, NoStart, base_aliases, base_flags
 from jupyter_server._version import version_info as jpserver_version_info
 from jupyter_server.serverapp import flags
+from jupyter_server.utils import to_os_path
 from jupyter_server.utils import url_path_join as ujoin
 from jupyterlab_server import (
     LabServerApp,
@@ -724,6 +725,15 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
         super()._prepare_templates()
         self.jinja2_env.globals.update(custom_css=self.custom_css)
 
+    def _preferred_path_is_home(self):
+        """Whether the preferred path resolves to the user's home directory."""
+        try:
+            contents_manager = self.serverapp.contents_manager
+            preferred_dir = to_os_path(contents_manager.preferred_dir, contents_manager.root_dir)
+            return os.path.samefile(preferred_dir, os.path.expanduser("~"))
+        except (AttributeError, OSError):
+            return False
+
     def initialize_handlers(self):  # noqa
         handlers = []
 
@@ -738,6 +748,7 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
         page_config["exposeAppInBrowser"] = self.expose_app_in_browser
         page_config["quitButton"] = self.serverapp.quit_button
         page_config["allow_hidden_files"] = self.serverapp.contents_manager.allow_hidden
+        page_config["preferredPathIsHome"] = self._preferred_path_is_home()
         if hasattr(self.serverapp.contents_manager, "delete_to_trash"):
             page_config["delete_to_trash"] = self.serverapp.contents_manager.delete_to_trash
 

--- a/packages/filebrowser/src/crumbs.ts
+++ b/packages/filebrowser/src/crumbs.ts
@@ -8,6 +8,7 @@ import type { ITranslator, TranslationBundle } from '@jupyterlab/translation';
 import { nullTranslator } from '@jupyterlab/translation';
 import {
   ellipsesIcon,
+  homeIcon,
   folderFavoriteIcon as preferredIcon,
   folderIcon as rootIcon
 } from '@jupyterlab/ui-components';
@@ -1136,8 +1137,13 @@ namespace Private {
     ellipsis.tabIndex = -1;
 
     const preferredPath = PageConfig.getOption('preferredPath');
-    const path = preferredPath ? '/' + preferredPath : preferredPath;
-    const preferred = preferredIcon.element({
+    const path =
+      preferredPath && preferredPath !== '/'
+        ? '/' + preferredPath
+        : preferredPath;
+    const preferredPathIsHome =
+      PageConfig.getOption('preferredPathIsHome').toLowerCase() === 'true';
+    const preferred = (preferredPathIsHome ? homeIcon : preferredIcon).element({
       className: BREADCRUMB_PREFERRED_CLASS,
       tag: 'span',
       title: path || 'Jupyter Preferred Path',

--- a/packages/filebrowser/test/crumbs.spec.ts
+++ b/packages/filebrowser/test/crumbs.spec.ts
@@ -93,6 +93,7 @@ describe('filebrowser/model', () => {
     // Remove leading '/' from preferredPath (as done by jupyter server)
     const preferredPath = path.startsWith('/') ? path.slice(1) : path;
     PageConfig.setOption('preferredPath', preferredPath);
+    PageConfig.setOption('preferredPathIsHome', 'false');
     crumbs = new LogCrumbs({ model });
   });
 
@@ -119,6 +120,44 @@ describe('filebrowser/model', () => {
 
       it('should add the jp-BreadCrumbs class', () => {
         expect(crumbs.hasClass('jp-BreadCrumbs')).toBe(true);
+      });
+
+      it('should use the home icon only when the preferred path is home', () => {
+        PageConfig.setOption('preferredPathIsHome', 'true');
+        const bread = new BreadCrumbs({ model });
+        Widget.attach(bread, document.body);
+        MessageLoop.sendMessage(bread, Widget.Msg.UpdateRequest);
+
+        const rootIcon = bread.node.querySelector(
+          `.${BREADCRUMB_ROOT_CLASS} svg`
+        );
+        const preferredHomeIcon = bread.node.querySelector(
+          `.${BREADCRUMB_PREFERRED_CLASS} svg`
+        );
+        expect(rootIcon?.getAttribute('data-icon')).toBe(
+          'ui-components:folder'
+        );
+        expect(preferredHomeIcon?.getAttribute('data-icon')).toBe(
+          'ui-components:home'
+        );
+
+        Widget.detach(bread);
+        bread.dispose();
+
+        PageConfig.setOption('preferredPathIsHome', 'false');
+        const nonHomeBread = new BreadCrumbs({ model });
+        Widget.attach(nonHomeBread, document.body);
+        MessageLoop.sendMessage(nonHomeBread, Widget.Msg.UpdateRequest);
+
+        const preferredIcon = nonHomeBread.node.querySelector(
+          `.${BREADCRUMB_PREFERRED_CLASS} svg`
+        );
+        expect(preferredIcon?.getAttribute('data-icon')).toBe(
+          'ui-components:folder-favorite'
+        );
+
+        Widget.detach(nonHomeBread);
+        nonHomeBread.dispose();
       });
     });
 


### PR DESCRIPTION
## References
Closes #18931 

## Code changes

Adds a page config flag that resolves the configured preferred directory with existing Jupyter Server path utilities and checks whether it is the user’s home directory. The file browser breadcrumbs now use the home icon only for a preferred directory that points to home, while non-home preferred directories continue using the folder-favorite icon and the server-root shortcut remains unchanged.

## User-facing changes

The preferred directory breadcrumb shows the home icon only when the preferred directory is the user’s home directory. Non-home preferred directories continue to show the folder-favorite icon.

## Backwards-incompatible changes
None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: ChatGPT 5.5
