### PR TITLE
Fix session-path matching for custom drives in file browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,5 @@ untitled*.txt
 
 # temporary files, useful for testing
 tmp
+.venv/
+jupyterlab-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -163,4 +163,3 @@ untitled*.txt
 # temporary files, useful for testing
 tmp
 .venv/
-jupyterlab-debug.log

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -654,7 +654,8 @@ export class DirListing extends Widget {
   shutdownKernels(): Promise<void> {
     const model = this._model;
     const items = this._sortedItems;
-    const paths = items.map(item => item.path);
+    const prefix = model.driveName ? model.driveName + ':' : '';
+    const paths = items.map(item => prefix + item.path);
 
     const promises = Array.from(this._model.sessions())
       .filter(session => {
@@ -1209,7 +1210,8 @@ export class DirListing extends Widget {
     }
 
     // Handle file session statuses.
-    const paths = items.map(item => item.path);
+    const prefix = this._model.driveName ? this._model.driveName + ':' : '';
+    const paths = items.map(item => prefix + item.path);
     for (const session of this._model.sessions()) {
       const index = ArrayExt.firstIndexOf(paths, session.path);
       const node = nodes[index];

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -628,8 +628,9 @@ export class FileBrowserModel implements IDisposable {
     };
     this._items = contents.content;
     this._paths.clear();
+    const prefix = this.driveName.length > 0 ? this.driveName + ':' : '';
     contents.content.forEach((model: Contents.IModel) => {
-      this._paths.add(model.path);
+      this._paths.add(prefix + model.path);
     });
   }
 

--- a/packages/filebrowser/test/model.spec.ts
+++ b/packages/filebrowser/test/model.spec.ts
@@ -300,6 +300,32 @@ describe('filebrowser/model', () => {
       });
     });
 
+    describe('#sessions() with a custom drive', () => {
+      it('should include sessions for notebooks on a named drive', async () => {
+        await state.clear();
+        const driveName = 'RTC';
+        const modelWithName = new FileBrowserModel({
+          manager,
+          state,
+          driveName
+        });
+
+        const contents = await manager.newUntitled({ type: 'notebook' });
+        const sessionPath = `${driveName}:${contents.path}`;
+        const session = await serviceManager.sessions.startNew({
+          name: '',
+          path: sessionPath,
+          type: 'test'
+        });
+
+        await modelWithName.cd();
+        expect(!modelWithName.sessions().next().done).toBe(true);
+
+        await session.shutdown();
+        modelWithName.dispose();
+      });
+    });
+
     describe('#dispose()', () => {
       it('should dispose of the resources held by the model', () => {
         model.dispose();


### PR DESCRIPTION
The file browser's kernel-running indicator, kernel shutdown, and session tracking all failed to account for the drive-name prefix when comparing session paths against directory listing paths, causing them to silently never match for any non-default drive.

Fixes #17425 
https://github.com/jupyterlab/jupyterlab/issues/17425

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

## AI usage

- **<!-- YES -->**: Some or all of the content of this PR was generated by AI.
- **<!-- YES -->**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: <!-- Claude Sonnet 5 -->
