### PR TITLE
Fix settings search matches by property key

### DIFF
--- a/packages/settingeditor/src/SettingsFormEditor.tsx
+++ b/packages/settingeditor/src/SettingsFormEditor.tsx
@@ -345,10 +345,10 @@ export class SettingsFormEditor extends React.Component<
       const filteredSchema = JSONExt.deepCopy(this.props.settings.schema);
       if (this.props.filteredValues?.length ?? 0 > 0) {
         for (const field in filteredSchema.properties) {
+          const title = filteredSchema.properties[field].title;
           if (
-            !this.props.filteredValues?.includes(
-              filteredSchema.properties[field].title ?? field
-            )
+            !this.props.filteredValues?.includes(field) &&
+            !this.props.filteredValues?.includes(title ?? field)
           ) {
             delete filteredSchema.properties[field];
           }

--- a/packages/settingeditor/test/settingsformeditor.spec.tsx
+++ b/packages/settingeditor/test/settingsformeditor.spec.tsx
@@ -89,7 +89,7 @@ describe('@jupyterlab/settingeditor', () => {
           keyA: { type: 'string', default: 'A' },
           keyB: { type: 'string', default: 'B' },
           keyC: { title: 'Third key', type: 'string', default: 'C' },
-          keyD: { type: 'string', default: 'D' }
+          keyD: { title: 'Fourth key', type: 'string', default: 'D' }
         }
       };
       connector.schemas[id] = schema;
@@ -99,7 +99,7 @@ describe('@jupyterlab/settingeditor', () => {
       const component = renderer.create(
         <SettingsFormEditor
           // Filter by field and by title
-          filteredValues={['keyA', 'Third key']}
+          filteredValues={['keyA', 'Third key', 'keyD']}
           hasError={() => void 0}
           onSelect={() => void 0}
           renderers={{}}
@@ -112,7 +112,7 @@ describe('@jupyterlab/settingeditor', () => {
       // Then
       const instance = component.root;
       const form = instance.findByType(FormComponent);
-      expect(form.props.formData).toEqual({ keyA: 'A', keyC: 'C' });
+      expect(form.props.formData).toEqual({ keyA: 'A', keyC: 'C', keyD: 'D' });
       expect(Object.keys(form.props.schema.properties)).toEqual(
         Object.keys(form.props.formData)
       );


### PR DESCRIPTION
Fixes #19237

## Summary
- keep a setting visible when search matched its schema property key even if it also has a human-readable title
- continue accepting title matches
- extend the existing subset-rendering test to cover a titled property selected by key

## Test plan
- Regression test updated in packages/settingeditor/test/settingsformeditor.spec.tsx.
- Not run locally in this relay path; opening as draft for CI and human review.

## AI usage
- YES: Some or all content generated with AI assistance.
- NO: This relay path did not run the code locally; keep this PR draft until a human has reviewed and run it.
- AI tool/model: ChatGPT GPT-5.6 Sol.

<!-- pr-relay-job relay-78-f32c6a8168984f0138e6 -->