### PR TITLE
Rename "Revert" button to "Reload from Disk" in file conflict dialog

### DIFF
--- a/packages/docmanager/test/savehandler.spec.ts
+++ b/packages/docmanager/test/savehandler.spec.ts
@@ -186,7 +186,7 @@ describe('docregistry/savehandler', () => {
           const buttons = dialog.getElementsByTagName('button');
 
           for (let i = 0; i < buttons.length; i++) {
-            if (buttons[i].textContent === 'Revert') {
+            if (buttons[i].textContent === 'Reload from Disk') {
               buttons[i].click();
               return;
             }

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -874,7 +874,7 @@ or load the version on disk (revert)?`,
       this.path
     );
     const revertBtn = Dialog.okButton({
-      label: this._trans.__('Revert'),
+      label: this._trans.__('Reload from Disk'),
       actions: ['revert']
     });
     const overwriteBtn = Dialog.warnButton({


### PR DESCRIPTION
## References

Fixes #19173

## Code changes

- Renamed the **"Revert"** button in the file conflict dialog to **"Reload from Disk"**.
- This makes the button label accurately describe its behavior and aligns it with the existing **"Reload from Disk"** menu action.

## User-facing changes

Users will now see **"Reload from Disk"** instead of **"Revert"** in the file conflict dialog when a file has been modified on disk.

## Backwards-incompatible changes

None.