### PR TITLE
Remove unused shortcut conflict callbacks

### DIFF
--- a/packages/shortcuts-extension/src/components/ShortcutInput.tsx
+++ b/packages/shortcuts-extension/src/components/ShortcutInput.tsx
@@ -24,8 +24,6 @@ type CapturePhase = 'capturing' | 'ready' | 'incompleteIdle';
 export interface IConflicts {
   keys: string[];
   conflictsWith: IShortcutTarget[];
-  overwrite: () => void;
-  cancel: () => void;
 }
 
 export interface IShortcutInputProps {
@@ -121,14 +119,7 @@ export class ShortcutInput extends React.Component<
     this.setState({ activeConflicts: conflicts });
     this.props.displayConflicts({
       conflictsWith: conflicts,
-      keys,
-      overwrite: async () => {
-        await this._overwriteConflicts(conflicts, keys);
-      },
-      cancel: () => {
-        // Hide the input
-        this.props.toggleInput();
-      }
+      keys
     });
   }
 


### PR DESCRIPTION
## References

Fixes [[#19238](https://github.com/jupyterlab/jupyterlab/issues/19238)]

## Code changes

The shortcut conflict handling code contains callbacks that are no longer used.

This PR:

* Removes the unused `overwrite` and `cancel` callbacks from `IConflicts`.
* Removes the unused callback creation from `ShortcutInput._emitConflicts()`.
* Preserves the existing shortcut conflict handling behavior.
* Does not introduce any changes to the conflict resolution flow.

Only `packages/shortcuts-extension/src/components/ShortcutInput.tsx` is changed.

## User-facing changes

None. This is a cleanup of unused callback parameters and does not change the existing shortcut conflict behavior.

## Backwards-incompatible changes

None.

## Validation

* `corepack yarn build:test` passed in `packages/shortcuts-extension`.
* `corepack yarn test --runInBand` passed: 3 test suites, 39 tests.
* `git diff --check` passed; the only output was the expected Windows LF/CRLF warning.
* The documentation UI test continues to fail consistently with the same 2401-pixel snapshot mismatch, while the other 38 documentation tests pass. This PR does not modify the Altair documentation or related rendering code.

## AI usage

* YES: Some or all of the content of this PR was generated by AI.
* YES: The human author has carefully reviewed this PR and run this code.