### PR TITLE
Update dessant/lock-threads to v6.0.2 to fix the token length check

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -14,7 +14,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7 # v6
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
         with:
           github-token: ${{ github.token }}
           issue-inactive-days: '180'


### PR DESCRIPTION
## References

No open issue. Evidence is the run history for [`Lock Closed Threads`](https://github.com/jupyterlab/jupyterlab/actions/workflows/lock.yml).

## Code changes

The workflow has failed 89 scheduled runs in a row on `main`. Last green run was 2026-05-28. Every failure since is the same error, most recently in [run 32793241518](https://github.com/jupyterlab/jupyterlab/actions/runs/32793241518) on 2026-08-25:

```
##[error]"github-token" length must be less than or equal to 100 characters long
```

`dessant/lock-threads` validates its own input with `Joi.string().trim().max(100)` in `src/schema.js`. The `GITHUB_TOKEN` that Actions issues grew past 100 characters in late May 2026, so the action exits at input validation before doing any work.

The pinned SHA `7266a7ce` is the `v6.0.0` tag. The `# v6` comment reads as current, but v6.0.0 and v6.0.1 both cap at 100. Only v6.0.2 raises the cap, to 1000 ([upstream fix](https://github.com/dessant/lock-threads/commit/a329c89), closing dessant/lock-threads#55). This repins to the `v6.0.2` tag and changes nothing else.

## User-facing changes

Closed issues and PRs inactive for 180 days resume being locked.

## Backwards-incompatible changes

None.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **NO**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude Code (Claude Opus 5)
