### PR TITLE
Add notebook setting for default scrolled output height

### DIFF
--- a/galata/test/jupyterlab/output-scrolling.test.ts
+++ b/galata/test/jupyterlab/output-scrolling.test.ts
@@ -109,4 +109,88 @@ test.describe('Output Scrolling', () => {
       /jp-mod-outputsScrolled/
     );
   });
+
+  test.describe('Configurable default height', () => {
+    test.use({
+      mockSettings: {
+        ...galata.DEFAULT_SETTINGS,
+        '@jupyterlab/notebook-extension:tracker': {
+          ...galata.DEFAULT_SETTINGS['@jupyterlab/notebook-extension:tracker'],
+          scrolledOutputMaxHeight: '120px'
+        }
+      }
+    });
+
+    test('uses the configured default scrolled output height', async ({
+      page
+    }) => {
+      await page.notebook.selectCells(0);
+      await page.evaluate(() => {
+        return window.jupyterapp.commands.execute(
+          'notebook:enable-output-scrolling'
+        );
+      });
+      await expect(page.locator(`${cellSelector} >> nth=0`)).toHaveClass(
+        /jp-mod-outputsScrolled/
+      );
+
+      const outputArea = page.locator(
+        `${cellSelector} >> nth=0 >> .jp-Cell-outputArea`
+      );
+      await expect(outputArea).toHaveCSS('max-height', '120px');
+    });
+
+    test('updates the default height when the setting changes', async ({
+      page
+    }) => {
+      await page.notebook.selectCells(0);
+      await page.evaluate(() => {
+        return window.jupyterapp.commands.execute(
+          'notebook:enable-output-scrolling'
+        );
+      });
+
+      const outputArea = page.locator(
+        `${cellSelector} >> nth=0 >> .jp-Cell-outputArea`
+      );
+      await expect(outputArea).toHaveCSS('max-height', '120px');
+
+      await page.evaluate(async () => {
+        const settingRegistry = await window.galata.getPlugin(
+          '@jupyterlab/apputils-extension:settings'
+        );
+        const settings = await settingRegistry!.load(
+          '@jupyterlab/notebook-extension:tracker'
+        );
+        await settings.set('scrolledOutputMaxHeight', '80px');
+      });
+
+      await expect(outputArea).toHaveCSS('max-height', '80px');
+    });
+
+    test('manual resize still overrides the default height', async ({
+      page
+    }) => {
+      await page.notebook.selectCells(0);
+      await page.evaluate(() => {
+        return window.jupyterapp.commands.execute(
+          'notebook:enable-output-scrolling'
+        );
+      });
+      await expect(page.locator(`${cellSelector} >> nth=0`)).toHaveClass(
+        /jp-mod-outputsScrolled/
+      );
+
+      const outputArea = page.locator(
+        `${cellSelector} >> nth=0 >> .jp-Cell-outputArea`
+      );
+      await expect(outputArea).toHaveCSS('max-height', '120px');
+
+      await outputArea.evaluate(el => {
+        (el as HTMLElement).style.height = '50px';
+      });
+      await expect(outputArea).toHaveCSS('max-height', 'none');
+      await expect(outputArea).toHaveCSS('height', '50px');
+    });
+  });
 });

