### PR TITLE
Show "starting" rather than "idle" status when changing kernel via `SessionContext.changeKernel()`

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -620,6 +620,10 @@ export class SessionContext implements ISessionContext {
       return 'restarting';
     }
 
+    if (this._isChangingKernel) {
+      return 'starting';
+    }
+
     if (this._pendingKernelName === this.noKernelName) {
       return 'unknown';
     }
@@ -950,12 +954,19 @@ export class SessionContext implements ISessionContext {
 
     // If we already have a session, just change the kernel.
     if (this._session && !this._isTerminating) {
+      this._isChangingKernel = true;
+      this._statusChanged.emit('starting');
       try {
         await this._session.changeKernel(model);
         return this._session.kernel;
       } catch (err) {
         void this._handleSessionError(err);
         throw err;
+      } finally {
+        this._isChangingKernel = false;
+        this._statusChanged.emit(
+          this._session?.kernel?.status ?? 'unknown'
+        );
       }
     }
 
@@ -1243,6 +1254,7 @@ export class SessionContext implements ISessionContext {
   private _isReady = false;
   private _isTerminating = false;
   private _isRestarting = false;
+  private _isChangingKernel = false;
   private _kernelChanged = new Signal<
     this,
     Session.ISessionConnection.IKernelChangedArgs

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -965,7 +965,7 @@ export class SessionContext implements ISessionContext {
       } finally {
         this._isChangingKernel = false;
         this._statusChanged.emit(
-          this._session?.kernel?.status ?? 'unknown'
+          this._session?.kernel?.status || 'unknown'
         );
       }
     }

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -964,9 +964,7 @@ export class SessionContext implements ISessionContext {
         throw err;
       } finally {
         this._isChangingKernel = false;
-        this._statusChanged.emit(
-          this._session?.kernel?.status || 'unknown'
-        );
+        this._statusChanged.emit(this._session?.kernel?.status || 'unknown');
       }
     }
 

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -958,14 +958,14 @@ export class SessionContext implements ISessionContext {
       this._statusChanged.emit('starting');
       try {
         await this._session.changeKernel(model);
-        return this._session.kernel;
       } catch (err) {
+        this._isChangingKernel = false;
         void this._handleSessionError(err);
         throw err;
-      } finally {
-        this._isChangingKernel = false;
-        this._statusChanged.emit(this._session?.kernel?.status || 'unknown');
       }
+      this._isChangingKernel = false;
+      this._statusChanged.emit(this._session?.kernel?.status || 'unknown');
+      return this._session.kernel;
     }
 
     // Use a UUID for the path to overcome a race condition on the server

--- a/packages/apputils/test/sessioncontext.spec.ts
+++ b/packages/apputils/test/sessioncontext.spec.ts
@@ -502,13 +502,32 @@ describe('@jupyterlab/apputils', () => {
         // different kernel: without an in-flight signal, the getter falls
         // through to the previous kernel's status (typically "idle"),
         // masking the fact that a new kernel is being provisioned.
+        //
+        // We can't reliably assert on `kernelDisplayStatus` right after
+        // calling `changeKernel()` because that method awaits
+        // `_initStarted.promise` before reaching `_changeKernel` where
+        // the flag is set. Instead, hook `statusChanged` and snapshot
+        // the display status the moment `'starting'` is emitted from
+        // inside `_changeKernel`.
         await sessionContext.initialize();
         await sessionContext.session!.kernel!.info;
         const name = sessionContext.session?.kernel?.name;
 
-        const changePromise = sessionContext.changeKernel({ name });
-        expect(sessionContext.kernelDisplayStatus).toBe('starting');
-        await changePromise;
+        let displayWhileChanging: string | undefined;
+        const handler = (_: any, status: string) => {
+          if (status === 'starting' && displayWhileChanging === undefined) {
+            displayWhileChanging = sessionContext.kernelDisplayStatus;
+          }
+        };
+        sessionContext.statusChanged.connect(handler);
+
+        try {
+          await sessionContext.changeKernel({ name });
+        } finally {
+          sessionContext.statusChanged.disconnect(handler);
+        }
+
+        expect(displayWhileChanging).toBe('starting');
       });
     });
 

