### PR TITLE
Use dedicated font stack for DataGrid instead of content font alias

### DIFF
--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -188,7 +188,9 @@ all of MD as it is not optimized for dense, information rich UIs.
    * Data grid needs higher density than other user content to accommodate large data sets.
    */
   --jp-datagrid-font-size: 12px;
-  --jp-datagrid-font-family: var(--jp-content-font-family);
+  --jp-datagrid-font-family:
+    'Segoe UI', 'Helvetica Neue', helvetica, arial, roboto, 'Noto Sans',
+    sans-serif;
 
   /*
    * Code Fonts

--- a/packages/theme-dark-high-contrast-extension/style/variables.css
+++ b/packages/theme-dark-high-contrast-extension/style/variables.css
@@ -188,7 +188,9 @@ all of MD as it is not optimized for dense, information rich UIs.
    * Data grid needs higher density than other user content to accommodate large data sets.
    */
   --jp-datagrid-font-size: 12px;
-  --jp-datagrid-font-family: var(--jp-content-font-family);
+  --jp-datagrid-font-family:
+    'Segoe UI', 'Helvetica Neue', helvetica, arial, roboto, 'Noto Sans',
+    sans-serif;
 
   /*
    * Code Fonts

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -185,7 +185,9 @@ all of MD as it is not optimized for dense, information rich UIs.
    * Data grid needs higher density than other user content to accommodate large data sets.
    */
   --jp-datagrid-font-size: 12px;
-  --jp-datagrid-font-family: var(--jp-content-font-family);
+  --jp-datagrid-font-family:
+    'Segoe UI', 'Helvetica Neue', helvetica, arial, roboto, 'Noto Sans',
+    sans-serif;
 
   /*
    * Code Fonts


### PR DESCRIPTION
Use dedicated font stack for DataGrid instead of content font alias

DataGrid text is rendered through Lumino's canvas-based `TextRenderer`, where the content font alias does not reliably provide the desired font behavior. Define an explicit, cross-platform font stack for DataGrid text to improve font consistency and numeric alignment across platforms.

## References

Addresses #18557

## Code changes

* Replaced the `--jp-content-font-family` alias used by DataGrid with a dedicated, explicit font stack.
* Added the following cross-platform font stack for DataGrid text:
  `'Segoe UI', 'Helvetica Neue', helvetica, arial, roboto, 'Noto Sans', sans-serif`.
* Applied the dedicated font stack consistently across all three shipped JupyterLab themes.
* Kept the change scoped to DataGrid typography without modifying the global content font configuration.

## User-facing changes

DataGrid text now uses a dedicated cross-platform font stack instead of inheriting the content font alias. This provides more consistent text rendering and improved numeric alignment across supported platforms and themes.

## Backwards-incompatible changes

None.

## AI usage

* **YES**: Some or all of the content of this PR was generated by AI.
* **YES**: The human author has carefully reviewed and run this code (keep this PR "draft" until the answer is YES).
* AI tools and models used: opencode (mimo-v2.5)
