### PR TITLE
Fix notebook initialization stealing focus

### DIFF
--- a/galata/src/helpers/notebook.ts
+++ b/galata/src/helpers/notebook.ts
@@ -475,11 +475,6 @@ export class NotebookHelper {
         .locator('[data-icon="ui-components:not-trusted"]')
         .count()) === 1
     ) {
-      // Workaround for https://github.com/jupyterlab/jupyterlab/issues/18457
-      await this.page
-        .locator('.jp-Notebook-ExecutionIndicator[data-status="idle"]')
-        .waitFor();
-
       await this.page.keyboard.press('Control+Shift+C');
       await this.page.getByPlaceholder('SEARCH', { exact: true }).fill('trust');
       await this.page.getByText('Trust Notebook').click();

--- a/galata/test/jupyterlab/help.test.ts
+++ b/galata/test/jupyterlab/help.test.ts
@@ -30,9 +30,6 @@ test('Switch back and forth to an iframe', async ({ page }) => {
 
   await page.notebook.setCell(0, 'markdown', cellContent);
 
-  // Workaround for https://github.com/jupyterlab/jupyterlab/issues/18457
-  await page.getByText('Python 3 (ipykernel) | Idle').waitFor();
-
   // Open a local page (the unauthenticated Jupyter Server `/api` version
   // endpoint) in an in-app iframe tab, avoiding a dependency on an external
   // website which would make this test flaky.

--- a/galata/test/jupyterlab/metadataform.test.ts
+++ b/galata/test/jupyterlab/metadataform.test.ts
@@ -511,9 +511,6 @@ test.describe('Notebook level and cell type metadata', () => {
     let nbMetadata = await getNotebookMetadata(page);
     expect(nbMetadata['nb-nested']).toBeUndefined();
 
-    // Workaround for https://github.com/jupyterlab/jupyterlab/issues/18457
-    await page.getByText('Python 3 (ipykernel) | Idle').waitFor();
-
     // Fill the first level nested metadata.
     await formGroup.locator('input').first().fill('Cell input');
     await formGroup.locator('input').last().fill('Notebook input');

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -2883,6 +2883,10 @@ export class Notebook extends StaticNotebook {
    * Ensure that the notebook has proper focus.
    */
   private _ensureFocus(force = false): void {
+    const activeElement = document.activeElement;
+    if (!force && activeElement && !this.node.contains(activeElement)) {
+      return;
+    }
     // No-op is the footer has the focus.
     const footer = (this.layout as NotebookWindowedLayout).footer;
     if (footer && document.activeElement === footer.node) {

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -1025,6 +1025,29 @@ describe('@jupyter/notebook', () => {
         expect(widget.mode).toBe('edit');
       });
 
+      it('should not steal focus from outside the notebook when setting mode', async () => {
+        const widget = createActiveWidget();
+        const input = document.createElement('input');
+        document.body.appendChild(input);
+        Widget.attach(widget, document.body);
+        try {
+          await framePromise();
+
+          input.focus();
+          expect(document.activeElement).toBe(input);
+          expect(widget.node.contains(input)).toBe(false);
+          widget.mode = 'edit';
+          expect(document.activeElement).toBe(input);
+          await framePromise();
+
+          expect(widget.mode).toBe('edit');
+          expect(document.activeElement).toBe(input);
+        } finally {
+          widget.dispose();
+          input.remove();
+        }
+      });
+
       it('should emit the `stateChanged` signal', () => {
         const widget = createActiveWidget();
         let called = false;


### PR DESCRIPTION
## References

Fixes #18457 

## Code changes

This fixes a notebook focus issue where switching a notebook to edit mode during initialization could steal focus from other active UI, such as metadata form inputs or open menus. The change makes non-forced notebook focus handling return early when the current focus is outside the notebook, while preserving forced focus for explicit user actions like notebook activation, mouse, and keyboard interaction. A regression test verifies that setting notebook mode to edit does not move focus away from an external input.

## User-facing changes

Notebook initialization no longer steals focus from inputs, dialogs, menus, or other active UI.

## Backwards-incompatible changes

None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: ChatGPT 5.5
