### PR TITLE
Restore running examples tests on CI

### DIFF
--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -152,7 +152,7 @@ jobs:
         id: pw-version
         run: |
           set -e
-          PW_VERSION=$(grep -m1 "playwright@" yarn.lock)
+          PW_VERSION=$(grep -m1 '^"playwright@npm:' yarn.lock)
           echo "Playwright version: $PW_VERSION"
           echo "version=$PW_VERSION" >> $GITHUB_OUTPUT
         working-directory: core
@@ -347,7 +347,7 @@ jobs:
         id: pw-version
         run: |
           set -e
-          PW_VERSION=$(grep -m1 "playwright@" yarn.lock)
+          PW_VERSION=$(grep -m1 '^"playwright@npm:' yarn.lock)
           PW_PACKAGE_VERSION=$(echo "$PW_VERSION" | sed -E 's/^"playwright@npm:([^"]+)":/\1/')
           echo "Playwright version: $PW_VERSION"
           echo "version=$PW_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -378,7 +378,6 @@ jobs:
           bash ./scripts/ci_script.sh
           TEST_EXIT_CODE=$?
 
-          mkdir -p galata/test-results
           mkdir -p galata/blob-report
 
           find examples packages/services/examples -type d -name test-results | while read -r RESULTS_DIR; do
@@ -390,6 +389,14 @@ jobs:
           find examples packages/services/examples -type d -name blob-report | while read -r BLOB_DIR; do
             cp -R "${BLOB_DIR}/." galata/blob-report/
           done
+
+          REPORT_COUNT=$(find galata/test-results -name report.json 2>/dev/null | wc -l)
+          BLOB_COUNT=$(find galata/blob-report -name '*.zip' 2>/dev/null | wc -l)
+          echo "Collected ${REPORT_COUNT} Playwright report(s) and ${BLOB_COUNT} blob report(s)."
+          if [[ "${REPORT_COUNT}" -eq 0 ]]; then
+            echo "::error::No Playwright report was collected: the example tests did not run."
+            exit 1
+          fi
 
           exit $TEST_EXIT_CODE
 

--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -68,7 +68,7 @@ jobs:
         id: pw-version
         run: |
           set -e
-          PW_VERSION=$(grep -m1 "playwright@" yarn.lock)
+          PW_VERSION=$(grep -m1 '^"playwright@npm:' yarn.lock)
           echo "Playwright version: $PW_VERSION"
           echo "version=$PW_VERSION" >> $GITHUB_OUTPUT
 

--- a/examples/app/rspack.config.js
+++ b/examples/app/rspack.config.js
@@ -61,6 +61,12 @@ module.exports = [
           test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
           issuer: /\.js$/,
           type: 'asset/source'
+        },
+        {
+          test: /\.m?js/,
+          resolve: {
+            fullySpecified: false
+          }
         }
       ]
     },

--- a/examples/cell/rspack.config.js
+++ b/examples/cell/rspack.config.js
@@ -44,6 +44,12 @@ module.exports = {
       {
         test: /\.(png|jpg|gif|ttf|woff|woff2|eot)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         type: 'asset'
+      },
+      {
+        test: /\.m?js/,
+        resolve: {
+          fullySpecified: false
+        }
       }
     ]
   },

--- a/examples/console/rspack.config.js
+++ b/examples/console/rspack.config.js
@@ -44,6 +44,12 @@ module.exports = {
       {
         test: /\.(png|jpg|gif|ttf|woff|woff2|eot)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         type: 'asset'
+      },
+      {
+        test: /\.m?js/,
+        resolve: {
+          fullySpecified: false
+        }
       }
     ]
   },

--- a/examples/filebrowser/rspack.config.js
+++ b/examples/filebrowser/rspack.config.js
@@ -44,6 +44,12 @@ module.exports = {
       {
         test: /\.(png|jpg|gif|ttf|woff|woff2|eot)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         type: 'asset'
+      },
+      {
+        test: /\.m?js/,
+        resolve: {
+          fullySpecified: false
+        }
       }
     ]
   },

--- a/examples/localization/rspack.config.js
+++ b/examples/localization/rspack.config.js
@@ -40,6 +40,12 @@ module.exports = {
       {
         test: /\.(png|jpg|gif|ttf|woff|woff2|eot)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         type: 'asset'
+      },
+      {
+        test: /\.m?js/,
+        resolve: {
+          fullySpecified: false
+        }
       }
     ]
   },

--- a/examples/notebook/rspack.config.js
+++ b/examples/notebook/rspack.config.js
@@ -44,6 +44,12 @@ module.exports = {
       {
         test: /\.(png|jpg|gif|ttf|woff|woff2|eot)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         type: 'asset'
+      },
+      {
+        test: /\.m?js/,
+        resolve: {
+          fullySpecified: false
+        }
       }
     ]
   },

--- a/examples/terminal/rspack.config.js
+++ b/examples/terminal/rspack.config.js
@@ -43,6 +43,12 @@ module.exports = {
       {
         test: /\.(png|jpg|gif|ttf|woff|woff2|eot)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         type: 'asset'
+      },
+      {
+        test: /\.m?js/,
+        resolve: {
+          fullySpecified: false
+        }
       }
     ]
   },

--- a/packages/services/examples/typescript-browser-with-output/rspack.config.js
+++ b/packages/services/examples/typescript-browser-with-output/rspack.config.js
@@ -52,6 +52,12 @@ module.exports = {
       {
         test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
         type: 'asset'
+      },
+      {
+        test: /\.m?js/,
+        resolve: {
+          fullySpecified: false
+        }
       }
     ]
   },

--- a/packages/ui-components/examples/simple-windowed-list/rspack.config.js
+++ b/packages/ui-components/examples/simple-windowed-list/rspack.config.js
@@ -43,6 +43,12 @@ module.exports = {
         test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
         issuer: /\.js$/,
         type: 'asset/source'
+      },
+      {
+        test: /\.m?js/,
+        resolve: {
+          fullySpecified: false
+        }
       }
     ]
   },

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -181,6 +181,19 @@ if [[ $GROUP == release_test ]]; then
 fi
 
 
+if [[ $GROUP == examples ]]; then
+    # Run the integrity script to link binary files
+    jlpm integrity
+
+    # Build the examples.
+    jlpm build:packages
+    jlpm build:examples
+
+    # Test the examples
+    jlpm test:examples
+fi
+
+
 if [[ $GROUP == usage ]]; then
     # Run the integrity script to link binary files
     jlpm integrity


### PR DESCRIPTION
## References

- Noticed in https://github.com/jupyterlab/jupyterlab/pull/19557#discussion_r3850033668
- Incorrectly dropped in #19007 - no example tests were run since

## Code changes

- [x] Add a step to confirm that examples tests ran
   <img width="704" height="543" alt="image" src="https://github.com/user-attachments/assets/740ff244-2e80-42c3-8a34-d9234b876c4c" />
- [x] Restore running `jlpm test:examples` on CI
- [x] Fix failures accumulated since it was disabled (if needed)

After

<img width="481" height="150" alt="image" src="https://github.com/user-attachments/assets/63a67915-de3f-4859-843d-22ba9beee8bb" />

https://github.com/jupyterlab/jupyterlab/actions/runs/32827397258/job/97738321191?pr=19607#step:7:1434

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage


- **Yes**: Some or all of the content of this PR was generated by AI.
- **Yes**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Opus 5