### PR TITLE
Expose cell tags as data attributes

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -228,6 +228,7 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
   initializeState(): this {
     this.loadCollapseState();
     this.loadEditableState();
+    this._handleTags();
     return this;
   }
 
@@ -725,8 +726,31 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
           this.loadEditableState();
         }
         break;
+      case 'tags':
+        this._handleTags();
+        break;
       default:
         break;
+    }
+  }
+
+  private _handleTags(): void {
+    const dataset = this.node.dataset;
+    for (const key of Object.keys(dataset)) {
+      if (key === 'tag' || /^tag[A-Z]/.test(key)) {
+        delete dataset[key];
+      }
+    }
+
+    const tags = this.model.getMetadata('tags');
+    if (!Array.isArray(tags)) {
+      return;
+    }
+
+    for (const tag of tags) {
+      if (typeof tag === 'string' && /^[^\s"'/>=]+$/.test(tag)) {
+        this.node.setAttribute(`data-tag-${tag}`, '');
+      }
     }
   }
 

--- a/packages/cells/test/widget.spec.ts
+++ b/packages/cells/test/widget.spec.ts
@@ -326,6 +326,59 @@ describe('cells/widget', () => {
       });
     });
 
+    describe('#tags', () => {
+      it('should reflect tag metadata on initialization', () => {
+        const model = new TestModel({
+          sharedModel: createStandaloneCell({
+            cell_type: 'code',
+            metadata: { tags: ['parameters', 'hide-input'] }
+          }) as YCodeCell
+        });
+        const widget = new Cell({
+          contentFactory: NBTestUtils.createBaseCellFactory(),
+          model
+        }).initializeState();
+
+        expect(widget.node.hasAttribute('data-tag-parameters')).toEqual(true);
+        expect(widget.node.hasAttribute('data-tag-hide-input')).toEqual(true);
+      });
+
+      it('should reflect tag metadata changes', () => {
+        const model = new TestModel({
+          sharedModel: createStandaloneCell({ cell_type: 'code' }) as YCodeCell
+        });
+        const widget = new Cell({
+          contentFactory: NBTestUtils.createBaseCellFactory(),
+          model
+        }).initializeState();
+
+        model.setMetadata('tags', ['parameters', 'hide-input']);
+        expect(widget.node.hasAttribute('data-tag-parameters')).toEqual(true);
+        expect(widget.node.hasAttribute('data-tag-hide-input')).toEqual(true);
+
+        model.setMetadata('tags', ['hide-input']);
+        expect(widget.node.hasAttribute('data-tag-parameters')).toEqual(false);
+        expect(widget.node.hasAttribute('data-tag-hide-input')).toEqual(true);
+      });
+
+      it('should clear tag attributes when tag metadata is unset', () => {
+        const model = new TestModel({
+          sharedModel: createStandaloneCell({
+            cell_type: 'code',
+            metadata: { tags: ['parameters'] }
+          }) as YCodeCell
+        });
+        const widget = new Cell({
+          contentFactory: NBTestUtils.createBaseCellFactory(),
+          model
+        }).initializeState();
+
+        expect(widget.node.hasAttribute('data-tag-parameters')).toEqual(true);
+        model.deleteMetadata('tags');
+        expect(widget.node.hasAttribute('data-tag-parameters')).toEqual(false);
+      });
+    });
+
     describe('#loadCollapseState()', () => {
       it('should load the input collapse state from the model', () => {
         const model = new TestModel({


### PR DESCRIPTION
## References

Fixes #8298.

This follows the generic direction from #8410/#8627: expose all cell tags as `data-tag-*` attributes instead of special-casing the papermill `parameters` tag.

## Code changes

- Sync the base cell widget with the `tags` metadata during initialization.
- Refresh `data-tag-*` attributes when the `tags` metadata changes.
- Clear stale tag attributes before applying the current tags.
- Add widget tests for initial tag metadata, tag changes, and tag metadata removal.

## User-facing changes

Cells with tag metadata now expose matching DOM attributes, for example a cell tagged `parameters` receives `data-tag-parameters`. This lets themes and extensions target tagged cells with CSS selectors.

## Backwards-incompatible changes

None.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **NO**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: OpenAI Codex

## Validation

- `git diff --check`
- `prettier --check packages/cells/src/widget.ts packages/cells/test/widget.spec.ts`
- `yarn workspace @jupyterlab/cells run build`
- `yarn workspace @jupyterlab/cells run test --runInBand packages/cells/test/widget.spec.ts -t "#tags"`

I also tried the full `packages/cells/test/widget.spec.ts` file, but the server-backed `CodeCell.execute()` tests require `jupyter-lab` on `PATH` and fail in this environment with `spawn jupyter-lab ENOENT`. The new focused tag tests pass.
