### PR TITLE
refactor(settingeditor): remove legacy plugin layout

### DIFF
--- a/packages/settingeditor/src/plugineditor.ts
+++ b/packages/settingeditor/src/plugineditor.ts
@@ -13,7 +13,7 @@ import { JSONExt } from '@lumino/coreutils';
 import type { Message } from '@lumino/messaging';
 import type { ISignal } from '@lumino/signaling';
 import { Signal } from '@lumino/signaling';
-import { StackedLayout, Widget } from '@lumino/widgets';
+import { PanelLayout, Widget } from '@lumino/widgets';
 import { RawEditor } from './raweditor';
 import type { JsonSettingEditor } from './jsonsettingeditor';
 
@@ -40,11 +40,7 @@ export class PluginEditor extends Widget {
     this.translator = translator || nullTranslator;
     this._trans = this.translator.load('jupyterlab');
 
-    // TODO: Remove this layout. We were using this before when we
-    // when we had a way to switch between the raw and table editor
-    // Now, the raw editor is the only child and probably could merged into
-    // this class directly in the future.
-    const layout = (this.layout = new StackedLayout());
+    const layout = (this.layout = new PanelLayout());
     const { onSaveError } = Private;
 
     this.raw = this._rawEditor = new RawEditor({


### PR DESCRIPTION
## References

Fixes #18336.

## Code changes

Replace the single-child `StackedLayout` in `PluginEditor` with `PanelLayout` and remove the obsolete comment describing the former raw/table editor switch.

## User-facing changes

None intended. The plugin editor still hosts the same `RawEditor` child.

## Backwards-incompatible changes

None.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **NO**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES).
- AI tools and models used: OpenAI Codex.