### PR TITLE
Add Show Markdown Preview to the command palette

### DIFF
--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -945,7 +945,10 @@ export namespace Commands {
       isVisible: () => {
         const widget = tracker.currentWidget;
         return (
-          (widget && PathExt.extname(widget.context.path) === '.md') || false
+          (isEnabled() &&
+            widget &&
+            PathExt.extname(widget.context.path) === '.md') ||
+          false
         );
       },
       icon: markdownIcon,
@@ -1481,6 +1484,8 @@ export namespace Commands {
 
     addCreateNewMarkdownCommandToPalette(palette, trans);
 
+    addMarkdownPreviewCommandToPalette(palette, trans);
+
     addChangeFontSizeCommandsToPalette(palette, trans);
   }
 
@@ -1532,6 +1537,20 @@ export namespace Commands {
     palette.addItem({
       command: CommandIDs.createNewMarkdown,
       args: { isPalette: true },
+      category: paletteCategory
+    });
+  }
+
+  /**
+   * Add a Markdown Preview command to the File Editor palette
+   */
+  export function addMarkdownPreviewCommandToPalette(
+    palette: ICommandPalette,
+    trans: TranslationBundle
+  ): void {
+    const paletteCategory = trans.__('Text Editor');
+    palette.addItem({
+      command: CommandIDs.markdownPreview,
       category: paletteCategory
     });
   }


### PR DESCRIPTION
## References

Having the "Show Markdown Preview" command in the palette is useful to avoid right clicking and manually selecting the context menu entry.

## Code changes

- [x] Add the command to the palette

## User-facing changes

https://github.com/user-attachments/assets/79de008a-7d21-4f35-a08a-964038f5b449



## Backwards-incompatible changes

None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude Fable 5