### PR TITLE
Show context actions for all images, not only SVGs

### DIFF
--- a/galata/test/jupyterlab/contextmenu.test.ts
+++ b/galata/test/jupyterlab/contextmenu.test.ts
@@ -141,6 +141,18 @@ test.describe('Application Context Menu', () => {
     await image.click({ button: 'right' });
 
     expect(await page.menu.isAnyOpen()).toBe(true);
+    for (const action of [
+      'Zoom In',
+      'Zoom Out',
+      'Reset Image',
+      'Rotate Clockwise',
+      'Rotate Counterclockwise',
+      'Flip image horizontally',
+      'Flip image vertically',
+      'Invert Colors'
+    ]) {
+      await expect(page.getByRole('menuitem', { name: action })).toBeVisible();
+    }
     await expect(
       page.getByRole('menuitem', { name: 'Copy Image' })
     ).toBeVisible();

--- a/packages/imageviewer-extension/schema/plugin.json
+++ b/packages/imageviewer-extension/schema/plugin.json
@@ -5,42 +5,42 @@
     "context": [
       {
         "command": "imageviewer:zoom-in",
-        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "selector": ".jp-ImageViewer",
         "rank": 1
       },
       {
         "command": "imageviewer:zoom-out",
-        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "selector": ".jp-ImageViewer",
         "rank": 2
       },
       {
         "command": "imageviewer:reset-image",
-        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "selector": ".jp-ImageViewer",
         "rank": 3
       },
       {
         "command": "imageviewer:rotate-clockwise",
-        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "selector": ".jp-ImageViewer",
         "rank": 4
       },
       {
         "command": "imageviewer:rotate-counterclockwise",
-        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "selector": ".jp-ImageViewer",
         "rank": 5
       },
       {
         "command": "imageviewer:flip-horizontal",
-        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "selector": ".jp-ImageViewer",
         "rank": 6
       },
       {
         "command": "imageviewer:flip-vertical",
-        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "selector": ".jp-ImageViewer",
         "rank": 7
       },
       {
         "command": "imageviewer:invert-colors",
-        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "selector": ".jp-ImageViewer",
         "rank": 8
       }
     ]


### PR DESCRIPTION
## References

Fixes #19610.

The security changes in #19184 introduced the SVG-specific class and the context-menu entries. This pull request corrects the selector scope of those entries; it does not alter the security handling or command implementations.

Related image-viewer PRs #18237 and #18811 focus on zoom behavior and do not change this selector.

## Code changes

- Change all eight image-viewer context-menu selectors from `.jp-ImageViewer.jp-mod-svg` to `.jp-ImageViewer`.
- Add a Galata regression assertion that opens a PNG and checks that all eight image actions are present.

The common selector matches the class applied to every `ImageViewer`, the existing keyboard shortcut selectors, and the format-independent command implementations.

## User-facing changes

Zoom, reset, rotate, flip, and invert actions are now available from an image context menu for supported raster and text-backed image formats, instead of only for SVG images. Command behavior and keyboard shortcuts are unchanged.

## Backwards-incompatible changes

None.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **NO**: The human author has not yet completed the required review of this PR; it remains a draft until that review is complete.
- AI tools and models used: OpenAI Codex (GPT-5).

OpenAI Codex assisted with the implementation and verification. Human review remains required before this PR is marked ready.

## Verification

- `jlpm workspace @jupyterlab/imageviewer test --runInBand` (12 passed)
- `jlpm workspace @jupyterlab/imageviewer-extension build`
- `jlpm workspace @jupyterlab/galata build:galata`
- `jlpm test test/jupyterlab/contextmenu.test.ts --project jupyterlab --grep "Open image context menu"` (1 passed)
- `pre-commit run --files packages/imageviewer-extension/schema/plugin.json galata/test/jupyterlab/contextmenu.test.ts`
- `git diff --check`
