### PR TITLE
Fix respecting `commsOverSubshells` option in `connectTo()`

### DIFF
--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -121,6 +121,8 @@ export class KernelManager extends BaseManager implements Kernel.IManager {
    * #### Notes
    * This will use the manager's server settings and ignore any server
    * settings passed in the options.
+   *
+   * The manager's `commsOverSubshells` is used unless the options give one.
    */
   connectTo(
     options: Omit<Kernel.IKernelConnection.IOptions, 'serverSettings'>
@@ -138,11 +140,11 @@ export class KernelManager extends BaseManager implements Kernel.IManager {
       }
     }
 
-    options.commsOverSubshells = this._commsOverSubshells;
-
     const kernelConnection = new KernelConnection({
       handleComms,
       ...options,
+      commsOverSubshells:
+        options.commsOverSubshells ?? this._commsOverSubshells,
       serverSettings: this.serverSettings,
       kernelAPIClient: this._kernelAPIClient,
       kernelSpecAPIClient: this._kernelSpecAPIClient,

--- a/packages/services/test/kernel/comm.spec.ts
+++ b/packages/services/test/kernel/comm.spec.ts
@@ -83,6 +83,26 @@ describe('jupyter.services - Comm', () => {
         comm.dispose();
       });
 
+      it('should not spawn a subshell when disabled in the connection options', async () => {
+        const noSubshellKernel = await kernelManager.startNew(
+          {},
+          { commsOverSubshells: CommsOverSubshells.Disabled }
+        );
+        await noSubshellKernel.info;
+        expect(noSubshellKernel.supportsSubshells).toBeTruthy();
+        await noSubshellKernel.requestExecute({ code: TARGET }, true).done;
+
+        const comm = noSubshellKernel.createComm('test') as CommHandler;
+        await comm.open({ foo: 'bar' }).done;
+
+        // Check before closing, because closing a comm deletes its subshell.
+        expect(comm.subshellId).toBeNull();
+        await expect(getSubshellIds(noSubshellKernel)).resolves.toEqual([]);
+
+        await comm.close().done;
+        await noSubshellKernel.shutdown();
+      });
+
       it('should spawn a subshell per-comm', async () => {
         await echoKernel.info;
 

--- a/packages/services/test/kernel/manager.spec.ts
+++ b/packages/services/test/kernel/manager.spec.ts
@@ -3,7 +3,7 @@
 
 import { JupyterServer, sleep, testEmission } from '@jupyterlab/testing';
 import type { Kernel } from '../../src';
-import { KernelAPI, KernelManager } from '../../src';
+import { CommsOverSubshells, KernelAPI, KernelManager } from '../../src';
 import { makeSettings } from '../utils';
 
 describe('kernel/manager', () => {
@@ -139,6 +139,15 @@ describe('kernel/manager', () => {
         await kernel.info;
         expect(called).toBe(true);
       });
+
+      it('should keep the comms over subshells mode given in the options', async () => {
+        manager.commsOverSubshells = CommsOverSubshells.PerComm;
+        const kernel = await manager.startNew(
+          {},
+          { commsOverSubshells: CommsOverSubshells.Disabled }
+        );
+        expect(kernel.commsOverSubshells).toBe(CommsOverSubshells.Disabled);
+      });
     });
 
     describe('#findById()', () => {
@@ -154,6 +163,32 @@ describe('kernel/manager', () => {
         const id = kernel.id;
         const newConnection = manager.connectTo({ model: kernel });
         expect(newConnection.model.id).toBe(id);
+      });
+
+      it('should use the comms over subshells mode of the manager', () => {
+        manager.commsOverSubshells = CommsOverSubshells.PerComm;
+        const connection = manager.connectTo({ model: kernel });
+        expect(connection.commsOverSubshells).toBe(CommsOverSubshells.PerComm);
+        connection.dispose();
+      });
+
+      it('should keep the comms over subshells mode given in the options', () => {
+        manager.commsOverSubshells = CommsOverSubshells.PerComm;
+        const connection = manager.connectTo({
+          model: kernel,
+          commsOverSubshells: CommsOverSubshells.Disabled
+        });
+        expect(connection.commsOverSubshells).toBe(CommsOverSubshells.Disabled);
+        connection.dispose();
+      });
+
+      it('should not add the comms over subshells mode to the given options', () => {
+        const options: Omit<
+          Kernel.IKernelConnection.IOptions,
+          'serverSettings'
+        > = { model: kernel };
+        manager.connectTo(options).dispose();
+        expect(options.commsOverSubshells).toBeUndefined();
       });
     });
 

--- a/packages/services/test/session/manager.spec.ts
+++ b/packages/services/test/session/manager.spec.ts
@@ -5,6 +5,7 @@ import { JupyterServer, testEmission } from '@jupyterlab/testing';
 import { UUID } from '@lumino/coreutils';
 import type { Session } from '../../src';
 import {
+  CommsOverSubshells,
   KernelManager,
   ServerConnection,
   SessionAPI,
@@ -167,6 +168,22 @@ describe('session/manager', () => {
         });
         await startNew(manager);
         expect(called).toBe(true);
+      });
+
+      it('should keep the comms over subshells mode given in the kernel connection options', async () => {
+        kernelManager.commsOverSubshells = CommsOverSubshells.PerComm;
+        const session = await manager.startNew(
+          { path: UUID.uuid4(), name: UUID.uuid4(), type: 'MYTEST' },
+          {
+            kernelConnectionOptions: {
+              commsOverSubshells: CommsOverSubshells.Disabled
+            }
+          }
+        );
+        expect(session.kernel!.commsOverSubshells).toBe(
+          CommsOverSubshells.Disabled
+        );
+        return session.shutdown();
       });
     });
 


### PR DESCRIPTION
## References

- Follow-up to:
  - https://github.com/jupyterlab/jupyterlab/pull/19725
  - https://github.com/jupyterlab/jupyterlab/pull/17363

## Code changes

Effectively:

```diff
-  commsOverSubshells: this._commsOverSubshells,
+  commsOverSubshells: options.commsOverSubshells ?? this._commsOverSubshells,
```

\+ docs + tests.

The signature was already accepting the `commsOverSubshells` and discarding it was not documented. I think this was a mistake that slipped thought but pinging @martinRenou (author of the original code) for review.

## User-facing changes

None

## Backwards-incompatible changes

None

## AI usage

- **Yes**: Some or all of the content of this PR was generated by AI.
- **Yes**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Fable 5.1