### PR TITLE
Fix windowed notebook scroll snapback on user input

### DIFF
--- a/galata/test/jupyterlab/windowed-notebook.test.ts
+++ b/galata/test/jupyterlab/windowed-notebook.test.ts
@@ -292,20 +292,6 @@ test.describe('Scrolling on keyboard interaction when active editor is above the
       for (let i = 0; i < testCase.times; i++) {
         await page.keyboard.press(testCase.key);
         // Allow for small delay between pressing keys
-        if (i === 0 && testCase.key === 'PageDown' && testCase.times === 10) {
-          // TODO: for some reason the notebook scrolls back to the selected cell after a few seconds.
-          // The exact mechanism is not clear but it is easily reproducible with the test case
-          // "Show neither cell on pressing PageDown 10 times" by commenting out the timeout below,
-          // and decreasing the timeout for each iteration (say down to 10ms).
-          // It might be unrelated to this test, but instead a different bug in the windowing
-          // logic where some stale request remains beyond its intended lifetime
-          // (i.e. when user requested a different scroll).
-          // This could be related related to the scrollback logic; PR #18973 demonstrated
-          // a potential fix, however it made the scrollback test for full windowing flaky
-          // ("should keep active cell when a cell above generates a lot of output").
-          // eslint-disable-next-line playwright/no-wait-for-timeout
-          await page.waitForTimeout(3000);
-        }
         // eslint-disable-next-line playwright/no-wait-for-timeout
         await page.waitForTimeout(100);
       }

--- a/galata/test/jupyterlab/windowed-notebook.test.ts
+++ b/galata/test/jupyterlab/windowed-notebook.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 import { expect, galata, test } from '@jupyterlab/galata';
+import type { IJupyterLabPageFixture } from '@jupyterlab/galata';
 import type { Locator } from '@playwright/test';
 import * as path from 'path';
 
@@ -310,6 +311,183 @@ test.describe('Scrolling on keyboard interaction when active editor is above the
       }
     });
   }
