### PR TITLE
Avoid duplicate content visibility listeners

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -378,13 +378,9 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
     if (this.isDisposed) {
       return;
     }
+    this._disconnectContentVisibilityObserver();
     this._notebookModel = null;
     (this.layout as NotebookWindowedLayout).header?.dispose();
-    //  Disconnect the content-visibility observer
-    if (this._contentVisibilityObserver) {
-      this._contentVisibilityObserver.disconnect();
-      this._contentVisibilityObserver = null;
-    }
     super.dispose();
     // In the windowing modes that detach out-of-viewport cells from the
     // layout ('full' and 'defer'), `Widget.dispose()` above only disposes
@@ -406,11 +402,8 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
   }
 
   protected onBeforeDetach(msg: Message): void {
-    //  Disconnect the content-visibility observer
-    if (this._contentVisibilityObserver) {
-      this._contentVisibilityObserver.disconnect();
-      this._contentVisibilityObserver = null;
-    }
+    // Disconnect the content-visibility observer and its model listener.
+    this._disconnectContentVisibilityObserver();
     super.onBeforeDetach(msg);
   }
 
@@ -607,6 +600,13 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
     newValue: INotebookModel | null
   ): void {
     if (oldValue) {
+      oldValue.cells.changed.disconnect(
+        this._onContentVisibilityCellsChanged,
+        this
+      );
+      if (this._contentVisibilityModel === oldValue) {
+        this._contentVisibilityModel = null;
+      }
       oldValue.contentChanged.disconnect(this.onModelContentChanged, this);
       oldValue.metadataChanged.disconnect(this.onMetadataChanged, this);
       oldValue.cells.changed.disconnect(this._onCellsChanged, this);
@@ -641,6 +641,9 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
     newValue.cells.changed.connect(this._onCellsChanged, this);
     newValue.metadataChanged.connect(this.onMetadataChanged, this);
     newValue.contentChanged.connect(this.onModelContentChanged, this);
+    if (this._notebookConfig.windowingMode === 'contentVisibility') {
+      this._setupContentVisibilityObserver();
+    }
   }
 
   /**
@@ -1159,11 +1162,7 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
         cell.node.style.removeProperty('contain');
       });
 
-      // Disconnect observer if it exists
-      if (this._contentVisibilityObserver) {
-        this._contentVisibilityObserver.disconnect();
-        this._contentVisibilityObserver = null;
-      }
+      this._disconnectContentVisibilityObserver();
     }
   }
 
@@ -1214,16 +1213,42 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
       this._contentVisibilityObserver!.observe(cell.node)
     );
 
-    // Watch for newly added cells and set intrinsic size for them too
-    this.model?.cells.changed.connect(() => {
-      requestAnimationFrame(() => {
-        this.cellsArray.forEach((cell, i) => {
-          const estHeight = this._viewModel.estimateWidgetSize(i);
-          cell.node.style.containIntrinsicSize = `auto ${estHeight}px`;
-          this._contentVisibilityObserver!.observe(cell.node);
-        });
+    // Watch for newly added cells and set intrinsic size for them too. Keep a
+    // stable callback so repeated setup calls do not accumulate listeners.
+    const model = this.model;
+    if (model && this._contentVisibilityModel !== model) {
+      this._contentVisibilityModel?.cells.changed.disconnect(
+        this._onContentVisibilityCellsChanged,
+        this
+      );
+      model.cells.changed.connect(this._onContentVisibilityCellsChanged, this);
+      this._contentVisibilityModel = model;
+    }
+  }
+
+  private _onContentVisibilityCellsChanged = (): void => {
+    requestAnimationFrame(() => {
+      if (!this._contentVisibilityObserver || this.isDisposed) {
+        return;
+      }
+      this.cellsArray.forEach((cell, i) => {
+        const estHeight = this._viewModel.estimateWidgetSize(i);
+        cell.node.style.containIntrinsicSize = `auto ${estHeight}px`;
+        this._contentVisibilityObserver!.observe(cell.node);
       });
-    }, this);
+    });
+  };
+
+  private _disconnectContentVisibilityObserver(): void {
+    if (this._contentVisibilityObserver) {
+      this._contentVisibilityObserver.disconnect();
+      this._contentVisibilityObserver = null;
+    }
+    this._contentVisibilityModel?.cells.changed.disconnect(
+      this._onContentVisibilityCellsChanged,
+      this
+    );
+    this._contentVisibilityModel = null;
   }
 
   protected cellsArray: Array<Cell>;
@@ -1242,6 +1267,7 @@ export class StaticNotebook extends WindowedList<NotebookViewModel> {
   private _renderingLayout: RenderingLayout | undefined;
   private _renderingLayoutChanged = new Signal<this, RenderingLayout>(this);
   private _contentVisibilityObserver: IntersectionObserver | null = null;
+  private _contentVisibilityModel: INotebookModel | null = null;
   private _pageHandler: IPageHandler | undefined;
 }
 

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -875,6 +875,32 @@ describe('@jupyter/notebook', () => {
       });
     });
 
+    describe('content visibility setup', () => {
+      it('should not accumulate cell-list listeners', () => {
+        const widget = createWidget();
+        const model = widget.model!;
+        const connect = jest.spyOn(model.cells.changed, 'connect');
+
+        const contentVisibilityConfig = {
+          ...widget.notebookConfig,
+          windowingMode: 'contentVisibility' as const
+        };
+        widget.notebookConfig = contentVisibilityConfig;
+        widget.notebookConfig = contentVisibilityConfig;
+
+        expect(connect).toHaveBeenCalledTimes(1);
+
+        widget.notebookConfig = {
+          ...contentVisibilityConfig,
+          windowingMode: 'none'
+        };
+        widget.notebookConfig = contentVisibilityConfig;
+        expect(connect).toHaveBeenCalledTimes(2);
+
+        widget.dispose();
+      });
+    });
+
     describe('#onCellInserted()', () => {
       it('should be called when a cell is inserted', () => {
         const widget = createWidget();


### PR DESCRIPTION
## References

Fixes #19268

## Code changes

The notebook widget now owns the content-visibility cell-list listener. Repeated setup calls reuse one listener, and it is disconnected when content visibility is disabled, the widget detaches, or the model changes.

## User-facing changes

No intentional user-facing behavior change. This prevents duplicate listeners and repeated cell rescans.

## Backwards-incompatible changes

None.

## Tests

`corepack yarn workspace @jupyterlab/notebook test --runInBand test/widget.spec.ts --testNamePattern content visibility setup`