### PR TITLE
Update the copyright year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2025 Project Jupyter Contributors
+Copyright (c) 2015-2026 Project Jupyter Contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -204,7 +204,7 @@ const about: JupyterFrontEndPlugin<void> = {
         );
         const copyright = (
           <span className="jp-About-copyright">
-            {trans.__('© %1-%2 Project Jupyter Contributors', 2015, 2025)}
+            {trans.__('© %1-%2 Project Jupyter Contributors', 2015, 2026)}
           </span>
         );
         const body = (


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Updating copyright year as it has been done previously.

## Code changes

Changed 2025 to 2026 in packages/help-extension/src/index.tsx and LICENSE

## User-facing changes

<img width="407" height="312" alt="image" src="https://github.com/user-attachments/assets/87271ab6-2ffc-422c-9ef6-7111564c5ead" />


## Backwards-incompatible changes

None

## AI usage

- **NO**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: -
