### PR TITLE
Add support for renaming code consoles

### DIFF
--- a/docs/source/user/code_console.md
+++ b/docs/source/user/code_console.md
@@ -56,6 +56,11 @@ right-clicking on the code console and selecting “Clear Console Cells”:
 </div>
 ```
 
+(rename-console)=
+
+Rename a code console by right-clicking on its tab and selecting “Rename
+Console…”.
+
 (log-inspect)=
 
 Creating a code console from the {ref}`file menu <menu-bar>` lets you select an existing

--- a/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
+++ b/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
@@ -1558,6 +1558,21 @@
     }
   },
   {
+    "id": "console:rename",
+    "label": "Rename Console…",
+    "caption": "",
+    "shortcuts": [],
+    "args": {
+      "type": "object",
+      "properties": {
+        "activate": {
+          "type": "boolean",
+          "description": "Whether to activate the widget"
+        }
+      }
+    }
+  },
+  {
     "id": "console:replace-selection",
     "label": "Replace Selection in Console",
     "caption": "",

--- a/galata/test/jupyterlab/console.test.ts
+++ b/galata/test/jupyterlab/console.test.ts
@@ -44,6 +44,20 @@ test.describe('Console', () => {
     // Expect the editor content to not change
     expect(await cellEditor.innerText()).toBe('2 + 2');
   });
+
+  test('Should rename the console from the tab context menu', async ({
+    page
+  }) => {
+    const newName = 'Custom Name';
+
+    await page.activity.getTabLocator('Console 1').click({ button: 'right' });
+    await page.getByRole('menuitem', { name: 'Rename Console…' }).click();
+
+    await page.locator('.jp-Dialog >> input').fill(newName);
+    await page.click('.jp-Dialog >> button >> text=Rename');
+
+    await expect(page.activity.getTabLocator(newName)).toBeVisible();
+  });
 });
 
 test.describe('Console (terminal mode)', () => {

--- a/packages/console-extension/schema/tracker.json
+++ b/packages/console-extension/schema/tracker.json
@@ -75,6 +75,11 @@
         "rank": 10
       },
       {
+        "command": "console:rename",
+        "selector": "[data-type=\"console-title\"]",
+        "rank": 20
+      },
+      {
         "command": "console:restart-kernel",
         "selector": ".jp-CodeConsole",
         "rank": 30

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -17,6 +17,7 @@ import {
   Dialog,
   ICommandPalette,
   IKernelStatusModel,
+  InputDialog,
   ISanitizer,
   ISessionContextDialogs,
   IToolbarWidgetRegistry,
@@ -106,6 +107,8 @@ namespace CommandIDs {
   export const interactionMode = 'console:interaction-mode';
 
   export const redo = 'console:redo';
+
+  export const rename = 'console:rename';
 
   export const replaceSelection = 'console:replace-selection';
 
@@ -477,6 +480,10 @@ async function activateConsole(
       setBusy: (status && (() => status.setBusy())) ?? undefined,
       ...(options as Partial<ConsolePanel.IOptions>)
     });
+    panel.title.dataset = {
+      type: 'console-title',
+      ...panel.title.dataset
+    };
 
     if (toolbarFactory) {
       setToolbar(panel, toolbarFactory);
@@ -834,6 +841,16 @@ async function activateConsole(
       shell.activateById(widget.id);
     }
     return widget;
+  }
+
+  // Get the console panel associated with the most recent context menu event.
+  function contextMenuConsole(): ConsolePanel | null {
+    const test = (node: HTMLElement) => !!node.dataset.id;
+    const node = app.contextMenuHitTest(test);
+    if (!node) {
+      return null;
+    }
+    return tracker.find(panel => panel.id === node.dataset.id) ?? null;
   }
 
   /**
@@ -1224,6 +1241,39 @@ async function activateConsole(
       });
     },
     isEnabled,
+    describedBy: {
+      args: {
+        type: 'object',
+        properties: {
+          activate: {
+            type: 'boolean',
+            description: trans.__('Whether to activate the widget')
+          }
+        }
+      }
+    }
+  });
+
+  commands.addCommand(CommandIDs.rename, {
+    label: trans.__('Rename Console…'),
+    execute: async args => {
+      const current = contextMenuConsole() ?? getCurrent(args);
+      const session = current?.console.sessionContext.session;
+      if (!session) {
+        return;
+      }
+      const result = await InputDialog.getText({
+        title: trans.__('Rename Console'),
+        okLabel: trans.__('Rename'),
+        text: session.name,
+        required: true
+      });
+      if (session.isDisposed || !result.button.accept || !result.value) {
+        return;
+      }
+      return session.setName(result.value);
+    },
+    isEnabled: () => contextMenuConsole() !== null || isEnabled(),
     describedBy: {
       args: {
         type: 'object',

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -26,6 +26,7 @@ import {
   SessionContextDialogs,
   setToolbar,
   showDialog,
+  showErrorMessage,
   Toolbar,
   WidgetTracker
 } from '@jupyterlab/apputils';
@@ -1271,7 +1272,11 @@ async function activateConsole(
       if (session.isDisposed || !result.button.accept || !result.value) {
         return;
       }
-      return session.setName(result.value);
+      try {
+        await session.setName(result.value);
+      } catch (error) {
+        void showErrorMessage(trans.__('Rename Error'), error);
+      }
     },
     isEnabled: () => contextMenuConsole() !== null || isEnabled(),
     describedBy: {


### PR DESCRIPTION


## References

Partially addresses https://github.com/jupyterlab/jupyterlab/issues/4393

## Code changes

- [x] Add support for renaming code consoles
- [x] Quick mention in the documentation
- [x] Test

## User-facing changes

https://github.com/user-attachments/assets/63fd7cd7-a777-4f3f-a320-0c26e1e3f34a

## Backwards-incompatible changes

None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude Fable 5
