### PR TITLE
Save sidebar section expansion state from the hidden flag

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -2451,7 +2451,7 @@ namespace Private {
         if (w.id && w.content instanceof SplitPanel) {
           widgetStates[w.id] = {
             sizes: w.content.relativeSizes() as number[],
-            expansionStates: w.content.widgets.map(wi => wi.isVisible)
+            expansionStates: w.content.widgets.map(wi => !wi.isHidden)
           };
         }
       });


### PR DESCRIPTION
## References

This should help fix the issue with sections being collapsed after refreshing the page.

## Code changes

- [x] Save sidebar section expansion state from the hidden flag

## User-facing changes

**Before**

https://github.com/user-attachments/assets/5782cf68-4d45-437e-b579-18b320f89f59

**After**


https://github.com/user-attachments/assets/3df011dd-f17d-4825-bd61-4e87b7a9befb



## Backwards-incompatible changes

None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude Fable 5