### PR TITLE
Support recently used commands in the command palette

### DIFF
--- a/docs/source/user/commands.md
+++ b/docs/source/user/commands.md
@@ -47,6 +47,13 @@ The command palette can be accessed from the View menu or using the keyboard sho
 
 The command palette can be displayed in the sidebar by adding `'modal': false` to the Settings.
 
+The commands most recently run from the command palette are displayed at the top of the
+palette with a `recently used` hint, as long as the search input is empty. When searching,
+the results are ordered by relevance, and the recently run commands among them keep the
+`recently used` hint. Commands triggered from menus or keyboard shortcuts are not tracked.
+The number of recently used commands to display can be configured with the
+`'maxRecentCommands'` setting. Setting it to `0` disables the recently used commands.
+
 (commands-list)=
 
 ## Commands List

--- a/docs/source/user/commands.md
+++ b/docs/source/user/commands.md
@@ -53,6 +53,9 @@ the results are ordered by relevance, and the recently run commands among them k
 `recently used` hint. Commands triggered from menus or keyboard shortcuts are not tracked.
 The number of recently used commands to display can be configured with the
 `'maxRecentCommands'` setting. Setting it to `0` disables the recently used commands.
+The recently used commands are saved as part of the current workspace, so they are
+preserved when the page is reloaded. The history can be cleared by running the
+`Clear Recently Used Commands` command, available from the command palette itself.
 
 (commands-list)=
 

--- a/packages/apputils-extension/schema/palette.json
+++ b/packages/apputils-extension/schema/palette.json
@@ -33,6 +33,13 @@
       "description": "Whether the command palette should be modal or in the left panel.",
       "type": "boolean",
       "default": true
+    },
+    "maxRecentCommands": {
+      "title": "Maximum Number of Recently Used Commands",
+      "description": "The maximum number of recently executed commands to display at the top of the command palette. Set to 0 to disable the recently used commands section.",
+      "type": "integer",
+      "minimum": 0,
+      "default": 5
     }
   },
   "type": "object",

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -97,13 +97,14 @@ const palette: JupyterFrontEndPlugin<ICommandPalette> = {
   autoStart: true,
   requires: [ITranslator],
   provides: ICommandPalette,
-  optional: [ISettingRegistry],
+  optional: [ISettingRegistry, IStateDB],
   activate: (
     app: JupyterFrontEnd,
     translator: ITranslator,
-    settingRegistry: ISettingRegistry | null
+    settingRegistry: ISettingRegistry | null,
+    state: IStateDB | null
   ) => {
-    return Palette.activate(app, translator, settingRegistry);
+    return Palette.activate(app, translator, settingRegistry, state);
   }
 };
 

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -120,9 +120,13 @@ const paletteRestorer: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/apputils-extension:palette-restorer',
   description: 'Restores the command palette.',
   autoStart: true,
-  requires: [ILayoutRestorer],
-  activate: (app: JupyterFrontEnd, restorer: ILayoutRestorer) => {
-    Palette.restore(app, restorer);
+  requires: [ILayoutRestorer, ITranslator],
+  activate: (
+    app: JupyterFrontEnd,
+    restorer: ILayoutRestorer,
+    translator: ITranslator
+  ) => {
+    Palette.restore(app, restorer, translator);
   }
 };
 

--- a/packages/apputils-extension/src/palette.ts
+++ b/packages/apputils-extension/src/palette.ts
@@ -5,7 +5,10 @@
 
 import type { ILayoutRestorer, JupyterFrontEnd } from '@jupyterlab/application';
 import type { ICommandPalette, IPaletteItem } from '@jupyterlab/apputils';
-import { ModalCommandPalette } from '@jupyterlab/apputils';
+import {
+  ModalCommandPalette,
+  RecentsCommandPalette
+} from '@jupyterlab/apputils';
 import type { ISettingRegistry } from '@jupyterlab/settingregistry';
 import type { ITranslator } from '@jupyterlab/translation';
 import { nullTranslator } from '@jupyterlab/translation';
@@ -14,7 +17,7 @@ import { find } from '@lumino/algorithm';
 import { CommandRegistry } from '@lumino/commands';
 import type { IDisposable } from '@lumino/disposable';
 import { DisposableDelegate } from '@lumino/disposable';
