### PR TITLE
Update JEP 91 link to the new MyST docs URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -361,7 +361,7 @@ This improves compatibility with extensions that do not support arbitrary drives
 
 ### Kernel subshells support
 
-Kernel subshells, introduced in [JEP 91](https://jupyter.org/enhancement-proposals/91-kernel-subshells/kernel-subshells.html),
+Kernel subshells, introduced in [JEP 91](https://jupyter.org/enhancement-proposals/kernel-subshells/),
 enable concurrent code execution in kernels that support them.
 When performing long-running computations (such as training a model), subshells enable users to:
 - Use `ipywidgets` with updates displayed immediately

--- a/docs/source/extension/extension_points.md
+++ b/docs/source/extension/extension_points.md
@@ -1164,7 +1164,7 @@ Kernel subshells enable concurrent code execution within kernels that support th
 Subshells are supported by:
 
 - **ipykernel 7.0.0+** (Python kernels) - Kernels advertise support via `supported_features: ['kernel subshells']` in kernel info replies
-- Other kernels implementing [JEP 91](https://jupyter.org/enhancement-proposals/91-kernel-subshells/kernel-subshells.html)
+- Other kernels implementing [JEP 91](https://jupyter.org/enhancement-proposals/kernel-subshells/)
 
 **User Interface**
 
@@ -1209,7 +1209,7 @@ if (kernel.supportsSubshells) {
 }
 ```
 
-For detailed specifications, see [JEP 91](https://jupyter.org/enhancement-proposals/91-kernel-subshells/kernel-subshells.html).
+For detailed specifications, see [JEP 91](https://jupyter.org/enhancement-proposals/kernel-subshells/).
 
 ## LSP Features
 


### PR DESCRIPTION
## References

To fix the failing CI

Seems related to https://github.com/jupyter/enhancement-proposals/pull/147

## Code changes

Update link to JEP

## User-facing changes

Fix broken link in docs and changelog.

## Backwards-incompatible changes

None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Opus 5
