### PR TITLE
Update the item positions when an item is removed from reactive toolbar

### DIFF
--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -413,7 +413,10 @@ export class ReactiveToolbar extends Toolbar<Widget> {
   protected onChildRemoved(msg: Widget.ChildMessage): void {
     // If the widget is being moved to the popup opener, keep tracking its
     // intended position so it can be restored to the right slot later.
-    if (msg.child.parent === this.popupOpener) {
+    // NOTE: we cannot check msg.child.parent here because Lumino fires
+    // child-removed before updating the parent reference; use the transit
+    // set instead.
+    if (this._movingToPopup.has(msg.child)) {
       return;
     }
     const name = Private.nameProperty.get(msg.child);
@@ -627,7 +630,9 @@ export class ReactiveToolbar extends Toolbar<Widget> {
 
           // Insert the widget in the popup toolbar.
           const index = position - openerFirstIndex;
+          this._movingToPopup.add(widget);
           opener.insertWidget(index, widget);
+          this._movingToPopup.delete(widget);
         }
         if (opener.widgetCount() > 0) {
           const widgetsToAdd = [];
@@ -755,6 +760,7 @@ export class ReactiveToolbar extends Toolbar<Widget> {
   private readonly _resizer: Throttler;
   private readonly _widgetWidths = new Map<string, number>();
   private _widgetPositions = new Map<string, number>();
+  private _movingToPopup = new Set<Widget>();
   // The zoom property is not the real browser zoom, but a value proportional to
   // the zoom, which is modified when the zoom changes.
   private _zoom: number;

--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -410,6 +410,30 @@ export class ReactiveToolbar extends Toolbar<Widget> {
     super.dispose();
   }
 
+  protected onChildRemoved(msg: Widget.ChildMessage): void {
+    // If the widget is being moved to the popup opener, keep tracking its
+    // intended position so it can be restored to the right slot later.
+    if (msg.child.parent === this.popupOpener) {
+      return;
+    }
+    const name = Private.nameProperty.get(msg.child);
+    if (!name || name === TOOLBAR_OPENER_NAME) {
+      return;
+    }
+    const position = this._widgetPositions.get(name);
+    if (position === undefined) {
+      return;
+    }
+    this._widgetPositions.delete(name);
+    this._widgetWidths.delete(name);
+    // Shift down all items that were logically after the removed one.
+    this._widgetPositions.forEach((pos, key) => {
+      if (pos > position) {
+        this._widgetPositions.set(key, pos - 1);
+      }
+    });
+  }
+
   /**
    * Insert an item into the toolbar at the after a target item.
    *

--- a/packages/ui-components/test/toolbar.spec.ts
+++ b/packages/ui-components/test/toolbar.spec.ts
@@ -529,6 +529,65 @@ describe('@jupyterlab/ui-components', () => {
         }
         expect(stored).toEqual([1, 2, 0, 3]);
       });
+
+      it('should remove the entry and shift higher positions when a widget is disposed', () => {
+        toolbar.addItem('a', new Widget());
+        toolbar.addItem('b', new Widget());
+        toolbar.addItem('c', new Widget());
+        const positions = (toolbar as any)._widgetPositions;
+        expect(positions.get('a')).toEqual(0);
+        expect(positions.get('b')).toEqual(1);
+        expect(positions.get('c')).toEqual(2);
+
+        // Dispose 'b' — 'c' should shift down by one.
+        (toolbar.layout as PanelLayout).widgets
+          .find(w => w.node.dataset['jpItemName'] === 'b')!
+          .dispose();
+
+        expect(positions.has('b')).toBe(false);
+        expect(positions.get('a')).toEqual(0);
+        expect(positions.get('c')).toEqual(1);
+      });
+    });
+
+    describe('#insertBefore()', () => {
+      it('should insert before the target after intermediate items have been removed', () => {
+        // Reproduce the pattern used by SidePanelWidget: a permanent 'close'
+        // button is added last, then factory items are inserted before it.
+        toolbar.addItem('spacer', new Widget());
+        const closeBtn = new Widget();
+        toolbar.addItem('close', closeBtn);
+
+        const f1 = new Widget();
+        const f2 = new Widget();
+        toolbar.insertBefore('close', 'f1', f1);
+        toolbar.insertBefore('close', 'f2', f2);
+        expect(Array.from(toolbar.names())).toEqual([
+          'spacer',
+          'f1',
+          'f2',
+          'close',
+          'toolbar-popup-opener'
+        ]);
+
+        // Simulate a factory refresh: dispose old widgets and re-add new ones.
+        f1.dispose();
+        f2.dispose();
+
+        const newF1 = new Widget();
+        const newF2 = new Widget();
+        toolbar.insertBefore('close', 'f1', newF1);
+        toolbar.insertBefore('close', 'f2', newF2);
+
+        // Items must still appear before 'close' and in the original order.
+        expect(Array.from(toolbar.names())).toEqual([
+          'spacer',
+          'f1',
+          'f2',
+          'close',
+          'toolbar-popup-opener'
+        ]);
+      });
     });
   });
 


### PR DESCRIPTION
## References

Fixes #19226

## Code changes

Update the position of all items following a removed item in the reactive toolbar.
That way the `widgetPositions` map is always up to date.

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: claude code, Sonnet 4.6

## Additional context

This PR could be backported to previous branches (until 4.1.x)