-import { CommandPalette } from '@lumino/widgets';
+import type { CommandPalette } from '@lumino/widgets';
 
 /**
  * The command IDs used by the apputils extension.
@@ -94,7 +97,7 @@ export namespace Palette {
   ): ICommandPalette {
     const { commands, shell } = app;
     const trans = translator.load('jupyterlab');
-    const palette = Private.createPalette(app);
+    const palette = Private.createPalette(app, translator);
     const modalPalette = new ModalCommandPalette({
       commandPalette: palette,
       restore: () => {
@@ -128,6 +131,8 @@ export namespace Palette {
           modalPalette.attach();
         }
         modal = newModal;
+        palette.maxRecentCommands = settings.get('maxRecentCommands')
+          .composite as number;
       };
 
       Promise.all([loadSettings, app.restored])
@@ -187,9 +192,10 @@ export namespace Palette {
    */
   export function restore(
     app: JupyterFrontEnd,
-    restorer: ILayoutRestorer
+    restorer: ILayoutRestorer,
+    translator: ITranslator
   ): void {
-    const palette = Private.createPalette(app);
+    const palette = Private.createPalette(app, translator);
     // Let the application restorer track the command palette for restoration of
     // application state (e.g. setting the command palette as the current side bar
     // widget).
@@ -204,17 +210,24 @@ namespace Private {
   /**
    * The private command palette instance.
    */
-  let palette: CommandPalette;
+  let palette: RecentsCommandPalette;
 
   /**
    * Create the application-wide command palette.
    */
-  export function createPalette(app: JupyterFrontEnd): CommandPalette {
+  export function createPalette(
+    app: JupyterFrontEnd,
+    translator: ITranslator
+  ): RecentsCommandPalette {
     if (!palette) {
-      // use a renderer tweaked to use inline svg icons
-      palette = new CommandPalette({
+      // use a renderer tweaked to use inline svg icons and to display a
+      // badge for the recently executed commands
+      palette = new RecentsCommandPalette({
         commands: app.commands,
-        renderer: CommandPaletteSvg.defaultRenderer
+        renderer: new CommandPaletteSvg.Renderer({
+          translator,
+          isRecent: item => palette.isRecent(item)
+        })
       });
       palette.id = 'command-palette';
       palette.title.icon = paletteIcon;

--- a/packages/apputils-extension/src/palette.ts
+++ b/packages/apputils-extension/src/palette.ts
@@ -10,6 +10,7 @@ import {
   RecentsCommandPalette
 } from '@jupyterlab/apputils';
 import type { ISettingRegistry } from '@jupyterlab/settingregistry';
+import type { IStateDB } from '@jupyterlab/statedb';
 import type { ITranslator } from '@jupyterlab/translation';
 import { nullTranslator } from '@jupyterlab/translation';
 import { CommandPaletteSvg, paletteIcon } from '@jupyterlab/ui-components';
@@ -24,9 +25,16 @@ import type { CommandPalette } from '@lumino/widgets';
  */
 namespace CommandIDs {
   export const activate = 'apputils:activate-command-palette';
+
+  export const clearRecents = 'apputils:clear-recent-commands';
 }
 
 const PALETTE_PLUGIN_ID = '@jupyterlab/apputils-extension:palette';
+
+/**
+ * The key used to store the recently executed commands in the state database.
+ */
+const RECENTS_STATE_KEY = 'command-palette:recents';
 
 /**
  * A thin wrapper around the `CommandPalette` class to conform with the
@@ -93,7 +101,8 @@ export namespace Palette {
   export function activate(
     app: JupyterFrontEnd,
     translator: ITranslator,
-    settingRegistry: ISettingRegistry | null
+    settingRegistry: ISettingRegistry | null,
+    state: IStateDB | null = null
   ): ICommandPalette {
     const { commands, shell } = app;
     const trans = translator.load('jupyterlab');
@@ -116,6 +125,7 @@ export namespace Palette {
       trans.__('Command Palette Section')
     );
     shell.add(palette, 'left', { rank: 300, type: 'Command Palette' });
+    let settingsApplied: Promise<void> = Promise.resolve();
     if (settingRegistry) {
       const loadSettings = settingRegistry.load(PALETTE_PLUGIN_ID);
       const updateSettings = (settings: ISettingRegistry.ISettings): void => {
@@ -135,7 +145,7 @@ export namespace Palette {
           .composite as number;
       };
 
-      Promise.all([loadSettings, app.restored])
+      settingsApplied = Promise.all([loadSettings, app.restored])
         .then(([settings]) => {
           updateSettings(settings);
           settings.changed.connect(settings => {
@@ -145,6 +155,43 @@ export namespace Palette {
         .catch((reason: Error) => {
           console.error(reason.message);
         });
+    }
+
+    if (state) {
+      // Restore the recently executed commands once the settings have been
+      // applied, so that the restored history is not truncated by a
+      // `maxRecentCommands` limit which is about to change.
+      const restored = settingsApplied
+        .then(() => state.fetch(RECENTS_STATE_KEY))
+        .then(value => {
+          const saved = (
+            value as
+              | { commands?: RecentsCommandPalette.IRecentCommand[] }
+              | undefined
+          )?.commands;
+          if (Array.isArray(saved)) {
+            // List the commands executed during this session first.
+            palette.recentCommands = [...palette.recentCommands, ...saved];
+          }
+        })
+        .catch((reason: Error) => {
+          console.error(
+            'Failed to restore the recently used commands.',
+            reason
+          );
+        });
+
+      // Save the history when it changes, once the restoration has completed
+      // so that an early save cannot overwrite the stored history.
+      palette.recentsChanged.connect(() => {
+        void restored
+          .then(() =>
+            state.save(RECENTS_STATE_KEY, { commands: palette.recentCommands })
+          )
+          .catch((reason: Error) => {
+            console.warn('Failed to save the recently used commands.', reason);
+          });
+      });
     }
 
     // Show the current palette shortcut in its title.
@@ -180,6 +227,30 @@ export namespace Palette {
         }
       },
       label: trans.__('Activate Command Palette')
+    });
+
+    commands.addCommand(CommandIDs.clearRecents, {
+      describedBy: {
+        args: {
+          type: 'object',
+          properties: {}
+        }
+      },
+      execute: () => {
+        palette.recentCommands = [];
+      },
+      isEnabled: () => palette.recentCommands.length > 0,
+      label: trans.__('Clear Recently Used Commands'),
+      caption: trans.__('Clear the list of recently used commands.')
+    });
+    palette.addItem({
+      command: CommandIDs.clearRecents,
+      category: trans.__('Command Palette')
+    });
+
+    // Keep the enabled state of the clear command up to date.
+    palette.recentsChanged.connect(() => {
+      commands.notifyCommandChanged(CommandIDs.clearRecents);
     });
 
     palette.inputNode.placeholder = trans.__('SEARCH');

--- a/packages/apputils-extension/test/palette.spec.ts
+++ b/packages/apputils-extension/test/palette.spec.ts
@@ -2,13 +2,19 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { Palette } from '../src/palette';
+import type { RecentsCommandPalette } from '@jupyterlab/apputils';
 import { nullTranslator } from '@jupyterlab/translation';
 import type { JupyterFrontEnd } from '@jupyterlab/application';
+import { StateDB } from '@jupyterlab/statedb';
+import { signalToPromise } from '@jupyterlab/testing';
 import { Application } from '@lumino/application';
 import { Widget } from '@lumino/widgets';
 
 class DummyShell extends Widget {
+  widgets: Widget[] = [];
+
   add(widget: Widget): void {
+    this.widgets.push(widget);
     document.body.appendChild(widget.node);
   }
 }
@@ -18,13 +24,106 @@ describe('Palette', () => {
     it('command palette should have aria-label and role for accessibility', async () => {
       const app = new Application({ shell: new DummyShell() });
       const settingRegistry = null;
-      Palette.activate(app as JupyterFrontEnd, nullTranslator, settingRegistry);
+      Palette.activate(
+        app as unknown as JupyterFrontEnd,
+        nullTranslator,
+        settingRegistry
+      );
 
       const node = document.getElementById('command-palette')!;
       expect(node.getAttribute('aria-label')).toEqual(
         'Command Palette Section'
       );
       expect(node.getAttribute('role')).toEqual('region');
+    });
+
+    it('should restore and save the recently used commands with the state database', async () => {
+      const state = new StateDB();
+      await state.save('command-palette:recents', {
+        commands: [{ command: 'test:restored', args: {} }]
+      });
+
+      const shell = new DummyShell();
+      const app = new Application({ shell });
+      Palette.activate(
+        app as unknown as JupyterFrontEnd,
+        nullTranslator,
+        null,
+        state
+      );
+      const palette = shell.widgets.find(
+        widget => widget.id === 'command-palette'
+      ) as RecentsCommandPalette;
+
+      // The recently used commands are restored from the state database.
+      await signalToPromise(palette.recentsChanged);
+      expect(palette.recentCommands).toEqual([
+        { command: 'test:restored', args: {} }
+      ]);
+
+      // A change of the recently used commands is saved to the state database.
+      const saved = signalToPromise(state.changed);
+      palette.recentCommands = [
+        { command: 'test:executed', args: {} },
+        ...palette.recentCommands
+      ];
+      await saved;
+      const value = (await state.fetch('command-palette:recents')) as
+        | { commands?: RecentsCommandPalette.IRecentCommand[] }
+        | undefined;
+      expect(value?.commands).toEqual([
+        { command: 'test:executed', args: {} },
+        { command: 'test:restored', args: {} }
+      ]);
+    });
+
+    it('should provide a command to clear the recently used commands', async () => {
+      const state = new StateDB();
+      await state.save('command-palette:recents', {
+        commands: [{ command: 'test:restored', args: {} }]
+      });
+
+      const shell = new DummyShell();
+      const app = new Application({ shell });
+      Palette.activate(
+        app as unknown as JupyterFrontEnd,
+        nullTranslator,
+        null,
+        state
+      );
+      const palette = shell.widgets.find(
+        widget => widget.id === 'command-palette'
+      ) as RecentsCommandPalette;
+      // Reset the history leaking from the other tests of this file, since
+      // the palette is a module-level singleton.
+      palette.recentCommands = [];
+
+      await signalToPromise(palette.recentsChanged);
+      expect(app.commands.isEnabled('apputils:clear-recent-commands')).toBe(
+        true
+      );
+
+      let notified = 0;
+      app.commands.commandChanged.connect((registry, args) => {
+        if (args.id === 'apputils:clear-recent-commands') {
+          notified += 1;
+        }
+      });
+      // Observe the save triggered by clearing the history.
+      const saved = signalToPromise(state.changed);
+      await app.commands.execute('apputils:clear-recent-commands');
+      expect(palette.recentCommands).toEqual([]);
+      expect(app.commands.isEnabled('apputils:clear-recent-commands')).toBe(
+        false
+      );
+      expect(notified).toBe(1);
+
+      // The cleared history is saved to the state database.
+      await saved;
+      const value = (await state.fetch('command-palette:recents')) as
+        | { commands?: RecentsCommandPalette.IRecentCommand[] }
+        | undefined;
+      expect(value?.commands).toEqual([]);
     });
   });
 });

--- a/packages/apputils/src/commandpalette.ts
+++ b/packages/apputils/src/commandpalette.ts
@@ -4,9 +4,14 @@
 |----------------------------------------------------------------------------*/
 
 import { searchIcon } from '@jupyterlab/ui-components';
-import type { ReadonlyJSONObject } from '@lumino/coreutils';
+import type {
+  ReadonlyJSONObject,
+  ReadonlyPartialJSONObject
+} from '@lumino/coreutils';
 import { JSONExt } from '@lumino/coreutils';
 import type { Message } from '@lumino/messaging';
+import type { ISignal } from '@lumino/signaling';
+import { Signal } from '@lumino/signaling';
 import { CommandPalette, Panel, Widget } from '@lumino/widgets';
 
 /**
@@ -201,8 +206,10 @@ export namespace ModalCommandPalette {
  * Commands triggered from a menu, a keyboard shortcut, or a direct
  * invocation of the command registry are not tracked.
  *
- * The commands are tracked in memory, so the recently executed commands
- * are not preserved across page reloads.
+ * The commands are tracked in memory. The `recentCommands` accessors and
+ * the `recentsChanged` signal allow an external actor to save and restore
+ * the recently executed commands, for example to preserve them across
+ * page reloads.
  */
 export class RecentsCommandPalette extends CommandPalette {
   /**
@@ -215,7 +222,7 @@ export class RecentsCommandPalette extends CommandPalette {
     if (options.maxRecentCommands !== undefined) {
       this.maxRecentCommands = options.maxRecentCommands;
     }
-    this.itemExecuted.connect(this._onItemExecuted, this);
+    this.itemTriggered.connect(this._onItemTriggered, this);
   }
 
   /**
@@ -265,10 +272,83 @@ export class RecentsCommandPalette extends CommandPalette {
     // Drop the oldest commands which exceed the new limit.
     if (this._recentCommands.length > value) {
       this._recentCommands.length = value;
+      this._recentsChanged.emit(undefined);
     }
 
     // Refresh the search results.
     this.refresh();
+  }
+
+  /**
+   * The recently executed commands, ordered from most recently executed
+   * to least recently executed.
+   *
+   * #### Notes
+   * Assigning to this property replaces the command history, for example
+   * to restore the recently executed commands from an external storage.
+   *
+   * The assigned entries are normalized: an entry which is not a valid
+   * recent command is ignored, duplicate entries are deduplicated, and
+   * the history is truncated to the `maxRecentCommands` limit.
+   */
+  get recentCommands(): ReadonlyArray<RecentsCommandPalette.IRecentCommand> {
+    return [...this._recentCommands];
+  }
+
+  set recentCommands(
+    value: ReadonlyArray<RecentsCommandPalette.IRecentCommand>
+  ) {
+    // Normalize the entries, dropping the ones which do not conform to
+    // the expected shape, e.g. corrupted entries from an external storage.
+    const normalized: RecentsCommandPalette.IRecentCommand[] = [];
+    for (const entry of value as ReadonlyArray<unknown>) {
+      if (normalized.length >= this._maxRecentCommands) {
+        break;
+      }
+      if (!Private.isRecentCommand(entry)) {
+        continue;
+      }
+      const { command, args } = entry;
+      const duplicate = normalized.some(recent => {
+        return (
+          recent.command === command && JSONExt.deepEqual(recent.args, args)
+        );
+      });
+      if (!duplicate) {
+        normalized.push({ command, args });
+      }
+    }
+
+    // Bail if the history does not change.
+    const unchanged =
+      normalized.length === this._recentCommands.length &&
+      normalized.every((recent, index) => {
+        const current = this._recentCommands[index];
+        return (
+          recent.command === current.command &&
+          JSONExt.deepEqual(recent.args, current.args)
+        );
+      });
+    if (unchanged) {
+      return;
+    }
+
+    // Update the history and refresh the search results.
+    this._recentCommands = normalized;
+    this._recentsChanged.emit(undefined);
+    this.refresh();
+  }
+
+  /**
+   * A signal emitted when the recently executed commands change.
+   *
+   * #### Notes
+   * The signal is emitted when a command is executed from the palette,
+   * when the history is truncated by a lower `maxRecentCommands` limit,
+   * and when the history is replaced via the `recentCommands` setter.
+   */
+  get recentsChanged(): ISignal<this, void> {
+    return this._recentsChanged;
   }
 
   /**
@@ -355,9 +435,9 @@ export class RecentsCommandPalette extends CommandPalette {
   }
 
   /**
-   * Handle the `itemExecuted` signal of the command palette.
+   * Handle the `itemTriggered` signal of the command palette.
    */
-  private _onItemExecuted(
+  private _onItemTriggered(
     sender: CommandPalette,
     item: CommandPalette.IItem
   ): void {
@@ -384,10 +464,13 @@ export class RecentsCommandPalette extends CommandPalette {
     if (this._recentCommands.length > this._maxRecentCommands) {
       this._recentCommands.length = this._maxRecentCommands;
     }
+
+    this._recentsChanged.emit(undefined);
   }
 
   private _maxRecentCommands = DEFAULT_MAX_RECENT_COMMANDS;
-  private _recentCommands: Private.IRecentCommand[] = [];
+  private _recentCommands: RecentsCommandPalette.IRecentCommand[] = [];
+  private _recentsChanged = new Signal<this, void>(this);
   private _resolvedRecents = new Set<CommandPalette.IItem>();
 }
 
@@ -406,16 +489,16 @@ export namespace RecentsCommandPalette {
      */
     maxRecentCommands?: number;
   }
-}
 
-/**
- * The namespace for module private data.
- */
-namespace Private {
   /**
    * An object which represents a recently executed command.
+   *
+   * #### Notes
+   * The interface extends a read-only JSON object so that the recently
+   * executed commands can be serialized, for example to preserve them
+   * across page reloads.
    */
-  export interface IRecentCommand {
+  export interface IRecentCommand extends ReadonlyPartialJSONObject {
     /**
      * The command which was executed.
      */
@@ -425,5 +508,28 @@ namespace Private {
      * The arguments for the command.
      */
     readonly args: ReadonlyJSONObject;
+  }
+}
+
+/**
+ * The namespace for module private data.
+ */
+namespace Private {
+  /**
+   * Test whether a value is a valid recent command entry.
+   */
+  export function isRecentCommand(
+    value: unknown
+  ): value is RecentsCommandPalette.IRecentCommand {
+    if (typeof value !== 'object' || value === null) {
+      return false;
+    }
+    const entry = value as { command?: unknown; args?: unknown };
+    return (
+      typeof entry.command === 'string' &&
+      typeof entry.args === 'object' &&
+      entry.args !== null &&
+      !Array.isArray(entry.args)
+    );
   }
 }

--- a/packages/apputils/src/commandpalette.ts
+++ b/packages/apputils/src/commandpalette.ts
@@ -4,14 +4,20 @@
 |----------------------------------------------------------------------------*/
 
 import { searchIcon } from '@jupyterlab/ui-components';
+import type { ReadonlyJSONObject } from '@lumino/coreutils';
+import { JSONExt } from '@lumino/coreutils';
 import type { Message } from '@lumino/messaging';
-import type { CommandPalette } from '@lumino/widgets';
-import { Panel, Widget } from '@lumino/widgets';
+import { CommandPalette, Panel, Widget } from '@lumino/widgets';
 
 /**
  * Class name identifying the input group with search icon.
  */
 const SEARCH_ICON_GROUP_CLASS = 'jp-SearchIconGroup';
+
+/**
+ * The default maximum number of recently executed commands to display.
+ */
+const DEFAULT_MAX_RECENT_COMMANDS = 5;
 
 /**
  * Wrap the command palette in a modal to make it more usable.
@@ -182,5 +188,242 @@ export namespace ModalCommandPalette {
      * Used to restore focus to the previously active widget.
      */
     restore?: () => void;
+  }
+}
+
+/**
+ * A command palette which displays the recently executed commands at the
+ * top of the palette while the search input is empty.
+ *
+ * #### Notes
+ * Only the commands executed from the palette itself are tracked, either
+ * by clicking an item or by pressing `Enter` while the item is active.
+ * Commands triggered from a menu, a keyboard shortcut, or a direct
+ * invocation of the command registry are not tracked.
+ *
+ * The commands are tracked in memory, so the recently executed commands
+ * are not preserved across page reloads.
+ */
+export class RecentsCommandPalette extends CommandPalette {
+  /**
+   * Construct a new recents command palette.
+   *
+   * @param options - The options for creating the command palette.
+   */
+  constructor(options: RecentsCommandPalette.IOptions) {
+    super(options);
+    if (options.maxRecentCommands !== undefined) {
+      this.maxRecentCommands = options.maxRecentCommands;
+    }
+    this.itemExecuted.connect(this._onItemExecuted, this);
+  }
+
+  /**
+   * Dispose of the resources held by the widget.
+   */
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this._recentCommands.length = 0;
+    this._resolvedRecents.clear();
+    super.dispose();
+  }
+
+  /**
+   * The maximum number of recently executed commands to display.
+   *
+   * #### Notes
+   * When the limit is positive, the most recently executed commands
+   * are displayed at the top of the palette when the search query is
+   * empty. When searching, the results are ordered as usual.
+   *
+   * Setting the limit to `0` disables the tracking and display of the
+   * recently executed commands, and clears the existing history.
+   *
+   * Setting the limit to a value smaller than the current history
+   * drops the oldest commands from the history.
+   *
+   * The default value is `5`.
+   */
+  get maxRecentCommands(): number {
+    return this._maxRecentCommands;
+  }
+
+  set maxRecentCommands(value: number) {
+    // Normalize the limit to a non-negative integer, coercing `NaN` to `0`.
+    value = Math.max(0, Math.floor(value)) || 0;
+
+    // Bail if the limit does not change.
+    if (this._maxRecentCommands === value) {
+      return;
+    }
+
+    // Update the limit.
+    this._maxRecentCommands = value;
+
+    // Drop the oldest commands which exceed the new limit.
+    if (this._recentCommands.length > value) {
+      this._recentCommands.length = value;
+    }
+
+    // Refresh the search results.
+    this.refresh();
+  }
+
+  /**
+   * Test whether a command item is a recently executed command.
+   *
+   * @param item - The command item of interest.
+   *
+   * @returns Whether the item was resolved as a recently executed
+   *   command by the most recent update of the palette.
+   *
+   * #### Notes
+   * This method can be used by a renderer to decorate the recently
+   * executed commands.
+   */
+  isRecent(item: CommandPalette.IItem): boolean {
+    return this._resolvedRecents.has(item);
+  }
+
+  /**
+   * Generate the search results for the given query text.
+   *
+   * @param query - The query text of the palette search input.
+   *
+   * @returns The array of search results to display.
+   *
+   * #### Notes
+   * When the query is empty, the recently executed commands are pinned
+   * to the top of the palette, without a category header, and the
+   * remaining items are listed after them in the default order.
+   *
+   * When searching, the default results are returned, ordered by match
+   * quality.
+   */
+  protected search(query: string): CommandPalette.SearchResult[] {
+    // Resolve the recently executed commands to their palette items.
+    const recentItems = this._resolveRecentItems();
+
+    // Remember the resolved items for `isRecent()`.
+    this._resolvedRecents = new Set(recentItems);
+
+    // Use the default search behavior when there is a query or when
+    // there are no recently executed commands to pin.
+    if (recentItems.length === 0 || query.replace(/\s+/g, '')) {
+      return super.search(query);
+    }
+
+    // Pin the recently executed commands to the top of the palette,
+    // without a category header.
+    const pinned: CommandPalette.SearchResult[] = recentItems.map(item => {
+      return { type: 'item', item, indices: null };
+    });
+
+    // List the other items after the pinned items, in the default order,
+    // so that a pinned item is not displayed twice.
+    const others = this.items.filter(item => !this._resolvedRecents.has(item));
+    return [...pinned, ...CommandPalette.search(others, query)];
+  }
+
+  /**
+   * Resolve the recently executed commands to their palette items.
+   *
+   * @returns The resolved items, ordered from most recently executed to
+   *   least recently executed.
+   *
+   * #### Notes
+   * A command which does not resolve to a visible and enabled item is
+   * ignored. A disabled item cannot be executed again, so it is
+   * displayed in its own category instead until it is enabled again.
+   */
+  private _resolveRecentItems(): CommandPalette.IItem[] {
+    const resolved: CommandPalette.IItem[] = [];
+    for (const recent of this._recentCommands) {
+      const item = this.items.find(candidate => {
+        return (
+          candidate.command === recent.command &&
+          JSONExt.deepEqual(candidate.args, recent.args)
+        );
+      });
+      if (item && item.isVisible && item.isEnabled) {
+        resolved.push(item);
+      }
+    }
+    return resolved;
+  }
+
+  /**
+   * Handle the `itemExecuted` signal of the command palette.
+   */
+  private _onItemExecuted(
+    sender: CommandPalette,
+    item: CommandPalette.IItem
+  ): void {
+    // Bail if recently executed commands are not tracked.
+    if (this._maxRecentCommands === 0) {
+      return;
+    }
+
+    // Remove any existing entry for the command.
+    const index = this._recentCommands.findIndex(recent => {
+      return (
+        recent.command === item.command &&
+        JSONExt.deepEqual(recent.args, item.args)
+      );
+    });
+    if (index !== -1) {
+      this._recentCommands.splice(index, 1);
+    }
+
+    // Add the command to the front of the history.
+    this._recentCommands.unshift({ command: item.command, args: item.args });
+
+    // Drop the oldest command if the history exceeds the limit.
+    if (this._recentCommands.length > this._maxRecentCommands) {
+      this._recentCommands.length = this._maxRecentCommands;
+    }
+  }
+
+  private _maxRecentCommands = DEFAULT_MAX_RECENT_COMMANDS;
+  private _recentCommands: Private.IRecentCommand[] = [];
+  private _resolvedRecents = new Set<CommandPalette.IItem>();
+}
+
+/**
+ * The namespace for the `RecentsCommandPalette` class statics.
+ */
+export namespace RecentsCommandPalette {
+  /**
+   * An options object for creating a recents command palette.
+   */
+  export interface IOptions extends CommandPalette.IOptions {
+    /**
+     * The maximum number of recently executed commands to display.
+     *
+     * The default value is `5`.
+     */
+    maxRecentCommands?: number;
+  }
+}
+
+/**
+ * The namespace for module private data.
+ */
+namespace Private {
+  /**
+   * An object which represents a recently executed command.
+   */
+  export interface IRecentCommand {
+    /**
+     * The command which was executed.
+     */
+    readonly command: string;
+
+    /**
+     * The arguments for the command.
+     */
+    readonly args: ReadonlyJSONObject;
   }
 }

--- a/packages/apputils/style/commandpalette.css
+++ b/packages/apputils/style/commandpalette.css
@@ -220,6 +220,18 @@
   flex: 0 0 auto;
 }
 
+.jp-CommandPalette-recentBadge {
+  flex: 0 0 auto;
+  align-self: center;
+  padding: 0 4px;
+  color: var(--jp-brand-color1);
+  font-size: var(--jp-ui-font-size0);
+}
+
+.lm-CommandPalette-item.lm-mod-active .jp-CommandPalette-recentBadge {
+  color: var(--jp-ui-inverse-font-color1);
+}
+
 .lm-CommandPalette-itemCaption {
   display: none;
 }

--- a/packages/apputils/test/commandpalette.spec.ts
+++ b/packages/apputils/test/commandpalette.spec.ts
@@ -193,6 +193,141 @@ describe('@jupyterlab/apputils', () => {
       });
     });
 
+    describe('#recentCommands', () => {
+      it('should return the recently executed commands, most recent first', () => {
+        click(itemNode('test:b'));
+        click(itemNode('test:a'));
+        expect(palette.recentCommands).toEqual([
+          { command: 'test:a', args: {} },
+          { command: 'test:b', args: {} }
+        ]);
+      });
+
+      it('should restore and pin the assigned commands', () => {
+        palette.recentCommands = [
+          { command: 'test:a', args: {} },
+          { command: 'test:b', args: {} }
+        ];
+        MessageLoop.flush();
+        const children = palette.contentNode.children;
+        expect(children[0].getAttribute('data-command')).toBe('test:a');
+        expect(children[1].getAttribute('data-command')).toBe('test:b');
+        expect(palette.isRecent(itemA)).toBe(true);
+        expect(palette.isRecent(itemB)).toBe(true);
+      });
+
+      it('should keep a command which does not resolve to an item', () => {
+        palette.recentCommands = [{ command: 'test:missing', args: {} }];
+        MessageLoop.flush();
+        expect(palette.recentCommands).toEqual([
+          { command: 'test:missing', args: {} }
+        ]);
+        const first = palette.contentNode.firstElementChild!;
+        expect(first.classList.contains('lm-CommandPalette-header')).toBe(true);
+      });
+
+      it('should deduplicate the assigned commands', () => {
+        palette.recentCommands = [
+          { command: 'test:a', args: {} },
+          { command: 'test:a', args: {} },
+          { command: 'test:b', args: {} }
+        ];
+        expect(palette.recentCommands).toEqual([
+          { command: 'test:a', args: {} },
+          { command: 'test:b', args: {} }
+        ]);
+      });
+
+      it('should truncate the assigned commands to the limit', () => {
+        palette.maxRecentCommands = 1;
+        palette.recentCommands = [
+          { command: 'test:a', args: {} },
+          { command: 'test:b', args: {} }
+        ];
+        expect(palette.recentCommands).toEqual([
+          { command: 'test:a', args: {} }
+        ]);
+      });
+
+      it('should clear the history when assigned an empty array', () => {
+        click(itemNode('test:a'));
+        click(itemNode('test:b'));
+        palette.recentCommands = [];
+        MessageLoop.flush();
+        expect(palette.recentCommands).toEqual([]);
+        const first = palette.contentNode.firstElementChild!;
+        expect(first.classList.contains('lm-CommandPalette-header')).toBe(true);
+      });
+
+      it('should let a command clear the history from its execute body', () => {
+        // The palette emits `itemTriggered` before the command runs, so
+        // the effects of the command on the history win over the
+        // tracking of the command itself.
+        commands.addCommand('test:clear', {
+          label: 'Clear',
+          execute: () => {
+            palette.recentCommands = [];
+          }
+        });
+        palette.addItem({ command: 'test:clear', category: 'One' });
+        MessageLoop.flush();
+
+        click(itemNode('test:a'));
+        click(itemNode('test:clear'));
+        expect(palette.recentCommands).toEqual([]);
+      });
+
+      it('should ignore malformed entries and strip extra fields', () => {
+        palette.recentCommands = [
+          null,
+          42,
+          'test:a',
+          { command: 42, args: {} },
+          { command: 'test:missing-args' },
+          { command: 'test:array-args', args: [] },
+          { command: 'test:a', args: {}, extra: 'dropped' }
+        ] as unknown as RecentsCommandPalette.IRecentCommand[];
+        expect(palette.recentCommands).toEqual([
+          { command: 'test:a', args: {} }
+        ]);
+      });
+    });
+
+    describe('#recentsChanged', () => {
+      it('should emit when a command is executed from the palette', () => {
+        let count = 0;
+        palette.recentsChanged.connect(() => count++);
+        click(itemNode('test:a'));
+        expect(count).toBe(1);
+      });
+
+      it('should emit when the history is truncated by a lower limit', () => {
+        click(itemNode('test:a'));
+        click(itemNode('test:b'));
+        let count = 0;
+        palette.recentsChanged.connect(() => count++);
+        palette.maxRecentCommands = 1;
+        expect(count).toBe(1);
+        palette.maxRecentCommands = 4;
+        expect(count).toBe(1);
+      });
+
+      it('should emit when the history is replaced', () => {
+        let count = 0;
+        palette.recentsChanged.connect(() => count++);
+        palette.recentCommands = [{ command: 'test:a', args: {} }];
+        expect(count).toBe(1);
+      });
+
+      it('should not emit when the history does not change', () => {
+        palette.recentCommands = [{ command: 'test:a', args: {} }];
+        let count = 0;
+        palette.recentsChanged.connect(() => count++);
+        palette.recentCommands = [{ command: 'test:a', args: {} }];
+        expect(count).toBe(0);
+      });
+    });
+
     describe('#isRecent()', () => {
       it('should test whether an item is a recently executed command', () => {
         click(itemNode('test:b'));

--- a/packages/apputils/test/commandpalette.spec.ts
+++ b/packages/apputils/test/commandpalette.spec.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { ModalCommandPalette } from '@jupyterlab/apputils';
+import {
+  ModalCommandPalette,
+  RecentsCommandPalette
+} from '@jupyterlab/apputils';
 import type { ITranslator } from '@jupyterlab/translation';
 import { nullTranslator } from '@jupyterlab/translation';
 import { CommandPaletteSvg, paletteIcon } from '@jupyterlab/ui-components';
@@ -98,6 +101,203 @@ describe('@jupyterlab/apputils', () => {
         void commands.execute('mock-command');
         expect(modalPalette.isVisible).toBe(false);
         expect(palette.inputNode.value).toEqual('');
+      });
+    });
+  });
+
+  describe('RecentsCommandPalette', () => {
+    let commands: CommandRegistry;
+    let palette: RecentsCommandPalette;
+    let itemA: CommandPalette.IItem;
+    let itemB: CommandPalette.IItem;
+    let enabled: boolean;
+
+    const click = (node: Element): void => {
+      node.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      MessageLoop.flush();
+    };
+
+    const itemNode = (command: string): Element => {
+      return palette.contentNode.querySelector(`[data-command="${command}"]`)!;
+    };
+
+    beforeEach(() => {
+      enabled = true;
+      commands = new CommandRegistry();
+      commands.addCommand('test:a', {
+        label: 'Alpha',
+        execute: () => void 0
+      });
+      commands.addCommand('test:b', {
+        label: 'Beta',
+        execute: () => void 0,
+        isEnabled: () => enabled
+      });
+      palette = new RecentsCommandPalette({ commands });
+      itemA = palette.addItem({ command: 'test:a', category: 'One' });
+      itemB = palette.addItem({ command: 'test:b', category: 'Two' });
+      Widget.attach(palette, document.body);
+      MessageLoop.flush();
+    });
+
+    afterEach(() => {
+      palette.dispose();
+    });
+
+    describe('#constructor()', () => {
+      it('should default the limit of recently executed commands to 5', () => {
+        expect(palette.maxRecentCommands).toBe(5);
+      });
+
+      it('should accept a limit of recently executed commands', () => {
+        const recents = new RecentsCommandPalette({
+          commands,
+          maxRecentCommands: 3
+        });
+        expect(recents.maxRecentCommands).toBe(3);
+        recents.dispose();
+      });
+    });
+
+    describe('#maxRecentCommands', () => {
+      it('should normalize the limit to a non-negative integer', () => {
+        palette.maxRecentCommands = -3;
+        expect(palette.maxRecentCommands).toBe(0);
+        palette.maxRecentCommands = 2.7;
+        expect(palette.maxRecentCommands).toBe(2);
+        palette.maxRecentCommands = NaN;
+        expect(palette.maxRecentCommands).toBe(0);
+      });
+
+      it('should drop the oldest commands which exceed the new limit', () => {
+        click(itemNode('test:b'));
+        click(itemNode('test:a'));
+        palette.maxRecentCommands = 1;
+        MessageLoop.flush();
+        const children = palette.contentNode.children;
+        expect(children[0].getAttribute('data-command')).toBe('test:a');
+        expect(children[1].classList.contains('lm-CommandPalette-header')).toBe(
+          true
+        );
+      });
+
+      it('should disable the tracking and clear the history when set to 0', () => {
+        click(itemNode('test:b'));
+        expect(palette.isRecent(itemB)).toBe(true);
+        palette.maxRecentCommands = 0;
+        MessageLoop.flush();
+        const first = palette.contentNode.firstElementChild!;
+        expect(first.classList.contains('lm-CommandPalette-header')).toBe(true);
+        click(itemNode('test:b'));
+        expect(palette.isRecent(itemB)).toBe(false);
+      });
+    });
+
+    describe('#isRecent()', () => {
+      it('should test whether an item is a recently executed command', () => {
+        click(itemNode('test:b'));
+        expect(palette.isRecent(itemB)).toBe(true);
+        expect(palette.isRecent(itemA)).toBe(false);
+      });
+    });
+
+    describe('#search()', () => {
+      it('should pin an executed command to the top without a header', () => {
+        let first = palette.contentNode.firstElementChild!;
+        expect(first.classList.contains('lm-CommandPalette-header')).toBe(true);
+
+        click(itemNode('test:b'));
+
+        first = palette.contentNode.firstElementChild!;
+        expect(first.classList.contains('lm-CommandPalette-item')).toBe(true);
+        expect(first.getAttribute('data-command')).toBe('test:b');
+        expect(
+          palette.contentNode.querySelectorAll('[data-command="test:b"]').length
+        ).toBe(1);
+      });
+
+      it('should move the most recently executed command to the front', () => {
+        click(itemNode('test:b'));
+        click(itemNode('test:a'));
+        let children = palette.contentNode.children;
+        expect(children[0].getAttribute('data-command')).toBe('test:a');
+        expect(children[1].getAttribute('data-command')).toBe('test:b');
+
+        click(itemNode('test:b'));
+        children = palette.contentNode.children;
+        expect(children[0].getAttribute('data-command')).toBe('test:b');
+        expect(children[1].getAttribute('data-command')).toBe('test:a');
+      });
+
+      it('should use the default results while searching', () => {
+        click(itemNode('test:b'));
+
+        // Both `Alpha` and `Beta` match the query `a`, in that order.
+        palette.inputNode.value = 'a';
+        palette.refresh();
+        MessageLoop.flush();
+
+        const children = palette.contentNode.children;
+        expect(children[0].classList.contains('lm-CommandPalette-header')).toBe(
+          true
+        );
+        expect(children[1].getAttribute('data-command')).toBe('test:a');
+        expect(palette.isRecent(itemB)).toBe(true);
+      });
+
+      it('should not pin a disabled command', () => {
+        click(itemNode('test:b'));
+        enabled = false;
+        palette.refresh();
+        MessageLoop.flush();
+
+        const first = palette.contentNode.firstElementChild!;
+        expect(first.classList.contains('lm-CommandPalette-header')).toBe(true);
+        expect(itemNode('test:b')).not.toBeNull();
+      });
+
+      it('should not pin a command removed from the palette', () => {
+        click(itemNode('test:b'));
+        palette.removeItem(itemB);
+        MessageLoop.flush();
+
+        const first = palette.contentNode.firstElementChild!;
+        expect(first.classList.contains('lm-CommandPalette-header')).toBe(true);
+        expect(itemNode('test:b')).toBeNull();
+      });
+
+      it('should track items with the same command but different args separately', () => {
+        commands.addCommand('test:c', {
+          label: args => `C ${args['n']}`,
+          execute: () => void 0
+        });
+        const recents = new RecentsCommandPalette({ commands });
+        recents.addItem({ command: 'test:c', category: 'One', args: { n: 1 } });
+        recents.addItem({ command: 'test:c', category: 'Two', args: { n: 2 } });
+        Widget.attach(recents, document.body);
+        MessageLoop.flush();
+
+        const labels = () => {
+          return Array.from(
+            recents.contentNode.querySelectorAll('.lm-CommandPalette-itemLabel')
+          ).map(node => node.textContent);
+        };
+        const clickLabel = (label: string): void => {
+          const node = Array.from(
+            recents.contentNode.querySelectorAll('.lm-CommandPalette-item')
+          ).find(candidate => candidate.textContent!.includes(label))!;
+          node.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+          MessageLoop.flush();
+        };
+
+        clickLabel('C 1');
+        clickLabel('C 2');
+        expect(labels()).toEqual(['C 2', 'C 1']);
+
+        clickLabel('C 1');
+        expect(labels()).toEqual(['C 1', 'C 2']);
+
+        recents.dispose();
       });
     });
   });

--- a/packages/ui-components/src/icon/widgets/commandpalettesvg.ts
+++ b/packages/ui-components/src/icon/widgets/commandpalettesvg.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import type { ITranslator, TranslationBundle } from '@jupyterlab/translation';
+import { nullTranslator } from '@jupyterlab/translation';
 import type { VirtualElement } from '@lumino/virtualdom';
 import { h } from '@lumino/virtualdom';
 import { CommandPalette } from '@lumino/widgets';
@@ -19,6 +21,18 @@ export namespace CommandPaletteSvg {
    */
   export class Renderer extends CommandPalette.Renderer {
     /**
+     * Construct a new renderer.
+     *
+     * @param options - The options for initializing the renderer.
+     */
+    constructor(options: Renderer.IOptions = {}) {
+      super();
+      this.translator = options.translator ?? nullTranslator;
+      this._isRecent = options.isRecent;
+      this._trans = this.translator.load('jupyterlab');
+    }
+
+    /**
      * Render the virtual element for a command palette header.
      *
      * @param data - The data to use for rendering the header.
@@ -31,6 +45,56 @@ export namespace CommandPaletteSvg {
         { className: classes('lm-CommandPalette-header', 'jp-icon-hoverShow') },
         content,
         h.span(searchHeaderIcon)
+      );
+    }
+
+    /**
+     * Render the virtual element for a command palette item.
+     *
+     * @param data - The data to use for rendering the item.
+     *
+     * @returns A virtual element representing the item.
+     */
+    renderItem(data: CommandPalette.IItemRenderData): VirtualElement {
+      const className = this.createItemClass(data);
+      const dataset = this.createItemDataset(data);
+      const recent = this._isRecent?.(data.item) ?? false;
+      const content = [
+        this.renderItemIcon(data),
+        this.renderItemContent(data),
+        recent ? this.renderRecentBadge() : null,
+        this.renderItemShortcut(data)
+      ];
+      if (data.item.isToggleable) {
+        return h.li(
+          {
+            className,
+            dataset,
+            role: 'menuitemcheckbox',
+            'aria-checked': `${data.item.isToggled}`
+          },
+          ...content
+        );
+      }
+      return h.li(
+        {
+          className,
+          dataset,
+          role: 'menuitem'
+        },
+        ...content
+      );
+    }
+
+    /**
+     * Render the badge for a recently executed command item.
+     *
+     * @returns A virtual element representing the badge.
+     */
+    renderRecentBadge(): VirtualElement {
+      return h.div(
+        { className: 'jp-CommandPalette-recentBadge' },
+        this._trans.__('recently used')
       );
     }
 
@@ -70,6 +134,37 @@ export namespace CommandPaletteSvg {
         data.item.iconClass,
         name
       );
+    }
+
+    protected translator: ITranslator;
+    private _isRecent?: (item: CommandPalette.IItem) => boolean;
+    private _trans: TranslationBundle;
+  }
+
+  /**
+   * The namespace for the `Renderer` class statics.
+   */
+  export namespace Renderer {
+    /**
+     * An options object for initializing a command palette svg renderer.
+     */
+    export interface IOptions {
+      /**
+       * The application language translator.
+       */
+      translator?: ITranslator;
+
+      /**
+       * A function which tests whether a command item is a recently
+       * executed command.
+       *
+       * #### Notes
+       * A recently executed command item is rendered with a
+       * `recently used` badge.
+       *
+       * If this function is not provided, no badge is rendered.
+       */
+      isRecent?: (item: CommandPalette.IItem) => boolean;
     }
   }
 

--- a/packages/ui-components/test/commandpalettesvg.spec.ts
+++ b/packages/ui-components/test/commandpalettesvg.spec.ts
@@ -1,0 +1,107 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { CommandPaletteSvg } from '@jupyterlab/ui-components';
+import { CommandRegistry } from '@lumino/commands';
+import { VirtualDOM } from '@lumino/virtualdom';
+import { CommandPalette } from '@lumino/widgets';
+
+describe('@jupyterlab/ui-components', () => {
+  describe('CommandPaletteSvg.Renderer', () => {
+    let commands: CommandRegistry;
+    let palette: CommandPalette;
+    let item: CommandPalette.IItem;
+    let toggleableItem: CommandPalette.IItem;
+    let recents: CommandPalette.IItem[];
+    const renderer = new CommandPaletteSvg.Renderer({
+      isRecent: candidate => recents.includes(candidate)
+    });
+
+    beforeEach(() => {
+      commands = new CommandRegistry();
+      commands.addCommand('test', {
+        execute: () => void 0,
+        label: 'Test Command'
+      });
+      commands.addCommand('test:toggleable', {
+        execute: () => void 0,
+        label: 'Toggleable Command',
+        isToggleable: true,
+        isToggled: () => true
+      });
+      palette = new CommandPalette({ commands });
+      item = palette.addItem({ command: 'test', category: 'Test' });
+      toggleableItem = palette.addItem({
+        command: 'test:toggleable',
+        category: 'Test'
+      });
+      recents = [];
+    });
+
+    afterEach(() => {
+      palette.dispose();
+    });
+
+    describe('#renderItem()', () => {
+      it('should render a badge for a recently executed command item', () => {
+        recents = [item];
+        const vNode = renderer.renderItem({
+          item,
+          indices: null,
+          active: false
+        });
+        const node = VirtualDOM.realize(vNode);
+        const badge = node.querySelector('.jp-CommandPalette-recentBadge');
+        expect(badge).not.toBeNull();
+        expect(badge!.textContent).toBe('recently used');
+        // The badge is rendered between the item content and the shortcut.
+        expect(
+          badge!.previousElementSibling!.classList.contains(
+            'lm-CommandPalette-itemContent'
+          )
+        ).toBe(true);
+        expect(
+          badge!.nextElementSibling!.classList.contains(
+            'lm-CommandPalette-itemShortcut'
+          )
+        ).toBe(true);
+      });
+
+      it('should not render a badge for other items', () => {
+        recents = [toggleableItem];
+        const vNode = renderer.renderItem({
+          item,
+          indices: null,
+          active: false
+        });
+        const node = VirtualDOM.realize(vNode);
+        expect(node.querySelector('.jp-CommandPalette-recentBadge')).toBeNull();
+      });
+
+      it('should not render a badge when no isRecent function is provided', () => {
+        const vNode = CommandPaletteSvg.defaultRenderer.renderItem({
+          item,
+          indices: null,
+          active: false
+        });
+        const node = VirtualDOM.realize(vNode);
+        expect(node.querySelector('.jp-CommandPalette-recentBadge')).toBeNull();
+      });
+
+      it('should preserve the toggleable state of recently executed items', () => {
+        recents = [toggleableItem];
+        const vNode = renderer.renderItem({
+          item: toggleableItem,
+          indices: null,
+          active: false
+        });
+        const node = VirtualDOM.realize(vNode);
+        expect(node.getAttribute('role')).toBe('menuitemcheckbox');
+        expect(node.getAttribute('aria-checked')).toBe('true');
+        expect(
+          node.querySelector('.jp-CommandPalette-recentBadge')
+        ).not.toBeNull();
+      });
+    });
+  });
+});


### PR DESCRIPTION

## References

Depends on https://github.com/jupyterlab/lumino/pull/836

## Code changes

- [x] Support recently executed commands in the palette
- [ ] Persist across page reloads
- [ ] Support clearing the recently used commands
- [x] Test

## User-facing changes


https://github.com/user-attachments/assets/51455362-e332-43b9-8cec-9c874bf24d68



## Backwards-incompatible changes

None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude Fable 5