### PR TITLE
Clear stale Table of Contents error markers

### DIFF
--- a/packages/notebook/src/toc.ts
+++ b/packages/notebook/src/toc.ts
@@ -244,8 +244,15 @@ export class NotebookToCModel extends TableOfContentsModel<
    */
   protected async getHeadings(): Promise<INotebookHeading[] | null> {
     const cells = this.widget.content.widgets;
+    const currentCells = new Set(cells);
     const headings: INotebookHeading[] = [];
     const documentLevels = new Array<number>();
+
+    this._cellToHeadingIndex = new WeakMap<Cell, number>();
+    this._runningCells = this._runningCells.filter(cell =>
+      currentCells.has(cell)
+    );
+    this._errorCells = this._errorCells.filter(cell => currentCells.has(cell));
 
     // Generate headings by iterating through all notebook cells...
     for (let i = 0; i < cells.length; i++) {
@@ -329,7 +336,8 @@ export class NotebookToCModel extends TableOfContentsModel<
   ): boolean {
     return (
       super.isHeadingEqual(heading1, heading2) &&
-      heading1.cellRef === heading2.cellRef
+      heading1.cellRef === heading2.cellRef &&
+      heading1.isRunning === heading2.isRunning
     );
   }
 
@@ -463,11 +471,15 @@ export class NotebookToCModel extends TableOfContentsModel<
   }
 
   protected updateRunningStatus(headings: INotebookHeading[]): void {
+    headings.forEach(heading => {
+      heading.isRunning = RunningStatus.Idle;
+    });
+
     // Update isRunning
     this._runningCells.forEach((cell, index) => {
       const headingIndex = this._cellToHeadingIndex.get(cell);
       if (headingIndex !== undefined) {
-        const heading = this.headings[headingIndex];
+        const heading = headings[headingIndex];
         // Running is prioritized over Scheduled, so if a heading is
         // running don't change status
         if (heading.isRunning !== RunningStatus.Running) {
@@ -480,7 +492,7 @@ export class NotebookToCModel extends TableOfContentsModel<
     this._errorCells.forEach((cell, index) => {
       const headingIndex = this._cellToHeadingIndex.get(cell);
       if (headingIndex !== undefined) {
-        const heading = this.headings[headingIndex];
+        const heading = headings[headingIndex];
         // Running and Scheduled are prioritized over Error, so only if
         // a heading is idle will it be set to Error
         if (heading.isRunning === RunningStatus.Idle) {

--- a/packages/notebook/src/toc.ts
+++ b/packages/notebook/src/toc.ts
@@ -247,12 +247,7 @@ export class NotebookToCModel extends TableOfContentsModel<
     const currentCells = new Set(cells);
     const headings: INotebookHeading[] = [];
     const documentLevels = new Array<number>();
-
-    this._cellToHeadingIndex = new WeakMap<Cell, number>();
-    this._runningCells = this._runningCells.filter(cell =>
-      currentCells.has(cell)
-    );
-    this._errorCells = this._errorCells.filter(cell => currentCells.has(cell));
+    const cellToHeadingIndex = new WeakMap<Cell, number>();
 
     // Generate headings by iterating through all notebook cells...
     for (let i = 0; i < cells.length; i++) {
@@ -313,12 +308,15 @@ export class NotebookToCModel extends TableOfContentsModel<
       }
 
       if (headings.length > 0) {
-        this._cellToHeadingIndex.set(cell, headings.length - 1);
-      } else {
-        // If no headings were found, remove the cell from the map
-        this._cellToHeadingIndex.delete(cell);
+        cellToHeadingIndex.set(cell, headings.length - 1);
       }
     }
+
+    this._cellToHeadingIndex = cellToHeadingIndex;
+    this._runningCells = this._runningCells.filter(cell =>
+      currentCells.has(cell)
+    );
+    this._errorCells = this._errorCells.filter(cell => currentCells.has(cell));
     this.updateRunningStatus(headings);
     return Promise.resolve(headings);
   }

--- a/packages/notebook/test/toc.spec.ts
+++ b/packages/notebook/test/toc.spec.ts
@@ -128,6 +128,43 @@ describe('@jupyterlab/notebook', () => {
           RunningStatus.Idle.toString()
         );
       });
+
+      it('should preserve execution status updates during heading refresh', async () => {
+        panel.model!.sharedModel.insertCells(1, [
+          { cell_type: 'code', source: '1 / 0' }
+        ]);
+
+        await model.refresh();
+
+        const headingCell = panel.content.widgets[0];
+        const erroredCell = panel.content.widgets[1];
+        const getHeadings = headingCell.getHeadings.bind(headingCell);
+        let resumeRefresh: (() => void) | undefined;
+        const refreshGate = new Promise<void>(resolve => {
+          resumeRefresh = resolve;
+        });
+        const getHeadingsSpy = jest
+          .spyOn(headingCell, 'getHeadings')
+          .mockImplementation(async () => {
+            await refreshGate;
+            return getHeadings();
+          });
+
+        const refresh = model.refresh();
+        await Promise.resolve();
+
+        model.scheduleExecution(erroredCell);
+        model.finishExecution(erroredCell, false, new TestKernelError());
+
+        resumeRefresh!();
+        await refresh;
+        getHeadingsSpy.mockRestore();
+
+        expect(model.headings[0].isRunning).toBe(RunningStatus.Error);
+        expect(model.headings[0].dataset!['data-running']).toBe(
+          RunningStatus.Error.toString()
+        );
+      });
     });
   });
 });

