### PR TITLE
test(filebrowser): cover adaptive last-modified dates

### DIFF
--- a/packages/filebrowser/test/listing.spec.ts
+++ b/packages/filebrowser/test/listing.spec.ts
@@ -105,43 +105,6 @@ describe('filebrowser/listing', () => {
       });
     });
 
-    describe('last modified column', () => {
-      const ITEM_MODIFIED_CLASS = 'jp-DirListing-itemModified';
-
-      beforeEach(async () => {
-        // Use a stable timestamp so that the rendered relative time is
-        // different for the narrow, short, and long column styles.
-        const items = [...dirListing.sortedItems()].filter(
-          item => item.type !== 'directory'
-        );
-        const contents = dirListing.model.manager.services.contents;
-        for (const item of items) {
-          await contents.save(item.path, {
-            last_modified: new Date(2020, 0, 1).toISOString()
-          } as any);
-        }
-        await signalToPromise(dirListing.updated);
-      });
-
-      it('should update the relative time when the column is resized', async () => {
-        const itemNode = dirListing.contentNode.children[0] as HTMLElement;
-        const modifiedCell = itemNode.querySelector(
-          `.${ITEM_MODIFIED_CLASS}`
-        ) as HTMLElement;
-
-        expect(modifiedCell).not.toBeNull();
-        const renderedValues: string[] = [];
-
-        for (const width of [180, 300, 500]) {
-          dirListing.onResize(new Widget.ResizeMessage('resize', width, 300));
-          await framePromise();
-          renderedValues.push(modifiedCell.textContent ?? '');
-        }
-
-        expect(new Set(renderedValues).size).toBe(3);
-      });
-    });
-
     describe('#handleEvent()', () => {
       it('should upload a nested folder on drag', async () => {
         const dt = new DataTransfer();
@@ -869,6 +832,43 @@ describe('filebrowser/listing', () => {
             expect(Array.from(dirListing.selectedItems())).toHaveLength(0);
           });
         });
+      });
+    });
+
+    describe('last modified column', () => {
+      const ITEM_MODIFIED_CLASS = 'jp-DirListing-itemModified';
+
+      beforeEach(async () => {
+        // Use a stable timestamp so that the rendered relative time is
+        // different for the narrow, short, and long column styles.
+        const items = [...dirListing.sortedItems()].filter(
+          item => item.type !== 'directory'
+        );
+        const contents = dirListing.model.manager.services.contents;
+        for (const item of items) {
+          await contents.save(item.path, {
+            last_modified: new Date(2020, 0, 1).toISOString()
+          } as any);
+        }
+        await signalToPromise(dirListing.updated);
+      });
+
+      it('should update the relative time when the column is resized', async () => {
+        const itemNode = dirListing.contentNode.children[0] as HTMLElement;
+        const modifiedCell = itemNode.querySelector(
+          `.${ITEM_MODIFIED_CLASS}`
+        ) as HTMLElement;
+
+        expect(modifiedCell).not.toBeNull();
+        const renderedValues: string[] = [];
+
+        for (const width of [180, 300, 500]) {
+          dirListing.onResize(new Widget.ResizeMessage(width, 300));
+          await framePromise();
+          renderedValues.push(modifiedCell.textContent ?? '');
+        }
+
+        expect(new Set(renderedValues).size).toBe(3);
       });
     });
 

--- a/packages/filebrowser/test/listing.spec.ts
+++ b/packages/filebrowser/test/listing.spec.ts
@@ -105,6 +105,43 @@ describe('filebrowser/listing', () => {
       });
     });
 
