### PR TITLE
Backport PR #19618 on branch 4.6.x (Show context actions for all images, not only SVGs)

### DIFF
--- a/galata/test/jupyterlab/contextmenu.test.ts
+++ b/galata/test/jupyterlab/contextmenu.test.ts
@@ -6,6 +6,7 @@ import { expect, galata, test } from '@jupyterlab/galata';
 import * as path from 'path';
 
 const filebrowserId = 'filebrowser';
+const testImageName = 'lighthouse.png';
 const testFileName = 'simple.md';
 const testNotebook = 'simple_notebook.ipynb';
 const testFolderName = 'test-folder';
@@ -26,6 +27,10 @@ test.describe('Application Context Menu', () => {
     await contents.uploadFile(
       path.resolve(__dirname, `./notebooks/${testFileName}`),
       `${tmpPath}/${testFileName}`
+    );
+    await contents.uploadFile(
+      path.resolve(__dirname, '../../../docs/source/images/lighthouse.png'),
+      `${tmpPath}/${testImageName}`
     );
     // Create a dummy folder
     await contents.createDirectory(`${tmpPath}/${testFolderName}`);
@@ -126,6 +131,28 @@ test.describe('Application Context Menu', () => {
     const imageName = `tab-launcher.png`;
     const menu = await page.menu.getOpenMenuLocator();
     expect(await menu.screenshot()).toMatchSnapshot(imageName);
+  });
+
+  test('Open image context menu', async ({ page, tmpPath }) => {
+    await page.filebrowser.open(`${tmpPath}/${testImageName}`);
+
+    const image = page.locator('.jp-ImageViewer img');
+    await image.waitFor();
+    await image.click({ button: 'right' });
+
+    expect(await page.menu.isAnyOpen()).toBe(true);
+    for (const action of [
+      'Zoom In',
+      'Zoom Out',
+      'Reset Image',
+      'Rotate Clockwise',
+      'Rotate Counterclockwise',
+      'Flip image horizontally',
+      'Flip image vertically',
+      'Invert Colors'
+    ]) {
+      await expect(page.getByRole('menuitem', { name: action })).toBeVisible();
+    }
   });
 
   test.describe('Notebook context menus', () => {

--- a/packages/imageviewer-extension/schema/plugin.json
+++ b/packages/imageviewer-extension/schema/plugin.json
@@ -5,42 +5,42 @@
     "context": [
       {
         "command": "imageviewer:zoom-in",
-        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "selector": ".jp-ImageViewer",
         "rank": 1
       },
       {
         "command": "imageviewer:zoom-out",
-        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "selector": ".jp-ImageViewer",
         "rank": 2
       },
       {
         "command": "imageviewer:reset-image",
-        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "selector": ".jp-ImageViewer",
         "rank": 3
       },
       {
         "command": "imageviewer:rotate-clockwise",
-        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "selector": ".jp-ImageViewer",
         "rank": 4
       },
       {
         "command": "imageviewer:rotate-counterclockwise",
-        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "selector": ".jp-ImageViewer",
         "rank": 5
       },
       {
         "command": "imageviewer:flip-horizontal",
-        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "selector": ".jp-ImageViewer",
         "rank": 6
       },
       {
         "command": "imageviewer:flip-vertical",
-        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "selector": ".jp-ImageViewer",
         "rank": 7
       },
       {
         "command": "imageviewer:invert-colors",
-        "selector": ".jp-ImageViewer.jp-mod-svg",
+        "selector": ".jp-ImageViewer",
         "rank": 8
       }
     ]


### PR DESCRIPTION
## References

- Backport of the merged [#19618](https://github.com/jupyterlab/jupyterlab/pull/19618) to `4.6.x`.
- Related to [#19610](https://github.com/jupyterlab/jupyterlab/issues/19610), which tracked the original image context-menu bug.
- The original PR was merged by a maintainer and labeled `Still Needs Manual Backport`; this PR carries only the maintenance-branch-compatible changes.

## Code changes

- Change all eight image-viewer context-menu selectors from `.jp-ImageViewer.jp-mod-svg` to `.jp-ImageViewer`.
- Add a Galata regression test that uploads the existing `lighthouse.png` fixture, opens it, and checks all eight image actions in the context menu.
- Keep the test setup compatible with `4.6.x`; newer `Copy Image` assertions are intentionally omitted because that command is not present on this branch.

## User-facing changes

Image context menus on supported raster and text-backed image formats now expose the same zoom, reset, rotate, flip, and invert actions that were previously available only for SVG images. Command behavior and keyboard shortcuts are unchanged.

## Backwards-incompatible changes

None.

## AI usage

- **YES**: OpenAI Codex assisted with the backport, test setup, and verification.
- **NO**: The human author has not yet completed the required review of this draft; it should remain a draft until that review is complete.
- AI tools and models used: OpenAI Codex (GPT-5).

## Verification

- `jlpm install --immutable`
- `jlpm build:dev`
- `jlpm workspace @jupyterlab/imageviewer test --runInBand` (12 passed)
- `jlpm workspace @jupyterlab/imageviewer-extension build`
- `jlpm workspace @jupyterlab/galata build:galata`
- `pre-commit run --files packages/imageviewer-extension/schema/plugin.json galata/test/jupyterlab/contextmenu.test.ts`
- `TARGET_URL=http://127.0.0.1:8888 jlpm test test/jupyterlab/contextmenu.test.ts --project jupyterlab --grep "Open image context menu"` (1 passed, 4.8s)
- `git diff --check`
- `git verify-commit` (GitHub-Verified SSH signature for `fly1d <309400591+fly1d@users.noreply.github.com>`)