--- a/packages/cells/style/widget.css
+++ b/packages/cells/style/widget.css
@@ -4,11 +4,12 @@
 |----------------------------------------------------------------------------*/
 
 /*-----------------------------------------------------------------------------
-| Private CSS variables
+| CSS variables
 |----------------------------------------------------------------------------*/
 
 :root {
   --jp-private-cell-scrolling-output-offset: 5px;
+  --jp-cell-scrolled-output-max-height: 24em;
 }
 
 /*-----------------------------------------------------------------------------
@@ -71,7 +72,7 @@
 
 .jp-CodeCell.jp-mod-outputsScrolled .jp-Cell-outputArea {
   overflow-y: auto;
-  max-height: 24em;
+  max-height: var(--jp-cell-scrolled-output-max-height);
   margin-left: var(--jp-private-cell-scrolling-output-offset);
   resize: vertical;
 }

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -793,6 +793,13 @@
       "type": "number",
       "default": 50
     },
+    "scrolledOutputMaxHeight": {
+      "title": "Scrolled output max height",
+      "description": "The default maximum height of cell outputs when scrolling is enabled. Accepts a CSS length. Manually resized outputs keep their custom height.",
+      "type": "string",
+      "pattern": "^(?:0|(?:[0-9]+|[0-9]*\\.[0-9]+)(?:px|em|rem|%|vw|vh|vmin|vmax|ch|ex|cm|mm|in|pt|pc))$",
+      "default": "24em"
+    },
     "scrollHeadingToTop": {
       "title": "Scroll heading to top",
       "description": "Whether to scroll heading to the document top when selecting it in the table of contents.",

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -2180,6 +2180,12 @@ function activateNotebookHandler(
       `${sideBySideOutputRatio}fr`
     );
 
+  const setScrolledOutputMaxHeight = (scrolledOutputMaxHeight: string) =>
+    document.documentElement.style.setProperty(
+      '--jp-cell-scrolled-output-max-height',
+      scrolledOutputMaxHeight
+    );
+
   // Fetch settings if possible.
   const fetchSettings = settingRegistry
     ? settingRegistry.load(trackerPlugin.id)
@@ -2470,6 +2476,9 @@ function activateNotebookHandler(
       showMinimap: settings.get('showMinimap').composite as boolean
     };
     setSideBySideOutputRatio(factory.notebookConfig.sideBySideOutputRatio);
+    setScrolledOutputMaxHeight(
+      settings.get('scrolledOutputMaxHeight').composite as string
+    );
     const sideBySideMarginStyle = `.jp-mod-sideBySide.jp-Notebook .jp-Notebook-cell {
       margin-left: ${factory.notebookConfig.sideBySideLeftMarginOverride} !important;
       margin-right: ${factory.notebookConfig.sideBySideRightMarginOverride} !important;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Fixes #7567

No overlapping open or closed PRs found for a configurable default scrolled-output height. Related history: #12740 added the per-cell resize handle; this PR only adds the default-height setting that issue was kept open for.

## Code changes

Scrolled outputs were hardcoded to `max-height: 24em`. This adds a notebook setting and applies it through a CSS custom property, without changing per-cell resize behavior.

Implementation contract:

- Setting: `scrolledOutputMaxHeight` in `@jupyterlab/notebook-extension:tracker`
- Type: CSS length (`px`, `em`, `rem`, `%`, viewport units, etc.)
- Default: `"24em"` (preserves current behavior)
- Applied via `--jp-cell-scrolled-output-max-height` on `:root`
- Hardcoded `max-height: 24em` in `packages/cells/style/widget.css` is replaced with that variable
- Settings updates apply immediately through the existing tracker settings listener
- Manual per-cell resize still uses `resize: vertical` and `[style*='height'] { max-height: unset; }`

## User-facing changes

Settings → Notebook now includes **Scrolled output max height**. Changing it updates the default scrolled-output cap without a reload. Drag-resizing a scrolled output still overrides the default.

Before (default `24em`):

![Default scrolled output height of 24em](https://raw.githubusercontent.com/nicolasdmolina/jupyterlab/screenshots-7567/before-24em-default.png)

After (`scrolledOutputMaxHeight: "120px"`):

![Configured scrolled output height of 120px](https://raw.githubusercontent.com/nicolasdmolina/jupyterlab/screenshots-7567/after-120px.png)

The after case is visibly shorter; the inset scroll shadow is unchanged.

## Backwards-incompatible changes

None. The default remains `24em`.

## Test evidence

- **TDD:** Galata test first failed with received `312px` (`24em`) vs expected `120px`, then passed after the implementation.
- Galata `output-scrolling.test.ts` (chromium, local darwin):
  - `uses the configured default scrolled output height` — passed
  - `updates the default height when the setting changes` — passed
  - `manual resize still overrides the default height` — passed
- `@jupyterlab/cells` `widget.spec.ts`: 71 passed
- `@jupyterlab/notebook-extension` `tsc -b`: passed
- prettier / eslint / stylelint on changed files: passed
- `jlpm integrity`: passed
- `git diff --check`: passed
- Targeted rebuild: `@jupyterlab/notebook-extension` + `dev_mode`

Additional local test context:

- Running the complete `output-scrolling.test.ts` file on macOS produced 3 passing new behavioral tests and 2 unevaluable pre-existing visual tests because this repository does not track Darwin baseline snapshots for them; Linux visual snapshots are unchanged.
- The full cross-platform `jlpm test` / Galata matrix (Linux snapshots, Firefox, documentation) was not run locally.
- Python tests were not run because this PR changes no Python code.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Grok 4.6 (xAI)