### PR TITLE
Add accessible announcement service

### DIFF
--- a/packages/apputils-extension/schema/accessible-announcer.json
+++ b/packages/apputils-extension/schema/accessible-announcer.json
@@ -1,0 +1,22 @@
+{
+  "title": "Accessibility announcements",
+  "description": "Settings for messages announced to screen readers.",
+  "jupyter.lab.setting-icon": "ui-components:accessibility",
+  "additionalProperties": false,
+  "properties": {
+    "enabled": {
+      "title": "Enable accessibility announcements",
+      "description": "Whether application messages should be announced to screen readers.",
+      "type": "boolean",
+      "default": true
+    },
+    "clearTimeout": {
+      "title": "Announcement clear timeout",
+      "description": "The time in milliseconds after which an announcement is cleared. Set to 0 to keep announcements until they are replaced.",
+      "type": "number",
+      "minimum": 0,
+      "default": 5000
+    }
+  },
+  "type": "object"
+}

--- a/packages/apputils-extension/src/accessibleAnnouncer.ts
+++ b/packages/apputils-extension/src/accessibleAnnouncer.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import type { JupyterFrontEndPlugin } from '@jupyterlab/application';
+import {
+  AccessibleAnnouncer,
+  IAccessibleAnnouncer
+} from '@jupyterlab/apputils';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+
+/**
+ * The accessibility announcement service.
+ */
+export const accessibleAnnouncerPlugin: JupyterFrontEndPlugin<IAccessibleAnnouncer> =
+  {
+    id: '@jupyterlab/apputils-extension:accessible-announcer',
+    description: 'Provides an API for announcing messages to screen readers.',
+    autoStart: true,
+    provides: IAccessibleAnnouncer,
+    optional: [ISettingRegistry],
+    activate: (_app, settingRegistry: ISettingRegistry | null) => {
+      const announcer = new AccessibleAnnouncer();
+
+      if (settingRegistry) {
+        void settingRegistry
+          .load(accessibleAnnouncerPlugin.id)
+          .then(settings => {
+            const updateSettings = () => {
+              announcer.enabled = settings.get('enabled').composite as boolean;
+              announcer.clearTimeout = settings.get('clearTimeout')
+                .composite as number;
+            };
+
+            updateSettings();
+            settings.changed.connect(updateSettings);
+          });
+      }
+
+      return announcer;
+    }
+  };

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -54,6 +54,7 @@ import { displayShortcuts } from './shortcuts';
 import type { Kernel } from '@jupyterlab/services';
 import { IKernelManager } from '@jupyterlab/services';
 import { moveSectionsPlugin } from './movesectionsplugin';
