### PR TITLE
Preserve drive name for root-level sessions

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -378,6 +378,7 @@ export class SessionContext implements ISessionContext {
     this.translator = options.translator || nullTranslator;
     this._trans = this.translator.load('jupyterlab');
     this._path = options.path ?? UUID.uuid4();
+    this._driveName = options.driveName ?? '';
     this._type = options.type ?? '';
     this._name = options.name ?? '';
     this._setBusy = options.setBusy;
@@ -964,7 +965,9 @@ export class SessionContext implements ISessionContext {
     // the kernel finishes starting.
     // We later switch to the real path below.
     // Use the correct directory so the kernel will be started in that directory.
-    const dirName = PathExt.dirname(this._path);
+    const dirName =
+      PathExt.dirname(this._path) ||
+      (this._driveName ? `${this._driveName}:` : '');
     const requestId = (this._pendingSessionRequest = PathExt.join(
       dirName,
       UUID.uuid4()
@@ -1229,6 +1232,7 @@ export class SessionContext implements ISessionContext {
   }
 
   private _path = '';
+  private _driveName = '';
   private _name = '';
   private _type = '';
   private _prevKernelName: string = '';
@@ -1306,6 +1310,11 @@ export namespace SessionContext {
      * The initial path of the file.
      */
     path?: string;
+
+    /**
+     * The drive name for the path.
+     */
+    driveName?: string;
 
     /**
      * The name of the session.

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -80,6 +80,7 @@ export class Context<
 
     const ext = PathExt.extname(this._path);
     this.sessionContext = new SessionContext({
+      driveName: manager.contents.driveName(this._path),
       kernelManager: manager.kernels,
       sessionManager: manager.sessions,
       specsManager: manager.kernelspecs,

--- a/packages/docregistry/test/context.spec.ts
+++ b/packages/docregistry/test/context.spec.ts
@@ -53,16 +53,22 @@ describe('docregistry/context', () => {
         expect(context).toBeInstanceOf(Context);
       });
 
-      it('should set the session path with global path', () => {
+      it('should set and start the session with global path', async () => {
         const localPath = `${UUID.uuid4()}.txt`;
         const globalPath = `TestDrive:${localPath}`;
+        const startNew = jest.mocked(manager.sessions.startNew);
+        startNew.mockClear();
         context = new Context({
           manager,
           factory,
-          path: globalPath
+          path: globalPath,
+          kernelPreference: { name: manager.kernelspecs.specs!.default }
         });
 
+        await context.sessionContext.initialize();
+
         expect(context.sessionContext.path).toEqual(globalPath);
+        expect(startNew.mock.calls[0][0].path).toMatch(/^TestDrive:\//);
       });
     });
 


### PR DESCRIPTION

## References

Fixes a bug to properly handle drive names for root-level sessions.

This was already working as expected for nested paths, but not for the root-level folder, mostly by accident with the use of `dirname` because:

- `FileSystemAccess:folder/notebook.ipynb` would give `FileSystemAccess:folder`
- `FileSystemAccess:notebook.ipynb` would give an empty string


This should help with https://github.com/jupyterlite/jupyterlite/pull/1998

See also: https://github.com/jupyterlite/jupyterlite/issues/1794

## Code changes

- [x] Preserve drive name for root-level sessions
- [x] Update existing test

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: GPT 5.6