### PR TITLE
fix: correct selected cell count in search filters

### DIFF
--- a/packages/notebook/src/searchprovider.ts
+++ b/packages/notebook/src/searchprovider.ts
@@ -62,6 +62,19 @@ export class NotebookSearchProvider extends SearchProvider<NotebookPanel> {
     );
     this._observeActiveCell();
     this._filtersChanged.connect(this._setEnginesSelectionSearchMode, this);
+
+    // Synchronously initialize _selectedCells from the widget's current
+    // selection state.  The reactive path (_onCellSelectionChanged →
+    // _updateCellSelection) only fires on future changes, so without this
+    // initialization a provider created while multiple cells are already
+    // selected would always report "Search in 1 Selected Cell" (issue #8015).
+    let initialSelectedCells = 0;
+    for (const cell of this.widget.content.widgets) {
+      if (this.widget.content.isSelectedOrActive(cell)) {
+        initialSelectedCells += 1;
+      }
+    }
+    this._selectedCells = initialSelectedCells;
   }
 
   private _onNotebookStateChanged(_: Notebook, args: IChangedArgs<unknown>) {

--- a/packages/notebook/test/searchprovider.spec.ts
+++ b/packages/notebook/test/searchprovider.spec.ts
@@ -581,6 +581,29 @@ describe('@jupyterlab/notebook', () => {
       });
     });
 
+    describe('#getFilters()', () => {
+      it('should report the correct selected-cell count when provider is created with two cells already selected (issue #8015)', () => {
+        // Arrange: put the notebook in command mode and select both cells
+        // before the search provider is instantiated, mimicking the
+        // user workflow: Shift+Up selects cells → Ctrl+F opens search.
+        panel.content.mode = 'command';
+        panel.content.activeCellIndex = 1;
+        panel.content.select(panel.content.widgets[0]);
+        panel.content.select(panel.content.widgets[1]);
+
+        // Act: create a fresh provider now that the selection is in place.
+        // The original code hard-coded _selectedCells = 1 and never
+        // initialised it synchronously, so getFilters() would always read 1.
+        const freshProvider = new NotebookSearchProvider(panel);
+        const filters = freshProvider.getFilters();
+
+        // Assert: both cells must be counted immediately, with no signal needed.
+        expect(filters['selection'].title).toBe('Search in 2 Selected Cells');
+
+        freshProvider.dispose();
+      });
+    });
+
     describe('#getSelectionState()', () => {
       it('should reflect cell selection state in command mode', async () => {
         panel.content.mode = 'command';


### PR DESCRIPTION
## Description

Fixes #8015.

When multiple notebook cells were already selected before the
`NotebookSearchProvider` was created, the Search and Replace filter
incorrectly reported only one selected cell.

The provider previously initialized `_selectedCells` to `1` and relied
on subsequent selection signals to update the value. This change
synchronously initializes the selected-cell count from the notebook's
current selection state when the provider is constructed.

## Tests

Added a regression test covering provider initialization when two cells
are already selected.

Tested with:

`jlpm test -- searchprovider.spec.ts`

Result:

- 1 test suite passed
- 30 tests passed
- 0 snapshots

Fixes #8015