### PR TITLE
Use plugin IDs to defer loading extension disabled by disabling all its plugins

### DIFF
--- a/dev_mode/index.js
+++ b/dev_mode/index.js
@@ -144,11 +144,36 @@ export async function main() {
     return disabledExtensions.some(val => val === name);
   }
 
-  // Report a plugin which is only disabled because the whole package providing
-  // it is disabled. Such a plugin does not follow the plugin id convention, so
-  // the user cannot tell from the config that it was disabled too.
+  // Whether a federated module has no plugin left to register: either the
+  // package providing it is disabled as a whole, or every plugin it provides is
+  // disabled on its own. The plugin ids are recorded at build time by the
+  // extension builder, and are absent for an extension built before the builder
+  // recorded them.
+  const isModuleDisabled = (data, module) => {
+    if (isExtensionDisabled(data.name)) {
+      return true;
+    }
+    const plugins = data.plugins && data.plugins[module];
+    return (
+      plugins !== undefined && plugins.every(plugin => isPluginDisabled(plugin.id))
+    );
+  }
+
+  // Report a plugin which is disabled only because the package providing it is
+  // disabled by name. Its id does not follow the plugin id convention, so the
+  // disable list does not name it and the user cannot tell from the config that
+  // it was disabled too.
   const warnAboutPackageLevelDisable = (pluginId, scope) => {
     console.warn(`Plugin ${pluginId} does not start with the name of the extension providing it (${scope}), which is disabled, so this plugin is disabled too. To keep it enabled, list the plugin ids to disable in disabledExtensions instead of ${scope}.`);
+  }
+
+  // Report a plugin the extension provides but did not record at build time.
+  // The recorded ids said every plugin of the module was disabled, which is why
+  // the module was not loaded during startup, so this plugin was skipped even
+  // though the config leaves it enabled. Rebuilding the extension records the
+  // ids again and fixes it.
+  const warnAboutStaleMetadata = (pluginId, scope) => {
+    console.error(`Plugin ${pluginId} is provided by extension ${scope} but is missing from the plugin ids recorded when the extension was built, so it was not activated. Rebuild the extension to record its plugins again.`);
   }
 
   // This is basically a copy of PageConfig.Extension.isDeferred to
