### PR TITLE
docs(contributing): explain what `--extensions-in-dev-mode` actually changes

### DIFF
--- a/docs/source/developer/contributing.md
+++ b/docs/source/developer/contributing.md
@@ -499,9 +499,23 @@ jupyter lab --dev-mode
 ```
 
 Development mode ensures that you are running the JavaScript assets that
-are built in the dev-installed Python package. Note that when running in
-dev mode, extensions will not be activated by default - refer
-{ref}`documentation on extension development <prebuilt-dev-workflow>` to know more.
+are built in the dev-installed Python package. This includes the core
+packages in `packages/`, so changes there only require rebuilding those
+assets (see `--watch` below); no extra flag is needed for them.
+
+What dev mode does skip are the prebuilt extensions found in the
+`labextensions` search paths, that is third-party extensions installed with
+`pip`/`conda` or with `jupyter-builder develop` (`@jupyterlab/galata-extension`,
+used by the UI tests, is the only exception). To load them as well, for
+example when developing a prebuilt extension against the JupyterLab source
+repository, add `--extensions-in-dev-mode`:
+
+```bash
+jupyter lab --dev-mode --extensions-in-dev-mode
+```
+
+Refer to the {ref}`documentation on extension development <prebuilt-dev-workflow>`
+to know more.
 
 When running in dev mode, a red stripe will appear at the top of the
 page; this is to indicate running an unreleased version.


### PR DESCRIPTION
## References

Fixes #17420

## Problem

The "Run JupyterLab" section of the contributing guide says only:

> Note that when running in dev mode, extensions will not be activated by default

which does not say *which* extensions, and never mentions the flag that
changes this. In #17420 a maintainer asked for a mention of
`--extensions-in-dev-mode` closer to the `--dev-mode` instructions, and then
pointed out that two earlier attempts (#18915, #19131) documented the wrong
semantics — they claimed the flag is needed for changes to core packages in
`packages/` to show up, which is not true.

## Approach

Reword the paragraph so it states what dev mode actually does, and add the
flag next to the `jupyter lab --dev-mode` invocation:

- dev mode serves the JS assets built from the core `packages/` — no extra
  flag is involved there, only a rebuild (`--watch` is documented right below);
- what dev mode drops are the *prebuilt* extensions in the `labextensions`
  search paths (pip/conda installs, `jupyter-builder develop`), with
  `@jupyterlab/galata-extension` as the single exception;
- `--extensions-in-dev-mode` is what loads those, which is the case when
  developing a prebuilt extension against the JupyterLab source repo.

This matches `LabApp.initialize_templates()`, which only rewrites
`labextensions_path` / `extra_labextensions_path` (keeping the galata
exception) and leaves `static_paths` — the dev build of the core packages —
untouched:

https://github.com/jupyterlab/jupyterlab/blob/9312e29b7b/jupyterlab/labapp.py#L706-L723

and the flag's own help string, "Load prebuilt extensions in dev-mode"
(`labapp.py#L490-L493`).

Docs only, one file, no code change.

## Verification

Rather than trusting the prose, I ran `LabApp.initialize_templates()` with a
fake prebuilt-extension directory on both labextensions paths, once with the
flag and once without (jupyterlab 4.6.3, same branch code):

```python
app = LabApp(dev_mode=True)                      # or extensions_in_dev_mode=True
app.labextensions_path = [fake]
app.extra_labextensions_path = [fake]
app.initialize_templates()
```

```
default (flag absent)       : labextensions_path=[] extra=[]
                              static_paths=['.../dev_mode/static']
extensions_in_dev_mode=True : labextensions_path=['/tmp/fake-labextensions-...']
                              extra=['/tmp/fake-labextensions-...']
                              static_paths=['.../dev_mode/static']
```

So the flag only restores the labextensions search paths, and `static_paths`
(the core packages' dev build) is identical either way — which is exactly why
the "needed for `packages/` changes" wording in the earlier PRs was wrong.

Gates run on the changed file: `prettier@3.8.1 --check` (clean) and
`codespell --ignore-words=.codespellignore` (clean).

## Deliberately left out

- No change to `docs/source/extension/extension_dev.md`; the prebuilt
  development workflow there already documents the flag, and this PR just
  links to it from the contributing guide.
- No wording change to the `--watch` paragraph or to the `labapp.py` help
  strings.
