### PR TITLE
Update execution indicator after selection execution

### DIFF
--- a/packages/notebook/src/executionindicator.tsx
+++ b/packages/notebook/src/executionindicator.tsx
@@ -380,12 +380,28 @@ export namespace ExecutionIndicator {
             this
           );
 
+          const selectionExecuted = (
+            _: unknown,
+            args: { notebook: Notebook }
+          ) => {
+            if (state && args.notebook === nb && state.scheduledCell.size > 0) {
+              state.scheduledCell.clear();
+              this._scheduleSwitchToIdle(state);
+              this.stateChanged.emit(void 0);
+            }
+          };
+          NotebookActions.selectionExecuted.connect(selectionExecuted, this);
+
           context.disposed.connect(ctx => {
             ctx.connectionStatusChanged.disconnect(
               contextConnectionStatusChanged,
               this
             );
             ctx.statusChanged.disconnect(contextStatusChanged, this);
+            NotebookActions.selectionExecuted.disconnect(
+              selectionExecuted,
+              this
+            );
           });
           const handleKernelMsg = (
             sender: Kernel.IKernelConnection,

--- a/packages/notebook/test/executionindicator.spec.tsx
+++ b/packages/notebook/test/executionindicator.spec.tsx
@@ -174,6 +174,28 @@ describe('@jupyterlab/notebook', () => {
         expect(executed).toEqual(expect.arrayContaining([3, 3, 3, 2, 2, 2, 0]));
       });
 
+      it('should clear scheduled cells when all cells have executed', async () => {
+        const state = indicator.model.executionState(widget)!;
+        const onExecuted = (_: unknown, args: { notebook: Notebook }) => {
+          if (args.notebook === widget) {
+            state.scheduledCell.add('request-id');
+          }
+        };
+        NotebookActions.executed.connect(onExecuted);
+
+        try {
+          await NotebookActions.runCells(
+            widget,
+            [widget.widgets[0]],
+            ipySessionContext
+          );
+        } finally {
+          NotebookActions.executed.disconnect(onExecuted);
+        }
+
+        expect(state.scheduledCell.size).toBe(0);
+      });
+
       it(
         'should reset to idle when kernel gets abruptly terminated',
         async () => {


### PR DESCRIPTION
Fixes #19235

## Summary

`ExecutionIndicator` did not update after `NotebookActions.selectionExecuted`, so its scheduled-cell state could remain stale after execution completed. This change listens to the public selection-execution signal for the relevant notebook, clears the stale request, schedules the idle transition, emits `stateChanged`, and disconnects the listener when the session context is disposed.

The regression test exercises the public `NotebookActions.runCells` execution flow and verifies that a pending request is cleared when selection execution completes.

## Validation

- `corepack yarn workspace @jupyterlab/notebook test --runInBand test/executionindicator.spec.tsx` — 10 passed
- Prettier check passed
- ESLint passed; the existing TSDoc warning remains at `executionindicator.tsx:306`
- `git diff --check` passed