--- a/packages/notebook/test/toc.spec.ts
+++ b/packages/notebook/test/toc.spec.ts
@@ -1,26 +1,56 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import type { INotebookModel, NotebookPanel } from '@jupyterlab/notebook';
-import { NotebookToCModel } from '@jupyterlab/notebook';
-import type { Context } from '@jupyterlab/docregistry';
-import { NBTestUtils } from '@jupyterlab/notebook/lib/testutils';
 import { Sanitizer } from '@jupyterlab/apputils';
+import type { Cell } from '@jupyterlab/cells';
+import type { Context } from '@jupyterlab/docregistry';
+import type {
+  INotebookModel,
+  KernelError,
+  NotebookPanel
+} from '@jupyterlab/notebook';
+import { NotebookToCModel, RunningStatus } from '@jupyterlab/notebook';
+import { NBTestUtils } from '@jupyterlab/notebook/lib/testutils';
 import { signalToPromise } from '@jupyterlab/testing';
 import * as utils from './utils';
+
+class TestKernelError extends Error {
+  readonly errorName = 'ZeroDivisionError';
+  readonly errorValue = 'division by zero';
+  readonly traceback: string[] = [];
+}
+
+class TestNotebookToCModel extends NotebookToCModel {
+  scheduleExecution(cell: Cell): void {
+    this.onExecutionScheduled(null, { notebook: this.widget.content, cell });
+  }
+
+  finishExecution(
+    cell: Cell,
+    success: boolean,
+    error: KernelError | null
+  ): void {
+    this.onExecuted(null, {
+      notebook: this.widget.content,
+      cell,
+      success,
+      error
+    });
+  }
+}
 
 describe('@jupyterlab/notebook', () => {
   describe('NotebookToCModel', () => {
     let context: Context<INotebookModel>;
     let panel: NotebookPanel;
-    let model: NotebookToCModel;
+    let model: TestNotebookToCModel;
     const sanitizer = new Sanitizer();
     const initialCells = [{ cell_type: 'markdown', source: '# heading' }];
 
     beforeEach(async () => {
       context = await NBTestUtils.createMockContext(false);
       panel = utils.createNotebookPanel(context);
-      model = new NotebookToCModel(panel, null, sanitizer);
+      model = new TestNotebookToCModel(panel, null, sanitizer);
       panel.model!.sharedModel.insertCells(0, initialCells);
     });
 
@@ -70,6 +100,33 @@ describe('@jupyterlab/notebook', () => {
         promise = signalToPromise(model.headingsChanged);
         await model.refresh();
         await promise;
+      });
+    });
+
+    describe('#refresh', () => {
+      it('should clear error status when an errored cell is deleted', async () => {
+        panel.model!.sharedModel.insertCells(1, [
+          { cell_type: 'code', source: '1 / 2' },
+          { cell_type: 'code', source: '1 / 0' },
+          { cell_type: 'code', source: '1 / 2' }
+        ]);
+
+        await model.refresh();
+
+        const erroredCell = panel.content.widgets[2];
+        model.scheduleExecution(erroredCell);
+        model.finishExecution(erroredCell, false, new TestKernelError());
+
+        expect(model.headings[0].isRunning).toBe(RunningStatus.Error);
+
+        panel.model!.sharedModel.deleteCell(2);
+        expect(panel.content.widgets).not.toContain(erroredCell);
+        await model.refresh();
+
+        expect(model.headings[0].isRunning).toBe(RunningStatus.Idle);
+        expect(model.headings[0].dataset!['data-running']).toBe(
+          RunningStatus.Idle.toString()
+        );
       });
     });
   });


### PR DESCRIPTION
## References
Fixes #19141 

## Code changes

Fixes notebook table of contents error indicators staying visible after the errored cell is deleted. The ToC now prunes deleted cells from its running/error tracking during refresh, updates status on the recomputed headings, and includes a regression test for the stale warning case.

## User-facing changes

Yes, as a bug fix, it now shows no marker when errored cell is cleared.

## Backwards-incompatible changes
None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: ChatGPT 5.5
