### PR TITLE
Guard the contentVisibility cells-changed handler against re-attachment

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -593,6 +593,13 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
       oldValue.contentChanged.disconnect(this.onModelContentChanged, this);
       oldValue.metadataChanged.disconnect(this.onMetadataChanged, this);
       oldValue.cells.changed.disconnect(this._onCellsChanged, this);
+      if (this._contentVisibilityCellsChangedSlot) {
+        oldValue.cells.changed.disconnect(
+          this._contentVisibilityCellsChangedSlot,
+          this
+        );
+        this._contentVisibilityCellsChangedSlot = null;
+      }
       while (this.cellsArray.length) {
         this._removeCell(0);
       }
@@ -1197,16 +1204,26 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
       this._contentVisibilityObserver!.observe(cell.node)
     );
 
-    // Watch for newly added cells and set intrinsic size for them too
-    this.model?.cells.changed.connect(() => {
-      requestAnimationFrame(() => {
-        this.cellsArray.forEach((cell, i) => {
-          const estHeight = this._viewModel.estimateWidgetSize(i);
-          cell.node.style.containIntrinsicSize = `auto ${estHeight}px`;
-          this._contentVisibilityObserver!.observe(cell.node);
+    // Watch for newly added cells and set intrinsic size for them too. The
+    // connection is stored and guarded: _setupContentVisibilityObserver runs
+    // from both _updateNotebookConfig and onAfterAttach, so an unguarded
+    // connect would stack one handler per call and rescan all cells once per
+    // accumulated handler (gh #19268).
+    if (!this._contentVisibilityCellsChangedSlot) {
+      this._contentVisibilityCellsChangedSlot = () => {
+        requestAnimationFrame(() => {
+          this.cellsArray.forEach((cell, i) => {
+            const estHeight = this._viewModel.estimateWidgetSize(i);
+            cell.node.style.containIntrinsicSize = `auto ${estHeight}px`;
+            this._contentVisibilityObserver!.observe(cell.node);
+          });
         });
-      });
-    }, this);
+      };
+      this.model?.cells.changed.connect(
+        this._contentVisibilityCellsChangedSlot,
+        this
+      );
+    }
   }
 
   protected cellsArray: Array<Cell>;
@@ -1225,6 +1242,7 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
   private _renderingLayout: RenderingLayout | undefined;
   private _renderingLayoutChanged = new Signal<this, RenderingLayout>(this);
   private _contentVisibilityObserver: IntersectionObserver | null = null;
+  private _contentVisibilityCellsChangedSlot: (() => void) | null = null;
   private _pageHandler: IPageHandler | undefined;
 }
 


### PR DESCRIPTION
## Summary

With `windowinMode: 'contentVisibility'` (the default), `_setupContentVisibilityObserver()` is called from both `_updateNotebookConfig` and `onAfterAttach`. The `IntersectionObserver` was guarded, but the `model.cells.changed.connect(...)` inside was not — every call stacked another anonymous listener, and each `cells.changed` event then ran one full-notebook rescan per accumulated handler (gh #19268).

## Changes

- The `cells.changed` handler is stored in `_contentVisibilityCellsChangedSlot` and connected at most once; later setup calls observe existing cells but do not re-attach.
- `_onModelChanged` disconnects the slot from the old model (mirroring `_onCellsChanged`) so a model swap cannot leave a stale connection or block re-attachment on the new model.

## Validation

- `yarn workspace @jupyterlab/notebook build` — passes with zero TypeScript errors (baseline verified on the same checkout)
- `eslint` on `widget.ts` — same 22 warnings as the unmodified baseline, no new diagnostics
- The package's jest suites are currently broken in this local environment by the pre-existing JupyterServer startup timeout in the sparse checkout; they were verified to fail identically on the unmodified baseline (414 failed / 111 passed both before and after), so the change introduces no new test failures
- `git diff --check` — clean
