### PR TITLE
Do not lock an extension when it is only disabled

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1233,6 +1233,13 @@ class _AppHandler:
 
         if did_something:
             level_page_config["disabledExtensions"] = disabled_at_level
+            # Record the (unlocked) lock status explicitly, otherwise the 4.0 -> 4.1
+            # migration in `_maybe_mirror_disabled_in_locked` would mirror the entry
+            # written above onto `lockedExtensions` on the next command, locking an
+            # extension the user only meant to disable.
+            locked_at_level = level_page_config.get("lockedExtensions", {})
+            locked_at_level.setdefault(extension, False)
+            level_page_config["lockedExtensions"] = locked_at_level
             write_page_config(level_page_config, level=level)
         return did_something
 

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -572,6 +572,17 @@ class TestExtension(AppHandlerTest):
         assert not check_extension(name, app_options=options)
         assert check_extension(name, installed=True, app_options=options)
 
+    def test_disable_extension_does_not_lock_it(self):
+        options = AppOptions(app_dir=self.tempdir())
+        assert install_extension(self.mock_extension, app_options=options) is True
+        name = self.pkg_names["extension"]
+        assert disable_extension(name, app_options=options) is True
+        # Reading the info goes through a new handler, which runs the
+        # `disabledExtensions` -> `lockedExtensions` migration from 4.0
+        info = get_app_info(app_options=options)
+        assert info["disabled"].get(name) is True
+        assert info["locked"].get(name, False) is False
+
     def test_enable_extension(self):
         options = AppOptions(app_dir=self.tempdir())
         assert install_extension(self.mock_extension, app_options=options) is True


### PR DESCRIPTION
## References

Fixes #19647

## Code changes

`_AppHandler.__init__` runs `_maybe_mirror_disabled_in_locked`, the 4.0 → 4.1 migration that mirrors `disabledExtensions` onto `lockedExtensions`. It short-circuits when `lockedExtensions` is already present, but that marker is only written when there was something to migrate. On an installation whose `disabledExtensions` was empty at upgrade time, the marker is never written, the migration stays armed, and the next `_AppHandler` construction mirrors entries that `toggle_extension` itself wrote — locking an extension the user only disabled.

`toggle_extension` now records the (unlocked) lock status next to the disabled status it writes, so its own entries are not later mistaken for 4.0 state. An existing `True` lock is preserved (`setdefault`), and genuine 4.0 state still migrates, because the migration runs in `__init__` before `toggle_extension` writes anything.

An empty `lockedExtensions: {}` cannot be used as the marker instead: `jupyter_server.config_manager.recursive_update` prunes empty sub-dictionaries, so it is gone by the time the page config is read back.

## User-facing changes

Before, on an installation with no `labconfig/page_config.json`:

```console
$ jupyter labextension disable @jupyterlab/notebook-extension
Starting with JupyterLab 4.1 individual plugins can be re-enabled in the user interface. While all
plugins which were previously disabled have been locked, you need to explicitly lock any newly
disabled plugins by using `jupyter labextension lock` command.

$ jupyter labextension enable @jupyterlab/notebook-extension

$ cat <sys-prefix>/etc/jupyter/labconfig/page_config.json
{
  "disabledExtensions": {
    "@jupyterlab/notebook-extension": false
  },
  "lockedExtensions": {
    "@jupyterlab/notebook-extension": true
  }
}
```

After, same commands:

```console
$ cat <sys-prefix>/etc/jupyter/labconfig/page_config.json
{
  "disabledExtensions": {
    "@jupyterlab/notebook-extension": false
  },
  "lockedExtensions": {
    "@jupyterlab/notebook-extension": false
  }
}
```

`jupyter labextension disable` no longer locks the extension, matching what the command prints. On a setup where `SYSTEM_CONFIG_PATH == ENV_CONFIG_PATH` (the default on Windows) the spurious lock also made `jupyter labextension enable` fail with `Extension locked at a higher level, cannot toggle status`; that no longer happens either.

`jupyter labextension disable` now writes a `lockedExtensions` entry with value `false` for the toggled extension. `_is_locked` already skips entries explicitly marked `false`, and this is the same shape `jupyter labextension unlock` writes.

## Backwards-incompatible changes

None.

## Testing

- Added `TestExtension::test_disable_extension_does_not_lock_it`. It fails on `main` (`AssertionError: assert True is False`) and passes with this change.
- `pytest jupyterlab/tests` — 119 passed, 3 skipped (`test_jupyterlab.py`: 35 passed, 1 skipped; rest: 84 passed, 2 skipped), on Windows 11 / Python 3.12.10.
- `ruff check`, `ruff format --check` (0.16.1) and `mypy --config-file pyproject.toml` (1.20.2) all clean.
- Verified by hand that a pre-existing lock survives a subsequent `disable`, and that a hand-written 4.0-style `page_config.json` (`disabledExtensions` only) is still migrated to `lockedExtensions` on the next command.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **NO**: The human author has carefully reviewed this PR and run this code (keeping this PR draft until the answer is YES).
- AI tools and models used: Claude Code (Claude Opus). The defect was found by auditing `jupyterlab/commands.py`, reproduced on an unmodified checkout before any change was written, and every command output quoted above was actually run.
