### PR TITLE
Add optional `ILatexTypesetter.withParseOptions()`

### DIFF
--- a/packages/mathjax-extension/src/index.ts
+++ b/packages/mathjax-extension/src/index.ts
@@ -60,6 +60,23 @@ export class MathJaxTypesetter implements ILatexTypesetter {
    */
   readonly mathParseOptions: IRenderMime.ILatexTypesetter.IMathParseOptions;
 
+  /**
+   * Create a new MathJax typesetter with the given parse options.
+   *
+   * Options which are not given are inherited from this typesetter; this
+   * typesetter is left unchanged. The underlying MathDocument is shared with
+   * any other typesetter using the same options, so this is cheap to call.
+   *
+   * @param options - The parse options to apply.
+   */
+  withParseOptions(
+    options: IRenderMime.ILatexTypesetter.IMathParseOptions
+  ): MathJaxTypesetter {
+    return new MathJaxTypesetter(
+      Private.mergeParseOptions(this.mathParseOptions, options)
+    );
+  }
+
   protected async _ensureInitialized() {
     if (!this._initialized) {
       this._mathDocument = await Private.ensureMathDocument(
@@ -213,6 +230,23 @@ namespace Private {
     ['$', '$'],
     ['\\(', '\\)']
   ];
+
+  /**
+   * Merge parse options, where an `undefined` value in `overrides` means
+   * "keep the current value" rather than "reset to the default".
+   */
+  export function mergeParseOptions(
+    base: IRenderMime.ILatexTypesetter.IMathParseOptions,
+    overrides: IRenderMime.ILatexTypesetter.IMathParseOptions
+  ): IRenderMime.ILatexTypesetter.IMathParseOptions {
+    const merged: Record<string, unknown> = { ...base };
+    for (const [key, value] of Object.entries(overrides)) {
+      if (value !== undefined) {
+        merged[key] = value;
+      }
+    }
+    return merged as IRenderMime.ILatexTypesetter.IMathParseOptions;
+  }
 
   /**
    * The inline math delimiters with the single `$` pair removed, so that `$`

--- a/packages/mathjax-extension/test/typesetter.spec.ts
+++ b/packages/mathjax-extension/test/typesetter.spec.ts
@@ -83,6 +83,47 @@ describe('@jupyterlab/mathjax-extension', () => {
       });
     });
 
+    describe('#withParseOptions()', () => {
+      it('should return a new typesetter with the given options', () => {
+        const configured = typesetter.withParseOptions({
+          dollarInlineMath: false
+        });
+        expect(configured).not.toBe(typesetter);
+        expect(configured.mathParseOptions?.dollarInlineMath).toBe(false);
+      });
+
+      it('should leave the original typesetter unchanged', () => {
+        typesetter.withParseOptions({ dollarInlineMath: false });
+        expect(typesetter.mathParseOptions?.dollarInlineMath).toBe(true);
+      });
+
+      it('should inherit options which were not given', () => {
+        const configured = new MathJaxTypesetter({
+          dollarInlineMath: false
+        }).withParseOptions({});
+        expect(configured.mathParseOptions?.dollarInlineMath).toBe(false);
+      });
+
+      it('should inherit options which were given as `undefined`', () => {
+        const configured = new MathJaxTypesetter({
+          dollarInlineMath: false
+        }).withParseOptions({ dollarInlineMath: undefined });
+        expect(configured.mathParseOptions?.dollarInlineMath).toBe(false);
+      });
+
+      it('should not typeset `$...$` when dollar inline math is disabled', async () => {
+        const configured = typesetter.withParseOptions({
+          dollarInlineMath: false
+        });
+        const host = document.createElement('div');
+        host.innerHTML = '$1 + 1$';
+        document.body.appendChild(host);
+        await configured.typeset(host);
+        expect(host.innerHTML).toContain('$1 + 1$');
+        expect(host.innerHTML).not.toContain('<mn>1</mn>');
+      });
+    });
+
     describe('#mathDocument()', () => {
       it('should share a MathDocument between typesetters with equal options', async () => {
         const a = new MathJaxTypesetter();

--- a/packages/metapackage/test/rendermime/latex.spec.ts
+++ b/packages/metapackage/test/rendermime/latex.spec.ts
@@ -1,0 +1,103 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { Sanitizer } from '@jupyterlab/apputils';
+import { EditorLanguageRegistry } from '@jupyterlab/codemirror';
+import { MathJaxTypesetter } from '@jupyterlab/mathjax-extension';
+import { createMarkdownParser } from '@jupyterlab/markedparser-extension';
+import {
+  MimeModel,
+  RenderMimeRegistry,
+  standardRendererFactories
+} from '@jupyterlab/rendermime';
+import type { Widget } from '@lumino/widgets';
+
+/**
+ * End-to-end test of per-renderer `$` inline math handling.
+ *
+ * Unlike the unit tests (which mock either the typesetter or the parser), this
+ * exercises the real Markdown parser (marked) and the real MathJax typesetter
+ * together through a `RenderMimeRegistry`, the same path the application uses.
+ */
+describe('@jupyterlab/rendermime', () => {
+  describe('RenderMimeRegistry latexTypesetter', () => {
+    const markdownParser = createMarkdownParser(new EditorLanguageRegistry());
+    const sanitizer = new Sanitizer();
+
+    async function render(
+      source: string,
+      typesetter: MathJaxTypesetter
+    ): Promise<Widget> {
+      const registry = new RenderMimeRegistry({
+        initialFactories: standardRendererFactories,
+        markdownParser,
+        latexTypesetter: typesetter,
+        sanitizer
+      });
+      const widget = registry.createRenderer('text/markdown');
+      // Render (which runs `removeMath` with the typesetter's `mathParseOptions`)
+      // then typeset explicitly so the assertions are deterministic; the widget
+      // otherwise typesets asynchronously on attach.
+      await widget.renderModel(
+        new MimeModel({ trusted: true, data: { 'text/markdown': source } })
+      );
+      await typesetter.typeset(widget.node);
+      return widget;
+    }
+
+    it('should render `$` literally with a dollar-disabled typesetter', async () => {
+      const widget = await render(
+        'You owe me $5 and $10.',
+        new MathJaxTypesetter({ dollarInlineMath: false })
+      );
+      expect(widget.node.textContent).toContain('$5 and $10');
+      expect(widget.node.querySelector('mjx-container')).toBeNull();
+      widget.dispose();
+    });
+
+    it('should typeset `$...$` with the default typesetter', async () => {
+      const widget = await render(
+        'The value $x$ is unknown.',
+        new MathJaxTypesetter()
+      );
+      expect(widget.node.querySelector('mjx-container')).not.toBeNull();
+      widget.dispose();
+    });
+
+    it('should allow deriving a dollar-disabled typesetter with `withParseOptions`', async () => {
+      // The flow extensions are expected to use: derive a typesetter from the
+      // one the registry provides, rather than hard-coding `MathJaxTypesetter`.
+      const registry = new RenderMimeRegistry({
+        initialFactories: standardRendererFactories,
+        markdownParser,
+        latexTypesetter: new MathJaxTypesetter(),
+        sanitizer
+      });
+      const original = registry.latexTypesetter!;
+      const latexTypesetter =
+        original.withParseOptions?.({ dollarInlineMath: false }) ?? original;
+      const widget = registry
+        .clone({ latexTypesetter })
+        .createRenderer('text/markdown');
+      await widget.renderModel(
+        new MimeModel({
+          trusted: true,
+          data: { 'text/markdown': 'You owe me $5 and $10.' }
+        })
+      );
+      await latexTypesetter.typeset(widget.node);
+      expect(widget.node.textContent).toContain('$5 and $10');
+      expect(widget.node.querySelector('mjx-container')).toBeNull();
+      widget.dispose();
+    });
+
+    it('should keep `$$...$$` display math with a dollar-disabled typesetter', async () => {
+      const widget = await render(
+        'Display: $$x = 5$$',
+        new MathJaxTypesetter({ dollarInlineMath: false })
+      );
+      expect(widget.node.querySelector('mjx-container')).not.toBeNull();
+      widget.dispose();
+    });
+  });
+});

--- a/packages/rendermime-interfaces/src/index.ts
+++ b/packages/rendermime-interfaces/src/index.ts
@@ -594,6 +594,33 @@ export namespace IRenderMime {
      * are assumed, including a single `$` delimiter for inline math.
      */
     readonly mathParseOptions?: ILatexTypesetter.IMathParseOptions;
+
+    /**
+     * Create a typesetter of the same kind, using the given parse options.
+     *
+     * This allows extensions to adjust how math is recognized without
+     * hard-coding a specific implementation, so that the typesetter chosen by
+     * the user (e.g. KaTeX rather than MathJax) is respected:
+     *
+     * ```ts
+     * const typesetter = rmRegistry.latexTypesetter;
+     * const latexTypesetter =
+     *   typesetter?.withParseOptions?.({ dollarInlineMath: false }) ?? typesetter;
+     * const renderer = rmRegistry
+     *   .clone({ latexTypesetter })
+     *   .createRenderer('text/markdown');
+     * ```
+     *
+     * Implementing this method is optional; callers should fall back to the
+     * original typesetter when it is not available.
+     *
+     * @param options - The parse options to apply. Options which are omitted
+     *   (or `undefined`) are inherited from this typesetter.
+     * @returns A new typesetter; this typesetter is left unchanged.
+     */
+    withParseOptions?(
+      options: ILatexTypesetter.IMathParseOptions
+    ): ILatexTypesetter;
   }
 
   /**


### PR DESCRIPTION
## References

- Step towards https://github.com/jupyterlab/jupyterlab/issues/17245
- Follow-up to https://github.com/jupyterlab/jupyterlab/pull/19177

## Code changes

To avoid hard-coding the LaTeX typesetter to `MathJaxTypesetter` in extensions this PR introduces:

```diff
interface ILatexTypesetter {
+   withParseOptions?(options: IMathParseOptions): ILatexTypesetter;
}
```

## Developer-facing changes

Extensions can render Markdown without treating individual `$` signs as math delimiters, respecting the LaTeX typesetter chosen by the user.

For example, after https://github.com/jupyterlab/jupyterlab/pull/19177 `jupyter-chat` could define:

```ts
const latexTypesetter = new MathJaxTypesetter({ dollarInlineMath: false });
const rmRegistryClone = rmRegistry.clone({ latexTypesetter });
renderer = rmRegistryClone.createRenderer(DEFAULT_MIME_TYPE);
```


but that hard-codes the LaTeX typesetter, to JupyterLab's default `MathJaxTypesetter`.


To allow respecting say [`jupyterlab-katex`](https://pypi.org/project/jupyterlab-katex/) for KaTeX) preference with this PR the extensions could instead create a second copy of the current typesetter, say KaTeX with:

```ts
const typesetter = rmRegistry.latexTypesetter;
const latexTypesetter = typesetter.withParseOptions?.({ dollarInlineMath: false }) ?? typesetter;
const rmRegistryClone = rmRegistry.clone({ latexTypesetter });
renderer = rmRegistryClone.createRenderer(DEFAULT_MIME_TYPE);
```

## Backwards-incompatible changes

None

## AI usage

- **Yes**: Some or all of the content of this PR was generated by AI.
- **Yes**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Opus 5