### PR TITLE
Keep position on output resize in `full` windowing mode

### DIFF
--- a/galata/test/jupyterlab/notebook-scroll-no-windowing.test.ts
+++ b/galata/test/jupyterlab/notebook-scroll-no-windowing.test.ts
@@ -333,6 +333,58 @@ test.describe('Notebook scroll on execution (no windowing)', () => {
     );
   });
 
+  test('should keep the position the user scrolled to while a cell above generates a lot of output', async ({
+    page
+  }) => {
+    const notebook = await page.notebook.getNotebookInPanelLocator();
+    const thirdCell = await page.notebook.getCellLocator(2);
+
+    // Set second cell to produce long output with a delay long enough
+    // to allow scrolling away while the execution is ongoing.
+    await page.notebook.setCell(
+      1,
+      'code',
+      'from time import sleep\nsleep(2)\nfor i in range(100):\n    print(i)\n    sleep(0.05)\n'
+    );
+
+    // Select the second cell and clear its output
+    await page.notebook.selectCells(1);
+    await page.evaluate(() => {
+      return window.jupyterapp.commands.execute('notebook:clear-cell-output');
+    });
+
+    // Position the viewport over the top of the third cell (which has
+    // a long existing output, providing space to scroll into)
+    await positionCellPartiallyBelowViewport(page, notebook!, thirdCell!, 1);
+
+    // Start running the second cell with advance, without waiting for it
+    const execution = page.evaluate(() => {
+      return window.jupyterapp.commands.execute(
+        'notebook:run-cell-and-select-next'
+      );
+    });
+
+    // Scroll away while the initial `sleep` holds the output back
+    const bbox = (await notebook!.boundingBox())!;
+    await page.mouse.move(bbox.x + bbox.width / 2, bbox.y + bbox.height / 2);
+    await page.mouse.wheel(0, 600);
+
+    // Let the scroll settle before taking the reference measurement
+    // eslint-disable-next-line playwright/no-wait-for-timeout
+    await page.waitForTimeout(500);
+    const referenceBox = (await thirdCell!.boundingBox())!;
+
+    await execution;
+    // Allow the layout to settle after the last output arrived
+    // eslint-disable-next-line playwright/no-wait-for-timeout
+    await page.waitForTimeout(500);
+
+    // The position the user scrolled to should have been kept while the
+    // output of the cell above was growing
+    const finalBox = (await thirdCell!.boundingBox())!;
+    expect(Math.abs(finalBox.y - referenceBox.y)).toBeLessThan(150);
+  });
+
   test('should not scroll when advancing if top is non-marginally visible', async ({
     page
   }) => {

--- a/galata/test/jupyterlab/notebook-scroll.test.ts
+++ b/galata/test/jupyterlab/notebook-scroll.test.ts
@@ -350,6 +350,58 @@ test.describe('Notebook scroll on execution (with windowing)', () => {
     );
   });
 
+  test('should keep the position the user scrolled to while a cell above generates a lot of output', async ({
+    page
+  }) => {
+    const notebook = await page.notebook.getNotebookInPanelLocator();
+    const thirdCell = await page.notebook.getCellLocator(2);
+
+    // Set second cell to produce long output with a delay long enough
+    // to allow scrolling away while the execution is ongoing.
+    await page.notebook.setCell(
+      1,
+      'code',
+      'from time import sleep\nsleep(2)\nfor i in range(100):\n    print(i)\n    sleep(0.05)\n'
+    );
+
+    // Select the second cell and clear its output
+    await page.notebook.selectCells(1);
+    await page.evaluate(() => {
+      return window.jupyterapp.commands.execute('notebook:clear-cell-output');
+    });
+
+    // Position the viewport over the top of the third cell (which has
+    // a long existing output, providing space to scroll into)
+    await positionCellPartiallyBelowViewport(page, notebook!, thirdCell!, 1);
+
+    // Start running the second cell with advance, without waiting for it
+    const execution = page.evaluate(() => {
+      return window.jupyterapp.commands.execute(
+        'notebook:run-cell-and-select-next'
+      );
+    });
+
+    // Scroll away while the initial `sleep` holds the output back
+    const bbox = (await notebook!.boundingBox())!;
+    await page.mouse.move(bbox.x + bbox.width / 2, bbox.y + bbox.height / 2);
+    await page.mouse.wheel(0, 600);
+
+    // Let the scroll settle before taking the reference measurement
+    // eslint-disable-next-line playwright/no-wait-for-timeout
+    await page.waitForTimeout(500);
+    const referenceBox = (await thirdCell!.boundingBox())!;
+
+    await execution;
+    // Allow the layout to settle after the last output arrived
+    // eslint-disable-next-line playwright/no-wait-for-timeout
+    await page.waitForTimeout(500);
+
+    // The position the user scrolled to should have been kept while the
+    // output of the cell above was growing
+    const finalBox = (await thirdCell!.boundingBox())!;
+    expect(Math.abs(finalBox.y - referenceBox.y)).toBeLessThan(150);
+  });
+
   test('should not scroll when advancing if top is non-marginally visible', async ({
     page
   }) => {

--- a/galata/test/jupyterlab/windowed-notebook.test.ts
+++ b/galata/test/jupyterlab/windowed-notebook.test.ts
@@ -292,20 +292,6 @@ test.describe('Scrolling on keyboard interaction when active editor is above the
       for (let i = 0; i < testCase.times; i++) {
         await page.keyboard.press(testCase.key);
         // Allow for small delay between pressing keys
-        if (i === 0 && testCase.key === 'PageDown' && testCase.times === 10) {
-          // TODO: for some reason the notebook scrolls back to the selected cell after a few seconds.
-          // The exact mechanism is not clear but it is easily reproducible with the test case
-          // "Show neither cell on pressing PageDown 10 times" by commenting out the timeout below,
-          // and decreasing the timeout for each iteration (say down to 10ms).
-          // It might be unrelated to this test, but instead a different bug in the windowing
-          // logic where some stale request remains beyond its intended lifetime
-          // (i.e. when user requested a different scroll).
-          // This could be related related to the scrollback logic; PR #18973 demonstrated
-          // a potential fix, however it made the scrollback test for full windowing flaky
-          // ("should keep active cell when a cell above generates a lot of output").
-          // eslint-disable-next-line playwright/no-wait-for-timeout
-          await page.waitForTimeout(3000);
-        }
         // eslint-disable-next-line playwright/no-wait-for-timeout
         await page.waitForTimeout(100);
       }

--- a/galata/test/jupyterlab/windowed-notebook.test.ts
+++ b/galata/test/jupyterlab/windowed-notebook.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 import { expect, galata, test } from '@jupyterlab/galata';
+import type { IJupyterLabPageFixture } from '@jupyterlab/galata';
 import type { Locator } from '@playwright/test';
 import * as path from 'path';
 
@@ -310,6 +311,183 @@ test.describe('Scrolling on keyboard interaction when active editor is above the
       }
     });
   }
+});
+
+test.describe('Scrollback cancellation on user scrolling', () => {
+  /**
+   * Arm the scrollback anchor: type into the active editor which is above
+   * the viewport, which scrolls back to the active cell and keeps the
+   * scrollback target armed for the next few seconds (renewed on cell
+   * resizes, e.g. those caused by re-rendering of windowed cells).
+   */
+  const armScrollback = async (
+    page: IJupyterLabPageFixture,
+    tmpPath: string
+  ) => {
+    await page.notebook.openByPath(`${tmpPath}/${fileName}`);
+
+    await page.notebook.selectCells(0);
+    await page.notebook.enterCellEditingMode(0);
+    const notebook = (await page.notebook.getNotebookInPanelLocator())!;
+    const firstCell = notebook.locator(
+      '.jp-Cell[data-windowed-list-index="0"]'
+    );
+    const secondCell = notebook.locator(
+      '.jp-Cell[data-windowed-list-index="1"]'
+    );
+    await firstCell.waitFor();
+    await secondCell.waitFor();
+
+    // Position the mouse in the bounding box to allow for scrolling with mouse wheel
+    const bbox = (await notebook.boundingBox())!;
+    await page.mouse.move(bbox.x + bbox.width / 2, bbox.y + bbox.height / 2);
+
+    await scrollAwayWithWheel(page, firstCell, secondCell);
+
+    // Typing scrolls back to the active cell and arms the scrollback anchor.
+    await page.keyboard.type('T');
+    await firstCell.waitFor({ state: 'visible' });
+
+    return { notebook, firstCell, secondCell };
+  };
+
+  /**
+   * Scroll down with the wheel until the first and second cell get hidden:
+   * the scroll distance performed for a wheel event differs between browsers.
+   */
+  const scrollAwayWithWheel = async (
+    page: IJupyterLabPageFixture,
+    firstCell: Locator,
+    secondCell: Locator
+  ) => {
+    await Promise.all([
+      firstCell.waitFor({ state: 'hidden' }),
+      secondCell.waitFor({ state: 'hidden' }),
+      (async () => {
+        for (let i = 0; i < 8; i++) {
+          await page.mouse.wheel(0, 1200);
+          // eslint-disable-next-line playwright/no-wait-for-timeout
+          await page.waitForTimeout(150);
+          if ((await firstCell.isHidden()) && (await secondCell.isHidden())) {
+            return;
+          }
+        }
+      })()
+    ]);
+  };
+
+  /**
+   * Force a resize of a stably rendered cell: this is what triggers the
+   * scrollback (an armed anchor scrolls the view back to the active cell
+   * on any cell resize, as happens when a cell above streams output).
+   */
+  const forceCellResize = async (
+    page: IJupyterLabPageFixture,
+    notebook: Locator
+  ) => {
+    // Let the windowed rendering settle so the resized cell stays observed.
+    // eslint-disable-next-line playwright/no-wait-for-timeout
+    await page.waitForTimeout(400);
+    await notebook.locator('.jp-WindowedPanel-outer').evaluate(node => {
+      const cells = node.querySelectorAll(
+        '.jp-WindowedPanel-viewport .jp-Cell'
+      );
+      const mid = cells[Math.floor(cells.length / 2)] as HTMLElement;
+      mid.style.minHeight = `${mid.clientHeight + 300}px`;
+    });
+  };
+
+  /**
+   * Check that the view does not scroll back to the active cell,
+   * waiting long enough to cover the delayed scrollback paths
+   * (`scrollend` events and their 750 ms fallback timer).
+   */
+  const expectNoScrollback = async (
+    page: IJupyterLabPageFixture,
+    firstCell: Locator,
+    secondCell: Locator
+  ) => {
+    // eslint-disable-next-line playwright/no-wait-for-timeout
+    await page.waitForTimeout(1000);
+    await expect(firstCell).toBeHidden();
+    await expect(secondCell).toBeHidden();
+  };
+
+  test('should not scroll back to the active cell after scrolling away with the wheel', async ({
+    page,
+    tmpPath
+  }) => {
+    const { notebook, firstCell, secondCell } = await armScrollback(
+      page,
+      tmpPath
+    );
+
+    // Scroll away with the wheel; this should cancel the scrollback.
+    await scrollAwayWithWheel(page, firstCell, secondCell);
+
+    await forceCellResize(page, notebook);
+    await expectNoScrollback(page, firstCell, secondCell);
+  });
+
+  test('should not scroll back to the active cell after pressing the middle mouse button', async ({
+    page,
+    tmpPath
+  }) => {
+    const { notebook, firstCell, secondCell } = await armScrollback(
+      page,
+      tmpPath
+    );
+
+    // Press the middle button (which can start browser autoscroll) over
+    // the cell prompt area; this should cancel the scrollback. Synthetic
+    // input cannot trigger the actual browser autoscroll, so the scrolling
+    // it would cause is emulated by setting `scrollTop`.
+    const bbox = (await notebook.boundingBox())!;
+    await page.mouse.move(bbox.x + 30, bbox.y + bbox.height / 2);
+    await page.mouse.down({ button: 'middle' });
+    await page.mouse.up({ button: 'middle' });
+
+    const outer = notebook.locator('.jp-WindowedPanel-outer');
+    await Promise.all([
+      firstCell.waitFor({ state: 'hidden' }),
+      secondCell.waitFor({ state: 'hidden' }),
+      outer.evaluate(node => {
+        node.scrollTop += 1200;
+      })
+    ]);
+
+    await forceCellResize(page, notebook);
+    await expectNoScrollback(page, firstCell, secondCell);
+  });
+
+  test('should scroll back to the active cell when the scroll was not caused by user input', async ({
+    page,
+    tmpPath
+  }) => {
+    const { notebook, firstCell } = await armScrollback(page, tmpPath);
+
+    // Scroll away programmatically, without any user input event: the
+    // scrollback must NOT be cancelled (in particular, cancellation must
+    // not be keyed on `scroll` events: programmatic scrolling fires them
+    // too and cancelling on them proved flaky, see #18973).
+    const outer = notebook.locator('.jp-WindowedPanel-outer');
+    const scrolled = await outer.evaluate(node => {
+      node.scrollTop += 1200;
+      return node.scrollTop;
+    });
+    expect(scrolled).toBeGreaterThan(1000);
+
+    // Force a cell resize in case the scroll alone did not produce size
+    // corrections (the scrollback may fire at different points of the
+    // scroll handling depending on the browser).
+    await forceCellResize(page, notebook);
+
+    // The armed scrollback should bring the view back to the active cell.
+    await expect
+      .poll(() => outer.evaluate(node => Math.round(node.scrollTop)))
+      .toBeLessThan(500);
+    await expect(firstCell).toBeVisible();
+  });
 });
 
 test('should detach a markdown code cell when scrolling out of the viewport', async ({

--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -1698,8 +1698,28 @@ export class WindowedList<
       }
     }
 
+    // When no scrollback is pending, compensate the scroll offset for size
+    // changes of items lying entirely above the viewport so that the content
+    // the user is looking at does not shift. This is the windowed equivalent
+    // of the browser-native scroll anchoring, which has to be disabled in
+    // full windowing mode. The sizes must be read before `setWidgetSize`.
+    let scrollCompensation = 0;
+    if (this.viewModel.windowingActive && this._scrollToItem === null) {
+      const scrollOffset = this.viewModel.scrollOffset;
+      for (const { index, size } of newSizes) {
+        const [offset, oldSize] = this.viewModel.getSpan(index, index);
+        if (offset + oldSize <= scrollOffset) {
+          scrollCompensation += size - oldSize;
+        }
+      }
+    }
+
     // If some sizes changed
     if (this.viewModel.setWidgetSize(newSizes)) {
+      if (scrollCompensation !== 0) {
+        this.viewModel.scrollOffset += scrollCompensation;
+        this._scrollUpdateWasRequested = true;
+      }
       this._scrollBackToItemOnResize();
       // Update the list
       this.update();

--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -50,6 +50,12 @@ const PROGRAMMATIC_SCROLL_TIMEOUT = 3000;
  */
 const MAXIMUM_TIME_WAITING_FOR_ITEM = 10000;
 
+/**
+ * CSS selector for elements in which keys like Space or Home/End edit
+ * or navigate text rather than scroll the list.
+ */
+const EDITABLE_SELECTOR = 'input, textarea, select, [contenteditable="true"]';
+
 /*
  * Feature detection
  *
@@ -1104,6 +1110,10 @@ export class WindowedList<
    * @param align Type of alignment
    * @param margin In 'smart' mode the viewport proportion to add
    * @param alignPreference Allows to override the alignment of item when the `auto` heuristic decides that the item needs to be scrolled into view.
+   * @returns A promise which resolves once the scroll has settled; it rejects
+   * when the request is superseded by a new `scrollToItem` call or cancelled
+   * by explicit user scrolling input (wheel, scrolling keys, touch scrolling,
+   * or scrollbar and middle-click interactions).
    */
   scrollToItem(
     index: number,
@@ -1493,16 +1503,30 @@ export class WindowedList<
       this._areaResizeObserver.observe(this._innerElement);
     }
     this._outerElement.addEventListener('scroll', this, passiveIfSupported);
-    this._outerElement.addEventListener(
-      'wheel',
-      this._onUserScrollIntent,
-      passiveIfSupported
-    );
-    this._outerElement.addEventListener(
-      'keydown',
-      this._onUserScrollIntent,
-      true
-    );
+    if (this.viewModel.windowingActive) {
+      // Scrollback (and thus its cancellation) only applies in full
+      // windowing mode; `onStateChanged` re-runs `_removeListeners` and
+      // `_addListeners` when the windowing mode changes at runtime.
+      this._outerElement.addEventListener(
+        'wheel',
+        this._onUserScrollIntent,
+        passiveIfSupported
+      );
+      this._outerElement.addEventListener(
+        'keydown',
+        this._onUserScrollIntent,
+        true
+      );
+      this._outerElement.addEventListener(
+        'touchmove',
+        this._onUserScrollIntent,
+        passiveIfSupported
+      );
+      this._outerElement.addEventListener(
+        'mousedown',
+        this._onUserScrollIntent
+      );
+    }
   }
 
   /**
@@ -1535,6 +1559,14 @@ export class WindowedList<
       'keydown',
       this._onUserScrollIntent,
       true
+    );
+    this._outerElement.removeEventListener(
+      'touchmove',
+      this._onUserScrollIntent
+    );
+    this._outerElement.removeEventListener(
+      'mousedown',
+      this._onUserScrollIntent
     );
     this._areaResizeObserver?.disconnect();
     this._areaResizeObserver = null;
@@ -1702,20 +1734,85 @@ export class WindowedList<
       return;
     }
     this.scrollToItem(...this._scrollToItem).catch(reason => {
-      console.log(reason);
+      // Rejection is expected when the user cancels the scrollback
+      // or a new scroll request supersedes this one.
+      console.debug(reason);
     });
   }
 
   /**
    * Handle explicit user input which can scroll the list.
+   *
+   * Cancellation is deliberately keyed on input events (wheel, keydown,
+   * touchmove, mousedown) rather than on the `scroll` event: programmatic
+   * scrolling, including the scrollback itself, fires `scroll` too, and
+   * cancelling based on it proved flaky (see #18973).
    */
   private _onUserScrollIntent = (event: Event): void => {
-    if (
-      event.type === 'wheel' ||
-      (event instanceof KeyboardEvent &&
-        (event.key === 'PageDown' || event.key === 'PageUp'))
-    ) {
-      this._cancelScrollback();
+    switch (event.type) {
+      case 'wheel':
+        if (
+          event instanceof WheelEvent &&
+          // Ctrl+wheel zooms rather than scrolls; since the scrollback
+          // target is an item index, scrolling back keeps the followed
+          // item in view through the zoom reflow.
+          !event.ctrlKey &&
+          // A wheel event without vertical delta cannot scroll the list.
+          event.deltaY !== 0
+        ) {
+          this._cancelScrollback();
+        }
+        break;
+      case 'keydown':
+        if (event instanceof KeyboardEvent) {
+          if (
+            // Paging through IME candidates does not scroll the list.
+            event.isComposing ||
+            // Modified keys are shortcuts (e.g. browser tab switching).
+            event.ctrlKey ||
+            event.altKey ||
+            event.metaKey
+          ) {
+            break;
+          }
+          if (event.key === 'PageDown' || event.key === 'PageUp') {
+            this._cancelScrollback();
+          } else if (
+            event.key === ' ' ||
+            event.key === 'Home' ||
+            event.key === 'End'
+          ) {
+            // These keys scroll the list via the browser default action
+            // only when focus is outside of a text editing context.
+            const target = event.target;
+            if (
+              target instanceof Element &&
+              !target.closest(EDITABLE_SELECTOR)
+            ) {
+              this._cancelScrollback();
+            }
+          }
+        }
+        break;
+      case 'touchmove':
+        this._cancelScrollback();
+        break;
+      case 'mousedown':
+        if (event instanceof MouseEvent) {
+          // A primary-button press on the outer element itself (rather than
+          // on the content) is a native scrollbar interaction: the scrollbar
+          // gutter lies outside of the client area (right of it, or left of
+          // it in right-to-left layouts).
+          const onScrollbarGutter =
+            event.target === this._outerElement &&
+            (event.offsetX >= this._outerElement.clientWidth ||
+              event.offsetX < 0);
+          // Middle-click can start browser autoscroll anywhere in the list.
+          if (event.button === 1 || (event.button === 0 && onScrollbarGutter)) {
+            this._cancelScrollback();
+          }
+        }
+        break;
     }
   };
 
@@ -1728,7 +1825,14 @@ export class WindowedList<
     }
 
     this._scrollToItem = null;
-    this._scrollUpdateWasRequested = false;
+    if (this._scrollUpdateWasRequested) {
+      // A programmatic scroll was requested but not yet applied by `_update()`:
+      // drop the pending `scrollTop` write and restore the view model offset
+      // to the actual scroll position, otherwise the next update would render
+      // the window for the abandoned target while the viewport stays put.
+      this._scrollUpdateWasRequested = false;
+      this.viewModel.scrollOffset = this._outerElement.scrollTop;
+    }
 
     if (this._resetScrollToItemTimeout !== null) {
       clearTimeout(this._resetScrollToItemTimeout);
@@ -1738,7 +1842,13 @@ export class WindowedList<
       clearTimeout(this._programmaticScrollTimeout);
       this._programmaticScrollTimeout = null;
     }
-    this._markProgrammaticScrollingDone();
+    if (this._isScrolling) {
+      // Reject like the supersede path in `scrollToItem`: resolving would run
+      // the callers' success continuations (scroll within cell, focus, etc.)
+      // which re-scroll to the target the user just navigated away from.
+      this._isScrolling.reject('Scrolling was cancelled by user input.');
+      this._isScrolling = null;
+    }
   }
 
   /**
@@ -1880,7 +1990,13 @@ export class WindowedList<
       if (target.hasAttribute('data-index')) {
         const index = parseInt(target.getAttribute('data-index')!, 10);
         return void (async () => {
-          await this.scrollToItem(index);
+          try {
+            await this.scrollToItem(index);
+          } catch (reason) {
+            // The jump was superseded or cancelled by the user;
+            // the target was never reached so do not emit `jumped`.
+            return;
+          }
           this.jumped.emit(index);
         })();
       }

--- a/packages/ui-components/src/components/windowedlist.ts
+++ b/packages/ui-components/src/components/windowedlist.ts
@@ -1493,6 +1493,16 @@ export class WindowedList<
       this._areaResizeObserver.observe(this._innerElement);
     }
     this._outerElement.addEventListener('scroll', this, passiveIfSupported);
+    this._outerElement.addEventListener(
+      'wheel',
+      this._onUserScrollIntent,
+      passiveIfSupported
+    );
+    this._outerElement.addEventListener(
+      'keydown',
+      this._onUserScrollIntent,
+      true
+    );
   }
 
   /**
@@ -1520,6 +1530,12 @@ export class WindowedList<
    */
   private _removeListeners() {
     this._outerElement.removeEventListener('scroll', this);
+    this._outerElement.removeEventListener('wheel', this._onUserScrollIntent);
+    this._outerElement.removeEventListener(
+      'keydown',
+      this._onUserScrollIntent,
+      true
+    );
     this._areaResizeObserver?.disconnect();
     this._areaResizeObserver = null;
     this._itemsResizeObserver?.disconnect();
@@ -1688,6 +1704,41 @@ export class WindowedList<
     this.scrollToItem(...this._scrollToItem).catch(reason => {
       console.log(reason);
     });
+  }
+
+  /**
+   * Handle explicit user input which can scroll the list.
+   */
+  private _onUserScrollIntent = (event: Event): void => {
+    if (
+      event.type === 'wheel' ||
+      (event instanceof KeyboardEvent &&
+        (event.key === 'PageDown' || event.key === 'PageUp'))
+    ) {
+      this._cancelScrollback();
+    }
+  };
+
+  /**
+   * Cancel scrollback when the user explicitly scrolls away from its target.
+   */
+  private _cancelScrollback(): void {
+    if (!this.viewModel.windowingActive || !this._scrollToItem) {
+      return;
+    }
+
+    this._scrollToItem = null;
+    this._scrollUpdateWasRequested = false;
+
+    if (this._resetScrollToItemTimeout !== null) {
+      clearTimeout(this._resetScrollToItemTimeout);
+      this._resetScrollToItemTimeout = null;
+    }
+    if (this._programmaticScrollTimeout !== null) {
+      clearTimeout(this._programmaticScrollTimeout);
+      this._programmaticScrollTimeout = null;
+    }
+    this._markProgrammaticScrollingDone();
   }
 
   /**

--- a/packages/ui-components/test/windowedlist.spec.ts
+++ b/packages/ui-components/test/windowedlist.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { WindowedListModel } from '@jupyterlab/ui-components';
+import { WindowedList, WindowedListModel } from '@jupyterlab/ui-components';
 import { Widget } from '@lumino/widgets';
 import { ObservableList } from '@jupyterlab/observables';
 
@@ -242,6 +242,150 @@ describe('@jupyterlab/ui-components', () => {
           }
         ]);
         expect(getOffset(2)).toBe(30);
+      });
+    });
+  });
+
+  describe('WindowedList', () => {
+    let list: WindowedList;
+    let model: TestModel;
+
+    const expectPending = async (promise: Promise<void>): Promise<void> => {
+      let settled: string | null = null;
+      promise.then(
+        () => (settled = 'resolved'),
+        () => (settled = 'rejected')
+      );
+      // Flush microtasks without waiting for the update animation frame.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(settled).toBeNull();
+    };
+
+    beforeEach(() => {
+      model = new TestModel({
+        itemsList: new ObservableList({
+          values: Array.from({ length: 100 }, (_, i) => i)
+        })
+      });
+      model.windowingActive = true;
+      list = new WindowedList({ model });
+      Widget.attach(list, document.body);
+      // In JSDOM `getComputedStyle().paddingTop` is empty, which yields NaN.
+      model.paddingTop = 0;
+    });
+
+    afterEach(() => {
+      // Cancel any outstanding scroll request so that no timers are left.
+      list.outerNode.dispatchEvent(new WheelEvent('wheel', { deltaY: 100 }));
+      Widget.detach(list);
+      list.dispose();
+    });
+
+    describe('#scrollToItem()', () => {
+      it('should reject the pending scroll when the user scrolls with the wheel', async () => {
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(new WheelEvent('wheel', { deltaY: 100 }));
+        await expect(promise).rejects.toMatch('cancelled');
+      });
+
+      it('should reject the pending scroll when the user presses PageDown', async () => {
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'PageDown' })
+        );
+        await expect(promise).rejects.toMatch('cancelled');
+      });
+
+      it('should reject the pending scroll on scrolling keys outside of text editing', async () => {
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(
+          new KeyboardEvent('keydown', { key: ' ' })
+        );
+        await expect(promise).rejects.toMatch('cancelled');
+      });
+
+      it('should reject the pending scroll on touch scrolling', async () => {
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(new Event('touchmove'));
+        await expect(promise).rejects.toMatch('cancelled');
+      });
+
+      it('should reject the pending scroll on middle-click (autoscroll)', async () => {
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(
+          new MouseEvent('mousedown', { button: 1 })
+        );
+        await expect(promise).rejects.toMatch('cancelled');
+      });
+
+      it('should not settle the pending scroll on non-scrolling keys', async () => {
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'ArrowDown' })
+        );
+        await expectPending(promise);
+      });
+
+      it('should not settle the pending scroll on ctrl+wheel (zoom)', async () => {
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(
+          new WheelEvent('wheel', { deltaY: 100, ctrlKey: true })
+        );
+        await expectPending(promise);
+      });
+
+      it('should not settle the pending scroll on horizontal-only wheel', async () => {
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(
+          new WheelEvent('wheel', { deltaX: 100, deltaY: 0 })
+        );
+        await expectPending(promise);
+      });
+
+      it('should not settle the pending scroll on modified PageDown (e.g. tab switching)', async () => {
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'PageDown', ctrlKey: true })
+        );
+        await expectPending(promise);
+      });
+
+      it('should not settle the pending scroll on PageDown during IME composition', async () => {
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'PageDown', isComposing: true })
+        );
+        await expectPending(promise);
+      });
+
+      it('should not settle the pending scroll on scrolling keys in text editing context', async () => {
+        const editable = document.createElement('div');
+        editable.setAttribute('contenteditable', 'true');
+        list.viewportNode.appendChild(editable);
+        const promise = list.scrollToItem(50);
+        editable.dispatchEvent(
+          new KeyboardEvent('keydown', { key: ' ', bubbles: true })
+        );
+        await expectPending(promise);
+      });
+
+      it('should not settle the pending scroll on primary-button press on the content', async () => {
+        const promise = list.scrollToItem(50);
+        list.viewportNode.dispatchEvent(
+          new MouseEvent('mousedown', { button: 0, bubbles: true })
+        );
+        await expectPending(promise);
+      });
+
+      it('should restore the view model offset when cancelled before the update', async () => {
+        const promise = list.scrollToItem(50);
+        // The model should point at the target of the pending scroll.
+        expect(model.scrollOffset).toBeGreaterThan(0);
+        list.outerNode.dispatchEvent(new WheelEvent('wheel', { deltaY: 100 }));
+        // The model should be back in sync with the actual scroll position.
+        expect(model.scrollOffset).toBe(list.outerNode.scrollTop);
+        await promise.catch(() => undefined);
       });
     });
   });

--- a/packages/ui-components/test/windowedlist.spec.ts
+++ b/packages/ui-components/test/windowedlist.spec.ts
@@ -378,6 +378,96 @@ describe('@jupyterlab/ui-components', () => {
         await expectPending(promise);
       });
 
+      it('should not settle the pending scroll on scroll events', async () => {
+        // Cancellation must not be keyed on `scroll` events: programmatic
+        // scrolling (including the scrollback itself) fires them too and
+        // cancelling based on them proved flaky (see #18973).
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(new Event('scroll'));
+        await expectPending(promise);
+      });
+
+      it('should resolve the pending scroll when no cancelling input occurs', async () => {
+        await expect(list.scrollToItem(50)).resolves.toBeUndefined();
+      });
+
+      it('should reject the pending scroll when superseded by a new request', async () => {
+        const promise = list.scrollToItem(50);
+        const superseding = list.scrollToItem(10);
+        await expect(promise).rejects.toMatch('new item');
+        await expect(superseding).resolves.toBeUndefined();
+      });
+
+      it('should not cancel while windowing is inactive and cancel once it is re-enabled', async () => {
+        model.windowingActive = false;
+        const promise = list.scrollToItem(50);
+        list.outerNode.dispatchEvent(new WheelEvent('wheel', { deltaY: 100 }));
+        // In non-windowed mode the scroll completes normally:
+        // user input must not reject it (no cancellation applies).
+        await expect(promise).resolves.toBeUndefined();
+
+        // Once windowing is re-enabled the listeners are re-registered
+        // and the cancellation applies again.
+        model.windowingActive = true;
+        const promise2 = list.scrollToItem(60);
+        list.outerNode.dispatchEvent(new WheelEvent('wheel', { deltaY: 100 }));
+        await expect(promise2).rejects.toMatch('cancelled');
+      });
+
+      it('should not emit jumped when the user cancels a minimap jump', async () => {
+        const model2 = new TestModel({
+          itemsList: new ObservableList({
+            values: Array.from({ length: 100 }, (_, i) => i)
+          })
+        });
+        model2.windowingActive = true;
+        class ExposedList extends WindowedList {
+          get jumpedSignal() {
+            return this.jumped;
+          }
+        }
+        const list2 = new ExposedList({ model: model2, scrollbar: true });
+        Widget.attach(list2, document.body);
+        model2.paddingTop = 0;
+        try {
+          const jumps: number[] = [];
+          list2.jumpedSignal.connect((_, index) => {
+            jumps.push(index);
+          });
+          // Render the scrollbar items.
+          list2.update();
+          await new Promise(resolve => {
+            requestAnimationFrame(() => requestAnimationFrame(resolve));
+          });
+          const item = list2.node.querySelector('[data-index="30"]')!;
+          expect(item).not.toBeNull();
+
+          // A wheel arriving while the jump is in flight cancels it:
+          // `jumped` should not be emitted as the target was never reached.
+          item.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+          list2.outerNode.dispatchEvent(
+            new WheelEvent('wheel', { deltaY: 100 })
+          );
+          await new Promise(resolve => {
+            requestAnimationFrame(() => requestAnimationFrame(resolve));
+          });
+          expect(jumps).toEqual([]);
+
+          // An undisturbed jump completes and emits `jumped`. Re-query the
+          // item as the scrollbar content is re-rendered on each update.
+          const freshItem = list2.node.querySelector('[data-index="30"]')!;
+          freshItem.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+          while (jumps.length === 0) {
+            await new Promise(resolve => {
+              requestAnimationFrame(resolve);
+            });
+          }
+          expect(jumps).toEqual([30]);
+        } finally {
+          list2.dispose();
+        }
+      });
+
       it('should restore the view model offset when cancelled before the update', async () => {
         const promise = list.scrollToItem(50);
         // The model should point at the target of the pending scroll.


### PR DESCRIPTION

## References

Builds on top of https://github.com/jupyterlab/jupyterlab/pull/19232 to align `full` windowed mode with other mode with respect to scroll anchoring.

## Code changes

Rember the offset one scrolling away.

## User-facing changes

When user scrolls away and an output above keeps populating, remember the offset.

## Backwards-incompatible changes

None

## AI usage

- **Yes**: Some or all of the content of this PR was generated by AI.
- **Yes**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Fable 5
