### PR TITLE
Fix Alt+W not closing the current tab when focus is outside the main area

### DIFF
--- a/packages/application-extension/schema/commands.json
+++ b/packages/application-extension/schema/commands.json
@@ -25,7 +25,7 @@
     {
       "command": "application:close",
       "keys": ["Alt W"],
-      "selector": ".jp-Activity"
+      "selector": "body"
     },
     {
       "command": "application:toggle-mode",

--- a/packages/application-extension/schema/commands.json
+++ b/packages/application-extension/schema/commands.json
@@ -25,7 +25,7 @@
     {
       "command": "application:close",
       "keys": ["Alt W"],
-      "selector": "body"
+      "selector": ".jp-LabShell"
     },
     {
       "command": "application:toggle-mode",


### PR DESCRIPTION
## References
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
<!-- Note any other pull requests that address this issue and how this pull request is different. -->
Fixes #4530
No other open pull requests address this issue.
## Code changes
<!-- Describe the code changes and how they address the issue. -->
`application:close` is bound to <kbd>Alt</kbd>+<kbd>W</kbd> with `"selector": ".jp-Activity"` in `packages/application-extension/schema/commands.json`. That selector only matches when focus is inside a main-area widget, so the keybinding never fires when focus is anywhere else — the file browser, the status bar, the debugger panel, or any sidebar. At the same time, File ▸ Close Tab is unaffected and works as intended, because menu commands are not gated by the keybinding selector. That asymmetry between the mouse path and the keyboard path is what #4530 describes.

The change is one line: `".jp-Activity"` → `".jp-LabShell"`.

`.jp-LabShell` is the shell root (`APPLICATION_SHELL_CLASS` in `packages/application/src/shell.ts`). It covers the main area, both sidebars, the file browser, and the status bar — every focus target in the report — while keeping the binding scoped to the application, so it does not leak outside JupyterLab when the shell is grafted into a custom host page.
The command already works from any focus. `contextMenuWidget()` falls back to `shell.currentWidget` when there is no context-menu target, and `isEnabled` guards on `!!widget && widget.title.closable`, so the command is a no-op when there is nothing closable. Widening the selector removes a gate on a command that is already safe rather than changing what it does.
## User-facing changes
<!-- Describe any visual or user interaction changes and how they address the issue. -->
<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->
<kbd>Alt</kbd>+<kbd>W</kbd> now closes the current tab regardless of where focus is within the application, matching the behavior of File ▸ Close Tab (mouse path). There are no visual changes.
Tested on Chrome/Linux against a local `--dev-mode` build, comparing this branch against `main`:
| Scenario | `main` | This branch (`.jp-LabShell`) |
|---|---|---|
| Focus in file browser / status bar / debugger panel | shortcut does nothing | closes the current tab |
| Notebook cell in edit mode | closes; no stray input | closes; no stray input, unsaved-changes dialog still appears |
| File browser rename in progress | shortcut does nothing | closes the tab; rename continues unaffected |
| Terminal with focus inside it | does not close | does not close (xterm.js consumes the key) |
| Terminal tab, focus elsewhere | shortcut does nothing | closes the terminal tab |
| Dialog open | shortcut does nothing | shortcut does nothing |
| Modal command palette open | shortcut does nothing | shortcut does nothing |

Dialogs and the modal command palette attach to document.body (`apputils/src/dialog.tsx`, `apputils/src/commandpalette.ts`) rather than inside the shell, so they fall outside `.jp-LabShell`. 

## Backwards-incompatible changes
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None.
## AI usage
- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude Opus 5 (chat)