+});
+
+test.describe('Scrollback cancellation on user scrolling', () => {
+  /**
+   * Arm the scrollback anchor: type into the active editor which is above
+   * the viewport, which scrolls back to the active cell and keeps the
+   * scrollback target armed for the next few seconds (renewed on cell
+   * resizes, e.g. those caused by re-rendering of windowed cells).
+   */
+  const armScrollback = async (
+    page: IJupyterLabPageFixture,
+    tmpPath: string
+  ) => {
+    await page.notebook.openByPath(`${tmpPath}/${fileName}`);
+
+    await page.notebook.selectCells(0);
+    await page.notebook.enterCellEditingMode(0);
+    const notebook = (await page.notebook.getNotebookInPanelLocator())!;
+    const firstCell = notebook.locator(
+      '.jp-Cell[data-windowed-list-index="0"]'
+    );
+    const secondCell = notebook.locator(
+      '.jp-Cell[data-windowed-list-index="1"]'
+    );
+    await firstCell.waitFor();
+    await secondCell.waitFor();
+
+    // Position the mouse in the bounding box to allow for scrolling with mouse wheel
+    const bbox = (await notebook.boundingBox())!;
+    await page.mouse.move(bbox.x + bbox.width / 2, bbox.y + bbox.height / 2);
+
+    await scrollAwayWithWheel(page, firstCell, secondCell);
+
+    // Typing scrolls back to the active cell and arms the scrollback anchor.
+    await page.keyboard.type('T');
+    await firstCell.waitFor({ state: 'visible' });
+
+    return { notebook, firstCell, secondCell };
+  };
+
+  /**
+   * Scroll down with the wheel until the first and second cell get hidden:
+   * the scroll distance performed for a wheel event differs between browsers.
+   */
+  const scrollAwayWithWheel = async (
+    page: IJupyterLabPageFixture,
+    firstCell: Locator,
+    secondCell: Locator
+  ) => {
+    await Promise.all([
+      firstCell.waitFor({ state: 'hidden' }),
+      secondCell.waitFor({ state: 'hidden' }),
+      (async () => {
+        for (let i = 0; i < 8; i++) {
+          await page.mouse.wheel(0, 1200);
+          // eslint-disable-next-line playwright/no-wait-for-timeout
+          await page.waitForTimeout(150);
+          if ((await firstCell.isHidden()) && (await secondCell.isHidden())) {
+            return;
+          }
+        }
+      })()
+    ]);
+  };
+
+  /**
+   * Force a resize of a stably rendered cell: this is what triggers the
+   * scrollback (an armed anchor scrolls the view back to the active cell
+   * on any cell resize, as happens when a cell above streams output).
+   */
+  const forceCellResize = async (
+    page: IJupyterLabPageFixture,
+    notebook: Locator
+  ) => {
+    // Let the windowed rendering settle so the resized cell stays observed.
+    // eslint-disable-next-line playwright/no-wait-for-timeout
+    await page.waitForTimeout(400);
+    await notebook.locator('.jp-WindowedPanel-outer').evaluate(node => {
+      const cells = node.querySelectorAll(
+        '.jp-WindowedPanel-viewport .jp-Cell'
+      );
+      const mid = cells[Math.floor(cells.length / 2)] as HTMLElement;
+      mid.style.minHeight = `${mid.clientHeight + 300}px`;
+    });
+  };
+
+  /**
+   * Check that the view does not scroll back to the active cell,
+   * waiting long enough to cover the delayed scrollback paths
+   * (`scrollend` events and their 750 ms fallback timer).
+   */
+  const expectNoScrollback = async (
+    page: IJupyterLabPageFixture,
+    firstCell: Locator,
+    secondCell: Locator
+  ) => {
+    // eslint-disable-next-line playwright/no-wait-for-timeout
+    await page.waitForTimeout(1000);
+    await expect(firstCell).toBeHidden();
+    await expect(secondCell).toBeHidden();
+  };
+
+  test('should not scroll back to the active cell after scrolling away with the wheel', async ({
+    page,
+    tmpPath
+  }) => {
+    const { notebook, firstCell, secondCell } = await armScrollback(
+      page,
+      tmpPath
+    );
+
+    // Scroll away with the wheel; this should cancel the scrollback.
+    await scrollAwayWithWheel(page, firstCell, secondCell);
+
+    await forceCellResize(page, notebook);
+    await expectNoScrollback(page, firstCell, secondCell);
+  });
+
+  test('should not scroll back to the active cell after pressing the middle mouse button', async ({
+    page,
+    tmpPath
+  }) => {
+    const { notebook, firstCell, secondCell } = await armScrollback(
+      page,
+      tmpPath
+    );
+
+    // Press the middle button (which can start browser autoscroll) over
+    // the cell prompt area; this should cancel the scrollback. Synthetic
+    // input cannot trigger the actual browser autoscroll, so the scrolling
+    // it would cause is emulated by setting `scrollTop`.
+    const bbox = (await notebook.boundingBox())!;
+    await page.mouse.move(bbox.x + 30, bbox.y + bbox.height / 2);
+    await page.mouse.down({ button: 'middle' });
+    await page.mouse.up({ button: 'middle' });
+
+    const outer = notebook.locator('.jp-WindowedPanel-outer');
+    await Promise.all([
+      firstCell.waitFor({ state: 'hidden' }),
+      secondCell.waitFor({ state: 'hidden' }),
+      outer.evaluate(node => {
+        node.scrollTop += 1200;
+      })
+    ]);
+
+    await forceCellResize(page, notebook);
+    await expectNoScrollback(page, firstCell, secondCell);
+  });
+
+  test('should scroll back to the active cell when the scroll was not caused by user input', async ({
+    page,
+    tmpPath
+  }) => {
+    const { notebook, firstCell } = await armScrollback(page, tmpPath);
+
+    // Scroll away programmatically, without any user input event: the
+    // scrollback must NOT be cancelled (in particular, cancellation must
+    // not be keyed on `scroll` events: programmatic scrolling fires them
+    // too and cancelling on them proved flaky, see #18973).
+    const outer = notebook.locator('.jp-WindowedPanel-outer');
+    const scrolled = await outer.evaluate(node => {
+      node.scrollTop += 1200;
+      return node.scrollTop;
+    });
+    expect(scrolled).toBeGreaterThan(1000);
+
+    // Force a cell resize in case the scroll alone did not produce size
+    // corrections (the scrollback may fire at different points of the
+    // scroll handling depending on the browser).
+    await forceCellResize(page, notebook);
+
+    // The armed scrollback should bring the view back to the active cell.
+    await expect
+      .poll(() => outer.evaluate(node => Math.round(node.scrollTop)))
+      .toBeLessThan(500);
+    await expect(firstCell).toBeVisible();
+  });
 });
 
 test('should detach a markdown code cell when scrolling out of the viewport', async ({

--- a/galata/test/jupyterlab/windowed-notebook.test.ts
+++ b/galata/test/jupyterlab/windowed-notebook.test.ts
@@ -2,6 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 import { expect, galata, test } from '@jupyterlab/galata';
 import type { IJupyterLabPageFixture } from '@jupyterlab/galata';
+import type { NotebookPanel } from '@jupyterlab/notebook';
 import type { Locator } from '@playwright/test';
 import * as path from 'path';
 
@@ -314,6 +315,104 @@ test.describe('Scrolling on keyboard interaction when active editor is above the
 });
 
 test.describe('Scrollback cancellation on user scrolling', () => {
+  for (const [atBoundary, overscrollBehaviorY] of [
+    [false, 'auto'],
+    [true, 'auto'],
+    [true, 'contain'],
+    [true, 'none']
+  ] as const) {
+    const cancels = atBoundary && overscrollBehaviorY === 'auto';
+    test(`should ${cancels ? 'cancel' : 'preserve'} scrollback when wheeling ${atBoundary ? 'at the output boundary' : 'inside an output'} (overscroll=${overscrollBehaviorY})`, async ({
+      page,
+      tmpPath,
+      browserName
+    }) => {
+      test.skip(
+        browserName === 'firefox' && overscrollBehaviorY !== 'auto',
+        'Firefox synthetic wheel events ignore overscroll-behavior.'
+      );
+      const outputNotebook = 'output_scrolling.ipynb';
+      await page.contents.uploadFile(
+        path.resolve(__dirname, `notebooks/${outputNotebook}`),
+        `${tmpPath}/${outputNotebook}`
+      );
+      await page.notebook.openByPath(`${tmpPath}/${outputNotebook}`);
+      await page.notebook.selectCells(0, 1);
+      await page.evaluate(() =>
+        window.jupyterapp.commands.execute('notebook:enable-output-scrolling')
+      );
+      await page.evaluate(() => {
+        const panel = window.jupyterapp.shell.currentWidget as NotebookPanel;
+        panel.content.model!.sharedModel.insertCell(2, {
+          cell_type: 'raw',
+          source: 'Trailing content\n'.repeat(100)
+        });
+      });
+      const notebook = await page.notebook.getNotebookInPanelLocator();
+      const outer = notebook.locator('.jp-WindowedPanel-outer');
+      const firstCell = notebook.locator('[data-windowed-list-index="0"]');
+      const secondCell = notebook.locator('[data-windowed-list-index="1"]');
+      const output = firstCell.locator('.jp-Cell-outputArea');
+      await notebook.locator('.jp-Cell-outputArea').evaluateAll(nodes => {
+        for (const node of nodes) {
+          (node as HTMLElement).style.height = '120px';
+        }
+      });
+      await expect(secondCell).toBeInViewport();
+      await output.evaluate((node, atBoundary) => {
+        node.scrollTop = atBoundary
+          ? node.scrollHeight - node.clientHeight
+          : 100;
+      }, atBoundary);
+      await output.evaluate((node, overscrollBehaviorY) => {
+        node.style.overscrollBehaviorY = overscrollBehaviorY;
+        node.addEventListener('wheel', () => (node.dataset.wheeled = 'true'), {
+          once: true
+        });
+      }, overscrollBehaviorY);
+      await output.hover();
+      await page.evaluate(async () => {
+        const panel = window.jupyterapp.shell.currentWidget as NotebookPanel;
+        await panel.content.scrollToItem(1);
+      });
+      const initialOuterTop = await outer.evaluate(node => node.scrollTop);
+      const initialOutputTop = await output.evaluate(node => node.scrollTop);
+      await page.mouse.wheel(0, 100);
+      await expect(output).toHaveAttribute('data-wheeled', 'true');
+      if (cancels) {
+        await expect
+          .poll(() => outer.evaluate(node => node.scrollTop))
+          .toBeGreaterThan(initialOuterTop);
+      } else {
+        if (!atBoundary) {
+          await expect
+            .poll(() => output.evaluate(node => node.scrollTop))
+            .toBeGreaterThan(initialOutputTop);
+        }
+        expect(await outer.evaluate(node => node.scrollTop)).toBe(
+          initialOuterTop
+        );
+      }
+
+      // A cell growing above the followed cell must still keep it in view
+      // unless the user has scrolled the notebook itself.
+      await firstCell.evaluate(node => {
+        (node as HTMLElement).style.minHeight = '1500px';
+      });
+      if (cancels) {
+        // Cover the delayed scrollback paths, including the scrollend fallback.
+        // eslint-disable-next-line playwright/no-wait-for-timeout
+        await page.waitForTimeout(1000);
+        await expect(secondCell).not.toBeInViewport();
+      } else {
+        await expect
+          .poll(() => outer.evaluate(node => node.scrollTop))
+          .toBeGreaterThan(initialOuterTop);
+        await expect(secondCell).toBeInViewport();
+      }
+    });
+  }
+
   /**
    * Arm the scrollback anchor: type into the active editor which is above
    * the viewport, which scrolls back to the active cell and keeps the

--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -1801,12 +1801,15 @@ export class WindowedList<
         if (event instanceof MouseEvent) {
           // A primary-button press on the outer element itself (rather than
           // on the content) is a native scrollbar interaction: the scrollbar
-          // gutter lies outside of the client area (right of it, or left of
-          // it in right-to-left layouts).
+          // gutter lies within the border box but outside of the client
+          // area, which spans `clientWidth` starting at `clientLeft`
+          // (`clientLeft` includes the width of the scrollbar when it is
+          // placed on the left in right-to-left layouts).
+          const outer = this._outerElement;
+          const x = event.clientX - outer.getBoundingClientRect().left;
           const onScrollbarGutter =
-            event.target === this._outerElement &&
-            (event.offsetX >= this._outerElement.clientWidth ||
-              event.offsetX < 0);
+            event.target === outer &&
+            (x < outer.clientLeft || x >= outer.clientLeft + outer.clientWidth);
           // Middle-click can start browser autoscroll anywhere in the list.
           if (event.button === 1 || (event.button === 0 && onScrollbarGutter)) {
             this._cancelScrollback();

--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -50,6 +50,12 @@ const PROGRAMMATIC_SCROLL_TIMEOUT = 3000;
  */
 const MAXIMUM_TIME_WAITING_FOR_ITEM = 10000;
 
+/**
+ * CSS selector for elements in which keys like Space or Home/End edit
+ * or navigate text rather than scroll the list.
+ */
+const EDITABLE_SELECTOR = 'input, textarea, select, [contenteditable="true"]';
+
 /*
  * Feature detection
  *
@@ -1104,6 +1110,10 @@ export class WindowedList<
    * @param align Type of alignment
    * @param margin In 'smart' mode the viewport proportion to add
    * @param alignPreference Allows to override the alignment of item when the `auto` heuristic decides that the item needs to be scrolled into view.
+   * @returns A promise which resolves once the scroll has settled; it rejects
+   * when the request is superseded by a new `scrollToItem` call or cancelled
+   * by explicit user scrolling input (wheel, scrolling keys, touch scrolling,
+   * or scrollbar and middle-click interactions).
    */
   scrollToItem(
     index: number,
@@ -1493,16 +1503,30 @@ export class WindowedList<
       this._areaResizeObserver.observe(this._innerElement);
     }
     this._outerElement.addEventListener('scroll', this, passiveIfSupported);
-    this._outerElement.addEventListener(
-      'wheel',
-      this._onUserScrollIntent,
-      passiveIfSupported
-    );
-    this._outerElement.addEventListener(
-      'keydown',
-      this._onUserScrollIntent,
-      true
-    );
+    if (this.viewModel.windowingActive) {
+      // Scrollback (and thus its cancellation) only applies in full
+      // windowing mode; `onStateChanged` re-runs `_removeListeners` and
+      // `_addListeners` when the windowing mode changes at runtime.
+      this._outerElement.addEventListener(
+        'wheel',
+        this._onUserScrollIntent,
+        passiveIfSupported
+      );
+      this._outerElement.addEventListener(
+        'keydown',
+        this._onUserScrollIntent,
+        true
+      );
+      this._outerElement.addEventListener(
+        'touchmove',
+        this._onUserScrollIntent,
+        passiveIfSupported
+      );
+      this._outerElement.addEventListener(
+        'mousedown',
+        this._onUserScrollIntent
+      );
+    }
   }
 
   /**
@@ -1535,6 +1559,14 @@ export class WindowedList<
       'keydown',
       this._onUserScrollIntent,
       true
+    );
+    this._outerElement.removeEventListener(
+      'touchmove',
+      this._onUserScrollIntent
+    );
+    this._outerElement.removeEventListener(
+      'mousedown',
+      this._onUserScrollIntent
     );
     this._areaResizeObserver?.disconnect();
     this._areaResizeObserver = null;
@@ -1702,20 +1734,85 @@ export class WindowedList<
       return;
     }
     this.scrollToItem(...this._scrollToItem).catch(reason => {
-      console.log(reason);
+      // Rejection is expected when the user cancels the scrollback
+      // or a new scroll request supersedes this one.
+      console.debug(reason);
     });
   }
 
   /**
    * Handle explicit user input which can scroll the list.
+   *
+   * Cancellation is deliberately keyed on input events (wheel, keydown,
+   * touchmove, mousedown) rather than on the `scroll` event: programmatic
+   * scrolling, including the scrollback itself, fires `scroll` too, and
+   * cancelling based on it proved flaky (see #18973).
    */
   private _onUserScrollIntent = (event: Event): void => {
-    if (
-      event.type === 'wheel' ||
-      (event instanceof KeyboardEvent &&
-        (event.key === 'PageDown' || event.key === 'PageUp'))
-    ) {
-      this._cancelScrollback();
+    switch (event.type) {
+      case 'wheel':
+        if (
+          event instanceof WheelEvent &&
+          // Ctrl+wheel zooms rather than scrolls; since the scrollback
+          // target is an item index, scrolling back keeps the followed
+          // item in view through the zoom reflow.
+          !event.ctrlKey &&
+          // A wheel event without vertical delta cannot scroll the list.
+          event.deltaY !== 0
+        ) {
+          this._cancelScrollback();
+        }
+        break;
+      case 'keydown':
+        if (event instanceof KeyboardEvent) {
+          if (
+            // Paging through IME candidates does not scroll the list.
+            event.isComposing ||
+            // Modified keys are shortcuts (e.g. browser tab switching).
+            event.ctrlKey ||
+            event.altKey ||
+            event.metaKey
+          ) {
+            break;
+          }
+          if (event.key === 'PageDown' || event.key === 'PageUp') {
+            this._cancelScrollback();
+          } else if (
+            event.key === ' ' ||
+            event.key === 'Home' ||
+            event.key === 'End'
+          ) {
+            // These keys scroll the list via the browser default action
+            // only when focus is outside of a text editing context.
+            const target = event.target;
+            if (
+              target instanceof Element &&
+              !target.closest(EDITABLE_SELECTOR)
+            ) {
+              this._cancelScrollback();
+            }
+          }
+        }
+        break;
+      case 'touchmove':
+        this._cancelScrollback();
+        break;
+      case 'mousedown':
+        if (event instanceof MouseEvent) {
+          // A primary-button press on the outer element itself (rather than
+          // on the content) is a native scrollbar interaction: the scrollbar
+          // gutter lies outside of the client area (right of it, or left of
+          // it in right-to-left layouts).
+          const onScrollbarGutter =
+            event.target === this._outerElement &&
+            (event.offsetX >= this._outerElement.clientWidth ||
+              event.offsetX < 0);
+          // Middle-click can start browser autoscroll anywhere in the list.
+          if (event.button === 1 || (event.button === 0 && onScrollbarGutter)) {
+            this._cancelScrollback();
+          }
+        }
+        break;
     }
   };
 
@@ -1728,7 +1825,14 @@ export class WindowedList<
     }
 
     this._scrollToItem = null;
-    this._scrollUpdateWasRequested = false;
+    if (this._scrollUpdateWasRequested) {
+      // A programmatic scroll was requested but not yet applied by `_update()`:
+      // drop the pending `scrollTop` write and restore the view model offset
+      // to the actual scroll position, otherwise the next update would render
+      // the window for the abandoned target while the viewport stays put.
+      this._scrollUpdateWasRequested = false;
+      this.viewModel.scrollOffset = this._outerElement.scrollTop;
+    }
 
     if (this._resetScrollToItemTimeout !== null) {
       clearTimeout(this._resetScrollToItemTimeout);
@@ -1738,7 +1842,13 @@ export class WindowedList<
       clearTimeout(this._programmaticScrollTimeout);
       this._programmaticScrollTimeout = null;
     }
-    this._markProgrammaticScrollingDone();
+    if (this._isScrolling) {
+      // Reject like the supersede path in `scrollToItem`: resolving would run
+      // the callers' success continuations (scroll within cell, focus, etc.)
+      // which re-scroll to the target the user just navigated away from.
+      this._isScrolling.reject('Scrolling was cancelled by user input.');
+      this._isScrolling = null;
+    }
   }
 
   /**
@@ -1880,7 +1990,13 @@ export class WindowedList<
       if (target.hasAttribute('data-index')) {
         const index = parseInt(target.getAttribute('data-index')!, 10);
         return void (async () => {
-          await this.scrollToItem(index);
+          try {
+            await this.scrollToItem(index);
+          } catch (reason) {
+            // The jump was superseded or cancelled by the user;
+            // the target was never reached so do not emit `jumped`.
+            return;
+          }
           this.jumped.emit(index);
         })();
       }

--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -1493,6 +1493,16 @@ export class WindowedList<
       this._areaResizeObserver.observe(this._innerElement);
     }
     this._outerElement.addEventListener('scroll', this, passiveIfSupported);
+    this._outerElement.addEventListener(
+      'wheel',
+      this._onUserScrollIntent,
+      passiveIfSupported
+    );
+    this._outerElement.addEventListener(
+      'keydown',
+      this._onUserScrollIntent,
+      true
+    );
   }
 
   /**
@@ -1520,6 +1530,12 @@ export class WindowedList<
    */
   private _removeListeners() {
     this._outerElement.removeEventListener('scroll', this);
+    this._outerElement.removeEventListener('wheel', this._onUserScrollIntent);
+    this._outerElement.removeEventListener(
+      'keydown',
+      this._onUserScrollIntent,
+      true
+    );
     this._areaResizeObserver?.disconnect();
     this._areaResizeObserver = null;
     this._itemsResizeObserver?.disconnect();
@@ -1688,6 +1704,41 @@ export class WindowedList<
     this.scrollToItem(...this._scrollToItem).catch(reason => {
       console.log(reason);
     });
+  }
+
+  /**
+   * Handle explicit user input which can scroll the list.
+   */
+  private _onUserScrollIntent = (event: Event): void => {
+    if (
+      event.type === 'wheel' ||
+      (event instanceof KeyboardEvent &&
+        (event.key === 'PageDown' || event.key === 'PageUp'))
+    ) {
+      this._cancelScrollback();
+    }
+  };
+
+  /**
+   * Cancel scrollback when the user explicitly scrolls away from its target.
+   */
+  private _cancelScrollback(): void {
+    if (!this.viewModel.windowingActive || !this._scrollToItem) {
+      return;
+    }
+
+    this._scrollToItem = null;
+    this._scrollUpdateWasRequested = false;
+
+    if (this._resetScrollToItemTimeout !== null) {
+      clearTimeout(this._resetScrollToItemTimeout);
+      this._resetScrollToItemTimeout = null;
+    }
+    if (this._programmaticScrollTimeout !== null) {
+      clearTimeout(this._programmaticScrollTimeout);
+      this._programmaticScrollTimeout = null;
+    }
+    this._markProgrammaticScrollingDone();
   }
 
   /**

--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -1752,13 +1752,16 @@ export class WindowedList<
     switch (event.type) {
       case 'wheel':
         if (
+          this._scrollToItem !== null &&
           event instanceof WheelEvent &&
           // Ctrl+wheel zooms rather than scrolls; since the scrollback
           // target is an item index, scrolling back keeps the followed
           // item in view through the zoom reflow.
           !event.ctrlKey &&
           // A wheel event without vertical delta cannot scroll the list.
-          event.deltaY !== 0
+          event.deltaY !== 0 &&
+          !event.defaultPrevented &&
+          !this._isWheelEventConsumed(event)
         ) {
           this._cancelScrollback();
         }
@@ -1818,6 +1821,35 @@ export class WindowedList<
         break;
     }
   };
+
+  /**
+   * Whether a nested scroll container keeps a wheel event from scrolling the list.
+   */
+  private _isWheelEventConsumed(event: WheelEvent): boolean {
+    for (const target of event.composedPath()) {
+      if (target === this._outerElement) {
+        break;
+      }
+      if (!(target instanceof Element)) {
+        continue;
+      }
+      const style = window.getComputedStyle(target);
+      if (style.overflowY !== 'auto' && style.overflowY !== 'scroll') {
+        continue;
+      }
+      if (
+        (event.deltaY < 0 && target.scrollTop > 0) ||
+        (event.deltaY > 0 &&
+          target.scrollTop < target.scrollHeight - target.clientHeight) ||
+        // Containment prevents scroll chaining even at the nested boundary.
+        style.overscrollBehaviorY === 'contain' ||
+        style.overscrollBehaviorY === 'none'
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   /**
    * Cancel scrollback when the user explicitly scrolls away from its target.

--- a/packages/ui-components/test/windowedlist.spec.ts
+++ b/packages/ui-components/test/windowedlist.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { WindowedListModel } from '@jupyterlab/ui-components';
+import { WindowedList, WindowedListModel } from '@jupyterlab/ui-components';
 import { Widget } from '@lumino/widgets';
 import { ObservableList } from '@jupyterlab/observables';
 
@@ -242,6 +242,150 @@ describe('@jupyterlab/ui-components', () => {
           }
         ]);
         expect(getOffset(2)).toBe(30);
+      });
+    });
+  });
+
+  describe('WindowedList', () => {
+    let list: WindowedList;
+    let model: TestModel;
+
+    const expectPending = async (promise: Promise<void>): Promise<void> => {
+      let settled: string | null = null;
+      promise.then(
+        () => (settled = 'resolved'),
+        () => (settled = 'rejected')
+      );
+      // Flush microtasks without waiting for the update animation frame.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(settled).toBeNull();
+    };
+
+    beforeEach(() => {
+      model = new TestModel({
+        itemsList: new ObservableList({
+          values: Array.from({ length: 100 }, (_, i) => i)
+        })
+      });
+      model.windowingActive = true;
+      list = new WindowedList({ model });
+      Widget.attach(list, document.body);
+      // In JSDOM `getComputedStyle().paddingTop` is empty, which yields NaN.
+      model.paddingTop = 0;
+    });
+
+    afterEach(() => {
+      // Cancel any outstanding scroll request so that no timers are left.
+      list.outerNode.dispatchEvent(new WheelEvent('wheel', { deltaY: 100 }));
+      Widget.detach(list);
+      list.dispose();
+    });
+
+    describe('#scrollToItem()', () => {
+      it('should reject the pending scroll when the user scrolls with the wheel', async () => {
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(new WheelEvent('wheel', { deltaY: 100 }));
+        await expect(promise).rejects.toMatch('cancelled');
+      });
+
+      it('should reject the pending scroll when the user presses PageDown', async () => {
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'PageDown' })
+        );
+        await expect(promise).rejects.toMatch('cancelled');
+      });
+
+      it('should reject the pending scroll on scrolling keys outside of text editing', async () => {
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(
+          new KeyboardEvent('keydown', { key: ' ' })
+        );
+        await expect(promise).rejects.toMatch('cancelled');
+      });
+
+      it('should reject the pending scroll on touch scrolling', async () => {
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(new Event('touchmove'));
+        await expect(promise).rejects.toMatch('cancelled');
+      });
+
+      it('should reject the pending scroll on middle-click (autoscroll)', async () => {
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(
+          new MouseEvent('mousedown', { button: 1 })
+        );
+        await expect(promise).rejects.toMatch('cancelled');
+      });
+
+      it('should not settle the pending scroll on non-scrolling keys', async () => {
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'ArrowDown' })
+        );
+        await expectPending(promise);
+      });
+
+      it('should not settle the pending scroll on ctrl+wheel (zoom)', async () => {
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(
+          new WheelEvent('wheel', { deltaY: 100, ctrlKey: true })
+        );
+        await expectPending(promise);
+      });
+
+      it('should not settle the pending scroll on horizontal-only wheel', async () => {
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(
+          new WheelEvent('wheel', { deltaX: 100, deltaY: 0 })
+        );
+        await expectPending(promise);
+      });
+
+      it('should not settle the pending scroll on modified PageDown (e.g. tab switching)', async () => {
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'PageDown', ctrlKey: true })
+        );
+        await expectPending(promise);
+      });
+
+      it('should not settle the pending scroll on PageDown during IME composition', async () => {
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'PageDown', isComposing: true })
+        );
+        await expectPending(promise);
+      });
+
+      it('should not settle the pending scroll on scrolling keys in text editing context', async () => {
+        const editable = document.createElement('div');
+        editable.setAttribute('contenteditable', 'true');
+        list.viewportNode.appendChild(editable);
+        const promise = list.scrollToItem(50);
+        editable.dispatchEvent(
+          new KeyboardEvent('keydown', { key: ' ', bubbles: true })
+        );
+        await expectPending(promise);
+      });
+
+      it('should not settle the pending scroll on primary-button press on the content', async () => {
+        const promise = list.scrollToItem(50);
+        list.viewportNode.dispatchEvent(
+          new MouseEvent('mousedown', { button: 0, bubbles: true })
+        );
+        await expectPending(promise);
+      });
+
+      it('should restore the view model offset when cancelled before the update', async () => {
+        const promise = list.scrollToItem(50);
+        // The model should point at the target of the pending scroll.
+        expect(model.scrollOffset).toBeGreaterThan(0);
+        list.outerNode.dispatchEvent(new WheelEvent('wheel', { deltaY: 100 }));
+        // The model should be back in sync with the actual scroll position.
+        expect(model.scrollOffset).toBe(list.outerNode.scrollTop);
+        await promise.catch(() => undefined);
       });
     });
   });

--- a/packages/ui-components/test/windowedlist.spec.ts
+++ b/packages/ui-components/test/windowedlist.spec.ts
@@ -378,6 +378,96 @@ describe('@jupyterlab/ui-components', () => {
         await expectPending(promise);
       });
 
+      it('should not settle the pending scroll on scroll events', async () => {
+        // Cancellation must not be keyed on `scroll` events: programmatic
+        // scrolling (including the scrollback itself) fires them too and
+        // cancelling based on them proved flaky (see #18973).
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(new Event('scroll'));
+        await expectPending(promise);
+      });
+
+      it('should resolve the pending scroll when no cancelling input occurs', async () => {
+        await expect(list.scrollToItem(50)).resolves.toBeUndefined();
+      });
+
+      it('should reject the pending scroll when superseded by a new request', async () => {
+        const promise = list.scrollToItem(50);
+        const superseding = list.scrollToItem(10);
+        await expect(promise).rejects.toMatch('new item');
+        await expect(superseding).resolves.toBeUndefined();
+      });
+
+      it('should not cancel while windowing is inactive and cancel once it is re-enabled', async () => {
+        model.windowingActive = false;
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(new WheelEvent('wheel', { deltaY: 100 }));
+        // In non-windowed mode the scroll completes normally:
+        // user input must not reject it (no cancellation applies).
+        await expect(promise).resolves.toBeUndefined();
+
+        // Once windowing is re-enabled the listeners are re-registered
+        // and the cancellation applies again.
+        model.windowingActive = true;
+        const promise2 = list.scrollToItem(60);
+        list.outerNode.dispatchEvent(new WheelEvent('wheel', { deltaY: 100 }));
+        await expect(promise2).rejects.toMatch('cancelled');
+      });
+
+      it('should not emit jumped when the user cancels a minimap jump', async () => {
+        const model2 = new TestModel({
+          itemsList: new ObservableList({
+            values: Array.from({ length: 100 }, (_, i) => i)
+          })
+        });
+        model2.windowingActive = true;
+        class ExposedList extends WindowedList {
+          get jumpedSignal() {
+            return this.jumped;
+          }
+        }
+        const list2 = new ExposedList({ model: model2, scrollbar: true });
+        Widget.attach(list2, document.body);
+        model2.paddingTop = 0;
+        try {
+          const jumps: number[] = [];
+          list2.jumpedSignal.connect((_, index) => {
+            jumps.push(index);
+          });
+          // Render the scrollbar items.
+          list2.update();
+          await new Promise(resolve => {
+            requestAnimationFrame(() => requestAnimationFrame(resolve));
+          });
+          const item = list2.node.querySelector('[data-index="30"]')!;
+          expect(item).not.toBeNull();
+
+          // A wheel arriving while the jump is in flight cancels it:
+          // `jumped` should not be emitted as the target was never reached.
+          item.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+          list2.outerNode.dispatchEvent(
+            new WheelEvent('wheel', { deltaY: 100 })
+          );
+          await new Promise(resolve => {
+            requestAnimationFrame(() => requestAnimationFrame(resolve));
+          });
+          expect(jumps).toEqual([]);
+
+          // An undisturbed jump completes and emits `jumped`. Re-query the
+          // item as the scrollbar content is re-rendered on each update.
+          const freshItem = list2.node.querySelector('[data-index="30"]')!;
+          freshItem.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+          while (jumps.length === 0) {
+            await new Promise(resolve => {
+              requestAnimationFrame(resolve);
+            });
+          }
+          expect(jumps).toEqual([30]);
+        } finally {
+          list2.dispose();
+        }
+      });
+
       it('should restore the view model offset when cancelled before the update', async () => {
         const promise = list.scrollToItem(50);
         // The model should point at the target of the pending scroll.

--- a/packages/ui-components/test/windowedlist.spec.ts
+++ b/packages/ui-components/test/windowedlist.spec.ts
@@ -289,6 +289,67 @@ describe('@jupyterlab/ui-components', () => {
         await expect(promise).rejects.toMatch('cancelled');
       });
 
+      it.each([-100, 100])(
+        'should preserve nested scrolling and cancel at its boundary (deltaY=%s)',
+        async deltaY => {
+          const output = document.createElement('div');
+          output.style.overflowY = 'auto';
+          Object.defineProperties(output, {
+            clientHeight: { value: 100 },
+            scrollHeight: { value: 300 }
+          });
+          output.scrollTop = 100;
+          const content = output.appendChild(document.createElement('span'));
+          list.viewportNode.appendChild(output);
+          const promise = list.scrollToItem(50);
+
+          content.dispatchEvent(
+            new WheelEvent('wheel', { deltaY, bubbles: true })
+          );
+          await expectPending(promise);
+
+          output.scrollTop = deltaY > 0 ? 200 : 0;
+          content.dispatchEvent(
+            new WheelEvent('wheel', { deltaY, bubbles: true })
+          );
+          await expect(promise).rejects.toMatch('cancelled');
+        }
+      );
+
+      it.each(['visible', 'hidden'])(
+        'should cancel when nested content cannot consume wheel events (overflow=%s)',
+        async overflowY => {
+          const content = document.createElement('div');
+          content.style.overflowY = overflowY;
+          Object.defineProperties(content, {
+            clientHeight: { value: 100 },
+            scrollHeight: { value: 300 }
+          });
+          list.viewportNode.appendChild(content);
+          const promise = list.scrollToItem(50);
+          content.dispatchEvent(
+            new WheelEvent('wheel', { deltaY: 100, bubbles: true })
+          );
+          await expect(promise).rejects.toMatch('cancelled');
+        }
+      );
+
+      it('should preserve the pending scroll when nested content prevents wheel scrolling', async () => {
+        expect.assertions(1);
+        const content = document.createElement('div');
+        content.addEventListener('wheel', event => event.preventDefault());
+        list.viewportNode.appendChild(content);
+        const promise = list.scrollToItem(50);
+        content.dispatchEvent(
+          new WheelEvent('wheel', {
+            deltaY: 100,
+            bubbles: true,
+            cancelable: true
+          })
+        );
+        await expectPending(promise);
+      });
+
       it('should reject the pending scroll when the user presses PageDown', async () => {
         const promise = list.scrollToItem(50);
         list.outerNode.dispatchEvent(


### PR DESCRIPTION
## References

Fixes #19005.

## Code changes

Cancel pending scrollback when a user explicitly scrolls a fully windowed list with the mouse wheel, PageUp, or PageDown. The dedicated listener cannot be bypassed by notebook subclasses that override `handleEvent()`, and cancellation clears the pending target, queued update, timers, and programmatic scroll delegate.

Remove the three-second test workaround so the regression is exercised directly.

## User-facing changes

Windowed notebooks no longer snap back to the active cell after the user scrolls away.

## Backwards-incompatible changes

None.

## Validation

- Full development build
- UI components unit tests: 110 passed, 2 skipped
- Windowed notebook browser suite: 20 passed
- Target PageDown regression repeated 10 times: 10 passed
- Scrollback regression with and without windowing: 2 passed
- Prettier, ESLint, and type-aware ESLint

## AI usage

- **Yes**: AI was used only as an auxiliary tool.
- Tools/models used: ChatGPT
