### PR TITLE
Restore "Clear Outputs of All Cells" in Notebook context menu

### DIFF
--- a/docs/source/user/interface_customization.md
+++ b/docs/source/user/interface_customization.md
@@ -411,6 +411,26 @@ Users can add a "Open in Simple Mode" context menu option by adding the followin
 }
 ```
 
+### Notebook
+
+The selector is matched against the element which was clicked and all its parents.
+Because the cells are inside the notebook, `.jp-Notebook` matches both a click on a
+cell and a click on the empty space of the notebook. To tell the two apart, the
+notebook records what the click was on in its `data-jp-context-menu-target`
+attribute, which is either `cell` or `notebook`:
+
+```json
+{
+  "command": "notebook:clear-all-cell-outputs",
+  "selector": ".jp-Notebook[data-jp-context-menu-target=\"notebook\"]",
+  "rank": 22
+}
+```
+
+This is how "Clear Outputs of All Cells" is offered on the empty space of the
+notebook only. Use `.jp-Notebook` instead to also offer an entry on the cells, or
+`.jp-Notebook .jp-Cell` to offer it on the cells only.
+
 (custom-css)=
 
 ```{include} custom_css.md

--- a/galata/test/jupyterlab/contextmenu.test.ts
+++ b/galata/test/jupyterlab/contextmenu.test.ts
@@ -224,6 +224,33 @@ test.describe('Application Context Menu', () => {
       const menu = await page.menu.getOpenMenuLocator();
       expect(await menu.screenshot()).toMatchSnapshot(imageName);
     });
+
+    test('Open context on notebook empty space', async ({ page }) => {
+      // Right-click in the notebook padding, which is left of the cells.
+      await page
+        .locator('.jp-Notebook .jp-WindowedPanel-viewport')
+        .click({ button: 'right', position: { x: 5, y: 20 } });
+
+      await expect(
+        page.getByRole('menuitem', { name: 'Clear Outputs of All Cells' })
+      ).toBeVisible();
+    });
+
+    test('Clear Outputs of All Cells is not offered on a cell', async ({
+      page
+    }) => {
+      await page.click('text=from IPython.display import Image', {
+        button: 'right'
+      });
+      // Wait for the cell context menu to open.
+      await expect(
+        page.getByRole('menuitem', { name: 'Clear Cell Output' })
+      ).toBeVisible();
+
+      await expect(
+        page.getByRole('menuitem', { name: 'Clear Outputs of All Cells' })
+      ).toBeHidden();
+    });
   });
 
   test('Open file editor context menu', async ({ page }) => {

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -334,6 +334,11 @@
         "rank": 21
       },
       {
+        "command": "notebook:clear-all-cell-outputs",
+        "selector": ".jp-Notebook[data-jp-context-menu-target=\"notebook\"]",
+        "rank": 22
+      },
+      {
         "type": "separator",
         "selector": ".jp-Notebook",
         "rank": 30

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -57,6 +57,12 @@ const CODE_RUNNER = 'jpCodeRunner';
 const UNDOER = 'jpUndoer';
 
 /**
+ * The data attribute recording what the most recent context menu event of the
+ * notebook happened over: `cell` or `notebook`.
+ */
+const CONTEXT_MENU_TARGET = 'jpContextMenuTarget';
+
+/**
  * The class name added to notebook widgets.
  */
 const NB_CLASS = 'jp-Notebook';
@@ -3163,6 +3169,12 @@ export class Notebook extends StaticNotebook {
    * Handle `contextmenu` event.
    */
   private _evtContextMenuCapture(event: PointerEvent): void {
+    const [target, index] = this._findEventTargetAndCell(event);
+
+    // Record what the context menu was opened over; this runs before the
+    // application builds the menu, so items can be scoped with a selector.
+    this.node.dataset[CONTEXT_MENU_TARGET] = index === -1 ? 'notebook' : 'cell';
+
     // Allow the event to propagate un-modified if the user
     // is holding the shift-key (and probably requesting
     // the native context menu).
@@ -3170,7 +3182,6 @@ export class Notebook extends StaticNotebook {
       return;
     }
 
-    const [target, index] = this._findEventTargetAndCell(event);
     const widget = this.widgets[index];
 
     if (widget && widget.editorWidget?.node.contains(target)) {


### PR DESCRIPTION


## References

Closes #19413 
 
## Code changes

Adds `data-jp-context-menu-target` data attribute to allow targeting the context menu opened over notebook but not over a cell.

> It is not strictly needed - one could already use `.jp-Notebook:not(:has(.jp-Cell:hover))` selector - but that selector is quite cryptic and has a small, but not entirely negligible) cost to evaluate.

## User-facing changes

Restores "Clear Outputs of All Cells" context menu item that was dropped in 4.6.0 but only when menu is opened over a notebook but not over a cell.

## Backwards-incompatible changes

None

## AI usage

- **Yes**: Some or all of the content of this PR was generated by AI.
- **Yes**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Opus 5