### PR TITLE
Fix execution count requirement for execute replies

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1856,7 +1856,7 @@ export namespace CodeCell {
       // Save this execution's future so we can compare in the catch below.
       future = cell.outputArea.future;
       const msg = (await msgPromise)!;
-      if (msg.content.status === 'ok') {
+      if ('execution_count' in msg.content) {
         model.executionCount = msg.content.execution_count;
       }
       if (recordTiming) {

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1856,7 +1856,9 @@ export namespace CodeCell {
       // Save this execution's future so we can compare in the catch below.
       future = cell.outputArea.future;
       const msg = (await msgPromise)!;
-      model.executionCount = msg.content.execution_count;
+      if (msg.content.status === 'ok') {
+        model.executionCount = msg.content.execution_count;
+      }
       if (recordTiming) {
         const timingInfo = Object.assign(
           {},

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1858,6 +1858,8 @@ export namespace CodeCell {
       const msg = (await msgPromise)!;
       if ('execution_count' in msg.content) {
         model.executionCount = msg.content.execution_count;
+      } else {
+        model.executionState = 'idle';
       }
       if (recordTiming) {
         const timingInfo = Object.assign(

--- a/packages/cells/test/widget.spec.ts
+++ b/packages/cells/test/widget.spec.ts
@@ -23,7 +23,6 @@ import { NBTestUtils } from '@jupyterlab/cells/lib/testutils';
 import { CodeEditorWrapper } from '@jupyterlab/codeeditor';
 import { OutputArea, OutputPrompt } from '@jupyterlab/outputarea';
 import { defaultRenderMime } from '@jupyterlab/rendermime/lib/testutils';
-import type { IExecuteReplyMsg } from '@jupyterlab/services/lib/kernel/messages';
 import {
   framePromise,
   JupyterServer,
@@ -975,9 +974,12 @@ describe('cells/widget', () => {
         expect(widget.promptNode!.textContent).toEqual('[*]:');
         const msg = await future2;
         expect(msg).not.toBeUndefined();
+        if (msg?.content.status !== 'ok') {
+          throw new Error('Expected an ok execute reply');
+        }
 
         expect(widget.promptNode!.textContent).toEqual(
-          `[${(msg as IExecuteReplyMsg).content.execution_count}]:`
+          `[${msg.content.execution_count}]:`
         );
       });
 

--- a/packages/cells/test/widget.spec.ts
+++ b/packages/cells/test/widget.spec.ts
@@ -23,6 +23,7 @@ import { NBTestUtils } from '@jupyterlab/cells/lib/testutils';
 import { CodeEditorWrapper } from '@jupyterlab/codeeditor';
 import { OutputArea, OutputPrompt } from '@jupyterlab/outputarea';
 import { defaultRenderMime } from '@jupyterlab/rendermime/lib/testutils';
+import { KernelMessage } from '@jupyterlab/services';
 import {
   framePromise,
   JupyterServer,
@@ -922,6 +923,29 @@ describe('cells/widget', () => {
         await CodeCell.execute(widget, sessionContext);
         const executionCount = widget.model.executionCount;
         expect(executionCount).not.toEqual(originalCount);
+      });
+
+      it('should return to idle after an uncounted aborted reply', async () => {
+        const widget = new CodeCell({
+          model,
+          rendermime,
+          contentFactory,
+          placeholder: false
+        });
+        widget.initializeState();
+        widget.model.sharedModel.setSource('foo');
+        const reply =
+          KernelMessage.createMessage<KernelMessage.IExecuteReplyMsg>({
+            msgType: 'execute_reply',
+            channel: 'shell',
+            session: 'baz',
+            content: { status: 'aborted' }
+          });
+        jest.spyOn(OutputArea, 'execute').mockResolvedValueOnce(reply);
+
+        await CodeCell.execute(widget, sessionContext);
+
+        expect(widget.model.executionState).toBe('idle');
       });
 
       const TIMING_KEYS = [

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -2783,7 +2783,9 @@ namespace Private {
           // The future is authoritative for the prompt number; a snapshot
           // taken before completion would be stale (still null). Setting a
           // non-null execution count also flips the state back to 'idle'.
-          cellRef.model.executionCount = reply.content.execution_count;
+          if (reply.content.status === 'ok') {
+            cellRef.model.executionCount = reply.content.execution_count;
+          }
           cellRef.model.executionState = 'idle';
         }
       },

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -62,14 +62,15 @@ export class KernelError extends Error {
    * Construct the kernel error.
    */
   constructor(content: KernelMessage.IExecuteReplyMsg['content']) {
-    const errorContent = content as KernelMessage.IReplyErrorContent;
-    const errorName = errorContent.ename;
-    const errorValue = errorContent.evalue;
+    const errorName =
+      content.status === 'error' ? content.ename : 'ExecutionAborted';
+    const errorValue =
+      content.status === 'error' ? content.evalue : 'Execution was aborted';
     super(`KernelReplyNotOK: ${errorName} ${errorValue}`);
 
     this.errorName = errorName;
     this.errorValue = errorValue;
-    this.traceback = errorContent.traceback;
+    this.traceback = content.status === 'error' ? content.traceback : [];
     Object.setPrototypeOf(this, KernelError.prototype);
   }
 }
@@ -2783,7 +2784,7 @@ namespace Private {
           // The future is authoritative for the prompt number; a snapshot
           // taken before completion would be stale (still null). Setting a
           // non-null execution count also flips the state back to 'idle'.
-          if (reply.content.status === 'ok') {
+          if ('execution_count' in reply.content) {
             cellRef.model.executionCount = reply.content.execution_count;
           }
           cellRef.model.executionState = 'idle';

--- a/packages/outputarea/test/widget.spec.ts
+++ b/packages/outputarea/test/widget.spec.ts
@@ -400,8 +400,10 @@ describe('outputarea/widget', () => {
         });
         widget.future = future;
         const reply = await future.done;
-        expect(reply!.content.execution_count).toBeTruthy();
         expect(reply!.content.status).toBe('ok');
+        if (reply!.content.status === 'ok') {
+          expect(reply!.content.execution_count).toBeTruthy();
+        }
         expect(model.length).toBe(1);
       });
 
@@ -412,7 +414,10 @@ describe('outputarea/widget', () => {
         });
         widget.future = future;
         const reply = await future.done;
-        expect(reply!.content.execution_count).toBeTruthy();
+        expect(reply!.content.status).toBe('ok');
+        if (reply!.content.status === 'ok') {
+          expect(reply!.content.execution_count).toBeTruthy();
+        }
         expect(model.length).toBe(1);
       });
     });
@@ -583,15 +588,20 @@ describe('outputarea/widget', () => {
 
       it('should execute code on a kernel and send outputs to the model', async () => {
         const reply = await OutputArea.execute(CODE, widget, sessionContext);
-        expect(reply!.content.execution_count).toBeTruthy();
         expect(reply!.content.status).toBe('ok');
+        if (reply!.content.status === 'ok') {
+          expect(reply!.content.execution_count).toBeTruthy();
+        }
         expect(model.length).toBe(1);
       });
 
       it('should clear existing outputs', async () => {
         widget.model.fromJSON(DEFAULT_OUTPUTS);
         const reply = await OutputArea.execute(CODE, widget, sessionContext);
-        expect(reply!.content.execution_count).toBeTruthy();
+        expect(reply!.content.status).toBe('ok');
+        if (reply!.content.status === 'ok') {
+          expect(reply!.content.execution_count).toBeTruthy();
+        }
         expect(model.length).toBe(1);
       });
 

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -1167,6 +1167,14 @@ export interface IExecuteReply extends IExecuteReplyBase {
 }
 
 /**
+ * The content of an `execute_reply` message.
+ */
+export type IExecuteReplyContent =
+  | IExecuteReply
+  | (IReplyErrorContent & IExecuteCount)
+  | IReplyAbortContent;
+
+/**
  * An `'execute_reply'` message on the `'stream'` channel.
  *
  * See [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html#execution-results).
@@ -1175,7 +1183,7 @@ export interface IExecuteReply extends IExecuteReplyBase {
  */
 export interface IExecuteReplyMsg extends IShellMessage<'execute_reply'> {
   parent_header: IHeader<'execute_request'>;
-  content: ReplyContent<IExecuteReply>;
+  content: IExecuteReplyContent;
 }
 
 /**

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -1175,7 +1175,7 @@ export interface IExecuteReply extends IExecuteReplyBase {
  */
 export interface IExecuteReplyMsg extends IShellMessage<'execute_reply'> {
   parent_header: IHeader<'execute_request'>;
-  content: ReplyContent<IExecuteReply> & IExecuteCount;
+  content: ReplyContent<IExecuteReply>;
 }
 
 /**

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -1172,7 +1172,8 @@ export interface IExecuteReply extends IExecuteReplyBase {
 export type IExecuteReplyContent =
   | IExecuteReply
   | (IReplyErrorContent & IExecuteCount)
-  | IReplyAbortContent;
+  | IReplyAbortContent
+  | (IReplyAbortContent & IExecuteCount);
 
 /**
  * An `'execute_reply'` message on the `'stream'` channel.

--- a/packages/services/test/kernel/messages.spec.ts
+++ b/packages/services/test/kernel/messages.spec.ts
@@ -74,6 +74,35 @@ describe('kernel/messages', () => {
     });
   });
 
+  describe('KernelMessage.IExecuteReplyMsg', () => {
+    it('should only require an execution count for successful replies', () => {
+      const replies: KernelMessage.IExecuteReplyMsg['content'][] = [
+        { status: 'abort' },
+        { status: 'aborted' },
+        {
+          status: 'error',
+          ename: 'Error',
+          evalue: 'failed',
+          traceback: []
+        },
+        {
+          status: 'ok',
+          execution_count: 1,
+          user_expressions: {}
+        }
+      ];
+
+      // @ts-expect-error execution_count is required for successful replies
+      const invalidReply: KernelMessage.IExecuteReplyMsg['content'] = {
+        status: 'ok',
+        user_expressions: {}
+      };
+
+      expect(replies).toHaveLength(4);
+      expect(invalidReply.status).toBe('ok');
+    });
+  });
+
   describe('KernelMessage.isStatusMsg()', () => {
     it('should check for a status message type', () => {
       const msg = KernelMessage.createMessage({

--- a/packages/services/test/kernel/messages.spec.ts
+++ b/packages/services/test/kernel/messages.spec.ts
@@ -75,12 +75,13 @@ describe('kernel/messages', () => {
   });
 
   describe('KernelMessage.IExecuteReplyMsg', () => {
-    it('should only require an execution count for successful replies', () => {
+    it('should only omit an execution count for aborted replies', () => {
       const replies: KernelMessage.IExecuteReplyMsg['content'][] = [
         { status: 'abort' },
         { status: 'aborted' },
         {
           status: 'error',
+          execution_count: 1,
           ename: 'Error',
           evalue: 'failed',
           traceback: []
@@ -98,8 +99,17 @@ describe('kernel/messages', () => {
         user_expressions: {}
       };
 
+      // @ts-expect-error execution_count is required for error replies
+      const invalidError: KernelMessage.IExecuteReplyMsg['content'] = {
+        status: 'error',
+        ename: 'Error',
+        evalue: 'failed',
+        traceback: []
+      };
+
       expect(replies).toHaveLength(4);
       expect(invalidReply.status).toBe('ok');
+      expect(invalidError.status).toBe('error');
     });
   });
 

--- a/packages/services/test/kernel/messages.spec.ts
+++ b/packages/services/test/kernel/messages.spec.ts
@@ -79,6 +79,8 @@ describe('kernel/messages', () => {
       const replies: KernelMessage.IExecuteReplyMsg['content'][] = [
         { status: 'abort' },
         { status: 'aborted' },
+        { status: 'abort', execution_count: 1 },
+        { status: 'aborted', execution_count: 1 },
         {
           status: 'error',
           execution_count: 1,
@@ -107,7 +109,7 @@ describe('kernel/messages', () => {
         traceback: []
       };
 
-      expect(replies).toHaveLength(4);
+      expect(replies).toHaveLength(6);
       expect(invalidReply.status).toBe('ok');
       expect(invalidError.status).toBe('error');
     });


### PR DESCRIPTION
## References

Fixes #17686. Replaces #19463 after its branch history was repaired.

## Code changes

Allow abort and aborted execute replies with or without `execution_count`, keep it required for successful and error replies, and return cells to idle when an aborted reply omits the count. Output-area tests now narrow reply status before reading the count.

## User-facing changes

Aborted executions no longer leave directly executed code cells stuck in the running state.

## Backwards-incompatible changes

None.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code.
- AI tools and models used: OpenAI Codex (GPT-5)