### PR TITLE
Fix the IPython display link in the json-extension README

### DIFF
--- a/packages/json-extension/README.md
+++ b/packages/json-extension/README.md
@@ -6,7 +6,7 @@ This extension is in the official JupyterLab distribution.
 
 ## Usage
 
-To render [JSON-able dict or list](https://ipython.org/ipython-doc/3/api/generated/IPython.display.html#IPython.display.JSON) in IPython:
+To render [JSON-able dict or list](https://ipython.readthedocs.io/en/stable/api/generated/IPython.display.html#IPython.display.JSON) in IPython:
 
 ```python
 from IPython.display import JSON


### PR DESCRIPTION

## References

Should help fix the recently failing CI.

## Code changes

Fix broken link.

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude
