### PR TITLE
Remove pin to old ipykernel v7 pre-release in UI tests

### DIFF
--- a/.github/workflows/galata.yml
+++ b/.github/workflows/galata.yml
@@ -173,12 +173,6 @@ jobs:
           bash ./scripts/ci_install.sh
         working-directory: core
 
-      - name: Install ipykernel pre-release that supports subshells (TEMPORARY)
-        if: ${{ matrix.project != 'documentation' }}
-        run: |
-          uv pip install --system --upgrade --pre "ipykernel<=7.0.0a1"
-        working-directory: core
-
       - name: Launch JupyterLab
         run: |
           set -ex

--- a/scripts/ci_install.sh
+++ b/scripts/ci_install.sh
@@ -56,13 +56,6 @@ uv pip install --system -e "${SPEC}" || uv pip install --verbose --system -e "${
 node -p process.versions
 jlpm config
 
-if [[ $GROUP != js-services ]]; then
-    # Tests run much faster in ipykernel 6, so use that except for
-    # ikernel.spec.ts in js-services, which tests subshell compatibility in
-    # ipykernel 7.
-    uv pip install --system "ipykernel<7"
-fi
-
 if [[ $GROUP == nonode ]]; then
     # Build the wheel
     uv pip install --system build


### PR DESCRIPTION

## References

- closes #19671
- will bring up flaky tests noted in #17955 :( - but that's a problem for another day

## Code changes

Use released ipykernel v7 version on UI Tests CI

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

NA
