### PR TITLE
Fix tab order in find and replace overlay

### DIFF
--- a/galata/test/jupyterlab/notebook-search.test.ts
+++ b/galata/test/jupyterlab/notebook-search.test.ts
@@ -124,7 +124,7 @@ test.describe('Notebook Search', () => {
     await page.keyboard.press('Shift+Tab');
     await expect(page.getByPlaceholder('Find')).toBeFocused();
 
-    await page.getByPlaceholder('Replace').focus();
+    await page.getByRole('button', { name: 'Replace All' }).focus();
     await page.keyboard.press('Tab');
     await expect(page.getByTitle('Match Case')).toBeFocused();
   });

--- a/galata/test/jupyterlab/notebook-search.test.ts
+++ b/galata/test/jupyterlab/notebook-search.test.ts
@@ -111,6 +111,24 @@ test.describe('Notebook Search', () => {
     expect(await overlay.screenshot()).toMatchSnapshot('multi-line-search.png');
   });
 
+  test('Tab from Find focuses Replace when replace is shown', async ({
+    page
+  }) => {
+    await page.keyboard.press('Control+f');
+    await page.click('button[title="Show Replace"]');
+
+    await page.getByPlaceholder('Find').focus();
+    await page.keyboard.press('Tab');
+    await expect(page.getByPlaceholder('Replace')).toBeFocused();
+
+    await page.keyboard.press('Shift+Tab');
+    await expect(page.getByPlaceholder('Find')).toBeFocused();
+
+    await page.getByPlaceholder('Replace').focus();
+    await page.keyboard.press('Tab');
+    await expect(page.getByTitle('Match Case')).toBeFocused();
+  });
+
   test('Populate search box with selected text', async ({ page }) => {
     // Enter first cell
     await page.notebook.enterCellEditingMode(0);

--- a/galata/test/jupyterlab/notebook-search.test.ts
+++ b/galata/test/jupyterlab/notebook-search.test.ts
@@ -67,6 +67,20 @@ test.describe('Notebook Search', () => {
     await expect(page.locator('[placeholder="Find"]')).toHaveValue('1234');
   });
 
+  test('Typing in replace box', async ({ page }) => {
+    // Replace shares SearchInput with Find, but must not select() on each
+    // replaceText update or typed characters get overwritten.
+    await page.keyboard.press('Control+f');
+    await page.click('button[title="Show Replace"]');
+
+    await page.fill('[placeholder="Replace"]', '14');
+    await page.press('[placeholder="Replace"]', 'ArrowLeft');
+    await page.locator('[placeholder="Replace"]').pressSequentially('2');
+    await page.locator('[placeholder="Replace"]').pressSequentially('3');
+
+    await expect(page.locator('[placeholder="Replace"]')).toHaveValue('1234');
+  });
+
   test('Consecutive searches in the search box', async ({ page }) => {
     await page.keyboard.press('Control+f');
 

--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -141,11 +141,13 @@ interface ISearchEntryProps {
   onWordToggled: () => void;
   onKeydown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
   onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onMatchCaseKeyDown?: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
   caseSensitive: boolean;
   useRegex: boolean;
   wholeWords: boolean;
   initialSearchText: string;
   lastSearchText: string;
+  matchCaseButtonRef?: React.RefObject<HTMLButtonElement>;
   translator?: ITranslator;
 }
 
@@ -185,6 +187,8 @@ function SearchEntry(props: ISearchEntryProps): JSX.Element {
         onClick={() => {
           props.onCaseSensitiveToggled();
         }}
+        onKeyDown={props.onMatchCaseKeyDown}
+        ref={props.matchCaseButtonRef}
         tabIndex={0}
         title={trans.__('Match Case')}
       >
@@ -219,6 +223,7 @@ interface IReplaceEntryProps {
   preserveCase: boolean;
   replaceOptionsSupport: IReplaceOptionsSupport | undefined;
   replaceText: string;
+  inputRef?: React.RefObject<HTMLTextAreaElement>;
   translator?: ITranslator;
 }
 
@@ -238,6 +243,7 @@ function ReplaceEntry(props: IReplaceEntryProps): JSX.Element {
           initialValue={props.replaceText ?? ''}
           onKeyDown={e => props.onReplaceKeydown(e)}
           onChange={e => props.onChange(e)}
+          inputRef={props.inputRef}
           title={trans.__('Replace')}
           autoFocus={false}
           autoUpdate={false}
@@ -556,12 +562,27 @@ class SearchOverlay extends React.Component<ISearchOverlayProps> {
     this.translator = props.translator || nullTranslator;
   }
 
+  private _replaceTabStopVisible(): boolean {
+    return !this.props.isReadOnly && this.props.replaceEntryVisible;
+  }
+
   private _onSearchChange(event: React.ChangeEvent) {
     const searchText = (event.target as HTMLTextAreaElement).value;
     this.props.onSearchChanged(searchText);
   }
 
   private _onSearchKeydown(event: React.KeyboardEvent) {
+    // Tab from Find should land on Replace first, not Match Case.
+    if (
+      event.key === 'Tab' &&
+      !event.shiftKey &&
+      this._replaceTabStopVisible()
+    ) {
+      event.preventDefault();
+      event.stopPropagation();
+      this._replaceInput.current?.focus();
+      return;
+    }
     if (event.key === 'Enter') {
       event.stopPropagation();
       event.preventDefault();
@@ -578,6 +599,18 @@ class SearchOverlay extends React.Component<ISearchOverlayProps> {
   }
 
   private _onReplaceKeydown(event: React.KeyboardEvent) {
+    if (event.key === 'Tab' && event.shiftKey) {
+      event.preventDefault();
+      event.stopPropagation();
+      this.props.searchInputRef.current?.focus();
+      return;
+    }
+    if (event.key === 'Tab' && !event.shiftKey) {
+      event.preventDefault();
+      event.stopPropagation();
+      this._matchCaseButton.current?.focus();
+      return;
+    }
     if (event.key === 'Enter') {
       event.stopPropagation();
       event.preventDefault();
@@ -586,6 +619,18 @@ class SearchOverlay extends React.Component<ISearchOverlayProps> {
       } else {
         this.props.onReplaceCurrent();
       }
+    }
+  }
+
+  private _onMatchCaseKeyDown(event: React.KeyboardEvent<HTMLButtonElement>) {
+    if (
+      event.key === 'Tab' &&
+      event.shiftKey &&
+      this._replaceTabStopVisible()
+    ) {
+      event.preventDefault();
+      event.stopPropagation();
+      this._replaceInput.current?.focus();
     }
   }
 
@@ -721,6 +766,10 @@ class SearchOverlay extends React.Component<ISearchOverlayProps> {
             onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
               this._onSearchChange(e)
             }
+            onMatchCaseKeyDown={(e: React.KeyboardEvent<HTMLButtonElement>) =>
+              this._onMatchCaseKeyDown(e)
+            }
+            matchCaseButtonRef={this._matchCaseButton}
             initialSearchText={this.props.initialSearchText}
             lastSearchText={this.props.lastSearchText}
             translator={this.translator}
@@ -773,6 +822,7 @@ class SearchOverlay extends React.Component<ISearchOverlayProps> {
                 replaceOptionsSupport={this.props.replaceOptionsSupport}
                 replaceText={this.props.replaceText}
                 preserveCase={this.props.preserveCase}
+                inputRef={this._replaceInput}
                 translator={this.translator}
               />
               <div className={SPACER_CLASS}></div>
@@ -788,6 +838,8 @@ class SearchOverlay extends React.Component<ISearchOverlayProps> {
   }
 
   protected translator: ITranslator;
+  private _replaceInput = React.createRef<HTMLTextAreaElement>();
+  private _matchCaseButton = React.createRef<HTMLButtonElement>();
 }
 
 /**

--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -219,11 +219,13 @@ interface IReplaceEntryProps {
   onReplaceCurrent: () => void;
   onReplaceAll: () => void;
   onReplaceKeydown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  onReplaceAllKeyDown?: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
   onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   preserveCase: boolean;
   replaceOptionsSupport: IReplaceOptionsSupport | undefined;
   replaceText: string;
   inputRef?: React.RefObject<HTMLTextAreaElement>;
+  replaceAllButtonRef?: React.RefObject<HTMLButtonElement>;
   translator?: ITranslator;
 }
 
@@ -272,6 +274,8 @@ function ReplaceEntry(props: IReplaceEntryProps): JSX.Element {
       <button
         className={REPLACE_BUTTON_WRAPPER_CLASS}
         onClick={() => props.onReplaceAll()}
+        onKeyDown={props.onReplaceAllKeyDown}
+        ref={props.replaceAllButtonRef}
       >
         <span className={`${REPLACE_BUTTON_CLASS} ${BUTTON_CONTENT_CLASS}`}>
           {trans.__('Replace All')}
@@ -566,6 +570,12 @@ class SearchOverlay extends React.Component<ISearchOverlayProps> {
     return !this.props.isReadOnly && this.props.replaceEntryVisible;
   }
 
+  private _isPlainTab(event: React.KeyboardEvent): boolean {
+    return (
+      event.key === 'Tab' && !event.ctrlKey && !event.metaKey && !event.altKey
+    );
+  }
+
   private _onSearchChange(event: React.ChangeEvent) {
     const searchText = (event.target as HTMLTextAreaElement).value;
     this.props.onSearchChanged(searchText);
@@ -574,7 +584,7 @@ class SearchOverlay extends React.Component<ISearchOverlayProps> {
   private _onSearchKeydown(event: React.KeyboardEvent) {
     // Tab from Find should land on Replace first, not Match Case.
     if (
-      event.key === 'Tab' &&
+      this._isPlainTab(event) &&
       !event.shiftKey &&
       this._replaceTabStopVisible()
     ) {
@@ -599,16 +609,10 @@ class SearchOverlay extends React.Component<ISearchOverlayProps> {
   }
 
   private _onReplaceKeydown(event: React.KeyboardEvent) {
-    if (event.key === 'Tab' && event.shiftKey) {
+    if (this._isPlainTab(event) && event.shiftKey) {
       event.preventDefault();
       event.stopPropagation();
       this.props.searchInputRef.current?.focus();
-      return;
-    }
-    if (event.key === 'Tab' && !event.shiftKey) {
-      event.preventDefault();
-      event.stopPropagation();
-      this._matchCaseButton.current?.focus();
       return;
     }
     if (event.key === 'Enter') {
@@ -622,15 +626,27 @@ class SearchOverlay extends React.Component<ISearchOverlayProps> {
     }
   }
 
+  private _onReplaceAllKeyDown(event: React.KeyboardEvent<HTMLButtonElement>) {
+    if (
+      this._isPlainTab(event) &&
+      !event.shiftKey &&
+      this._replaceTabStopVisible()
+    ) {
+      event.preventDefault();
+      event.stopPropagation();
+      this._matchCaseButton.current?.focus();
+    }
+  }
+
   private _onMatchCaseKeyDown(event: React.KeyboardEvent<HTMLButtonElement>) {
     if (
-      event.key === 'Tab' &&
+      this._isPlainTab(event) &&
       event.shiftKey &&
       this._replaceTabStopVisible()
     ) {
       event.preventDefault();
       event.stopPropagation();
-      this._replaceInput.current?.focus();
+      this._replaceAllButton.current?.focus();
     }
   }
 
@@ -812,6 +828,9 @@ class SearchOverlay extends React.Component<ISearchOverlayProps> {
                 onReplaceKeydown={(e: React.KeyboardEvent) =>
                   this._onReplaceKeydown(e)
                 }
+                onReplaceAllKeyDown={(
+                  e: React.KeyboardEvent<HTMLButtonElement>
+                ) => this._onReplaceAllKeyDown(e)}
                 onChange={(e: React.ChangeEvent) =>
                   this.props.onReplaceChanged(
                     (e.target as HTMLTextAreaElement).value
@@ -823,6 +842,7 @@ class SearchOverlay extends React.Component<ISearchOverlayProps> {
                 replaceText={this.props.replaceText}
                 preserveCase={this.props.preserveCase}
                 inputRef={this._replaceInput}
+                replaceAllButtonRef={this._replaceAllButton}
                 translator={this.translator}
               />
               <div className={SPACER_CLASS}></div>
@@ -839,6 +859,7 @@ class SearchOverlay extends React.Component<ISearchOverlayProps> {
 
   protected translator: ITranslator;
   private _replaceInput = React.createRef<HTMLTextAreaElement>();
+  private _replaceAllButton = React.createRef<HTMLButtonElement>();
   private _matchCaseButton = React.createRef<HTMLButtonElement>();
 }
 

--- a/packages/documentsearch/src/searchview.tsx
+++ b/packages/documentsearch/src/searchview.tsx
@@ -101,7 +101,11 @@ function SearchInput(props: ISearchInputProps): JSX.Element {
     // triggers React re-render to update `defaultValue` (implemented via `key`)
     // which means that `focusSearchInput` is no longer effective as it has
     // already fired before the re-render, hence we use this conditional effect.
-    props.inputRef?.current?.select();
+    // Only the Find field remounts via `autoUpdate`. Do not select on Replace:
+    // typing updates model.replaceText and would otherwise overwrite the field.
+    if (props.autoUpdate) {
+      props.inputRef?.current?.select();
+    }
     // After any change to initial value we also want to update rows in case if
     // multi-line text was selected.
     updateDimensions();

--- a/packages/documentsearch/test/searchview.spec.ts
+++ b/packages/documentsearch/test/searchview.spec.ts
@@ -16,6 +16,7 @@ import { Widget } from '@lumino/widgets';
 
 class EditableSearchProvider extends SearchProvider {
   readonly isReadOnly = false;
+  replaceOptionsSupport = { preserveCase: false };
 
   async startQuery(_query: RegExp, _filters: IFilters): Promise<void> {
     return;
@@ -80,12 +81,16 @@ describe('documentsearch/searchview', () => {
       const replace = view.node.querySelector(
         '[placeholder="Replace"]'
       ) as HTMLTextAreaElement;
+      const replaceAll = Array.from(view.node.querySelectorAll('button')).find(
+        button => button.textContent?.includes('Replace All')
+      ) as HTMLButtonElement | undefined;
       const matchCase = view.node.querySelector(
         'button[title="Match Case"]'
       ) as HTMLButtonElement;
 
       expect(find).toBeTruthy();
       expect(replace).toBeTruthy();
+      expect(replaceAll).toBeTruthy();
       expect(matchCase).toBeTruthy();
 
       find.focus();
@@ -110,8 +115,8 @@ describe('documentsearch/searchview', () => {
       );
       expect(document.activeElement).toBe(find);
 
-      replace.focus();
-      replace.dispatchEvent(
+      replaceAll!.focus();
+      replaceAll!.dispatchEvent(
         new KeyboardEvent('keydown', {
           key: 'Tab',
           bubbles: true,
@@ -119,6 +124,68 @@ describe('documentsearch/searchview', () => {
         })
       );
       expect(document.activeElement).toBe(matchCase);
+    });
+
+    it('should not steal Ctrl+Tab from the Find field', async () => {
+      view.showReplace();
+      await framePromise();
+      await view.renderPromise;
+
+      const find = view.node.querySelector(
+        '[placeholder="Find"]'
+      ) as HTMLTextAreaElement;
+      const replace = view.node.querySelector(
+        '[placeholder="Replace"]'
+      ) as HTMLTextAreaElement;
+
+      find.focus();
+      find.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Tab',
+          ctrlKey: true,
+          bubbles: true,
+          cancelable: true
+        })
+      );
+      expect(document.activeElement).toBe(find);
+      expect(document.activeElement).not.toBe(replace);
+    });
+
+    it('should tab from Replace to Preserve Case when that option exists', async () => {
+      provider.replaceOptionsSupport = { preserveCase: true };
+      view.showReplace();
+      await framePromise();
+      await view.renderPromise;
+
+      const find = view.node.querySelector(
+        '[placeholder="Find"]'
+      ) as HTMLTextAreaElement;
+      const replace = view.node.querySelector(
+        '[placeholder="Replace"]'
+      ) as HTMLTextAreaElement;
+      const preserveCase = view.node.querySelector(
+        'button[title="Preserve Case"]'
+      ) as HTMLButtonElement;
+
+      expect(preserveCase).toBeTruthy();
+
+      find.focus();
+      find.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Tab',
+          bubbles: true,
+          cancelable: true
+        })
+      );
+      expect(document.activeElement).toBe(replace);
+
+      const tabEvent = new KeyboardEvent('keydown', {
+        key: 'Tab',
+        bubbles: true,
+        cancelable: true
+      });
+      replace.dispatchEvent(tabEvent);
+      expect(tabEvent.defaultPrevented).toBe(false);
     });
   });
 });

--- a/packages/documentsearch/test/searchview.spec.ts
+++ b/packages/documentsearch/test/searchview.spec.ts
@@ -1,0 +1,124 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  SearchDocumentModel,
+  SearchDocumentView,
+  SearchProvider
+} from '@jupyterlab/documentsearch';
+import type {
+  IFilters,
+  IReplaceOptions,
+  ISearchMatch
+} from '@jupyterlab/documentsearch';
+import { framePromise } from '@jupyterlab/testing';
+import { Widget } from '@lumino/widgets';
+
+class EditableSearchProvider extends SearchProvider {
+  readonly isReadOnly = false;
+
+  async startQuery(_query: RegExp, _filters: IFilters): Promise<void> {
+    return;
+  }
+  async endQuery(): Promise<void> {
+    return;
+  }
+  async clearHighlight(): Promise<void> {
+    return;
+  }
+  async highlightNext(): Promise<ISearchMatch | undefined> {
+    return undefined;
+  }
+  async highlightPrevious(): Promise<ISearchMatch | undefined> {
+    return undefined;
+  }
+  async replaceCurrentMatch(
+    _newText: string,
+    _loop?: boolean,
+    _options?: IReplaceOptions
+  ): Promise<boolean> {
+    return false;
+  }
+  async replaceAllMatches(
+    _newText: string,
+    _options?: IReplaceOptions
+  ): Promise<boolean> {
+    return false;
+  }
+}
+
+describe('documentsearch/searchview', () => {
+  describe('SearchDocumentView', () => {
+    let host: Widget;
+    let provider: EditableSearchProvider;
+    let model: SearchDocumentModel;
+    let view: SearchDocumentView;
+
+    beforeEach(async () => {
+      host = new Widget();
+      provider = new EditableSearchProvider(host);
+      model = new SearchDocumentModel(provider, 0);
+      view = new SearchDocumentView(model);
+      Widget.attach(view, document.body);
+      await framePromise();
+      await view.renderPromise;
+    });
+
+    afterEach(() => {
+      view.dispose();
+      host.dispose();
+    });
+
+    it('should tab from Find to Replace when replace is shown', async () => {
+      view.showReplace();
+      await framePromise();
+      await view.renderPromise;
+
+      const find = view.node.querySelector(
+        '[placeholder="Find"]'
+      ) as HTMLTextAreaElement;
+      const replace = view.node.querySelector(
+        '[placeholder="Replace"]'
+      ) as HTMLTextAreaElement;
+      const matchCase = view.node.querySelector(
+        'button[title="Match Case"]'
+      ) as HTMLButtonElement;
+
+      expect(find).toBeTruthy();
+      expect(replace).toBeTruthy();
+      expect(matchCase).toBeTruthy();
+
+      find.focus();
+      expect(document.activeElement).toBe(find);
+
+      find.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Tab',
+          bubbles: true,
+          cancelable: true
+        })
+      );
+      expect(document.activeElement).toBe(replace);
+
+      replace.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Tab',
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true
+        })
+      );
+      expect(document.activeElement).toBe(find);
+
+      replace.focus();
+      replace.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Tab',
+          bubbles: true,
+          cancelable: true
+        })
+      );
+      expect(document.activeElement).toBe(matchCase);
+    });
+  });
+});

--- a/packages/documentsearch/test/searchview.spec.ts
+++ b/packages/documentsearch/test/searchview.spec.ts
@@ -126,6 +126,29 @@ describe('documentsearch/searchview', () => {
       expect(document.activeElement).toBe(matchCase);
     });
 
+    it('should not select Replace text when replaceText changes', async () => {
+      view.showReplace();
+      await framePromise();
+      await view.renderPromise;
+
+      const replace = view.node.querySelector(
+        '[placeholder="Replace"]'
+      ) as HTMLTextAreaElement;
+
+      replace.focus();
+      replace.value = 'hello';
+      replace.setSelectionRange(5, 5);
+
+      model.replaceText = 'hello';
+      await framePromise();
+      await view.renderPromise;
+
+      expect(document.activeElement).toBe(replace);
+      expect(replace.value).toBe('hello');
+      expect(replace.selectionStart).toBe(5);
+      expect(replace.selectionEnd).toBe(5);
+    });
+
     it('should not steal Ctrl+Tab from the Find field', async () => {
       view.showReplace();
       await framePromise();


### PR DESCRIPTION
## References

Fixes #16808

## Code changes

When the replace row is open, Tab from the Find field went to Match Case because those option buttons sit next to Find in the DOM.

The overlay now intercepts Tab in that case so Find goes to Replace, Shift+Tab goes back, and Tab from Replace continues to Match Case. The visual layout is unchanged, and the option buttons stay in the keyboard sequence.

## User-facing changes

With Find and Replace both visible, Tab from Find lands on Replace first, matching typical find/replace dialogs. Keyboard users can still reach Match Case, Whole Word, and Use Regular Expression after Replace.

## Backwards-incompatible changes

None.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: coding assistant