### PR TITLE
Use `ui-test-report-comment` action from `maintainer-tools`

### DIFF
--- a/.github/workflows/galata-pr-comment.yml
+++ b/.github/workflows/galata-pr-comment.yml
@@ -11,85 +11,11 @@ jobs:
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-22.04
     permissions:
+      actions: read
       pull-requests: write
     steps:
-      - name: Download PR comment data
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: jupyterlab/maintainer-tools/.github/actions/ui-test-report-comment@1139fd4ebe0dff50be32fa160d445d5fb80ee4d6
         with:
-          name: galata-pr-comment-data
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
-
-      - name: Update binder preview comment
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const { prNumber, reportUrl, failing, flaky } = JSON.parse(
-              fs.readFileSync('pr-comment-data.json', 'utf8')
-            );
-
-            if (!prNumber || !reportUrl) {
-              console.warn('Missing PR number or report URL; skipping preview comment update.');
-              return;
-            }
-
-            const reportLinePrefix = 'View the integration tests report in the browser: ';
-
-            let badgeStatus;
-            let badgeColor;
-            let badgeTitle;
-            if (failing > 0) {
-              badgeStatus = `${failing}_failing`;
-              badgeColor = 'red';
-              badgeTitle = `${failing} failing UI tests`;
-            } else if (flaky > 0) {
-              badgeStatus = `${flaky}_flaky`;
-              badgeColor = 'orange';
-              badgeTitle = `${flaky} flaky UI tests`;
-            } else {
-              badgeStatus = 'All_passing';
-              badgeColor = 'success';
-              badgeTitle = 'All tests UI tests passed';
-            }
-
-            const reportUrlWithFilter = failing > 0
-              ? `${reportUrl}#?q=s%3Afailed`
-              : flaky > 0
-              ? `${reportUrl}#?q=s%3Aflaky`
-              : reportUrl;
-
-            const badgeUrl = `https://img.shields.io/badge/UI_tests-${badgeStatus}-${badgeColor}`;
-            const reportBadge = `[![UI tests report](${badgeUrl} '${badgeTitle}')](${reportUrlWithFilter})`;
-            const reportLine = `${reportLinePrefix}${reportBadge}`;
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber
-            });
-            const binderComment = comments
-              .slice()
-              .reverse()
-              .find(comment => comment.body.includes("![Binder]("));
-            if (!binderComment) {
-              return;
-            }
-
-            const existingReportLine = binderComment.body
-              .split('\n')
-              .find(line => line.startsWith(reportLinePrefix));
-            const updatedBody =
-              existingReportLine === undefined
-                ? `${binderComment.body.trimEnd()}\n\n${reportLine}`
-                : binderComment.body.replace(existingReportLine, reportLine);
-
-            if (binderComment.body.trim() !== updatedBody.trim()) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: binderComment.id,
-                body: updatedBody
-              });
-            }
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run_id: ${{ github.event.workflow_run.id }}
+          report_line_prefix: "View the integration tests report in the browser: "

--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -542,7 +542,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: galata-pr-comment-data
+          name: ui-test-report-comment-data
           path: pr-comment-data.json
           retention-days: 1
 


### PR DESCRIPTION
## References

- follow-up to https://github.com/jupyterlab/jupyterlab/pull/18798
- after upstreaming in https://github.com/jupyterlab/maintainer-tools/pull/301

## Code changes

- Removes a bunch of code that was moved to `maintainer-tools`
- Now also checks for current run to avoid result from previous commit that tok longer to execute overwriting the newer commit
- Hardens security edge cases
- Changes the name of the temporary artifact from `galata-pr-comment-data` to `ui-test-report-comment-data`

## Developer-facing changes

No overwriting

## Backwards-incompatible changes

None