@@ -165,31 +190,39 @@ export async function main() {
   const queuedFederated = [];
 
   extensions.forEach(data => {
-    const isDisabled = isExtensionDisabled(data.name);
+    // A module is deferred when it has no plugin left to register. Styles
+    // belong to the package as a whole, so they are loaded as long as one of
+    // its modules is; a package providing no module follows the disable list
+    // by name.
+    let hasEnabledModule =
+      !data.extension && !data.mimeExtension && !isExtensionDisabled(data.name);
+
     if (data.extension) {
       queuedFederated.push(data.name);
-      if (isDisabled) {
+      if (isModuleDisabled(data, data.extension)) {
         deferredDisabledFederatedModules.push({
           name: data.name,
           module: data.extension
         });
       } else {
+        hasEnabledModule = true;
         federatedExtensionPromises.push(createModule(data.name, data.extension));
       }
     }
     if (data.mimeExtension) {
       queuedFederated.push(data.name);
-      if (isDisabled) {
+      if (isModuleDisabled(data, data.mimeExtension)) {
         deferredDisabledFederatedModules.push({
           name: data.name,
           module: data.mimeExtension
         });
       } else {
+        hasEnabledModule = true;
         federatedMimeExtensionPromises.push(createModule(data.name, data.mimeExtension));
       }
     }
 
-    if (data.style && !isDisabled) {
+    if (data.style && hasEnabledModule) {
       federatedStylePromises.push(createModule(data.name, data.style));
     }
   });
@@ -233,13 +266,23 @@ export async function main() {
   }
 
   /**
-   * Collect the metadata of the plugins of an extension disabled as a whole.
+   * Collect the metadata of the plugins of a module which was not loaded
+   * during startup.
+   *
+   * #### Notes
+   * A plugin which the config does not disable can only turn up here when the
+   * plugin ids recorded at build time are out of date, so the module was
+   * skipped without this plugin being known.
    */
   function collectDisabledPlugins(extension) {
     const plugins = [];
     for (let plugin of getPlugins(extension)) {
       if (!isPluginDisabled(plugin.id)) {
-        warnAboutPackageLevelDisable(plugin.id, extension.__scope__);
+        if (isExtensionDisabled(extension.__scope__)) {
+          warnAboutPackageLevelDisable(plugin.id, extension.__scope__);
+        } else {
+          warnAboutStaleMetadata(plugin.id, extension.__scope__);
+        }
       }
       plugins.push(createPluginInfo(plugin, extension, true));
     }
@@ -277,7 +320,9 @@ export async function main() {
   // to discover their plugin metadata; they must not be registered or activated.
   async function loadDeferredDisabledFederatedPlugins() {
     const deferredDisabledFederatedPlugins = await Promise.allSettled(
-      deferredDisabledFederatedModules.map(data => createModule(data.name, data.module))
+      deferredDisabledFederatedModules.map(data =>
+        createModule(data.name, data.module)
+      )
     );
     const disabledPlugins = [];
 

--- a/docs/source/extension/extension_migration.md
+++ b/docs/source/extension/extension_migration.md
@@ -11,10 +11,18 @@
 ### Behavior updates
 
 - Listing an extension package name in `disabledExtensions` now disables every plugin that
-  package provides. Before, a plugin whose id did not start with the package name stayed
-  enabled, so a package not following the plugin id convention could not be disabled as a
-  whole. Each such plugin is named in a browser console warning. To keep it enabled, list
-  the plugin ids to disable in `disabledExtensions` instead of the package name.
+  package provides. Before, only a plugin whose id started with the package name was
+  disabled, so an extension breaking the
+  {ref}`plugin id convention <plugin-id-convention>` was left partly running, or could not
+  be disabled by name at all. Each plugin the disable list does not name itself is reported
+  in a browser console warning. To disable part of such an extension, list the plugin ids
+  instead of the package name.
+- A prebuilt extension is no longer loaded during the initial page load when every plugin
+  it provides is disabled. Acting on a disable by plugin id needs the ids recorded in
+  `jupyterlab._build.plugins` of the built `package.json`, which jupyter-builder 1.X and
+  later write. Without them only a disable by package name is acted on. The extension is
+  loaded once the application has started, so its plugins keep appearing in the Advanced
+  Plugin Manager and can be enabled again from there.
 
 ### API updates
 

--- a/galata/test/jupyterlab/disabled-federated-extensions.test.ts
+++ b/galata/test/jupyterlab/disabled-federated-extensions.test.ts
@@ -1,0 +1,387 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { expect, test } from '@jupyterlab/galata';
+
+/**
+ * Two federated extensions are injected into the page config of a real
+ * JupyterLab page: one is deferred and one is disabled at the package level.
+ * Their remote entries are served by Playwright, so no extension has to be
+ * built and installed to run this test.
+ */
+const DEFERRED_EXTENSION = '@jupyterlab/mock-deferred-extension';
+const DISABLED_EXTENSION = '@jupyterlab/mock-disabled-extension';
+
+/**
+ * How long the disabled extension blocks the main thread when its module is
+ * evaluated. This stands in for the cost of evaluating a real extension.
+ */
+const BLOCK_MS = 500;
+
+interface IMarks {
+  restored?: number;
+  recordedModuleRequested?: number;
+  recordedStyleRequested?: number;
+  allPluginsActivated?: number;
+  deferredModuleRequested?: number;
+  deferredPluginActivated?: number;
+  disabledModuleRequested?: number;
+  disabledModuleEvaluated?: number;
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  interface Window {
+    __jlabMarks: IMarks;
+  }
+}
+
+/**
+ * Build a module federation container which records when it is asked for a
+ * module and returns `moduleBody` as the module.
+ */
+function containerScript(scope: string, mark: string, moduleBody: string) {
+  return `
+(function () {
+  window._JUPYTERLAB = window._JUPYTERLAB || {};
+  window.__jlabMarks = window.__jlabMarks || {};
+  window._JUPYTERLAB[${JSON.stringify(scope)}] = {
+    init: function () {
+      return Promise.resolve();
+    },
+    get: function () {
+      window.__jlabMarks[${JSON.stringify(mark)}] = performance.now();
+      return Promise.resolve(function () {
+        ${moduleBody}
+      });
+    }
+  };
+})();
+`;
+}
+
+const deferredContainer = containerScript(
+  DEFERRED_EXTENSION,
+  'deferredModuleRequested',
+  `
+  return {
+    __esModule: true,
+    default: [
+      {
+        id: ${JSON.stringify(DEFERRED_EXTENSION + ':plugin')},
+        description: 'Mock deferred plugin',
+        autoStart: true,
+        activate: function () {
+          // Yield to the event loop so that any work scheduled before this
+          // plugin was activated gets a chance to run first.
+          return new Promise(function (resolve) {
+            window.setTimeout(function () {
+              window.__jlabMarks.deferredPluginActivated = performance.now();
+              resolve();
+            }, 0);
+          });
+        }
+      }
+    ]
+  };
+`
+);
+
+const disabledContainer = containerScript(
+  DISABLED_EXTENSION,
+  'disabledModuleRequested',
+  `
+  var start = performance.now();
+  while (performance.now() - start < ${BLOCK_MS}) {
+    // Block the main thread, as evaluating a large extension module would.
+  }
+  window.__jlabMarks.disabledModuleEvaluated = performance.now();
+  return {
+    __esModule: true,
+    default: [
+      {
+        id: ${JSON.stringify(DISABLED_EXTENSION + ':plugin')},
+        description: 'Mock disabled plugin',
+        autoStart: true,
+        activate: function () {
+          throw new Error('A disabled plugin must not be activated');
+        }
+      }
+    ]
+  };
+`
+);
+
+test.describe('Disabled federated extensions', () => {
+  test.use({ autoGoto: false });
+
+  test.beforeEach(async ({ page }) => {
+    // Record when the application reports being restored and having activated
+    // all of its plugins.
+    await page.addInitScript(() => {
+      window.__jlabMarks = {};
+      const poll = window.setInterval(() => {
+        const app = (window as any).jupyterapp;
+        if (!app) {
+          return;
+        }
+        window.clearInterval(poll);
+        void app.restored.then(() => {
+          window.__jlabMarks.restored = performance.now();
+        });
+        void app.allPluginsActivated.then(() => {
+          window.__jlabMarks.allPluginsActivated = performance.now();
+        });
+      }, 1);
+    });
+
+    // Add the two mock extensions to the page config of the lab page.
+    await page.route(
+      url => /\/lab\/?$/.test(url.pathname),
+      async route => {
+        const response = await route.fetch();
+        const html = await response.text();
+        const body = html.replace(
+          /(<script id="jupyter-config-data" type="application\/json">)([\s\S]*?)(<\/script>)/,
+          (_match, open: string, json: string, close: string) => {
+            const config = JSON.parse(json);
+            config['federated_extensions'] = [
+              ...(config['federated_extensions'] ?? []),
+              {
+                name: DEFERRED_EXTENSION,
+                load: 'static/remoteEntry.js',
+                extension: './extension'
+              },
+              {
+                name: DISABLED_EXTENSION,
+                load: 'static/remoteEntry.js',
+                extension: './extension'
+              }
+            ];
+            config.deferredExtensions = [
+              ...(config.deferredExtensions ?? []),
+              DEFERRED_EXTENSION
+            ];
+            config.disabledExtensions = [
+              ...(config.disabledExtensions ?? []),
+              DISABLED_EXTENSION
+            ];
+            return open + JSON.stringify(config) + close;
+          }
+        );
+        await route.fulfill({ response, body });
+      }
+    );
+
+    for (const [name, script] of [
+      [DEFERRED_EXTENSION, deferredContainer],
+      [DISABLED_EXTENSION, disabledContainer]
+    ] as const) {
+      await page.route(
+        url => url.pathname.endsWith(`/${name}/static/remoteEntry.js`),
+        route =>
+          route.fulfill({
+            contentType: 'application/javascript',
+            body: script
+          })
+      );
+    }
+  });
+
+  test('should be loaded only once the application finished starting', async ({
+    page
+  }) => {
+    await page.goto();
+
+    await page.waitForFunction(
+      () => window.__jlabMarks.disabledModuleEvaluated !== undefined
+    );
+    const marks = await page.evaluate(() => window.__jlabMarks);
+
+    // The enabled extension is loaded during the initial page load, the
+    // disabled one is not.
+    expect(marks.deferredModuleRequested).toBeLessThan(marks.restored!);
+    expect(marks.disabledModuleRequested).toBeGreaterThanOrEqual(
+      marks.restored!
+    );
+
+    // Loading the disabled extension does not delay activating the deferred
+    // plugins, nor anything else the application does while starting.
+    expect(marks.deferredPluginActivated).toBeLessThan(
+      marks.disabledModuleRequested!
+    );
+    expect(marks.allPluginsActivated).toBeLessThanOrEqual(
+      marks.disabledModuleRequested!
+    );
+
+    // The disabled plugin is listed as available so that it can be re-enabled,
+    // and it is not activated.
+    const plugins = await page.evaluate(() => ({
+      available: (window as any).jupyterapp.info.availablePlugins.map(
+        (plugin: { id: string; enabled: boolean }) => [
+          plugin.id,
+          plugin.enabled
+        ]
+      ),
+      listed: (window as any).jupyterapp.listPlugins()
+    }));
+    expect(plugins.available).toContainEqual([
+      `${DISABLED_EXTENSION}:plugin`,
+      false
+    ]);
+    expect(plugins.listed).not.toContain(`${DISABLED_EXTENSION}:plugin`);
+  });
+});
+
+const RECORDED_EXTENSION = '@jupyterlab/mock-recorded-extension';
+
+const recordedContainer = `
+(function () {
+  window._JUPYTERLAB = window._JUPYTERLAB || {};
+  window.__jlabMarks = window.__jlabMarks || {};
+  window._JUPYTERLAB[${JSON.stringify(RECORDED_EXTENSION)}] = {
+    init: function () {
+      return Promise.resolve();
+    },
+    get: function (module) {
+      window.__jlabMarks[
+        module === './style' ? 'recordedStyleRequested' : 'recordedModuleRequested'
+      ] = performance.now();
+      return Promise.resolve(function () {
+        if (module === './style') {
+          return { __esModule: true, default: [] };
+        }
+        return {
+          __esModule: true,
+          default: [
+            {
+              id: ${JSON.stringify(RECORDED_EXTENSION + ':a')},
+              description: 'First recorded plugin',
+              autoStart: true,
+              activate: function () {
+                throw new Error('A disabled plugin must not be activated');
+              }
+            },
+            {
+              id: 'other-prefix:b',
+              description: 'Recorded plugin with a mismatched id',
+              autoStart: true,
+              activate: function () {
+                throw new Error('A disabled plugin must not be activated');
+              }
+            }
+          ]
+        };
+      });
+    }
+  };
+})();
+`;
+
+test.describe('Federated extension with recorded plugin ids', () => {
+  test.use({ autoGoto: false });
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__jlabMarks = {};
+      const poll = window.setInterval(() => {
+        const app = (window as any).jupyterapp;
+        if (!app) {
+          return;
+        }
+        window.clearInterval(poll);
+        void app.restored.then(() => {
+          window.__jlabMarks.restored = performance.now();
+        });
+        void app.allPluginsActivated.then(() => {
+          window.__jlabMarks.allPluginsActivated = performance.now();
+        });
+      }, 1);
+    });
+
+    await page.route(
+      url => /\/lab\/?$/.test(url.pathname),
+      async route => {
+        const response = await route.fetch();
+        const html = await response.text();
+        const body = html.replace(
+          /(<script id="jupyter-config-data" type="application\/json">)([\s\S]*?)(<\/script>)/,
+          (_match, open: string, json: string, close: string) => {
+            const config = JSON.parse(json);
+            config['federated_extensions'] = [
+              ...(config['federated_extensions'] ?? []),
+              {
+                name: RECORDED_EXTENSION,
+                load: 'static/remoteEntry.js',
+                extension: './extension',
+                style: './style',
+                // Recorded when the extension was built.
+                plugins: {
+                  './extension': [
+                    { id: `${RECORDED_EXTENSION}:a` },
+                    { id: 'other-prefix:b' }
+                  ]
+                }
+              }
+            ];
+            // Each plugin is disabled by its own id; the package name is not
+            // listed, which is what the Advanced Plugin Manager writes.
+            config.disabledExtensions = [
+              ...(config.disabledExtensions ?? []),
+              `${RECORDED_EXTENSION}:a`,
+              'other-prefix:b'
+            ];
+            return open + JSON.stringify(config) + close;
+          }
+        );
+        await route.fulfill({ response, body });
+      }
+    );
+
+    await page.route(
+      url =>
+        url.pathname.endsWith(`/${RECORDED_EXTENSION}/static/remoteEntry.js`),
+      route =>
+        route.fulfill({
+          contentType: 'application/javascript',
+          body: recordedContainer
+        })
+    );
+  });
+
+  test('should not be loaded during startup when every plugin is disabled by id', async ({
+    page
+  }) => {
+    await page.goto();
+
+    await page.waitForFunction(
+      () => window.__jlabMarks.recordedModuleRequested !== undefined
+    );
+    const marks = await page.evaluate(() => window.__jlabMarks);
+
+    expect(marks.recordedModuleRequested).toBeGreaterThan(marks.restored!);
+    expect(marks.allPluginsActivated).toBeLessThanOrEqual(
+      marks.recordedModuleRequested!
+    );
+    // Styles of a package with nothing left to register are not loaded at all.
+    expect(marks.recordedStyleRequested).toBeUndefined();
+
+    const plugins = await page.evaluate(() => ({
+      available: (window as any).jupyterapp.info.availablePlugins
+        .filter(
+          (plugin: { extension: string }) =>
+            plugin.extension === '@jupyterlab/mock-recorded-extension'
+        )
+        .map((plugin: { id: string; enabled: boolean }) => [
+          plugin.id,
+          plugin.enabled
+        ]),
+      listed: (window as any).jupyterapp.listPlugins()
+    }));
+    expect(plugins.available).toEqual([
+      [`${RECORDED_EXTENSION}:a`, false],
+      ['other-prefix:b', false]
+    ]);
+    expect(plugins.listed).not.toContain(`${RECORDED_EXTENSION}:a`);
+  });
+});

--- a/packages/application/test/bootstrap.spec.ts
+++ b/packages/application/test/bootstrap.spec.ts
@@ -170,6 +170,7 @@ interface IHarnessOptions {
     extension?: string;
     mimeExtension?: string;
     style?: string;
+    plugins?: Record<string, { id: string }[]>;
   }[];
   /**
    * Modules the federated containers expose, by package and then module name.
@@ -619,21 +620,35 @@ describe('bootstrap federated extensions', () => {
   });
 
   it('disables every plugin of a package disabled by name', async () => {
-    // Both packages provide a plugin whose id does not start with the package
+    // Each package provides a plugin whose id does not start with the package
     // name, which the plugin id convention discourages but does not prevent.
+    // Whether the package is statically linked, prebuilt with its plugin ids
+    // recorded, or prebuilt without them, disabling it by name disables every
+    // plugin it provides.
     const harness = createHarness({
       federated: [
         {
-          name: '@jupyterlab/federated-disabled-extension',
+          name: '@jupyterlab/recorded-extension',
+          extension: './extension',
+          plugins: {
+            './extension': [
+              { id: 'recorded-other-prefix:plugin' },
+              { id: '@jupyterlab/recorded-extension:plugin' }
+            ]
+          }
+        },
+        {
+          name: '@jupyterlab/unrecorded-extension',
           extension: './extension'
         }
       ],
       disabled: [
-        '@jupyterlab/federated-disabled-extension',
-        '@jupyterlab/static-disabled-extension'
+        '@jupyterlab/static-extension',
+        '@jupyterlab/recorded-extension',
+        '@jupyterlab/unrecorded-extension'
       ],
       staticExtensions: {
-        '@jupyterlab/static-disabled-extension': {
+        '@jupyterlab/static-extension': {
           __esModule: true,
           default: [
             {
@@ -642,7 +657,7 @@ describe('bootstrap federated extensions', () => {
               autoStart: true
             },
             {
-              id: '@jupyterlab/static-disabled-extension:plugin',
+              id: '@jupyterlab/static-extension:plugin',
               description: 'Static plugin',
               autoStart: true
             }
@@ -650,18 +665,35 @@ describe('bootstrap federated extensions', () => {
         }
       },
       modules: {
-        '@jupyterlab/federated-disabled-extension': {
+        '@jupyterlab/recorded-extension': {
           './extension': {
             __esModule: true,
             default: [
               {
-                id: 'federated-other-prefix:plugin',
-                description: 'Federated plugin with a mismatched id',
+                id: 'recorded-other-prefix:plugin',
+                description: 'Recorded plugin with a mismatched id',
                 autoStart: true
               },
               {
-                id: '@jupyterlab/federated-disabled-extension:plugin',
-                description: 'Federated plugin',
+                id: '@jupyterlab/recorded-extension:plugin',
+                description: 'Recorded plugin',
+                autoStart: true
+              }
+            ]
+          }
+        },
+        '@jupyterlab/unrecorded-extension': {
+          './extension': {
+            __esModule: true,
+            default: [
+              {
+                id: 'unrecorded-other-prefix:plugin',
+                description: 'Unrecorded plugin with a mismatched id',
+                autoStart: true
+              },
+              {
+                id: '@jupyterlab/unrecorded-extension:plugin',
+                description: 'Unrecorded plugin',
                 autoStart: true
               }
             ]
@@ -672,8 +704,9 @@ describe('bootstrap federated extensions', () => {
 
     await harness.main();
 
-    // No plugin of the statically linked package is registered, including the
-    // one whose id does not start with the package name.
+    // Neither prebuilt package is loaded during the initial page load, and no
+    // plugin of the statically linked one is registered.
+    expect(harness.moduleRequests).toEqual([]);
     expect(harness.registeredPlugins).toEqual([]);
     expect(
       harness
@@ -681,14 +714,14 @@ describe('bootstrap federated extensions', () => {
         .availablePlugins.map(plugin => [plugin.id, plugin.enabled])
     ).toEqual([
       ['static-other-prefix:plugin', false],
-      ['@jupyterlab/static-disabled-extension:plugin', false]
+      ['@jupyterlab/static-extension:plugin', false]
     ]);
     expect(harness.labOptions().disabled.matches).toEqual([
       'static-other-prefix:plugin',
-      '@jupyterlab/static-disabled-extension:plugin'
+      '@jupyterlab/static-extension:plugin'
     ]);
-    // Only the plugin which does not follow the id convention is reported, as
-    // the user cannot tell from the config that it was disabled too.
+    // Only the plugin the disable list does not name is reported, as the user
+    // cannot tell from the config that it was disabled too.
     expect(harness.console.warn).toHaveBeenCalledTimes(1);
     expect(harness.console.warn).toHaveBeenCalledWith(
       expect.stringContaining('static-other-prefix:plugin')
@@ -699,9 +732,9 @@ describe('bootstrap federated extensions', () => {
     await flushPromises();
     await flushPromises();
 
-    // The federated package is treated the same way once it is loaded.
     expect(harness.moduleRequests).toEqual([
-      '@jupyterlab/federated-disabled-extension:./extension'
+      '@jupyterlab/recorded-extension:./extension',
+      '@jupyterlab/unrecorded-extension:./extension'
     ]);
     expect(harness.registeredPlugins).toEqual([]);
     expect(
@@ -710,13 +743,187 @@ describe('bootstrap federated extensions', () => {
       )
     ).toEqual([
       [
-        ['federated-other-prefix:plugin', false],
-        ['@jupyterlab/federated-disabled-extension:plugin', false]
+        ['recorded-other-prefix:plugin', false],
+        ['@jupyterlab/recorded-extension:plugin', false],
+        ['unrecorded-other-prefix:plugin', false],
+        ['@jupyterlab/unrecorded-extension:plugin', false]
       ]
     ]);
-    expect(harness.console.warn).toHaveBeenCalledTimes(2);
-    expect(harness.console.warn).toHaveBeenLastCalledWith(
-      expect.stringContaining('federated-other-prefix:plugin')
+    expect(harness.console.warn).toHaveBeenCalledTimes(3);
+    expect(harness.console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('recorded-other-prefix:plugin')
+    );
+    expect(harness.console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('unrecorded-other-prefix:plugin')
+    );
+    expect(harness.console.error).not.toHaveBeenCalled();
+  });
+
+  it('defers a module whose recorded plugins are all disabled by id', async () => {
+    const harness = createHarness({
+      federated: [
+        {
+          name: '@jupyterlab/recorded-extension',
+          extension: './extension',
+          mimeExtension: './mimeExtension',
+          style: './style',
+          // Recorded when the extension was built, so the ids are known before
+          // any of its modules is loaded.
+          plugins: {
+            './extension': [
+              { id: '@jupyterlab/recorded-extension:one' },
+              { id: 'other-prefix:two' }
+            ],
+            './mimeExtension': [{ id: '@jupyterlab/recorded-extension:mime' }]
+          }
+        },
+        {
+          name: '@jupyterlab/partly-disabled-extension',
+          extension: './extension',
+          plugins: {
+            './extension': [
+              { id: '@jupyterlab/partly-disabled-extension:disabled' },
+              { id: '@jupyterlab/partly-disabled-extension:enabled' }
+            ]
+          }
+        }
+      ],
+      // Every plugin of the first package is disabled by id, none of them by
+      // the name of the package providing them.
+      disabled: [
+        '@jupyterlab/recorded-extension:one',
+        'other-prefix:two',
+        '@jupyterlab/recorded-extension:mime',
+        '@jupyterlab/partly-disabled-extension:disabled'
+      ],
+      modules: {
+        '@jupyterlab/recorded-extension': {
+          './extension': {
+            __esModule: true,
+            default: [
+              {
+                id: '@jupyterlab/recorded-extension:one',
+                description: 'First plugin',
+                autoStart: true
+              },
+              {
+                id: 'other-prefix:two',
+                description: 'Plugin with a mismatched id',
+                autoStart: true
+              }
+            ]
+          },
+          './mimeExtension': {
+            __esModule: true,
+            default: {
+              id: '@jupyterlab/recorded-extension:mime',
+              description: 'Mime plugin',
+              autoStart: true
+            }
+          },
+          './style': { __esModule: true, default: [] }
+        },
+        '@jupyterlab/partly-disabled-extension': {
+          './extension': {
+            __esModule: true,
+            default: [
+              {
+                id: '@jupyterlab/partly-disabled-extension:disabled',
+                description: 'Disabled plugin',
+                autoStart: true
+              },
+              {
+                id: '@jupyterlab/partly-disabled-extension:enabled',
+                description: 'Sibling plugin',
+                autoStart: true
+              }
+            ]
+          }
+        }
+      }
+    });
+
+    await harness.main();
+
+    // Neither module of the first package is loaded, and its styles are left
+    // out too. The second package still has an enabled plugin, so it loads.
+    expect(harness.moduleRequests).toEqual([
+      '@jupyterlab/partly-disabled-extension:./extension'
+    ]);
+    expect(harness.registeredPlugins.map(plugin => plugin.id)).toEqual([
+      '@jupyterlab/partly-disabled-extension:enabled'
+    ]);
+
+    harness.resolveRestored();
+    harness.resolveAllPluginsActivated();
+    await flushPromises();
+    await flushPromises();
+
+    expect(harness.moduleRequests).toEqual([
+      '@jupyterlab/partly-disabled-extension:./extension',
+      '@jupyterlab/recorded-extension:./extension',
+      '@jupyterlab/recorded-extension:./mimeExtension'
+    ]);
+    expect(harness.registeredPlugins.map(plugin => plugin.id)).toEqual([
+      '@jupyterlab/partly-disabled-extension:enabled'
+    ]);
+    expect(
+      harness.announcedPlugins.map(batch =>
+        batch.map(plugin => [plugin.id, plugin.enabled])
+      )
+    ).toEqual([
+      [
+        ['@jupyterlab/recorded-extension:one', false],
+        ['other-prefix:two', false],
+        ['@jupyterlab/recorded-extension:mime', false]
+      ]
+    ]);
+    // The ids were known, so nothing was disabled that the config did not name.
+    expect(harness.console.warn).not.toHaveBeenCalled();
+    expect(harness.console.error).not.toHaveBeenCalled();
+  });
+
+  it('reports a plugin missing from the recorded plugin ids', async () => {
+    const harness = createHarness({
+      federated: [
+        {
+          name: '@jupyterlab/stale-extension',
+          extension: './extension',
+          plugins: {
+            './extension': [{ id: '@jupyterlab/stale-extension:recorded' }]
+          }
+        }
+      ],
+      disabled: ['@jupyterlab/stale-extension:recorded'],
+      modules: {
+        '@jupyterlab/stale-extension': {
+          './extension': {
+            __esModule: true,
+            default: [
+              {
+                id: '@jupyterlab/stale-extension:recorded',
+                description: 'Recorded plugin',
+                autoStart: true
+              },
+              {
+                id: '@jupyterlab/stale-extension:added-since',
+                description: 'Plugin added after the ids were recorded',
+                autoStart: true
+              }
+            ]
+          }
+        }
+      }
+    });
+
+    await harness.main();
+    harness.resolveRestored();
+    harness.resolveAllPluginsActivated();
+    await flushPromises();
+    await flushPromises();
+
+    expect(harness.console.error).toHaveBeenCalledWith(
+      expect.stringContaining('@jupyterlab/stale-extension:added-since')
     );
   });
 });


### PR DESCRIPTION

https://github.com/jupyterlab/jupyterlab/pull/19627 deferred loading (fetching via network) extensions that are disabled. It could not:
- a) defer loading an extension that was disabled by disabling all of its plugins (rather than disabled by disabling it by name)
- b) skip loading them altogether because the information about the extension needs to be shown in the Plugin Manager

This PR tackles (a). 
## References

- Follow-up to https://github.com/jupyterlab/jupyterlab/pull/19627
- Depends on:
  - https://github.com/jupyterlab/jupyter-builder/pull/179
  - https://github.com/jupyterlab/jupyterlab_server/pull/478

## Code changes

TBD

## User-facing changes

For an extension `@foo/ext` with plugins `@foo/ext:a` and `@foo/ext:b`:
- for `disabledExtension: ['@foo/ext']` the `main` branch defers the load correctly
- for equivalent `disabledExtension: ['@foo/ext:a', '@foo/ext:b']` it does not; this PR helps here

For a dual MIME and frontend extension `@bar/ext` with:
- `mimeExtension` containing `@bar/ext:mime-renderer`
- `extension` containing `@bar/ext:fontend-extension`

Disabling either plugin will now defer loading it.

## Backwards-incompatible changes

TBD

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **<!-- YES or NO -->**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Opus 5