### PR TITLE
Update announcement banner to point to jupyter-wide announcement banner

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -418,7 +418,9 @@ html_favicon = "_static/logo-icon.png"
 # documentation.
 #
 html_theme_options = {
-    "announcement": '🚀 JupyterLab 4.6.0 is now available · <a href="https://jupyterlab.rtfd.io/en/latest/getting_started/installation.html">INSTALL</a> · <a href="https://jupyterlab.rtfd.io/en/latest/getting_started/changelog.html#v4-6">RELEASE NOTES</a>',
+    # The announcement will not show if https://jupyter.org/assets/banner.html is empty.
+    # See https://github.com/jupyter/jupyter.github.io#site-wide-announcement-banner
+    "announcement": "https://jupyter.org/assets/banner.html",
     "icon_links": [
         {
             "name": "jupyter.org",


### PR DESCRIPTION
## References

https://github.com/jupyter/jupyter.github.io/issues/868

## Code changes

This pulls in a jupyter-wide banner to automatically update the JupyterLab documentation banner as the banner on jupyter.org updates.

I see there is currently a JupyterLab-specific announcement running. Feel free to wait until that announcement has run its course before merging this to update the announcement to the jupyter-wide announcement.

## User-facing changes

Adds a banner to the docs that is pulled from jupyter.org.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

## AI usage

- **NO**: Some or all of the content of this PR was generated by AI.
- **NO**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: N/A
