### PR TITLE
Fix memory leak when Property Inspector is open and other issues exposed by new linter rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -248,11 +248,8 @@ export default defineConfig([
       'jupyter/require-signal-cleanup': 'error',
       'jupyter/require-signal-this-arg': 'error',
       'jupyter/prefer-signal-this-arg': 'error',
-      // TODO: the disposable rules highlight genuine leaks, but require
-      // a larger refactor (e.g. hoisting a React field renderer out of
-      // the render callback, giving a per-render `Debouncer` a lifetime)
-      'jupyter/require-disposable-ownership': 'warn',
-      'jupyter/require-disposable-transfer': 'warn',
+      'jupyter/require-disposable-ownership': 'error',
+      'jupyter/require-disposable-transfer': 'error',
       'tsdoc/syntax': 'warn',
       'jupyter/require-soft-assertions-before-snapshots': 'error',
       '@typescript-eslint/naming-convention': [

--- a/packages/apputils/src/licenses.tsx
+++ b/packages/apputils/src/licenses.tsx
@@ -54,6 +54,7 @@ export class Licenses extends SplitPanel {
       return;
     }
     this._bundles.currentChanged.disconnect(this.onBundleSelected, this);
+    this._disposeBundleTabs();
     this.model.dispose();
     super.dispose();
   }
@@ -124,11 +125,16 @@ export class Licenses extends SplitPanel {
    */
   protected _updateBundles(): void {
     this._bundles.clearTabs();
+    // The tabs are rebuilt from scratch on every model change, and each one
+    // needs a widget to own its title, so the previous owners are released
+    // here rather than left behind once their tab is gone.
+    this._disposeBundleTabs();
     let i = 0;
     const { currentBundleName } = this.model;
     let currentIndex = 0;
     for (const bundle of this.model.bundleNames) {
       const tab = new Widget();
+      this._bundleTabs.push(tab);
       tab.title.label = bundle;
       if (bundle === currentBundleName) {
         currentIndex = i;
@@ -136,6 +142,16 @@ export class Licenses extends SplitPanel {
       this._bundles.insertTab(++i, tab.title);
     }
     this._bundles.currentIndex = currentIndex;
+  }
+
+  /**
+   * Dispose of the widgets owning the bundle tab titles.
+   */
+  private _disposeBundleTabs(): void {
+    for (const tab of this._bundleTabs) {
+      tab.dispose();
+    }
+    this._bundleTabs.length = 0;
   }
 
   /**
@@ -152,6 +168,11 @@ export class Licenses extends SplitPanel {
    * Tabs reflecting available bundles
    */
   protected _bundles: TabBar<Widget>;
+
+  /**
+   * The widgets owning the titles of the bundle tabs.
+   */
+  private _bundleTabs: Widget[] = [];
 
   /**
    * A grid of the current bundle's packages' license metadata

--- a/packages/lsp-extension/src/renderer.tsx
+++ b/packages/lsp-extension/src/renderer.tsx
@@ -212,10 +212,11 @@ function BuildSettingForm(props: ISettingFormProps): JSX.Element {
     }
   };
   // One debouncer for the lifetime of the component. Building a new one per
-  // render abandoned a live timer every time and reset the debounce window, so
-  // the debouncing never took effect. `setProperty` closes over `propertyMap`,
-  // so the debouncer reaches the current one through a ref instead of
-  // capturing the one from the first render.
+  // render meant a render between two edits put them on different debouncers,
+  // so they were never coalesced and a pending write carried the state of the
+  // render that scheduled it. `setProperty` closes over `propertyMap`, so the
+  // debouncer reaches the current one through a ref instead of capturing the
+  // one from the first render.
   const setPropertyRef = useRef(setProperty);
   setPropertyRef.current = setProperty;
   const debouncerRef = useRef<Debouncer<

--- a/packages/lsp-extension/src/renderer.tsx
+++ b/packages/lsp-extension/src/renderer.tsx
@@ -7,7 +7,7 @@ import { closeIcon } from '@jupyterlab/ui-components';
 import type { PartialJSONObject, PartialJSONValue } from '@lumino/coreutils';
 import { UUID } from '@lumino/coreutils';
 import { Debouncer } from '@lumino/polling';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { DOMUtils } from '@jupyterlab/apputils';
 
 import type { FieldProps } from '@rjsf/utils';
@@ -211,11 +211,30 @@ function BuildSettingForm(props: ISettingFormProps): JSX.Element {
         .catch(console.error);
     }
   };
-  const debouncedSetProperty = new Debouncer<
+  // One debouncer for the lifetime of the component. Building a new one per
+  // render abandoned a live timer every time and reset the debounce window, so
+  // the debouncing never took effect. `setProperty` closes over `propertyMap`,
+  // so the debouncer reaches the current one through a ref instead of
+  // capturing the one from the first render.
+  const setPropertyRef = useRef(setProperty);
+  setPropertyRef.current = setProperty;
+  const debouncerRef = useRef<Debouncer<
     void,
     unknown,
     [hash: string, property: ISettingProperty]
-  >(setProperty);
+  > | null>(null);
+  if (!debouncerRef.current) {
+    debouncerRef.current = new Debouncer(
+      (hash: string, property: ISettingProperty) =>
+        setPropertyRef.current(hash, property)
+    );
+  }
+  const debouncedSetProperty = debouncerRef.current;
+  useEffect(() => {
+    return () => {
+      debouncerRef.current?.dispose();
+    };
+  }, []);
   const textInputId = useRef<string>(
     DOMUtils.createDomID() + '-line-number-input'
   );

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1322,15 +1322,20 @@ const customMetadataEditorFields: JupyterFrontEndPlugin<void> = {
   ) => {
     const editorFactory: CodeEditor.Factory = options =>
       editorServices.factoryService.newInlineEditor(options);
-    // Register the custom fields.
+    // Register the custom fields. As with the active cell tool below, the
+    // field renderers are used by rjsf as React components, so they run on
+    // every rebuild of the metadata form. Each field is created once and
+    // reused: constructing one per render abandons an editor, its host node
+    // and its listeners on every keystroke that rebuilds the form.
+    const cellMetadataField = new CellMetadataField({
+      editorFactory,
+      tracker,
+      label: 'Cell metadata',
+      translator: translator
+    });
     const cellComponent: IFormRenderer = {
       fieldRenderer: (props: FieldProps) => {
-        return new CellMetadataField({
-          editorFactory,
-          tracker,
-          label: 'Cell metadata',
-          translator: translator
-        }).render(props);
+        return cellMetadataField.render(props);
       }
     };
     formRegistry.addRenderer(
@@ -1338,14 +1343,15 @@ const customMetadataEditorFields: JupyterFrontEndPlugin<void> = {
       cellComponent
     );
 
+    const notebookMetadataField = new NotebookMetadataField({
+      editorFactory,
+      tracker,
+      label: 'Notebook metadata',
+      translator: translator
+    });
     const notebookComponent: IFormRenderer = {
       fieldRenderer: (props: FieldProps) => {
-        return new NotebookMetadataField({
-          editorFactory,
-          tracker,
-          label: 'Notebook metadata',
-          translator: translator
-        }).render(props);
+        return notebookMetadataField.render(props);
       }
     };
     formRegistry.addRenderer(

--- a/packages/notebook-extension/src/tool-widgets/metadataEditorFields.tsx
+++ b/packages/notebook-extension/src/tool-widgets/metadataEditorFields.tsx
@@ -77,9 +77,13 @@ export class CellMetadataField extends NotebookTools.MetadataEditorTool {
 
   render(props: FieldProps): JSX.Element {
     const cell = this._tracker.activeCell;
+    // The editor detaches the previous source but does not dispose it, and
+    // this runs on every rebuild of the form.
+    const previousSource = this.editor.source;
     this.editor.source = cell
       ? new ObservableJSON({ values: cell.model.metadata as JSONObject })
       : null;
+    previousSource?.dispose();
     this.editor.source?.changed.connect(this._onSourceChanged, this);
 
     return (
@@ -120,9 +124,13 @@ export class NotebookMetadataField extends NotebookTools.MetadataEditorTool {
 
   render(props: FieldProps): JSX.Element {
     const notebook = this._tracker.currentWidget;
+    // The editor detaches the previous source but does not dispose it, and
+    // this runs on every rebuild of the form.
+    const previousSource = this.editor.source;
     this.editor.source = notebook
       ? new ObservableJSON({ values: notebook.model?.metadata as JSONObject })
       : null;
+    previousSource?.dispose();
     this.editor.source?.changed.connect(this._onSourceChanged, this);
 
     return (


### PR DESCRIPTION
## References

- Follow-up to #19307, which adopted `jupyter/require-disposable-ownership` and `jupyter/require-disposable-transfer` as warnings and left most findings unaddressed. This fixes them and promotes both rules to errors.
- Follow-up to #19168, which hoisted `ActiveCellTool` out of its field renderer, and addressed part of the memory leak

## Code changes

- `CellMetadataField` and `NotebookMetadataField` are created once at plugin activation instead of once per rjsf render.
- Their `render` disposes the `ObservableJSON` source it replaces.
- `Licenses` disposes the widgets that own the bundle tab titles.
- The LSP settings form keeps one `Debouncer` for the lifetime of the component and disposes it on unmount.

## Measurements

In a scenario with 30 active-cell changes (say pressing down key in a notebook with 30 cells for a few seconds), with the Property Inspector open and both Common Tools and Advanced Tools expanded.

|                         | 4.6.2 (before #19168) | 4.6.3 / `main`    | this PR |
| ----------------------- | ------------- | --------- | -------- |
| `ActiveCellTool`        | +29           | 0         | 0        |
| `CellMetadataField`     | +30           | +30       | 0        |
| `NotebookMetadataField` | +30           | +30       | 0        |
| `CodeMirrorEditor`      | +60           | +60       | 0        |
| heap growth             | +11.0 MiB     | +10.7 MiB | +7.1 MiB |

#19168 removed 29 abandoned tools but only about 10 KiB per cell change, because that tool renders its preview as highlighted `<pre>` and carries no CodeMirror editor. The metadata fields each carry one.

This scales with active-cell changes, not with notebook size and not with typing: selecting a cell, arrowing in command mode and shift+enter each rebuild the form, while 13 keystrokes inside one cell rebuild it zero times. Growth is linear, at 123 KiB per change over 30 changes and 119 KiB over 90. At 119 KiB, for a session that keeps the panel open:

| how often user switches cells?  | over 8 hours | reclaimed |
| --------------------------- | ------------ | --------- |
| every minute            | 480          | ~56 MiB   |
| every 30 s              | 960          | ~112 MiB  |
| every 10 s              | 2,880        | ~335 MiB  |

One shift+enter pass over a 100 cell notebook is 100 changes, so about 12 MiB. With the Property Inspector closed the field renderers do not run and nothing is reclaimed.

All of the measured reclaim comes from the two metadata fields. The other two findings are dropped ownership rather than retained memory, and are fixed for correctness: `TabBar.clearTabs()` already disconnects each title's signal before dropping it, and a `Debouncer` builds its `Poll` with `auto: false`, so one that was never invoked holds no timer.

Measured with a temporary Galata probe: instance counts through `Runtime.queryObjects` after a forced GC, heap size from `Runtime.getHeapUsage`. 

## User-facing changes

Lower memory use in long sessions that keep the Property Inspector open, by the amounts above. The same scenario still grows about 219 KiB per change from retention elsewhere in the cell-switching path, so this removes roughly a third of it.

Edits to LSP server settings are now coalesced into a single write. Previously a render between two edits put them on different debouncers, so each pending write carried the state of the render that scheduled it. A write now lands 500 ms after the last edit.

## Backwards-incompatible changes

None.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Opus 5
