### PR TITLE
Add Copy Image context menu action

### DIFF
--- a/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
+++ b/galata/test/documentation/commands.test.ts-snapshots/commandsList-documentation-linux.json
@@ -90,6 +90,16 @@
     }
   },
   {
+    "id": "application:copy-image",
+    "label": "Copy Image",
+    "caption": "Copy image to clipboard",
+    "shortcuts": [],
+    "args": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
     "id": "application:move-widget",
     "label": "Move Widget",
     "caption": "",

--- a/galata/test/jupyterlab/contextmenu.test.ts
+++ b/galata/test/jupyterlab/contextmenu.test.ts
@@ -6,6 +6,7 @@ import { expect, galata, test } from '@jupyterlab/galata';
 import * as path from 'path';
 
 const filebrowserId = 'filebrowser';
+const testImageName = 'lighthouse.png';
 const testFileName = 'simple.md';
 const testNotebook = 'simple_notebook.ipynb';
 const testFolderName = 'test-folder';
@@ -26,6 +27,10 @@ test.describe('Application Context Menu', () => {
     await contents.uploadFile(
       path.resolve(__dirname, `./notebooks/${testFileName}`),
       `${tmpPath}/${testFileName}`
+    );
+    await contents.uploadFile(
+      path.resolve(__dirname, '../../../docs/source/images/lighthouse.png'),
+      `${tmpPath}/${testImageName}`
     );
     // Create a dummy folder
     await contents.createDirectory(`${tmpPath}/${testFolderName}`);
@@ -126,6 +131,19 @@ test.describe('Application Context Menu', () => {
     const imageName = `tab-launcher.png`;
     const menu = await page.menu.getOpenMenuLocator();
     expect(await menu.screenshot()).toMatchSnapshot(imageName);
+  });
+
+  test('Open image context menu', async ({ page, tmpPath }) => {
+    await page.filebrowser.open(`${tmpPath}/${testImageName}`);
+
+    const image = page.locator('.jp-ImageViewer img');
+    await image.waitFor();
+    await image.click({ button: 'right' });
+
+    expect(await page.menu.isAnyOpen()).toBe(true);
+    await expect(
+      page.getByRole('menuitem', { name: 'Copy Image' })
+    ).toBeVisible();
   });
 
   test.describe('Notebook context menus', () => {

--- a/galata/test/jupyterlab/contextmenu.test.ts
+++ b/galata/test/jupyterlab/contextmenu.test.ts
@@ -146,6 +146,42 @@ test.describe('Application Context Menu', () => {
     ).toBeVisible();
   });
 
+  test.describe('Image clipboard', () => {
+    test.skip(
+      ({ browserName }) => browserName !== 'chromium',
+      'Image clipboard read is tested on Chromium.'
+    );
+
+    test('Copy image from context menu to clipboard', async ({
+      page,
+      tmpPath
+    }) => {
+      await page
+        .context()
+        .grantPermissions(['clipboard-read', 'clipboard-write']);
+      await page.filebrowser.open(`${tmpPath}/${testImageName}`);
+
+      const image = page.locator('.jp-ImageViewer img');
+      await image.waitFor();
+      await image.click({ button: 'right' });
+      await page.getByRole('menuitem', { name: 'Copy Image' }).click();
+
+      await expect
+        .poll(async () =>
+          page.evaluate(async () => {
+            const items = await navigator.clipboard.read();
+            const item = items.find(item => item.types.includes('image/png'));
+            if (!item) {
+              return 0;
+            }
+            const blob = await item.getType('image/png');
+            return blob.type === 'image/png' ? blob.size : 0;
+          })
+        )
+        .toBeGreaterThan(0);
+    });
+  });
+
   test.describe('Notebook context menus', () => {
     test.beforeEach(async ({ page, tmpPath }) => {
       await page.notebook.openByPath(`${tmpPath}/${testNotebook}`);

--- a/packages/application-extension/schema/commands.json
+++ b/packages/application-extension/schema/commands.json
@@ -382,6 +382,11 @@
     ],
     "context": [
       {
+        "command": "application:copy-image",
+        "selector": ".jp-MainAreaWidget img",
+        "rank": 0
+      },
+      {
         "command": "application:close",
         "selector": "#jp-main-dock-panel .lm-DockPanel-tabBar .lm-TabBar-tab",
         "rank": 4

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -461,14 +461,11 @@ const mainCommands: JupyterFrontEndPlugin<void> = {
           const errorMessage = trans.__(
             'Could not copy image. Browser security restrictions may prevent copying images loaded from another origin.'
           );
-          const blob = imageToPngBlob(image, errorMessage);
+          const blob = await imageToPngBlob(image, errorMessage);
 
           await navigator.clipboard.write([
             new ClipboardItem({ 'image/png': blob })
           ]);
-          Notification.success(trans.__('Image copied to clipboard.'), {
-            autoClose: COPY_IMAGE_NOTIFICATION_AUTO_CLOSE
-          });
         } catch (reason) {
           const error =
             reason instanceof Error

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -27,6 +27,7 @@ import {
   ICommandPalette,
   IWindowResolver,
   MenuFactory,
+  Notification,
   showDialog,
   showErrorMessage
 } from '@jupyterlab/apputils';
@@ -79,6 +80,8 @@ namespace CommandIDs {
 
   export const closeRightTabs = 'application:close-right-tabs';
 
+  export const copyImage = 'application:copy-image';
+
   export const closeAll: string = 'application:close-all';
 
   export const setActivityBarPosition: string =
@@ -130,6 +133,7 @@ namespace CommandIDs {
 
 const MIN_ZOOM = 0.5;
 const MAX_ZOOM = 3;
+const COPY_IMAGE_NOTIFICATION_AUTO_CLOSE = 5000;
 
 /**
  * A plugin to register the commands for the main application.
@@ -191,6 +195,65 @@ const mainCommands: JupyterFrontEndPlugin<void> = {
 
       const id = node.dataset.id;
       return id ? findWidgetById(id) : null;
+    };
+
+    const contextMenuImage = (): HTMLImageElement | undefined => {
+      const node = app.contextMenuHitTest(
+        node => node instanceof HTMLImageElement
+      );
+      return node instanceof HTMLImageElement ? node : undefined;
+    };
+
+    const imageToPngBlob = async (
+      image: HTMLImageElement,
+      errorMessage: string
+    ): Promise<Blob> => {
+      const canvasBlob = (): Promise<Blob> => {
+        const canvas = document.createElement('canvas');
+        canvas.width = image.naturalWidth || image.width;
+        canvas.height = image.naturalHeight || image.height;
+
+        const context = canvas.getContext('2d');
+        if (!context || !canvas.width || !canvas.height) {
+          return Promise.reject(new Error(errorMessage));
+        }
+
+        try {
+          context.drawImage(image, 0, 0);
+        } catch {
+          return Promise.reject(new Error(errorMessage));
+        }
+
+        return new Promise<Blob>((resolve, reject) => {
+          try {
+            canvas.toBlob(blob => {
+              if (blob) {
+                resolve(blob);
+              } else {
+                reject(new Error(errorMessage));
+              }
+            }, 'image/png');
+          } catch {
+            reject(new Error(errorMessage));
+          }
+        });
+      };
+
+      const src = image.currentSrc || image.src;
+      if (!src) {
+        return canvasBlob();
+      }
+
+      try {
+        const response = await fetch(src);
+        if (!response.ok) {
+          throw new Error(errorMessage);
+        }
+        const blob = await response.blob();
+        return blob.type === 'image/png' ? blob : canvasBlob();
+      } catch {
+        return canvasBlob();
+      }
     };
 
     // Closes an array of widgets.
@@ -369,6 +432,62 @@ const mainCommands: JupyterFrontEndPlugin<void> = {
           return;
         }
         closeWidgets(widgetsRightOf(widget));
+      }
+    });
+
+    commands.addCommand(CommandIDs.copyImage, {
+      label: trans.__('Copy Image'),
+      caption: trans.__('Copy image to clipboard'),
+      execute: async () => {
+        const image = contextMenuImage();
+        if (!image) {
+          return;
+        }
+
+        try {
+          if (
+            !navigator.clipboard?.write ||
+            typeof ClipboardItem === 'undefined'
+          ) {
+            throw new Error(
+              trans.__('Image copying is not supported in this browser.')
+            );
+          }
+
+          if (!image.complete) {
+            throw new Error(trans.__('Could not copy image.'));
+          }
+
+          const errorMessage = trans.__(
+            'Could not copy image. Browser security restrictions may prevent copying images loaded from another origin.'
+          );
+          const blob = imageToPngBlob(image, errorMessage);
+
+          await navigator.clipboard.write([
+            new ClipboardItem({ 'image/png': blob })
+          ]);
+          Notification.success(trans.__('Image copied to clipboard.'), {
+            autoClose: COPY_IMAGE_NOTIFICATION_AUTO_CLOSE
+          });
+        } catch (reason) {
+          const error =
+            reason instanceof Error
+              ? reason
+              : new Error(trans.__('Could not copy image.'));
+          Notification.error(error.message, {
+            autoClose: COPY_IMAGE_NOTIFICATION_AUTO_CLOSE
+          });
+        }
+      },
+      isEnabled: () =>
+        !!contextMenuImage() &&
+        !!navigator.clipboard?.write &&
+        typeof ClipboardItem !== 'undefined',
+      describedBy: {
+        args: {
+          type: 'object',
+          properties: {}
+        }
       }
     });
 


### PR DESCRIPTION
## References

Closes #19216 

## Code changes

This adds an `application:copy-image` command and registers it in the context menu for images inside main area widgets. The command uses JupyterLab’s existing context menu hit testing to find the right-clicked `HTMLImageElement`, then writes PNG image data to the browser clipboard using `navigator.clipboard.write` and `ClipboardItem`. The implementation first tries to fetch the image source and reuse the PNG blob directly when possible. If the source is unavailable, not PNG, or cannot be fetched, it falls back to drawing the rendered image to a canvas and exporting it as PNG. Copy success and failure both show JupyterLab notifications with a short auto-close timeout (5 sec). Failure messaging includes the browser security limitation for cross-origin images, since browsers can block JavaScript from reading image bytes or canvas pixels when the remote server does not allow it. A Galata regression test was added for the image viewer context menu. It opens a local PNG image, right-clicks the rendered image, and verifies that Copy Image is available.

## User-facing changes

A new Copy Image item in the right-click context menu, plus success/error notifications when they use it.

https://github.com/user-attachments/assets/0a88c2cb-ce7e-4716-9da8-608c679ceac2



## Backwards-incompatible changes

No

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: ChatGPT 5.5
