### PR TITLE
Add notebook kernel locking metadata feature

### DIFF
--- a/galata/test/jupyterlab/settings.test.ts
+++ b/galata/test/jupyterlab/settings.test.ts
@@ -620,7 +620,11 @@ test('Read-only cells should remain read-only after changing settings', async ({
   await page.notebook
     .getToolbarItemLocator('kernelName')
     .then(item => item?.click());
-  await page.locator('.jp-Dialog-checkbox').click();
+  await page
+    .locator(
+      '.jp-Dialog-checkbox:has-text("Always start the preferred kernel")'
+    )
+    .click();
   await page.locator('.jp-Dialog-button:has-text("Select")').click();
 
   // Assert the first cell is still read-only

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -306,6 +306,15 @@ export namespace ISessionContext {
      * Skip showing the kernel restart dialog if checked (default `false`).
      */
     readonly skipKernelRestartDialog?: boolean;
+
+    /**
+     * Lock the kernel.
+     *
+     * #### Notes
+     * When `true`, the notebook kernel cannot be changed. When `undefined`,
+     * the lock feature is disabled.
+     */
+    readonly locked?: boolean;
   }
 
   export type KernelDisplayStatus =
@@ -1393,6 +1402,27 @@ export class SessionContextDialogs implements ISessionContext.IDialogs {
     const translator = this._translator;
     const trans = translator.load('jupyterlab');
 
+    // Check whether the kernel choice is locked.
+    const wasLocked = sessionContext.kernelPreference.locked === true;
+    if (wasLocked) {
+      const name = sessionContext.kernelPreference.name;
+      const specs = sessionContext.specsManager.specs;
+      const nameAvailable = !!name && !!specs?.kernelspecs[name];
+      if (sessionContext.hasNoKernel && !nameAvailable) {
+        if (name) {
+          await showDialog({
+            title: trans.__('Kernel Unavailable'),
+            body: trans.__(
+              'This notebook requires the %1 kernel, which is not available.',
+              name
+            ),
+            buttons: [Dialog.okButton({ label: trans.__('Ok') })]
+          });
+        }
+        return;
+      }
+    }
+
     // If there is no existing kernel, offer the option to keep no kernel.
     let label = trans.__('Cancel');
     if (sessionContext.hasNoKernel) {
@@ -1406,22 +1436,10 @@ export class SessionContextDialogs implements ISessionContext.IDialogs {
       })
     ];
 
-    const autoStartDefault = sessionContext.kernelPreference.autoStartDefault;
-    const hasCheckbox = typeof autoStartDefault === 'boolean';
-
     const dialog = new Dialog({
       title: trans.__('Select Kernel'),
       body: Private.createKernelSelector(sessionContext, translator),
-      buttons,
-      checkbox: hasCheckbox
-        ? {
-            label: trans.__('Always start the preferred kernel'),
-            caption: trans.__(
-              'Remember my choice and always start the preferred kernel'
-            ),
-            checked: autoStartDefault
-          }
-        : null
+      buttons
     });
 
     const result = await dialog.launch();
@@ -1430,14 +1448,29 @@ export class SessionContextDialogs implements ISessionContext.IDialogs {
       return;
     }
 
-    if (hasCheckbox && result.isChecked !== null) {
+    const { model, autoStartDefault, locked } = result.value ?? {
+      model: null,
+      autoStartDefault: null,
+      locked: null
+    };
+
+    if (autoStartDefault !== null) {
       sessionContext.kernelPreference = {
         ...sessionContext.kernelPreference,
-        autoStartDefault: result.isChecked
+        autoStartDefault
+      };
+    }
+    if (locked !== null) {
+      sessionContext.kernelPreference = {
+        ...sessionContext.kernelPreference,
+        locked
       };
     }
 
-    const model = result.value;
+    if (wasLocked && locked === true) {
+      return;
+    }
+
     if (model === null && !sessionContext.hasNoKernel) {
       return sessionContext.shutdown();
     }
@@ -1850,9 +1883,23 @@ namespace Private {
     /**
      * Get the value of the kernel selector widget.
      */
-    getValue(): Kernel.IModel {
+    getValue(): {
+      model: Kernel.IModel;
+      autoStartDefault: boolean | null;
+      locked: boolean | null;
+    } {
       const selector = this.node.querySelector<HTMLSelectElement>('select')!;
-      return JSON.parse(selector.value) as Kernel.IModel;
+      const autoStartCheckbox = this.node.querySelector<HTMLInputElement>(
+        'input[data-role="autoStartDefault"]'
+      );
+      const lockCheckbox = this.node.querySelector<HTMLInputElement>(
+        'input[data-role="kernelLock"]'
+      );
+      return {
+        model: JSON.parse(selector.value) as Kernel.IModel,
+        autoStartDefault: autoStartCheckbox ? autoStartCheckbox.checked : null,
+        locked: lockCheckbox ? lockCheckbox.checked : null
+      };
     }
   }
 
@@ -1893,6 +1940,46 @@ namespace Private {
       select.appendChild(optgroup);
     }
     body.appendChild(select);
+
+    const preference = sessionContext.kernelPreference;
+
+    const addCheckbox = (
+      role: string,
+      label: string,
+      caption: string,
+      checked: boolean
+    ): void => {
+      const checkboxLabel = document.createElement('label');
+      checkboxLabel.className = 'jp-Dialog-checkbox';
+      checkboxLabel.style.alignSelf = 'flex-start';
+      checkboxLabel.title = caption;
+      checkboxLabel.textContent = label;
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.checked = checked;
+      input.dataset.role = role;
+      checkboxLabel.insertAdjacentElement('afterbegin', input);
+      body.appendChild(checkboxLabel);
+    };
+
+    if (typeof preference.autoStartDefault === 'boolean') {
+      addCheckbox(
+        'autoStartDefault',
+        trans.__('Always start the preferred kernel'),
+        trans.__('Remember my choice and always start the preferred kernel'),
+        preference.autoStartDefault
+      );
+    }
+
+    if (typeof preference.locked === 'boolean') {
+      addCheckbox(
+        'kernelLock',
+        trans.__('Lock kernel choice'),
+        trans.__('Prevent changing the kernel for this notebook'),
+        preference.locked
+      );
+    }
+
     return body;
   }
 

--- a/packages/apputils/src/toolbar/widget.tsx
+++ b/packages/apputils/src/toolbar/widget.tsx
@@ -160,12 +160,27 @@ namespace Private {
         initialSender={props.sessionContext}
       >
         {sessionContext => (
-          <ToolbarButtonComponent
-            className={TOOLBAR_KERNEL_NAME_CLASS}
-            onClick={callback}
-            tooltip={trans.__('Switch kernel')}
-            label={sessionContext?.kernelDisplayName}
-          />
+          <UseSignal
+            signal={props.sessionContext.kernelPreferenceChanged}
+            initialSender={props.sessionContext}
+          >
+            {() => {
+              const locked =
+                props.sessionContext.kernelPreference.locked === true;
+              return (
+                <ToolbarButtonComponent
+                  className={TOOLBAR_KERNEL_NAME_CLASS}
+                  onClick={callback}
+                  tooltip={trans.__('Switch kernel')}
+                  disabledTooltip={trans.__(
+                    'The kernel is locked for this notebook'
+                  )}
+                  enabled={!locked}
+                  label={sessionContext?.kernelDisplayName}
+                />
+              );
+            }}
+          </UseSignal>
         )}
       </UseSignal>
     );

--- a/packages/apputils/test/sessioncontext.spec.ts
+++ b/packages/apputils/test/sessioncontext.spec.ts
@@ -22,7 +22,8 @@ import {
   acceptDialog,
   dismissDialog,
   JupyterServer,
-  testEmission
+  testEmission,
+  waitForDialog
 } from '@jupyterlab/testing';
 import { PromiseDelegate, UUID } from '@lumino/coreutils';
 import * as fs from 'fs-extra';
@@ -759,6 +760,74 @@ describe('@jupyterlab/apputils', () => {
         const session = sessionContext.session;
         expect(session!.kernel!.id).toBe(id);
         expect(session!.kernel!.name).toBe(name);
+      });
+
+      it('should persist the lock choice into the kernel preference', async () => {
+        sessionContext.kernelPreference = {
+          ...sessionContext.kernelPreference,
+          locked: false
+        };
+        await sessionContext.initialize();
+
+        const select = sessionContextDialogs.selectKernel(sessionContext);
+        await waitForDialog();
+        const checkbox = document.querySelector<HTMLInputElement>(
+          '.jp-Dialog-body input[data-role="kernelLock"]'
+        )!;
+        checkbox.checked = true;
+        await acceptDialog();
+        await select;
+
+        expect(sessionContext.kernelPreference.locked).toBe(true);
+      });
+
+      it('should start the selected kernel when locking a new notebook', async () => {
+        // A new notebook with no kernel.
+        sessionContext.kernelPreference = {
+          ...sessionContext.kernelPreference,
+          locked: false,
+          shouldStart: false
+        };
+        await sessionContext.initialize();
+        expect(sessionContext.hasNoKernel).toBe(true);
+
+        const select = sessionContextDialogs.selectKernel(sessionContext);
+        await waitForDialog();
+        const dropdown = document.querySelector<HTMLSelectElement>(
+          '.jp-Dialog-body select'
+        )!;
+        const lockCheckbox = document.querySelector<HTMLInputElement>(
+          '.jp-Dialog-body input[data-role="kernelLock"]'
+        )!;
+        // Select a kernel and lock it in the same dialog.
+        const defaultName = specsManager.specs!.default;
+        dropdown.value = JSON.stringify({ name: defaultName });
+        lockCheckbox.checked = true;
+        await acceptDialog();
+        await select;
+
+        // The selected kernel must be applied, and the lock set.
+        expect(sessionContext.session?.kernel?.name).toBe(defaultName);
+        expect(sessionContext.kernelPreference.locked).toBe(true);
+      });
+
+      it('should show warning when a locked kernel is unavailable', async () => {
+        sessionContext.kernelPreference = {
+          ...sessionContext.kernelPreference,
+          locked: true,
+          name: 'not-a-real-kernel'
+        };
+
+        const select = sessionContextDialogs.selectKernel(sessionContext);
+        await waitForDialog();
+        // The warning dialog has no kernel selector.
+        const selector = document.querySelector('.jp-Dialog-body select');
+        expect(selector).toBeNull();
+        await acceptDialog();
+        await select;
+
+        // The kernel was not changed.
+        expect(sessionContext.session?.kernel).toBeFalsy();
       });
     });
 

--- a/packages/apputils/test/toolbar.spec.ts
+++ b/packages/apputils/test/toolbar.spec.ts
@@ -79,6 +79,34 @@ describe('@jupyterlab/apputils', () => {
           const node = item.node.querySelector('.jp-Toolbar-kernelName')!;
           expect(node.textContent).toBe(sessionContext.kernelDisplayName);
         });
+
+        it('should be disabled when the kernel choice is locked', async () => {
+          const item = Toolbar.createKernelNameItem(
+            sessionContext,
+            new SessionContextDialogs()
+          );
+          await sessionContext.initialize();
+          Widget.attach(item, document.body);
+          await framePromise();
+          const button = item.node.querySelector('.jp-Toolbar-kernelName')!;
+          expect(button.getAttribute('aria-disabled')).toBe('false');
+
+          // Locking the kernel disables the switch-kernel button.
+          sessionContext.kernelPreference = {
+            ...sessionContext.kernelPreference,
+            locked: true
+          };
+          await framePromise();
+          expect(button.getAttribute('aria-disabled')).toBe('true');
+
+          // Unlocking re-enables it.
+          sessionContext.kernelPreference = {
+            ...sessionContext.kernelPreference,
+            locked: false
+          };
+          await framePromise();
+          expect(button.getAttribute('aria-disabled')).toBe('false');
+        });
       });
 
       describe('.createKernelStatusItem()', () => {

--- a/packages/nbformat/src/index.ts
+++ b/packages/nbformat/src/index.ts
@@ -49,6 +49,7 @@ export interface INotebookMetadata extends PartialJSONObject {
   kernelspec?: IKernelspecMetadata;
   language_info?: ILanguageInfoMetadata;
   orig_nbformat?: number;
+  kernel_lock?: boolean;
 }
 
 /**

--- a/packages/notebook-extension/schema/tools.json
+++ b/packages/notebook-extension/schema/tools.json
@@ -108,6 +108,21 @@
           "/toc/base_numbering": {
             "title": "Table of content - Base number",
             "type": "integer"
+          },
+          "/kernel_lock": {
+            "title": "Notebook kernel",
+            "type": "boolean",
+            "default": false,
+            "oneOf": [
+              {
+                "const": false,
+                "title": "Unlocked"
+              },
+              {
+                "const": true,
+                "title": "Locked"
+              }
+            ]
           }
         }
       },
@@ -116,6 +131,9 @@
           "ui:widget": "select"
         },
         "/deletable": {
+          "ui:widget": "select"
+        },
+        "/kernel_lock": {
           "ui:widget": "select"
         }
       },
@@ -127,6 +145,9 @@
           "cellTypes": ["raw"]
         },
         "/toc/base_numbering": {
+          "metadataLevel": "notebook"
+        },
+        "/kernel_lock": {
           "metadataLevel": "notebook"
         }
       }

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -2558,6 +2558,13 @@ function addCommands(
     return Private.isEnabledAndSingleSelected(shell, tracker);
   };
 
+  const isKernelLocked = (): boolean => {
+    return (
+      tracker.currentWidget?.context.sessionContext.kernelPreference.locked ===
+      true
+    );
+  };
+
   const refreshCellCollapsed = (notebook: Notebook): void => {
     for (const cell of notebook.widgets) {
       if (cell instanceof MarkdownCell && cell.headingCollapsed) {
@@ -2652,6 +2659,9 @@ function addCommands(
         commands.notifyCommandChanged(CommandIDs.selectLastModifiedCell);
         commands.notifyCommandChanged(CommandIDs.selectNextModifiedCell);
       }
+    });
+    panel.context.sessionContext.kernelPreferenceChanged.connect(() => {
+      commands.notifyCommandChanged(CommandIDs.changeKernel);
     });
   });
 
@@ -4301,7 +4311,7 @@ function addCommands(
         return sessionDialogs.selectKernel(current.context.sessionContext);
       }
     },
-    isEnabled,
+    isEnabled: () => isEnabled() && !isKernelLocked(),
     describedBy: {
       args: {
         type: 'object',

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -63,6 +63,22 @@ export interface INotebookModel extends DocumentRegistry.IModel {
   readonly deletedCells: string[];
 
   /**
+   * Whether the notebook's chosen kernel is locked.
+   *
+   * ### Notes
+   * When `true`, the user should be prevented from changing the kernel.
+   * Represented through the `kernel_lock` notebook metadata field.
+   */
+  readonly kernelLocked: boolean;
+
+  /**
+   * Set whether the notebook's chosen kernel is locked.
+   *
+   * @param locked Whether the kernel should be locked.
+   */
+  setKernelLocked(locked: boolean): void;
+
+  /**
    * Shared model
    */
   readonly sharedModel: ISharedNotebook;
@@ -235,6 +251,26 @@ export class NotebookModel implements INotebookModel {
   get defaultKernelLanguage(): string {
     const info = this.getMetadata('language_info');
     return info?.name ?? '';
+  }
+
+  /**
+   * Whether the notebook's chosen kernel is locked.
+   */
+  get kernelLocked(): boolean {
+    return this.getMetadata('kernel_lock') === true;
+  }
+
+  /**
+   * Set whether the notebook's chosen kernel is locked.
+   *
+   * @param locked Whether the kernel should be locked.
+   */
+  setKernelLocked(locked: boolean): void {
+    if (locked) {
+      this.setMetadata('kernel_lock', true);
+    } else {
+      this.deleteMetadata('kernel_lock');
+    }
   }
 
   /**

--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -5,11 +5,13 @@
 import type { ISessionContext } from '@jupyterlab/apputils';
 import { Dialog, Printing, showDialog } from '@jupyterlab/apputils';
 import { isMarkdownCellModel } from '@jupyterlab/cells';
+import type { IChangedArgs } from '@jupyterlab/coreutils';
 import { PageConfig } from '@jupyterlab/coreutils';
 import type { DocumentRegistry } from '@jupyterlab/docregistry';
 import { DocumentWidget } from '@jupyterlab/docregistry';
 import type { Kernel, KernelMessage, Session } from '@jupyterlab/services';
 import type { ITranslator } from '@jupyterlab/translation';
+import type { IMapChange } from '@jupyter/ydoc';
 import { Token } from '@lumino/coreutils';
 import type { INotebookModel } from './model';
 import type { StaticNotebook } from './widget';
@@ -54,6 +56,19 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
       this._onSessionStatusChanged,
       this
     );
+    this.context.sessionContext.kernelPreferenceChanged.connect(
+      this._onKernelPreferenceChanged,
+      this
+    );
+    // Apply the `kernel_lock` metadata to the kernel preference once it is available.
+    void this.context.ready.then(() => {
+      if (this.isDisposed) {
+        return;
+      }
+      this._updateKernelLockPreference();
+      this.model?.metadataChanged.connect(this._onModelMetadataChanged, this);
+    });
+
     // this.content.fullyRendered.connect(this._onFullyRendered, this);
     this.context.saveState.connect(this._onSave, this);
     void this.revealed.then(() => {
@@ -257,6 +272,51 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
       display_name: spec?.display_name,
       language: spec?.language
     });
+  }
+
+  /**
+   * Propagate the `kernel_lock` metadata into the kernel preference.
+   */
+  private _updateKernelLockPreference(): void {
+    const model = this.model;
+    if (!model) {
+      return;
+    }
+    const locked = model.kernelLocked;
+    const preference = this.context.sessionContext.kernelPreference;
+    if (preference.locked !== locked) {
+      this.context.sessionContext.kernelPreference = {
+        ...preference,
+        locked
+      };
+    }
+  }
+
+  /**
+   * Handle a change to the notebook metadata by propagating the `kernel_lock`
+   * field into the kernel preference.
+   */
+  private _onModelMetadataChanged(
+    sender: INotebookModel,
+    change: IMapChange
+  ): void {
+    if (change.key === 'kernel_lock') {
+      this._updateKernelLockPreference();
+    }
+  }
+
+  /**
+   * Handle a change to the kernel preference by persisting the lock state into
+   * the notebook metadata.
+   */
+  private _onKernelPreferenceChanged(
+    sender: ISessionContext,
+    args: IChangedArgs<ISessionContext.IKernelPreference>
+  ): void {
+    const locked = args.newValue.locked === true;
+    if (this.model && locked !== this.model.kernelLocked) {
+      this.model.setKernelLocked(locked);
+    }
   }
 
   /**

--- a/packages/notebook/test/model.spec.ts
+++ b/packages/notebook/test/model.spec.ts
@@ -194,6 +194,40 @@ describe('@jupyterlab/notebook', () => {
       });
     });
 
+    describe('#kernelLock', () => {
+      it('should default to false', () => {
+        const model = new NotebookModel();
+        expect(model.kernelLocked).toBe(false);
+      });
+
+      it('should reflect the `kernel_lock` metadata', () => {
+        const model = new NotebookModel();
+        model.setMetadata('kernel_lock', true);
+        expect(model.kernelLocked).toBe(true);
+      });
+
+      it('should be false when `kernel_lock` is false', () => {
+        const model = new NotebookModel();
+        model.setMetadata('kernel_lock', false);
+        expect(model.kernelLocked).toBe(false);
+      });
+
+      it('should set the `kernel_lock` metadata when locking', () => {
+        const model = new NotebookModel();
+        model.setKernelLocked(true);
+        expect(model.kernelLocked).toBe(true);
+        expect(model.getMetadata('kernel_lock')).toBe(true);
+      });
+
+      it('should remove the `kernel_lock` metadata when unlocking', () => {
+        const model = new NotebookModel();
+        model.setKernelLocked(true);
+        model.setKernelLocked(false);
+        expect(model.kernelLocked).toBe(false);
+        expect(model.getMetadata('kernel_lock')).toBeUndefined();
+      });
+    });
+
     describe('#dispose()', () => {
       it('should dispose of the resources held by the model', () => {
         const model = new NotebookModel();

--- a/packages/notebook/test/panel.spec.ts
+++ b/packages/notebook/test/panel.spec.ts
@@ -89,6 +89,51 @@ describe('@jupyterlab/notebook', () => {
       });
     });
 
+    describe('#kernelLock', () => {
+      it('should apply the `kernel_lock` metadata to the kernel preference on load', async () => {
+        const panel = utils.createNotebookPanel(context);
+        await context.initialize(true);
+        await context.ready;
+        panel.model!.setKernelLocked(true);
+        // The metadata change propagates into the kernel preference.
+        expect(context.sessionContext.kernelPreference.locked).toBe(true);
+      });
+
+      it('should propagate later `kernel_lock` metadata changes to the preference', async () => {
+        const panel = utils.createNotebookPanel(context);
+        await context.initialize(true);
+        await context.ready;
+        expect(context.sessionContext.kernelPreference.locked).toBeFalsy();
+
+        // Changing the metadata directly (e.g. from the Common Tools dropdown)
+        // must be reflected in the kernel preference.
+        panel.model!.setKernelLocked(true);
+        expect(context.sessionContext.kernelPreference.locked).toBe(true);
+
+        panel.model!.setKernelLocked(false);
+        expect(context.sessionContext.kernelPreference.locked).toBe(false);
+      });
+
+      it('should persist preference lock changes into the metadata', async () => {
+        const panel = utils.createNotebookPanel(context);
+        await context.initialize(true);
+        await context.ready;
+
+        // Locking through the kernel digalog must be written to the notebook metadata.
+        context.sessionContext.kernelPreference = {
+          ...context.sessionContext.kernelPreference,
+          locked: true
+        };
+        expect(panel.model!.kernelLocked).toBe(true);
+
+        context.sessionContext.kernelPreference = {
+          ...context.sessionContext.kernelPreference,
+          locked: false
+        };
+        expect(panel.model!.kernelLocked).toBe(false);
+      });
+    });
+
     describe('.ContentFactory', () => {
       describe('#constructor', () => {
         it('should create a new ContentFactory', () => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Proposes the solution for https://github.com/jupyterlab/jupyterlab/issues/19050. 

As mentioned in the linked issue, a problem often encountered in educational settings and with beginner users is that they accidentally change the active kernel of a notebook which causes changes in the notebook's execution environment, making it confusing and difficult to diagnose. This PR offers support for this through a notebook metadata field `kernel_lock`, which locks the chosen kernel for a notebook, significantly minimizing the risk of accidental changes, as well as giving users the option to share a notebook with the kernel they intended. 
 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

The notebook metadata schema is extended with an optional `kernel_lock` field, which serves as the persisted source of truth for whether a notebook's chosen kernel is locked.

The `NotebookModel` has an additional `kernelLocked` getter and a `setKernelLocked()` method, which writes the metadata when locking and removes the field when unlocking. The `IKernelPreference` is also extended with an optional `locked` property, which carries the lock state from the notebook to the kernel dialog, and when undefined, the feature is disabled.

The notebook panel bridges the notebook metadata and the session's `kernelPreference` in both directions. Once the context is ready, it initializes `kernelPreference.locked` from the notebook metadata and keeps the two in sync, persisting preference changes back to the metadata while propagating metadata updates to the kernel preference.

On the UI side, the kernel selector dialog has an additional `Lock kernel` checkbox. To place it beneath the existing `Always start the preferred kernel` checkbox, both were moved into the dialog body, since the dialog footer supports only a single checkbox. A warning is shown if a required locked kernel is unavailable: `This notebook requires the %1 kernel, which is not available`.

When a notebook is locked, the toolbar button `Switch Kernel` is disabled, as well as the `notebook:change-kernel` command, which also disables the corresponding Kernel menu item and Command Palette entry. Restart, interrupt, and reconnect actions remain available. A new `Notebook kernel` (Locked/Unlocked) dropdown is also added to the `Common Tools` panel, backed by the notebook's `kernel_lock` metadata.

Tests were added to cover the new model accessors, metadata/preference synchronization, dialog lock persistence, toolbar button status, the unavailable-kernel warning path, and a regression ensuring a newly created notebook starts its selected kernel when locked in the same dialog. 

## User-facing changes

Users will now see an additional checkbox for locking the kernel inside the kernel selection dialog. When checked, the `Switch Kernel` toolbar button will be disabled and the `kernel_lock` metadata field will be added to the notebook. A new `Notebook kernel` dropdown can be used from the `Common Tools` panel to change the locking state. The additional `kernel_lock` metadata field can also be observed in `Advanced tools -> Notebook Metadata`, where it can also be changed. 

[Screencast from 09.07.2026 15:00:55.webm](https://github.com/user-attachments/assets/aa2bb939-637a-43f1-befa-d6beaf90c9a0)

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes
N/A
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

## AI usage

- **NO**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: N/A