--- a/packages/apputils/test/sessioncontext.spec.ts
+++ b/packages/apputils/test/sessioncontext.spec.ts
@@ -496,6 +496,20 @@ describe('@jupyterlab/apputils', () => {
         await sessionContext.shutdown();
         expect(sessionContext.kernelDisplayStatus).toBe('unknown');
       });
+
+      it('should be "starting" while a change-kernel request is in flight', async () => {
+        // Reproduces the case where an existing session switches to a
+        // different kernel: without an in-flight signal, the getter falls
+        // through to the previous kernel's status (typically "idle"),
+        // masking the fact that a new kernel is being provisioned.
+        await sessionContext.initialize();
+        await sessionContext.session!.kernel!.info;
+        const name = sessionContext.session?.kernel?.name;
+
+        const changePromise = sessionContext.changeKernel({ name });
+        expect(sessionContext.kernelDisplayStatus).toBe('starting');
+        await changePromise;
+      });
     });
 
     describe('#isDisposed', () => {

--- a/packages/apputils/test/sessioncontext.spec.ts
+++ b/packages/apputils/test/sessioncontext.spec.ts
@@ -529,6 +529,46 @@ describe('@jupyterlab/apputils', () => {
 
         expect(displayWhileChanging).toBe('starting');
       });
+
+      it('should not emit a redundant "unknown" status if change-kernel is rejected', async () => {
+        // Before the fix, `_changeKernel`'s `finally` block emitted the
+        // post-change status unconditionally, even though the `catch`
+        // branch's `_handleSessionError()` call already tears down the
+        // session (and therefore already emits a settled status). That
+        // made the `finally` emission a redundant *third* "unknown" on
+        // top of the two inherent emissions that any session teardown
+        // produces: one proxied from the disposed kernel's own status
+        // change, and one from `_handleNewSession(null)`'s explicit
+        // fallback. This test guards against that redundant emission
+        // reappearing; it does not assert only one "unknown" is emitted,
+        // since the two teardown-inherent emissions are pre-existing
+        // behavior of `_handleNewSession` unrelated to `changeKernel`.
+        await sessionContext.initialize();
+        await sessionContext.session!.kernel!.info;
+
+        jest
+          .spyOn(sessionContext.session!, 'changeKernel')
+          .mockRejectedValue(new Error('mock error'));
+
+        const statuses: string[] = [];
+        const handler = (_: any, status: string) => {
+          statuses.push(status);
+        };
+        sessionContext.statusChanged.connect(handler);
+
+        let caught = false;
+        const promise = sessionContext
+          .changeKernel({ name: 'echo' })
+          .catch(() => {
+            caught = true;
+          });
+        await Promise.all([promise, acceptDialog()]);
+        sessionContext.statusChanged.disconnect(handler);
+
+        expect(caught).toBe(true);
+        expect(statuses).toEqual(['starting', 'unknown', 'unknown']);
+        expect(sessionContext.kernelDisplayStatus).toBe('unknown');
+      });
     });
 
     describe('#isDisposed', () => {


### PR DESCRIPTION
`SessionContext.kernelDisplayStatus` returns `'restarting'` when a restart is in flight and `'terminating'` when a shutdown is in flight, but nothing equivalent for the change-kernel window. During `_changeKernel()` on an existing session, `session.changeKernel(model)` is awaited (a PATCH round-trip plus new kernel provisioning), and `session.kernel` is still the previous kernel throughout that window. The `!kernel && _pendingKernelName` branch of the display getter is skipped because `kernel` is truthy, so the getter falls through to the previous kernel's `status`, typically `'idle'`.

The result is that when a user picks a different kernel from the kernel picker, the indicator keeps reporting the old kernel's state (usually `'idle'`) through the entire provisioning window, then jumps straight to the new kernel's post-`kernel_info_reply` `'idle'`. Any transient `'starting'` emitted by the new kernel is invisible.

Track an `_isChangingKernel` flag alongside `_isRestarting`, set it around the `session.changeKernel(model)` call, and return `'starting'` from the display getter while it's set. Also emit `statusChanged` at the boundaries so consumers repaint.