+import { accessibleAnnouncerPlugin } from './accessibleAnnouncer';
 
 /**
  * The interval in milliseconds before recover options appear during splash.
@@ -928,6 +929,7 @@ const movableSectionRegistry: JupyterFrontEndPlugin<IMovableSectionRegistry> = {
  */
 const plugins: JupyterFrontEndPlugin<any>[] = [
   kernelSettings,
+  accessibleAnnouncerPlugin,
   announcements,
   kernelStatus,
   licensesClient,

--- a/packages/apputils/src/accessibleAnnouncer.ts
+++ b/packages/apputils/src/accessibleAnnouncer.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import type { IDisposable } from '@lumino/disposable';
+import type { IAccessibleAnnouncer } from './tokens';
+
+/**
+ * A DOM-backed screen-reader announcement service.
+ */
+export class AccessibleAnnouncer implements IAccessibleAnnouncer, IDisposable {
+  /**
+   * Create an accessibility announcer.
+   *
+   * @param host - The element to which the live region is attached.
+   */
+  constructor(host: HTMLElement = document.body) {
+    this.node = document.createElement('div');
+    this.node.className = 'jp-sr-only';
+    this.node.setAttribute('role', 'status');
+    this.node.setAttribute('aria-live', 'polite');
+    this.node.setAttribute('aria-atomic', 'true');
+    host.appendChild(this.node);
+  }
+
+  /**
+   * The live region DOM node.
+   */
+  readonly node: HTMLElement;
+
+  /**
+   * Whether announcements are enabled.
+   */
+  get enabled(): boolean {
+    return this._enabled;
+  }
+
+  set enabled(value: boolean) {
+    this._enabled = value;
+    if (!value) {
+      this.clear();
+    }
+  }
+
+  /**
+   * The default time in milliseconds before an announcement is cleared.
+   */
+  get clearTimeout(): number {
+    return this._clearTimeout;
+  }
+
+  set clearTimeout(value: number) {
+    this._clearTimeout = Math.max(0, value);
+  }
+
+  /**
+   * Whether the announcer has been disposed.
+   */
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
+  /**
+   * Announce a message to screen readers.
+   */
+  announce(message: string, options: IAccessibleAnnouncer.IOptions = {}): void {
+    if (this._isDisposed || !this._enabled) {
+      return;
+    }
+
+    this._clearTimer();
+    this.node.setAttribute(
+      'aria-live',
+      options.assertive ? 'assertive' : 'polite'
+    );
+    this.node.textContent = '';
+    this.node.textContent = message;
+
+    const timeout = options.clearTimeout ?? this._clearTimeout;
+    if (timeout > 0) {
+      this._timer = window.setTimeout(() => this.clear(), timeout);
+    }
+  }
+
+  /**
+   * Clear the current announcement.
+   */
+  clear(): void {
+    this._clearTimer();
+    this.node.textContent = '';
+  }
+
+  /**
+   * Dispose the announcer and remove its live region.
+   */
+  dispose(): void {
+    if (this._isDisposed) {
+      return;
+    }
+
+    this._isDisposed = true;
+    this._clearTimer();
+    this.node.remove();
+  }
+
+  private _clearTimer(): void {
+    if (this._timer !== null) {
+      window.clearTimeout(this._timer);
+      this._timer = null;
+    }
+  }
+
+  private _enabled = true;
+  private _clearTimeout = 5000;
+  private _isDisposed = false;
+  private _timer: number | null = null;
+}

--- a/packages/apputils/src/index.ts
+++ b/packages/apputils/src/index.ts
@@ -35,6 +35,7 @@ export type {
 } from '@jupyterlab/ui-components';
 
 export * from './clipboard';
+export * from './accessibleAnnouncer';
 export * from './commandlinker';
 export * from './commandpalette';
 export * from './dialog';

--- a/packages/apputils/src/tokens.ts
+++ b/packages/apputils/src/tokens.ts
@@ -21,6 +21,54 @@ export const ICommandPalette = new Token<ICommandPalette>(
 );
 
 /**
+ * An accessibility service for announcing messages to screen readers.
+ */
+export const IAccessibleAnnouncer = new Token<IAccessibleAnnouncer>(
+  '@jupyterlab/apputils:IAccessibleAnnouncer',
+  'A service for announcing application messages to screen readers.'
+);
+
+/**
+ * A service for announcing messages to screen readers.
+ */
+export interface IAccessibleAnnouncer {
+  /**
+   * Announce a message.
+   *
+   * @param message - The message to announce.
+   * @param options - Announcement options.
+   */
+  announce(message: string, options?: IAccessibleAnnouncer.IOptions): void;
+
+  /**
+   * Clear the current announcement.
+   */
+  clear(): void;
+}
+
+export namespace IAccessibleAnnouncer {
+  /**
+   * Options for an accessibility announcement.
+   */
+  export interface IOptions {
+    /**
+     * Whether to announce the message assertively.
+     *
+     * Defaults to `false`.
+     */
+    assertive?: boolean;
+
+    /**
+     * Time in milliseconds after which to clear the message.
+     *
+     * A value of `0` keeps the message until the next announcement or an
+     * explicit call to `clear`.
+     */
+    clearTimeout?: number;
+  }
+}
+
+/**
  * The options for creating a command palette item.
  */
 export interface IPaletteItem extends CommandPalette.IItemOptions {}

--- a/packages/apputils/test/accessibleAnnouncer.spec.ts
+++ b/packages/apputils/test/accessibleAnnouncer.spec.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { AccessibleAnnouncer } from '@jupyterlab/apputils';
+
+describe('AccessibleAnnouncer', () => {
+  let announcer: AccessibleAnnouncer;
+
+  beforeEach(() => {
+    announcer = new AccessibleAnnouncer();
+  });
+
+  afterEach(() => {
+    announcer.dispose();
+  });
+
+  it('creates a polite live region', () => {
+    expect(announcer.node.getAttribute('role')).toEqual('status');
+    expect(announcer.node.getAttribute('aria-live')).toEqual('polite');
+    expect(announcer.node.getAttribute('aria-atomic')).toEqual('true');
+    expect(document.body.contains(announcer.node)).toBe(true);
+  });
+
+  it('announces messages and supports assertive priority', () => {
+    announcer.announce('A polite message');
+    expect(announcer.node.textContent).toEqual('A polite message');
+    expect(announcer.node.getAttribute('aria-live')).toEqual('polite');
+
+    announcer.announce('An urgent message', { assertive: true });
+    expect(announcer.node.textContent).toEqual('An urgent message');
+    expect(announcer.node.getAttribute('aria-live')).toEqual('assertive');
+  });
+
+  it('clears announcements after the configured timeout', () => {
+    jest.useFakeTimers();
+    announcer.clearTimeout = 1000;
+    announcer.announce('Temporary message');
+
+    jest.advanceTimersByTime(999);
+    expect(announcer.node.textContent).toEqual('Temporary message');
+
+    jest.advanceTimersByTime(1);
+    expect(announcer.node.textContent).toEqual('');
+    jest.useRealTimers();
+  });
+
+  it('does not announce when disabled', () => {
+    announcer.enabled = false;
+    announcer.announce('Hidden message');
+
+    expect(announcer.node.textContent).toEqual('');
+  });
+
+  it('removes the live region on dispose', () => {
+    const node = announcer.node;
+    announcer.dispose();
+
+    expect(document.body.contains(node)).toBe(false);
+    expect(announcer.isDisposed).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #16145

## Summary

- Add a public `IAccessibleAnnouncer` token and DOM-backed implementation to `@jupyterlab/apputils`.
- Register the service from `@jupyterlab/apputils-extension`.
- Add settings to enable/disable announcements and configure live-region cleanup.
- Clear pending messages and remove the live region on disposal to avoid stale announcements.
- Add focused regression tests for polite/assertive announcements, disabling, timeout cleanup, and disposal.

## Validation

- `yarn workspace @jupyterlab/apputils build:test`
- `yarn workspace @jupyterlab/apputils-extension build:test`
- `yarn workspace @jupyterlab/apputils test --runInBand --watchman=false accessibleAnnouncer.spec.ts`
- `yarn workspace @jupyterlab/apputils-extension test --runInBand --watchman=false`
- Prettier and ESLint on changed files