### PR TITLE
Fix stale document load after rename during initialization

### DIFF
--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -693,6 +693,9 @@ export class Context<
         if (this.isDisposed) {
           return;
         }
+        if (path !== this._path) {
+          return this._revert(initializeModel);
+        }
         if (contents.content) {
           if (contents.format === 'json') {
             model.fromJSON(contents.content);
@@ -719,6 +722,9 @@ export class Context<
         }
       })
       .catch(async err => {
+        if (!this.isDisposed && path !== this._path) {
+          return this._revert(initializeModel);
+        }
         const localPath = this._manager.contents.localPath(this._path);
         const name = PathExt.basename(localPath);
         void this._handleError(

--- a/packages/docregistry/test/context.spec.ts
+++ b/packages/docregistry/test/context.spec.ts
@@ -343,6 +343,51 @@ describe('docregistry/context', () => {
           get.mockImplementation(getImplementation);
         }
       });
+
+      it('should ignore stale contents if the file is renamed while it is loading', async () => {
+        const oldPath = context.path;
+        const newPath = UUID.uuid4() + '.txt';
+        const staleContents = await manager.contents.save(oldPath, {
+          type: factory.contentType,
+          format: factory.fileFormat,
+          content: 'foo'
+        });
+
+        const get = manager.contents.get as jest.MockedFunction<
+          typeof manager.contents.get
+        >;
+        const getImplementation = get.getMockImplementation();
+        if (!getImplementation) {
+          throw new Error('Missing contents get mock implementation');
+        }
+
+        const started = new PromiseDelegate<void>();
+        const delayedGet = new PromiseDelegate<Contents.IModel>();
+        let isFirstGet = true;
+        get.mockImplementation((path, options) => {
+          if (path === oldPath && isFirstGet) {
+            isFirstGet = false;
+            started.resolve();
+            return delayedGet.promise;
+          }
+          return getImplementation(path, options);
+        });
+
+        try {
+          const initialized = context.initialize(false);
+          await started.promise;
+          await manager.contents.rename(oldPath, newPath);
+          delayedGet.resolve(staleContents);
+
+          await expect(initialized).resolves.not.toThrow();
+          await expect(context.ready).resolves.not.toThrow();
+          expect(context.path).toBe(newPath);
+          expect(context.contentsModel!.path).toBe(newPath);
+          expect(context.model.toString()).toBe('foo');
+        } finally {
+          get.mockImplementation(getImplementation);
+        }
+      });
     });
 
     describe('#disposed', () => {

--- a/packages/docregistry/test/context.spec.ts
+++ b/packages/docregistry/test/context.spec.ts
@@ -14,7 +14,7 @@ import {
   waitForDialog
 } from '@jupyterlab/testing';
 import { ServiceManagerMock } from '@jupyterlab/services/lib/testutils';
-import { UUID } from '@lumino/coreutils';
+import { PromiseDelegate, UUID } from '@lumino/coreutils';
 import { Widget } from '@lumino/widgets';
 
 describe('docregistry/context', () => {
@@ -294,6 +294,54 @@ describe('docregistry/context', () => {
         });
         await context.initialize(false);
         await expect(context.ready).resolves.not.toThrow();
+      });
+
+      it('should resolve if the file is renamed while it is loading', async () => {
+        const oldPath = context.path;
+        const newPath = UUID.uuid4() + '.txt';
+        await manager.contents.save(oldPath, {
+          type: factory.contentType,
+          format: factory.fileFormat,
+          content: 'foo'
+        });
+
+        const get = manager.contents.get as jest.MockedFunction<
+          typeof manager.contents.get
+        >;
+        const getImplementation = get.getMockImplementation();
+        if (!getImplementation) {
+          throw new Error('Missing contents get mock implementation');
+        }
+
+        const started = new PromiseDelegate<void>();
+        const delayedGet = new PromiseDelegate<Contents.IModel>();
+        let isFirstGet = true;
+        get.mockImplementation((path, options) => {
+          if (path === oldPath && isFirstGet) {
+            isFirstGet = false;
+            started.resolve();
+            return delayedGet.promise;
+          }
+          return getImplementation(path, options);
+        });
+
+        try {
+          const initialized = context.initialize(false);
+          await started.promise;
+          await manager.contents.rename(oldPath, newPath);
+          delayedGet.reject(new Error('Stale path'));
+
+          await expect(initialized).resolves.not.toThrow();
+          await expect(context.ready).resolves.not.toThrow();
+          expect(context.path).toBe(newPath);
+          expect(context.contentsModel!.path).toBe(newPath);
+          expect(context.model.toString()).toBe('foo');
+          expect(
+            document.body.getElementsByClassName('jp-Dialog')
+          ).toHaveLength(0);
+        } finally {
+          get.mockImplementation(getImplementation);
+        }
       });
     });
 


### PR DESCRIPTION
## References

Fixes #18455 

## Code changes

Fixes a race in `Context._revert() `where an in-flight load for an old path could fail or apply stale metadata after the document was renamed, causing a misleading file load error. The context now retries against the current path when the path changes mid-load, with a regression test covering rename during initialization.

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: ChatGPT 5.5
