### PR TITLE
Fix drive handling for consoles

### DIFF
--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -38,7 +38,10 @@ import {
   IConsoleCellExecutor,
   IConsoleTracker
 } from '@jupyterlab/console';
-import { IDefaultFileBrowser } from '@jupyterlab/filebrowser';
+import {
+  IDefaultFileBrowser,
+  IFileBrowserFactory
+} from '@jupyterlab/filebrowser';
 import { ILauncher } from '@jupyterlab/launcher';
 import { IMainMenu } from '@jupyterlab/mainmenu';
 import { IPageHandler } from '@jupyterlab/outputarea';
@@ -138,6 +141,7 @@ const tracker: JupyterFrontEndPlugin<IConsoleTracker> = {
   optional: [
     ILayoutRestorer,
     IDefaultFileBrowser,
+    IFileBrowserFactory,
     IMainMenu,
     ICommandPalette,
     ILauncher,
@@ -280,6 +284,7 @@ async function activateConsole(
   settingRegistry: ISettingRegistry,
   restorer: ILayoutRestorer | null,
   filebrowser: IDefaultFileBrowser | null,
+  filebrowserFactory: IFileBrowserFactory | null,
   mainMenu: IMainMenu | null,
   palette: ICommandPalette | null,
   launcher: ILauncher | null,
@@ -821,10 +826,12 @@ async function activateConsole(
       }
     },
     execute: args => {
+      const currentBrowser =
+        filebrowserFactory?.tracker.currentWidget ?? filebrowser;
       const basePath =
         ((args['basePath'] as string) ||
           (args['cwd'] as string) ||
-          filebrowser?.model.path) ??
+          currentBrowser?.model.path) ??
         '';
       return createConsole({ basePath, ...args });
     }

--- a/packages/console/src/panel.ts
+++ b/packages/console/src/panel.ts
@@ -63,10 +63,11 @@ export class ConsolePanel extends MainAreaWidget<Panel> {
     sessionContext = this._sessionContext =
       sessionContext ??
       new SessionContext({
+        driveName: manager.contents.driveName(path),
         kernelManager: manager.kernels,
         sessionManager: manager.sessions,
         specsManager: manager.kernelspecs,
-        path: manager.contents.localPath(path),
+        path,
         name: name || trans.__('Console %1', count),
         type: 'console',
         kernelPreference: options.kernelPreference,

--- a/packages/console/test/panel.spec.ts
+++ b/packages/console/test/panel.spec.ts
@@ -64,18 +64,38 @@ describe('console/panel', () => {
         );
       });
 
-      it('should set the session context path to local path', () => {
+      it('should keep the drive name in the session context path', () => {
         manager.contents.addDrive(new Drive({ name: 'TestDrive' }));
         const localPath = `${UUID.uuid4()}.txt`;
+        const globalPath = `TestDrive:${localPath}`;
         const panel = new TestPanel({
           manager,
           contentFactory,
           rendermime,
           mimeTypeService,
-          path: `TestDrive:${localPath}`
+          path: globalPath
         });
 
-        expect(panel.sessionContext.path).toEqual(localPath);
+        expect(panel.sessionContext.path).toEqual(globalPath);
+        panel.dispose();
+      });
+
+      it('should start the session with the drive name for root-level paths', async () => {
+        manager.contents.addDrive(new Drive({ name: 'TestDrive' }));
+        const startNew = jest.mocked(manager.sessions.startNew);
+        startNew.mockClear();
+        const panel = new TestPanel({
+          manager,
+          contentFactory,
+          rendermime,
+          mimeTypeService,
+          path: `TestDrive:${UUID.uuid4()}.txt`,
+          kernelPreference: { name: manager.kernelspecs.specs!.default }
+        });
+
+        await panel.sessionContext.initialize();
+
+        expect(startNew.mock.calls[0][0].path).toMatch(/^TestDrive:\//);
         panel.dispose();
       });
     });


### PR DESCRIPTION

## References

Fixes #19258 

## Code changes

- [x] Fix handling of drives for code consoles

## User-facing changes

This will mostly be useful to users of JupyterLite, where kernels have access to files: 

**Before**

https://github.com/user-attachments/assets/03e61802-20bc-4e8d-ad6a-9fcc66d80e03



**After**


https://github.com/user-attachments/assets/d966fa83-b284-4201-9f48-f6d1ff600914



## Backwards-incompatible changes

None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude Fable 5