### PR TITLE
Backport of security patches to `4.5.x` branch

### DIFF
--- a/docs/source/extension/extension_dev.md
+++ b/docs/source/extension/extension_dev.md
@@ -110,7 +110,18 @@ const plugin: JupyterFrontEndPlugin<MyToken> = {
 
 The `id` and `activate` fields are required and the other fields may be omitted. For more information about how to use the `requires`, `optional`, or `provides` fields, see {ref}`services`.
 
-- `id` is a required unique string. The convention is to use the NPM extension package name, a colon, then a string identifying the plugin inside the extension.
+(plugin-id-convention)=
+
+- `id` is a required unique string. The convention is to use the NPM
+  extension package name, a colon, then a string identifying the plugin inside
+  the extension, for example `my-extension:plugin`. JupyterLab treats the part
+  before the first colon as the extension name when applying extension-level
+  configuration such as enabling, disabling, deferring, or locking all plugins
+  in that extension.
+  The `jupyter/token-format` rule from
+  [`@jupyter/eslint-plugin`](https://eslint-plugin.readthedocs.io/en/latest/rules/token-format/)
+  can enforce the related `<package>:<TokenSymbol>` convention for token IDs
+  used with `new Token(...)`.
 - `description` is an optional string. It allows to document the purpose of a plugin.
 - `autostart` indicates whether your plugin should be activated at application startup. Typically this should be `true`. If it is `false` or omitted, your plugin will be activated when any other plugin requests the token your plugin is providing.
 - `requires` and `optional` are lists of {ref}`tokens <tokens>` corresponding to services other plugins provide. These services will be given as arguments to the `activate` function when the plugin is activated. If a `requires` service is not registered with JupyterLab, an error will be thrown and the plugin will not be activated.

--- a/docs/source/user/extensions.md
+++ b/docs/source/user/extensions.md
@@ -211,6 +211,19 @@ search result and the user is free to install any source extension. This is the 
 To bring more security, you or your administrator can enable `blocklists` or `allowlists`
 mode. JupyterLab will check the extensions against the defined listings.
 
+:::{note}
+In security-sensitive multi-user deployments, extension manager listings are not
+a substitute for isolating the JupyterLab server environment from user-controlled
+kernels. If users can import JupyterLab server internals such as
+`jupyterlab.extensions.pypi.PyPIExtensionManager` from a kernel, the kernel and
+server are sharing an environment that users may be able to modify outside the
+Extension Manager. Administrators should run the server in an environment users
+cannot modify, and may run kernels in separate user-writable environments. With
+that separation, installing packages in a kernel environment does not install
+extension code into the server environment. See JupyterHub's guidance on
+[isolating packages in a read-only environment](https://jupyterhub.readthedocs.io/en/latest/explanation/websecurity.html#isolate-packages-in-a-read-only-environment).
+:::
+
 :::{warning}
 Only one mode at a time is allowed. If you or your server administrator configures
 both block and allow listings, the allow listing takes precedence.

--- a/docs/source/user/extensions.md
+++ b/docs/source/user/extensions.md
@@ -400,7 +400,7 @@ only to plugins whose IDs use the same prefix up to the colon, such as
 `my-extension:plugin` and `my-extension:other-plugin`. Extension authors should
 use the NPM extension package name, a colon, then a string identifying the
 plugin inside the extension, as described in the
-[plugin ID convention](../extension/extension_dev.md#plugin-id-convention), so
+{ref}`plugin ID convention <plugin-id-convention>`, so
 administrators can lock or unlock all plugins in an extension consistently.
 
 To unlock a locked plugin:

--- a/docs/source/user/extensions.md
+++ b/docs/source/user/extensions.md
@@ -386,10 +386,33 @@ Administrators may lock specific plugins with:
 jupyter labextension lock my-extension:plugin
 ```
 
+They may also add an extension-level lock by using the extension name without
+a plugin suffix:
+
+```bash
+jupyter labextension lock my-extension
+```
+
+JupyterLab identifies the extension for a plugin from the plugin ID prefix
+before the first colon. For example, `my-extension:plugin` is treated as a
+plugin in the `my-extension` extension. Extension-level locks therefore apply
+only to plugins whose IDs use the same prefix up to the colon, such as
+`my-extension:plugin` and `my-extension:other-plugin`. Extension authors should
+use the NPM extension package name, a colon, then a string identifying the
+plugin inside the extension, as described in the
+[plugin ID convention](../extension/extension_dev.md#plugin-id-convention), so
+administrators can lock or unlock all plugins in an extension consistently.
+
 To unlock a locked plugin:
 
 ```bash
 jupyter labextension unlock my-extension:plugin
+```
+
+To remove an extension-level lock:
+
+```bash
+jupyter labextension unlock my-extension
 ```
 
 The locked plugins appear on the plugin list with a lock icon and cannot be enabled/disabled from the user interface:

--- a/jupyterlab/extensions/manager.py
+++ b/jupyterlab/extensions/manager.py
@@ -544,8 +544,8 @@ class ExtensionManager(PluginManager):
             return True
         if self._listings_cache is None:
             await self._fetch_listings()
-        normalized = self._normalize_name(name)
-        normalized_cache = {self._normalize_name(k) for k in self._listings_cache}
+        normalized = self._canonicalize_name(name)
+        normalized_cache = {self._canonicalize_name(k) for k in self._listings_cache}
         if self._listings_block_mode:
             return normalized not in normalized_cache
         else:
@@ -687,6 +687,10 @@ class ExtensionManager(PluginManager):
             Normalized name
         """
         return name
+
+    def _canonicalize_name(self, name: str) -> str:
+        """Canonicalize extension name for listing policy comparisons."""
+        return self._normalize_name(name)
 
     async def _update_extensions_list(
         self, query: Optional[str] = None, page: int = 1, per_page: int = 30

--- a/jupyterlab/extensions/manager.py
+++ b/jupyterlab/extensions/manager.py
@@ -236,7 +236,8 @@ class PluginManager(LoggingConfigurable):
         for plugin in plugins_or_extensions:
             if ":" in plugin:
                 # check directly if this is a plugin identifier (has colon)
-                if plugin in self.options.lock_rules:
+                extension = plugin.split(":")[0]
+                if plugin in self.options.lock_rules or extension in self.options.lock_rules:
                     locked_subset.add(plugin)
             elif plugin in extensions_with_locked_plugins:
                 # this is an extension - we need to check for >any< plugin

--- a/jupyterlab/extensions/pypi.py
+++ b/jupyterlab/extensions/pypi.py
@@ -400,7 +400,7 @@ class PyPIExtensionManager(ExtensionManager):
         Returns:
             The action result
         """
-        if not self.is_install_allowed(name, version):
+        if not await self.is_install_allowed(name, version):
             # is_install_allowed will log the reason
             return ActionResult(status="error", message="install is not allowed")
 

--- a/jupyterlab/extensions/pypi.py
+++ b/jupyterlab/extensions/pypi.py
@@ -31,6 +31,11 @@ from packaging.version import InvalidVersion, Version
 from packaging.version import parse as parse_version
 from traitlets import CFloat, CInt, Unicode, config, observe
 
+try:
+    from typing import override
+except ImportError:
+    from typing_extensions import override
+
 from jupyterlab._version import __version__
 from jupyterlab.extensions.manager import (
     ActionResult,
@@ -171,6 +176,7 @@ class PyPIExtensionManager(ExtensionManager):
         """Extension manager metadata."""
         return ExtensionManagerMetadata("PyPI", True, sys.prefix)
 
+    @override
     async def is_install_allowed(self, name: str, version: Union[str, None] = None) -> bool:
         try:
             canonicalize_name(name, validate=True)
@@ -187,6 +193,11 @@ class PyPIExtensionManager(ExtensionManager):
         if not allowed:
             self.log.warning(f"Installation denied by allowlist/blocklist for {name}")
         return allowed
+
+    @override
+    def _canonicalize_name(self, name: str) -> str:
+        """Canonicalize PyPI package names for listing policy comparisons."""
+        return canonicalize_name(name)
 
     async def get_latest_version(self, pkg: str) -> Union[str, None]:
         """Return the latest available version for a given extension.

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -868,7 +868,7 @@ class LabApp(NotebookConfigShimMixin, LabServerApp):
                             app_options=app_options,
                             ext_options={
                                 "lock_rules": lock_rules,
-                                "all_locked": self.lock_all_plugins,
+                                "lock_all": self.lock_all_plugins,
                             },
                             parent=self,
                         )

--- a/jupyterlab/tests/test_extensions.py
+++ b/jupyterlab/tests/test_extensions.py
@@ -10,6 +10,7 @@ from traitlets.config import Config, Configurable
 
 from jupyterlab.extensions import PyPIExtensionManager, ReadOnlyExtensionManager
 from jupyterlab.extensions.manager import (
+    ActionResult,
     ExtensionManager,
     ExtensionPackage,
     PluginManager,
@@ -154,6 +155,22 @@ async def test_ExtensionManager_is_install_allowed_allowlist(mock_client):
     assert await manager.is_install_allowed("jupyterlab-evil") is False
 
 
+@pytest.mark.parametrize(
+    "name",
+    ["jupyterlab-git", "JupyterLab-Git", "JupyterLab.Git", "jupyterlab_git"],
+)
+async def test_pypi_manager_allows_canonical_package_name_allowlist_matches(name):
+    manager = PyPIExtensionManager(
+        ext_options={"allowed_extensions_uris": {"http://dummy-allowed-extension"}}
+    )
+    manager._listings_cache = {"jupyterlab-git": {"name": "jupyterlab-git"}}
+    if manager._listing_fetch is not None:
+        manager._listing_fetch.stop()
+
+    assert await manager.is_install_allowed(name) is True
+    assert await manager.is_install_allowed("jupyterlab-evil") is False
+
+
 @patch("tornado.httpclient.AsyncHTTPClient", new_callable=fake_client_factory)
 async def test_ExtensionManager_is_install_allowed_blocklist(mock_client):
     mock_client.body = json.dumps({"blocked_extensions": [{"name": "jupyterlab-evil"}]}).encode()
@@ -162,6 +179,48 @@ async def test_ExtensionManager_is_install_allowed_blocklist(mock_client):
     )
     assert await manager.is_install_allowed("jupyterlab-evil") is False
     assert await manager.is_install_allowed("jupyterlab-git") is True
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["jupyterlab-git", "JupyterLab-Git", "JupyterLab.Git", "jupyterlab_git"],
+)
+async def test_handler_blocks_pypi_canonical_package_name_blocklist_matches(name):
+    manager = PyPIExtensionManager(
+        ext_options={"blocked_extensions_uris": {"http://dummy-blocked-extension"}}
+    )
+    manager._listings_cache = {"jupyterlab-git": {"name": "jupyterlab-git"}}
+    if manager._listing_fetch is not None:
+        manager._listing_fetch.stop()
+    manager.install = AsyncMock(return_value=ActionResult(status="ok", needs_restart=[]))
+
+    handler = Mock()
+    handler.current_user = "user"
+    handler.get_json_body.return_value = {"cmd": "install", "extension_name": name}
+    handler.manager = manager
+    handler.set_status = Mock()
+    handler.finish = Mock()
+
+    with pytest.raises(web.HTTPError) as exc_info:
+        await ExtensionHandler.post(handler)
+    assert exc_info.value.status_code == 422
+    assert "was blocked" in exc_info.value.log_message
+    manager.install.assert_not_called()
+
+
+async def test_pypi_manager_install_blocks_policy_denial_before_pip():
+    manager = PyPIExtensionManager(
+        ext_options={"blocked_extensions_uris": {"http://dummy-blocked-extension"}}
+    )
+    manager._listings_cache = {"jupyterlab-git": {"name": "jupyterlab-git"}}
+    if manager._listing_fetch is not None:
+        manager._listing_fetch.stop()
+
+    with patch("jupyterlab.extensions.pypi.run") as run_mock:
+        result = await manager.install("JupyterLab.Git")
+
+    assert result == ActionResult(status="error", message="install is not allowed")
+    run_mock.assert_not_called()
 
 
 @patch("tornado.httpclient.AsyncHTTPClient", new_callable=fake_client_factory)

--- a/jupyterlab/tests/test_extensions.py
+++ b/jupyterlab/tests/test_extensions.py
@@ -511,6 +511,19 @@ async def test_pypi_manager_is_install_allowed_rejects_non_pypi_versions(version
     assert await manager.is_install_allowed("package", version) is expected
 
 
+async def test_pypi_manager_install_blocks_when_policy_denies():
+    manager = PyPIExtensionManager()
+    manager.is_install_allowed = AsyncMock(return_value=False)
+
+    with patch("jupyterlab.extensions.pypi.tornado.ioloop.IOLoop.current") as current_loop:
+        result = await manager.install("jupyterlab-evil", "1.0.0")
+
+    assert result.status == "error"
+    assert result.message == "install is not allowed"
+    manager.is_install_allowed.assert_awaited_once_with("jupyterlab-evil", "1.0.0")
+    current_loop.assert_not_called()
+
+
 async def test_handler_blocks_install_when_policy_denies():
     handler = Mock()
     handler.current_user = "user"

--- a/jupyterlab/tests/test_plugin_manager_handler.py
+++ b/jupyterlab/tests/test_plugin_manager_handler.py
@@ -3,14 +3,17 @@
 
 import json
 
+import pytest
 from jupyterlab_server.config import get_static_page_config
+from tornado.httpclient import HTTPClientError
 
 from jupyterlab.commands import get_app_info, lock_extension, unlock_extension
+from jupyterlab.extensions import manager as manager_module
 from jupyterlab.extensions.manager import PluginManager
 from jupyterlab.handlers.plugin_manager_handler import PluginHandler, plugins_handler_path
 
 
-def plugin_handler_labapp(jp_serverapp, make_labserver_extension_app):
+def plugin_handler_labapp(jp_serverapp, make_labserver_extension_app, lock_all_plugins=False):
     app = make_labserver_extension_app()
     app._link_jupyter_server_extension(jp_serverapp)
 
@@ -30,7 +33,7 @@ def plugin_handler_labapp(jp_serverapp, make_labserver_extension_app):
                     "manager": PluginManager(
                         ext_options={
                             "lock_rules": lock_rules,
-                            "all_locked": False,
+                            "lock_all": lock_all_plugins,
                         }
                     )
                 },
@@ -80,3 +83,77 @@ async def test_pluginHandler_unlock_extension(jp_serverapp, jp_fetch, make_labse
     payload = json.loads(response.body)
     assert response.code == 200
     assert payload["lockRules"] == []
+
+
+async def test_pluginHandler_lock_all_rejects_direct_post(
+    jp_serverapp, jp_fetch, make_labserver_extension_app, monkeypatch
+):
+    dispatched = []
+
+    def mock_disable_extension(plugin, app_options=None, level="sys_prefix"):
+        dispatched.append(plugin)
+
+    monkeypatch.setattr(manager_module, "disable_extension", mock_disable_extension)
+
+    labapp = plugin_handler_labapp(
+        jp_serverapp=jp_serverapp,
+        make_labserver_extension_app=make_labserver_extension_app,
+        lock_all_plugins=True,
+    )
+    labapp.initialize()
+
+    response = await jp_fetch("lab", "api", "plugins", method="GET")
+    payload = json.loads(response.body)
+    assert response.code == 200
+    assert payload["allLocked"] is True
+
+    plugin = "@jupyterlab/apputils-extension:sanitizer"
+    with pytest.raises(HTTPClientError) as e:
+        await jp_fetch(
+            "lab",
+            "api",
+            "plugins",
+            method="POST",
+            body=json.dumps({"cmd": "disable", "plugin_name": plugin}),
+        )
+    assert e.value.code == 500
+    payload = json.loads(e.value.response.body)
+    assert payload["status"] == "error"
+    assert plugin in payload["message"]
+    assert dispatched == []
+
+
+@pytest.mark.parametrize("cmd", ("disable", "enable"))
+async def test_pluginHandler_extension_lock_rejects_child_plugin_direct_post(
+    jp_serverapp, jp_fetch, make_labserver_extension_app, monkeypatch, cmd
+):
+    dispatched = []
+
+    def mock_toggle_extension(plugin, app_options=None, level="sys_prefix"):
+        dispatched.append(plugin)
+
+    monkeypatch.setattr(manager_module, "disable_extension", mock_toggle_extension)
+    monkeypatch.setattr(manager_module, "enable_extension", mock_toggle_extension)
+
+    extension = "@jupyterlab/apputils-extension"
+    plugin = f"{extension}:sanitizer"
+    lock_extension(extension)
+
+    labapp = plugin_handler_labapp(
+        jp_serverapp=jp_serverapp, make_labserver_extension_app=make_labserver_extension_app
+    )
+    labapp.initialize()
+
+    with pytest.raises(HTTPClientError) as e:
+        await jp_fetch(
+            "lab",
+            "api",
+            "plugins",
+            method="POST",
+            body=json.dumps({"cmd": cmd, "plugin_name": plugin}),
+        )
+    assert e.value.code == 500
+    payload = json.loads(e.value.response.body)
+    assert payload["status"] == "error"
+    assert plugin in payload["message"]
+    assert dispatched == []

--- a/packages/imageviewer-extension/schema/plugin.json
+++ b/packages/imageviewer-extension/schema/plugin.json
@@ -1,6 +1,50 @@
 {
   "title": "Image Viewer",
   "description": "Image viewer settings.",
+  "jupyter.lab.menus": {
+    "context": [
+      {
+        "command": "imageviewer:zoom-in",
+        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "rank": 1
+      },
+      {
+        "command": "imageviewer:zoom-out",
+        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "rank": 2
+      },
+      {
+        "command": "imageviewer:reset-image",
+        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "rank": 3
+      },
+      {
+        "command": "imageviewer:rotate-clockwise",
+        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "rank": 4
+      },
+      {
+        "command": "imageviewer:rotate-counterclockwise",
+        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "rank": 5
+      },
+      {
+        "command": "imageviewer:flip-horizontal",
+        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "rank": 6
+      },
+      {
+        "command": "imageviewer:flip-vertical",
+        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "rank": 7
+      },
+      {
+        "command": "imageviewer:invert-colors",
+        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "rank": 8
+      }
+    ]
+  },
   "jupyter.lab.shortcuts": [
     {
       "command": "imageviewer:flip-horizontal",

--- a/packages/imageviewer/src/widget.ts
+++ b/packages/imageviewer/src/widget.ts
@@ -24,6 +24,16 @@ import { Widget } from '@lumino/widgets';
 const IMAGE_CLASS = 'jp-ImageViewer';
 
 /**
+ * The class name added to an SVG imageviewer.
+ */
+const SVG_CLASS = 'jp-mod-svg';
+
+/**
+ * The MIME type for SVG images.
+ */
+const SVG_MIME_TYPE = 'image/svg+xml';
+
+/**
  * A widget for images.
  */
 export class ImageViewer extends Widget implements Printing.IPrintable {
@@ -106,9 +116,7 @@ export class ImageViewer extends Widget implements Printing.IPrintable {
    * Dispose of resources held by the image viewer.
    */
   dispose(): void {
-    if (this._img.src) {
-      URL.revokeObjectURL(this._img.src || '');
-    }
+    this._revokeObjectUrl();
     super.dispose();
   }
 
@@ -188,15 +196,38 @@ export class ImageViewer extends Widget implements Printing.IPrintable {
     if (!cm) {
       return;
     }
-    const oldurl = this._img.src || '';
-    let content = context.model.toString();
+    this._mimeType = cm.mimetype;
+    this.toggleClass(SVG_CLASS, this._mimeType === SVG_MIME_TYPE);
+    this._revokeObjectUrl();
+    const content = context.model.toString();
     if (cm.format === 'base64') {
       this._img.src = `data:${this._mimeType};base64,${content}`;
     } else {
-      const a = new Blob([content], { type: this._mimeType });
-      this._img.src = URL.createObjectURL(a);
+      const blob = new Blob([content], { type: this._mimeType });
+      const objectUrl = URL.createObjectURL(blob);
+      this._objectUrl = objectUrl;
+      const revokeObjectUrl = () => {
+        this._img.removeEventListener('load', revokeObjectUrl);
+        this._img.removeEventListener('error', revokeObjectUrl);
+        if (this._objectUrl === objectUrl) {
+          this._objectUrl = null;
+        }
+        URL.revokeObjectURL(objectUrl);
+      };
+      this._img.addEventListener('load', revokeObjectUrl);
+      this._img.addEventListener('error', revokeObjectUrl);
+      this._img.src = objectUrl;
     }
-    URL.revokeObjectURL(oldurl);
+  }
+
+  /**
+   * Revoke the active object URL if the image viewer has one.
+   */
+  private _revokeObjectUrl(): void {
+    if (this._objectUrl) {
+      URL.revokeObjectURL(this._objectUrl);
+      this._objectUrl = null;
+    }
   }
 
   /**
@@ -218,6 +249,7 @@ export class ImageViewer extends Widget implements Printing.IPrintable {
   private _colorinversion = 0;
   private _ready = new PromiseDelegate<void>();
   private _img: HTMLImageElement;
+  private _objectUrl: string | null = null;
 }
 
 /**

--- a/packages/imageviewer/test/widget.spec.ts
+++ b/packages/imageviewer/test/widget.spec.ts
@@ -5,7 +5,8 @@ import {
   Base64ModelFactory,
   Context,
   DocumentRegistry,
-  DocumentWidget
+  DocumentWidget,
+  TextModelFactory
 } from '@jupyterlab/docregistry';
 import { createFileContext } from '@jupyterlab/docregistry/lib/testutils';
 import { ImageViewer, ImageViewerFactory } from '@jupyterlab/imageviewer';
@@ -31,10 +32,19 @@ class LogImage extends ImageViewer {
 
 // jsdom does not have createObjectURL and revokeObjectURL, so we define them.
 if (typeof window.URL.createObjectURL === 'undefined') {
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  const noOp = () => {};
-  Object.defineProperty(window.URL, 'createObjectURL', { value: noOp });
-  Object.defineProperty(window.URL, 'revokeObjectURL', { value: noOp });
+  Object.defineProperty(window.URL, 'createObjectURL', {
+    configurable: true,
+    value: () => '',
+    writable: true
+  });
+}
+
+if (typeof window.URL.revokeObjectURL === 'undefined') {
+  Object.defineProperty(window.URL, 'revokeObjectURL', {
+    configurable: true,
+    value: () => undefined,
+    writable: true
+  });
 }
 
 /**
@@ -46,6 +56,17 @@ const IMAGE: Partial<Contents.IModel> = {
   mimetype: 'image/png',
   content: 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
   format: 'base64'
+};
+
+/**
+ * The common SVG image model.
+ */
+const SVG: Partial<Contents.IModel> = {
+  path: UUID.uuid4() + '.svg',
+  type: 'file',
+  mimetype: 'image/svg+xml',
+  content: '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+  format: 'text'
 };
 
 /**
@@ -65,7 +86,8 @@ describe('ImageViewer', () => {
   beforeAll(async () => {
     manager = new ServiceManagerMock();
     await manager.ready;
-    return manager.contents.save(IMAGE.path!, IMAGE);
+    await manager.contents.save(IMAGE.path!, IMAGE);
+    await manager.contents.save(SVG.path!, SVG);
   });
 
   beforeEach(() => {
@@ -108,6 +130,46 @@ describe('ImageViewer', () => {
       MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
       const img = widget.node.querySelector('img') as HTMLImageElement;
       expect(img.src).toContain(OTHER);
+    });
+
+    it('should revoke object URLs after text images load', async () => {
+      const objectUrl = 'blob:http://localhost/imageviewer-test-svg';
+      const createObjectURL = jest
+        .spyOn(window.URL, 'createObjectURL')
+        .mockReturnValue(objectUrl);
+      const revokeObjectURL = jest
+        .spyOn(window.URL, 'revokeObjectURL')
+        .mockImplementation(() => undefined);
+      const svgContext = new Context({
+        manager,
+        factory: new TextModelFactory(),
+        path: SVG.path!
+      });
+      const svgWidget = new LogImage(svgContext);
+
+      try {
+        await svgContext.initialize(false);
+        await svgWidget.ready;
+
+        const img = svgWidget.node.querySelector('img') as HTMLImageElement;
+        expect(createObjectURL).toHaveBeenCalledTimes(1);
+        expect(svgWidget.hasClass('jp-mod-svg')).toBe(true);
+        expect(img.src).toBe(objectUrl);
+        expect(revokeObjectURL).not.toHaveBeenCalled();
+
+        img.dispatchEvent(new Event('load'));
+
+        expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+        expect(revokeObjectURL).toHaveBeenCalledWith(objectUrl);
+
+        svgWidget.dispose();
+        expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+      } finally {
+        svgWidget.dispose();
+        svgContext.dispose();
+        createObjectURL.mockRestore();
+        revokeObjectURL.mockRestore();
+      }
     });
   });
 

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -822,12 +822,14 @@
       "title": "Side-by-side left margin override",
       "description": "Side-by-side left margin override.",
       "type": "string",
+      "pattern": "^-?(?:0|(?:[0-9]+|[0-9]*\\.[0-9]+)(?:px|em|rem|%|vw|vh|vmin|vmax|ch|ex|cm|mm|in|pt|pc))$",
       "default": "10px"
     },
     "sideBySideRightMarginOverride": {
       "title": "Side-by-side right margin override",
       "description": "Side-by-side right margin override.",
       "type": "string",
+      "pattern": "^-?(?:0|(?:[0-9]+|[0-9]*\\.[0-9]+)(?:px|em|rem|%|vw|vh|vmin|vmax|ch|ex|cm|mm|in|pt|pc))$",
       "default": "10px"
     },
     "sideBySideOutputRatio": {

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -2103,15 +2103,16 @@ function activateNotebookHandler(
     setSideBySideOutputRatio(factory.notebookConfig.sideBySideOutputRatio);
     const sideBySideMarginStyle = `.jp-mod-sideBySide.jp-Notebook .jp-Notebook-cell {
       margin-left: ${factory.notebookConfig.sideBySideLeftMarginOverride} !important;
-      margin-right: ${factory.notebookConfig.sideBySideRightMarginOverride} !important;`;
+      margin-right: ${factory.notebookConfig.sideBySideRightMarginOverride} !important;
+    }`;
     const sideBySideMarginTag = document.getElementById(SIDE_BY_SIDE_STYLE_ID);
     if (sideBySideMarginTag) {
-      sideBySideMarginTag.innerText = sideBySideMarginStyle;
+      sideBySideMarginTag.textContent = sideBySideMarginStyle;
     } else {
-      document.head.insertAdjacentHTML(
-        'beforeend',
-        `<style id="${SIDE_BY_SIDE_STYLE_ID}">${sideBySideMarginStyle}}</style>`
-      );
+      const style = document.createElement('style');
+      style.id = SIDE_BY_SIDE_STYLE_ID;
+      style.textContent = sideBySideMarginStyle;
+      document.head.appendChild(style);
     }
     factory.autoStartDefault = settings.get('autoStartDefaultKernel')
       .composite as boolean;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "tomli>=1.2.2;python_version<\"3.11\"",
     "tornado>=6.2.0",
     "traitlets",
+    "typing-extensions>=4.4.0;python_version<\"3.12\"",
 ]
 dynamic = [
     "version",

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -239,6 +239,36 @@ if [[ $GROUP == usage ]]; then
     jupyter labextension enable @jupyterlab/notebook-extension --level user
     cat $USER_PAGE_CONFIG | grep "\"@jupyterlab/notebook-extension\": false"
 
+    # Test all-plugin lock configuration reaches the plugin manager API
+    LOCK_LOG="/tmp/jupyter_lock_log_$$.txt"
+    jupyter lab \
+        --no-browser \
+        --ServerApp.ip=127.0.0.1 \
+        --ServerApp.port=9988 \
+        --ServerApp.port_retries=0 \
+        --ServerApp.token='' \
+        --ServerApp.password='' \
+        --LabApp.lock_all_plugins=True \
+        > "$LOCK_LOG" 2>&1 &
+    TASK_PID=$!
+    if wait_for_condition 60 grep -q 'is running at:' "$LOCK_LOG"; then
+        if ! curl -fsS http://127.0.0.1:9988/lab/api/plugins | grep '"allLocked": true'; then
+            cat "$LOCK_LOG"
+            kill "$TASK_PID"
+            wait "$TASK_PID" || true
+            rm -f "$LOCK_LOG"
+            exit 1
+        fi
+    else
+        echo "Server failed to start within 60 seconds"
+        cat "$LOCK_LOG"
+        rm -f "$LOCK_LOG"
+        exit 1
+    fi
+    kill "$TASK_PID"
+    wait "$TASK_PID" || true
+    rm -f "$LOCK_LOG"
+
     # Test with a prebuilt install
     jupyter labextension develop extension --debug
     jupyter labextension build extension


### PR DESCRIPTION
Fixes for:
- GHSA-gx64-gj6p-pc4c
- GHSA-89vp-jrxv-24w8
- GHSA-h5v5-8746-g7mm
- GHSA-pppj-hq3g-57pj
- GHSA-whvh-wf3x-g77j

Slight departure from normal process due to GitHub private forks being broken, see https://github.com/jupyter/security/issues/126.