+    describe('last modified column', () => {
+      const ITEM_MODIFIED_CLASS = 'jp-DirListing-itemModified';
+
+      beforeEach(async () => {
+        // Use a stable timestamp so that the rendered relative time is
+        // different for the narrow, short, and long column styles.
+        const items = [...dirListing.sortedItems()].filter(
+          item => item.type !== 'directory'
+        );
+        const contents = dirListing.model.manager.services.contents;
+        for (const item of items) {
+          await contents.save(item.path, {
+            last_modified: new Date(2020, 0, 1).toISOString()
+          } as any);
+        }
+        await signalToPromise(dirListing.updated);
+      });
+
+      it('should update the relative time when the column is resized', async () => {
+        const itemNode = dirListing.contentNode.children[0] as HTMLElement;
+        const modifiedCell = itemNode.querySelector(
+          `.${ITEM_MODIFIED_CLASS}`
+        ) as HTMLElement;
+
+        expect(modifiedCell).not.toBeNull();
+        const renderedValues: string[] = [];
+
+        for (const width of [180, 300, 500]) {
+          dirListing.onResize(new Widget.ResizeMessage('resize', width, 300));
+          await framePromise();
+          renderedValues.push(modifiedCell.textContent ?? '');
+        }
+
+        expect(new Set(renderedValues).size).toBe(3);
+      });
+    });
+
     describe('#handleEvent()', () => {
       it('should upload a nested folder on drag', async () => {
         const dt = new DataTransfer();

--- a/packages/filebrowser/test/listing.spec.ts
+++ b/packages/filebrowser/test/listing.spec.ts
@@ -838,21 +838,6 @@ describe('filebrowser/listing', () => {
     describe('last modified column', () => {
       const ITEM_MODIFIED_CLASS = 'jp-DirListing-itemModified';
 
-      beforeEach(async () => {
-        // Use a stable timestamp so that the rendered relative time is
-        // different for the narrow, short, and long column styles.
-        const items = [...dirListing.sortedItems()].filter(
-          item => item.type !== 'directory'
-        );
-        const contents = dirListing.model.manager.services.contents;
-        for (const item of items) {
-          await contents.save(item.path, {
-            last_modified: new Date(2020, 0, 1).toISOString()
-          } as any);
-        }
-        await signalToPromise(dirListing.updated);
-      });
-
       it('should update the relative time when the column is resized', async () => {
         const itemNode = dirListing.contentNode.children[0] as HTMLElement;
         const modifiedCell = itemNode.querySelector(
@@ -860,14 +845,31 @@ describe('filebrowser/listing', () => {
         ) as HTMLElement;
 
         expect(modifiedCell).not.toBeNull();
+
+        // The contents manager mock stamps `last_modified` with the current
+        // time on every save, so set a stable past timestamp directly on the
+        // model to make the rendered strings differ between date styles.
+        const firstItem = [...dirListing.sortedItems()].find(
+          item => item.type !== 'directory'
+        );
+        expect(firstItem).toBeDefined();
+        (firstItem as any).last_modified = new Date(2020, 0, 1).toISOString();
+
         const renderedValues: string[] = [];
 
-        for (const width of [180, 300, 500]) {
-          dirListing.onResize(new Widget.ResizeMessage(width, 300));
+        // jsdom has no layout, so the column width measured from the DOM is
+        // always 0. Drive the recorded column size, which is what the
+        // adaptive date style is computed from, and go through the resize
+        // path to trigger the re-render.
+        const dirListingAny = dirListing as any;
+        for (const width of [90, 110, 300]) {
+          dirListingAny._columnSizes['last_modified'] = width;
+          dirListing.onResize(new Widget.ResizeMessage(200, 300));
           await framePromise();
           renderedValues.push(modifiedCell.textContent ?? '');
         }
 
+        // The widths map to the narrow, short, and long date styles.
         expect(new Set(renderedValues).size).toBe(3);
       });
     });


### PR DESCRIPTION
## References

Fixes #16192.

## Code changes

Add focused unit coverage for the file browser's adaptive last-modified column. The test assigns a stable historical timestamp, simulates three available widths, and verifies that the rendered relative time changes for the narrow, short, and long styles.

## User-facing changes

None.

## Backwards-incompatible changes

None.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **NO**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES).
- AI tools and models used: OpenAI Codex.