### PR TITLE
Attach notebook collapse-state listeners once per panel

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -2867,12 +2867,21 @@ function addCommands(
     }
   };
 
-  // Set up signal handler to keep the collapse state consistent
+  // Set up signal handler to keep the collapse state consistent.
+  // The listener attachment is guarded per panel: currentChanged fires on
+  // every switch back to a notebook, so an unguarded connect would stack one
+  // cells.changed + activeCellChanged pair per activation and make each
+  // cell-list change cost O(activations * cells) (gh #19267).
+  const collapseListenersAttached = new WeakSet<NotebookPanel>();
   tracker.currentChanged.connect(
     (sender: INotebookTracker, panel: NotebookPanel) => {
       if (!panel?.content?.model?.cells) {
         return;
       }
+      if (collapseListenersAttached.has(panel)) {
+        return;
+      }
+      collapseListenersAttached.add(panel);
       panel.content.model.cells.changed.connect(
         (list: any, args: IObservableList.IChangedArgs<ICellModel>) => {
           // Might be overkill to refresh this every time, but


### PR DESCRIPTION
## Summary

Notebook collapse-state listeners are attached inside `tracker.currentChanged`, which fires every time the user switches back to a notebook. Each activation stacks another anonymous `cells.changed` and `activeCellChanged` pair on the same `NotebookPanel`, so a later cell-list change costs `O(activations × cells)` — `refreshCellCollapsed` rescans all cells once per accumulated handler (gh #19267).

## Changes

- `packages/notebook-extension/src/index.ts`: a `WeakSet<NotebookPanel>` guards the listener attachment; the first `currentChanged` for a panel connects the `cells.changed` + `activeCellChanged` pair and later activations skip. Disposal is handled by the WeakSet (the panel is collectable once the tracker drops it, matching the existing anonymous-listener lifecycle).

## Validation

- `yarn workspace @jupyterlab/notebook-extension build` — passes with zero TypeScript errors
- `git diff --check` — clean
- The extension package's jest suites hit the same pre-existing JupyterServer startup timeout as the rest of this local sparse checkout (verified identical before/after on the sibling #19268 branch)
