### PR TITLE
Show an inline error when JSON viewer content is invalid

### DIFF
--- a/packages/docregistry/src/mimedocument.ts
+++ b/packages/docregistry/src/mimedocument.ts
@@ -8,7 +8,7 @@ import type { IRenderMime, IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { MimeModel } from '@jupyterlab/rendermime';
 import type { ITranslator, TranslationBundle } from '@jupyterlab/translation';
 import { nullTranslator } from '@jupyterlab/translation';
-import type { PartialJSONObject } from '@lumino/coreutils';
+import type { PartialJSONObject, PartialJSONValue } from '@lumino/coreutils';
 import { JSONExt, PromiseDelegate } from '@lumino/coreutils';
 import type { Message } from '@lumino/messaging';
 import { MessageLoop } from '@lumino/messaging';
@@ -144,8 +144,20 @@ export class MimeContent extends Widget {
     if (this._dataType === 'string') {
       data[this.mimeType] = model.toString();
     } else {
-      data[this.mimeType] = model.toJSON();
+      // `model.toJSON()` parses the document source, which throws when the
+      // content is not valid JSON. Surface that as an inline error in the
+      // widget (and keep the document open) rather than letting the render
+      // pass fail silently. See https://github.com/jupyterlab/jupyterlab/issues/4490
+      try {
+        data[this.mimeType] = model.toJSON();
+      } catch (reason) {
+        this._setError(
+          this._trans.__('The file does not contain valid JSON: %1', `${reason}`)
+        );
+        return;
+      }
     }
+    this._setError(null);
     const mimeModel = new MimeModel({
       data,
       callback: this._changeCallback,
@@ -175,6 +187,39 @@ export class MimeContent extends Widget {
   }
 
   /**
+   * Show or clear an inline error banner in the widget.
+   *
+   * @param message - The error message to show, or `null` to clear it.
+   *
+   * #### Notes
+   * While an error is shown, the (now stale) rendered content is hidden so
+   * that the viewer reflects the current error state rather than the last
+   * successfully rendered value. The content is shown again once the error
+   * is cleared and the document is valid.
+   */
+  private _setError(message: string | null): void {
+    if (message === null) {
+      if (this._errorNode) {
+        this._errorNode.remove();
+        this._errorNode = null;
+      }
+      this.removeClass('jp-MimeDocument-error');
+      this.renderer.show();
+      return;
+    }
+    if (!this._errorNode) {
+      this._errorNode = document.createElement('div');
+      this._errorNode.className = 'jp-MimeDocument-errorBanner';
+      this._errorNode.setAttribute('role', 'alert');
+      this.node.insertBefore(this._errorNode, this.node.firstChild);
+    }
+    this._errorNode.textContent = message;
+    this.addClass('jp-MimeDocument-error');
+    // Hide the stale rendered content while the source is invalid.
+    this.renderer.hide();
+  }
+
+  /**
    * A bound change callback.
    */
   private _changeCallback = (
@@ -188,12 +233,19 @@ export class MimeContent extends Widget {
       if (data !== this._context.model.toString()) {
         this._context.model.fromString(data);
       }
-    } else if (
-      data !== null &&
-      data !== undefined &&
-      !JSONExt.deepEqual(data, this._context.model.toJSON())
-    ) {
-      this._context.model.fromJSON(data);
+    } else if (data !== null && data !== undefined) {
+      // `model.toJSON()` throws when the current source is not valid JSON.
+      // In that case the renderer callback is operating on stale data, so
+      // skip applying the write rather than letting the parse error escape.
+      let current: PartialJSONValue;
+      try {
+        current = this._context.model.toJSON();
+      } catch {
+        return;
+      }
+      if (!JSONExt.deepEqual(data, current)) {
+        this._context.model.fromJSON(data);
+      }
     }
   };
 
@@ -206,6 +258,7 @@ export class MimeContent extends Widget {
   private _monitor: ActivityMonitor<DocumentRegistry.IModel, void> | null;
   private _ready = new PromiseDelegate<void>();
   private _dataType: 'string' | 'json';
+  private _errorNode: HTMLDivElement | null = null;
   private _isRendering = false;
   private _renderRequested = false;
 }

--- a/packages/docregistry/style/base.css
+++ b/packages/docregistry/style/base.css
@@ -6,3 +6,19 @@
 .jp-MimeDocument {
   outline: none;
 }
+
+/* The children managed by the StackedLayout are absolutely positioned, so the
+ * error banner is floated on top of the rendered content at the top of the
+ * widget rather than participating in the normal flow. */
+.jp-MimeDocument-errorBanner {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1;
+  padding: 4px 12px;
+  color: var(--jp-ui-inverse-font-color1);
+  background-color: var(--jp-error-color1);
+  font-size: var(--jp-ui-font-size1);
+  white-space: pre-wrap;
+}

--- a/packages/docregistry/test/mimedocument.spec.ts
+++ b/packages/docregistry/test/mimedocument.spec.ts
@@ -121,5 +121,79 @@ describe('docregistry/mimedocument', () => {
         await emission;
       });
     });
+
+    describe('invalid JSON', () => {
+      const errorSelector = '.jp-MimeDocument-errorBanner';
+
+      it('should show an inline error banner instead of failing silently', async () => {
+        const renderer = RENDERMIME.createRenderer('application/json');
+        const widget = new MimeContent({
+          context: dContext,
+          renderer,
+          mimeType: 'application/json',
+          renderTimeout: 1000,
+          dataType: 'json'
+        });
+        dContext.model.fromString('{ invalid');
+        await widget.ready;
+        const banner = widget.node.querySelector(errorSelector);
+        expect(banner).not.toBeNull();
+        expect(widget.hasClass('jp-MimeDocument-error')).toBe(true);
+        // The stale rendered content is hidden while invalid.
+        expect(widget.renderer.isHidden).toBe(true);
+        // The document is not disposed on invalid JSON.
+        expect(widget.isDisposed).toBe(false);
+        widget.dispose();
+      });
+
+      it('should hide stale content when valid JSON is edited into invalid JSON', async () => {
+        const renderer = RENDERMIME.createRenderer('application/json');
+        const widget = new MimeContent({
+          context: dContext,
+          renderer,
+          mimeType: 'application/json',
+          renderTimeout: 1000,
+          dataType: 'json'
+        });
+        // Start valid and let the viewer render successfully.
+        dContext.model.fromString('{ "valid": true }');
+        await widget.ready;
+        expect(widget.node.querySelector(errorSelector)).toBeNull();
+        expect(widget.renderer.isHidden).toBe(false);
+
+        // Edit into invalid JSON through the normal update path.
+        dContext.model.fromString('{ invalid');
+        widget.update();
+        await new Promise(resolve => setTimeout(resolve, 100));
+        expect(widget.node.querySelector(errorSelector)).not.toBeNull();
+        expect(widget.hasClass('jp-MimeDocument-error')).toBe(true);
+        expect(widget.renderer.isHidden).toBe(true);
+        widget.dispose();
+      });
+
+      it('should clear the error banner once the content is valid again', async () => {
+        const renderer = RENDERMIME.createRenderer('application/json');
+        const widget = new MimeContent({
+          context: dContext,
+          renderer,
+          mimeType: 'application/json',
+          renderTimeout: 1000,
+          dataType: 'json'
+        });
+        dContext.model.fromString('{ invalid');
+        await widget.ready;
+        expect(widget.node.querySelector(errorSelector)).not.toBeNull();
+
+        // Make the content valid and request a re-render.
+        dContext.model.fromString('{ "valid": true }');
+        widget.update();
+        // Allow the asynchronous update-driven render to complete.
+        await new Promise(resolve => setTimeout(resolve, 100));
+        expect(widget.node.querySelector(errorSelector)).toBeNull();
+        expect(widget.hasClass('jp-MimeDocument-error')).toBe(false);
+        expect(widget.renderer.isHidden).toBe(false);
+        widget.dispose();
+      });
+    });
   });
 });


### PR DESCRIPTION
Fixes #4490.

When a .json file open in the JSON viewer is edited to become invalid, MimeContent currently fails to render without any feedback — the parse error from model.toJSON() is thrown outside the render try/catch, so the viewer silently keeps showing the last valid content and the user assumes their JSON is fine.

This catches that parse failure and shows an inline error banner at the top of the viewer while keeping the document open; the banner clears automatically once the content is valid again. This follows @ian-r-rose's suggestion in the issue to surface a JSON error in-widget rather than failing silently or closing the document.

Line/ndjson support (raised later in the thread) is out of scope here.

AI usage
YES: Some or all of the content of this PR was generated by AI.
AI tools and models used: Claude (Anthropic)