### PR TITLE
Cache and throttle path resolution to avoid requests storm

### DIFF
--- a/packages/metapackage/test/rendermime/registry.spec.ts
+++ b/packages/metapackage/test/rendermime/registry.spec.ts
@@ -608,6 +608,41 @@ describe('rendermime/registry', () => {
           expect(resolutions[199]).toEqual({ scope: 'server', path: 'foo.py' });
         });
 
+        it('should send at most four requests at a time', async () => {
+          // Distinct paths cannot be answered from the cache, and the server
+          // takes one path per request, so they are paced instead.
+          const answer: (() => void)[] = [];
+          const { resolver, fetchMock } = resolverWithMockedServer({
+            respond: () =>
+              new Promise<Response>(resolve => {
+                answer.push(() =>
+                  resolve(new Response(JSON.stringify({ resolved: [] })))
+                );
+              })
+          });
+          const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+          const asked = Promise.all(
+            Array.from({ length: 20 }, (_, path) =>
+              resolver.resolvePath(`/tmp/foo${path}.py`)
+            )
+          );
+          await flush();
+          expect(fetchMock).toHaveBeenCalledTimes(4);
+
+          // Each answer lets the next resolution in that lane start.
+          answer[0]();
+          await flush();
+          expect(fetchMock).toHaveBeenCalledTimes(5);
+
+          while (answer.length) {
+            answer.pop()!();
+            await flush();
+          }
+          await asked;
+          expect(fetchMock).toHaveBeenCalledTimes(20);
+        });
+
         it('should forget results obtained for a previous kernel', async () => {
           let kernelId = UUID.uuid4();
           const { resolver, fetchMock } = resolverWithMockedServer({

--- a/packages/metapackage/test/rendermime/registry.spec.ts
+++ b/packages/metapackage/test/rendermime/registry.spec.ts
@@ -594,6 +594,35 @@ describe('rendermime/registry', () => {
           expect(fetchMock).toHaveBeenCalledTimes(1);
         });
 
+        it('should not remember a path the server failed to answer', async () => {
+          // A failed request does not show whether the file exists, unlike an
+          // answer of `resolved: []`.
+          const answers = [
+            () => Promise.reject(new TypeError('offline')),
+            () => Promise.resolve(new Response('', { status: 500 })),
+            () =>
+              Promise.resolve(
+                new Response(
+                  JSON.stringify({
+                    resolved: [{ scope: 'server', path: 'foo.py' }]
+                  }),
+                  { status: 200 }
+                )
+              )
+          ];
+          const { resolver, fetchMock } = resolverWithMockedServer({
+            respond: () => answers.shift()!()
+          });
+
+          expect(await resolver.resolvePath('/tmp/foo.py')).toBeNull();
+          expect(await resolver.resolvePath('/tmp/foo.py')).toBeNull();
+          expect(await resolver.resolvePath('/tmp/foo.py')).toEqual({
+            scope: 'server',
+            path: 'foo.py'
+          });
+          expect(fetchMock).toHaveBeenCalledTimes(3);
+        });
+
         it('should send one request for concurrent resolutions of a path', async () => {
           // A streamed output which prints a path-like string on every line
           // (see https://github.com/jupyterlab/jupyterlab/issues/19721) asks

--- a/packages/metapackage/test/rendermime/registry.spec.ts
+++ b/packages/metapackage/test/rendermime/registry.spec.ts
@@ -581,6 +581,19 @@ describe('rendermime/registry', () => {
           expect(fetchMock).toHaveBeenCalledTimes(1);
         });
 
+        it('should send one request for a path which is not a file', async () => {
+          // The reported case: the path-like text resolves to nothing, and
+          // that answer has to be remembered like any other.
+          const { resolver, fetchMock } = resolverWithMockedServer({
+            respond: async () =>
+              new Response(JSON.stringify({ resolved: [] }), { status: 200 })
+          });
+
+          expect(await resolver.resolvePath('/18/2025')).toBeNull();
+          expect(await resolver.resolvePath('/18/2025')).toBeNull();
+          expect(fetchMock).toHaveBeenCalledTimes(1);
+        });
+
         it('should send one request for concurrent resolutions of a path', async () => {
           // A streamed output which prints a path-like string on every line
           // (see https://github.com/jupyterlab/jupyterlab/issues/19721) asks
@@ -668,23 +681,21 @@ describe('rendermime/registry', () => {
       });
 
       describe('path links in a streamed output', () => {
-        it('should resolve a repeated path once', async () => {
-          // A program writing a date to stderr prints a path-like string on
-          // every line, and every chunk of the stream re-renders the whole
-          // output, so the same path is looked up over and over. Resolving
-          // each of those separately froze the application, see
-          // https://github.com/jupyterlab/jupyterlab/issues/19721
+        /**
+         * Render 50 stderr lines carrying the same path-like string, one line
+         * per chunk, against a server answering every path with `resolved`.
+         */
+        async function renderStreamedLines(
+          resolved: { scope: string; path: string }[]
+        ) {
           const contents = new ContentsManager();
           const settings = contents.serverSettings as IWritableSettings;
           const previousFetch = settings.fetch;
-          const fetchMock = jest.fn().mockResolvedValue(
-            new Response(
-              JSON.stringify({
-                resolved: [{ scope: 'server', path: 'dates.log' }]
-              }),
-              { status: 200 }
-            )
-          );
+          const fetchMock = jest
+            .fn()
+            .mockResolvedValue(
+              new Response(JSON.stringify({ resolved }), { status: 200 })
+            );
           settings.fetch = fetchMock as ServerConnection.ISettings['fetch'];
 
           const rendermime = new RenderMimeRegistry({
@@ -716,15 +727,38 @@ describe('rendermime/registry', () => {
               ).runAllTimersAsync();
               await rendered;
             }
-            const anchors = renderer.node.querySelectorAll('a');
-            expect(anchors).toHaveLength(50);
-            expect(anchors[49].getAttribute('href')).toBe('dates.log');
-            expect(fetchMock).toHaveBeenCalledTimes(1);
+            return {
+              anchors: Array.from(renderer.node.querySelectorAll('a')),
+              requests: fetchMock.mock.calls.length
+            };
           } finally {
             jest.useRealTimers();
             renderer.dispose();
             settings.fetch = previousFetch;
           }
+        }
+
+        // A program writing a date to stderr prints a path-like string on
+        // every line, and every chunk of the stream re-renders the whole
+        // output, so the same path is looked up over and over. Resolving each
+        // of those separately froze the application, see
+        // https://github.com/jupyterlab/jupyterlab/issues/19721
+        it('should resolve a repeated path once', async () => {
+          const { anchors, requests } = await renderStreamedLines([
+            { scope: 'server', path: 'dates.log' }
+          ]);
+
+          expect(anchors).toHaveLength(50);
+          expect(anchors[49].getAttribute('href')).toBe('dates.log');
+          expect(requests).toBe(1);
+        });
+
+        it('should resolve a repeated path which is not a file once', async () => {
+          const { anchors, requests } = await renderStreamedLines([]);
+
+          expect(anchors).toHaveLength(50);
+          expect(anchors[49].getAttribute('href')).toBeNull();
+          expect(requests).toBe(1);
         });
       });
     });

--- a/packages/metapackage/test/rendermime/registry.spec.ts
+++ b/packages/metapackage/test/rendermime/registry.spec.ts
@@ -645,30 +645,6 @@ describe('rendermime/registry', () => {
           await resolver.resolvePath('/tmp/foo500.py');
           expect(fetchMock).toHaveBeenCalledTimes(502);
         });
-
-        it('should keep a path whose request is still in flight', async () => {
-          // More requests in flight than the cache holds; dropping one of them
-          // would send a second request for the same path.
-          const answer: (() => void)[] = [];
-          const { resolver, fetchMock } = resolverWithMockedServer({
-            respond: () =>
-              new Promise<Response>(resolve => {
-                answer.push(() =>
-                  resolve(new Response(JSON.stringify({ resolved: [] })))
-                );
-              })
-          });
-
-          const asked = Array.from({ length: 600 }, (_, path) =>
-            resolver.resolvePath(`/tmp/foo${path}.py`)
-          );
-          asked.push(resolver.resolvePath('/tmp/foo0.py'));
-          await new Promise(resolve => setTimeout(resolve, 0));
-
-          expect(fetchMock).toHaveBeenCalledTimes(600);
-          answer.forEach(release => release());
-          await Promise.all(asked);
-        });
       });
 
       describe('#isLocal', () => {

--- a/packages/metapackage/test/rendermime/registry.spec.ts
+++ b/packages/metapackage/test/rendermime/registry.spec.ts
@@ -535,6 +535,140 @@ describe('rendermime/registry', () => {
           expect(resolved).toEqual({ scope: 'server', path: 'foo.py' });
           expect(getSpy).not.toHaveBeenCalled();
         });
+
+        /**
+         * Create a resolver whose server answers every path with `resolved`,
+         * and a fetch mock counting the requests it received.
+         */
+        function resolverWithMockedServer(options?: {
+          getKernelId?: () => string | null | undefined;
+          respond?: (url: string) => Promise<Response>;
+        }) {
+          const localContents = new ContentsManager();
+          const resolver = new RenderMimeRegistry.UrlResolver({
+            path: pathParent + '/pr%25 ' + UUID.uuid4(),
+            contents: localContents,
+            getKernelId: options?.getKernelId
+          });
+          const settings = localContents.serverSettings as IWritableSettings;
+          const previousFetch = settings.fetch;
+          const fetchMock = jest.fn(async (request: Request) => {
+            if (options?.respond) {
+              return options.respond(request.url);
+            }
+            return new Response(
+              JSON.stringify({
+                resolved: [{ scope: 'server', path: 'foo.py' }]
+              }),
+              { status: 200 }
+            );
+          });
+          settings.fetch =
+            fetchMock as unknown as ServerConnection.ISettings['fetch'];
+          restoreFetch = () => {
+            settings.fetch = previousFetch;
+          };
+          return { resolver, fetchMock };
+        }
+
+        it('should send one request for repeated resolutions of a path', async () => {
+          const { resolver, fetchMock } = resolverWithMockedServer();
+
+          const first = await resolver.resolvePath('/tmp/foo.py');
+          const second = await resolver.resolvePath('/tmp/foo.py');
+
+          expect(second).toEqual(first);
+          expect(fetchMock).toHaveBeenCalledTimes(1);
+        });
+
+        it('should send one request for concurrent resolutions of a path', async () => {
+          // A streamed output which prints a path-like string on every line
+          // (see https://github.com/jupyterlab/jupyterlab/issues/19721) asks
+          // for the same path once per line, all at once.
+          const { resolver, fetchMock } = resolverWithMockedServer();
+
+          const resolutions = await Promise.all(
+            Array.from({ length: 200 }, () => resolver.resolvePath('/18/2025'))
+          );
+
+          expect(fetchMock).toHaveBeenCalledTimes(1);
+          expect(resolutions[199]).toEqual({ scope: 'server', path: 'foo.py' });
+        });
+
+        it('should forget results obtained for a previous kernel', async () => {
+          let kernelId = UUID.uuid4();
+          const { resolver, fetchMock } = resolverWithMockedServer({
+            getKernelId: () => kernelId
+          });
+
+          await resolver.resolvePath('/tmp/foo.py');
+          expect(fetchMock).toHaveBeenCalledTimes(1);
+
+          kernelId = UUID.uuid4();
+          await resolver.resolvePath('/tmp/foo.py');
+          expect(fetchMock).toHaveBeenCalledTimes(2);
+          expect((fetchMock.mock.calls[1][0] as Request).url).toContain(
+            `&kernel=${kernelId}`
+          );
+        });
+
+        it('should resolve a path again once the result is a minute old', async () => {
+          const { resolver, fetchMock } = resolverWithMockedServer();
+          const now = Date.now();
+          const clock = jest.spyOn(Date, 'now').mockReturnValue(now);
+
+          await resolver.resolvePath('/tmp/foo.py');
+          expect(fetchMock).toHaveBeenCalledTimes(1);
+
+          clock.mockReturnValue(now + 59 * 1000);
+          await resolver.resolvePath('/tmp/foo.py');
+          expect(fetchMock).toHaveBeenCalledTimes(1);
+
+          clock.mockReturnValue(now + 61 * 1000);
+          await resolver.resolvePath('/tmp/foo.py');
+          expect(fetchMock).toHaveBeenCalledTimes(2);
+          clock.mockRestore();
+        });
+
+        it('should forget the oldest path once it holds five hundred', async () => {
+          const { resolver, fetchMock } = resolverWithMockedServer();
+          for (let path = 0; path < 501; path++) {
+            await resolver.resolvePath(`/tmp/foo${path}.py`);
+          }
+          expect(fetchMock).toHaveBeenCalledTimes(501);
+
+          // The first path was dropped to make room for the last one.
+          await resolver.resolvePath('/tmp/foo0.py');
+          expect(fetchMock).toHaveBeenCalledTimes(502);
+
+          // The last one is still remembered.
+          await resolver.resolvePath('/tmp/foo500.py');
+          expect(fetchMock).toHaveBeenCalledTimes(502);
+        });
+
+        it('should keep a path whose request is still in flight', async () => {
+          // More requests in flight than the cache holds; dropping one of them
+          // would send a second request for the same path.
+          const answer: (() => void)[] = [];
+          const { resolver, fetchMock } = resolverWithMockedServer({
+            respond: () =>
+              new Promise<Response>(resolve => {
+                answer.push(() =>
+                  resolve(new Response(JSON.stringify({ resolved: [] })))
+                );
+              })
+          });
+
+          const asked = Array.from({ length: 600 }, (_, path) =>
+            resolver.resolvePath(`/tmp/foo${path}.py`)
+          );
+          asked.push(resolver.resolvePath('/tmp/foo0.py'));
+          await new Promise(resolve => setTimeout(resolve, 0));
+
+          expect(fetchMock).toHaveBeenCalledTimes(600);
+          answer.forEach(release => release());
+          await Promise.all(asked);
+        });
       });
 
       describe('#isLocal', () => {
@@ -554,6 +688,67 @@ describe('rendermime/registry', () => {
           expect(resolverPath.isLocal('http://www.example.com%bad')).toBe(
             false
           );
+        });
+      });
+
+      describe('path links in a streamed output', () => {
+        it('should resolve a repeated path once', async () => {
+          // A program writing a date to stderr prints a path-like string on
+          // every line, and every chunk of the stream re-renders the whole
+          // output, so the same path is looked up over and over. Resolving
+          // each of those separately froze the application, see
+          // https://github.com/jupyterlab/jupyterlab/issues/19721
+          const contents = new ContentsManager();
+          const settings = contents.serverSettings as IWritableSettings;
+          const previousFetch = settings.fetch;
+          const fetchMock = jest.fn().mockResolvedValue(
+            new Response(
+              JSON.stringify({
+                resolved: [{ scope: 'server', path: 'dates.log' }]
+              }),
+              { status: 200 }
+            )
+          );
+          settings.fetch = fetchMock as ServerConnection.ISettings['fetch'];
+
+          const rendermime = new RenderMimeRegistry({
+            initialFactories: standardRendererFactories,
+            resolver: new RenderMimeRegistry.UrlResolver({
+              path: 'notebook.ipynb',
+              contents
+            }),
+            linkHandler: {
+              handleLink: () => undefined,
+              handlePath: () => undefined
+            }
+          });
+          const mimeType = 'application/vnd.jupyter.stderr';
+          const renderer = rendermime.createRenderer(mimeType);
+          Widget.attach(renderer, document.body);
+          jest.useFakeTimers();
+
+          try {
+            let text = '';
+            for (let line = 0; line < 50; line++) {
+              text += `${line}: date=/18/2025\n`;
+              const rendered = renderer.renderModel(
+                createModel({ [mimeType]: text })
+              );
+              // Rendering runs across animation frames, which are timers here.
+              await (
+                jest as unknown as { runAllTimersAsync(): Promise<void> }
+              ).runAllTimersAsync();
+              await rendered;
+            }
+            const anchors = renderer.node.querySelectorAll('a');
+            expect(anchors).toHaveLength(50);
+            expect(anchors[49].getAttribute('href')).toBe('dates.log');
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+          } finally {
+            jest.useRealTimers();
+            renderer.dispose();
+            settings.fetch = previousFetch;
+          }
         });
       });
     });

--- a/packages/rendermime/src/registry.ts
+++ b/packages/rendermime/src/registry.ts
@@ -3,7 +3,7 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 import { Sanitizer } from '@jupyterlab/apputils';
-import { PageConfig, PathExt, URLExt } from '@jupyterlab/coreutils';
+import { LruCache, PageConfig, PathExt, URLExt } from '@jupyterlab/coreutils';
 import type { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 import { ServerConnection } from '@jupyterlab/services';
 import type { Contents } from '@jupyterlab/services';
@@ -16,13 +16,12 @@ import type { IRenderMimeRegistry } from './tokens';
 /**
  * How long the result of a path resolution stays usable, in milliseconds.
  *
- * Whether a file exists can change, so an answer is not kept indefinitely: a
- * file created after the output was rendered links on the next render.
+ * A file named in an output may be created after it was rendered.
  */
 const RESOLVE_PATH_CACHE_TTL = 60 * 1000;
 
 /**
- * How many resolved paths one resolver keeps; the oldest are dropped first.
+ * How many resolved paths one resolver keeps.
  */
 const RESOLVE_PATH_CACHE_SIZE = 500;
 
@@ -436,8 +435,7 @@ export namespace RenderMimeRegistry {
      *
      * #### Notes
      * Results are cached: resolution asks the server, and an output can hold
-     * thousands of path-like strings (a log printing `date=/18/2025` gives one
-     * per line).
+     * thousands of path-like strings.
      */
     async resolvePath(
       path: string
@@ -487,29 +485,17 @@ export namespace RenderMimeRegistry {
       entry.result = entry.result.then(
         result => {
           entry.pending = false;
-          // Time the entry from the answer, not from the question.
           entry.time = Date.now();
           return result;
         },
         error => {
-          // Do not keep a failure: the next caller should ask again.
-          if (this._resolvePathCache.get(path) === entry) {
-            this._resolvePathCache.delete(path);
-          }
+          // Leave the entry expired so that the next caller asks again.
+          entry.pending = false;
+          entry.time = 0;
           throw error;
         }
       );
       this._resolvePathCache.set(path, entry);
-      // `Map` iterates in insertion order, so the oldest entry goes first. A
-      // request still in flight is kept whatever the size, otherwise the next
-      // caller would send it again.
-      while (this._resolvePathCache.size > RESOLVE_PATH_CACHE_SIZE) {
-        const oldest = this._resolvePathCache.entries().next();
-        if (oldest.done || oldest.value[1].pending) {
-          break;
-        }
-        this._resolvePathCache.delete(oldest.value[0]);
-      }
       return entry.result;
     }
 
@@ -635,10 +621,10 @@ export namespace RenderMimeRegistry {
     private _contents: Contents.IManager;
     private _getKernelId?: () => string | null | undefined;
     private _resolvePathApiAvailable: boolean | null = null;
-    private _resolvePathCache = new Map<
+    private _resolvePathCache = new LruCache<
       string,
       Private.IResolvePathCacheEntry
-    >();
+    >({ maxSize: RESOLVE_PATH_CACHE_SIZE });
     private _resolvePathCacheKernelId = '';
   }
 
@@ -706,8 +692,7 @@ namespace Private {
      */
     time: number;
     /**
-     * Whether the request is still in flight; a pending entry is always reused,
-     * which keeps a burst of identical paths down to one request.
+     * Whether the request is still in flight; a pending entry never expires.
      */
     pending: boolean;
   }

--- a/packages/rendermime/src/registry.ts
+++ b/packages/rendermime/src/registry.ts
@@ -26,6 +26,15 @@ const RESOLVE_PATH_CACHE_TTL = 60 * 1000;
 const RESOLVE_PATH_CACHE_SIZE = 500;
 
 /**
+ * How many path resolutions one resolver runs at a time.
+ *
+ * Browsers allow about six connections per host, and an output can hold
+ * thousands of distinct path-like strings; leaving connections free keeps such
+ * an output from delaying the rest of the application.
+ */
+const RESOLVE_PATH_LANES = 4;
+
+/**
  * An object which manages mime renderer factories.
  *
  * This object is used to render mime models using registered mime
@@ -480,7 +489,7 @@ export namespace RenderMimeRegistry {
       const entry: Private.IResolvePathCacheEntry = {
         pending: true,
         time: Date.now(),
-        result: this._resolveUncachedPath(path)
+        result: this._resolveInLane(path)
       };
       entry.result = entry.result.then(
         result => {
@@ -497,6 +506,23 @@ export namespace RenderMimeRegistry {
       );
       this._resolvePathCache.set(path, entry);
       return entry.result;
+    }
+
+    /**
+     * Resolve a path in one of the lanes, each of which runs the resolutions
+     * given to it one after another.
+     */
+    private _resolveInLane(
+      path: string
+    ): Promise<IRenderMime.IResolvedLocation | null> {
+      const lane = (this._resolvePathLane + 1) % RESOLVE_PATH_LANES;
+      this._resolvePathLane = lane;
+      const result = this._resolvePathLanes[lane].then(() =>
+        this._resolveUncachedPath(path)
+      );
+      // A rejection must not stop the lane from taking the next resolution.
+      this._resolvePathLanes[lane] = result.catch(() => undefined);
+      return result;
     }
 
     private async _resolveUncachedPath(
@@ -626,6 +652,11 @@ export namespace RenderMimeRegistry {
       Private.IResolvePathCacheEntry
     >({ maxSize: RESOLVE_PATH_CACHE_SIZE });
     private _resolvePathCacheKernelId = '';
+    private _resolvePathLanes: Promise<unknown>[] = Array.from(
+      { length: RESOLVE_PATH_LANES },
+      () => Promise.resolve()
+    );
+    private _resolvePathLane = 0;
   }
 
   /**

--- a/packages/rendermime/src/registry.ts
+++ b/packages/rendermime/src/registry.ts
@@ -14,6 +14,19 @@ import { MimeModel } from './mimemodel';
 import type { IRenderMimeRegistry } from './tokens';
 
 /**
+ * How long the result of a path resolution stays usable, in milliseconds.
+ *
+ * Whether a file exists can change, so an answer is not kept indefinitely: a
+ * file created after the output was rendered links on the next render.
+ */
+const RESOLVE_PATH_CACHE_TTL = 60 * 1000;
+
+/**
+ * How many resolved paths one resolver keeps; the oldest are dropped first.
+ */
+const RESOLVE_PATH_CACHE_SIZE = 500;
+
+/**
  * An object which manages mime renderer factories.
  *
  * This object is used to render mime models using registered mime
@@ -420,15 +433,29 @@ export namespace RenderMimeRegistry {
      * - path understood and known by kernel (if such a path exists).
      * Returns `null` if there is no file matching provided path in neither
      * kernel nor jupyter-server contents manager.
+     *
+     * #### Notes
+     * Results are cached: resolution asks the server, and an output can hold
+     * thousands of path-like strings (a log printing `date=/18/2025` gives one
+     * per line).
      */
     async resolvePath(
       path: string
     ): Promise<IRenderMime.IResolvedLocation | null> {
-      const resolved = await this._resolvePathUsingServerApi(path);
-      if (resolved !== undefined) {
-        return resolved;
+      const kernelId = this._getKernelId?.() ?? '';
+      if (kernelId !== this._resolvePathCacheKernelId) {
+        // A path can resolve to a file which only the kernel can see.
+        this._resolvePathCache.clear();
+        this._resolvePathCacheKernelId = kernelId;
       }
-      return this._resolvePathUsingLegacyHeuristics(path);
+      const cached = this._resolvePathCache.get(path);
+      if (
+        cached &&
+        (cached.pending || Date.now() - cached.time < RESOLVE_PATH_CACHE_TTL)
+      ) {
+        return cached.result;
+      }
+      return this._resolveAndRememberPath(path);
     }
 
     /**
@@ -444,6 +471,56 @@ export namespace RenderMimeRegistry {
         }
         throw error;
       }
+    }
+
+    /**
+     * Resolve a path and keep the result for the callers which follow.
+     */
+    private _resolveAndRememberPath(
+      path: string
+    ): Promise<IRenderMime.IResolvedLocation | null> {
+      const entry: Private.IResolvePathCacheEntry = {
+        pending: true,
+        time: Date.now(),
+        result: this._resolveUncachedPath(path)
+      };
+      entry.result = entry.result.then(
+        result => {
+          entry.pending = false;
+          // Time the entry from the answer, not from the question.
+          entry.time = Date.now();
+          return result;
+        },
+        error => {
+          // Do not keep a failure: the next caller should ask again.
+          if (this._resolvePathCache.get(path) === entry) {
+            this._resolvePathCache.delete(path);
+          }
+          throw error;
+        }
+      );
+      this._resolvePathCache.set(path, entry);
+      // `Map` iterates in insertion order, so the oldest entry goes first. A
+      // request still in flight is kept whatever the size, otherwise the next
+      // caller would send it again.
+      while (this._resolvePathCache.size > RESOLVE_PATH_CACHE_SIZE) {
+        const oldest = this._resolvePathCache.entries().next();
+        if (oldest.done || oldest.value[1].pending) {
+          break;
+        }
+        this._resolvePathCache.delete(oldest.value[0]);
+      }
+      return entry.result;
+    }
+
+    private async _resolveUncachedPath(
+      path: string
+    ): Promise<IRenderMime.IResolvedLocation | null> {
+      const resolved = await this._resolvePathUsingServerApi(path);
+      if (resolved !== undefined) {
+        return resolved;
+      }
+      return this._resolvePathUsingLegacyHeuristics(path);
     }
 
     private async _resolvePathUsingServerApi(
@@ -558,6 +635,11 @@ export namespace RenderMimeRegistry {
     private _contents: Contents.IManager;
     private _getKernelId?: () => string | null | undefined;
     private _resolvePathApiAvailable: boolean | null = null;
+    private _resolvePathCache = new Map<
+      string,
+      Private.IResolvePathCacheEntry
+    >();
+    private _resolvePathCacheKernelId = '';
   }
 
   /**
@@ -609,6 +691,25 @@ namespace Private {
   export interface IResolvePathResponse {
     resolved?: unknown[];
     unresolved?: unknown[];
+  }
+
+  /**
+   * A remembered path resolution.
+   */
+  export interface IResolvePathCacheEntry {
+    /**
+     * The resolution, shared by every caller asking for the same path.
+     */
+    result: Promise<IRenderMime.IResolvedLocation | null>;
+    /**
+     * When the request finished, or when it started while it is pending.
+     */
+    time: number;
+    /**
+     * Whether the request is still in flight; a pending entry is always reused,
+     * which keeps a burst of identical paths down to one request.
+     */
+    pending: boolean;
   }
 
   export function isResolvedLocation(

--- a/packages/rendermime/src/registry.ts
+++ b/packages/rendermime/src/registry.ts
@@ -498,10 +498,13 @@ export namespace RenderMimeRegistry {
           return result;
         },
         error => {
-          // Leave the entry expired so that the next caller asks again.
+          // A failed lookup does not show whether the file exists, so it is
+          // reported as unresolved and left expired: a server hiccup must not
+          // hide a link until the entry ages out.
+          console.warn(`Could not resolve location of ${path}`, error);
           entry.pending = false;
           entry.time = 0;
-          throw error;
+          return null;
         }
       );
       this._resolvePathCache.set(path, entry);
@@ -551,8 +554,7 @@ export namespace RenderMimeRegistry {
 
       let response = await this._makeResolvePathRequest(params);
       if (!response) {
-        console.warn(`Could not resolve location of ${path} using server API`);
-        return null;
+        throw new Error(`Could not reach the server to resolve ${path}`);
       }
 
       if (response.status === 404) {
@@ -560,8 +562,9 @@ export namespace RenderMimeRegistry {
         return undefined;
       }
       if (!response.ok) {
-        console.warn(`Could not resolve location of ${path} using server API`);
-        return null;
+        throw new Error(
+          `Server answered ${response.status} when resolving ${path}`
+        );
       }
       this._resolvePathApiAvailable = true;
 
@@ -587,8 +590,7 @@ export namespace RenderMimeRegistry {
         // Prefer server-scoped paths when both scopes are available.
         return resolved.find(item => item.scope === 'server') ?? resolved[0];
       } catch {
-        console.warn(`Could not resolve location of ${path} using server API`);
-        return null;
+        throw new Error(`Could not read the resolution of ${path}`);
       }
     }
 
@@ -626,10 +628,15 @@ export namespace RenderMimeRegistry {
             path: response.path,
             scope: 'server'
           };
-        } catch {
-          // The file seems like it should be on the server but is not.
-          console.warn(`Could not resolve location of ${path} on server`);
-          return null;
+        } catch (error) {
+          if (
+            error instanceof ServerConnection.ResponseError &&
+            error.response.status === 404
+          ) {
+            // The file seems like it should be on the server but is not.
+            return null;
+          }
+          throw error;
         }
       }
       // The file is not accessible from jupyter-server but maybe it is

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -2324,8 +2324,9 @@ namespace Private {
       const resolution = await resolver.resolvePath(path);
 
       if (!resolution) {
-        // Bail if the file does not exist
-        console.log('Path resolution bailing: does not exist');
+        // Bail if the file does not exist. This is the ordinary outcome for
+        // any path-like string which is not a file, of which an output can
+        // hold thousands, so it is not reported.
         return;
       }
 

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -2324,9 +2324,8 @@ namespace Private {
       const resolution = await resolver.resolvePath(path);
 
       if (!resolution) {
-        // Bail if the file does not exist. This is the ordinary outcome for
-        // any path-like string which is not a file, of which an output can
-        // hold thousands, so it is not reported.
+        // Not a file: the ordinary outcome for a path-like string, and an
+        // output can hold thousands, so it is not reported.
         return;
       }
 

--- a/packages/services/examples/browser/src/comm.ts
+++ b/packages/services/examples/browser/src/comm.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { KernelManager } from '@jupyterlab/services';
+import { CommsOverSubshells, KernelManager } from '@jupyterlab/services';
 import { PromiseDelegate } from '@lumino/coreutils';
 
 import { log } from './log';
@@ -9,7 +9,10 @@ import { log } from './log';
 export async function main(): Promise<void> {
   // Start a python kernel
   const kernelManager = new KernelManager();
-  const kernel = await kernelManager.startNew({ name: 'python' });
+  const kernel = await kernelManager.startNew(
+    { name: 'python' },
+    { commsOverSubshells: CommsOverSubshells.Disabled }
+  );
 
   log('Register a comm target in the kernel');
   await kernel.requestExecute({


### PR DESCRIPTION
## References

Fixes #19721

## Code changes

- Add a cache behind `resolvePath` calls

## User-facing changes

- Resolved URLs show up faster
- Patterns which do not map to an URL do not get spurious retries within 1 minute
- Limit number of `resolvePath` requests send at any given time to 4 

## Backwards-incompatible changes

None

## AI usage

- **Yes**: Some or all of the content of this PR was generated by AI.
- **Yes**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Opus 5, Fable 5.1
